### PR TITLE
Support for Snowflake TO_TIMESTAMP function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -15,10 +15,8 @@ def _check_int(s):
 
 # from https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html
 def _snowflake_to_timestamp(args):
-    args_num = len(args)
-    if args_num == 2:
-        first_arg = list_get(args, 0)
-        second_arg = list_get(args, 1)
+    if len(args) == 2:
+        first_arg, second_arg = args
         if first_arg.is_string:
             # case: <string_expr> [ , <format> ]
             return format_time_lambda(exp.StrToTime, "snowflake")
@@ -39,13 +37,13 @@ def _snowflake_to_timestamp(args):
 
         return _convert_time_scale_and_run
 
-    arg = list_get(args, 0)
-    if not isinstance(arg, Literal):
+    first_arg = list_get(args, 0)
+    if not isinstance(first_arg, Literal):
         # case: <variant_expr>
         return format_time_lambda(exp.StrToTime, "snowflake", default=True)
 
-    if arg.is_string:
-        if _check_int(arg.this):
+    if first_arg.is_string:
+        if _check_int(first_arg.this):
             # case: <integer>
             return exp.UnixToTime.from_arg_list
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -52,7 +52,7 @@ def _snowflake_to_timestamp(args):
     return exp.UnixToTime.from_arg_list
 
 class Snowflake(Dialect):
-    time_format = "'%Y-%m-%d %H:%I:%S.%f'"
+    time_format = "'yyyy-mm-dd hh24:mi:ss'"
 
     time_mapping = {
         "YYYY": "%Y",
@@ -64,7 +64,7 @@ class Snowflake(Dialect):
         "MON": "%b",
         "mon": "%b",
         "MM": "%m",
-        "%mm": "%m",
+        "mm": "%m",
         "DD": "%d",
         "dd": "%d",
         "d": "%-d",
@@ -102,6 +102,6 @@ class Snowflake(Dialect):
     class Generator(Generator):
         TRANSFORMS = {
             **Generator.TRANSFORMS,
-            exp.StrToTime: rename_func("TO_TIMESTAMP"),
+            exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.UnixToTime: rename_func("TO_TIMESTAMP"),
         }

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -6,10 +6,12 @@ from sqlglot.parser import Parser
 from sqlglot.tokens import Tokenizer, TokenType
 from sqlglot.generator import Generator
 
+
 def _check_int(s):
-    if s[0] in ('-', '+'):
+    if s[0] in ("-", "+"):
         return s[1:].isdigit()
     return s.isdigit()
+
 
 # from https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html
 def _snowflake_to_timestamp(args):
@@ -22,13 +24,15 @@ def _snowflake_to_timestamp(args):
             return format_time_lambda(exp.StrToTime, "snowflake")
 
         # case: <numeric_expr> [ , <scale> ]
-        if second_arg.this not in ['0', '3', '9']:
-            raise ValueError(f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9")
+        if second_arg.this not in ["0", "3", "9"]:
+            raise ValueError(
+                f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9"
+            )
 
         def _convert_time_scale_and_run(args):
             conv_args = []
             exponent = int(list_get(args, 1).this)
-            retval = int(int(list_get(args, 0).this) / (10 ** exponent))
+            retval = int(int(list_get(args, 0).this) / (10**exponent))
             conv_args.append(str(retval))
             args[:] = args[:1]
             return exp.UnixToTime.from_arg_list(conv_args)
@@ -50,6 +54,7 @@ def _snowflake_to_timestamp(args):
 
     # case: <numeric_expr>
     return exp.UnixToTime.from_arg_list
+
 
 class Snowflake(Dialect):
     time_format = "'yyyy-mm-dd hh24:mi:ss'"
@@ -81,14 +86,14 @@ class Snowflake(Dialect):
         "FF": "%f",
         "ff": "%f",
         "FF6": "%f",
-        "ff6": "%f"
+        "ff6": "%f",
     }
 
     class Parser(Parser):
         FUNCTIONS = {
             **Parser.FUNCTIONS,
             "IFF": exp.If.from_arg_list,
-            "TO_TIMESTAMP": lambda args: _snowflake_to_timestamp(args)(args)
+            "TO_TIMESTAMP": lambda args: _snowflake_to_timestamp(args)(args),
         }
 
     class Tokenizer(Tokenizer):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -89,6 +89,7 @@ class Snowflake(Dialect):
 
         FUNCTIONS = {
             **Parser.FUNCTIONS,
+            "IFF": exp.If.from_arg_list,
             "TO_TIMESTAMP": lambda args: _snowflake_to_timestamp(args)(args)
         }
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1,9 +1,10 @@
 from sqlglot import exp
-from sqlglot.dialects.dialect import Dialect, format_time_lambda
+from sqlglot.dialects.dialect import Dialect, format_time_lambda, rename_func
 from sqlglot.expressions import Literal
 from sqlglot.helper import list_get
 from sqlglot.parser import Parser
 from sqlglot.tokens import Tokenizer, TokenType
+from sqlglot.generator import Generator
 
 def _check_int(s):
     if s[0] in ('-', '+'):
@@ -96,4 +97,11 @@ class Snowflake(Dialect):
             **Tokenizer.KEYWORDS,
             "QUALIFY": TokenType.QUALIFY,
             "DOUBLE PRECISION": TokenType.DOUBLE,
+        }
+
+    class Generator(Generator):
+        TRANSFORMS = {
+            **Generator.TRANSFORMS,
+            exp.StrToTime: rename_func("TO_TIMESTAMP"),
+            exp.UnixToTime: rename_func("TO_TIMESTAMP"),
         }

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -82,7 +82,6 @@ class Snowflake(Dialect):
         "ff": "%f",
         "FF6": "%f",
         "ff6": "%f"
