### PR TITLE
add support for table and column check constraints

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -570,6 +570,10 @@ class AutoIncrementColumnConstraint(Expression):
     pass
 
 
+class CheckColumnConstraint(Expression):
+    pass
+
+
 class CollateColumnConstraint(Expression):
     pass
 
@@ -608,6 +612,10 @@ class Drop(Expression):
 
 class Filter(Expression):
     arg_types = {"this": True, "expression": True}
+
+
+class Check(Expression):
+    pass
 
 
 class ForeignKey(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -306,7 +306,9 @@ class Generator:
     def columndef_sql(self, expression):
         column = self.sql(expression, "this")
         kind = self.sql(expression, "kind")
-        constraints = self.expressions(expression, key="constraints", sep=" ", flat=True)
+        constraints = self.expressions(
+            expression, key="constraints", sep=" ", flat=True
+        )
 
         if not constraints:
             return f"{column} {kind}"
@@ -319,6 +321,10 @@ class Generator:
 
     def autoincrementcolumnconstraint_sql(self, _):
         return self.token_sql(TokenType.AUTO_INCREMENT)
+
+    def checkcolumnconstraint_sql(self, expression):
+        this = self.sql(expression, "this")
+        return f"CHECK {this}"
 
     def commentcolumnconstraint_sql(self, expression):
         comment = self.sql(expression, "this")
@@ -872,6 +878,10 @@ class Generator:
         this = self.sql(expression, "this")
         expression_sql = self.sql(expression, "expression")
         return f"EXTRACT({this} FROM {expression_sql})"
+
+    def check_sql(self, expression):
+        this = self.sql(expression, key="this")
+        return f"CHECK {this}"
 
     def foreignkey_sql(self, expression):
         expressions = self.expressions(expression, flat=True)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -350,6 +350,7 @@ class Parser:
     }
 
     CONSTRAINT_PARSERS = {
+        TokenType.CHECK: lambda self: self._parse_check(),
         TokenType.FOREIGN_KEY: lambda self: self._parse_foreign_key(),
         TokenType.UNIQUE: lambda self: self._parse_unique(),
     }
@@ -1730,6 +1731,10 @@ class Parser:
 
         if self._match(TokenType.AUTO_INCREMENT):
             kind = exp.AutoIncrementColumnConstraint()
+        elif self._match(TokenType.CHECK):
+            kind = self.expression(
+                exp.CheckColumnConstraint, this=self._parse_expression()
+            )
         elif self._match(TokenType.COLLATE):
             kind = self.expression(exp.CollateColumnConstraint, this=self._parse_var())
         elif self._match(TokenType.DEFAULT):
@@ -1772,6 +1777,12 @@ class Parser:
             return None
 
         return self.CONSTRAINT_PARSERS[self._prev.token_type](self)
+
+    def _parse_check(self):
+        self._match(TokenType.CHECK)
+        expression = self._parse_expression()
+
+        return self.expression(exp.Check, this=expression)
 
     def _parse_unique(self):
         self._match(TokenType.UNIQUE)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -98,6 +98,7 @@ class TokenType(AutoName):
     CASE = auto()
     CAST = auto()
     CHARACTER_SET = auto()
+    CHECK = auto()
     CLUSTER_BY = auto()
     COLLATE = auto()
     COMMENT = auto()
@@ -380,6 +381,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "CASE": TokenType.CASE,
         "CAST": TokenType.CAST,
         "CHARACTER SET": TokenType.CHARACTER_SET,
+        "CHECK": TokenType.CHECK,
         "CLUSTER BY": TokenType.CLUSTER_BY,
         "COLLATE": TokenType.COLLATE,
         "COMMENT": TokenType.SCHEMA_COMMENT,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -23,6 +23,24 @@ class TestPostgres(Validator):
                 "postgres": "CREATE TABLE products (product_no INT, name TEXT, price DECIMAL, UNIQUE (product_no, name))"
             },
         )
+        self.validate_all(
+            "CREATE TABLE products ("
+            "product_no INT UNIQUE,"
+            " name TEXT,"
+            " price DECIMAL CHECK (price > 0),"
+            " discounted_price DECIMAL CONSTRAINT positive_discount CHECK (discounted_price > 0),"
+            " CHECK (product_no > 1),"
+            " CONSTRAINT valid_discount CHECK (price > discounted_price))",
+            write={
+                "postgres": "CREATE TABLE products ("
+                "product_no INT UNIQUE,"
+                " name TEXT,"
+                " price DECIMAL CHECK (price > 0),"
+                " discounted_price DECIMAL CONSTRAINT positive_discount CHECK (discounted_price > 0),"
+                " CHECK (product_no > 1),"
+                " CONSTRAINT valid_discount CHECK (price > discounted_price))"
+            },
+        )
 
     def test_postgres(self):
         self.validate_all(


### PR DESCRIPTION
add support for table and column check constraints. fixes https://github.com/tobymao/sqlglot/issues/389

references:
https://www.postgresql.org/docs/current/sql-createtable.html
https://www.sqlite.org/syntax/column-constraint.html
https://dev.mysql.com/doc/refman/8.0/en/create-table.html