### PR TITLE
Use date_diff in duckdb

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -64,7 +64,7 @@ class DuckDB(Dialect):
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySum: rename_func("LIST_SUM"),
             exp.DateAdd: _date_add,
-            exp.DateDiff: lambda self, e: f"{self.sql(e, 'this')} - {self.sql(e, 'expression')}",
+            exp.DateDiff: lambda self, e: f"""DATE_DIFF({self.sql(e, 'unit') or "'day'"}, {self.sql(e, 'expression')}, {self.sql(e, 'this')})""",
             exp.DateStrToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE)",
             exp.DateToDateStr: lambda self, e: f"STRFTIME({self.sql(e, 'this')}, {DuckDB.date_format})",
             exp.DateToDi: lambda self, e: f"CAST(STRFTIME({self.sql(e, 'this')}, {DuckDB.dateint_format}) AS INT)",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -102,7 +102,7 @@ class TestDialects(unittest.TestCase):
 
         self.validate(
             "DATEDIFF(a, b)",
-            "CAST(a AS DATE) - CAST(b AS DATE)",
+            "DATE_DIFF('day', CAST(b AS DATE), CAST(a AS DATE))",
             read="hive",
             write="duckdb",
         )
@@ -686,6 +686,19 @@ class TestDialects(unittest.TestCase):
             "DATE_DIFF(a, b)",
             "DATE_DIFF('day', b, a)",
             write="presto",
+            identity=False,
+        )
+        self.validate(
+            "DATE_DIFF(a, b)",
+            "DATE_DIFF('day', b, a)",
+            write="duckdb",
+            identity=False,
+        )
+        self.validate(
+            "DATE_DIFF('month', b, a)",
+            "DATE_DIFF('month', b, a)",
+            read="presto",
+            write="duckdb",
             identity=False,
         )
         self.validate(


### PR DESCRIPTION
Duckdb dialect transpiles `DATE_DIFF` to `DATE_0 - DATE_1` which is an interval

`DATE_DIFF` exists in duckdb: https://duckdb.org/docs/sql/functions/date and returns an int as expected
