### PR TITLE
Support alternative syntax for postgres substring

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -32,6 +32,20 @@ def _date_add_sql(kind):
     return func
 
 
+def _substring_sql():
+    def func(self, expression):
+        this = self.sql(expression, "this")
+        start = self.sql(expression, "start")
+        length = self.sql(expression, "length")
+
+        from_part = f" FROM {start}" if start else ""
+        for_part = f" FOR {length}" if length else ""
+
+        return f"SUBSTRING({this}{from_part}{for_part})"
+
+    return func
+
+
 class Postgres(Dialect):
     null_ordering = "nulls_are_large"
     time_format = "'YYYY-MM-DD HH24:MI:SS'"
@@ -69,6 +83,7 @@ class Postgres(Dialect):
             **Tokenizer.KEYWORDS,
             "SERIAL": TokenType.AUTO_INCREMENT,
             "UUID": TokenType.UUID,
+            "FOR": TokenType.FOR,
         }
 
     class Parser(Parser):
@@ -103,6 +118,7 @@ class Postgres(Dialect):
             exp.DateAdd: _date_add_sql("+"),
             exp.DateSub: _date_add_sql("-"),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
+            exp.Substring: _substring_sql(),
             exp.TimeToStr: lambda self, e: f"TO_CHAR({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TableSample: no_tablesample_sql,
             exp.TryCast: no_trycast_sql,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2306,8 +2306,10 @@ class Split(Func):
     arg_types = {"this": True, "expression": True}
 
 
+# Start may be omitted in the case of postgres
+# https://www.postgresql.org/docs/9.1/functions-string.html @ Table 9-6
 class Substring(Func):
-    arg_types = {"this": True, "start": True, "length": False}
+    arg_types = {"this": True, "start": False, "length": False}
 
 
 class StrPosition(Func):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -134,6 +134,7 @@ class TokenType(AutoName):
     FINAL = auto()
     FIRST = auto()
     FOLLOWING = auto()
+    FOR = auto()
     FOREIGN_KEY = auto()
     FORMAT = auto()
     FULL = auto()
@@ -210,6 +211,7 @@ class TokenType(AutoName):
     SORT_BY = auto()
     STORED = auto()
     STRUCT = auto()
+    SUBSTRING = auto()
     TABLE_FORMAT = auto()
     TABLE_SAMPLE = auto()
     TEMPORARY = auto()
@@ -416,6 +418,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "FULL": TokenType.FULL,
         "FUNCTION": TokenType.FUNCTION,
         "FOLLOWING": TokenType.FOLLOWING,
+        "FOR": TokenType.FOR,
         "FOREIGN KEY": TokenType.FOREIGN_KEY,
         "FORMAT": TokenType.FORMAT,
         "FROM": TokenType.FROM,
@@ -482,6 +485,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "SOME": TokenType.SOME,
         "SORT BY": TokenType.SORT_BY,
         "STORED": TokenType.STORED,
+        "SUBSTRING": TokenType.SUBSTRING,
         "TABLE": TokenType.TABLE,
         "TABLE_FORMAT": TokenType.TABLE_FORMAT,
         "TBLPROPERTIES": TokenType.PROPERTIES,


### PR DESCRIPTION
Initial draft aiming to solve [#421](https://github.com/tobymao/sqlglot/issues/421).

- Is there a way to avoid changing the `arg_types` of `Substring` globally, so that the changes will only apply to a specific dialect? In this commit, I changed it globally so now `substring('foo')` is not regarded as a parse error. This might be true for postgres but not for other dialects. Is this a problem?

- According to the [docs](https://www.postgresql.org/docs/9.1/functions-string.html) (Table 9-6) [1], postgres allows for regex matching inside the substring function. This is currently supported, but the `Substring` attributes have misleading names. Ideally, we'd want `pattern` and `escape`, instead of `start` and `length`, if we have string literals in the `from`, `for` parts [2]. I can try clearing this up a little if needed.

- Finally, I made it so that postgres now generates sql code for the substring function in the from..for.. syntax, which is also compatible with the csv syntax.

[1] These features are supported in postgres 14.5 as well.
[2] Postgres 14.5 also supports the `SUBSTRING(text SIMILAR pattern ESCAPE escape` syntax.
