### PR TITLE
Fix bug with parenthesis on single lambda variable

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -503,7 +503,7 @@ class Generator:
 
     def lambda_sql(self, expression):
         args = self.expressions(expression, flat=True)
-        args = f"({args})" if len(args) > 1 else args
+        args = f"({args})" if len(args.split(",")) > 1 else args
         return self.no_identify(lambda: f"{args} -> {self.sql(expression, 'this')}")
 
     def lateral_sql(self, expression):

--- a/tests/fixtures/optimizer/tpc-h/tpc-h.sql
+++ b/tests/fixtures/optimizer/tpc-h/tpc-h.sql
@@ -1724,9 +1724,9 @@ JOIN (
 WHERE
   (
     "_u_2"."l_orderkey" IS NULL
-    OR NOT ARRAY_ANY("_u_2"."_u_3", ("_x") -> "_x" <> "l1"."l_suppkey")
+    OR NOT ARRAY_ANY("_u_2"."_u_3", "_x" -> "_x" <> "l1"."l_suppkey")
   )
-  AND ARRAY_ANY("_u_0"."_u_1", ("_x") -> "_x" <> "l1"."l_suppkey")
+  AND ARRAY_ANY("_u_0"."_u_1", "_x" -> "_x" <> "l1"."l_suppkey")
   AND NOT "_u_0"."l_orderkey" IS NULL
 GROUP BY
   "s_name"

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -147,7 +147,7 @@ WHERE
     AND NOT "_u_8".a IS NULL
   )
   AND (
-    ARRAY_ANY("_u_9".a, (_x) -> _x = x.a)
+    ARRAY_ANY("_u_9".a, _x -> _x = x.a)
     AND NOT "_u_9"."_u_10" IS NULL
   )
   AND (
@@ -158,7 +158,7 @@ WHERE
       )
       AND NOT "_u_11"."_u_12" IS NULL
     )
-    AND ARRAY_ANY("_u_11"."_u_13", ("_x") -> "_x" <> x.d)
+    AND ARRAY_ANY("_u_11"."_u_13", "_x" -> "_x" <> x.d)
   )
   AND (
     NOT "_u_14".a IS NULL

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1513,7 +1513,7 @@ class TestDialects(unittest.TestCase):
         )
         self.validate(
             "REDUCE(x, 0, (acc, x) -> acc + x, acc -> acc)",
-            "AGGREGATE(x, 0, (acc, x) -> acc + x, (acc) -> acc)",
+            "AGGREGATE(x, 0, (acc, x) -> acc + x, acc -> acc)",
             write="spark",
         )
 


### PR DESCRIPTION
It looks like the code originally intended to have this behavior but was doing a length check on a string when it looks like the author thought it was a list. I confirmed that Spark and Presto prefer this syntax.