### PR TITLE
Add dateint support

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -278,9 +278,7 @@ class DuckDB(Dialect):
             unit = "DAY"
 
         first_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=start_date_value)
-        second_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=end_date_value
-        )
+        second_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=end_date_value)
 
         return f"DATE_DIFF('{unit}', {first_date}, {second_date})"
 
@@ -839,9 +837,7 @@ class Presto(Dialect):
             unit = "DAY"
 
         start_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=start_date_value)
-        end_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=end_date_value
-        )
+        end_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=end_date_value)
 
         return f"DATE_DIFF('{unit}', {start_date}, {end_date})"
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -221,8 +221,12 @@ class DuckDB(Dialect):
         f"{TS_OR_DS_OR_DI_TO_MONTH} || '-' || "
         f"{TS_OR_DS_OR_DI_TO_DAY} as date)"
     )
-    TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = f"strftime({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, {DATE_FORMAT})"
-    TS_OR_DS_OR_DI_TO_DI_EXPRESSION = "CAST(SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 1, 8) as int)"
+    TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = (
+        f"strftime({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, {DATE_FORMAT})"
+    )
+    TS_OR_DS_OR_DI_TO_DI_EXPRESSION = (
+        "CAST(SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 1, 8) as int)"
+    )
 
     def _unix_to_time(self, expression):
         return f"TO_TIMESTAMP(CAST({self.sql(expression, 'this')} AS BIGINT))"
@@ -272,8 +276,12 @@ class DuckDB(Dialect):
             second_date_value = self.sql(expression, "first_date")
             unit = "'DAY'"
 
-        first_date = DuckDB.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(this=first_date_value)
-        second_date = DuckDB.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(this=second_date_value)
+        first_date = DuckDB.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(
+            this=first_date_value
+        )
+        second_date = DuckDB.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(
+            this=second_date_value
+        )
 
         return f"DATE_DIFF({unit}, {first_date}, {second_date})"
 
@@ -377,9 +385,15 @@ class Hive(Dialect):
     DATE_FORMAT = "'yyyy-MM-dd'"
     TIME_FORMAT = "'yyyy-MM-dd HH:mm:ss'"
 
-    TS_OR_DS_OR_DI_TO_DATE_EXPRESSION = "TO_DATE(SUBSTR(REPLACE(CAST({this} as string), '-', ''), 1, 8), 'yyyyMMdd')"
-    TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = f"DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, 'yyyy-MM-dd')"
-    TS_OR_DS_OR_DI_TO_DI_EXPRESSION = f"CAST(DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, 'yyyyMMdd') as int)"
+    TS_OR_DS_OR_DI_TO_DATE_EXPRESSION = (
+        "TO_DATE(SUBSTR(REPLACE(CAST({this} as string), '-', ''), 1, 8), 'yyyyMMdd')"
+    )
+    TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = (
+        f"DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, 'yyyy-MM-dd')"
+    )
+    TS_OR_DS_OR_DI_TO_DI_EXPRESSION = (
+        f"CAST(DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, 'yyyyMMdd') as int)"
+    )
 
     class HiveMap(exp.Map):
         is_var_len_args = True
@@ -511,8 +525,12 @@ class Hive(Dialect):
             second_date_value = self.sql(expression, "first_date")
             unit = "'DAY'"
 
-        first_date = Hive.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(this=first_date_value)
-        second_date = Hive.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(this=second_date_value)
+        first_date = Hive.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(
+            this=first_date_value
+        )
+        second_date = Hive.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(
+            this=second_date_value
+        )
 
         if unit == "'DAY'":
             return f"DATEDIFF({first_date}, {second_date})"
@@ -665,9 +683,15 @@ class Presto(Dialect):
     index_offset = 1
     TIME_FORMAT = "'%Y-%m-%d %H:%i:%S'"
 
-    TS_OR_DS_OR_DI_TO_DATE_EXPRESSION = "DATE_PARSE(SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 1, 8), '%Y%m%d')"
-    TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = f"DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, '%Y-%m-%d')"
-    TS_OR_DS_OR_DI_TO_DI_EXPRESSION = f"CAST(DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, '%Y%m%d') as int)"
+    TS_OR_DS_OR_DI_TO_DATE_EXPRESSION = (
+        "DATE_PARSE(SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 1, 8), '%Y%m%d')"
+    )
+    TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = (
+        f"DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, '%Y-%m-%d')"
+    )
+    TS_OR_DS_OR_DI_TO_DI_EXPRESSION = (
+        f"CAST(DATE_FORMAT({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, '%Y%m%d') as int)"
+    )
 
     def _approx_distinct_sql(self, expression):
         accuracy = expression.args.get("accuracy")
@@ -763,11 +787,14 @@ class Presto(Dialect):
             second_date_value = self.sql(expression, "first_date")
             unit = "'DAY'"
 
-        first_date = Presto.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(this=first_date_value)
-        second_date = Presto.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(this=second_date_value)
+        first_date = Presto.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(
+            this=first_date_value
+        )
+        second_date = Presto.TS_OR_DS_OR_DI_TO_DATE_EXPRESSION.format(
+            this=second_date_value
+        )
 
         return f"DATE_DIFF({unit}, {first_date}, {second_date})"
