### PR TITLE
Example PR for timestamp issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Pycharm metadata
+.idea/

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -65,7 +65,12 @@ def transpile(code, read=None, write=None, identity=True, error_level=None, **op
         the list of transpiled SQL statements / expressions.
     """
     write = write or read if identity else write
-    return [
-        Dialect.get_or_raise(write)().generate(expression, **opts)
-        for expression in parse(code, read, error_level=error_level)
-    ]
+    dialect = Dialect.get_or_raise(write)()
+    expressions = []
+    for expression in parse(code, read, error_level=error_level):
+        expressions.append(expression)
+
+    outputs = []
+    for expr in expressions:
+        outputs.append(dialect.generate(expression, **opts))
+    return outputs

--- a/sqlglot/__main__.py
+++ b/sqlglot/__main__.py
@@ -26,10 +26,7 @@ parser.add_argument(
     help="Don't auto identify fields",
 )
 parser.add_argument(
-    "--no-pretty",
-    dest="pretty",
-    action="store_false",
-    help="Compress sql",
+    "--no-pretty", dest="pretty", action="store_false", help="Compress sql",
 )
 parser.add_argument(
     "--parse",

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -42,9 +42,7 @@ class Dialect(metaclass=RegisteringMeta):
 
     def tokenizer(self):
         return Tokenizer(
-            identifier=self.identifier,
-            quotes=self.quotes,
-            escape=self.escape,
+            identifier=self.identifier, quotes=self.quotes, escape=self.escape,
         )
 
     @classmethod
@@ -155,10 +153,7 @@ class DuckDB(Dialect):
         "APPROX_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
         "EPOCH": exp.TimeToUnix.from_arg_list,
         "EPOCH_MS": lambda args: exp.UnixToTime(
-            this=exp.Div(
-                this=list_get(args, 0),
-                expression=exp.Literal.number(1000),
-            )
+            this=exp.Div(this=list_get(args, 0), expression=exp.Literal.number(1000),)
         ),
         "LIST_VALUE": exp.Array.from_arg_list,
         "QUANTILE": exp.Quantile.from_arg_list,
@@ -185,8 +180,7 @@ class Hive(Dialect):
             keys.append(args[i])
             values.append(args[i + 1])
         return exp.Map(
-            keys=exp.Array(expressions=keys),
-            values=exp.Array(expressions=values),
+            keys=exp.Array(expressions=keys), values=exp.Array(expressions=values),
         )
 
     def _time_format(self, expression):
@@ -275,16 +269,14 @@ class Hive(Dialect):
         "DATE_SUB": lambda args: exp.TsOrDsAdd(
             this=list_get(args, 0),
             expression=exp.Mul(
-                this=list_get(args, 1),
-                expression=exp.Literal.number(-1),
+                this=list_get(args, 1), expression=exp.Literal.number(-1),
             ),
             unit=exp.Literal.string("DAY"),
         ),
         "DATE_FORMAT": exp.TimeToStr.from_arg_list,
         "DAY": lambda args: exp.Day(this=exp.TsOrDsToDate(this=list_get(args, 0))),
         "FROM_UNIXTIME": lambda args: exp.UnixToStr(
-            this=list_get(args, 0),
-            format=list_get(args, 1) or Hive.TIME_FORMAT,
+            this=list_get(args, 0), format=list_get(args, 1) or Hive.TIME_FORMAT,
         ),
         "GET_JSON_OBJECT": exp.JSONPath.from_arg_list,
         "LOCATE": lambda args: exp.StrPosition(
@@ -297,8 +289,7 @@ class Hive(Dialect):
         "SIZE": exp.ArraySize.from_arg_list,
         "TO_DATE": exp.TsOrDsToDateStr.from_arg_list,
         "UNIX_TIMESTAMP": lambda args: exp.StrToUnix(
-            this=list_get(args, 0),
-            format=list_get(args, 1) or Hive.TIME_FORMAT,
+            this=list_get(args, 0), format=list_get(args, 1) or Hive.TIME_FORMAT,
         ),
     }
 
@@ -386,6 +377,7 @@ class Presto(Dialect):
         exp.DataType.Type.FLOAT: "REAL",
         exp.DataType.Type.BINARY: "VARBINARY",
         exp.DataType.Type.TEXT: "VARCHAR",
+        exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP WITH TIME ZONE",
     }
 
     transforms = {
@@ -502,4 +494,7 @@ class SQLite(Dialect):
 
 
 class Trino(Presto):
-    pass
+    ...
+    # transforms = {
+    #     exp.Array: foo#lambda self, e: f"ARRAY({self.expressions(e, flat=True)})",
+    # }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -14,7 +14,7 @@ class Expression:
         arg_types (dict): determines arguments supported by this expression.
             The key in a dictionary defines a unique key of an argument using
             which the argument's value can be retrieved. The value is a boolean
-            flag which indiciates whether the argument's value is required (True)
+            flag which indicates whether the argument's value is required (True)
             or optional (False).
     """
 

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -116,10 +116,7 @@ class TestDialects(unittest.TestCase):
             write="duckdb",
         )
         self.validate(
-            "TIME_TO_UNIX(x)",
-            "EPOCH(x)",
-            identity=False,
-            write="duckdb",
+            "TIME_TO_UNIX(x)", "EPOCH(x)", identity=False, write="duckdb",
         )
         self.validate(
             "TS_OR_DS_TO_DATE_STR(x)",
@@ -152,29 +149,17 @@ class TestDialects(unittest.TestCase):
             write="presto",
         )
         self.validate(
-            "TS_OR_DS_TO_DATE(x)",
-            "CAST(x AS DATE)",
-            write="duckdb",
-            identity=False,
+            "TS_OR_DS_TO_DATE(x)", "CAST(x AS DATE)", write="duckdb", identity=False,
         )
         self.validate(
-            "CAST(x AS DATE)",
-            "CAST(x AS DATE)",
-            read="duckdb",
-            identity=False,
+            "CAST(x AS DATE)", "CAST(x AS DATE)", read="duckdb", identity=False,
         )
 
         self.validate(
-            "UNNEST(x)",
-            "EXPLODE(x)",
-            read="duckdb",
-            write="spark",
+            "UNNEST(x)", "EXPLODE(x)", read="duckdb", write="spark",
         )
         self.validate(
-            "EXPLODE(x)",
-            "UNNEST(x)",
-            read="spark",
-            write="duckdb",
+            "EXPLODE(x)", "UNNEST(x)", read="spark", write="duckdb",
         )
 
     def test_mysql(self):
