### PR TITLE
ErrorLevel.IMMEDIATE

### DIFF
--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -4,9 +4,10 @@ from sqlglot.helper import AutoName
 
 
 class ErrorLevel(AutoName):
-    IGNORE = auto()
-    WARN = auto()
-    RAISE = auto()
+    IGNORE = auto()  # Ignore any parser errors
+    WARN = auto()  # Log any parser errors with ERROR level
+    RAISE = auto()  # Collect all parser errors and raise a single exception
+    IMMEDIATE = auto()  # Immediately raise an exception on the first parser error
 
 
 class SqlglotError(Exception):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -476,11 +476,11 @@ class Parser:
         return expressions
 
     def check_errors(self):
-        for error in self.errors:
-            if self.error_level == ErrorLevel.RAISE:
-                raise error
-            if self.error_level == ErrorLevel.WARN:
+        if self.error_level == ErrorLevel.WARN:
+            for error in self.errors:
                 logger.error(error)
+        elif self.error_level == ErrorLevel.RAISE and self.errors:
+            raise ParseError("\n\n".join(self.errors))
 
     def raise_error(self, message, token=None):
         token = token or self._curr or self._prev or Token.string("")
@@ -489,12 +489,13 @@ class Parser:
         start_context = self.sql[max(start - self.error_message_context, 0) : start]
         highlight = self.sql[start:end]
         end_context = self.sql[end : end + self.error_message_context]
-        self.errors.append(
-            ParseError(
-                f"{message}. Line {token.line}, Col: {token.col}.\n"
-                f"  {start_context}\033[4m{highlight}\033[0m{end_context}"
-            )
+        error = (
+            f"{message}. Line {token.line}, Col: {token.col}.\n"
+            f"  {start_context}\033[4m{highlight}\033[0m{end_context}"
         )
+        if self.error_level == ErrorLevel.IMMEDIATE:
+            raise ParseError(error)
+        self.errors.append(error)
 
     def expression(self, exp_class, **kwargs):
         instance = exp_class(**kwargs)
@@ -1905,7 +1906,11 @@ class Parser:
         if identifier:
             return identifier
 
-        if any_token and self._curr.token_type not in self.RESERVED_KEYWORDS:
+        if (
+            any_token
+            and self._curr
+            and self._curr.token_type not in self.RESERVED_KEYWORDS
+        ):
             return self._advance() or exp.Identifier(this=self._prev.text, quoted=False)
 
         return self._match_set(self.ID_VAR_TOKENS) and exp.Identifier(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -478,9 +478,9 @@ class Parser:
     def check_errors(self):
         if self.error_level == ErrorLevel.WARN:
             for error in self.errors:
-                logger.error(error)
+                logger.error(str(error))
         elif self.error_level == ErrorLevel.RAISE and self.errors:
-            raise ParseError("\n\n".join(self.errors))
+            raise ParseError("\n\n".join(str(e) for e in self.errors))
 
     def raise_error(self, message, token=None):
         token = token or self._curr or self._prev or Token.string("")
@@ -489,12 +489,12 @@ class Parser:
         start_context = self.sql[max(start - self.error_message_context, 0) : start]
         highlight = self.sql[start:end]
         end_context = self.sql[end : end + self.error_message_context]
-        error = (
+        error = ParseError(
             f"{message}. Line {token.line}, Col: {token.col}.\n"
             f"  {start_context}\033[4m{highlight}\033[0m{end_context}"
         )
         if self.error_level == ErrorLevel.IMMEDIATE:
-            raise ParseError(error)
+            raise error
         self.errors.append(error)
 
     def expression(self, exp_class, **kwargs):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -23,7 +23,8 @@ def _extract_meta(sql):
 
 
 def assert_logger_contains(message, logger):
-    assert message in str(logger.error.call_args_list[0][0][0])
+    output = "\n".join(str(args[0][0]) for args in logger.error.call_args_list)
+    assert message in output
 
 
 def load_sql_fixtures(filename):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -90,7 +90,7 @@ class TestParser(unittest.TestCase):
 
         warn = Parser(error_level=ErrorLevel.WARN)
         warn.expression(exp.Hint, y="")
-        assert isinstance(warn.errors[0], ParseError)
+        self.assertEqual(len(warn.errors), 2)
 
     def test_parse_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -302,9 +302,20 @@ class TestTranspile(unittest.TestCase):
             assert_logger_contains(error, logger)
 
         with self.assertRaises(ParseError) as ctx:
+            transpile(invalid, error_level=ErrorLevel.IMMEDIATE)
+        self.assertEqual(str(ctx.exception), errors[0])
+
+        with self.assertRaises(ParseError) as ctx:
             transpile(invalid, error_level=ErrorLevel.RAISE)
         self.assertEqual(str(ctx.exception), "\n\n".join(errors))
 
+        more_than_max_errors = "(((("
+        expected = (
+            "Expecting ). Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
+            "Required keyword: 'this' missing for <class 'sqlglot.expressions.Paren'>. Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
+            "Expecting ). Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
+            "... and 2 more"
+        )
         with self.assertRaises(ParseError) as ctx:
-            transpile(invalid, error_level=ErrorLevel.IMMEDIATE)
-        self.assertEqual(str(ctx.exception), errors[0])
+            transpile(more_than_max_errors, error_level=ErrorLevel.RAISE)
+        self.assertEqual(str(ctx.exception), expected)

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -291,11 +291,20 @@ class TestTranspile(unittest.TestCase):
 
     @mock.patch("sqlglot.parser.logger")
     def test_error_level(self, logger):
-        transpile("x + 1 (", error_level=ErrorLevel.WARN)
-        assert_logger_contains(
-            "Required keyword: 'expressions' missing for <class 'sqlglot.expressions.Aliases'>. Line 1, Col: 7.\n  x + 1 \033[4m(\033[0m",
-            logger,
-        )
+        invalid = "x + 1. ("
+        errors = [
+            "Required keyword: 'expressions' missing for <class 'sqlglot.expressions.Aliases'>. Line 1, Col: 8.\n  x + 1. \033[4m(\033[0m",
+            "Expecting ). Line 1, Col: 8.\n  x + 1. \033[4m(\033[0m",
+        ]
 
-        with self.assertRaises(ParseError):
-            transpile("x + 1 (")
+        transpile(invalid, error_level=ErrorLevel.WARN)
+        for error in errors:
+            assert_logger_contains(error, logger)
+
+        with self.assertRaises(ParseError) as ctx:
+            transpile(invalid, error_level=ErrorLevel.RAISE)
+        self.assertEqual(str(ctx.exception), "\n\n".join(errors))
+
+        with self.assertRaises(ParseError) as ctx:
+            transpile(invalid, error_level=ErrorLevel.IMMEDIATE)
+        self.assertEqual(str(ctx.exception), errors[0])


### PR DESCRIPTION
This is a big change, so let's think about it.

This raises a "super error" if error level is RAISE. That's still the default, so users will start getting larger error messages.

Other options:
1. Change RAISE to only raise the first error and log the rest
    - I'm not sure why a user would want this behavior
2. Make IMMEDIATE the default
3. Remove IMMEDIATE and make RAISE raise immediately