-
 
     time_mapping = MYSQL_TIME_MAPPING
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -216,7 +216,11 @@ class DuckDB(Dialect):
     TS_OR_DS_OR_DI_TO_YEAR = "SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 1, 4)"
     TS_OR_DS_OR_DI_TO_MONTH = "SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 5, 2)"
     TS_OR_DS_OR_DI_TO_DAY = "SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 7, 2)"
-    TS_OR_DS_OR_DI_TO_DATE_EXPRESSION = f"CAST({TS_OR_DS_OR_DI_TO_YEAR} || '-' || {TS_OR_DS_OR_DI_TO_MONTH} || '-' || {TS_OR_DS_OR_DI_TO_DAY} as date)"
+    TS_OR_DS_OR_DI_TO_DATE_EXPRESSION = (
+        f"CAST({TS_OR_DS_OR_DI_TO_YEAR} || '-' || "
+        f"{TS_OR_DS_OR_DI_TO_MONTH} || '-' || "
+        f"{TS_OR_DS_OR_DI_TO_DAY} as date)"
+    )
     TS_OR_DS_OR_DI_TO_DATE_STR_EXPRESSION = f"strftime({TS_OR_DS_OR_DI_TO_DATE_EXPRESSION}, {DATE_FORMAT})"
     TS_OR_DS_OR_DI_TO_DI_EXPRESSION = "CAST(SUBSTR(REPLACE(CAST({this} as varchar), '-', ''), 1, 8) as int)"
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -390,9 +390,7 @@ class Hive(Dialect):
     DATE_FORMAT = "'yyyy-MM-dd'"
     TIME_FORMAT = "'yyyy-MM-dd HH:mm:ss'"
 
-    MIXED_TYPE_TO_DATE_EXPRESSION = (
-        f"TO_DATE(SUBSTR(REPLACE(CAST({{this}} as string), '-', ''), 1, 8), {DATEINT_FORMAT})"
-    )
+    MIXED_TYPE_TO_DATE_EXPRESSION = f"TO_DATE(SUBSTR(REPLACE(CAST({{this}} as string), '-', ''), 1, 8), {DATEINT_FORMAT})"
     MIXED_TYPE_TO_DATE_STR_EXPRESSION = (
         f"DATE_FORMAT({MIXED_TYPE_TO_DATE_EXPRESSION}, {DATE_FORMAT})"
     )
@@ -722,9 +720,7 @@ class Presto(Dialect):
     DATEINT_FORMAT = "'%Y%m%d'"
     DATE_FORMAT = "'%Y-%m-%d'"
 
-    MIXED_TYPE_TO_DATE_EXPRESSION = (
-        f"DATE_PARSE(SUBSTR(REPLACE(CAST({{this}} AS VARCHAR), '-', ''), 1, 8), {DATEINT_FORMAT})"
-    )
+    MIXED_TYPE_TO_DATE_EXPRESSION = f"DATE_PARSE(SUBSTR(REPLACE(CAST({{this}} AS VARCHAR), '-', ''), 1, 8), {DATEINT_FORMAT})"
     MIXED_TYPE_TO_DATE_STR_EXPRESSION = (
         f"DATE_FORMAT({MIXED_TYPE_TO_DATE_EXPRESSION}, {DATE_FORMAT})"
     )

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -630,22 +630,24 @@ class Hive(Dialect):
 Hive.functions = {
     "APPROX_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
     "COLLECT_LIST": exp.ArrayAgg.from_arg_list,
-    "DATE_ADD": lambda args: exp.DateAdd(
+    "DATE_ADD": lambda args: exp.MixedTypeAdd(
         this=list_get(args, 0),
         expression=list_get(args, 1),
         unit=exp.Literal.string("DAY"),
+        output_format=exp.Literal.string("YYYY-MM-DD"),
     ),
     "DATEDIFF": lambda args: exp.DateDiff(
         this=exp.MixedTypeToDate(this=list_get(args, 0)),
         expression=exp.MixedTypeToDate(this=list_get(args, 1)),
     ),
-    "DATE_SUB": lambda args: exp.DateAdd(
+    "DATE_SUB": lambda args: exp.MixedTypeAdd(
         this=list_get(args, 0),
         expression=exp.Mul(
             this=list_get(args, 1),
             expression=exp.Literal.number(-1),
         ),
         unit=exp.Literal.string("DAY"),
+        output_format=exp.Literal.string("YYYY-MM-DD"),
     ),
     "DATE_FORMAT": _format_time(exp.TimeToStr, Hive),
     "DAY": lambda args: exp.Day(this=exp.MixedTypeToDate(this=list_get(args, 0))),

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -285,9 +285,8 @@ class DuckDB(Dialect):
         return f"DATE_DIFF('{unit}', {first_date}, {second_date})"
 
     def _mixed_type_add_sql(self, expression):
-        calling_key = expression.key.upper()
         output_format = expression.text("output_format").upper() or "YYYY-MM-DD"
-        if output_format == "YYYYMMDD" or calling_key == "DIADD":
+        if output_format == "YYYYMMDD" or isinstance(expression, exp.DiAdd):
             return DuckDB._mixed_type_add_to_di(self, expression)
         return DuckDB._mixed_type_add_to_ds(self, expression)
 
@@ -446,9 +445,8 @@ class Hive(Dialect):
         return add_expression
 
     def _mixed_type_add_sql(self, expression):
-        calling_key = expression.key.upper()
         output_format = expression.text("output_format").upper() or "YYYY-MM-DD"
-        if output_format == "YYYYMMDD" or calling_key == "DIADD":
+        if output_format == "YYYYMMDD" or isinstance(expression, exp.DiAdd):
             return Hive._mixed_type_add_to_di(self, expression)
         return Hive._mixed_type_add_to_ds(self, expression)
 
@@ -751,9 +749,8 @@ class Presto(Dialect):
         return f"DATE_FORMAT(DATE_ADD('{unit}', {e}, {date}), '%Y-%m-%d')"
 
     def _mixed_type_add_sql(self, expression):
-        calling_key = expression.key.upper()
         output_format = expression.text("output_format").upper() or "YYYY-MM-DD"
-        if output_format == "YYYYMMDD" or calling_key == "DIADD":
+        if output_format == "YYYYMMDD" or isinstance(expression, exp.DiAdd):
             return Presto._mixed_type_add_to_di(self, expression)
         return Presto._mixed_type_add_to_ds(self, expression)
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -277,9 +277,7 @@ class DuckDB(Dialect):
             second_date_value = expression.text("first_date")
             unit = "DAY"
 
-        first_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=first_date_value
-        )
+        first_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=first_date_value)
         second_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(
             this=second_date_value
         )
@@ -563,12 +561,8 @@ class Hive(Dialect):
             second_date_value = self.sql(expression, "first_date")
             unit = "DAY"
 
-        first_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=first_date_value
-        )
-        second_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=second_date_value
-        )
+        first_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=first_date_value)
+        second_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=second_date_value)
 
         response = None
         if unit == "DAY":
