### PR TITLE
Support Month function

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -276,10 +276,6 @@ class Presto(Dialect):
         this = self.sql(expression, 'this')
         return f"DATE_FORMAT(DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d'), '%Y-%m-%d')"
 
-    def str_to_date(self, expression):
-        this = self.sql(expression, 'this')
-        return f"DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d')"
-
     transforms = {
         TokenType.INT: 'INTEGER',
         TokenType.FLOAT: 'REAL',

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -167,7 +167,7 @@ class Hive(Dialect):
 
     def _unix_to_time(self, expression):
         return f"FROM_UNIXTIME({self.sql(expression, 'this')})"
-    
+
     def ts_or_ds_to_date(self, expression):
         this = self.sql(expression, 'this')
         return f"DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d')"

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -105,6 +105,7 @@ class DuckDB(Dialect):
         exp.TimeToTimeStr: lambda self, e: f"STRFTIME({self.sql(e, 'this')}, {DuckDB.TIME_FORMAT})",
         exp.TimeToUnix: lambda self, e: f"EPOCH({self.sql(e, 'this')})",
         exp.TsOrDsToDateStr: lambda self, e: f"STRFTIME(CAST({self.sql(e, 'this')} AS DATE), {DuckDB.DATE_FORMAT})",
+        exp.TsOrDsToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE)",
         exp.UnixToStr: lambda self, e: f"STRFTIME({DuckDB._unix_to_time(self, e)}, {self.sql(e, 'format')})",
         exp.UnixToTime: _unix_to_time,
         exp.UnixToTimeStr: lambda self, e: f"STRFTIME({DuckDB._unix_to_time(self, e)}, {DuckDB.TIME_FORMAT})",
@@ -166,6 +167,10 @@ class Hive(Dialect):
 
     def _unix_to_time(self, expression):
         return f"FROM_UNIXTIME({self.sql(expression, 'this')})"
+    
+    def ts_or_ds_to_date(self, expression):
+        this = self.sql(expression, 'this')
+        return f"DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d')"
 
     transforms = {
         TokenType.TEXT: 'STRING',
@@ -191,6 +196,7 @@ class Hive(Dialect):
         exp.TimeToTimeStr: lambda self, e: self.sql(e, 'this'),
         exp.TimeToUnix: _time_to_unix,
         exp.TsOrDsToDateStr: lambda self, e: f"TO_DATE({self.sql(e, 'this')})",
+        exp.TsOrDsToDate: lambda self, e: f"TO_DATE({self.sql(e, 'this')})",
         exp.UnixToStr: lambda self, e: f"FROM_UNIXTIME({csv(self.sql(e, 'this'), Hive._time_format(self, e))})",
         exp.UnixToTime: _unix_to_time,
         exp.UnixToTimeStr: _unix_to_time,
@@ -209,14 +215,14 @@ class Hive(Dialect):
             expression=exp.Star(this=args[1], expression=Token.number(-1)),
         ),
         'DATE_FORMAT': lambda args: exp.TimeToStr(this=args[0], format=args[1]),
-        'DAY': lambda args: exp.Day(this=exp.TimeStrToDate(this=args[0])),
+        'DAY': lambda args: exp.Day(this=exp.TsOrDsToDate(this=args[0])),
         'FROM_UNIXTIME': lambda args: exp.UnixToStr(
             this=args[0],
             format=list_get(args, 1) or Hive.TIME_FORMAT,
         ),
         'GET_JSON_OBJECT': lambda args: exp.JSONPath(this=args[0], path=args[1]),
         'LOCATE': lambda args: exp.StrPosition(this=args[1], substr=args[0], position=list_get(args, 2)),