-        # TODO: Snowflake also supports variable precisions FF0...FF9, but unclear how to support in Python
     }
 
     class Parser(Parser):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -104,6 +104,7 @@ class Snowflake(Dialect):
     class Generator(Generator):
         TRANSFORMS = {
             **Generator.TRANSFORMS,
+            exp.If: rename_func("IFF"),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.UnixToTime: rename_func("TO_TIMESTAMP"),
         }

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -29,7 +29,7 @@ def _snowflake_to_timestamp(args):
 
         timestamp = int(first_arg.name)
         scale = int(second_arg.name)
-        return exp.UnixToTime(this=str(int(int(timestamp) / (10 ** int(scale)))))
+        return exp.UnixToTime(this=str(timestamp // (10**scale)))
 
     first_arg = list_get(args, 0)
     if not isinstance(first_arg, Literal):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1,11 +1,96 @@
-from sqlglot.dialects.dialect import Dialect
+from sqlglot import exp
+from sqlglot.dialects.dialect import Dialect, format_time_lambda
+from sqlglot.expressions import Literal
+from sqlglot.helper import list_get
 from sqlglot.parser import Parser
 from sqlglot.tokens import Tokenizer, TokenType
 
+def _check_int(s):
+    if s[0] in ('-', '+'):
+        return s[1:].isdigit()
+    return s.isdigit()
+
+# from https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html
+def _snowflake_to_timestamp(args):
+    args_num = len(args)
+    if args_num == 2:
+        first_arg = list_get(args, 0)
+        second_arg = list_get(args, 1)
+        if first_arg.is_string:
+            # case: <string_expr> [ , <format> ]
+            return format_time_lambda(exp.StrToTime, "snowflake")
+
+        # case: <numeric_expr> [ , <scale> ]
+        if second_arg.this not in ['0', '3', '9']:
+            raise ValueError(f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9")
+
+        def _convert_time_scale_and_run(args):
+            conv_args = []
+            exponent = int(list_get(args, 1).this)
+            retval = int(list_get(args, 0).this) / (10 ** exponent)
+            conv_args.append(str(retval))
+            args[:] = args[:1]
+            return exp.UnixToTime.from_arg_list(conv_args)
+
+        return _convert_time_scale_and_run
+
+    arg = list_get(args, 0)
+    if not isinstance(arg, Literal):
+        # case: <variant_expr>
+        return format_time_lambda(exp.StrToTime, "snowflake", default=True)
+
+    if arg.is_string:
+        if _check_int(arg.this):
+            # case: <integer>
+            return exp.UnixToTime.from_arg_list
+
+        # case: <date_expr>
+        return format_time_lambda(exp.StrToTime, "snowflake", default=True)
+
+    # case: <numeric_expr>
+    return exp.UnixToTime.from_arg_list
 
 class Snowflake(Dialect):
+    time_format = "'%Y-%m-%d %H:%I:%S.%f'"
+
+    time_mapping = {
+        "YYYY": "%Y",
+        "yyyy": "%Y",
+        "YY": "%y",
+        "yy": "%y",
+        "MMMM": "%B",
+        "mmmm": "%B",
+        "MON": "%b",
+        "mon": "%b",
+        "MM": "%m",
+        "%mm": "%m",
+        "DD": "%d",
+        "dd": "%d",
+        "d": "%-d",
+        "DY": "%w",
+        "dy": "%w",
+        "HH24": "%H",
+        "hh24": "%H",
+        "HH12": "%I",
+        "hh12": "%I",
+        "MI": "%M",
+        "mi": "%M",
+        "SS": "%S",
+        "ss": "%S",
+        "FF": "%f",
+        "ff": "%f",
+        "FF6": "%f",
+        "ff6": "%f"
+        # TODO: Snowflake also supports variable precisions FF0...FF9, but unclear how to support in Python
+    }
+
     class Parser(Parser):
         COLUMN_OPERATORS = Parser.COLUMN_OPERATORS | {TokenType.COLON}
+
+        FUNCTIONS = {
+            **Parser.FUNCTIONS,
+            "TO_TIMESTAMP": lambda args: _snowflake_to_timestamp(args)(args)
+        }
 
     class Tokenizer(Tokenizer):
         KEYWORDS = {

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -28,10 +28,10 @@ def _snowflake_to_timestamp(args):
             )
 
         def _convert_time_scale_and_run(args):
-            conv_args = []
-            exponent = int(list_get(args, 1).this)
-            retval = int(int(list_get(args, 0).this) / (10**exponent))
-            conv_args.append(str(retval))
+            timestamp = int(first_arg.name)
+            scale = int(second_arg.name)
+            retval = int(timestamp / (10**scale))
+            conv_args = [str(retval)]
             args[:] = args[:1]
             return exp.UnixToTime.from_arg_list(conv_args)
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -51,6 +51,7 @@ def _snowflake_to_timestamp(args):
 class Snowflake(Dialect):
     time_format = "'yyyy-mm-dd hh24:mi:ss'"
 
+    # pylint: disable=duplicate-code
     time_mapping = {
         "YYYY": "%Y",
         "yyyy": "%Y",
@@ -80,6 +81,7 @@ class Snowflake(Dialect):
         "FF6": "%f",
         "ff6": "%f",
     }
+    # pylint: enable=duplicate-code
 
     class Parser(Parser):
         FUNCTIONS = {

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -85,8 +85,6 @@ class Snowflake(Dialect):
     }
 
     class Parser(Parser):
-        COLUMN_OPERATORS = Parser.COLUMN_OPERATORS | {TokenType.COLON}
-
         FUNCTIONS = {
             **Parser.FUNCTIONS,
             "IFF": exp.If.from_arg_list,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -29,7 +29,6 @@ def _snowflake_to_timestamp(args):
 
         timestamp = int(first_arg.name)
         scale = int(second_arg.name)
-        args[:] = args[:1]
         return exp.UnixToTime(this=str(int(int(timestamp) / (10 ** int(scale)))))
 
     first_arg = list_get(args, 0)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -27,7 +27,7 @@ def _snowflake_to_timestamp(args):
         def _convert_time_scale_and_run(args):
             conv_args = []
             exponent = int(list_get(args, 1).this)
-            retval = int(list_get(args, 0).this) / (10 ** exponent)
+            retval = int(int(list_get(args, 0).this) / (10 ** exponent))
             conv_args.append(str(retval))
             args[:] = args[:1]
             return exp.UnixToTime.from_arg_list(conv_args)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2121,7 +2121,7 @@ class UnixToStr(Func):
 
 
 class UnixToTime(Func):
-    pass
+    arg_types = {"this": True, "scale": False}
 
 
 class UnixToTimeStr(Func):

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1694,6 +1694,11 @@ class TestDialects(unittest.TestCase):
             "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss')",
             read="snowflake",
         )
+        self.validate(
+            "SELECT IFF(TRUE, 'true', 'false')",
+            "SELECT IFF(TRUE, 'true', 'false')",
+            read="snowflake",
+        )
 
     def test_sqlite(self):
         self.validate(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1695,6 +1695,18 @@ class TestDialects(unittest.TestCase):
             read="snowflake",
         )
         self.validate(
+            "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss')",
+            "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'MM/dd/yyyy HH:mm:ss')",
+            read="snowflake",
+            write="spark",
+        )
+        self.validate(
+            "SELECT strptime('04/05/2013 01:02:03', '%m/%d/%Y %H:%M:%S');",
+            "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss')",
+            read="duckdb",
+            write="snowflake",
+        )
+        self.validate(
             "SELECT IFF(TRUE, 'true', 'false')",
             "SELECT IFF(TRUE, 'true', 'false')",
             read="snowflake",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1669,6 +1669,31 @@ class TestDialects(unittest.TestCase):
             "SELECT a FROM test AS t QUALIFY ROW_NUMBER() OVER (PARTITION BY a ORDER BY Z) = 1",
             read="snowflake",
         )
+        self.validate(
+            "SELECT TO_TIMESTAMP(1659981729)",
+            "SELECT TO_TIMESTAMP(1659981729)",
+            read="snowflake",
+        )
+        self.validate(
+            "SELECT TO_TIMESTAMP(1659981729000, 3)",
+            "SELECT TO_TIMESTAMP(1659981729)",
+            read="snowflake",
+        )
+        self.validate(
+            "SELECT TO_TIMESTAMP('1659981729')",
+            "SELECT TO_TIMESTAMP('1659981729')",
+            read="snowflake",
+        )
+        self.validate(
+            "SELECT TO_TIMESTAMP('2013-04-05 01:02:03')",
+            "SELECT TO_TIMESTAMP('2013-04-05 01:02:03', 'yyyy-mm-dd hh24:mi:ss')",
+            read="snowflake",
+        )
+        self.validate(
+            "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss')",
+            "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss')",
+            read="snowflake",
+        )
 
     def test_sqlite(self):
         self.validate(


### PR DESCRIPTION
Snowflake's `TO_TIMESTAMP` function can be used in multiple different ways (corresponding to both of `sqlglot`'s `StrToTime` and `UnixToTime`); this PR adds support for parsing that function.