@@ -741,9 +735,9 @@ class Presto(Dialect):
         this = generator.sql(expression, "this")
         e = generator.sql(expression, "expression")
         unit = expression.text("unit") or "DAY"
-        
+
         date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=this)
-        
+
         return f"CAST(DATE_FORMAT(DATE_ADD('{unit}', {e}, {date}), '%Y%m%d') AS INT)"
 
     @classmethod
@@ -845,9 +839,7 @@ class Presto(Dialect):
             second_date_value = self.sql(expression, "first_date")
             unit = "DAY"
 
-        first_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=first_date_value
-        )
+        first_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=first_date_value)
         second_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(
             this=second_date_value
         )

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -236,7 +236,7 @@ class DuckDB(Dialect):
 
         date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=this)
 
-        return f"CAST(strftime({date} + INTERVAL {e} {unit}, {DuckDB.DATEINT_FORMAT}) AS INT)"
+        return f"CAST(STRFTIME({date} + INTERVAL {e} {unit}, {DuckDB.DATEINT_FORMAT}) AS INT)"
 
     @classmethod
     def _mixed_type_add_to_ds(cls, generator, expression):

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -267,19 +267,19 @@ class DuckDB(Dialect):
         return DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=this)
 
     def _mixed_type_date_diff_sql(self, expression):
-        third_arg = self.sql(expression, "second_date")
+        third_arg = self.sql(expression, "end_date")
         if third_arg:
-            first_date_value = expression.text("first_date")
-            second_date_value = third_arg
+            start_date_value = self.sql(expression, "start_date")
+            end_date_value = third_arg
             unit = expression.text("unit")
         else:
-            first_date_value = expression.text("unit")
-            second_date_value = expression.text("first_date")
+            start_date_value = expression.text("unit")
+            end_date_value = self.sql(expression, "start_date")
             unit = "DAY"
 
-        first_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=first_date_value)
+        first_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=start_date_value)
         second_date = DuckDB.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=second_date_value
+            this=end_date_value
         )
 
         return f"DATE_DIFF('{unit}', {first_date}, {second_date})"
@@ -549,26 +549,26 @@ class Hive(Dialect):
         return Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=this)
 
     def _mixed_type_date_diff_sql(self, expression):
-        third_arg = self.sql(expression, "second_date")
+        third_arg = self.sql(expression, "end_date")
         if third_arg:
-            first_date_value = self.sql(expression, "first_date")
-            second_date_value = third_arg
+            start_date_value = self.sql(expression, "start_date")
+            end_date_value = third_arg
             unit = expression.text("unit")
         else:
-            first_date_value = expression.text("unit")
-            second_date_value = self.sql(expression, "first_date")
+            start_date_value = expression.text("unit")
+            end_date_value = self.sql(expression, "start_date")
             unit = "DAY"
 
-        first_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=first_date_value)
-        second_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=second_date_value)
+        start_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=start_date_value)
+        end_date = Hive.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=end_date_value)
 
         response = None
         if unit == "DAY":
-            response = f"DATEDIFF({first_date}, {second_date})"
+            response = f"DATEDIFF({end_date}, {start_date})"
         elif unit == "MONTH":
-            response = f"MONTHS_BETWEEN({first_date}, {second_date})"
+            response = f"MONTHS_BETWEEN({end_date}, {start_date})"
         elif unit == "YEAR":
-            response = f"ROUND(MONTHS_BETWEEN({first_date}, {second_date}) / 12, 2)"
+            response = f"ROUND(MONTHS_BETWEEN({end_date}, {start_date}) / 12, 2)"
         else:
             self.unsupported(f"Unit not implemented for Spark Date Diff: {unit}")
 
@@ -828,22 +828,22 @@ class Presto(Dialect):
         return Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=this)
 
     def _mixed_type_date_diff_sql(self, expression):
-        third_arg = self.sql(expression, "second_date")
+        third_arg = self.sql(expression, "end_date")
         if third_arg:
