### PR TITLE
Support more cases for join builder:

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2,14 +2,11 @@ from copy import deepcopy
 from collections import deque
 from enum import auto
 import re
-import typing
 import inspect
 import sys
 
 from sqlglot.errors import ParseError
 from sqlglot.helper import AutoName, camel_to_snake_case, ensure_list
-
-T = typing.TypeVar("T")
 
 
 class Expression:
@@ -273,7 +270,7 @@ class Expression:
             new_node.args[k] = new_child_nodes if is_list_arg else new_child_nodes[0]
         return new_node
 
-    def assert_is(self, type_: typing.Type[T]) -> T:
+    def assert_is(self, type_):
         """
         Assert that this `Expression` is an instance of `type_`.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1969,14 +1969,12 @@ def condition(expression, dialect=None, **opts):
     Returns:
         Condition: the expression
     """
-    this = _maybe_parse(
+    return _maybe_parse(
         expression,
+        into=Condition,
         dialect=dialect,
         parser_opts=opts,
     )
-    if not isinstance(this, Condition):
-        raise ValueError(f"Failed to parse expression into condition: {expression}")
-    return this
 
 
 def and_(*expressions, dialect=None, **opts):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -935,7 +935,7 @@ class Select(Subqueryable, Expression):
                 join.set("kind", kind.text)
 
         if on:
-            on = _maybe_parse(on, into=Condition, **parse_args)
+            on = and_(*ensure_list(on), dialect=dialect, **(parser_opts or {}))
             join.set("on", on)
 
         if join_alias:

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -39,7 +39,7 @@ def list_get(arr, index):
 def ensure_list(value):
     if value is None:
         return []
-    return value if isinstance(value, (list, set)) else [value]
+    return value if isinstance(value, (list, tuple, set)) else [value]
 
 
 def csv(*args, sep=", "):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2,7 +2,7 @@ import logging
 
 import sqlglot.constants as c
 from sqlglot.errors import ErrorLevel, ParseError
-from sqlglot.helper import apply_index_offset, list_get
+from sqlglot.helper import apply_index_offset, ensure_list, list_get
 from sqlglot.tokens import Token, Tokenizer, TokenType
 import sqlglot.expressions as exp
 
@@ -268,7 +268,7 @@ class Parser:
             parse_method=self._parse_statement, raw_tokens=raw_tokens, sql=sql
         )
 
-    def parse_into(self, expression_type, raw_tokens, sql=None):
+    def parse_into(self, expression_types, raw_tokens, sql=None):
         methods = {
             exp.From: self._parse_from,
             exp.Group: self._parse_group,
@@ -279,18 +279,21 @@ class Parser:
             exp.Offset: self._parse_offset,
             exp.TableAlias: self._parse_table_alias,
             exp.Table: self._parse_table,
-            exp.CONJUNCTION: self._parse_conjunction,
+            exp.Condition: self._parse_conjunction,
+            exp.Expression: self._parse_statement,
+            "JOIN_TYPE": self._parse_join_side_and_kind,
         }
-        if expression_type not in methods:
-            raise TypeError(f"No parser registered for {expression_type}")
+        error = None
+        for expression_type in ensure_list(expression_types):
+            if expression_type not in methods:
+                raise TypeError(f"No parser registered for {expression_type}")
 
-        method = methods[expression_type]
-        expressions = self._parse(method, raw_tokens, sql)
-
-        if not expressions:
-            raise ValueError(f"Failed to parse into {expression_type}")
-
-        return expressions
+            method = methods[expression_type]
+            try:
+                return self._parse(method, raw_tokens, sql)
+            except ParseError as e:
+                error = e
+        raise ParseError(f"Failed to parse into {expression_types}") from error
 
     def _parse(self, parse_method, raw_tokens, sql=None):
         self.reset()
@@ -866,9 +869,14 @@ class Parser:
     def _parse_joins(self):
         return self._parse_all(self._parse_join)
 
+    def _parse_join_side_and_kind(self):
+        return (
+            self._match_set(self.JOIN_SIDES) and self._prev,
+            self._match_set(self.JOIN_KINDS) and self._prev,
+        )
+
     def _parse_join(self):
