### PR TITLE
Generate UNION DISTINCT correctly for BigQuery syntax

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -92,11 +92,17 @@ class BigQuery(Dialect):
             exp.DataType.Type.TEXT: "STRING",
         }
 
-        def union_sql(self, expression):
-            return self.prepend_ctes(
-                expression,
-                self.set_operation(
-                    expression,
-                    f"UNION{' DISTINCT' if expression.args.get('distinct') else ' ALL'}",
-                ),
-            )
+        def union_op(self, expression):
+            return f"UNION{' DISTINCT' if expression.args.get('distinct') else ' ALL'}"
+
+        def except_op(self, expression):
+            if not expression.args.get("distinct", False):
+                self.unsupported("EXCEPT without DISTINCT is not supported in BigQuery")
+            return super().except_op(expression)
+
+        def intersect_op(self, expression):
+            if not expression.args.get("distinct", False):
+                self.unsupported(
+                    "INTERSECT without DISTINCT is not supported in BigQuery"
+                )
+            return super().intersect_op(expression)

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -91,3 +91,11 @@ class BigQuery(Dialect):
             exp.DataType.Type.BOOLEAN: "BOOL",
             exp.DataType.Type.TEXT: "STRING",
         }
+
+        def union_sql(self, expression):
+            return self.prepend_ctes(
+                expression,
+                self.set_operation(
+                    expression, f"UNION{' DISTINCT' if expression.args.get('distinct') else ' ALL'}"
+                ),
+            )

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -96,6 +96,7 @@ class BigQuery(Dialect):
             return self.prepend_ctes(
                 expression,
                 self.set_operation(
-                    expression, f"UNION{' DISTINCT' if expression.args.get('distinct') else ' ALL'}"
+                    expression,
+                    f"UNION{' DISTINCT' if expression.args.get('distinct') else ' ALL'}",
                 ),
             )

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -352,11 +352,11 @@ class Generator:
     def except_sql(self, expression):
         return self.prepend_ctes(
             expression,
-            self.set_operation(
-                expression,
-                f"EXCEPT{' DISTINCT' if expression.args.get('distinct') else ''}",
-            ),
+            self.set_operation(expression, self.except_op(expression)),
         )
+
+    def except_op(self, expression):
+        return f"EXCEPT{' DISTINCT' if expression.args.get('distinct') else ''}"
 
     def fetch_sql(self, expression):
         direction = expression.args.get("direction")
@@ -453,11 +453,11 @@ class Generator:
     def intersect_sql(self, expression):
         return self.prepend_ctes(
             expression,
-            self.set_operation(
-                expression,
-                f"INTERSECT{' DISTINCT' if expression.args.get('distinct') else ''}",
-            ),
+            self.set_operation(expression, self.intersect_op(expression)),
         )
+
+    def intersect_op(self, expression):
+        return f"INTERSECT{' DISTINCT' if expression.args.get('distinct') else ''}"
 
     def table_sql(self, expression):
         return ".".join(
@@ -677,10 +677,11 @@ class Generator:
     def union_sql(self, expression):
         return self.prepend_ctes(
             expression,
-            self.set_operation(
-                expression, f"UNION{'' if expression.args.get('distinct') else ' ALL'}"
-            ),
+            self.set_operation(expression, self.union_op(expression)),
         )
+
+    def union_op(self, expression):
+        return f"UNION{'' if expression.args.get('distinct') else ' ALL'}"
 
     def unnest_sql(self, expression):
         args = self.expressions(expression, flat=True)

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -493,6 +493,12 @@ class TestDialects(unittest.TestCase):
             write="bigquery",
         )
 
+        self.validate(
+            "SELECT * FROM a UNION SELECT * FROM b",
+            "SELECT * FROM a UNION DISTINCT SELECT * FROM b",
+            write="bigquery",
+        )
+
     def test_postgres(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -499,6 +499,20 @@ class TestDialects(unittest.TestCase):
             write="bigquery",
         )
 
+        with self.assertRaises(UnsupportedError):
+            transpile(
+                "SELECT * FROM a INTERSECT SELECT * FROM b",
+                write="bigquery",
+                unsupported_level=ErrorLevel.RAISE,
+            )
+
+        with self.assertRaises(UnsupportedError):
+            transpile(
+                "SELECT * FROM a EXCEPT SELECT * FROM b",
+                write="bigquery",
+                unsupported_level=ErrorLevel.RAISE,
+            )
+
     def test_postgres(self):
         self.validate(
             "SELECT CAST(`a`.`b` AS DOUBLE) FROM foo",


### PR DESCRIPTION
According to https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#set_operators, for the UNION command in BigQuery, "You must specify ALL or DISTINCT". 

This updates the BigQuery dialect generator to output `UNION DISTINCT` rather than `UNION` when distinct is True.