### PR TITLE
[WIP] Spark only struct support

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -3,7 +3,7 @@ from sqlglot.generator import Generator
 from sqlglot.helper import csv, list_get
 from sqlglot.parser import Parser
 from sqlglot.time import format_time
-from sqlglot.tokens import Tokenizer
+from sqlglot.tokens import Tokenizer, TokenType
 from sqlglot.trie import new_trie
 
 
@@ -43,6 +43,10 @@ class Dialect(metaclass=_Dialect):
     index_offset = 0
     unnest_column_only = False
     alias_post_tablesample = False
+    struct_type_name_type_seperator_token = None
+    struct_type_name_type_seperator_char = None
+    struct_start_end_tokens = (TokenType.LT, TokenType.GT)
+    struct_start_end_chars = ("<", ">")
 
     date_format = "'%Y-%m-%d'"
     dateint_format = "'%Y%m%d'"
@@ -108,6 +112,8 @@ class Dialect(metaclass=_Dialect):
                 "index_offset": self.index_offset,
                 "unnest_column_only": self.unnest_column_only,
                 "alias_post_tablesample": self.alias_post_tablesample,
+                "struct_start_end_tokens": self.struct_start_end_tokens,
+                "struct_type_name_type_seperator_token": self.struct_type_name_type_seperator_token,
                 **opts,
             },
         )
@@ -124,6 +130,8 @@ class Dialect(metaclass=_Dialect):
                 "time_trie": self.inverse_time_trie,
                 "unnest_column_only": self.unnest_column_only,
                 "alias_post_tablesample": self.alias_post_tablesample,
+                "struct_start_end_chars": self.struct_start_end_chars,
+                "struct_type_name_type_seperator_char": self.struct_type_name_type_seperator_char,
                 **opts,
             }
         )

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -14,7 +14,7 @@ from sqlglot.dialects.dialect import (
 from sqlglot.generator import Generator
 from sqlglot.helper import csv, list_get
 from sqlglot.parser import Parser
-from sqlglot.tokens import Tokenizer
+from sqlglot.tokens import Tokenizer, TokenType
 
 
 def _parse_map(args):
@@ -147,6 +147,8 @@ class Hive(Dialect):
     identifier = "`"
     escape = "\\"
     alias_post_tablesample = True
+    struct_type_name_type_seperator_token = TokenType.COLON
+    struct_type_name_type_seperator_char = ":"
 
     time_mapping = {
         "y": "%Y",

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -12,6 +12,7 @@ from sqlglot.dialects.mysql import MySQL
 from sqlglot.generator import Generator
 from sqlglot.helper import csv, list_get
 from sqlglot.parser import Parser
+from sqlglot.tokens import TokenType
 
 
 def _approx_distinct_sql(self, expression):
@@ -116,8 +117,12 @@ class Presto(Dialect):
     index_offset = 1
     time_format = "'%Y-%m-%d %H:%i:%S'"
     time_mapping = MySQL.time_mapping
+    struct_start_end_tokens = (TokenType.L_PAREN, TokenType.R_PAREN)
+    struct_start_end_chars = ("(", ")")
 
     class Parser(Parser):
+        TYPE_TOKENS = {v for v in Parser.TYPE_TOKENS}.union({TokenType.ROWS})
+
         FUNCTIONS = {
             **Parser.FUNCTIONS,
             "APPROX_DISTINCT": exp.ApproxDistinct.from_arg_list,
@@ -147,6 +152,7 @@ class Presto(Dialect):
             exp.DataType.Type.BINARY: "VARBINARY",
             exp.DataType.Type.TEXT: "VARCHAR",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
+            exp.DataType.Type.STRUCT: "ROW",
         }
 
         TRANSFORMS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1447,6 +1447,7 @@ class DataType(Expression):
         ARRAY = auto()
         MAP = auto()
         UUID = auto()
+        STRUCT = auto()
 
     @classmethod
     def build(cls, dtype, **kwargs):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1423,7 +1423,9 @@ class DataType(Expression):
     arg_types = {
         "this": True,
         "expressions": False,
-        "nested": False,
+        "is_unnamed_nested": False,
+        "is_named_nested": False,
+        "name": None,
     }
 
     class Type(AutoName):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -315,6 +315,9 @@ class Generator:
     def datatype_sql(self, expression):
         type_value = expression.this
         type_sql = self.TYPE_MAPPING.get(type_value, type_value.value)
+        name = expression.args.get("name")
+        if name:
+            type_sql = f"{name}:{type_sql}"
         nested = ""
         interior = self.expressions(expression, flat=True)
         if interior:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -188,6 +188,7 @@ class TokenType(AutoName):
     SHOW = auto()
     SOME = auto()
     STORED = auto()
+    STRUCT = auto()
     TABLE_SAMPLE = auto()
     TEMPORARY = auto()
     TIME = auto()
@@ -486,6 +487,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "DATE": TokenType.DATE,
         "DATETIME": TokenType.DATETIME,
         "UNIQUE": TokenType.UNIQUE,
+        "STRUCT": TokenType.STRUCT,
     }
 
     WHITE_SPACE = {

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -425,6 +425,36 @@ class TestDialects(unittest.TestCase):
             read="bigquery",
         )
 
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:string>)",
+            "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a INT64, struct_col_b STRING>)",
+            read="spark",
+            write="bigquery",
+        )
+
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:struct<nested_col_a:string, nested_col_b:string>>)",
+            "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a INT64, struct_col_b STRUCT<nested_col_a STRING, nested_col_b STRING>>)",
+            read="spark",
+            write="bigquery",
+        )
+
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a int64, struct_col_b string>)",
+            "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a INT64, struct_col_b STRING>)",
+            read="bigquery",
+            write="bigquery",
+        )
+
+        # Known bug
+        # self.validate(
+        #     "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a INT64, struct_col_b STRUCT<nested_col_a STRING, nested_col_b STRING>>)",
+        #     "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a INT64, struct_col_b STRUCT<nested_col_a STRING, nested_col_b STRING>>)",
+        #     read="bigquery",
+        #     write="bigquery",
+        # )
+
+
     def test_postgres(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",
@@ -1077,6 +1107,34 @@ class TestDialects(unittest.TestCase):
             read="presto",
             identity=False,
         )
