### PR TITLE
Snowflake timestamps

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -120,17 +120,6 @@ class Snowflake(Dialect):
             ),
         }
 
-        def _parse_extract(self):
-            this = self._parse_var() or self._parse_type()
-
-            if self._match(TokenType.FROM):
-                return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
-
-            if not self._match(TokenType.COMMA):
-                self.raise_error("Expected FROM or comma after EXTRACT", self._prev)
-
-            return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
-
     class Tokenizer(Tokenizer):
         QUOTES = ["'", "$$"]
         ESCAPE = "\\"

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -122,6 +122,11 @@ class Snowflake(Dialect):
             **Tokenizer.KEYWORDS,
             "QUALIFY": TokenType.QUALIFY,
             "DOUBLE PRECISION": TokenType.DOUBLE,
+            "TIMESTAMP_TZ": TokenType.TIMESTAMPTZ,
+            "TIMESTAMPNTZ": TokenType.TIMESTAMP,
+            "TIMESTAMP_NTZ": TokenType.TIMESTAMP,
+            "TIMESTAMP_LTZ": TokenType.TIMESTAMPLTZ,
+            "TIMESTAMP": TokenType.TIMESTAMP,
         }
 
     class Generator(Generator):
@@ -130,6 +135,9 @@ class Snowflake(Dialect):
             exp.If: rename_func("IFF"),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.UnixToTime: _unix_to_time,
+            exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP_TZ",
+            exp.DataType.Type.TIMESTAMP: "TIMESTAMP_NTZ",
+            exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP_LTZ",
         }
 
         def except_op(self, expression):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -142,7 +142,6 @@ class Snowflake(Dialect):
             "TIMESTAMP_NTZ": TokenType.TIMESTAMP,
             "TIMESTAMP_TZ": TokenType.TIMESTAMPTZ,
             "TIMESTAMPNTZ": TokenType.TIMESTAMP,
-            "TIMESTAMP": TokenType.TIMESTAMP,
         }
 
     class Generator(Generator):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -126,7 +126,6 @@ class Snowflake(Dialect):
             "TIMESTAMPNTZ": TokenType.TIMESTAMP,
             "TIMESTAMP_NTZ": TokenType.TIMESTAMP,
             "TIMESTAMP_LTZ": TokenType.TIMESTAMPLTZ,
-            "TIMESTAMP": TokenType.TIMESTAMP,
         }
 
     class Generator(Generator):
@@ -135,9 +134,7 @@ class Snowflake(Dialect):
             exp.If: rename_func("IFF"),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.UnixToTime: _unix_to_time,
-            exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP_TZ",
             exp.DataType.Type.TIMESTAMP: "TIMESTAMP_NTZ",
-            exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP_LTZ",
         }
 
         def except_op(self, expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1688,6 +1688,7 @@ class DataType(Expression):
         INTERVAL = auto()
         TIMESTAMP = auto()
         TIMESTAMPTZ = auto()
+        TIMESTAMPLTZ = auto()
         DATE = auto()
         DATETIME = auto()
         ARRAY = auto()

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -62,7 +62,7 @@ class Generator:
     }
 
     NULL_ORDERING_SUPPORTED = True
-
+    # dict[exp.DataType.Type, str]
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -387,7 +387,11 @@ class Generator:
 
     def datatype_sql(self, expression):
         type_value = expression.this
+        # print(f'\ndatatype_sql{type_value}|{type(type_value)}|{type_value.value}|')
+        # for k, v in self.TYPE_MAPPING.items():
+        #     print(f'\n-> {k}|{type(k)}|{v} => {type_value == k}')
         type_sql = self.TYPE_MAPPING.get(type_value, type_value.value)
+        # print(f'\ntype_sql{type_sql}')
         nested = ""
         interior = self.expressions(expression, flat=True)
         if interior:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -62,7 +62,7 @@ class Generator:
     }
 
     NULL_ORDERING_SUPPORTED = True
-    # dict[exp.DataType.Type, str]
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -387,11 +387,7 @@ class Generator:
 
     def datatype_sql(self, expression):
         type_value = expression.this
-        # print(f'\ndatatype_sql{type_value}|{type(type_value)}|{type_value.value}|')
-        # for k, v in self.TYPE_MAPPING.items():
-        #     print(f'\n-> {k}|{type(k)}|{v} => {type_value == k}')
         type_sql = self.TYPE_MAPPING.get(type_value, type_value.value)
