### PR TITLE
Allow GROUP BY and ORDER BY to reference output columns

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -219,10 +219,16 @@ class Scope:
         table_name = column.text("table")
         column_name = column.text("this")
 
+        aliased_outputs = {
+            e.alias
+            for e in self.expression.args.get("expressions", [])
+            if isinstance(e, exp.Alias)
+        }
+
         return (
             not table_name
             and column.find_ancestor(exp.Group, exp.Order)
-            and column_name in self.outputs
+            and column_name in aliased_outputs
         )
 
 

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -30,7 +30,7 @@ FROM (
 WHERE
   "d"."a" > 1
 GROUP BY
-  "d"."a";
+  "a";
 SELECT x.a, SUM(y.b)
 FROM x, y
 WHERE

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -30,7 +30,7 @@ FROM (
 WHERE
   "d"."a" > 1
 GROUP BY
-  "a";
+  "d"."a";
 SELECT x.a, SUM(y.b)
 FROM x, y
 WHERE

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -29,7 +29,7 @@ SELECT a + b FROM x;
 SELECT x.a + x.b AS "_col_0" FROM x;
 
 SELECT a, SUM(b) FROM x WHERE a > 1 AND b > 1 GROUP BY a;
-SELECT x.a AS a, SUM(x.b) AS "_col_1" FROM x WHERE x.a > 1 AND x.b > 1 GROUP BY a;
+SELECT x.a AS a, SUM(x.b) AS "_col_1" FROM x WHERE x.a > 1 AND x.b > 1 GROUP BY x.a;
 
 SELECT a AS j, b FROM x ORDER BY j;
 SELECT x.a AS j, x.b AS b FROM x ORDER BY j;
@@ -41,7 +41,7 @@ SELECT a AS a, b FROM x ORDER BY a;
 SELECT x.a AS a, x.b AS b FROM x ORDER BY a;
 
 SELECT a, b FROM x ORDER BY a;
-SELECT x.a AS a, x.b AS b FROM x ORDER BY a;
+SELECT x.a AS a, x.b AS b FROM x ORDER BY x.a;
 
 --------------------------------------
 -- Derived tables

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -29,7 +29,19 @@ SELECT a + b FROM x;
 SELECT x.a + x.b AS "_col_0" FROM x;
 
 SELECT a, SUM(b) FROM x WHERE a > 1 AND b > 1 GROUP BY a;
-SELECT x.a AS a, SUM(x.b) AS "_col_1" FROM x WHERE x.a > 1 AND x.b > 1 GROUP BY x.a;
+SELECT x.a AS a, SUM(x.b) AS "_col_1" FROM x WHERE x.a > 1 AND x.b > 1 GROUP BY a;
+
+SELECT a AS j, b FROM x ORDER BY j;
+SELECT x.a AS j, x.b AS b FROM x ORDER BY j;
+
+SELECT a AS j, b FROM x GROUP BY j;
+SELECT x.a AS j, x.b AS b FROM x GROUP BY j;
+
+SELECT a AS a, b FROM x ORDER BY a;
+SELECT x.a AS a, x.b AS b FROM x ORDER BY a;
+
+SELECT a, b FROM x ORDER BY a;
+SELECT x.a AS a, x.b AS b FROM x ORDER BY a;
 
 --------------------------------------
 -- Derived tables

--- a/tests/fixtures/optimizer/tcp-h.sql
+++ b/tests/fixtures/optimizer/tcp-h.sql
@@ -37,11 +37,11 @@ FROM "lineitem" AS "lineitem"
 WHERE
   "lineitem"."l_shipdate" <= CAST('1998-12-01' AS DATE) - INTERVAL '90' "day"
 GROUP BY
-  "lineitem"."l_returnflag",
-  "lineitem"."l_linestatus"
+  "l_returnflag",
+  "l_linestatus"
 ORDER BY
-  "lineitem"."l_returnflag",
-  "lineitem"."l_linestatus";
+  "l_returnflag",
+  "l_linestatus";
 --------------------------------------
 -- TCP-H 2
 --------------------------------------
@@ -130,35 +130,57 @@ WHERE
   "part"."p_size" = 15
   AND "part"."p_type" LIKE '%BRASS'
 ORDER BY
-  "supplier"."s_acctbal" DESC,
-  "nation"."n_name",
-  "supplier"."s_name",
-  "part"."p_partkey"
+  "s_acctbal" DESC,
+  "n_name",
+  "s_name",
+  "p_partkey"
 LIMIT 100;
 --------------------------------------
 -- TCP-H 3
 --------------------------------------
---select
---        l_orderkey,
---        sum(l_extendedprice * (1 - l_discount)) as revenue,
---        o_orderdate,
---        o_shippriority
---from
---        customer,
---        orders,
---        lineitem
---where
---        c_mktsegment = 'BUILDING'
---        and c_custkey = o_custkey
---        and l_orderkey = o_orderkey
---        and o_orderdate < date '1995-03-15'
---        and l_shipdate > date '1995-03-15'
---group by
---        l_orderkey,
---        o_orderdate,
---        o_shippriority
---order by
---        revenue desc,
---        o_orderdate
---limit
---        10;
+select
+        l_orderkey,
+        sum(l_extendedprice * (1 - l_discount)) as revenue,
+        o_orderdate,
+        o_shippriority
+from
+        customer,
+        orders,
+        lineitem
+where
+        c_mktsegment = 'BUILDING'
+        and c_custkey = o_custkey
+        and l_orderkey = o_orderkey
+        and o_orderdate < date '1995-03-15'
+        and l_shipdate > date '1995-03-15'
+group by
+        l_orderkey,
+        o_orderdate,
+        o_shippriority
+order by
+        revenue desc,
+        o_orderdate
+limit
+        10;
+SELECT
+  "lineitem"."l_orderkey" AS "l_orderkey",
+  SUM("lineitem"."l_extendedprice" * (1 - "lineitem"."l_discount")) AS "revenue",
+  "orders"."o_orderdate" AS "o_orderdate",
+  "orders"."o_shippriority" AS "o_shippriority"
+FROM "customer" AS "customer"
+JOIN "orders" AS "orders"
+  ON "orders"."o_orderdate" < CAST('1995-03-15' AS DATE)
+  AND "lineitem"."l_orderkey" = "orders"."o_orderkey"
+  AND "customer"."c_custkey" = "orders"."o_custkey"
+JOIN "lineitem" AS "lineitem"
+  ON "lineitem"."l_shipdate" > CAST('1995-03-15' AS DATE)
+WHERE
+  "customer"."c_mktsegment" = 'BUILDING'
+GROUP BY
+  "l_orderkey",
+  "o_orderdate",
+  "o_shippriority"
+ORDER BY
+  "revenue" DESC,
+  "o_orderdate"
+LIMIT 10;

--- a/tests/fixtures/optimizer/tcp-h.sql
+++ b/tests/fixtures/optimizer/tcp-h.sql
@@ -37,11 +37,11 @@ FROM "lineitem" AS "lineitem"
 WHERE
   "lineitem"."l_shipdate" <= CAST('1998-12-01' AS DATE) - INTERVAL '90' "day"
 GROUP BY
-  "l_returnflag",
-  "l_linestatus"
+  "lineitem"."l_returnflag",
+  "lineitem"."l_linestatus"
 ORDER BY
-  "l_returnflag",
-  "l_linestatus";
+  "lineitem"."l_returnflag",
+  "lineitem"."l_linestatus";
 --------------------------------------
 -- TCP-H 2
 --------------------------------------
@@ -130,10 +130,10 @@ WHERE
   "part"."p_size" = 15
   AND "part"."p_type" LIKE '%BRASS'
 ORDER BY
-  "s_acctbal" DESC,
-  "n_name",
-  "s_name",
-  "p_partkey"
+  "supplier"."s_acctbal" DESC,
+  "nation"."n_name",
+  "supplier"."s_name",
+  "part"."p_partkey"
 LIMIT 100;
 --------------------------------------
 -- TCP-H 3
@@ -177,10 +177,10 @@ JOIN "lineitem" AS "lineitem"
 WHERE
   "customer"."c_mktsegment" = 'BUILDING'
 GROUP BY
-  "l_orderkey",
-  "o_orderdate",
-  "o_shippriority"
+  "lineitem"."l_orderkey",
+  "orders"."o_orderdate",
+  "orders"."o_shippriority"
 ORDER BY
   "revenue" DESC,
-  "o_orderdate"
+  "orders"."o_orderdate"
 LIMIT 10;


### PR DESCRIPTION
This seems to work.

I'm not too sure what we should for this case though:

```sql
SELECT a, b FROM x ORDER BY a;

-- this PR resolve this to:
SELECT x.a AS a, x.b AS b FROM x ORDER BY a;

-- but maybe it should be?:
SELECT x.a AS a, x.b AS b FROM x ORDER BY x.a;
```