### PR TITLE
Add MySQL-dialect `#` comment extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ SELECT
 FROM users
 ```
 
+SQL annotations are currently incompatible with MySQL, which uses the `#` character to introduce comments.
+
 ## AST Introspection
 
 You can see the AST version of the sql by calling repr.

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -88,9 +88,11 @@ class MySQL(Dialect):
 
     class Tokenizer(Tokenizer):
         QUOTES = ["'", '"']
+        COMMENTS = {"--", "#"}
 
         KEYWORDS = {
             **Tokenizer.KEYWORDS,
+            "#": TokenType.COMMENT,
             "_ARMSCII8": TokenType.INTRODUCER,
             "_ASCII": TokenType.INTRODUCER,
             "_BIG5": TokenType.INTRODUCER,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -69,3 +69,11 @@ class TestMySQL(Validator):
                 "mysql": "CAST(x AS CHAR CHARACTER SET latin1)",
             },
         )
+
+    def test_hash_comments(self):
+        self.validate_all(
+            "SELECT 1 # arbitrary content until end-of-line",
+            write={
+                "mysql": "SELECT 1",
+            },
+        )


### PR DESCRIPTION
And doc incompatibility with sqlglot annotations when reading the MySQL dialect.

Reference:

https://dev.mysql.com/doc/refman/8.0/en/comments.html

* "From a # character to the end of the line."

(And there's a small divergence from the SQL standard on `--`)