-        # print(f'\ntype_sql{type_sql}')
         nested = ""
         interior = self.expressions(expression, flat=True)
         if interior:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -233,6 +233,7 @@ class Parser:
     TIMESTAMPS = {
         TokenType.TIMESTAMP,
         TokenType.TIMESTAMPTZ,
+        TokenType.TIMESTAMPLTZ,
     }
 
     SET_OPERATIONS = {
@@ -1497,12 +1498,19 @@ class Parser:
 
         if type_token in self.TIMESTAMPS:
             tz = self._match(TokenType.WITH_TIME_ZONE) or type_token == TokenType.TIMESTAMPTZ
-            self._match(TokenType.WITHOUT_TIME_ZONE)
             if tz:
                 return exp.DataType(
                     this=exp.DataType.Type.TIMESTAMPTZ,
                     expressions=expressions,
                 )
+            ltz = self._match(TokenType.WITH_LOCAL_TIME_ZONE) or type_token == TokenType.TIMESTAMPLTZ
+            if ltz:
+                return exp.DataType(
+                    this=exp.DataType.Type.TIMESTAMPLTZ,
+                    expressions=expressions,
+                )
+            self._match(TokenType.WITHOUT_TIME_ZONE)
+
             return exp.DataType(
                 this=exp.DataType.Type.TIMESTAMP,
                 expressions=expressions,
@@ -1845,8 +1853,11 @@ class Parser:
     def _parse_extract(self):
         this = self._parse_var() or self._parse_type()
 
-        if not self._match(TokenType.FROM):
-            self.raise_error("Expected FROM after EXTRACT", self._prev)
+        if self._match(TokenType.FROM):
+            return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
+
+        if not self._match(TokenType.COMMA):
+            self.raise_error("Expected FROM or comma after EXTRACT", self._prev)
 
         return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1854,8 +1854,11 @@ class Parser:
     def _parse_extract(self):
         this = self._parse_var() or self._parse_type()
 
-        if not self._match(TokenType.FROM):
-            self.raise_error("Expected FROM after EXTRACT", self._prev)
+        if self._match(TokenType.FROM):
+            return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
+
+        if not self._match(TokenType.COMMA):
+            self.raise_error("Expected FROM or comma after EXTRACT", self._prev)
 
         return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -81,6 +81,7 @@ class Parser:
         TokenType.INTERVAL,
         TokenType.TIMESTAMP,
         TokenType.TIMESTAMPTZ,
+        TokenType.TIMESTAMPLTZ,
         TokenType.DATETIME,
         TokenType.DATE,
         TokenType.DECIMAL,
@@ -1853,11 +1854,8 @@ class Parser:
     def _parse_extract(self):
         this = self._parse_var() or self._parse_type()
 
-        if self._match(TokenType.FROM):
-            return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
-
-        if not self._match(TokenType.COMMA):
-            self.raise_error("Expected FROM or comma after EXTRACT", self._prev)
+        if not self._match(TokenType.FROM):
+            self.raise_error("Expected FROM after EXTRACT", self._prev)
 
         return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -75,6 +75,7 @@ class TokenType(AutoName):
     JSON = auto()
     TIMESTAMP = auto()
     TIMESTAMPTZ = auto()
+    TIMESTAMPLTZ = auto()
     DATETIME = auto()
     DATE = auto()
     UUID = auto()
@@ -247,6 +248,7 @@ class TokenType(AutoName):
     WINDOW = auto()
     WITH = auto()
     WITH_TIME_ZONE = auto()
+    WITH_LOCAL_TIME_ZONE = auto()
     WITHIN_GROUP = auto()
     WITHOUT_TIME_ZONE = auto()
     UNIQUE = auto()
@@ -520,6 +522,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "WHERE": TokenType.WHERE,
         "WITH": TokenType.WITH,
         "WITH TIME ZONE": TokenType.WITH_TIME_ZONE,
+        "WITH LOCAL TIME ZONE": TokenType.WITH_LOCAL_TIME_ZONE,
         "WITHIN GROUP": TokenType.WITHIN_GROUP,
         "WITHOUT TIME ZONE": TokenType.WITHOUT_TIME_ZONE,
         "ARRAY": TokenType.ARRAY,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -564,6 +564,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "BYTEA": TokenType.BINARY,
         "TIMESTAMP": TokenType.TIMESTAMP,
         "TIMESTAMPTZ": TokenType.TIMESTAMPTZ,
+        "TIMESTAMPLTZ": TokenType.TIMESTAMPLTZ,
         "DATE": TokenType.DATE,
         "DATETIME": TokenType.DATETIME,
         "UNIQUE": TokenType.UNIQUE,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -178,33 +178,40 @@ class TestSnowflake(Validator):
 
     def test_timestamps(self):
         self.validate_all(
-            "SELECT CAST(a AS TIMESTAMP_NTZ(9))",
+            "SELECT CAST(a AS TIMESTAMP)",
             write={
-                "snowflake": "SELECT CAST(a AS TIMESTAMP(9))",
+                "snowflake": "SELECT CAST(a AS TIMESTAMPNTZ)",
             },
         )
-        # TODO: fix this test, should be TIMESTAMP_LTZ
+        self.validate_all(
+            "SELECT a::TIMESTAMP_LTZ(9)",
+            write={
+                "snowflake": "SELECT CAST(a AS TIMESTAMPLTZ(9))",
+            },
+        )
+        self.validate_all(
+            "SELECT a::TIMESTAMPLTZ",
+            write={
+                "snowflake": "SELECT CAST(a AS TIMESTAMPLTZ)",
+            },
+        )
         self.validate_all(
             "SELECT a::TIMESTAMP WITH LOCAL TIME ZONE",
             write={
                 "snowflake": "SELECT CAST(a AS TIMESTAMPLTZ)",
             },
         )
+        self.validate_identity("SELECT EXTRACT(month FROM a)")
         self.validate_all(
             "SELECT EXTRACT('month', a)",
             write={
                 "snowflake": "SELECT EXTRACT('month' FROM a)",
             },
         )
+        self.validate_all("SELECT DATE_PART('month', a)")
         self.validate_all(
-            "SELECT EXTRACT(month FROM a)",
+            "SELECT DATE_PART(month FROM a::DATETIME)",
             write={
-                "snowflake": "SELECT EXTRACT(month FROM a)",
-            },
-        )
-        self.validate_all(
-            "SELECT DATE_PART('month', a)",
-            write={
-                "snowflake": "SELECT DATE_PART('month', a)",
+                "snowflake": "SELECT EXTRACT(month FROM CAST(a AS DATETIME))",
             },
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -208,7 +208,12 @@ class TestSnowflake(Validator):
                 "snowflake": "SELECT EXTRACT('month' FROM a)",
             },
         )
-        self.validate_all("SELECT DATE_PART('month', a)")
+        self.validate_all(
+            "SELECT DATE_PART('month', a)",
+            write={
+                "snowflake": "SELECT EXTRACT('month' FROM a)",
+            },
+        )
         self.validate_all(
             "SELECT DATE_PART(month FROM a::DATETIME)",
             write={

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -175,3 +175,36 @@ class TestSnowflake(Validator):
                 "snowflake": r"SELECT FIRST_VALUE(TABLE1.COLUMN1) IGNORE NULLS OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1"
             },
         )
+
+    def test_timestamps(self):
+        self.validate_all(
+            "SELECT CAST(a AS TIMESTAMP_NTZ(9))",
+            write={
+                "snowflake": "SELECT CAST(a AS TIMESTAMP(9))",
+            },
+        )
+        # TODO: fix this test, should be TIMESTAMP_LTZ
+        self.validate_all(
+            "SELECT a::TIMESTAMP WITH LOCAL TIME ZONE",
+            write={
+                "snowflake": "SELECT CAST(a AS TIMESTAMPLTZ)",
+            },
+        )
+        self.validate_all(
+            "SELECT EXTRACT('month', a)",
+            write={
+                "snowflake": "SELECT EXTRACT('month' FROM a)",
+            },
+        )
+        self.validate_all(
+            "SELECT EXTRACT(month FROM a)",
+            write={
+                "snowflake": "SELECT EXTRACT(month FROM a)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_PART('month', a)",
+            write={
+                "snowflake": "SELECT DATE_PART('month', a)",
+            },
+        )


### PR DESCRIPTION
This PR expands Snowflake dialect support for Snowflake-specific timestamp types and timestamp-related functions.

1. `EXTRACT` as a synonym for `DATE_PART`

Snowflake supports both `EXTRACT` and `DATE_PART`. The `FROM` and comma-delimited invocation style are supported for both. I confirmed all of the following are valid in Snowflake:

```
SELECT   EXTRACT( month from '2022-09-01'::DATETIME);
SELECT   EXTRACT( month,     '2022-09-01'::DATETIME);
SELECT   EXTRACT('month',    '2022-09-01'::DATETIME);
SELECT DATE_PART('month',    '2022-09-01'::DATETIME);
SELECT DATE_PART( month,     '2022-09-01'::DATETIME);
SELECT DATE_PART( month FROM '2022-09-01'::DATETIME);
```

2. `TIMESTAMPLTZ` type

Added support for Snowflake's relatively unique `TIMESTAMP WITH LOCAL TIME ZONE`.

3. `TIMESTAMP` type handling

Snowflake has no `TIMESTAMP` type. When Snowflake parses a `TIMESTAMP` expression it checks the current session parameters to determine how it should be interpreted, with `TIMESTAMPNTZ` as the default. I have reflected this default in sqlglot behavior.