-            first_date_value = self.sql(expression, "first_date")
-            second_date_value = third_arg
+            start_date_value = self.sql(expression, "start_date")
+            end_date_value = third_arg
             unit = expression.text("unit")
         else:
-            first_date_value = expression.text("unit")
-            second_date_value = self.sql(expression, "first_date")
+            start_date_value = expression.text("unit")
+            end_date_value = self.sql(expression, "start_date")
             unit = "DAY"
 
-        first_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=first_date_value)
-        second_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(
-            this=second_date_value
+        start_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(this=start_date_value)
+        end_date = Presto.MIXED_TYPE_TO_DATE_EXPRESSION.format(
+            this=end_date_value
         )
 
-        return f"DATE_DIFF('{unit}', {first_date}, {second_date})"
+        return f"DATE_DIFF('{unit}', {start_date}, {end_date})"
 
     time_mapping = MYSQL_TIME_MAPPING
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1598,7 +1598,12 @@ class Min(AggFunc):
 
 
 class MixedTypeAdd(Func):
-    arg_types = {"this": True, "expression": True, "unit": False, "output_format": False}
+    arg_types = {
+        "this": True,
+        "expression": True,
+        "unit": False,
+        "output_format": False,
+    }
 
 
 class MixedTypeDateDiff(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1506,6 +1506,14 @@ class DateDiff(Func):
     arg_types = {"this": True, "expression": True, "unit": False}
 
 
+class DiAdd(Func):
+    arg_types = {"this": True, "expression": True, "unit": False}
+
+
+class DiDiff(Func):
+    arg_types = {"this": True, "expression": True, "unit": False}
+
+
 class DateStrToDate(Func):
     pass
 
@@ -1694,11 +1702,27 @@ class TsOrDsAdd(Func):
     arg_types = {"this": True, "expression": True, "unit": False}
 
 
-class TsOrDsToDateStr(Func):
+class TsOrDsOrDiDateDiff(Func):
+    arg_types = {"unit": True, "first_date": True, "second_date": False}
+
+
+class TsOrDsOrDiToDate(Func):
+    pass
+
+
+class TsOrDsOrDiToDateStr(Func):
+    pass
+
+
+class TsOrDsOrDiToDi(Func):
     pass
 
 
 class TsOrDsToDate(Func):
+    pass
+
+
+class TsOrDsToDateStr(Func):
     pass
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1597,6 +1597,26 @@ class Min(AggFunc):
     pass
 
 
+class MixedTypeAdd(Func):
+    arg_types = {"this": True, "expression": True, "unit": False, "output_format": False}
+
+
+class MixedTypeDateDiff(Func):
+    arg_types = {"unit": True, "first_date": True, "second_date": False}
+
+
+class MixedTypeToDate(Func):
+    pass
+
+
+class MixedTypeToDateStr(Func):
+    pass
+
+
+class MixedTypeToDi(Func):
+    pass
+
+
 class Month(Func):
     pass
 
@@ -1702,27 +1722,11 @@ class TsOrDsAdd(Func):
     arg_types = {"this": True, "expression": True, "unit": False}
 
 
-class TsOrDsOrDiDateDiff(Func):
-    arg_types = {"unit": True, "first_date": True, "second_date": False}
-
-
-class TsOrDsOrDiToDate(Func):
-    pass
-
-
-class TsOrDsOrDiToDateStr(Func):
-    pass
-
-
-class TsOrDsOrDiToDi(Func):
+class TsOrDsToDateStr(Func):
     pass
 
 
 class TsOrDsToDate(Func):
-    pass
-
-
-class TsOrDsToDateStr(Func):
     pass
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1607,7 +1607,7 @@ class MixedTypeAdd(Func):
 
 
 class MixedTypeDateDiff(Func):
-    arg_types = {"unit": True, "first_date": True, "second_date": False}
+    arg_types = {"unit": True, "start_date": True, "end_date": False}
 
 
 class MixedTypeToDate(Func):

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -674,7 +674,7 @@ class TestDialects(unittest.TestCase):
         self.validate("MONTH(x)", "MONTH(x)", read="presto", write="hive")
         self.validate(
             "MONTH(x)",
-            "MONTH(DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d'))",
+            "MONTH(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'))",
             read="hive",
             write="presto",
         )
@@ -682,7 +682,7 @@ class TestDialects(unittest.TestCase):
         self.validate("DAY(x)", "DAY(x)", read="presto", write="hive")
         self.validate(
             "DAY(x)",
-            "DAY(DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d'))",
+            "DAY(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'))",
             read="hive",
             write="presto",
         )
@@ -691,7 +691,7 @@ class TestDialects(unittest.TestCase):
         self.validate("YEAR(x)", "YEAR(x)", read="presto", write="hive")
         self.validate(
             "YEAR(x)",
-            "YEAR(DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d'))",
+            "YEAR(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'))",
             read="hive",
             write="presto",
         )
@@ -1126,7 +1126,11 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "MONTH('2021-03-01')",
-            "MONTH(TS_OR_DS_OR_DI_TO_DATE('2021-03-01'))",
+            (
+                "MONTH(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+            ),
             read="hive",
             write="duckdb",
         )
@@ -1134,7 +1138,11 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "DAY('2021-03-01')",
-            "DAY(TS_OR_DS_OR_DI_TO_DATE('2021-03-01'))",
+            (
+                "DAY(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+             ),
             read="hive",
             write="duckdb",
         )
@@ -1291,13 +1299,21 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "MONTH('2021-03-01')",
-            "MONTH(CAST('2021-03-01' AS DATE))",
+            (
+                "MONTH(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+            ),
             read="spark",
             write="duckdb",
         )
         self.validate(
             "YEAR('2021-03-01')",
-            "YEAR(CAST('2021-03-01' AS DATE))",
+            (
+                "YEAR(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+            ),
             read="spark",
             write="duckdb",
         )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1152,7 +1152,7 @@ class TestDialects(unittest.TestCase):
                 "DAY(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
                 "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
                 "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
-             ),
+            ),
             read="hive",
             write="duckdb",
         )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1042,18 +1042,28 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATEDIFF('2020-01-02', '2020-01-01')",
