### PR TITLE
Support concatenation in like expressions

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -328,13 +328,13 @@ class Parser:
         TokenType.IN: lambda self, this: self._parse_in(this),
         TokenType.IS: lambda self, this: self._parse_is(this),
         TokenType.LIKE: lambda self, this: self._parse_escape(
-            self.expression(exp.Like, this=this, expression=self._parse_type())
+            self.expression(exp.Like, this=this, expression=self._parse_bitwise())
         ),
         TokenType.ILIKE: lambda self, this: self._parse_escape(
-            self.expression(exp.ILike, this=this, expression=self._parse_type())
+            self.expression(exp.ILike, this=this, expression=self._parse_bitwise())
         ),
         TokenType.RLIKE: lambda self, this: self.expression(
-            exp.RegexpLike, this=this, expression=self._parse_type()
+            exp.RegexpLike, this=this, expression=self._parse_bitwise()
         ),
     }
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -737,6 +737,11 @@ class TestDialect(Validator):
         )
 
     def test_operators(self):
+        self.validate_identity(
+            "some.column LIKE 'foo' || another.column || 'bar' || LOWER(x)"
+        )
+        self.validate_identity("some.column LIKE 'foo' + another.column + 'bar'")
+
         self.validate_all(
             "x ILIKE '%y'",
             read={


### PR DESCRIPTION
This aims to fix the following issue (mentioned in [this](https://github.com/tobymao/sqlglot/discussions/431) discussions post):

Example (valid sql):

```
SELECT * FROM foo WHERE some.column LIKE 'foo' || another.column || 'bar'
```

Result:

```
Invalid expression / Unexpected token. Line 1, Col: 48.
   SELECT * FROM foo WHERE some.column LIKE 'foo' || another.column || 'bar'
                                                  ~~
```