### PR TITLE
Introduce ability to calculate changes between two expression trees (diff)

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -1,5 +1,6 @@
 from sqlglot import expressions as exp
 from sqlglot.dialects import Dialect
+from sqlglot.diff import diff
 from sqlglot.errors import ErrorLevel, UnsupportedError, ParseError, TokenError
 from sqlglot.expressions import (
     Expression,

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -142,8 +142,19 @@ class ChangeDistiller:
         leaves_matching_set = self._compute_leaf_matching_set()
         matching_set = leaves_matching_set.copy()
 
-        for source_node_id in self._unmatched_source_nodes.copy():
-            for target_node_id in self._unmatched_target_nodes:
+        ordered_unmatched_source_nodes = {
+            id(n[0]): None
+            for n in self._source.bfs()
+            if id(n[0]) in self._unmatched_source_nodes
+        }
+        ordered_unmatched_target_nodes = {
+            id(n[0]): None
+            for n in self._target.bfs()
+            if id(n[0]) in self._unmatched_target_nodes
+        }
+
+        for source_node_id in ordered_unmatched_source_nodes.keys():
+            for target_node_id in ordered_unmatched_target_nodes.keys():
                 source_node = self._source_index[source_node_id]
                 target_node = self._target_index[target_node_id]
                 if _is_same_label(source_node, target_node):
@@ -174,6 +185,7 @@ class ChangeDistiller:
                         matching_set.add((source_node_id, target_node_id))
                         self._unmatched_source_nodes.remove(source_node_id)
                         self._unmatched_target_nodes.remove(target_node_id)
+                        ordered_unmatched_target_nodes.pop(target_node_id, None)
                         break
 
         return matching_set

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -1,10 +1,15 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from sqlglot.expressions import (
+    Boolean,
+    DataType,
     Expression,
     Identifier,
     Join,
     Literal,
+    Placeholder,
+    Null,
+    Star,
 )
 from sqlglot.helper import ensure_list
 
@@ -76,7 +81,15 @@ def diff(source, target):
     return ChangeDistiller().diff(source, target)
 
 
-LEAF_EXPRESSION_TYPES = (Identifier, Literal)
+LEAF_EXPRESSION_TYPES = (
+    Boolean,
+    DataType,
+    Identifier,
+    Literal,
+    Null,
+    Placeholder,
+    Star,
+)
 
 
 class ChangeDistiller:

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -8,15 +8,19 @@ from sqlglot.expressions import (
     Expression,
     Group,
     Identifier,
+    Join,
     In,
     Literal,
-    Select,
     Table,
     TableAlias,
     With,
 )
 from sqlglot.errors import DiffError
 from sqlglot.helper import ensure_list
+
+
+EXCLUDED_EXPRESSION_TYPES = {Identifier}
+SORT_ARGS_EXPRESSION_TYPES = {Connector, Group, In, With}
 
 
 @dataclass
@@ -35,13 +39,21 @@ class Keep:
     target: Expression
 
 
-def diff(source, target):
+def diff(
+    source,
+    target,
+    excluded_expression_types=None,
+    sort_args_expression_types=None,
+):
     """
     Returns changes between the source and the target expressions.
 
     The underlying logic relies on a variance of the Myers diff algorithm with a custom heuristics for checking
     equality between nodes. Provided the Myers algorithm operates on lists, the source and the target expressions
     are first unfolded into their list representations using the topological order.
+
+    NOTE: this functionality is largely based on heuristics. It does a pretty good job at estimating which AST nodes have
+    been impacted but neither accuracy nor optimality of this estimate are guaranteed. Use it at your own risk.
 
     Examples:
         >>> diff(parse_one("a + b"), parse_one("a + c"))
@@ -60,13 +72,27 @@ def diff(source, target):
 
     Args:
         source (sqlglot.Expression): the source expression.
-        target (sqlglot.Expression): the target expression against which the diff should be calculated.
+        target (sqlglot.Exexcluded_expression_typespression): the target expression against which the diff should be calculated.
+        excluded_expression_types (optional): the set of AST node types which should be excluded from the comparison.
+        sort_args_expression_types (optional): the set of AST node types for which arguments should be sorted. This parameter
+            can be used to tweak the accuracy of the algorithm. For example if a calling code expects the two ASTs to be mostly
+            the same and the position of a majority of nodes is expected to remain unchanged, it may make sense to omit sorting
+            for some nodes.
     Returns:
         the list of Insert, Remove and Keep objects for each node in the source and the target expression trees.
         This list represents a sequence of steps needed to transform the source expression tree into the target one.
     """
-    source_expression_list = _expression_to_list(source)
-    target_expression_list = _expression_to_list(target)
+    if excluded_expression_types is None:
+        excluded_expression_types = EXCLUDED_EXPRESSION_TYPES
+    if sort_args_expression_types is None:
+        sort_args_expression_types = SORT_ARGS_EXPRESSION_TYPES
+
+    source_expression_list = _expression_to_list(
+        source, excluded_expression_types, sort_args_expression_types
+    )
+    target_expression_list = _expression_to_list(
+        target, excluded_expression_types, sort_args_expression_types
+    )
     return _myers_diff(source_expression_list, target_expression_list)
 
 
@@ -121,37 +147,41 @@ def _is_expression_unchanged(source, target):
     if any(_all_same_type(t, source, target) for t in THIS_EQUALS_EXPRESSIONS):
         return source.this == target.this
 
+    if _all_same_type(Join, source, target):
+        return source.args.get("side") == target.args.get("side")
+
     return type(source) is type(target)
 
 
-EXCLUDED_EXPRESSION_TYPES = (Identifier,)
-
-
-def _expression_to_list(expression):
+def _expression_to_list(
+    expression, excluded_expression_types, sort_args_expression_types
+):
     return [
         n[0]
-        for n in _normalize_args_order(expression.copy()).bfs()
-        if not isinstance(n[0], EXCLUDED_EXPRESSION_TYPES)
+        for n in _normalize_args_order(
+            expression.copy(), sort_args_expression_types
+        ).bfs()
+        if not isinstance(n[0], tuple(excluded_expression_types))
     ]
 
 
-def _normalize_args_order(expression):
+def _normalize_args_order(expression, sort_args_expression_types):
     for arg in _expression_only_args(expression):
-        _normalize_args_order(arg)
+        _normalize_args_order(arg, sort_args_expression_types)
 
-    if isinstance(expression, (Group, In, Select, With)):
-        for k, a in expression.args.items():
-            if isinstance(a, list) and all(
-                isinstance(a_item, Expression) for a_item in a
-            ):
-                expression.args[k] = sorted(a, key=Expression.sql)
-    elif isinstance(expression, Connector):
+    if isinstance(expression, Connector) and Connector in sort_args_expression_types:
         unfolded_args = sorted(expression.flatten(), key=Expression.sql)
         folded_args = reduce(
             lambda l, r: type(expression)(this=l, expression=r), unfolded_args[:-1]
         )
         expression.set("this", folded_args)
         expression.set("expression", unfolded_args[-1])
+    elif isinstance(expression, tuple(sort_args_expression_types)):
+        for k, a in expression.args.items():
+            if isinstance(a, list) and all(
+                isinstance(a_item, Expression) for a_item in a
+            ):
+                expression.args[k] = sorted(a, key=Expression.sql)
 
     return expression
 

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -1,0 +1,162 @@
+from dataclasses import dataclass
+from sqlglot.expressions import (
+    Anonymous,
+    Column,
+    Connector,
+    DataType,
+    Expression,
+    Group,
+    Identifier,
+    In,
+    Literal,
+    Select,
+    Table,
+    TableAlias,
+    With,
+)
+from sqlglot.errors import DiffError
+from sqlglot.helper import ensure_list
+
+
+@dataclass
+class Insert:
+    expr: Expression
+
+
+@dataclass
+class Remove:
+    expr: Expression
+
+
+@dataclass
+class Keep:
+    expr_src: Expression
+    expr_tgt: Expression
+
+
+def diff(expr_src, expr_tgt):
+    """
+    Returns changes between the source and the target expressions.
+
+    The underlying logic relies on a variance of the Myers diff algorithm with a custom heuristics for checking
+    equality between nodes. Provided the Myers algorithm operates on lists, the source and the target expressions
+    are first unfolded into their list representations using the topological order.
+
+    Examples:
+        >>> diff(parse_one("a + b"), parse_one("a + c"))
+        [
+            Keep(
+                expr_src=(ADD this: ...),
+                expr_tgt=(ADD this: ...)
+            ),
+            Keep(
+                expr_src=(COLUMN this: (IDENTIFIER this: a, quoted: False)),
+                expr_tgt=(COLUMN this: (IDENTIFIER this: a, quoted: False))
+            ),
+            Remove(expr=(COLUMN this: (IDENTIFIER this: b, quoted: False))),
+            Insert(expr=(COLUMN this: (IDENTIFIER this: c, quoted: False)))
+        ]
+
+    Args:
+        expr_src (sqlglot.Expression): the source expression.
+        expr_tgt (sqlglot.Expression): the target expression against which the diff should be calculated.
+    Returns:
+        the list of Insert, Remove and Keep objects for each node in the source and the target expression trees.
+        This list represents a sequence of steps needed to transform the source expression tree into the target one.
+    """
+    expr_list_src = _expr_to_list(expr_src)
+    expr_list_tgt = _expr_to_list(expr_tgt)
+    return _myers_diff(expr_list_src, expr_list_tgt)
+
+
+def _myers_diff(expr_list_src, expr_list_tgt):
+    front = {1: (0, [])}
+
+    for d in range(0, len(expr_list_src) + len(expr_list_tgt) + 1):
+        for k in range(-d, d + 1, 2):
+            go_down = k == -d or (k != d and front[k - 1][0] < front[k + 1][0])
+
+            if go_down:
+                old_x, history = front[k + 1]
+                x = old_x
+            else:
+                old_x, history = front[k - 1]
+                x = old_x + 1
+            y = x - k
+
+            history = history[:]
+
+            if 1 <= y <= len(expr_list_tgt) and go_down:
+                history.append(Insert(expr_list_tgt[y - 1]))
+            elif 1 <= x <= len(expr_list_src):
+                history.append(Remove(expr_list_src[x - 1]))
+
+            while (
+                x < len(expr_list_src)
+                and y < len(expr_list_tgt)
+                and _is_expr_unchanged(expr_list_src[x], expr_list_tgt[y])
+            ):
+                history.append(Keep(expr_list_src[x], expr_list_tgt[y]))
+                x += 1
+                y += 1
+
+            if x >= len(expr_list_src) and y >= len(expr_list_tgt):
+                return history
+
+            front[k] = x, history
+
+    raise DiffError("Unexpected state")
+
+
+def _is_expr_unchanged(expr_src, expr_tgt):
+    equals_exprs = [Literal, Column, Table, TableAlias]
+    this_equals_exprs = [DataType, Anonymous]
+
+    if any(_all_same_type(t, expr_src, expr_tgt) for t in equals_exprs):
+        return expr_src == expr_tgt
+
+    if any(_all_same_type(t, expr_src, expr_tgt) for t in this_equals_exprs):
+        return expr_src.this == expr_tgt.this
+
+    return type(expr_src) is type(expr_tgt)
+
+
+EXCLUDED_EXPR_TYPES = (Identifier,)
+
+
+def _expr_to_list(expr):
+    return [
+        n[0]
+        for n in _normalize_args_order(expr.copy()).walk()
+        if not isinstance(n[0], EXCLUDED_EXPR_TYPES)
+    ]
+
+
+def _normalize_args_order(expr):
+    for arg in _expression_only_args(expr):
+        _normalize_args_order(arg)
+
+    if isinstance(expr, (Group, In, Select, With)):
+        for k, a in expr.args.items():
+            if isinstance(a, list) and all(
+                isinstance(a_item, Expression) for a_item in a
+            ):
+                expr.args[k] = sorted(a, key=Expression.sql)
+    elif isinstance(expr, Connector):
+        args = [expr.this, expr.args.get("expression")]
+        args = sorted(args, key=Expression.sql)
+        expr.args["this"], expr.args["expression"] = args
+
+    return expr
+
+
+def _expression_only_args(expr):
+    args = []
+    if expr:
+        for a in expr.args.values():
+            args.extend(ensure_list(a))
+    return [a for a in args if isinstance(a, Expression)]
+
+
+def _all_same_type(tpe, *args):
+    return all(isinstance(a, tpe) for a in args)

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -1,17 +1,7 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from sqlglot import Dialect
-from sqlglot.expressions import (
-    Boolean,
-    DataType,
-    Expression,
-    Identifier,
-    Join,
-    Literal,
-    Placeholder,
-    Null,
-    Star,
-)
+from sqlglot import expressions as exp
 from sqlglot.helper import ensure_list
 
 
@@ -19,37 +9,37 @@ from sqlglot.helper import ensure_list
 class Insert:
     """Indicates that a new node has been inserted"""
 
-    expression: Expression
+    expression: exp.Expression
 
 
 @dataclass(frozen=True)
 class Remove:
     """Indicates that an existing node has been removed"""
 
-    expression: Expression
+    expression: exp.Expression
 
 
 @dataclass(frozen=True)
 class Move:
     """Indicates that an existing node's position within the tree has changed"""
 
-    expression: Expression
+    expression: exp.Expression
 
 
 @dataclass(frozen=True)
 class Update:
     """Indicates that an existing node has been updated"""
 
-    source: Expression
-    target: Expression
+    source: exp.Expression
+    target: exp.Expression
 
 
 @dataclass(frozen=True)
 class Keep:
     """Indicates that an existing node hasn't been changed"""
 
-    source: Expression
-    target: Expression
+    source: exp.Expression
+    target: exp.Expression
 
 
 def diff(source, target):
@@ -83,13 +73,13 @@ def diff(source, target):
 
 
 LEAF_EXPRESSION_TYPES = (
-    Boolean,
-    DataType,
-    Identifier,
-    Literal,
-    Null,
-    Placeholder,
-    Star,
+    exp.Boolean,
+    exp.DataType,
+    exp.Identifier,
+    exp.Literal,
+    exp.Null,
+    exp.Placeholder,
+    exp.Star,
 )
 
 
@@ -266,7 +256,7 @@ def _get_leaves(expression):
 
 
 def _is_same_type(source, target):
-    if _all_same_type(Join, source, target):
+    if _all_same_type(exp.Join, source, target):
         return source.args.get("side") == target.args.get("side")
 
     return type(source) is type(target)
@@ -277,7 +267,7 @@ def _expression_only_args(expression):
     if expression:
         for a in expression.args.values():
             args.extend(ensure_list(a))
-    return [a for a in args if isinstance(a, Expression)]
+    return [a for a in args if isinstance(a, exp.Expression)]
 
 
 def _all_same_type(tpe, *args):

--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -27,3 +27,7 @@ class TokenError(SqlglotError):
 
 class OptimizeError(SqlglotError):
     pass
+
+
+class DiffError(Exception):
+    pass

--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -27,7 +27,3 @@ class TokenError(SqlglotError):
 
 class OptimizeError(SqlglotError):
     pass
-
-
-class DiffError(Exception):
-    pass

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -93,8 +93,16 @@ class TestDiff(unittest.TestCase):
 
         self._validate_delta_only(
             diff(
-                parse_one("SELECT a FROM t WHERE b AND c"),
-                parse_one("SELECT a FROM t WHERE c AND b"),
+                parse_one("SELECT a FROM t WHERE b AND c AND d"),
+                parse_one("SELECT a FROM t WHERE d AND b AND c"),
+            ),
+            [],
+        )
+
+        self._validate_delta_only(
+            diff(
+                parse_one("SELECT a FROM t WHERE b OR c OR d"),
+                parse_one("SELECT a FROM t WHERE d OR b OR c"),
             ),
             [],
         )

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -66,6 +66,17 @@ class TestDiff(unittest.TestCase):
             ],
         )
 
