### PR TITLE
Add TsOrDsAdd

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -251,7 +251,7 @@ class Hive(Dialect):
         "DATE_ADD": lambda args: exp.TsOrDsAdd(
             this=list_get(args, 0),
             expression=list_get(args, 1),
-            unit="'DAY'",
+            unit=exp.Literal.string('DAY'),
         ),
         "DATEDIFF": lambda args: exp.DateDiff(
             this=exp.DateStrToDate(this=list_get(args, 0)),
@@ -263,7 +263,7 @@ class Hive(Dialect):
                 this=list_get(args, 1),
                 expression=exp.Literal.number(-1),
             ),
-            unit="'DAY'",
+            unit=exp.Literal.string('DAY'),
         ),
         "DATE_FORMAT": exp.TimeToStr.from_arg_list,
         "DAY": lambda args: exp.Day(this=exp.TsOrDsToDate(this=list_get(args, 0))),

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -251,7 +251,7 @@ class Hive(Dialect):
         "DATE_ADD": lambda args: exp.TsOrDsAdd(
             this=list_get(args, 0),
             expression=list_get(args, 1),
-            unit=exp.Literal.string('DAY'),
+            unit=exp.Literal.string("DAY"),
         ),
         "DATEDIFF": lambda args: exp.DateDiff(
             this=exp.DateStrToDate(this=list_get(args, 0)),
@@ -263,7 +263,7 @@ class Hive(Dialect):
                 this=list_get(args, 1),
                 expression=exp.Literal.number(-1),
             ),
-            unit=exp.Literal.string('DAY'),
+            unit=exp.Literal.string("DAY"),
         ),
         "DATE_FORMAT": exp.TimeToStr.from_arg_list,
         "DAY": lambda args: exp.Day(this=exp.TsOrDsToDate(this=list_get(args, 0))),

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -112,6 +112,7 @@ class DuckDB(Dialect):
     transforms = {
         exp.ApproxDistinct: _approx_count_distinct_sql,
         exp.Array: lambda self, e: f"LIST_VALUE({self.expressions(e, flat=True)})",
+        exp.DateAdd: lambda self, e: f"""CAST({self.sql(e, 'this')} AS DATE) + INTERVAL {self.sql(e, 'expression')} {self.sql(e, 'unit') or "DAY"}""",
         exp.DateDiff: lambda self, e: f"{self.sql(e, 'this')} - {self.sql(e, 'expression')}",
         exp.DateStrToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE)",
         exp.Quantile: lambda self, e: f"QUANTILE({self.sql(e, 'this')}, {self.sql(e, 'quantile')})",
@@ -124,7 +125,7 @@ class DuckDB(Dialect):
         exp.TimeToStr: lambda self, e: f"STRFTIME({self.sql(e, 'this')}, {self.sql(e, 'format')})",
         exp.TimeToTimeStr: lambda self, e: f"STRFTIME({self.sql(e, 'this')}, {DuckDB.TIME_FORMAT})",
         exp.TimeToUnix: lambda self, e: f"EPOCH({self.sql(e, 'this')})",
-        exp.TsOrDsAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+        exp.TsOrDsAdd: lambda self, e: f"""STRFTIME(CAST(CAST({self.sql(e, 'this')} AS DATE) + INTERVAL {self.sql(e, 'expression')} {self.sql(e, 'unit') or "DAY"} AS DATE), {DuckDB.DATE_FORMAT})""",
         exp.TsOrDsToDateStr: lambda self, e: f"STRFTIME(CAST({self.sql(e, 'this')} AS DATE), {DuckDB.DATE_FORMAT})",
         exp.TsOrDsToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE)",
         exp.UnixToStr: lambda self, e: f"STRFTIME({DuckDB._unix_to_time(self, e)}, {self.sql(e, 'format')})",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -857,6 +857,10 @@ class TimeStrToUnix(Func):
     pass
 
 