-        'MONTH': lambda args: exp.Month(this=exp.TimeStrToDate(this=args[0])),
+        'MONTH': lambda args: exp.Month(this=exp.TsOrDsToDate(this=args[0])),
         'SIZE': lambda args: exp.ArraySize(this=args[0]),
         'TO_DATE': lambda args: exp.TsOrDsToDateStr(this=args[0]),
         'UNIX_TIMESTAMP': lambda args: exp.StrToUnix(
@@ -277,6 +283,11 @@ class Presto(Dialect):
         this = self.sql(expression, 'this')
         return f"DATE_FORMAT(DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d'), '%Y-%m-%d')"
 
+    def _ts_or_ds_to_date_sql(self, expression):
+        this = self.sql(expression, 'this')
+        return f"DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d')"
+
+
     transforms = {
         TokenType.INT: 'INTEGER',
         TokenType.FLOAT: 'REAL',
@@ -312,6 +323,7 @@ class Presto(Dialect):
         exp.TimeToTimeStr: lambda self, e: f"DATE_FORMAT({self.sql(e, 'this')}, {Presto.TIME_FORMAT})",
         exp.TimeToUnix: lambda self, e: f"TO_UNIXTIME({self.sql(e, 'this')})",
         exp.TsOrDsToDateStr: _ts_or_ds_to_date_str_sql,
+        exp.TsOrDsToDate: _ts_or_ds_to_date_sql,
         exp.UnixToStr: lambda self, e: f"DATE_FORMAT(FROM_UNIXTIME({self.sql(e, 'this')}), {self.sql(e, 'format')})",
         exp.UnixToTime: lambda self, e: f"FROM_UNIXTIME({self.sql(e, 'this')})",
         exp.UnixToTimeStr: lambda self, e: f"DATE_FORMAT(FROM_UNIXTIME({self.sql(e, 'this')}), {Presto.TIME_FORMAT})",

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -209,6 +209,7 @@ class Hive(Dialect):
             expression=exp.Star(this=args[1], expression=Token.number(-1)),
         ),
         'DATE_FORMAT': lambda args: exp.TimeToStr(this=args[0], format=args[1]),
+        'DAY': lambda args: exp.Day(this=exp.TimeStrToDate(this=args[0])),
         'FROM_UNIXTIME': lambda args: exp.UnixToStr(
             this=args[0],
             format=list_get(args, 1) or Hive.TIME_FORMAT,

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -215,6 +215,7 @@ class Hive(Dialect):
         ),
         'GET_JSON_OBJECT': lambda args: exp.JSONPath(this=args[0], path=args[1]),
         'LOCATE': lambda args: exp.StrPosition(this=args[1], substr=args[0], position=list_get(args, 2)),
+        'MONTH': lambda args: exp.Month(this=exp.TimeStrToDate(this=args[0])),
         'SIZE': lambda args: exp.ArraySize(this=args[0]),
         'TO_DATE': lambda args: exp.TsOrDsToDateStr(this=args[0]),
         'UNIX_TIMESTAMP': lambda args: exp.StrToUnix(
@@ -274,6 +275,10 @@ class Presto(Dialect):
     def _ts_or_ds_to_date_str_sql(self, expression):
         this = self.sql(expression, 'this')
         return f"DATE_FORMAT(DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d'), '%Y-%m-%d')"
+
+    def str_to_date(self, expression):
+        this = self.sql(expression, 'this')
+        return f"DATE_PARSE(SUBSTR({this}, 1, 10), '%Y-%m-%d')"
 
     transforms = {
         TokenType.INT: 'INTEGER',

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -524,6 +524,10 @@ class TsOrDsToDateStr(Func):
     pass
 
 
+class TsOrDsToDate(Func):
+    pass
+
+
 class UnixToStr(Func):
     arg_types = {'this': True, 'format': True}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -450,6 +450,10 @@ class DateStrToDate(Func):
     pass
 
 
+class Day(Func):
+    pass
+
+
 class If(Func):
     arg_types = {'this': True, 'true': True, 'false': False}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -467,6 +467,10 @@ class Map(Func):
     arg_types = {'keys': True, 'values': True}
 
 
+class Month(Func):
+    pass
+
+
 class RegexLike(Func):
     token_type = TokenType.RLIKE
     arg_types = {'this': True, 'expression': True}

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -39,6 +39,7 @@ class Generator:
         exp.DateAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         exp.DateStrToDate: lambda self, e: f"DATE_STR_TO_DATE({self.sql(e, 'this')})",
+        exp.Day: lambda self, e: f"DAY({self.sql(e, 'this')})",
         exp.Initcap: lambda self, e: f"INITCAP({self.sql(e, 'this')})",
         exp.JSONPath: lambda self, e: f"JSON_PATH({self.sql(e, 'this')}, {self.sql(e, 'path')})",
         exp.Month: lambda self, e: f"MONTH({self.sql(e, 'this')})",

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -54,6 +54,7 @@ class Generator:
         exp.TimeToTimeStr: lambda self, e: f"TIME_TO_TIME_STR({self.sql(e, 'this')})",
         exp.TimeToUnix: lambda self, e: f"TIME_TO_UNIX({self.sql(e, 'this')})",
         exp.TsOrDsToDateStr: lambda self, e: f"TS_OR_DS_TO_DATE_STR({self.sql(e, 'this')})",
+        exp.TsOrDsToDate: lambda self, e: f"TS_OR_DS_TO_DATE({self.sql(e, 'this')})",
         exp.UnixToStr: lambda self, e: f"UNIX_TO_STR({self.sql(e, 'this')}, {self.sql(e, 'format')})",
         exp.UnixToTime: lambda self, e: f"UNIX_TO_TIME({self.sql(e, 'this')})",
         exp.UnixToTimeStr: lambda self, e: f"UNIX_TO_TIME_STR({self.sql(e, 'this')})",

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -41,6 +41,7 @@ class Generator:
         exp.DateStrToDate: lambda self, e: f"DATE_STR_TO_DATE({self.sql(e, 'this')})",
         exp.Initcap: lambda self, e: f"INITCAP({self.sql(e, 'this')})",
         exp.JSONPath: lambda self, e: f"JSON_PATH({self.sql(e, 'this')}, {self.sql(e, 'path')})",
+        exp.Month: lambda self, e: f"MONTH({self.sql(e, 'this')})",
         exp.StrPosition: lambda self, e: f"STR_POSITION({csv(self.sql(e, 'this'), self.sql(e, 'substr'), self.sql(e, 'position'))})",
         exp.StrToTime: lambda self, e: f"STR_TO_TIME({self.sql(e, 'this')}, {self.sql(e, 'format')})",
         exp.StrToUnix: lambda self, e: f"STR_TO_UNIX({self.sql(e, 'this')}, {self.sql(e, 'format')})",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -31,6 +31,7 @@ class Parser:
         'IF': lambda args: exp.If(this=args[0], true=args[1], false=list_get(args, 2)),
         'INITCAP': lambda args: exp.Initcap(this=args[0]),
         'JSON_PATH': lambda args: exp.JSONPath(this=args[0], path=args[1]),
+        'MONTH': lambda args: exp.Month(this=args[0]),
         'STR_POSITION': lambda args: exp.StrPosition(this=args[0], substr=args[1], position=list_get(args, 2)),
         'STR_TO_TIME': lambda args: exp.StrToTime(this=args[0], format=args[1]),
         'STR_TO_UNIX': lambda args: exp.StrToUnix(this=args[0], format=args[1]),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -28,6 +28,7 @@ class Parser:
         'DATE_ADD': lambda args: exp.DateAdd(this=args[0], expression=args[1]),
         'DATE_DIFF': lambda args: exp.DateDiff(this=args[0], expression=args[1]),
         'DATE_STR_TO_DATE': lambda args: exp.DateStrToDate(this=args[0]),
+        'DAY': lambda args: exp.Day(this=args[0]),
         'IF': lambda args: exp.If(this=args[0], true=args[1], false=list_get(args, 2)),
         'INITCAP': lambda args: exp.Initcap(this=args[0]),
         'JSON_PATH': lambda args: exp.JSONPath(this=args[0], path=args[1]),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -44,6 +44,7 @@ class Parser:
         'TIME_TO_TIME_STR': lambda args: exp.TimeToTimeStr(this=args[0]),
         'TIME_TO_UNIX': lambda args: exp.TimeToUnix(this=args[0]),
         'TS_OR_DS_TO_DATE_STR': lambda args: exp.TsOrDsToDateStr(this=args[0]),
+        'TS_OR_DS_TO_DATE': lambda args: exp.TsOrDsToDate(this=args[0]),
         'UNIX_TO_STR': lambda args: exp.UnixToStr(this=args[0], format=args[1]),
         'UNIX_TO_TIME': lambda args: exp.UnixToTime(this=args[0]),
         'UNIX_TO_TIME_STR': lambda args: exp.UnixToTimeStr(this=args[0]),

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -32,6 +32,7 @@ class TestDialects(unittest.TestCase):
         self.validate("STRUCT_EXTRACT(x, 'abc')", "STRUCT_EXTRACT(x, 'abc')", read="duckdb")
 
         self.validate("MONTH(x)", "MONTH(x)", write='duckdb', identity=False)
+        self.validate("DAY(x)", "DAY(x)", write='duckdb', identity=False)
 
         self.validate(
             "DATEDIFF(a, b)",
@@ -260,6 +261,9 @@ class TestDialects(unittest.TestCase):
         self.validate("MONTH(x)", "MONTH(x)", read='presto', write='hive')
         self.validate("MONTH(x)", "MONTH(DATE_PARSE(x, '%Y-%m-%d %H:%i:%s'))", read='hive', write='presto')
 
+        self.validate("DAY(x)", "DAY(x)", read='presto', write='hive')
+        self.validate("DAY(x)", "DAY(DATE_PARSE(x, '%Y-%m-%d %H:%i:%s'))", read='hive', write='presto')
+        
         with self.assertRaises(UnsupportedError):
             transpile(
                 'SELECT APPROX_DISTINCT(a, 0.1) FROM foo',
@@ -415,6 +419,9 @@ class TestDialects(unittest.TestCase):
         
         self.validate("MONTH('2021-03-01')", "MONTH(CAST('2021-03-01' AS DATE))", read='hive', write='duckdb')
         self.validate("MONTH(x)", "MONTH(x)", read='duckdb', write='hive')
+
+        self.validate("DAY('2021-03-01')", "DAY(CAST('2021-03-01' AS DATE))", read='hive', write='duckdb')
+        self.validate("DAY(x)", "DAY(x)", read='duckdb', write='hive')
 
     def test_spark(self):
         self.validate(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -112,6 +112,18 @@ class TestDialects(unittest.TestCase):
             read='duckdb',
             write='presto',
         )
+        self.validate(
+            "TS_OR_DS_TO_DATE(x)",
+            "CAST(x AS DATE)",
+            write='duckdb',
+            identity=False,
+        )
+        self.validate(
+            "CAST(x AS DATE)",
+            "CAST(x AS DATE)",
+            read='duckdb',
+            identity=False,
+        )
 
     def test_mysql(self):
         self.validate(
@@ -211,6 +223,18 @@ class TestDialects(unittest.TestCase):
             "DATEDIFF(b, a)",
             read='presto',
             write='hive',
+        )
+        self.validate(
+            "TS_OR_DS_TO_DATE(x)",
+            "DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d')",
+            write='presto',
+            identity=False,
+        )
+        self.validate(
+            "DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d')",
+            "STR_TO_TIME(SUBSTR(x, 1, 10), '%Y-%m-%d')",
+            read='presto',
+            identity=False,
         )
 
         self.validate(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -437,6 +437,19 @@ class TestDialects(unittest.TestCase):
             "FROM_UNIXTIME(x)",
             write='hive',
         )
+        self.validate(
+            "TS_OR_DS_TO_DATE(x)",
+            "TO_DATE(x)",
+            write='hive',
+            identity=False,
+        )
+        self.validate(
+            "TO_DATE(x)",
+            "TS_OR_DS_TO_DATE_STR(x)",
+            read='hive',
+            identity=False,
+        )
+        
 
         self.validate("STRUCT_EXTRACT(x, 'abc')", "x.`abc`", read='duckdb', write='hive')
         self.validate("STRUCT_EXTRACT(STRUCT_EXTRACT(x, 'y'), 'abc')", "x.`y`.`abc`", read='duckdb', write='hive')

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -287,7 +287,7 @@ class TestDialects(unittest.TestCase):
 
         self.validate("DAY(x)", "DAY(x)", read='presto', write='hive')
         self.validate("DAY(x)", "DAY(DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d'))", read='hive', write='presto')
-        
+
         with self.assertRaises(UnsupportedError):
             transpile(
                 'SELECT APPROX_DISTINCT(a, 0.1) FROM foo',
@@ -449,11 +449,11 @@ class TestDialects(unittest.TestCase):
             read='hive',
             identity=False,
         )
-        
+
 
         self.validate("STRUCT_EXTRACT(x, 'abc')", "x.`abc`", read='duckdb', write='hive')
         self.validate("STRUCT_EXTRACT(STRUCT_EXTRACT(x, 'y'), 'abc')", "x.`y`.`abc`", read='duckdb', write='hive')
-        
+
         self.validate("MONTH('2021-03-01')", "MONTH(CAST('2021-03-01' AS DATE))", read='hive', write='duckdb')
         self.validate("MONTH(x)", "MONTH(x)", read='duckdb', write='hive')
 

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -259,10 +259,10 @@ class TestDialects(unittest.TestCase):
 
         self.validate("MONTH(x)", "MONTH(x)", read='presto', write='spark')
         self.validate("MONTH(x)", "MONTH(x)", read='presto', write='hive')
-        self.validate("MONTH(x)", "MONTH(DATE_PARSE(x, '%Y-%m-%d %H:%i:%s'))", read='hive', write='presto')
+        self.validate("MONTH(x)", "MONTH(DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d'))", read='hive', write='presto')
 
         self.validate("DAY(x)", "DAY(x)", read='presto', write='hive')
-        self.validate("DAY(x)", "DAY(DATE_PARSE(x, '%Y-%m-%d %H:%i:%s'))", read='hive', write='presto')
+        self.validate("DAY(x)", "DAY(DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d'))", read='hive', write='presto')
         
         with self.assertRaises(UnsupportedError):
             transpile(


### PR DESCRIPTION
Presto: https://prestodb.io/docs/current/functions/datetime.html#month
does not accept varchar, but accepts timestamp or date

Duckdb:
https://duckdb.org/docs/sql/functions/timestamp
does not accept string, but accepts timestamp or date

Hive/Spark:
accept string, date or timestamp
But we saw users using string