@@ -306,9 +291,7 @@ class TestDialects(unittest.TestCase):
             write="presto",
         )
         self.validate(
-            "TIME_STR_TO_TIME(x)",
-            "DATE_PARSE(x, '%Y-%m-%d %H:%i:%s')",
-            write="presto",
+            "TIME_STR_TO_TIME(x)", "DATE_PARSE(x, '%Y-%m-%d %H:%i:%s')", write="presto",
         )
         self.validate(
             "TIME_TO_TIME_STR(x)",
@@ -321,34 +304,19 @@ class TestDialects(unittest.TestCase):
             write="presto",
         )
         self.validate(
-            "FROM_UNIXTIME(x)",
-            "FROM_UNIXTIME(x)",
-            read="presto",
-            write="hive",
+            "FROM_UNIXTIME(x)", "FROM_UNIXTIME(x)", read="presto", write="hive",
         )
         self.validate(
-            "TO_UNIXTIME(x)",
-            "UNIX_TIMESTAMP(x)",
-            read="presto",
-            write="hive",
+            "TO_UNIXTIME(x)", "UNIX_TIMESTAMP(x)", read="presto", write="hive",
         )
         self.validate(
-            "DATE_ADD('day', 1, x)",
-            "DATE_ADD(x, 1)",
-            read="presto",
-            write="hive",
+            "DATE_ADD('day', 1, x)", "DATE_ADD(x, 1)", read="presto", write="hive",
         )
         self.validate(
-            "DATE_DIFF('day', a, b)",
-            "DATEDIFF(b, a)",
-            read="presto",
-            write="hive",
+            "DATE_DIFF('day', a, b)", "DATEDIFF(b, a)", read="presto", write="hive",
         )
         self.validate(
-            "DATE_DIFF(a, b)",
-            "DATE_DIFF('day', b, a)",
-            write="presto",
-            identity=False,
+            "DATE_DIFF(a, b)", "DATE_DIFF('day', b, a)", write="presto", identity=False,
         )
         self.validate(
             "TS_OR_DS_TO_DATE(x)",
@@ -463,6 +431,27 @@ class TestDialects(unittest.TestCase):
                 unsupported_level=ErrorLevel.RAISE,
             )
 
