### PR TITLE
Missing backslash on CRLF whitespace in tokenizer

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -523,7 +523,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "\t": TokenType.SPACE,
         "\n": TokenType.BREAK,
         "\r": TokenType.BREAK,
-        "\rn": TokenType.BREAK,
+        "\r\n": TokenType.BREAK,
     }
 
     COMMANDS = {


### PR DESCRIPTION
Or so I assume by eye.