### PR TITLE
Better unix timestamp with scale argument for Snowflake and Spark

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -54,13 +54,13 @@ def _snowflake_to_timestamp(args):
 
 
 def _unix_to_time(self, expression):
-    scale = expression.args.get("scale")
+    scale = expression.text("scale")
     timestamp = self.sql(expression, "this")
-    if not scale or scale == exp.UnixToTime.SECONDS:
+    if scale in ["", exp.UnixToTime.SECONDS.name]:
         return f"TO_TIMESTAMP({timestamp})"
-    if scale == exp.UnixToTime.MILLIS:
+    if scale == exp.UnixToTime.MILLIS.name:
         return f"TO_TIMESTAMP({timestamp}, 3)"
-    if scale == exp.UnixToTime.MICROS:
+    if scale == exp.UnixToTime.MICROS.name:
         return f"TO_TIMESTAMP({timestamp}, 9)"
 
     raise ValueError("Improper scale for timestamp")

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -22,16 +22,16 @@ def _snowflake_to_timestamp(args):
             return format_time_lambda(exp.StrToTime, "snowflake")(args)
 
         # case: <numeric_expr> [ , <scale> ]
-        if second_arg.this not in ["0", "3", "9"]:
+        if second_arg.name not in ["0", "3", "9"]:
             raise ValueError(
                 f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9"
             )
 
-        if second_arg.this == "0":
+        if second_arg.name == "0":
             timescale = exp.UnixToTime.SECONDS
-        elif second_arg.this == "3":
+        elif second_arg.name == "3":
             timescale = exp.UnixToTime.MILLIS
-        elif second_arg.this == "3":
+        elif second_arg.name == "3":
             timescale = exp.UnixToTime.MICROS
 
         return exp.UnixToTime(this=first_arg, scale=timescale)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -54,13 +54,13 @@ def _snowflake_to_timestamp(args):
 
 
 def _unix_to_time(self, expression):
-    scale = expression.text("scale")
+    scale = expression.args.get("scale")
     timestamp = self.sql(expression, "this")
-    if scale in ["", exp.UnixToTime.SECONDS.name]:
+    if scale in [None, exp.UnixToTime.SECONDS]:
         return f"TO_TIMESTAMP({timestamp})"
-    if scale == exp.UnixToTime.MILLIS.name:
+    if scale == exp.UnixToTime.MILLIS:
         return f"TO_TIMESTAMP({timestamp}, 3)"
-    if scale == exp.UnixToTime.MICROS.name:
+    if scale == exp.UnixToTime.MICROS:
         return f"TO_TIMESTAMP({timestamp}, 9)"
 
     raise ValueError("Improper scale for timestamp")

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -27,7 +27,14 @@ def _snowflake_to_timestamp(args):
                 f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9"
             )
 
-        return exp.UnixToTime(this=first_arg, scale=second_arg)
+        if second_arg.this == "0":
+            timescale = exp.UnixToTime.SECONDS
+        elif second_arg.this == "3":
+            timescale = exp.UnixToTime.MILLIS
+        elif second_arg.this == "3":
+            timescale = exp.UnixToTime.MICROS
+
+        return exp.UnixToTime(this=first_arg, scale=timescale)
 
     first_arg = list_get(args, 0)
     if not isinstance(first_arg, Literal):
@@ -44,6 +51,19 @@ def _snowflake_to_timestamp(args):
 
     # case: <numeric_expr>
     return exp.UnixToTime.from_arg_list(args)
+
+
+def _unix_to_time(self, expression):
+    scale = expression.args.get("scale")
+    timestamp = self.sql(expression, "this")
+    if not scale or scale == exp.UnixToTime.SECONDS:
+        return f"TO_TIMESTAMP({timestamp})"
+    if scale == exp.UnixToTime.MILLIS:
+        return f"TO_TIMESTAMP({timestamp}, 3)"
+    if scale == exp.UnixToTime.MICROS:
+        return f"TO_TIMESTAMP({timestamp}, 9)"
+
+    raise ValueError("Improper scale for timestamp")
 
 
 class Snowflake(Dialect):
@@ -110,7 +130,7 @@ class Snowflake(Dialect):
             **Generator.TRANSFORMS,
             exp.If: rename_func("IFF"),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