+        self._validate_delta_only(
+            diff(
+                parse_one("SELECT aaaa OR bbbb OR cccc"),
+                parse_one("SELECT cccc OR bbbb OR aaaa"),
+            ),
+            [
+                Move(parse_one("aaaa")),  # the Column node
+                Move(parse_one("cccc")),  # the Column node
+            ],
+        )
+
     def test_cte(self):
         expr_src = """
             WITH

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,0 +1,104 @@
+import unittest
+
+from sqlglot import parse_one
+from sqlglot.diff import diff, Insert, Remove, Keep
+from sqlglot.expressions import Identifier, Table
+
+
+class TestDiff(unittest.TestCase):
+    def test_simple(self):
+        self._validate_delta_only(
+            diff(parse_one("SELECT a + b"), parse_one("SELECT a - b")),
+            [
+                Remove(parse_one("a + b")),
+                Insert(parse_one("a - b")),
+            ],
+        )
+
+        self._validate_delta_only(
+            diff(parse_one("SELECT a, b, c"), parse_one("SELECT c, a")),
+            [
+                Remove(parse_one("b")),
+            ],
+        )
+
+        self._validate_delta_only(
+            diff(parse_one("SELECT a, b"), parse_one("SELECT c, b, a")),
+            [
+                Insert(parse_one("c")),
+            ],
+        )
+
+        self._validate_delta_only(
+            diff(
+                parse_one("SELECT a FROM table_one"),
+                parse_one("SELECT a FROM table_two"),
+            ),
+            [
+                Remove(
+                    Table(
+                        this=Identifier(this="table_one", quoted=False),
+                        db=None,
+                        catalog=None,
+                    )
+                ),
+                Insert(
+                    Table(
+                        this=Identifier(this="table_two", quoted=False),
+                        db=None,
+                        catalog=None,
+                    )
+                ),
+            ],
+        )
+
+    def test_cte(self):
+        expr_src = """
+            WITH
+                cte1 AS (SELECT a, b, LOWER(c) AS c FROM table_one WHERE d = 'filter'),
+                cte2 AS (SELECT d, e, f FROM table_two)
+            SELECT a, b, d, e FROM cte1 JOIN cte2 ON f = c
+        """
+        expr_tgt = """
+            WITH
+                cte2 AS (SELECT d, e, f FROM table_two),
+                cte1 AS (SELECT a, b, c FROM table_one WHERE d = 'different_filter')
+            SELECT a, b, d, e FROM cte1 JOIN cte2 ON f = c
+        """
+
+        self._validate_delta_only(
+            diff(parse_one(expr_src), parse_one(expr_tgt)),
+            [
+                Remove(parse_one("LOWER(c) AS c")),
+                Insert(parse_one("c")),
+                Remove(parse_one("LOWER(c)")),
+                Remove(parse_one("c")),
+                Remove(parse_one("'filter'")),
+                Insert(parse_one("'different_filter'")),
+            ],
+        )
+
+    def test_no_delta(self):
+        self._validate_delta_only(
+            diff(parse_one("SELECT a, b, c"), parse_one("SELECT c, b, a")), []
+        )
+
+        self._validate_delta_only(
+            diff(
+                parse_one("SELECT a FROM t WHERE b IN (1, 2, 3)"),
+                parse_one("SELECT a FROM t WHERE b IN (3, 2, 1)"),
+            ),
+            [],
+        )
+
+        self._validate_delta_only(
+            diff(
+                parse_one("SELECT a FROM t WHERE b AND c"),
+                parse_one("SELECT a FROM t WHERE c AND b"),
+            ),
+            [],
+        )
+
+    def _validate_delta_only(self, actual_diff, expected_delta):
+        actual_delta = [d for d in actual_diff if not isinstance(d, Keep)]
+        self.assertEqual(actual_delta, expected_delta)


### PR DESCRIPTION
Previous:

> The implementation relies on a variance of the Myers algorithm with additional heuristics. To apply the Myers algorithm both input expression trees are first unfolded into their list representation using the topological order. 
> 
> To make the output cleaner we apply the following heuristics when checking the equality of individual nodes:
> 1. If both nodes are a `Column`, `Literal`, `Table` or `TableAlias` we do full equality check.
> 2. For `Anonymous` and `DataType` nodes we only check the "this" attribute for equality.
> 3. For all other nodes we only check whether they have a matching type. 
> 
> Thus if the number of arguments changed for a particular node the algorithm doesn't interpret this as a change to this particular node. Instead we expect this change to be captured in children nodes.
> 
> Additionally to make the algorithm's output more stable and predictable we sort the arguments for node types for which the order of arguments doesn't impact semantics. Such node types include `Select` (eg. the list of projections and group by), `In`, `With`, `And` and `Or`. This detail does positively impact the algorithm's behavior, but I'm open to feedback if you think that it makes the algorithm less "correct".


The implementation of the Change Distiller algorithm described by Beat Fluri and Martin Pinzger in their paper https://ieeexplore.ieee.org/document/4339230, which in turn is based on the algorithm by Chawathe et al. described in http://ilpubs.stanford.edu:8090/115/1/1995-46.pdf.