+    def test_trino(self):
+        self.validate(
+            "SELECT CAST('2021-01-01 18:00:00' AS TIMESTAMP(3))",
+            "SELECT CAST('2021-01-01 18:00:00' AS TIMESTAMP(3))",
+            write="trino",
+            identity=True,
+        )
+        self.validate(
+            "SELECT CAST('2021-01-01 18:00:00 America/New_York' AS TIMESTAMP(3) WITH TIME ZONE)",
+            "SELECT CAST('2021-01-01 18:00:00 America/New_York' AS TIMESTAMP(3) WITH TIME ZONE)",
+            write="trino",
+            identity=True,
+        )
+        # This one fails because ARRAY(INTEGER) is the correct typing. ARRAY[INTEGER] is incorrect.
+        self.validate(
+            "SELECT CAST(ARRAY[1, 2, 3] AS ARRAY(INTEGER))",
+            "SELECT CAST(ARRAY[1, 2, 3] AS ARRAY(INTEGER))",
+            write="trino",
+            identity=True
+        )
+
     def test_hive(self):
         sql = transpile('SELECT "a"."b" FROM "foo"', write="hive")[0]
         self.assertEqual(sql, "SELECT `a`.`b` FROM `foo`")
@@ -539,14 +528,10 @@ class TestDialects(unittest.TestCase):
             identity=False,
         )
         self.validate(
-            "DATE_ADD('2020-01-01', 1)",
-            "DATE_ADD('2020-01-01', 1)",
-            read="hive",
+            "DATE_ADD('2020-01-01', 1)", "DATE_ADD('2020-01-01', 1)", read="hive",
         )
         self.validate(
-            "DATE_SUB('2020-01-01', 1)",
-            "DATE_ADD('2020-01-01', 1 * -1)",
-            read="hive",
+            "DATE_SUB('2020-01-01', 1)", "DATE_ADD('2020-01-01', 1 * -1)", read="hive",
         )
         self.validate(
             "DATE_SUB('2020-01-01', 1)",
@@ -626,36 +611,22 @@ class TestDialects(unittest.TestCase):
             identity=False,
         )
         self.validate(
-            "TIME_STR_TO_UNIX(x)",
-            "UNIX_TIMESTAMP(x)",
-            write="hive",
+            "TIME_STR_TO_UNIX(x)", "UNIX_TIMESTAMP(x)", write="hive",
         )
         self.validate(
-            "TIME_STR_TO_TIME(x)",
-            "x",
-            write="hive",
+            "TIME_STR_TO_TIME(x)", "x", write="hive",
         )
         self.validate(
-            "TIME_TO_TIME_STR(x)",
-            "x",
-            write="hive",
+            "TIME_TO_TIME_STR(x)", "x", write="hive",
         )
         self.validate(
-            "UNIX_TO_TIME_STR(x)",
-            "FROM_UNIXTIME(x)",
-            write="hive",
+            "UNIX_TO_TIME_STR(x)", "FROM_UNIXTIME(x)", write="hive",
         )
         self.validate(
-            "TS_OR_DS_TO_DATE(x)",
-            "TO_DATE(x)",
-            write="hive",
-            identity=False,
+            "TS_OR_DS_TO_DATE(x)", "TO_DATE(x)", write="hive", identity=False,
         )
         self.validate(
-            "TO_DATE(x)",
-            "TS_OR_DS_TO_DATE_STR(x)",
-            read="hive",
-            identity=False,
+            "TO_DATE(x)", "TS_OR_DS_TO_DATE_STR(x)", read="hive", identity=False,
         )
 
         self.validate(
@@ -686,9 +657,7 @@ class TestDialects(unittest.TestCase):
 
     def test_spark(self):
         self.validate(
-            'SELECT "a"."b" FROM "foo"',
-            "SELECT `a`.`b` FROM `foo`",
-            write="spark",
+            'SELECT "a"."b" FROM "foo"', "SELECT `a`.`b` FROM `foo`", write="spark",
         )
 
         self.validate("CAST(a AS TEXT)", "CAST(a AS STRING)", write="spark")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -203,8 +203,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsNone(column.args.get("table"))
         self.assertIsNone(column.args.get("db"))
         self.assertEqual(
-            [f.args["this"] for f in column.args["fields"]],
-            ["a", "b", "c", "d"],
+            [f.args["this"] for f in column.args["fields"]], ["a", "b", "c", "d"],
         )
 
     def test_text(self):

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -25,8 +25,7 @@ class TestRewriter(unittest.TestCase):
         rewriter = Rewriter(expression).ctas("x")
         self.assertEqual(rewriter.expression.sql(), "CREATE TABLE x AS SELECT * FROM y")
         self.assertEqual(
-            rewriter.ctas("y").expression.sql(),
-            "CREATE TABLE y AS SELECT * FROM y",
+            rewriter.ctas("y").expression.sql(), "CREATE TABLE y AS SELECT * FROM y",
         )
 
         expression = parse_one("CREATE TABLE x AS SELECT * FROM y")
@@ -40,10 +39,7 @@ class TestRewriter(unittest.TestCase):
 
         self.assertEqual(
             Rewriter(expression)
-            .add_selects(
-                "a",
-                "sum(b) as c",
-            )
+            .add_selects("a", "sum(b) as c",)
             .expression.sql("hive"),
             "SELECT *, a, SUM(b) AS c FROM (SELECT * FROM x) AS y",
         )

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -28,8 +28,7 @@ class TestTranspile(unittest.TestCase):
 
     def test_paren(self):
         self.validate(
-            "SELECT * FROM ((SELECT 1))",
-            "SELECT * FROM (SELECT 1)",
+            "SELECT * FROM ((SELECT 1))", "SELECT * FROM (SELECT 1)",
         )
 
     def test_space(self):
@@ -135,9 +134,7 @@ class TestTranspile(unittest.TestCase):
             write="duckdb",
         )
         self.validate(
-            "UNIX_TO_TIME(123)",
-            "TO_TIMESTAMP(CAST(123 AS BIGINT))",
-            write="duckdb",
+            "UNIX_TO_TIME(123)", "TO_TIMESTAMP(CAST(123 AS BIGINT))", write="duckdb",
         )
 
         self.validate(
@@ -155,9 +152,7 @@ class TestTranspile(unittest.TestCase):
         )
 
         self.validate(
-            "STR_TO_UNIX('x', 'y')",
-            "UNIX_TIMESTAMP('x', 'y')",
-            write="hive",
+            "STR_TO_UNIX('x', 'y')", "UNIX_TIMESTAMP('x', 'y')", write="hive",
         )
         self.validate("TIME_TO_STR(x, 'y')", "DATE_FORMAT(x, 'y')", write="hive")
 
