### PR TITLE
Allow additional function arguments in transform

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -48,10 +48,10 @@ ORDER BY
 short = "select 1 as a, case when 1 then 1 when 2 then 2 else 3 end as b, c from x"
 
 crazy = "SELECT 1+"
-crazy += '+'.join(str(i) for i in range(500))
-crazy += ' AS a, 2*'
-crazy += '*'.join(str(i) for i in range(500))
-crazy += ' AS b FROM x'
+crazy += "+".join(str(i) for i in range(500))
+crazy += " AS a, 2*"
+crazy += "*".join(str(i) for i in range(500))
+crazy += " AS b FROM x"
 
 
 def sqlglot_parse(sql):
@@ -65,10 +65,19 @@ def sqlparse_parse(sql):
 def moz_sql_parser_parse(sql):
     moz_sql_parser.parse(sql)
 
+
 def sqloxide_parse(sql):
-    sqloxide.parse_sql(sql, dialect='ansi')
+    sqloxide.parse_sql(sql, dialect="ansi")
 
 
-for lib in ['sqlglot_parse', 'sqlparse_parse', 'moz_sql_parser_parse', 'sqloxide_parse']:
-    for name, sql in {'short': short, 'long': long, 'crazy': crazy}.items():
-        print(f"{lib} {name}", np.mean(timeit.repeat(lambda: globals()[lib](sql), number=1)))
+for lib in [
+    "sqlglot_parse",
+    "sqlparse_parse",
+    "moz_sql_parser_parse",
+    "sqloxide_parse",
+]:
+    for name, sql in {"short": short, "long": long, "crazy": crazy}.items():
+        print(
+            f"{lib} {name}",
+            np.mean(timeit.repeat(lambda: globals()[lib](sql), number=1)),
+        )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 from setuptools import setup
 
 version = (
-    open('sqlglot/__init__.py')
+    open("sqlglot/__init__.py")
     .read()
-    .split('__version__ = ')[-1]
+    .split("__version__ = ")[-1]
     .split("\n")[0]
     .strip("")
     .strip("'")
@@ -11,23 +11,23 @@ version = (
 )
 
 setup(
-    name='sqlglot',
+    name="sqlglot",
     version=version,
-    description='An easily customizable SQL parser and transpiler',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/tobymao/sqlglot',
-    author='Toby Mao',
-    author_email='toby.mao@gmail.com',
-    license='MIT',
-    packages=['sqlglot'],
+    description="An easily customizable SQL parser and transpiler",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    url="https://github.com/tobymao/sqlglot",
+    author="Toby Mao",
+    author_email="toby.mao@gmail.com",
+    license="MIT",
+    packages=["sqlglot"],
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-        'Programming Language :: SQL',
-        'Programming Language :: Python :: 3 :: Only',
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+        "Programming Language :: SQL",
+        "Programming Language :: Python :: 3 :: Only",
     ],
 )

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -193,7 +193,7 @@ class Expression:
 
         return indent + left + right
 
-    def transform(self, fun, copy=True):
+    def transform(self, fun, *args, copy=True, **kwargs):
         """
         Recursively visits all tree nodes (excluding already transformed ones)
         and applies the given transformation function to each node.
@@ -208,7 +208,7 @@ class Expression:
             the transformed tree.
         """
         node = self.copy() if copy else self
-        new_node = fun(node)
+        new_node = fun(node, *args, **kwargs)
 
         if new_node is None:
             raise ValueError("A transformed node cannot be None")
@@ -223,7 +223,7 @@ class Expression:
 
             for cn in child_nodes:
                 if isinstance(cn, Expression):
-                    new_child_node = cn.transform(fun, copy=False)
+                    new_child_node = cn.transform(fun, *args, copy=False, **kwargs)
                     new_child_node.parent = new_node
                 else:
                     new_child_node = cn

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -95,6 +95,20 @@ class TestExpressions(unittest.TestCase):
             parse_one('select "x"').sql(dialect="hive", pretty=True) == "SELECT\n  `x`"
         )
 
+    def test_transform_with_arguments(self):
+        expression = parse_one("a")
+
+        def fun(node, alias=True):
+            if alias:
+                return parse_one("a AS a")
+            return node
+
+        transformed_expression = expression.transform(fun)
+        self.assertEqual(transformed_expression.sql(dialect="presto"), "a AS a")
+
+        transformed_expression_2 = expression.transform(fun, alias=False)
+        self.assertEqual(transformed_expression_2.sql(dialect="presto"), "a")
+
     def test_transform_simple(self):
         expression = parse_one("IF(a > 0, a, b)")
 


### PR DESCRIPTION
When using `expression.transform`, we often pass in a function. It would be more flexible if we can allow users to pass in additional arguments to the function to override certain behaviors.

@tobymao, PTAL