### PR TITLE
Logical expression builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,13 +182,14 @@ SELECT APPROX_COUNT_DISTINCT(a) FROM foo
 SQLGlot supports incrementally building sql expressions.
 
 ```python
-from sqlglot import select
+from sqlglot import select, condition
 
-select("*").from_("y").where("x > 1").sql()
+where = condition("x=1").and_("y=1")
+select("*").from_("y").where(where).sql()
 ```
-
+Which outputs:
 ```sql
-SELECT * FROM y WHERE x > 1
+SELECT * FROM y WHERE x = 1 AND y = 1
 ```
 
 You can also modify a parsed tree:
@@ -198,7 +199,7 @@ from sqlglot import parse_one
 
 parse_one("SELECT x FROM y").from_("z").sql()
 ```
-
+Which outputs:
 ```sql
 SELECT x FROM y, z
 ```
@@ -219,8 +220,7 @@ def transformer(node):
 transformed_tree = expression_tree.transform(transformer)
 transformed_tree.sql()
 ```
-
-The snippet above produces the following transformed expression:
+Which outputs:
 ```sql
 SELECT FUN(a) FROM x
 ```

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -1,6 +1,6 @@
 from sqlglot.dialects import Dialect
 from sqlglot.errors import ErrorLevel, UnsupportedError, ParseError, TokenError
-from sqlglot.expressions import Expression, Select, And, Or, Not, and_, or_, condition
+from sqlglot.expressions import Expression, Select, and_, or_, not_, condition
 from sqlglot.generator import Generator
 from sqlglot.tokens import Tokenizer, TokenType
 from sqlglot.parser import Parser

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -1,6 +1,6 @@
 from sqlglot.dialects import Dialect
 from sqlglot.errors import ErrorLevel, UnsupportedError, ParseError, TokenError
-from sqlglot.expressions import Expression, Select
+from sqlglot.expressions import Expression, Select, And, Or, Not, and_, or_, condition
 from sqlglot.generator import Generator
 from sqlglot.tokens import Tokenizer, TokenType
 from sqlglot.parser import Parser
@@ -102,7 +102,7 @@ def from_(*expressions, dialect=None, **opts):
         'SELECT col1, col2 FROM tbl'
 
     Args:
-        *expressionss (str or Expression): the SQL code string to parse as the FROM expressions of a
+        *expressions (str or Expression): the SQL code string to parse as the FROM expressions of a
             SELECT statement. If an Expression instance is passed, this is used as-is.
         dialect (str): the dialect used to parse the input expression (in the case that the
             input expression is a SQL string).

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1122,11 +1122,11 @@ class Star(Expression):
     arg_types = {}
 
 
-class Null(Expression):
+class Null(Condition):
     arg_types = {}
 
 
-class Boolean(Expression):
+class Boolean(Condition):
     pass
 
 
@@ -1316,7 +1316,7 @@ class Aliases(Expression):
         return self.args["expressions"]
 
 
-class Between(Expression):
+class Between(Condition):
     arg_types = {"this": True, "low": True, "high": True}
 
 
@@ -1340,7 +1340,7 @@ class Extract(Expression):
     arg_types = {"this": True, "expression": True}
 
 
-class In(Expression):
+class In(Condition):
     arg_types = {"this": True, "expressions": False, "query": False}
 
 
@@ -1353,7 +1353,7 @@ class TryCast(Cast):
 
 
 # Functions
-class Func(Expression):
+class Func(Condition):
     """
     The base class for all function expressions.
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,9 +1,8 @@
 import unittest
 import doctest
 
-from sqlglot import parse_one, select, from_, and_, or_, condition
+from sqlglot import parse_one, select, from_, and_, or_, condition, not_
 from sqlglot import expressions as exp
-from sqlglot.expressions import not_
 
 
 def load_tests(loader, tests, ignore):  # pylint: disable=unused-argument


### PR DESCRIPTION
Here's a stab at builders for logical expressions.

It supports both ways we discussed:

```python
from sqlglot import and_, or_, condition

and_("a=1", "b=1", or_("c=1", "d=1")

condition("c=1").or_("d=1").and_("b=1", "a=1")
```

@nolamesa @tobymao 