-            "DATEDIFF(TO_DATE(SUBSTR(REPLACE(CAST('2020-01-02' as string), '-', ''), 1, 8), 'yyyyMMdd'), TO_DATE(SUBSTR(REPLACE(CAST('2020-01-01' as string), '-', ''), 1, 8), 'yyyyMMdd'))",
+            (
+                "DATEDIFF(TO_DATE(SUBSTR(REPLACE(CAST('2020-01-02' as string), '-', ''), 1, 8), 'yyyyMMdd'), "
+                "TO_DATE(SUBSTR(REPLACE(CAST('2020-01-01' as string), '-', ''), 1, 8), 'yyyyMMdd'))"
+            ),
             read="hive",
         )
         self.validate(
             "DATEDIFF(TO_DATE(y), x)",
-            "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'), DATE_PARSE(SUBSTR(REPLACE(CAST(DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(y as varchar), '-', ''), 1, 8), '%Y%m%d'), '%Y-%m-%d') as varchar), '-', ''), 1, 8), '%Y%m%d'))",
+            (
+                "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'), "
+                "DATE_PARSE(SUBSTR(REPLACE(CAST(DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(y as varchar), '-', ''), 1, 8), "
+                "'%Y%m%d'), '%Y-%m-%d') as varchar), '-', ''), 1, 8), '%Y%m%d'))"
+            ),
             read="hive",
             write="presto",
         )
         self.validate(
             "DATEDIFF('2020-01-02', '2020-01-01')",
-            "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-01' as varchar), '-', ''), 1, 8), '%Y%m%d'), DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-02' as varchar), '-', ''), 1, 8), '%Y%m%d'))",
+            (
+                "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-01' as varchar), '-', ''), 1, 8), '%Y%m%d'), "
+                "DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-02' as varchar), '-', ''), 1, 8), '%Y%m%d'))"
+            ),
             read="hive",
             write="presto",
         )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -270,7 +270,7 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1, 'YEAR')",
             (
-                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
+                "CAST(STRFTIME(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
                 "|| SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
                 "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE) + INTERVAL 1 "
                 "YEAR, '%Y%m%d') AS INT)"
@@ -282,7 +282,7 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1, 'MONTH')",
             (
-                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
+                "CAST(STRFTIME(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
                 "|| SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
                 "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE) + INTERVAL 1 "
                 "MONTH, '%Y%m%d') AS INT)"
@@ -294,7 +294,7 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1)",
             (
-                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
+                "CAST(STRFTIME(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
                 "|| SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
                 "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE) + INTERVAL 1 "
                 "DAY, '%Y%m%d') AS INT)"
@@ -1021,30 +1021,30 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "DATE_ADD('2020-01-01', 1, 'DAY')",
+            "MIXED_TYPE_ADD('2020-01-01', 1, 'DAY', 'YYYY-MM-DD')",
             read="hive",
             write=None,
             identity=False,
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "DATE_ADD('2020-01-01', 1)",
+            "DATE_ADD(DATE_FORMAT(TO_DATE(SUBSTR(REPLACE(CAST('2020-01-01' as string), '-', ''), 1, 8), 'yyyyMMdd'), 'yyyy-MM-dd'), 1)",
             read="hive",
         )
         self.validate(
             "DATE_SUB('2020-01-01', 1)",
-            "DATE_ADD('2020-01-01', 1 * -1)",
+            "DATE_ADD(DATE_FORMAT(TO_DATE(SUBSTR(REPLACE(CAST('2020-01-01' as string), '-', ''), 1, 8), 'yyyyMMdd'), 'yyyy-MM-dd'), 1 * -1)",
             read="hive",
         )
         self.validate(
             "DATE_SUB('2020-01-01', 1)",
-            "DATE_ADD('DAY', 1 * -1, '2020-01-01')",
+            "DATE_FORMAT(DATE_ADD('DAY', 1 * -1, DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-01' AS VARCHAR), '-', ''), 1, 8), '%Y%m%d')), '%Y-%m-%d')",
             read="hive",
             write="presto",
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "DATE_ADD('DAY', 1, '2020-01-01')",
+            "DATE_FORMAT(DATE_ADD('DAY', 1, DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-01' AS VARCHAR), '-', ''), 1, 8), '%Y%m%d')), '%Y-%m-%d')",
             read="hive",
             write="presto",
         )
