### PR TITLE
Snowflake string literals

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -119,6 +119,7 @@ class Snowflake(Dialect):
 
     class Tokenizer(Tokenizer):
         QUOTES = ["'", "$$"]
+        ESCAPE = "\\"
         KEYWORDS = {
             **Tokenizer.KEYWORDS,
             "QUALIFY": TokenType.QUALIFY,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -118,6 +118,7 @@ class Snowflake(Dialect):
         }
 
     class Tokenizer(Tokenizer):
+        QUOTES = ["'", "$$"]
         KEYWORDS = {
             **Tokenizer.KEYWORDS,
             "QUALIFY": TokenType.QUALIFY,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -131,3 +131,9 @@ class TestSnowflake(Validator):
                 "snowflake": "SELECT NVL2(a, b, c)",
             },
         )
+        self.validate_all(
+            "SELECT $$a$$",
+            write={
+                "snowflake": "SELECT 'a'",
+            },
+        )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -137,3 +137,9 @@ class TestSnowflake(Validator):
                 "snowflake": "SELECT 'a'",
             },
         )
+        self.validate_all(
+            r"SELECT $$a ' \ \t \x21 z $ $$",
+            write={
+                "snowflake": r"SELECT 'a \' \\ \\t \\x21 z $ '",
+            },
+        )


### PR DESCRIPTION
- Added support for Snowflake's [dollar-quoted string constants](https://docs.snowflake.com/en/sql-reference/data-types-text.html#label-dollar-quoted-string-constants).
- Added string escape config for Snowflake. Snowflake supports single-quote as an escape character, but only for single-quote characters.
- Added a test case including a few escape sequences, adopted from the Snowflake documentation. 