### PR TITLE
Support functions after lateral & add distance op for postgres

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -32,10 +32,6 @@ def _date_add_sql(kind):
     return func
 
 
-def _distance_sql(self, expression):
-    return self.binary(expression, "<->")
-
-
 def _lateral_sql(self, expression):
     this = self.sql(expression, "this")
     if isinstance(expression.this, exp.Subquery):
@@ -111,7 +107,6 @@ class Postgres(Dialect):
     class Tokenizer(Tokenizer):
         KEYWORDS = {
             **Tokenizer.KEYWORDS,
-            "<->": TokenType.LR_ARROW,
             "SERIAL": TokenType.AUTO_INCREMENT,
             "UUID": TokenType.UUID,
             "FOR": TokenType.FOR,
@@ -125,8 +120,6 @@ class Postgres(Dialect):
             "TO_TIMESTAMP": format_time_lambda(exp.StrToTime, "postgres"),
             "TO_CHAR": format_time_lambda(exp.TimeToStr, "postgres"),
         }
-
-        FACTOR = {**Parser.FACTOR, TokenType.LR_ARROW: exp.Distance}
 
     class Generator(Generator):
         TYPE_MAPPING = {
@@ -151,7 +144,6 @@ class Postgres(Dialect):
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.DateAdd: _date_add_sql("+"),
             exp.DateSub: _date_add_sql("-"),
-            exp.Distance: _distance_sql,
             exp.Lateral: _lateral_sql,
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.Substring: _substring_sql,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1811,6 +1811,10 @@ class Like(Binary, Predicate):
     pass
 
 
+class Distance(Binary):
+    pass
+
+
 class LT(Binary, Predicate):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1048,6 +1048,9 @@ class Generator:
     def div_sql(self, expression):
         return self.binary(expression, "/")
 
+    def distance_sql(self, expression):
+        return self.binary(expression, "<->")
+
     def dot_sql(self, expression):
         return f"{self.sql(expression, 'this')}.{self.sql(expression, 'expression')}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -224,6 +224,7 @@ class Parser:
 
     FACTOR = {
         TokenType.DIV: exp.IntDiv,
+        TokenType.LR_ARROW: exp.Distance,
         TokenType.SLASH: exp.Div,
         TokenType.STAR: exp.Mul,
     }

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1077,9 +1077,8 @@ class Parser:
 
         if subquery:
             return self.expression(exp.Lateral, this=subquery)
-        elif not self._match(TokenType.VIEW):
-            self.raise_error("Expected subquery or VIEW after LATERAL")
 
+        self._match(TokenType.VIEW)
         outer = self._match(TokenType.OUTER)
 
         return self.expression(
@@ -1138,6 +1137,11 @@ class Parser:
         )
 
     def _parse_table(self, schema=False):
+        lateral = self._parse_lateral()
+
+        if lateral:
+            return lateral
+
         unnest = self._parse_unnest()
 
         if unnest:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -364,6 +364,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "->>": TokenType.DARROW,
         "#>": TokenType.HASH_ARROW,
         "#>>": TokenType.DHASH_ARROW,
+        "<->": TokenType.LR_ARROW,
         "ADD ARCHIVE": TokenType.ADD_FILE,
         "ADD ARCHIVES": TokenType.ADD_FILE,
         "ADD FILE": TokenType.ADD_FILE,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -38,6 +38,7 @@ class TokenType(AutoName):
     DARROW = auto()
     HASH_ARROW = auto()
     DHASH_ARROW = auto()
+    LR_ARROW = auto()
     ANNOTATION = auto()
     DOLLAR = auto()
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -163,3 +163,21 @@ class TestPostgres(Validator):
                 "presto": "RTRIM(' XXX ')",
             },
         )
+        self.validate_all(
+            "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss",
+            read={
+                "postgres": "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss"
+            },
+        )
+        self.validate_all(
+            "SELECT m.name FROM manufacturers AS m LEFT JOIN LATERAL GET_PRODUCT_NAMES(m.id) AS pname ON TRUE WHERE pname IS NULL",
+            read={
+                "postgres": "SELECT m.name FROM manufacturers AS m LEFT JOIN LATERAL GET_PRODUCT_NAMES(m.id) AS pname ON TRUE WHERE pname IS NULL",
+            },
+        )
+        self.validate_all(
+            "SELECT p1.id, p2.id, v1, v2 FROM polygons AS p1, polygons AS p2, LATERAL VERTICES(p1.poly) v1, LATERAL VERTICES(p2.poly) v2 WHERE (v1 <-> v2) < 10 AND p1.id <> p2.id",
+            read={
+                "postgres": "SELECT p1.id, p2.id, v1, v2 FROM polygons p1, polygons p2, LATERAL VERTICES(p1.poly) v1, LATERAL VERTICES(p2.poly) v2 WHERE (v1 <-> v2) < 10 AND p1.id != p2.id",
+            },
+        )


### PR DESCRIPTION
The following form is allowed by postgres but is not currently supported. This PR aims to fix that.

```
SELECT p1.id, p2.id, v1, v2
FROM polygons p1, polygons p2,
     LATERAL vertices(p1.poly) v1,
     LATERAL vertices(p2.poly) v2
WHERE (v1 <-> v2) < 10 AND p1.id != p2.id;
```

Source (7.2.1.5 LATERAL Subqueries): https://www.postgresql.org/docs/current/queries-table-expressions.html
