### PR TITLE
Add support for Spark left and right fns

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -587,7 +587,26 @@ class Spark(Hive):
         exp.Create: _create_sql,
     }
 
-    functions = {**Hive.functions, "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list}
+
+Spark.functions = {
+    **Hive.functions,
+    "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
+    "LEFT": lambda args: exp.Substring(
+        this=list_get(args, 0),
+        starting_position=exp.Literal.number(1),
+        length=list_get(args, 1),
+    ),
+    "RIGHT": lambda args: exp.Substring(
+        this=list_get(args, 0),
+        starting_position=exp.Sub(
+            this=exp.Length(this=list_get(args, 0)),
+            expression=exp.Add(
+                this=list_get(args, 1), expression=exp.Literal.number(1)
+            ),
+        ),
+        length=list_get(args, 1),
+    ),
+}
 
 
 class SQLite(Dialect):

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -593,12 +593,12 @@ Spark.functions = {
     "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
     "LEFT": lambda args: exp.Substring(
         this=list_get(args, 0),
-        starting_position=exp.Literal.number(1),
+        start=exp.Literal.number(1),
         length=list_get(args, 1),
     ),
     "RIGHT": lambda args: exp.Substring(
         this=list_get(args, 0),
-        starting_position=exp.Sub(
+        start=exp.Sub(
             this=exp.Length(this=list_get(args, 0)),
             expression=exp.Add(
                 this=list_get(args, 1), expression=exp.Literal.number(1)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -865,6 +865,10 @@ class Least(Func):
     is_var_len_args = True
 
 
+class Length(Func):
+    pass
+
+
 class Ln(Func):
     pass
 
@@ -917,6 +921,10 @@ class Round(Func):
 
 class SetAgg(AggFunc):
     pass
+
+
+class Substring(Func):
+    arg_types = {"this": True, "starting_position": True, "length": False}
 
 
 class StrPosition(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -924,7 +924,7 @@ class SetAgg(AggFunc):
 
 
 class Substring(Func):
-    arg_types = {"this": True, "starting_position": True, "length": False}
+    arg_types = {"this": True, "start": True, "length": False}
 
 
 class StrPosition(Func):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -111,6 +111,8 @@ class Parser:
         TokenType.REPLACE,
         TokenType.UNNEST,
         TokenType.VAR,
+        TokenType.LEFT,
+        TokenType.RIGHT,
         *NESTED_TYPE_TOKENS,
     }
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -655,4 +655,9 @@ class Tokenizer:
                 self._advance()
             else:
                 break
-        self._add(self.KEYWORDS.get(self._text.upper(), TokenType.VAR))
+
+        if self._text.upper() in ("LEFT", "RIGHT"):
+            if char == "(":
+                self._add(TokenType.VAR)
+        else:
+            self._add(self.KEYWORDS.get(self._text.upper(), TokenType.VAR))

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -655,9 +655,4 @@ class Tokenizer:
                 self._advance()
             else:
                 break
-
-        if self._text.upper() in ("LEFT", "RIGHT"):
-            if char == "(":
-                self._add(TokenType.VAR)
-        else:
-            self._add(self.KEYWORDS.get(self._text.upper(), TokenType.VAR))
+        self._add(self.KEYWORDS.get(self._text.upper(), TokenType.VAR))


### PR DESCRIPTION
The [`left`](https://spark.apache.org/docs/latest/api/sql/index.html#left) and [`right`](https://spark.apache.org/docs/latest/api/sql/index.html#right) functions are missing from the Spark dialect.

I've tried to implement the `left` and `right` functions in a way that's consistent with the rest of the codebase.

Separate to their implementation, a challenge is the collision between the `left` and `right` keywords, and the Spark functions with the same name. 

Totally understand if you would rather not introduce additional complexity into the tokeniser to resolve this ambiguity i.e. would rather just close this PR and not support the Spark-specific `left` and `right` SQL functions.  If so, at least I understand the codebase better and hopefully can provide future similar PRs for functions that don't have this keyword ambiguity problem.

I recognise my attempt to solve this problem of ambiguity is incorrect. I was just enough to allow me to test parsing and transpiling Spark SQL.  

Illustrative output from this PR:
```python
import sqlglot
sql = "left(x, 2)"
sqlglot.parse_one(sql, read="spark").sql()
>> 'SUBSTRING(x, 1, 2)'

sql = "right(x, 2)"
sqlglot.parse_one(orig_sql, read="spark").sql()
>> 'SUBSTRING(x, LENGTH(x) - 2 + 1, 2)'

```


### Implementation of Left and Right using the Substring function

I have attempted an implementation that translates their use into the ANSI SQL `substring`. Se 4.2.2.1 [here](http://web.cecs.pdx.edu/~len/sql1999.pdf):

> <character substring function> is a triadic function, SUBSTRING, that returns a string extracted from a given string according to a given numeric starting position and a given numeric length.

See also page 6.18 on page 163:

```
<character substring function> ::=
SUBSTRING <left paren> <character value expression> FROM <start position>
[ FOR <string length> ] <right paren>
```

### Challenges

#### Ambiguity of function vs keyword

`left` and `right` are both [tokenizer keywords](https://github.com/tobymao/sqlglot/blob/570d4c6657896225c2003871ef75d2976ac25429/sqlglot/tokens.py#L126).

The current implementation of the tokeniser therefore interprets them as such - see [this line](https://github.com/tobymao/sqlglot/blob/570d4c6657896225c2003871ef75d2976ac25429/sqlglot/tokens.py#L658).

A mechanism is needed to handle this ambiguity.

I don't understand the codebase well enough to propose a more robust/flexible approach to this problem of ambiguity. I'd be happy to have a go at something more robust if you'd like to provide a pointer of a recommended approach, or feel free to add commits to this PR.  I suspect the solution may only require a small amount of code, just in the right place.


#### Substring in different dialects

The implementation of the ANSI SQL `substring` varies between SQL implementations.

For instance:

- sqlite and Oracle allows `substr` but not `substring`
- MS SQL Server allows `substring` but not `substr`
- MySQL allows both `substring` and `substr`

Most flavours of `substring` allow the `length` argument to be empty. If it's empty, all characters from the starting position to the end of the string are selected. However, I don't think this is guaranteed.

MS SQL Server 2017 is an example implementation where three arguments are required of the `substring` function.

#### char_length in different dialects.

The implementation of the ANSI SQL `CHAR_LENGTH` function differs between dialects.

> All platforms stray from the ANSI standard in their support for scalar functions for determining the length of expressions. While the platform support is nonstandard, the equivalent functionality exists under different names.
> From [here](https://www.oreilly.com/library/view/sql-in-a/9780596155322/re81.html)

Most implementations (MySQL, Oracle, SQLite, Postgres, Spark) implements `length`
MS SQL Server 2017 uses `len`
