### PR TITLE
Add support for `SELECT` leading commas in SQL generation

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1137,10 +1137,10 @@ class Generator:
 
         sql = [self.sql(e) for e in expressions]
         # the only time leading_comma changes the output is if pretty print is enabled
-        # and there is more than 1 expression
-        if self._leading_comma and self.pretty and len(sql) > 1:
-            remaining_expr = "\n".join([f"{sep}{s}" for s in sql[1:]])
-            expressions = f"  {sql[0]}\n{remaining_expr}"
+        if self._leading_comma and self.pretty:
+            expressions = "\n".join(
+                f"{sep}{s}" if i > 0 else s for i, s in enumerate(sql)
+            )
         else:
             expressions = self.sep(sep).join(sql)
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1139,7 +1139,8 @@ class Generator:
         # the only time leading_comma changes the output is if pretty print is enabled
         if self._leading_comma and self.pretty:
             expressions = "\n".join(
-                f"{sep}{s}" if i > 0 else s for i, s in enumerate(sql)
+                f"{sep}{s}" if i > 0 else f"{' ' * self.pad}{s}"
+                for i, s in enumerate(sql)
             )
         else:
             expressions = self.sep(sep).join(sql)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -110,6 +110,7 @@ class Generator:
         "_indent",
         "_replace_backslash",
         "_escaped_quote_end",
+        "leading_comma",
     )
 
     def __init__(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -110,7 +110,7 @@ class Generator:
         "_indent",
         "_replace_backslash",
         "_escaped_quote_end",
-        "leading_comma",
+        "_leading_comma",
     )
 
     def __init__(
@@ -161,7 +161,7 @@ class Generator:
         self._indent = indent
         self._replace_backslash = self.escape == "\\"
         self._escaped_quote_end = self.escape + self.quote_end
-        self.leading_comma = leading_comma
+        self._leading_comma = leading_comma
 
     def generate(self, expression):
         """
@@ -1136,7 +1136,9 @@ class Generator:
             return sep.join(self.sql(e) for e in expressions)
 
         sql = [self.sql(e) for e in expressions]
-        if len(sql) > 1 and self.leading_comma:
+        # the only time leading_comma changes the output is if pretty print is enabled
+        # and there is more than 1 expression
+        if self._leading_comma and self.pretty and len(sql) > 1:
             remaining_expr = "\n".join([f"{sep}{s}" for s in sql[1:]])
             expressions = f"  {sql[0]}\n{remaining_expr}"
         else:

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -42,6 +42,20 @@ class TestTranspile(unittest.TestCase):
             "SELECT * FROM x WHERE a = ANY (SELECT 1)",
         )
 
+    def test_leading_comma(self):
+        self.validate(
+            "SELECT FOO, BAR, BAZ",
+            "SELECT\n    FOO\n  , BAR\n  , BAZ",
+            leading_comma=True,
+            pretty=True,
+        )
+        # without pretty, this should be a no-op
+        self.validate(
+            "SELECT FOO, BAR, BAZ",
+            "SELECT FOO, BAR, BAZ"
+            leading_comma=True,
+        )
+
     def test_space(self):
         self.validate("SELECT MIN(3)>MIN(2)", "SELECT MIN(3) > MIN(2)")
         self.validate("SELECT MIN(3)>=MIN(2)", "SELECT MIN(3) >= MIN(2)")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -52,7 +52,7 @@ class TestTranspile(unittest.TestCase):
         # without pretty, this should be a no-op
         self.validate(
             "SELECT FOO, BAR, BAZ",
-            "SELECT FOO, BAR, BAZ"
+            "SELECT FOO, BAR, BAZ",
             leading_comma=True,
         )
 


### PR DESCRIPTION
Some folks have a preference for leading commas, ex:
```sql
SELECT
    foo
  , bar
  , baz
```
instead of the current behavior, which is trailing commas:

```sql
SELECT 
  foo,
  bar,
  baz
```

this creates an option for leading commas