### PR TITLE
feat: column builder

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -388,6 +388,42 @@ class Condition(Expression):
         """
         return not_(self)
 
+    def eq(self, expression, dialect=None, parser_opts=None):
+        """
+        Equals.
+
+        Example:
+            >>> column("a").eq("b").sql()
+            'a = b'
+
+        Returns:
+            EQ: equality operation
+        """
+        return EQ(
+            this=self,
+            expression=_maybe_parse(
+                expression, dialect=dialect, parser_opts=parser_opts
+            ),
+        )
+
+    def neq(self, expression, dialect=None, parser_opts=None):
+        """
+        Not equals.
+
+        Example:
+            >>> column("a").neq("b").sql()
+            'a <> b'
+
+        Returns:
+            NEQ: equality operation
+        """
+        return NEQ(
+            this=self,
+            expression=_maybe_parse(
+                expression, dialect=dialect, parser_opts=parser_opts
+            ),
+        )
+
 
 class DerivedTable:
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2288,6 +2288,19 @@ def column_table_names(expression):
     )
 
 
+def column(col, table=None):
+    """
+    Build a Column.
+
+    Args:
+        col (str or Expression): column name
+        table (str or Expression): table name
+    Returns:
+        Column: column instance
+    """
+    return Column(this=to_identifier(col), table=to_identifier(table))
+
+
 TRUE = Boolean(this=True)
 FALSE = Boolean(this=False)
 NULL = Null()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -350,6 +350,18 @@ class TestBuild(unittest.TestCase):
                 ).select("x"),
                 "SELECT x FROM (SELECT x FROM tbl UNION SELECT x FROM bar) AS unioned",
             ),
+            (
+                lambda: exp.column("x"),
+                "x",
+            ),
+            (
+                lambda: exp.column("x", "a"),
+                "a.x",
+            ),
+            (
+                lambda: exp.column("x.y", "a.b"),
+                '"a.b"."x.y"',
+            ),
         ]:
             with self.subTest(sql):
                 self.assertEqual(expression().sql(dialect[0] if dialect else None), sql)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -362,6 +362,18 @@ class TestBuild(unittest.TestCase):
                 lambda: exp.column("x.y", "a.b"),
                 '"a.b"."x.y"',
             ),
+            (
+                lambda: exp.column("a").eq("b"),
+                "a = b",
+            ),
+            (
+                lambda: exp.column("a").eq(exp.column("b")),
+                "a = b",
+            ),
+            (
+                lambda: exp.column("a").neq("b"),
+                "a <> b",
+            ),
         ]:
             with self.subTest(sql):
                 self.assertEqual(expression().sql(dialect[0] if dialect else None), sql)


### PR DESCRIPTION
I see the a lot in Minerva: `"{table}.{col}"`. That's not safe if either values have dots.

