### PR TITLE
Fix rename_func so it handles var len arg functions

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -174,7 +174,7 @@ def rename_func(name):
     def _rename(self, expression):
         args = (
             self.expressions(expression, flat=True)
-            if expression.args.get("expressions")
+            if isinstance(expression, exp.Func) and expression.is_var_len_args
             else csv(*[self.sql(e) for e in expression.args.values()])
         )
         return f"{name}({args})"

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -171,7 +171,15 @@ class Dialect(metaclass=_Dialect):
 
 
 def rename_func(name):
-    return lambda self, expression: f"{name}({csv(*[self.sql(e) for e in expression.args.values()])})"
+    def _rename(self, expression):
+        args = (
+            self.expressions(expression, flat=True)
+            if expression.args.get("expressions")
+            else csv(*[self.sql(e) for e in expression.args.values()])
+        )
+        return f"{name}({args})"
+
+    return _rename
 
 
 def approx_count_distinct_sql(self, expression):

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -108,7 +108,7 @@ class DuckDB(Dialect):
         TRANSFORMS = {
             **Generator.TRANSFORMS,
             exp.ApproxDistinct: approx_count_distinct_sql,
-            exp.Array: lambda self, e: f"LIST_VALUE({self.expressions(e, flat=True)})",
+            exp.Array: rename_func("LIST_VALUE"),
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySort: _array_sort_sql,
             exp.ArraySum: rename_func("LIST_SUM"),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -66,6 +66,9 @@ class TestDuckDB(Validator):
     def test_duckdb(self):
         self.validate_all(
             "LIST_VALUE(0, 1, 2)",
+            read={
+                "spark": "ARRAY(0, 1, 2)",
+            },
             write={
                 "bigquery": "[0, 1, 2]",
                 "duckdb": "LIST_VALUE(0, 1, 2)",


### PR DESCRIPTION
This can probably be written in a better way. I tried making the intent clearer by doing `if expression.is_var_len_args`, but apparently it doesn't work because the BitwiseLeft/RightShift tests fail:

```
ERROR: test_bits (tests.dialects.test_hive.TestHive) [x >> 1 -> spark]
...
    if expression.is_var_len_args
AttributeError: 'BitwiseRightShift' object has no attribute 'is_var_len_args'
```

Fixes #474 