### PR TITLE
Add support for parenthesized joined tables

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -885,10 +885,6 @@ class Reference(Expression):
     arg_types = {"this": True, "expressions": True}
 
 
-class Table(Expression):
-    arg_types = {"this": True, "db": False, "catalog": False}
-
-
 class Tuple(Expression):
     arg_types = {"expressions": False}
 
@@ -996,6 +992,10 @@ QUERY_MODIFIERS = {
     "limit": False,
     "offset": False,
 }
+
+
+class Table(Expression):
+    arg_types = {"this": True, "db": False, "catalog": False, **QUERY_MODIFIERS}
 
 
 class Union(Subqueryable, Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -531,7 +531,7 @@ class Generator:
         return f"{self.sql(expression, 'this')} {self.sql(expression, 'expression')}"
 
     def table_sql(self, expression):
-        return ".".join(
+        table = ".".join(
             part
             for part in [
                 self.sql(expression, "catalog"),
@@ -540,6 +540,8 @@ class Generator:
             ]
             if part
         )
+
+        return f"{table}{self.query_modifiers(expression)}"
 
     def tablesample_sql(self, expression):
         if self.alias_post_tablesample and isinstance(expression.this, exp.Alias):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1032,7 +1032,7 @@ class Parser:
         return self.expression(exp.Subquery, this=this, alias=self._parse_table_alias())
 
     def _parse_query_modifiers(self, this):
-        if not isinstance(this, (exp.Subquery, exp.Subqueryable)):
+        if not isinstance(this, (exp.Subquery, exp.Subqueryable, exp.Table)):
             return
 
         for key, parser in self.QUERY_MODIFIER_PARSERS.items():

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -631,6 +631,33 @@ class TestDialect(Validator):
             },
         )
 
+    # https://dev.mysql.com/doc/refman/8.0/en/join.html
+    # https://www.postgresql.org/docs/current/queries-table-expressions.html
+    def test_joined_tables(self):
+        self.validate_identity("SELECT * FROM (tbl1 LEFT JOIN tbl2 ON 1 = 1)")
+        self.validate_identity("SELECT * FROM (tbl1 JOIN tbl2 JOIN tbl3)")
+        self.validate_identity(
+            "SELECT * FROM (tbl1 JOIN (tbl2 JOIN tbl3) ON bla = foo)"
+        )
+        self.validate_identity(
+            "SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)"
+        )
+
+        self.validate_all(
+            "SELECT * FROM (tbl1 LEFT JOIN tbl2 ON 1 = 1)",
+            write={
+                "postgres": "SELECT * FROM (tbl1 LEFT JOIN tbl2 ON 1 = 1)",
+                "mysql": "SELECT * FROM (tbl1 LEFT JOIN tbl2 ON 1 = 1)",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)",
+            write={
+                "postgres": "SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)",
+                "mysql": "SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)",
+            },
+        )
+
     def test_lateral_subquery(self):
         self.validate_identity(
             "SELECT art FROM tbl1 INNER JOIN LATERAL (SELECT art FROM tbl2) AS tbl2 ON tbl1.art = tbl2.art"


### PR DESCRIPTION
This PR aims to add support for the "joined tables" or "join construct" form that uses parentheses. Example:

```
SELECT * FROM (table1 LEFT JOIN table2 ON 1 = 1)
```

Sources:
- https://www.postgresql.org/docs/current/queries-table-expressions.html
- https://dev.mysql.com/doc/refman/8.0/en/join.html

fixes #423 