### PR TITLE
Add parsing for Snowflake ARRAYAGG to ArrayAgg

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -105,6 +105,7 @@ class Snowflake(Dialect):
     class Parser(Parser):
         FUNCTIONS = {
             **Parser.FUNCTIONS,
+            "ARRAYAGG": exp.ArrayAgg.from_arg_list,
             "IFF": exp.If.from_arg_list,
             "TO_TIMESTAMP": _snowflake_to_timestamp,
         }

--- a/tests/test_dialects.py
+++ b/tests/test_dialects.py
@@ -2148,6 +2148,13 @@ TBLPROPERTIES (
             write="snowflake",
         )
 
+        self.validate(
+            "SELECT ARRAYAGG(DISTINCT a)",
+            "SELECT COLLECT_LIST(DISTINCT a)",
+            read="snowflake",
+            write="spark",
+        )
+
         with self.assertRaises(UnsupportedError):
             transpile(
                 "SELECT * FROM a INTERSECT ALL SELECT * FROM b",


### PR DESCRIPTION
Snowflake uses both ARRAY_AGG and ARRAYAGG (https://docs.snowflake.com/en/sql-reference/functions/array_agg.html); this PR adds support to properly parse the latter.