@@ -1071,7 +1071,7 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "DATE_ADD('2020-01-01', 1)",
-            "'2020-01-01' + INTERVAL 1 DAY",
+            "STRFTIME(CAST('2020-01-01' AS DATE) + INTERVAL 1 DAY, '%Y-%m-%d')",
             read="hive",
             write="duckdb",
         )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1262,8 +1262,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MIXED_TYPE_DATE_DIFF('YEAR', 20220101, 20220102)",
             (
-                "ROUND(MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
-                "TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd')) / 12, 2)"
+                "ROUND(MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
+                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd')) / 12, 2)"
             ),
             write="hive",
             identity=False,
@@ -1272,8 +1272,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MIXED_TYPE_DATE_DIFF('MONTH', 20220101, 20220102)",
             (
-                "MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
-                "TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'))"
+                "MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
+                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd'))"
             ),
             write="hive",
             identity=False,
@@ -1282,8 +1282,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MIXED_TYPE_DATE_DIFF(20220101, 20220102)",
             (
-                "DATEDIFF(TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
-                "TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'))"
+                "DATEDIFF(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
+                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd'))"
             ),
             write="hive",
             identity=False,

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -104,12 +104,12 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DATEDIFF(a, b)",
             (
-                "CAST(SUBSTR(REPLACE(CAST(a as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(a as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(a as varchar), '-', ''), 7, 2) as date) - "
-                "CAST(SUBSTR(REPLACE(CAST(b as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(b as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(b as varchar), '-', ''), 7, 2) as date)"
+                "CAST(SUBSTR(REPLACE(CAST(a AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(a AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(a AS VARCHAR), '-', ''), 7, 2) AS DATE) - "
+                "CAST(SUBSTR(REPLACE(CAST(b AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(b AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(b AS VARCHAR), '-', ''), 7, 2) AS DATE)"
             ),
             read="hive",
             write="duckdb",
@@ -233,9 +233,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_TO_DATE_STR(x)",
             (
-                "strftime(CAST(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 7, 2) as date), '%Y-%m-%d')"
+                "STRFTIME(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE), '%Y-%m-%d')"
             ),
             write="duckdb",
             identity=False,
@@ -244,9 +244,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_TO_DATE(x)",
             (
-                "CAST(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 7, 2) as date)"
+                "CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE)"
             ),
             write="duckdb",
             identity=False,
@@ -254,7 +254,7 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "TS_OR_DS_OR_DI_TO_DI(x)",
-            "CAST(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8) as int)",
+            "CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8) AS INT)",
             write="duckdb",
             identity=False,
         )
@@ -262,10 +262,10 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1, 'YEAR')",
             (
-                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 4) || '-' "
-                "|| SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 7, 2) as date) + INTERVAL 1 "
-                "YEAR, '%Y%m%d') as int)"
+                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
+                "|| SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE) + INTERVAL 1 "
+                "YEAR, '%Y%m%d') AS INT)"
             ),
             write="duckdb",
             identity=False,
@@ -274,10 +274,10 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1, 'MONTH')",
             (
-                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 4) || '-' "
-                "|| SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 7, 2) as date) + INTERVAL 1 "
-                "MONTH, '%Y%m%d') as int)"
+                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
+                "|| SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE) + INTERVAL 1 "
+                "MONTH, '%Y%m%d') AS INT)"
             ),
             write="duckdb",
             identity=False,
@@ -286,10 +286,10 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1)",
             (
-                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 4) || '-' "
-                "|| SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 7, 2) as date) + INTERVAL 1 "
-                "DAY, '%Y%m%d') as int)"
+                "CAST(strftime(CAST(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 4) || '-' "
+                "|| SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 7, 2) AS DATE) + INTERVAL 1 "
+                "DAY, '%Y%m%d') AS INT)"
             ),
             write="duckdb",
             identity=False,