+
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:string>)",
+            "CREATE TABLE db.example_table (col_a ROW(struct_col_a INTEGER, struct_col_b VARCHAR))",
+            read="spark",
+            write="presto",
+        )
+
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:struct<nested_col_a:string, nested_col_b:string>>)",
+            "CREATE TABLE db.example_table (col_a ROW(struct_col_a INTEGER, struct_col_b ROW(nested_col_a VARCHAR, nested_col_b VARCHAR)))",
+            read="spark",
+            write="presto",
+        )
+
+        # self.validate(
+        #     "CREATE TABLE db.example_table (col_a ROW(struct_col_a INTEGER, struct_col_b VARCHAR))",
+        #     "CREATE TABLE db.example_table (col_a ROW(struct_col_a INTEGER, struct_col_b VARCHAR))",
+        #     read="presto",
+        #     write="presto",
+        # )
+        #
+        # self.validate(
+        #     "CREATE TABLE db.example_table (col_a ROW(struct_col_a INTEGER, struct_col_b ROW(nested_col_a VARCHAR, nested_col_b VARCHAR)))",
+        #     "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a INTEGER, struct_col_b STRUCT<nested_col_a VARCHAR, nested_col_b VARCHAR>>)",
+        #     read="presto",
+        #     write="presto",
+        # )
 
     def test_hive(self):
         sql = transpile('SELECT "a"."b" FROM "foo"', write="hive")[0]

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1635,6 +1635,55 @@ class TestDialects(unittest.TestCase):
             write="presto",
         )
 
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:string>)",
+            "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a:INT, struct_col_b:STRING>)",
+            read="spark",
+            write="spark",
+        )
+
+        self.validate(
+            "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:struct<nested_col_a:string, nested_col_b:string>>)",
+            "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a:INT, struct_col_b:STRUCT<nested_col_a:STRING, nested_col_b:STRING>>)",
+            read="spark",
+            write="spark",
+        )
+
+        self.validate(
+            "CREATE TABLE db.example_table (col_a array<int>)",
+            "CREATE TABLE db.example_table (col_a ARRAY<INT>)",
+            read="spark",
+            write="spark",
+        )
+
+        self.validate(
+            "SELECT 4 << 1",
+            "SELECT SHIFTLEFT(4, 1)",
+            read="hive",
+            write="spark",
+        )
+
+        self.validate(
+            "SELECT 4 >> 1",
+            "SELECT SHIFTRIGHT(4, 1)",
+            read="hive",
+            write="spark",
+        )
+
+        self.validate(
+            "SELECT SHIFTRIGHT(4, 1)",
+            "SELECT 4 >> 1",
+            read="spark",
+            write="hive",
+        )
+
+        self.validate(
+            "SELECT SHIFTLEFT(4, 1)",
+            "SELECT 4 << 1",
+            read="spark",
+            write="hive",
+        )
+
     def test_snowflake(self):
         self.validate(
             'x:a:"b c"',


### PR DESCRIPTION
Change to support struct data types for Spark only. BigQuery uses a similar syntax to spark but with a space instead of colon to separate the name and type. Presto is similar to BigQuery syntax but uses the term `ROW` instead of struct. Support for those dialects still needs to be implemented. I'm open to adding it but I need to at least stop here to unblock some work I am currently doing. 