### PR TITLE
change references generator

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -749,7 +749,7 @@ class Generator:
     def reference_sql(self, expression):
         this = self.sql(expression, "this")
         expressions = self.expressions(expression, flat=True)
-        return f"REFERENCES({this}) ({expressions})"
+        return f"REFERENCES {this}({expressions})"
 
     def anonymous_sql(self, expression):
         args = self.indent(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1855,7 +1855,7 @@ class TestDialects(unittest.TestCase):
             """,
             """CREATE TABLE "Track" (
   CONSTRAINT "PK_Track" FOREIGN KEY ("TrackId"),
-  FOREIGN KEY ("AlbumId") REFERENCES("Album") ("AlbumId") ON DELETE NO ACTION ON UPDATE NO ACTION,
+  FOREIGN KEY ("AlbumId") REFERENCES "Album"("AlbumId") ON DELETE NO ACTION ON UPDATE NO ACTION,
   FOREIGN KEY ("AlbumId") ON DELETE CASCADE ON UPDATE RESTRICT,
   FOREIGN KEY ("AlbumId") ON DELETE SET NULL ON UPDATE SET DEFAULT
 )""",


### PR DESCRIPTION
i've changed references generator because it was raising syntax error both on postgres and sqlite

```
sqlite> create table a (id INTEGER PRIMARY KEY);
sqlite> create table b (id integer primary key, a_id integer, foreign key (a_id) references a(id));
sqlite> create table c (id integer primary key, a_id integer, foreign key (a_id) references (a) (id));
Parse error: near "(": syntax error
   key, a_id integer, foreign key (a_id) references (a) (id));
                                      error here ---^
```

If theres a dialect which uses `REFERENCES (table) (id)`, how can i add that?