### PR TITLE
add COALESCE and COUNT SQL transform for Tableau dialect

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -779,8 +779,19 @@ class Tableau(Dialect):
     def _if_sql(self, expression):
         return f"IF {self.sql(expression, 'this')} THEN {self.sql(expression, 'true')} ELSE {self.sql(expression, 'false')} END"
 
+    def _coalesce_sql(self, expression):
+        return f"IFNULL({self.sql(expression, 'this')}, {self.expressions(expression)})"
+
+    def _count_sql(self, expression):
+        if expression.args.get("distinct"):
+            return f"COUNTD{self.sql(expression, 'this')}"
+        else:
+            return f"COUNT({self.sql(expression, 'this')})"
+
     transforms = {
         exp.If: _if_sql,
+        exp.Coalesce: _coalesce_sql,
+        exp.Count: _count_sql
     }
 
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -787,11 +787,7 @@ class Tableau(Dialect):
             return f"COUNTD{self.sql(expression, 'this')}"
         return f"COUNT({self.sql(expression, 'this')})"
 
-    transforms = {
-        exp.If: _if_sql,
-        exp.Coalesce: _coalesce_sql,
-        exp.Count: _count_sql
-    }
+    transforms = {exp.If: _if_sql, exp.Coalesce: _coalesce_sql, exp.Count: _count_sql}
 
 
 class Trino(Presto):

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -785,8 +785,7 @@ class Tableau(Dialect):
     def _count_sql(self, expression):
         if expression.args.get("distinct"):
             return f"COUNTD{self.sql(expression, 'this')}"
-        else:
-            return f"COUNT({self.sql(expression, 'this')})"
+        return f"COUNT({self.sql(expression, 'this')})"
 
     transforms = {
         exp.If: _if_sql,

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1160,3 +1160,18 @@ class TestDialects(unittest.TestCase):
             "IF x = 'a' THEN y ELSE NULL END",
             write="tableau",
         )
+        self.validate(
+            "COALESCE(a, 0)",
+            "IFNULL(a, 0)",
+            write="tableau",
+        )
+        self.validate(
+            "COUNT(DISTINCT(a))",
+            "COUNTD(a)",
+            write = "tableau",
+        )
+        self.validate(
+            "COUNT(a)",
+            "COUNT(a)",
+            write = "tableau",
+        )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1168,10 +1168,10 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "COUNT(DISTINCT(a))",
             "COUNTD(a)",
-            write = "tableau",
+            write="tableau",
         )
         self.validate(
             "COUNT(a)",
             "COUNT(a)",
-            write = "tableau",
+            write="tableau",
         )


### PR DESCRIPTION
This PR added COALESCE and COUNT SQL transform for Tableau dialect

Note: Tableau does not support COALESCE func, transform to use IFNULL instead.

Reviewers:
@tobymao