### PR TITLE
Properly catch parse error when no statement follows CTE

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -719,6 +719,10 @@ class Parser:
 
         this = self._parse_statement()
 
+        if this is None:
+            self.raise_error("Failed to parse any statement following CTE")
+            return
+
         if "with" not in this.arg_types:
             self.raise_error(f"{this.key} does not support CTE")
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -721,7 +721,7 @@ class Parser:
 
         if this is None:
             self.raise_error("Failed to parse any statement following CTE")
-            return
+            return None
 
         if "with" not in this.arg_types:
             self.raise_error(f"{this.key} does not support CTE")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -74,12 +74,15 @@ class TestParser(unittest.TestCase):
         warn.expression(exp.Hint, y="")
         assert isinstance(warn.errors[0], ParseError)
 
-    def test_function_arguments_validation(self):
+    def test_parse_errors(self):
         with self.assertRaises(ParseError):
             parse_one("IF(a > 0, a, b, c)")
 
         with self.assertRaises(ParseError):
             parse_one("IF(a > 0)")
+
+        with self.assertRaises(ParseError):
+            parse_one("WITH cte AS (SELECT * FROM x)")
 
     def test_space(self):
         self.assertEqual(


### PR DESCRIPTION
Parsing was raising an `AttributeError: 'NoneType' object has no attribute 'arg_types'` error is _parse_statement returned `None`.

This raises a proper ParseError instead.

@tobymao 