@@ -298,12 +298,12 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_DATE_DIFF('YEAR', 20220101, 20220102)",
             (
-                "DATE_DIFF('YEAR', CAST(SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), "
-                "1, 4) || '-' || SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 5, 2) || "
-                "'-' || SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 7, 2) as date), "
-                "CAST(SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 7, 2) as date))"
+                "DATE_DIFF('YEAR', CAST(SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), "
+                "1, 4) || '-' || SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 5, 2) || "
+                "'-' || SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 7, 2) AS DATE), "
+                "CAST(SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             write="duckdb",
             identity=False,
@@ -312,12 +312,12 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_DATE_DIFF('MONTH', 20220101, 20220102)",
             (
-                "DATE_DIFF('MONTH', CAST(SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), "
-                "1, 4) || '-' || SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 5, 2) || "
-                "'-' || SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 7, 2) as date), "
-                "CAST(SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 7, 2) as date))"
+                "DATE_DIFF('MONTH', CAST(SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), "
+                "1, 4) || '-' || SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 5, 2) || "
+                "'-' || SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 7, 2) AS DATE), "
+                "CAST(SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             write="duckdb",
             identity=False,
@@ -326,12 +326,12 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_DATE_DIFF(20220101, 20220102)",
             (
-                "DATE_DIFF('DAY', CAST(SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), "
-                "1, 4) || '-' || SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 5, 2) || "
-                "'-' || SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 7, 2) as date), "
-                "CAST(SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 1, 4) || '-' || "
-                "SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 5, 2) || '-' || "
-                "SUBSTR(REPLACE(CAST(20220102 as varchar), '-', ''), 7, 2) as date))"
+                "DATE_DIFF('DAY', CAST(SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), "
+                "1, 4) || '-' || SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 5, 2) || "
+                "'-' || SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 7, 2) AS DATE), "
+                "CAST(SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 1, 4) || '-' || "
+                "SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 5, 2) || '-' || "
+                "SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             write="duckdb",
             identity=False,
@@ -674,7 +674,7 @@ class TestDialects(unittest.TestCase):
         self.validate("MONTH(x)", "MONTH(x)", read="presto", write="hive")
         self.validate(
             "MONTH(x)",
-            "MONTH(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'))",
+            "MONTH(DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'))",
             read="hive",
             write="presto",
         )
@@ -682,7 +682,7 @@ class TestDialects(unittest.TestCase):
         self.validate("DAY(x)", "DAY(x)", read="presto", write="hive")
         self.validate(
             "DAY(x)",
-            "DAY(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'))",
+            "DAY(DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'))",
             read="hive",
             write="presto",
         )
@@ -691,7 +691,7 @@ class TestDialects(unittest.TestCase):
         self.validate("YEAR(x)", "YEAR(x)", read="presto", write="hive")
         self.validate(
             "YEAR(x)",
-            "YEAR(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'))",
+            "YEAR(DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'))",
             read="hive",
             write="presto",
         )
@@ -809,21 +809,21 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "TS_OR_DS_OR_DI_TO_DATE_STR(x)",
-            "DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'), '%Y-%m-%d')",
+            "DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'), '%Y-%m-%d')",
             write="presto",
             identity=False,
         )
 
         self.validate(
             "TS_OR_DS_OR_DI_TO_DATE(x)",
-            "DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d')",
+            "DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d')",
             write="presto",
             identity=False,
         )
 
         self.validate(
             "TS_OR_DS_OR_DI_TO_DI(x)",
-            "CAST(DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'), '%Y%m%d') as int)",
+            "CAST(DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'), '%Y%m%d') AS INT)",
             write="presto",
             identity=False,
         )
@@ -831,7 +831,7 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DI_ADD(x, 1, 'DAY')",
             (
-                "CAST(DATE_FORMAT(DATE_ADD('DAY', 1, DATE_PARSE(SUBSTR(CAST(x as varchar), 1, 8), '%Y%m%d')), '%Y%m%d') as int)"
+                "CAST(DATE_FORMAT(DATE_ADD('DAY', 1, DATE_PARSE(SUBSTR(CAST(x AS VARCHAR), 1, 8), '%Y%m%d')), '%Y%m%d') AS INT)"
             ),
             write="presto",
             identity=False,
@@ -840,8 +840,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_DATE_DIFF('MONTH', 20220101, 20220102)",
             (
-                "DATE_DIFF('MONTH', DATE_PARSE(SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 1, 8), '%Y%m%d'), "
-                "DATE_PARSE(SUBSTR(REPLACE(CAST(20220102 as varchar), "
+                "DATE_DIFF('MONTH', DATE_PARSE(SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'), "
+                "DATE_PARSE(SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), "
                 "'-', ''), 1, 8), '%Y%m%d'))"
             ),
             write="presto",
@@ -851,8 +851,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "TS_OR_DS_OR_DI_DATE_DIFF(20220101, 20220102)",
             (
-                "DATE_DIFF('DAY', DATE_PARSE(SUBSTR(REPLACE(CAST(20220101 as varchar), '-', ''), 1, 8), '%Y%m%d'), "
-                "DATE_PARSE(SUBSTR(REPLACE(CAST(20220102 as varchar), "
+                "DATE_DIFF('DAY', DATE_PARSE(SUBSTR(REPLACE(CAST(20220101 AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'), "
+                "DATE_PARSE(SUBSTR(REPLACE(CAST(20220102 AS VARCHAR), "
                 "'-', ''), 1, 8), '%Y%m%d'))"
             ),
             write="presto",
@@ -1051,9 +1051,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DATEDIFF(TO_DATE(y), x)",
             (
-                "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST(x as varchar), '-', ''), 1, 8), '%Y%m%d'), "
-                "DATE_PARSE(SUBSTR(REPLACE(CAST(DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(y as varchar), '-', ''), 1, 8), "
-                "'%Y%m%d'), '%Y-%m-%d') as varchar), '-', ''), 1, 8), '%Y%m%d'))"
+                "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST(x AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'), "
+                "DATE_PARSE(SUBSTR(REPLACE(CAST(DATE_FORMAT(DATE_PARSE(SUBSTR(REPLACE(CAST(y AS VARCHAR), '-', ''), 1, 8), "
+                "'%Y%m%d'), '%Y-%m-%d') AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'))"
             ),
             read="hive",
             write="presto",
@@ -1061,8 +1061,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DATEDIFF('2020-01-02', '2020-01-01')",
             (
-                "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-01' as varchar), '-', ''), 1, 8), '%Y%m%d'), "
-                "DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-02' as varchar), '-', ''), 1, 8), '%Y%m%d'))"
+                "DATE_DIFF('day', DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-01' AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'), "
+                "DATE_PARSE(SUBSTR(REPLACE(CAST('2020-01-02' AS VARCHAR), '-', ''), 1, 8), '%Y%m%d'))"
             ),
             read="hive",
             write="presto",
@@ -1137,9 +1137,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MONTH('2021-03-01')",
             (
-                "MONTH(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
-                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
-                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+                "MONTH(CAST(SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             read="hive",
             write="duckdb",
@@ -1149,9 +1149,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "DAY('2021-03-01')",
             (
-                "DAY(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
-                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
-                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+                "DAY(CAST(SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             read="hive",
             write="duckdb",
@@ -1191,28 +1191,28 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "TS_OR_DS_OR_DI_TO_DI(x)",
-            "CAST(DATE_FORMAT(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 'yyyyMMdd') as int)",
+            "CAST(DATE_FORMAT(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 'yyyyMMdd') AS INT)",
             write="hive",
             identity=False,
         )
 
         self.validate(
             "DI_ADD(x, 1, 'YEAR')",
-            "CAST(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1 * 12) as int)",
+            "CAST(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1 * 12) AS INT)",
             write="hive",
             identity=False,
         )
 
         self.validate(
             "DI_ADD(x, 1, 'MONTH')",
-            "CAST(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1) as int)",
+            "CAST(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1) AS INT)",
             write="hive",
             identity=False,
         )
 
         self.validate(
             "DI_ADD(x, 1)",
-            "CAST(DATE_ADD(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1) as int)",
+            "CAST(DATE_ADD(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1) AS INT)",
             write="hive",
             identity=False,
         )
@@ -1310,9 +1310,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MONTH('2021-03-01')",
             (
-                "MONTH(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
-                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
-                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+                "MONTH(CAST(SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             read="spark",
             write="duckdb",
@@ -1320,9 +1320,9 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "YEAR('2021-03-01')",
             (
-                "YEAR(CAST(SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 1, 4) || "
-                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 5, 2) || '-' "
-                "|| SUBSTR(REPLACE(CAST('2021-03-01' as varchar), '-', ''), 7, 2) as date))"
+                "YEAR(CAST(SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 1, 4) || "
+                "'-' || SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 5, 2) || '-' "
+                "|| SUBSTR(REPLACE(CAST('2021-03-01' AS VARCHAR), '-', ''), 7, 2) AS DATE))"
             ),
             read="spark",
             write="duckdb",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1240,21 +1240,21 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "DI_ADD(x, 1, 'YEAR')",
-            "CAST(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1 * 12) AS INT)",
+            "CAST(DATE_FORMAT(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1 * 12), 'yyyyMMdd') AS INT)",
             write="hive",
             identity=False,
         )
 
         self.validate(
             "DI_ADD(x, 1, 'MONTH')",
-            "CAST(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1) AS INT)",
+            "CAST(DATE_FORMAT(ADD_MONTHS(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1), 'yyyyMMdd') AS INT)",
             write="hive",
             identity=False,
         )
 
         self.validate(
             "DI_ADD(x, 1)",
-            "CAST(DATE_ADD(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1) AS INT)",
+            "CAST(DATE_FORMAT(DATE_ADD(TO_DATE(SUBSTR(REPLACE(CAST(x as string), '-', ''), 1, 8), 'yyyyMMdd'), 1), 'yyyyMMdd') AS INT)",
             write="hive",
             identity=False,
         )
@@ -1262,8 +1262,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MIXED_TYPE_DATE_DIFF('YEAR', 20220101, 20220102)",
             (
-                "ROUND(MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
-                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd')) / 12, 2)"
+                "CAST(MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
+                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd')) / 12 as int)"
             ),
             write="hive",
             identity=False,
@@ -1272,8 +1272,8 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "MIXED_TYPE_DATE_DIFF('MONTH', 20220101, 20220102)",
             (
-                "MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
-                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd'))"
+                "CAST(MONTHS_BETWEEN(TO_DATE(SUBSTR(REPLACE(CAST(20220102 as string), '-', ''), 1, 8), 'yyyyMMdd'), "
+                "TO_DATE(SUBSTR(REPLACE(CAST(20220101 as string), '-', ''), 1, 8), 'yyyyMMdd')) as int)"
             ),
             write="hive",
             identity=False,

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -26,7 +26,7 @@ class TestExpressions(unittest.TestCase):
         )
         self.assertEqual(
             parse_one("TO_DATE(x)", read="hive"),
-            parse_one("ts_or_ds_or_di_to_date_str(x)"),
+            parse_one("mixed_type_to_date_str(x)"),
         )
 
     def test_find(self):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -25,7 +25,7 @@ class TestExpressions(unittest.TestCase):
             parse_one("ROW() OVER (partition BY y)"),
         )
         self.assertEqual(
-            parse_one("TO_DATE(x)", read="hive"), parse_one("ts_or_ds_to_date_str(x)")
+            parse_one("TO_DATE(x)", read="hive"), parse_one("ts_or_ds_or_di_to_date_str(x)")
         )
 
     def test_find(self):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -25,7 +25,8 @@ class TestExpressions(unittest.TestCase):
             parse_one("ROW() OVER (partition BY y)"),
         )
         self.assertEqual(
-            parse_one("TO_DATE(x)", read="hive"), parse_one("ts_or_ds_or_di_to_date_str(x)")
+            parse_one("TO_DATE(x)", read="hive"),
+            parse_one("ts_or_ds_or_di_to_date_str(x)"),
         )
 
     def test_find(self):


### PR DESCRIPTION
Prior to this change sqlglot assumes that dates are either in date string (DS) format ('YYYY-MM-DD') or a timestamp (TS) that start with the DS format. This adds functions that allows users to say that the date could also be in dateint (DI) format (YYYYMMDD). 

This will generate new SQL in cases where the code previously assumed the date was either TS or DS format since it must now also check if it is DI. 