### PR TITLE
Fix numeric literal tokeniser

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -6,7 +6,7 @@ from sqlglot.tokens import Tokenizer, TokenType
 from sqlglot.parser import Parser
 
 
-__version__ = "1.17.0"
+__version__ = "1.17.1"
 
 
 def parse(code, read=None, **opts):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -596,7 +596,7 @@ class Tokenizer:
             elif self._peek.isalpha():
                 self._add(TokenType.NUMBER)
                 literal = []
-                while self._peek:
+                while self._peek.isalpha():
                     literal.append(self._peek.upper())
                     self._advance()
                 literal = "".join(literal)

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -179,7 +179,9 @@ class TestDialects(unittest.TestCase):
 
         self.validate("1d", "1 AS d", read="duckdb")
         self.validate("1d", "CAST(1 AS DOUBLE)", read="spark", write="duckdb")
-        self.validate("POW(2S, 3)", "POW(CAST(2 AS SMALLINT), 3)", read="spark", write="duckdb")
+        self.validate(
+            "POW(2S, 3)", "POW(CAST(2 AS SMALLINT), 3)", read="spark", write="duckdb"
+        )
 
     def test_mysql(self):
         self.validate(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -179,6 +179,7 @@ class TestDialects(unittest.TestCase):
 
         self.validate("1d", "1 AS d", read="duckdb")
         self.validate("1d", "CAST(1 AS DOUBLE)", read="spark", write="duckdb")
+        self.validate("POW(2S, 3)", "POW(CAST(2 AS SMALLINT), 3)", read="spark", write="duckdb")
 
     def test_mysql(self):
         self.validate(


### PR DESCRIPTION
Thanks so much for implementing this so quickly re: #58 

I've tested your changes against more complex SQL statements, and it all looks great with one tiny bug - the tokeniser keeps consuming tokens forever when encountering a literal.  

Example of error:
```
sql = """
POW(2S, 3)
"""
sqlglot.parse_one(sql, read="spark").sql(dialect="duckdb")
```

Here's a proposed fix, and associated test.