@@ -183,15 +178,11 @@ class TestTranspile(unittest.TestCase):
         self.validate("IF(x > 1, 1, 0)", "IF(x > 1, 1, 0)", write="hive")
 
         self.validate(
-            "TIME_TO_UNIX(x)",
-            "UNIX_TIMESTAMP(x)",
-            write="hive",
+            "TIME_TO_UNIX(x)", "UNIX_TIMESTAMP(x)", write="hive",
         )
         self.validate("UNIX_TO_STR(123, 'y')", "FROM_UNIXTIME(123, 'y')", write="hive")
         self.validate(
-            "UNIX_TO_TIME(123)",
-            "FROM_UNIXTIME(123)",
-            write="hive",
+            "UNIX_TO_TIME(123)", "FROM_UNIXTIME(123)", write="hive",
         )
 
         self.validate("STR_TO_TIME('x', 'y')", "DATE_PARSE('x', 'y')", write="presto")
@@ -214,15 +205,11 @@ class TestTranspile(unittest.TestCase):
         self.validate("TIME_TO_STR(x, 'y')", "DATE_FORMAT(x, 'y')", write="spark")
 
         self.validate(
-            "TIME_TO_UNIX(x)",
-            "UNIX_TIMESTAMP(x)",
-            write="spark",
+            "TIME_TO_UNIX(x)", "UNIX_TIMESTAMP(x)", write="spark",
         )
         self.validate("UNIX_TO_STR(123, 'y')", "FROM_UNIXTIME(123, 'y')", write="spark")
         self.validate(
-            "UNIX_TO_TIME(123)",
-            "FROM_UNIXTIME(123)",
-            write="spark",
+            "UNIX_TO_TIME(123)", "FROM_UNIXTIME(123)", write="spark",
         )
         self.validate(
             "CREATE TEMPORARY TABLE test AS SELECT 1",


### PR DESCRIPTION
Here I tried a couple things

0. I ran `black` and got all of these diffs, sorry about the noise.
1. We needed to add more information to `_parse_types` to allow it to recognize parametrized types. Currently we incorrectly parse them as anonymous functions
2. We needed to add stuff to `datatype_sql` to make it work. Currently, if you pass in `TIMESTAMP WITH TIME ZONE` and transpile back to the same trino/presto language you get back `TIMESTAMPTZ` which isn't a type. Getting parameters in like `TIMESTAMP(3) WITH TIME ZONE` was also a bit ugly/hacky.
3. I didn't do this, but we recognize `ARRAY` as both a Function as well as a data type. In the parse, we first recognize it as a function for `ARRAY(INTEGER)` which isn't correct. It should be considered a data type. As a result of this we get `ARRAY[INTEGER]` as the output during transpile. Proof that this isn't correct presto/trino syntax:

```
trino> SELECT CAST(ARRAY[1,2,3] AS ARRAY[BIGINT]);
Query failed: line 1:34: mismatched input '['. Expecting: '<'
```