### PR TITLE
Implement `TO_CHAR` format string translation

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -3,6 +3,7 @@ from sqlglot.dialects.dialect import (
     Dialect,
     arrow_json_extract_sql,
     arrow_json_extract_scalar_sql,
+    format_time_lambda,
     no_paren_current_date_sql,
     no_tablesample_sql,
     no_trycast_sql,
@@ -32,6 +33,36 @@ def _date_add_sql(kind):
 
 
 class Postgres(Dialect):
+    time_format = "'YYYY-MM-DD HH24:MI:SS'"
+    time_mapping = {
+        "AM": "%p",  # AM or PM
+        "D": "%w",  # 1-based day of week
+        "DD": "%d",  # day of month
+        "DDD": "%j",  # zero padded day of year
+        "FMDD": "%-d",  # - is no leading zero for Python; same for FM in postgres
+        "FMDDD": "%-j",  # day of year
+        "FMHH12": "%-I",  # 9
+        "FMHH24": "%-H",  # 9
+        "FMMI": "%-M",  # Minute
+        "FMMM": "%-m",  # 1
+        "FMSS": "%-S",  # Second
+        "HH12": "%I",  # 09
+        "HH24": "%H",  # 09
+        "MI": "%M",  # zero padded minute
+        "MM": "%m",  # 01
+        "OF": "%z",  # utc offset
+        "SS": "%S",  # zero padded second
+        "TMDay": "%A",  # TM is locale dependent
+        "TMDy": "%a",
+        "TMMon": "%b",  # Sep
+        "TMMonth": "%B",  # September
+        "TZ": "%Z",  # uppercase timezone name
+        "US": "%f",  # zero padded microsecond
+        "WW": "%U",  # 1-based week of year
+        "YY": "%y",  # 15
+        "YYYY": "%Y",  # 2015
+    }
+
     class Tokenizer(Tokenizer):
         KEYWORDS = {
             **Tokenizer.KEYWORDS,
@@ -41,7 +72,11 @@ class Postgres(Dialect):
 
     class Parser(Parser):
         STRICT_CAST = False
-        FUNCTIONS = {**Parser.FUNCTIONS, "TO_TIMESTAMP": exp.StrToTime.from_arg_list}
+        FUNCTIONS = {
+            **Parser.FUNCTIONS,
+            "TO_TIMESTAMP": format_time_lambda(exp.StrToTime, "postgres"),
+            "TO_CHAR": format_time_lambda(exp.TimeToStr, "postgres"),
+        }
 
     class Generator(Generator):
         TYPE_MAPPING = {
@@ -66,6 +101,7 @@ class Postgres(Dialect):
             exp.DateAdd: _date_add_sql("+"),
             exp.DateSub: _date_add_sql("-"),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
+            exp.TimeToStr: lambda self, e: f"TO_CHAR({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TableSample: no_tablesample_sql,
             exp.TryCast: no_trycast_sql,
         }

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -564,6 +564,13 @@ class TestDialects(unittest.TestCase):
             write="sqlite",
         )
 
+        self.validate(
+            "STRFTIME(x, '%y-%-m-%S')",
+            "TO_CHAR(x, 'YY-FMMM-SS')",
+            read="duckdb",
+            write="postgres",
+        )
+
         with self.assertRaises(UnsupportedError):
             transpile(
                 "DATE_ADD(x, y, 'day')",


### PR DESCRIPTION
This PR implements the necessary bits to translate [`TO_CHAR` format strings](https://www.postgresql.org/docs/current/functions-formatting.html)
into Python strftime format strings, enabling transpilation across the various
sqlglot dialects.
