### PR TITLE
add time formats fixes #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ sqlglot.transpile("SELECT EPOCH_MS(1618088028295)", read='duckdb', write='hive')
 SELECT TO_UTC_TIMESTAMP(FROM_UNIXTIME(1618088028295 / 1000, 'yyyy-MM-dd HH:mm:ss'), 'UTC')
 ```
 
+SQLGlot can even translate custom time formats.
+```python
+import sqlglot
+sqlglot.transpile("SELECT STRFTIME(x, '%y-%-m-%S')", read='duckdb', write='hive')
+```
+
+```sql
+SELECT DATE_FORMAT(x, 'yy-M-ss')"
+```
+
 ### Formatting and Transpiling
 Read in a SQL statement with a CTE and CASTING to a REAL and then transpiling to Spark.
 
@@ -74,7 +84,7 @@ A simple transform on types can be accomplished by providing a corresponding map
 from sqlglot import *
 from sqlglot import expressions as exp
 
-transpile("SELECT CAST(a AS INT) FROM x", type_mappings={exp.DataType.Type.INT: "SPECIAL INT"})[0]
+transpile("SELECT CAST(a AS INT) FROM x", type_mapping={exp.DataType.Type.INT: "SPECIAL INT"})[0]
 ```
 
 ```sql

--- a/sqlglot/__main__.py
+++ b/sqlglot/__main__.py
@@ -45,6 +45,7 @@ parser.add_argument(
     help="IGNORE, WARN, RAISE (default)",
 )
 
+
 args = parser.parse_args()
 error_level = sqlglot.ErrorLevel[args.error_level.upper()]
 

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -1,0 +1,39 @@
+# the generic time format is based on python time.strftime
+# https://docs.python.org/3/library/time.html#time.strftime
+from sqlglot.trie import in_trie, new_trie
+
+
+def format_time(string, mapping, trie=None):
+    """
+    Converts a time string given a mapping.
+
+    mapping: Dictionary of time format to target time format
+    trie: Optional trie, can be passed in for performance
+    """
+    start = 0
+    end = 1
+    size = len(string)
+    trie = trie or new_trie(mapping)
+    chunks = []
+    sym = None
+
+    while end <= size:
+        chars = string[start:end]
+        result = in_trie(trie, chars)
+
+        if result == 0:
+            if sym:
+                end -= 1
+                chars = sym
+                sym = None
+            start += len(chars)
+            chunks.append(chars)
+        elif result == 2:
+            sym = chars
+
+        end += 1
+
+        if result and end > size:
+            chunks.append(chars)
+
+    return "".join(mapping.get(chars, chars) for chars in chunks)

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -21,10 +21,16 @@ class TestDialects(unittest.TestCase):
             "EPOCH_MS(x)", "FROM_UNIXTIME(x / 1000)", read="duckdb", write="presto"
         )
         self.validate(
-            "STRFTIME(x, 'y')", "DATE_FORMAT(x, 'y')", read="duckdb", write="presto"
+            "STRFTIME(x, '%y-%-m-%S')",
+            "DATE_FORMAT(x, '%y-%c-%S')",
+            read="duckdb",
+            write="presto",
         )
         self.validate(
-            "STRPTIME(x, 'y')", "DATE_PARSE(x, 'y')", read="duckdb", write="presto"
+            "STRPTIME(x, '%y-%-m')",
+            "DATE_PARSE(x, '%y-%c')",
+            read="duckdb",
+            write="presto",
         )
         self.validate(
             "LIST_VALUE(0, 1, 2)", "ARRAY[0, 1, 2]", read="duckdb", write="presto"
@@ -144,6 +150,18 @@ class TestDialects(unittest.TestCase):
             "STRFTIME(TO_TIMESTAMP(CAST(x AS BIGINT)), '%Y-%m-%d %H:%M:%S')",
             identity=False,
             write="duckdb",
+        )
+        self.validate(
+            "STRFTIME(x, '%Y-%m-%d %H:%M:%S')",
+            "DATE_FORMAT(x, 'yyyy-MM-dd HH:mm:ss')",
+            read="duckdb",
+            write="hive",
+        )
+        self.validate(
+            "STRFTIME(x, '%Y-%m-%d %H:%M:%S')",
+            "DATE_FORMAT(x, '%Y-%m-%d %H:%i:%S')",
+            read="duckdb",
+            write="presto",
         )
         self.validate(
             "TO_TIMESTAMP(x)",
@@ -337,17 +355,26 @@ class TestDialects(unittest.TestCase):
         )
 
         self.validate(
-            "DATE_FORMAT(x, 'y')", "DATE_FORMAT(x, 'y')", read="presto", write="hive"
+            "DATE_FORMAT(x, '%Y-%m-%d %H:%i:%s')",
+            "DATE_FORMAT(x, 'yyyy-MM-dd HH:mm:ss')",
+            read="presto",
+            write="hive",
         )
         self.validate(
-            "DATE_PARSE(x, 'y')",
-            "FROM_UNIXTIME(UNIX_TIMESTAMP(x, 'y'))",
+            "DATE_PARSE(x, '%Y-%m-%d %H:%i:%s')",
+            "FROM_UNIXTIME(UNIX_TIMESTAMP(x))",
+            read="presto",
+            write="hive",
+        )
+        self.validate(
+            "DATE_PARSE(x, '%Y-%m-%d')",
+            "FROM_UNIXTIME(UNIX_TIMESTAMP(x, 'yyyy-MM-dd'))",
             read="presto",
             write="hive",
         )
         self.validate(
             "TIME_STR_TO_UNIX(x)",
-            "TO_UNIXTIME(DATE_PARSE(x, '%Y-%m-%d %H:%i:%s'))",
+            "TO_UNIXTIME(DATE_PARSE(x, '%Y-%m-%d %H:%i:%S'))",
             write="presto",
         )
         self.validate(
@@ -357,12 +384,12 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "TIME_TO_TIME_STR(x)",
-            "DATE_FORMAT(x, '%Y-%m-%d %H:%i:%s')",
+            "DATE_FORMAT(x, '%Y-%m-%d %H:%i:%S')",
             write="presto",
         )
         self.validate(
             "UNIX_TO_TIME_STR(x)",
-            "DATE_FORMAT(FROM_UNIXTIME(x), '%Y-%m-%d %H:%i:%s')",
+            "DATE_FORMAT(FROM_UNIXTIME(x), '%Y-%m-%d %H:%i:%S')",
             write="presto",
         )
         self.validate(

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,0 +1,14 @@
+import unittest
+
+from sqlglot.time import format_time
+
+
+class TestTime(unittest.TestCase):
+    def test_format_time(self):
+        self.assertEqual(format_time("", {}), "")
+        self.assertEqual(format_time(" ", {}), " ")
+        mapping = {"a": "b", "aa": "c"}
+        self.assertEqual(format_time("a", mapping), "b")
+        self.assertEqual(format_time("aa", mapping), "c")
+        self.assertEqual(format_time("aaada", mapping), "cbdb")
+        self.assertEqual(format_time("da", mapping), "db")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -21,7 +21,7 @@ class TestTranspile(unittest.TestCase):
         self.assertEqual(
             transpile(
                 "SELECT CAST(a AS INT) FROM x",
-                type_mappings={exp.DataType.Type.INT: "SPECIAL INT"},
+                type_mapping={exp.DataType.Type.INT: "SPECIAL INT"},
             )[0],
             "SELECT CAST(a AS SPECIAL INT) FROM x",
         )


### PR DESCRIPTION
longstanding tough issue, i finally fixed it

sqlglot parses time formats into python syntax, generator turns python syntax into target dialect