### PR TITLE
Simplify the Literal expression by removing the token type

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5,7 +5,6 @@ import weakref
 import sys
 
 from sqlglot.helper import AutoName, camel_to_snake_case, ensure_list
-from sqlglot.tokens import TokenType
 
 
 class Expression:
@@ -228,13 +227,13 @@ class Limit(Expression):
 
 
 class Literal(Expression):
-    arg_types = {"this": True, "token_type": True}
+    arg_types = {"this": True, "is_string": True}
 
     def __eq__(self, other):
         return (
             isinstance(other, Literal)
             and self.args.get("this") == other.args.get("this")
-            and self.args.get("token_type") == other.args.get("token_type")
+            and self.args.get("is_string") == other.args.get("is_string")
         )
 
     def __hash__(self):
@@ -242,17 +241,17 @@ class Literal(Expression):
             (
                 self.key,
                 self.args.get("this"),
-                self.args.get("token_type"),
+                self.args.get("is_string"),
             )
         )
 
     @classmethod
     def number(cls, number):
-        return cls(this=str(number), token_type=TokenType.NUMBER)
+        return cls(this=str(number), is_string=False)
 
     @classmethod
     def string(cls, string):
-        return cls(this=string, token_type=TokenType.STRING)
+        return cls(this=string, is_string=True)
 
 
 class Join(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3,7 +3,7 @@ import logging
 import sqlglot.expressions as exp
 from sqlglot.errors import ErrorLevel, UnsupportedError
 from sqlglot.helper import ensure_list, csv
-from sqlglot.tokens import TokenType, Tokenizer
+from sqlglot.tokens import Tokenizer
 
 
 class Generator:
@@ -291,8 +291,8 @@ class Generator:
 
     def literal_sql(self, expression):
         text = expression.args.get("this") or ""
-        token_type = expression.args.get("token_type")
-        if token_type == TokenType.STRING:
+        is_string = expression.args.get("is_string")
+        if is_string:
             text = text.replace(Tokenizer.ESCAPE_CODE, self.escape)
             return f"{self.quote}{text}{self.quote}"
         return text

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -131,8 +131,8 @@ class Parser:
     TOKEN_TO_EXPRESSION = {
         TokenType.STAR: lambda t: exp.Star(),
         TokenType.NULL: lambda t: exp.Null(),
-        TokenType.STRING: lambda t: exp.Literal(this=t.text, token_type=t.token_type),
-        TokenType.NUMBER: lambda t: exp.Literal(this=t.text, token_type=t.token_type),
+        TokenType.STRING: lambda t: exp.Literal.string(t.text),
+        TokenType.NUMBER: lambda t: exp.Literal.number(t.text),
         TokenType.IDENTIFIER: lambda t: exp.Identifier(this=t.text, quoted=True),
         TokenType.VAR: lambda t: exp.Identifier(this=t.text, quoted=False),
         **{


### PR DESCRIPTION
Decided to get rid of the TokenType in a tree completely.