### PR TITLE
WIP: support MySQL 0xFF-style hex literals

### DIFF
--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -7,6 +7,7 @@ SUM(CASE WHEN x > 1 THEN 1 ELSE 0 END) / y
 1E-2
 1.1E10
 1.12e-10
+0x0A
 -11.023E7 * 3
 (1 * 2) / (3 - 5)
 ((TRUE))
@@ -411,6 +412,8 @@ SELECT student, score FROM tests CROSS JOIN UNNEST(scores) AS t(a, b)
 SELECT student, score FROM tests CROSS JOIN UNNEST(scores) WITH ORDINALITY AS t(a, b)
 SELECT student, score FROM tests CROSS JOIN UNNEST(x.scores) AS t(score)
 SELECT student, score FROM tests CROSS JOIN UNNEST(ARRAY(x.scores)) AS t(score)
+SELECT 0x0A FROM table
+SELECT 0x0A
 CREATE TABLE a.b AS SELECT 1
 CREATE TABLE a.b AS SELECT a FROM a.c
 CREATE TABLE IF NOT EXISTS x AS SELECT a FROM d


### PR DESCRIPTION
First try.

These changes to `tokens.py` were sufficient to make tests pass.

But looking at `.walk()` I see the 0xFF-style literals are parsed as identifiers.  We want literals.  Looks like the next step would be `sqlglot/expressions.py`?  However the logic there seems centered around the idea that anything not string is a number.

Binary literals are mostly like strings.  But they must not be quoted.

What is better: a binary token type, distinct from both string and number?  Or a string type which is marked as unquoted (somehow)?

Also there's nothing here about making the construct specific to a dialect.