### PR TITLE
handle backslash escapes

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -411,6 +411,7 @@ class Generator:
         text = expression.args.get("this") or ""
         is_string = expression.args.get("is_string")
         if is_string:
+            text = text.replace("\\", "\\\\") if self.escape == "\\" else text
             text = text.replace(Tokenizer.ESCAPE_CODE, self.escape)
             return f"{self.quote}{text}{self.quote}"
         return text

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -602,10 +602,9 @@ class Tokenizer:
 
         text.append(self._char)
         text = "".join(text[1:-1])
-        self._add(
-            TokenType.STRING,
-            text.encode(self.encode).decode(self.encode) if self.encode else text,
-        )
+        text = text.encode(self.encode).decode(self.encode) if self.encode else text
+        text = text.replace("\\\\", "\\") if self.escape == "\\" else text
+        self._add(TokenType.STRING, text)
 
     def _scan_identifier(self):
         while self._peek != self.identifier:

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -712,6 +712,10 @@ class TestDialects(unittest.TestCase):
         )
         self.validate("DAY(x)", "DAY(x)", read="duckdb", write="hive")
 
+        self.validate("'\\\\a'", "'\\\\a'", read="hive")
+        self.validate("'\\\\a'", "'\\a'", read="hive", write="presto")
+        self.validate("'\\a'", "'\\\\a'", read="presto", write="hive")
+
     def test_spark(self):
         self.validate(
             'SELECT "a"."b" FROM "foo"',


### PR DESCRIPTION
hive uses backslash as an escape from both quotes and backslashes,
this is common in regexes and needs to be removed.

hive
select '\\hi'

presto
select '\hi'

even more confusing is that hive ignores odd numbers of backslashes

hive
select '\hi'

the backslash is ignored, i'm choosing to treat this as user error and
ignore this case