+class TsOrDsAdd(Func):
+    arg_types = {"this": True, "expression": True, "unit": False}
+
+
 class TsOrDsToDateStr(Func):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -45,6 +45,7 @@ class Generator:
     TRANSFORMS = {
         exp.DateAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+        exp.TsOrDsAdd: lambda self, e: f"TS_OR_DS_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
     }
 
     def __init__(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -43,9 +43,9 @@ class Generator:
     )
 
     TRANSFORMS = {
-        exp.DateAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+        exp.DateAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')}, {self.sql(e, 'unit')})",
         exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
-        exp.TsOrDsAdd: lambda self, e: f"TS_OR_DS_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+        exp.TsOrDsAdd: lambda self, e: f"TS_OR_DS_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')}, {self.sql(e, 'unit')})",
     }
 
     def __init__(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -491,7 +491,7 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "DATE_ADD(DATE_STR_TO_DATE('2020-01-01'), 1)",
+            "TS_OR_DS_ADD(DATE_STR_TO_DATE('2020-01-01'), 1)",
             read="hive",
             write=None,
             identity=False,
@@ -508,13 +508,13 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATE_SUB('2020-01-01', 1)",
-            "DATE_ADD('day', 1 * -1, DATE_PARSE('2020-01-01', '%Y-%m-%d'))",
+            "DATE_FORMAT(DATE_ADD('day', 1 * -1, DATE_PARSE('2020-01-01', '%Y-%m-%d')), '%Y-%m-%d')",
             read="hive",
             write="presto",
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "DATE_ADD('day', 1, DATE_PARSE('2020-01-01', '%Y-%m-%d'))",
+            "DATE_FORMAT(DATE_ADD('day', 1, DATE_PARSE('2020-01-01', '%Y-%m-%d')), '%Y-%m-%d')",
             read="hive",
             write="presto",
         )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -519,6 +519,18 @@ class TestDialects(unittest.TestCase):
             write="presto",
         )
         self.validate(
+            "DATE_ADD('2020-01-01', 1)",
+            "CAST('2020-01-01' AS DATE) + INTERVAL 1 DAY",
+            write="duckdb",
+            identity=False,
+        )
+        self.validate(
+            "DATE_ADD('2020-01-01', 1)",
+            "STRFTIME(CAST(CAST(CAST('2020-01-01' AS DATE) AS DATE) + INTERVAL 1 DAY AS DATE), '%Y-%m-%d')",
+            read="hive",
+            write="duckdb",
+        )
+        self.validate(
             "DATEDIFF('2020-01-02', '2020-01-02')",
             "DATE_DIFF(DATE_STR_TO_DATE('2020-01-02'), DATE_STR_TO_DATE('2020-01-02'))",
             read="hive",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -491,7 +491,7 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "TS_OR_DS_ADD(DATE_STR_TO_DATE('2020-01-01'), 1)",
+            "TS_OR_DS_ADD('2020-01-01', 1, 'DAY')",
             read="hive",
             write=None,
             identity=False,
@@ -508,25 +508,37 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATE_SUB('2020-01-01', 1)",
-            "DATE_FORMAT(DATE_ADD('day', 1 * -1, DATE_PARSE('2020-01-01', '%Y-%m-%d')), '%Y-%m-%d')",
+            "DATE_FORMAT(DATE_ADD('DAY', 1 * -1, DATE_PARSE(SUBSTR('2020-01-01', 1, 10), '%Y-%m-%d')), '%Y-%m-%d')",
             read="hive",
             write="presto",
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "DATE_FORMAT(DATE_ADD('day', 1, DATE_PARSE('2020-01-01', '%Y-%m-%d')), '%Y-%m-%d')",
+            "DATE_FORMAT(DATE_ADD('DAY', 1, DATE_PARSE(SUBSTR('2020-01-01', 1, 10), '%Y-%m-%d')), '%Y-%m-%d')",
             read="hive",
             write="presto",
         )
         self.validate(
-            "DATE_ADD('2020-01-01', 1)",
+            "TS_OR_DS_ADD('2021-02-01', 1, 'DAY')",
+            "DATE_FORMAT(DATE_ADD('DAY', 1, DATE_PARSE(SUBSTR('2021-02-01', 1, 10), '%Y-%m-%d')), '%Y-%m-%d')",
+            write="presto",
+            identity=False,
+        )
+        self.validate(
+            "DATE_ADD(CAST('2020-01-01' AS DATE), 1)",
             "CAST('2020-01-01' AS DATE) + INTERVAL 1 DAY",
             write="duckdb",
             identity=False,
         )
         self.validate(
+            "TS_OR_DS_ADD('2021-02-01', 1, 'DAY')",
+            "STRFTIME(CAST('2021-02-01' AS DATE) + INTERVAL 1 DAY, '%Y-%m-%d')",
+            write="duckdb",
+            identity=False,
+        )
+        self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "STRFTIME(CAST(CAST(CAST('2020-01-01' AS DATE) AS DATE) + INTERVAL 1 DAY AS DATE), '%Y-%m-%d')",
+            "STRFTIME(CAST('2020-01-01' AS DATE) + INTERVAL 1 DAY, '%Y-%m-%d')",
             read="hive",
             write="duckdb",
         )

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -174,6 +174,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("TIME_STR_TO_DATE(a)"), exp.TimeStrToDate)
         self.assertIsInstance(parse_one("TIME_STR_TO_TIME(a)"), exp.TimeStrToTime)
         self.assertIsInstance(parse_one("TIME_STR_TO_UNIX(a)"), exp.TimeStrToUnix)
+        self.assertIsInstance(parse_one("TS_OR_DS_ADD(a, 1)"), exp.TsOrDsAdd)
         self.assertIsInstance(parse_one("TS_OR_DS_TO_DATE(a)"), exp.TsOrDsToDate)
         self.assertIsInstance(parse_one("TS_OR_DS_TO_DATE_STR(a)"), exp.TsOrDsToDateStr)
         self.assertIsInstance(parse_one("UNIX_TO_STR(a, 'format')"), exp.UnixToStr)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -174,7 +174,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("TIME_STR_TO_DATE(a)"), exp.TimeStrToDate)
         self.assertIsInstance(parse_one("TIME_STR_TO_TIME(a)"), exp.TimeStrToTime)
         self.assertIsInstance(parse_one("TIME_STR_TO_UNIX(a)"), exp.TimeStrToUnix)
-        self.assertIsInstance(parse_one("TS_OR_DS_ADD(a, 1)"), exp.TsOrDsAdd)
+        self.assertIsInstance(parse_one("TS_OR_DS_ADD(a, 1, 'day')"), exp.TsOrDsAdd)
         self.assertIsInstance(parse_one("TS_OR_DS_TO_DATE(a)"), exp.TsOrDsToDate)
         self.assertIsInstance(parse_one("TS_OR_DS_TO_DATE_STR(a)"), exp.TsOrDsToDateStr)
         self.assertIsInstance(parse_one("UNIX_TO_STR(a, 'format')"), exp.UnixToStr)


### PR DESCRIPTION
https://duckdb.org/docs/sql/functions/timestamp

duckdb returns a ts if input is a ts
duckdb returns a date if input is a date

https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF#LanguageManualUDF-DateFunctions
hive always returns a date even if the input is ts, date or ts

https://prestodb.io/docs/current/functions/datetime.html#date_add
presto returns a ts if input is a ts
presto returns a date if input is a date

Let's add a new expression called `TsOrDsAdd`
