### PR TITLE
Fix spark binary type

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -56,7 +56,6 @@ class Spark(Hive):
             exp.DataType.Type.TINYINT: "BYTE",
             exp.DataType.Type.SMALLINT: "SHORT",
             exp.DataType.Type.BIGINT: "LONG",
-            exp.DataType.Type.BINARY: "ARRAY[BYTE]",
         }
 
         TRANSFORMS = {

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -1828,6 +1828,13 @@ TBLPROPERTIES (
             write="spark",
         )
 
+        self.validate(
+            "CREATE TABLE a (x BINARY)",
+            "CREATE TABLE a (x BINARY)",
+            read="spark",
+            write="spark",
+        )
+
     def test_snowflake(self):
         self.validate(
             'x:a:"b c"',


### PR DESCRIPTION
ARRAY[BYTE] isn't even valid spark sql (it should be ARRAY<BYTE>),
and it's not the same type as BINARY.

https://spark.apache.org/docs/latest/sql-ref-datatypes.html