### PR TITLE
Added tests for table parsing

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,6 +17,12 @@ class TestParser(unittest.TestCase):
         )
         assert len(list(columns)) == 1
 
+    def test_table(self):
+        tables = [
+            t.sql() for t in parse_one("select * from a, b.c, .d").find_all(exp.Table)
+        ]
+        self.assertEqual(tables, ["a", "b.c", "d"])
+
     def test_command(self):
         expressions = parse("SET x = 1; ADD JAR s3://a; SELECT 1")
         self.assertEqual(len(expressions), 3)


### PR DESCRIPTION
Currently sqlglot parses incorrectly qualified table names such as .foo
properly. Added a test to make sure this is a feature instead of a bug.
It can be very useful when people define tables with interpolation such
as "{database}.{table_name}" where database is empty string