### PR TITLE
Add trim function

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -49,6 +49,21 @@ def _str_to_date_sql(self, expression):
     return f"STR_TO_DATE({self.sql(expression.this)}, {date_format})"
 
 
+def _trim_sql(self, expression):
+    target = self.sql(expression, "this")
+    trim_type = self.sql(expression, "position")
+    remove_chars = self.sql(expression, "expression")
+
+    # Use TRIM/LTRIM/RTRIM syntax if the expression isn't mysql-specific
+    if not remove_chars:
+        return self.trim_sql(expression)
+
+    trim_type = f"{trim_type} " if trim_type else ""
+    remove_chars = f"{remove_chars} " if remove_chars else ""
+    from_part = "FROM " if trim_type or remove_chars else ""
+    return f"TRIM({trim_type}{remove_chars}{from_part}{target})"
+
+
 def _date_add(expression_class):
     def func(args):
         interval = list_get(args, 1)
@@ -160,4 +175,5 @@ class MySQL(Dialect):
             exp.DateTrunc: _date_trunc_sql,
             exp.StrToDate: _str_to_date_sql,
             exp.StrToTime: _str_to_date_sql,
+            exp.Trim: _trim_sql,
         }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2382,6 +2382,15 @@ class TimeStrToUnix(Func):
     pass
 
 
