### PR TITLE
Add support for nested double-colon cast

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1171,7 +1171,7 @@ class Select(Subqueryable, Expression):
                 Otherwise, this flattens all the `Order` expression into a single expression.
             dialect (str): the dialect used to parse the input expression.
             copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.            
+            opts (kwargs): other options to use to parse the input expressions.
 
         Returns:
             Select: the modified expression.
@@ -1204,7 +1204,7 @@ class Select(Subqueryable, Expression):
                 Otherwise, this flattens all the `Order` expression into a single expression.
             dialect (str): the dialect used to parse the input expression.
             copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.            
+            opts (kwargs): other options to use to parse the input expressions.
 
         Returns:
             Select: the modified expression.

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1477,11 +1477,11 @@ class Parser:
                 return self._parse_column()
             return type_token
 
-        if self._match(TokenType.DCOLON):
+        while self._match(TokenType.DCOLON):
             type_token = self._parse_types()
             if not type_token:
                 self.raise_error("Expected type")
-            return self.expression(exp.Cast, this=this, to=type_token)
+            this = self.expression(exp.Cast, this=this, to=type_token)
 
         return this
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -77,6 +77,9 @@ class TestTranspile(unittest.TestCase):
         self.validate("x::INTEGER", "CAST(x AS INT)")
         self.validate("x::INT y", "CAST(x AS INT) AS y")
         self.validate("x::INT AS y", "CAST(x AS INT) AS y")
+        self.validate("x::INT::BOOLEAN", "CAST(CAST(x AS INT) AS BOOLEAN)")
+        self.validate("CAST(x::INT AS BOOLEAN)", "CAST(CAST(x AS INT) AS BOOLEAN)")
+        self.validate("CAST(x AS INT)::BOOLEAN", "CAST(CAST(x AS INT) AS BOOLEAN)")
 
         with self.assertRaises(ParseError):
             transpile("x::z")


### PR DESCRIPTION
Added support for nested double-colon cast.

Example
```
SELECT expr::INT::BOOLEAN
```