### PR TITLE
feat: Add sort_by and cluster_by to expression builder

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1155,6 +1155,76 @@ class Select(Subqueryable, Expression):
             **opts,
         )
 
+    def sort_by(
+        self, *expressions, append=True, dialect=None, parser_opts=None, copy=True
+    ):
+        """
+        Set the CLUSTER BY expression.
+
+        Example:
+            >>> Select().from_("tbl").select("x").sort_by("x DESC").sql()
+            'SELECT x FROM tbl SORT BY x DESC'
+
+        Args:
+            *expressions (str or Expression): the SQL code strings to parse.
+                If a `Group` instance is passed, this is used as-is.
+                If another `Expression` instance is passed, it will be wrapped in a `SORT`.
+            append (bool): if `True`, add to any existing expressions.
+                Otherwise, this flattens all the `Order` expression into a single expression.
+            dialect (str): the dialect used to parse the input expression.
+            parser_opts (dict): other options to use to parse the input expressions.
+            copy (bool): if `False`, modify this expression instance in-place.
+
+        Returns:
+            Select: the modified expression.
+        """
+        return _apply_child_list_builder(
+            *expressions,
+            instance=self,
+            arg="sort",
+            append=append,
+            copy=copy,
+            prefix="SORT BY",
+            into=Sort,
+            dialect=dialect,
+            parser_opts=parser_opts,
+        )
+
+    def cluster_by(
+        self, *expressions, append=True, dialect=None, parser_opts=None, copy=True
+    ):
+        """
+        Set the CLUSTER BY expression.
+
+        Example:
+            >>> Select().from_("tbl").select("x").cluster_by("x DESC").sql()
+            'SELECT x FROM tbl CLUSTER BY x DESC'
+
+        Args:
+            *expressions (str or Expression): the SQL code strings to parse.
+                If a `Group` instance is passed, this is used as-is.
+                If another `Expression` instance is passed, it will be wrapped in a `Cluster`.
+            append (bool): if `True`, add to any existing expressions.
+                Otherwise, this flattens all the `Order` expression into a single expression.
+            dialect (str): the dialect used to parse the input expression.
+            parser_opts (dict): other options to use to parse the input expressions.
+            copy (bool): if `False`, modify this expression instance in-place.
+
+        Returns:
+            Select: the modified expression.
+        """
+        return _apply_child_list_builder(
+            *expressions,
+            instance=self,
+            arg="cluster",
+            append=append,
+            copy=copy,
+            prefix="CLUSTER BY",
+            into=Cluster,
+            dialect=dialect,
+            parser_opts=parser_opts,
+        )
+
     def limit(self, expression, dialect=None, copy=True, **opts):
         """
         Set the LIMIT expression.

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1155,11 +1155,9 @@ class Select(Subqueryable, Expression):
             **opts,
         )
 
-    def sort_by(
-        self, *expressions, append=True, dialect=None, parser_opts=None, copy=True
-    ):
+    def sort_by(self, *expressions, append=True, dialect=None, copy=True, **opts):
         """
-        Set the CLUSTER BY expression.
+        Set the SORT BY expression.
 
         Example:
             >>> Select().from_("tbl").select("x").sort_by("x DESC").sql()
@@ -1187,12 +1185,10 @@ class Select(Subqueryable, Expression):
             prefix="SORT BY",
             into=Sort,
             dialect=dialect,
-            parser_opts=parser_opts,
+            **opts,
         )
 
-    def cluster_by(
-        self, *expressions, append=True, dialect=None, parser_opts=None, copy=True
-    ):
+    def cluster_by(self, *expressions, append=True, dialect=None, copy=True, **opts):
         """
         Set the CLUSTER BY expression.
 
@@ -1222,7 +1218,7 @@ class Select(Subqueryable, Expression):
             prefix="CLUSTER BY",
             into=Cluster,
             dialect=dialect,
-            parser_opts=parser_opts,
+            **opts,
         )
 
     def limit(self, expression, dialect=None, copy=True, **opts):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1170,8 +1170,8 @@ class Select(Subqueryable, Expression):
             append (bool): if `True`, add to any existing expressions.
                 Otherwise, this flattens all the `Order` expression into a single expression.
             dialect (str): the dialect used to parse the input expression.
-            parser_opts (dict): other options to use to parse the input expressions.
             copy (bool): if `False`, modify this expression instance in-place.
+            opts (kwargs): other options to use to parse the input expressions.            
 
         Returns:
             Select: the modified expression.
@@ -1203,8 +1203,8 @@ class Select(Subqueryable, Expression):
             append (bool): if `True`, add to any existing expressions.
                 Otherwise, this flattens all the `Order` expression into a single expression.
             dialect (str): the dialect used to parse the input expression.
-            parser_opts (dict): other options to use to parse the input expressions.
             copy (bool): if `False`, modify this expression instance in-place.
+            opts (kwargs): other options to use to parse the input expressions.            
 
         Returns:
             Select: the modified expression.

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -273,6 +273,8 @@ class Parser:
         exp.Lateral: lambda self: self._parse_lateral(),
         exp.Join: lambda self: self._parse_join(),
         exp.Order: lambda self: self._parse_order(),
+        exp.Cluster: lambda self: self._parse_sort(TokenType.CLUSTER_BY, exp.Cluster),
+        exp.Sort: lambda self: self._parse_sort(TokenType.SORT_BY, exp.Sort),
         exp.Lambda: lambda self: self._parse_lambda(),
         exp.Limit: lambda self: self._parse_limit(),
         exp.Offset: lambda self: self._parse_offset(),

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -170,8 +170,24 @@ class TestBuild(unittest.TestCase):
                 "SELECT x FROM tbl ORDER BY y",
             ),
             (
+                lambda: select("x").from_("tbl").cluster_by("y"),
+                "SELECT x FROM tbl CLUSTER BY y",
+            ),
+            (
+                lambda: select("x").from_("tbl").sort_by("y"),
+                "SELECT x FROM tbl SORT BY y",
+            ),
+            (
                 lambda: select("x").from_("tbl").order_by("x, y DESC"),
                 "SELECT x FROM tbl ORDER BY x, y DESC",
+            ),
+            (
+                lambda: select("x").from_("tbl").cluster_by("x, y DESC"),
+                "SELECT x FROM tbl CLUSTER BY x, y DESC",
+            ),
+            (
+                lambda: select("x").from_("tbl").sort_by("x, y DESC"),
+                "SELECT x FROM tbl SORT BY x, y DESC",
             ),
             (
                 lambda: select("x", "y", "z", "a")
@@ -179,6 +195,20 @@ class TestBuild(unittest.TestCase):
                 .order_by("x, y", "z")
                 .order_by("a"),
                 "SELECT x, y, z, a FROM tbl ORDER BY x, y, z, a",
+            ),
+            (
+                lambda: select("x", "y", "z", "a")
+                .from_("tbl")
+                .cluster_by("x, y", "z")
+                .cluster_by("a"),
+                "SELECT x, y, z, a FROM tbl CLUSTER BY x, y, z, a",
+            ),
+            (
+                lambda: select("x", "y", "z", "a")
+                .from_("tbl")
+                .sort_by("x, y", "z")
+                .sort_by("a"),
+                "SELECT x, y, z, a FROM tbl SORT BY x, y, z, a",
             ),
             (lambda: select("x").from_("tbl").limit(10), "SELECT x FROM tbl LIMIT 10"),
             (


### PR DESCRIPTION
We already have SORT & CLUSTER expression and SORT_BY & CLUSTER_BY tokens, they are currently used in DDLs but they can also be used in expression builder. This PR adds that support.