### PR TITLE
feat(gh-203): Add support for BigQuery.

### DIFF
--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -556,7 +556,7 @@ class BigQuery(Dialect):
         exp.DataType.Type.TINYINT: "INT64",
         exp.DataType.Type.SMALLINT: "INT64",
         exp.DataType.Type.INT: "INT64",
-        exp.DataType.Type.BIGINT: "INT64"
+        exp.DataType.Type.BIGINT: "INT64",
     }
 
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -552,7 +552,12 @@ class Oracle(Dialect):
 
 
 class BigQuery(Dialect):
-    type_mapping = {}
+    type_mapping = {
+        exp.DataType.Type.TINYINT: "INT64",
+        exp.DataType.Type.SMALLINT: "INT64",
+        exp.DataType.Type.INT: "INT64",
+        exp.DataType.Type.BIGINT: "INT64"
+    }
 
 
 class Postgres(Dialect):

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -557,6 +557,10 @@ class BigQuery(Dialect):
         exp.DataType.Type.SMALLINT: "INT64",
         exp.DataType.Type.INT: "INT64",
         exp.DataType.Type.BIGINT: "INT64",
+        exp.DataType.Type.DECIMAL: "NUMERIC",
+        exp.DataType.Type.FLOAT: "FLOAT64",
+        exp.DataType.Type.DOUBLE: "FLOAT64",
+        exp.DataType.Type.BOOLEAN: "BOOL",
     }
 
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -561,6 +561,7 @@ class BigQuery(Dialect):
         exp.DataType.Type.FLOAT: "FLOAT64",
         exp.DataType.Type.DOUBLE: "FLOAT64",
         exp.DataType.Type.BOOLEAN: "BOOL",
+        exp.DataType.Type.TEXT: "STRING",
     }
 
 

--- a/sqlglot/dialects.py
+++ b/sqlglot/dialects.py
@@ -551,6 +551,10 @@ class Oracle(Dialect):
     }
 
 
+class BigQuery(Dialect):
+    type_mapping = {}
+
+
 class Postgres(Dialect):
     strict_cast = False
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -436,6 +436,8 @@ class Tokenizer:
         "TIMESTAMPTZ": TokenType.TIMESTAMPTZ,
         "DATE": TokenType.DATE,
         "UUID": TokenType.UUID,
+        "INT64": TokenType.BIGINT,
+        "FLOAT64": TokenType.DOUBLE,
     }
 
     WHITE_SPACE = {

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -364,6 +364,13 @@ class TestDialects(unittest.TestCase):
             write="bigquery",
         )
 
+        self.validate(
+            "SELECT CAST(`a`.`b` AS TEXT) FROM foo",
+            "SELECT CAST(`a`.`b` AS STRING) FROM foo",
+            read="bigquery",
+            write="bigquery",
+        )
+
     def test_postgres(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -307,6 +307,14 @@ class TestDialects(unittest.TestCase):
             write="starrocks",
         )
 
+    def test_bigquery(self):
+        self.validate(
+            "SELECT CAST(`a`.`b` AS INT) FROM foo",
+            "SELECT CAST(`a`.`b` AS INT) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
     def test_postgres(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -315,6 +315,13 @@ class TestDialects(unittest.TestCase):
         )
 
         self.validate(
+            "SELECT CAST(`a`.`b` AS INT64) FROM foo",
+            "SELECT CAST(`a`.`b` AS BIGINT) FROM foo",
+            read="bigquery",
+            write="duckdb",
+        )
+
+        self.validate(
             "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
             write="bigquery",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -336,6 +336,35 @@ class TestDialects(unittest.TestCase):
             write="bigquery",
         )
 
+        self.validate(
+            "SELECT CAST(`a`.`b` AS DECIMAL) FROM foo",
+            "SELECT CAST(`a`.`b` AS NUMERIC) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+        self.validate(
+            "SELECT CAST(`a`.`b` AS FLOAT) FROM foo",
+            "SELECT CAST(`a`.`b` AS FLOAT64) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+        self.validate(
+            "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",
+            "SELECT CAST(`a`.`b` AS FLOAT64) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+        self.validate(
+            "SELECT CAST(`a`.`b` AS BOOLEAN) FROM foo",
+            "SELECT CAST(`a`.`b` AS BOOL) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+
     def test_postgres(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -312,28 +312,28 @@ class TestDialects(unittest.TestCase):
             "SELECT CAST(`a`.`b` AS INT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS BIGINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS TINYINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
     def test_postgres(self):

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -340,30 +340,29 @@ class TestDialects(unittest.TestCase):
             "SELECT CAST(`a`.`b` AS DECIMAL) FROM foo",
             "SELECT CAST(`a`.`b` AS NUMERIC) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS FLOAT) FROM foo",
             "SELECT CAST(`a`.`b` AS FLOAT64) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",
             "SELECT CAST(`a`.`b` AS FLOAT64) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS BOOLEAN) FROM foo",
             "SELECT CAST(`a`.`b` AS BOOL) FROM foo",
             read="bigquery",
-            write="bigquery"
+            write="bigquery",
         )
-
 
     def test_postgres(self):
         self.validate(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -310,7 +310,28 @@ class TestDialects(unittest.TestCase):
     def test_bigquery(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS INT) FROM foo",
-            "SELECT CAST(`a`.`b` AS INT) FROM foo",
+            "SELECT CAST(`a`.`b` AS INT64) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+        self.validate(
+            "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
+            "SELECT CAST(`a`.`b` AS INT64) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+        self.validate(
+            "SELECT CAST(`a`.`b` AS BIGINT) FROM foo",
+            "SELECT CAST(`a`.`b` AS INT64) FROM foo",
+            read="bigquery",
+            write="bigquery"
+        )
+
+        self.validate(
+            "SELECT CAST(`a`.`b` AS TINYINT) FROM foo",
+            "SELECT CAST(`a`.`b` AS INT64) FROM foo",
             read="bigquery",
             write="bigquery"
         )

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -311,63 +311,54 @@ class TestDialects(unittest.TestCase):
         self.validate(
             "SELECT CAST(`a`.`b` AS INT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS BIGINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS TINYINT) FROM foo",
             "SELECT CAST(`a`.`b` AS INT64) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS DECIMAL) FROM foo",
             "SELECT CAST(`a`.`b` AS NUMERIC) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS FLOAT) FROM foo",
             "SELECT CAST(`a`.`b` AS FLOAT64) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",
             "SELECT CAST(`a`.`b` AS FLOAT64) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS BOOLEAN) FROM foo",
             "SELECT CAST(`a`.`b` AS BOOL) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 
         self.validate(
             "SELECT CAST(`a`.`b` AS TEXT) FROM foo",
             "SELECT CAST(`a`.`b` AS STRING) FROM foo",
-            read="bigquery",
             write="bigquery",
         )
 


### PR DESCRIPTION
# Overview

- Mappings between INT64 and INT, BIGINT, SMALLINT, TINYINT with unit tests
- Mappings between FLOAT64 and FLOAT, DOUBLE with unit tests
- Mappings between NUMERIC and DECIMAL with unit tests
- Mappings between STRING and TEXT with unit tests

Haven't added support for other types of casting (e.g. CHAR/VARCHAR/BYTES/TIMESTAMPTZ) due to additional overhead.

Reference: https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types