### PR TITLE
fix(optimizer): correlated subqueries are hard

### DIFF
--- a/sqlglot/optimizer/projection_pushdown.py
+++ b/sqlglot/optimizer/projection_pushdown.py
@@ -48,7 +48,7 @@ def projection_pushdown(expression):
 
             # Group columns by selectable name
             selects = defaultdict(set)
-            for col in scope.columns:
+            for col in scope.references:
                 table_name = col.text("table")
                 col_name = col.text("this")
                 selects[table_name].add(col_name)

--- a/tests/fixtures/optimizer/projection_pushdown.sql
+++ b/tests/fixtures/optimizer/projection_pushdown.sql
@@ -4,6 +4,9 @@ SELECT "_q_0".a AS a FROM (SELECT x.a AS a FROM x) AS "_q_0";
 SELECT 1 FROM (SELECT * FROM x) WHERE b = 2;
 SELECT 1 AS "_col_0" FROM (SELECT x.b AS b FROM x) AS "_q_0" WHERE "_q_0".b = 2;
 
+SELECT (SELECT c FROM y WHERE q.b = y.b) FROM (SELECT * FROM x) AS q;
+SELECT (SELECT y.c AS c FROM y WHERE q.b = y.b) AS "_col_0" FROM (SELECT x.b AS b FROM x) AS q;
+
 SELECT a FROM x JOIN (SELECT b, c FROM y) AS z ON x.b = z.b;
 SELECT x.a AS a FROM x JOIN (SELECT y.b AS b FROM y) AS z ON x.b = z.b;
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -7,9 +7,6 @@ SELECT x.a AS a FROM x;
 SELECT a FROM x AS z;
 SELECT z.a AS a FROM x AS z;
 
-SELECT z.a FROM z;
-SELECT z.a AS a FROM z;
-
 SELECT a AS a FROM x;
 SELECT x.a AS a FROM x;
 
@@ -43,8 +40,8 @@ SELECT y.a AS a FROM (SELECT x.a AS a FROM x) AS y;
 SELECT y.a AS a FROM (SELECT x.a AS a FROM x) AS y(a);
 SELECT y.a AS a FROM (SELECT x.a AS a FROM x) AS y;
 
-SELECT y.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x) AS y(c);
-SELECT y.a AS a FROM (SELECT x.a AS c, x.b AS b FROM x) AS y;
+SELECT y.c AS c FROM (SELECT x.a AS a, x.b AS b FROM x) AS y(c);
+SELECT y.c AS c FROM (SELECT x.a AS c, x.b AS b FROM x) AS y;
 
 SELECT a FROM (SELECT a FROM x) y;
 SELECT y.a AS a FROM (SELECT x.a AS a FROM x) AS y;
@@ -94,8 +91,11 @@ SELECT "_q_1".a AS a FROM (SELECT x.a AS a FROM x) AS "_q_1" WHERE "_q_1".a IN (
 --------------------------------------
 -- Correlated subqueries
 --------------------------------------
-SELECT a FROM x WHERE b IN (SELECT c FROM y WHERE y.b = a);
+SELECT a FROM x WHERE b IN (SELECT c FROM y WHERE y.b = x.a);
 SELECT x.a AS a FROM x WHERE x.b IN (SELECT y.c AS c FROM y WHERE y.b = x.a);
+
+SELECT a FROM x WHERE b IN (SELECT b FROM y AS x);
+SELECT x.a AS a FROM x WHERE x.b IN (SELECT x.b AS b FROM y AS x);
 
 --------------------------------------
 -- Expand *

--- a/tests/fixtures/optimizer/qualify_columns__invalid.sql
+++ b/tests/fixtures/optimizer/qualify_columns__invalid.sql
@@ -9,3 +9,4 @@ SELECT a FROM x AS z JOIN y AS z;
 WITH z AS (SELECT * FROM x) SELECT * FROM x AS z;
 SELECT a FROM x JOIN (SELECT b FROM y WHERE y.b = x.c);
 SELECT a FROM x AS y JOIN (SELECT a FROM y) AS q ON y.a = q.a;
+SELECT q.a FROM (SELECT x.b FROM x) AS z JOIN (SELECT a FROM z) AS q ON z.b = q.a;


### PR DESCRIPTION
I had some bugs with correlated subqueries.

I think this is a cleaner way of handling them.

@tobymao This removes "correlated_selectables". I know you need it in your other branch. However, this introduces "is_correlated_subquery", which I think will be better for you.