-        side = self._match_set(self.JOIN_SIDES) and self._prev
-        kind = self._match_set(self.JOIN_KINDS) and self._prev
+        side, kind = self._parse_join_side_and_kind()
 
         if not self._match(TokenType.JOIN):
             return None

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -287,10 +287,8 @@ class Parser:
         for expression_type in ensure_list(expression_types):
             if expression_type not in methods:
                 raise TypeError(f"No parser registered for {expression_type}")
-
-            method = methods[expression_type]
             try:
-                return self._parse(method, raw_tokens, sql)
+                return self._parse(methods[expression_type], raw_tokens, sql)
             except ParseError as e:
                 error = e
         raise ParseError(f"Failed to parse into {expression_types}") from error

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -107,6 +107,12 @@ class TestBuild(unittest.TestCase):
             (
                 lambda: select("x")
                 .from_("tbl")
+                .join(exp.Table(this="tbl2"), join_type="left outer", join_alias="foo"),
+                "SELECT x FROM tbl LEFT OUTER JOIN tbl2 AS foo",
+            ),
+            (
+                lambda: select("x")
+                .from_("tbl")
                 .join(select("y").from_("tbl2"), join_type="left outer"),
                 "SELECT x FROM tbl LEFT OUTER JOIN (SELECT y FROM tbl2)",
             ),
@@ -116,6 +122,16 @@ class TestBuild(unittest.TestCase):
                 .join(
                     select("y").from_("tbl2").subquery("aliased"),
                     join_type="left outer",
+                ),
+                "SELECT x FROM tbl LEFT OUTER JOIN (SELECT y FROM tbl2) AS aliased",
+            ),
+            (
+                lambda: select("x")
+                .from_("tbl")
+                .join(
+                    select("y").from_("tbl2"),
+                    join_type="left outer",
+                    join_alias="aliased",
                 ),
                 "SELECT x FROM tbl LEFT OUTER JOIN (SELECT y FROM tbl2) AS aliased",
             ),
@@ -134,6 +150,17 @@ class TestBuild(unittest.TestCase):
                 .from_("tbl")
                 .join("select b from tbl2", on="a=b", join_type="left"),
                 "SELECT x FROM tbl LEFT JOIN (SELECT b FROM tbl2) ON a = b",
+            ),
+            (
+                lambda: select("x")
+                .from_("tbl")
+                .join(
+                    "select b from tbl2",
+                    on="a=b",
+                    join_type="left",
+                    join_alias="aliased",
+                ),
+                "SELECT x FROM tbl LEFT JOIN (SELECT b FROM tbl2) AS aliased ON a = b",
             ),
             (
                 lambda: select("x", "COUNT(y)")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -95,6 +95,12 @@ class TestBuild(unittest.TestCase):
                 "SELECT x FROM tbl JOIN tbl2 ON tbl.y = tbl2.y",
             ),
             (
+                lambda: select("x")
+                .from_("tbl")
+                .join("tbl2", on=["tbl.y = tbl2.y", "a = b"]),
+                "SELECT x FROM tbl JOIN tbl2 ON tbl.y = tbl2.y AND a = b",
+            ),
+            (
                 lambda: select("x").from_("tbl").join("tbl2", join_type="left outer"),
                 "SELECT x FROM tbl LEFT OUTER JOIN tbl2",
             ),

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -126,6 +126,16 @@ class TestBuild(unittest.TestCase):
                 "SELECT x FROM tbl LEFT JOIN x ON a = b",
             ),
             (
+                lambda: select("x").from_("tbl").join("left join x", on="a=b"),
+                "SELECT x FROM tbl LEFT JOIN x ON a = b",
+            ),
+            (
+                lambda: select("x")
+                .from_("tbl")
+                .join("select b from tbl2", on="a=b", join_type="left"),
+                "SELECT x FROM tbl LEFT JOIN (SELECT b FROM tbl2) ON a = b",
+            ),
+            (
                 lambda: select("x", "COUNT(y)")
                 .from_("tbl")
                 .group_by("x")


### PR DESCRIPTION
* join('table')
* join('select x from table')
* join('x on a = b')
* join('join x on a = b')
* join (Join|Select|Table|Subquery)