-            exp.UnixToTime: rename_func("TO_TIMESTAMP"),
+            exp.UnixToTime: _unix_to_time,
         }
 
         def except_op(self, expression):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -31,7 +31,7 @@ def _snowflake_to_timestamp(args):
             timescale = exp.UnixToTime.SECONDS
         elif second_arg.name == "3":
             timescale = exp.UnixToTime.MILLIS
-        elif second_arg.name == "3":
+        elif second_arg.name == "9":
             timescale = exp.UnixToTime.MICROS
 
         return exp.UnixToTime(this=first_arg, scale=timescale)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -17,7 +17,7 @@ def _check_int(s):
 def _snowflake_to_timestamp(args):
     if len(args) == 2:
         first_arg, second_arg = args
-        if first_arg.is_string:
+        if second_arg.is_string:
             # case: <string_expr> [ , <format> ]
             return format_time_lambda(exp.StrToTime, "snowflake")(args)
 
@@ -27,9 +27,7 @@ def _snowflake_to_timestamp(args):
                 f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9"
             )
 
-        timestamp = int(first_arg.name)
-        scale = int(second_arg.name)
-        return exp.UnixToTime(this=str(timestamp // (10**scale)))
+        return exp.UnixToTime(this=first_arg, scale=second_arg)
 
     first_arg = list_get(args, 0)
     if not isinstance(first_arg, Literal):

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -32,11 +32,11 @@ def _unix_to_time(self, expression):
     timestamp = self.sql(expression, "this")
     if not scale:
         return f"FROM_UNIXTIME({timestamp})"
-    if scale.name == "0":
+    if scale == exp.UnixToTime.SECONDS:
         return f"TIMESTAMP_SECONDS({timestamp})"
-    if scale.name == "3":
+    if scale == exp.UnixToTime.MILLIS:
         return f"TIMESTAMP_MILLIS({timestamp})"
-    if scale.name == "9":
+    if scale == exp.UnixToTime.MICROS:
         return f"TIMESTAMP_MICROS({timestamp})"
 
     raise ValueError("Improper scale for timestamp")

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -32,11 +32,11 @@ def _unix_to_time(self, expression):
     timestamp = self.sql(expression, "this")
     if not scale:
         return f"FROM_UNIXTIME({timestamp})"
-    if scale == exp.UnixToTime.SECONDS:
+    if scale == exp.UnixToTime.SECONDS.name:
         return f"TIMESTAMP_SECONDS({timestamp})"
-    if scale == exp.UnixToTime.MILLIS:
+    if scale == exp.UnixToTime.MILLIS.name:
         return f"TIMESTAMP_MILLIS({timestamp})"
-    if scale == exp.UnixToTime.MICROS:
+    if scale == exp.UnixToTime.MICROS.name:
         return f"TIMESTAMP_MICROS({timestamp})"
 
     raise ValueError("Improper scale for timestamp")

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -27,6 +27,21 @@ def _str_to_date(self, expression):
     return f"TO_DATE({this}, {time_format})"
 
 
+def _unix_to_time(self, expression):
+    scale = expression.args.get("scale")
+    timestamp = self.sql(expression, "this")
+    if not scale:
+        return f"FROM_UNIXTIME({timestamp})"
+    if scale == 0:
+        return f"TIMESTAMP_SECONDS({timestamp})"
+    if scale == 3:
+        return f"TIMESTAMP_MILLIS({timestamp})"
+    if scale == 9:
+        return f"TIMESTAMP_MICROS({timestamp})"
+
+    raise ValueError("Improper scale for timestamp")
+
+
 class Spark(Hive):
     class Parser(Hive.Parser):
         FUNCTIONS = {
@@ -78,6 +93,7 @@ class Spark(Hive):
             exp.Hint: lambda self, e: f" /*+ {self.expressions(e).strip()} */",
             exp.StrToDate: _str_to_date,
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
+            exp.UnixToTime: _unix_to_time,
             exp.Create: _create_sql,
             exp.Map: _map_sql,
             exp.Reduce: rename_func("AGGREGATE"),

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -28,7 +28,7 @@ def _str_to_date(self, expression):
 
 
 def _unix_to_time(self, expression):
-    scale = expression.args.get("scale")
+    scale = expression.text("scale")
     timestamp = self.sql(expression, "this")
     if not scale:
         return f"FROM_UNIXTIME({timestamp})"

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -28,15 +28,15 @@ def _str_to_date(self, expression):
 
 
 def _unix_to_time(self, expression):
-    scale = expression.text("scale")
+    scale = expression.args.get("scale")
     timestamp = self.sql(expression, "this")
-    if not scale:
+    if scale is None:
         return f"FROM_UNIXTIME({timestamp})"
-    if scale == exp.UnixToTime.SECONDS.name:
+    if scale == exp.UnixToTime.SECONDS:
         return f"TIMESTAMP_SECONDS({timestamp})"
-    if scale == exp.UnixToTime.MILLIS.name:
+    if scale == exp.UnixToTime.MILLIS:
         return f"TIMESTAMP_MILLIS({timestamp})"
-    if scale == exp.UnixToTime.MICROS.name:
+    if scale == exp.UnixToTime.MICROS:
         return f"TIMESTAMP_MICROS({timestamp})"
 
     raise ValueError("Improper scale for timestamp")

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -32,11 +32,11 @@ def _unix_to_time(self, expression):
     timestamp = self.sql(expression, "this")
     if not scale:
         return f"FROM_UNIXTIME({timestamp})"
-    if scale == 0:
+    if scale.name == "0":
         return f"TIMESTAMP_SECONDS({timestamp})"
-    if scale == 3:
+    if scale.name == "3":
         return f"TIMESTAMP_MILLIS({timestamp})"
-    if scale == 9:
+    if scale.name == "9":
         return f"TIMESTAMP_MICROS({timestamp})"
 
     raise ValueError("Improper scale for timestamp")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2266,9 +2266,9 @@ class UnixToStr(Func):
 class UnixToTime(Func):
     arg_types = {"this": True, "scale": False}
 
-    SECONDS = "seconds"
-    MILLIS = "millis"
-    MICROS = "micros"
+    SECONDS = Literal.string("seconds")
+    MILLIS = Literal.string("millis")
+    MICROS = Literal.string("micros")
 
 
 class UnixToTimeStr(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2266,6 +2266,10 @@ class UnixToStr(Func):
 class UnixToTime(Func):
     arg_types = {"this": True, "scale": False}
 
+    SECONDS = "seconds"
+    MILLIS = "millis"
+    MICROS = "micros"
+
 
 class UnixToTimeStr(Func):
     pass

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -2086,7 +2086,7 @@ TBLPROPERTIES (
         )
         self.validate(
             "SELECT TO_TIMESTAMP(1659981729000, 3)",
-            "SELECT TO_TIMESTAMP(1659981729)",
+            "SELECT TO_TIMESTAMP(1659981729000, 3)",
             read="snowflake",
         )
         self.validate(

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -2095,6 +2095,18 @@ TBLPROPERTIES (
             read="snowflake",
         )
         self.validate(
+            "SELECT TO_TIMESTAMP(1659981729000, 3)",
+            "SELECT TIMESTAMP_MILLIS(1659981729000)",
+            read="snowflake",
+            write="spark",
+        )
+        self.validate(
+            "SELECT TO_TIMESTAMP(1659981729000000000, 9)",
+            "SELECT TIMESTAMP_MICROS(1659981729000000000)",
+            read="snowflake",
+            write="spark",
+        )
+        self.validate(
             "SELECT TO_TIMESTAMP('2013-04-05 01:02:03')",
             "SELECT TO_TIMESTAMP('2013-04-05 01:02:03', 'yyyy-mm-dd hh24:mi:ss')",
             read="snowflake",


### PR DESCRIPTION
In #307, I added support for Snowflake's TO_TIMESTAMP function, which includes the ability to parse timestamps with scale (seconds, milliseconds, or microseconds), where the parsing was done by using integer division to store the timestamp with adjusted scale.

This pull request modifies that to store the scale as a separate parameter. This means that generators for other dialects can choose the correct function based on scale (e.g., Spark has `TIMESTAMP_SECONDS`, `TIMESTAMP_MILLIS`, and `TIMESTAMP_MICROS`); doing it this way avoids lossiness in timestamps and also does not break when placeholders in prepared statements are passed as the timestamp itself.