+class Trim(Func):
+    arg_types = {
+        "this": True,
+        "position": False,
+        "expression": False,
+        "collation": False,
+    }
+
+
 class TsOrDsAdd(Func, TimeUnit):
     arg_types = {"this": True, "expression": True, "unit": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -879,6 +879,17 @@ class Generator:
         expression_sql = self.sql(expression, "expression")
         return f"EXTRACT({this} FROM {expression_sql})"
 
+    def trim_sql(self, expression):
+        target = self.sql(expression, "this")
+        trim_type = self.sql(expression, "position")
+        remove_chars = self.sql(expression, "expression")
+        collation = self.sql(expression, "collation")
+        trim_type = f"{trim_type} " if trim_type else ""
+        remove_chars = f"{remove_chars} " if remove_chars else ""
+        from_part = "FROM " if trim_type or remove_chars else ""
+        collation = f" COLLATE {collation}" if collation else ""
+        return f"TRIM({trim_type}{remove_chars}{from_part}{target}{collation})"
+
     def check_sql(self, expression):
         this = self.sql(expression, key="this")
         return f"CHECK ({this})"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -882,13 +882,13 @@ class Generator:
     def trim_sql(self, expression):
         target = self.sql(expression, "this")
         trim_type = self.sql(expression, "position")
-        remove_chars = self.sql(expression, "expression")
-        collation = self.sql(expression, "collation")
-        trim_type = f"{trim_type} " if trim_type else ""
-        remove_chars = f"{remove_chars} " if remove_chars else ""
-        from_part = "FROM " if trim_type or remove_chars else ""
-        collation = f" COLLATE {collation}" if collation else ""
-        return f"TRIM({trim_type}{remove_chars}{from_part}{target}{collation})"
+
+        if trim_type == "LEADING":
+            return f"LTRIM({target})"
+        elif trim_type == "TRAILING":
+            return f"RTRIM({target})"
+        else:
+            return f"TRIM({target})"
 
     def check_sql(self, expression):
         this = self.sql(expression, key="this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -160,6 +160,8 @@ class Parser:
         TokenType.TRY_CAST,
     }
 
+    TRIM_TYPES = {TokenType.LEADING, TokenType.TRAILING, TokenType.BOTH}
+
     FUNC_TOKENS = {
         TokenType.CONVERT,
         TokenType.CURRENT_DATE,
@@ -1949,7 +1951,7 @@ class Parser:
         position = None
         collation = None
 
-        if self._match_set((TokenType.LEADING, TokenType.TRAILING, TokenType.BOTH)):
+        if self._match_set(self.TRIM_TYPES):
             position = self._prev.text.upper()
 
         expression = self._parse_term()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -92,6 +92,7 @@ class TokenType(AutoName):
     AUTO_INCREMENT = auto()
     BEGIN = auto()
     BETWEEN = auto()
+    BOTH = auto()
     BUCKET = auto()
     CACHE = auto()
     CALL = auto()
@@ -160,6 +161,7 @@ class TokenType(AutoName):
     JOIN = auto()
     LATERAL = auto()
     LAZY = auto()
+    LEADING = auto()
     LEFT = auto()
     LIKE = auto()
     LIMIT = auto()
@@ -218,7 +220,9 @@ class TokenType(AutoName):
     TIME = auto()
     TOP = auto()
     THEN = auto()
+    TRIM = auto()
     TRUE = auto()
+    TRAILING = auto()
     TRUNCATE = auto()
     TRY_CAST = auto()
     UNBOUNDED = auto()
@@ -376,6 +380,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "AUTO_INCREMENT": TokenType.AUTO_INCREMENT,
         "BEGIN": TokenType.BEGIN,
         "BETWEEN": TokenType.BETWEEN,
+        "BOTH": TokenType.BOTH,
         "BUCKET": TokenType.BUCKET,
         "CALL": TokenType.CALL,
         "CACHE": TokenType.CACHE,
@@ -439,6 +444,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "JOIN": TokenType.JOIN,
         "LATERAL": TokenType.LATERAL,
         "LAZY": TokenType.LAZY,
+        "LEADING": TokenType.LEADING,
         "LEFT": TokenType.LEFT,
         "LIKE": TokenType.LIKE,
         "LIMIT": TokenType.LIMIT,
@@ -493,6 +499,8 @@ class Tokenizer(metaclass=_Tokenizer):
         "TEMPORARY": TokenType.TEMPORARY,
         "THEN": TokenType.THEN,
         "TRUE": TokenType.TRUE,
+        "TRAILING": TokenType.TRAILING,
+        "TRIM": TokenType.TRIM,
         "TRUNCATE": TokenType.TRUNCATE,
         "TRY_CAST": TokenType.TRY_CAST,
         "UNBOUNDED": TokenType.UNBOUNDED,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -15,6 +15,10 @@ class TestMySQL(Validator):
 
     def test_identity(self):
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")
+        self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ')")
+        self.validate_identity("SELECT TRIM(TRAILING 'bla' FROM ' XXX ')")
+        self.validate_identity("SELECT TRIM(BOTH 'bla' FROM ' XXX ')")
+        self.validate_identity("SELECT TRIM('bla' FROM ' XXX ')")
 
     def test_introducers(self):
         self.validate_all(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -72,6 +72,11 @@ class TestPostgres(Validator):
         self.validate_identity(
             "SELECT * FROM x WHERE SUBSTRING('Thomas' FROM '%#\"o_a#\"_' FOR '#') IN ('mas')"
         )
+        self.validate_identity("SELECT TRIM(BOTH FROM ' XXX ')")
+        self.validate_identity("SELECT TRIM(' X' FROM ' XXX ')")
+        self.validate_identity(
+            "SELECT TRIM(LEADING 'bla' FROM ' XXX ' COLLATE utf8_bin)"
+        )
 
         self.validate_all(
             "CREATE TABLE x (a INT SERIAL)",
@@ -122,5 +127,12 @@ class TestPostgres(Validator):
             write={
                 "hive": "SELECT * FROM x WHERE SUBSTRING(col1, 3 + LENGTH(col1) - 10, 10) IN (col2)",
                 "spark": "SELECT * FROM x WHERE SUBSTRING(col1, 3 + LENGTH(col1) - 10, 10) IN (col2)",
+            },
+        )
+        self.validate_all(
+            "SELECT TRIM(FROM ' XXX ')",
+            write={
+                "mysql": "SELECT TRIM(' XXX ')",
+                "postgres": "SELECT TRIM(' XXX ')",
             },
         )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -72,7 +72,6 @@ class TestPostgres(Validator):
         self.validate_identity(
             "SELECT * FROM x WHERE SUBSTRING('Thomas' FROM '%#\"o_a#\"_' FOR '#') IN ('mas')"
         )
-        self.validate_identity("SELECT TRIM(BOTH FROM ' XXX ')")
         self.validate_identity("SELECT TRIM(' X' FROM ' XXX ')")
         self.validate_identity(
             "SELECT TRIM(LEADING 'bla' FROM ' XXX ' COLLATE utf8_bin)"
@@ -130,9 +129,28 @@ class TestPostgres(Validator):
             },
         )
         self.validate_all(
-            "SELECT TRIM(FROM ' XXX ')",
+            "SELECT TRIM(BOTH ' XXX ')",
             write={
                 "mysql": "SELECT TRIM(' XXX ')",
                 "postgres": "SELECT TRIM(' XXX ')",
+                "hive": "SELECT TRIM(' XXX ')",
+            },
+        )
+        self.validate_all(
+            "TRIM(LEADING FROM ' XXX ')",
+            write={
+                "mysql": "LTRIM(' XXX ')",
+                "postgres": "LTRIM(' XXX ')",
+                "hive": "LTRIM(' XXX ')",
+                "presto": "LTRIM(' XXX ')",
+            },
+        )
+        self.validate_all(
+            "TRIM(TRAILING FROM ' XXX ')",
+            write={
+                "mysql": "RTRIM(' XXX ')",
+                "postgres": "RTRIM(' XXX ')",
+                "hive": "RTRIM(' XXX ')",
+                "presto": "RTRIM(' XXX ')",
             },
         )

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -334,6 +334,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("TIME_STR_TO_DATE(a)"), exp.TimeStrToDate)
         self.assertIsInstance(parse_one("TIME_STR_TO_TIME(a)"), exp.TimeStrToTime)
         self.assertIsInstance(parse_one("TIME_STR_TO_UNIX(a)"), exp.TimeStrToUnix)
+        self.assertIsInstance(parse_one("TRIM(LEADING 'b' FROM 'bla')"), exp.Trim)
         self.assertIsInstance(parse_one("TS_OR_DS_ADD(a, 1, 'day')"), exp.TsOrDsAdd)
         self.assertIsInstance(parse_one("TS_OR_DS_TO_DATE(a)"), exp.TsOrDsToDate)
         self.assertIsInstance(parse_one("TS_OR_DS_TO_DATE_STR(a)"), exp.Substring)


### PR DESCRIPTION
Implemented the trim function based (mostly) on [this](https://www.w3resource.com/sql/character-functions/trim.php).

- As I understand, Hive supports the syntax `[L|R]TRIM(target)`. If that's true, this implementation doesn't cover Hive.
- Do we generally want to provide links in comments (eg. for sources), like I did in `_parse_trim`?

fixes #425 