### PR TITLE
Add support for Spark's filter function

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -121,9 +121,7 @@ class Presto(Dialect):
 
     class Tokenizer(Tokenizer):
         KEYWORDS = {
-            k: v
-            for k, v in Tokenizer.KEYWORDS.items()
-            if v != TokenType.FILTER
+            k: v for k, v in Tokenizer.KEYWORDS.items() if v != TokenType.FILTER
         }
 
     class Parser(Parser):

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -118,12 +118,6 @@ class Presto(Dialect):
     index_offset = 1
     time_format = "'%Y-%m-%d %H:%i:%S'"
     time_mapping = MySQL.time_mapping
-
-    class Tokenizer(Tokenizer):
-        KEYWORDS = {
-            k: v for k, v in Tokenizer.KEYWORDS.items() if v != TokenType.FILTER
-        }
-
     class Parser(Parser):
         FUNCTIONS = {
             **Parser.FUNCTIONS,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -23,9 +23,7 @@ def _map_sql(self, expression):
 class Spark(Hive):
     class Tokenizer(Hive.Tokenizer):
         KEYWORDS = {
-            k: v
-            for k, v in Hive.Tokenizer.KEYWORDS.items()
-            if v != TokenType.FILTER
+            k: v for k, v in Hive.Tokenizer.KEYWORDS.items() if v != TokenType.FILTER
         }
 
     class Parser(Hive.Parser):

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -21,11 +21,6 @@ def _map_sql(self, expression):
 
 
 class Spark(Hive):
-    class Tokenizer(Hive.Tokenizer):
-        KEYWORDS = {
-            k: v for k, v in Hive.Tokenizer.KEYWORDS.items() if v != TokenType.FILTER
-        }
-
     class Parser(Hive.Parser):
         FUNCTIONS = {
             **Hive.Parser.FUNCTIONS,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -2,6 +2,7 @@ from sqlglot import exp
 from sqlglot.dialects.dialect import rename_func
 from sqlglot.dialects.hive import Hive, HiveMap
 from sqlglot.helper import list_get
+from sqlglot.tokens import TokenType
 
 
 def _create_sql(self, e):
@@ -20,9 +21,17 @@ def _map_sql(self, expression):
 
 
 class Spark(Hive):
+    class Tokenizer(Hive.Tokenizer):
+        KEYWORDS = {
+            k: v
+            for k, v in Hive.Tokenizer.KEYWORDS.items()
+            if v != TokenType.FILTER
+        }
+
     class Parser(Hive.Parser):
         FUNCTIONS = {
             **Hive.Parser.FUNCTIONS,
+            "FILTER": exp.ArrayFilter.from_arg_list,
             "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
             "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
             "LEFT": lambda args: exp.Substring(
@@ -57,12 +66,12 @@ class Spark(Hive):
                 for k, v in Hive.Generator.TRANSFORMS.items()
                 if k not in {exp.ArraySort}
             },
+            exp.ArrayFilter: rename_func("FILTER"),
             exp.ArraySum: lambda self, e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.Hint: lambda self, e: f" /*+ {self.expressions(e).strip()} */",
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.Create: _create_sql,
             exp.Map: _map_sql,
             exp.Reduce: rename_func("AGGREGATE"),
-            exp.ArrayFilter: rename_func("FILTER"),
             HiveMap: _map_sql,
         }

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -63,5 +63,6 @@ class Spark(Hive):
             exp.Create: _create_sql,
             exp.Map: _map_sql,
             exp.Reduce: rename_func("AGGREGATE"),
+            exp.ArrayFilter: rename_func("FILTER"),
             HiveMap: _map_sql,
         }

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1025,6 +1025,19 @@ class TestDialects(unittest.TestCase):
             write="presto",
         )
 
+        self.validate(
+            "ARRAY_FILTER(the_array, x -> x > 0)",
+            "FILTER(the_array, x -> x > 0)",
+            write="presto",
+        )
+
+        self.validate(
+            "FILTER(the_array, x -> x > 0)",
+            "ARRAY_FILTER(the_array, x -> x > 0)",
+            read="presto",
+            identity=False,
+        )
+
     def test_hive(self):
         sql = transpile('SELECT "a"."b" FROM "foo"', write="hive")[0]
         self.assertEqual(sql, "SELECT `a`.`b` FROM `foo`")
@@ -1554,6 +1567,13 @@ class TestDialects(unittest.TestCase):
             "ARRAY_FILTER(the_array, x -> x > 0)",
             "FILTER(the_array, x -> x > 0)",
             write="spark",
+        )
+
+        self.validate(
+            "FILTER(the_array, x -> x > 0)",
+            "ARRAY_FILTER(the_array, x -> x > 0)",
+            read="spark",
+            identity=False,
         )
 
     def test_snowflake(self):

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1550,6 +1550,12 @@ class TestDialects(unittest.TestCase):
             write="hive",
         )
 
+        self.validate(
+            "ARRAY_FILTER(the_array, x -> x > 0)",
+            "FILTER(the_array, x -> x > 0)",
+            write="spark",
+        )
+
     def test_snowflake(self):
         self.validate(
             'x:a:"b c"',


### PR DESCRIPTION
`ARRAY_FILTER` is called `FILTER` in spark. So I did a rename in the generator for Spark so it refers to the function correctly. 