### PR TITLE
Add support for removing AST nodes using transform

### DIFF
--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -247,6 +247,16 @@ class TestExpressions(unittest.TestCase):
 
         self.assertEqual(expression.transform(fun).sql(), "SELECT a, b FROM x")
 
+    def test_transform_node_removal(self):
+        expression = parse_one("SELECT a, b FROM x")
+
+        def fun(node):
+            if isinstance(node, exp.Column) and node.name == "b":
+                return None
+            return node
+
+        self.assertEqual(expression.transform(fun, allow_removals=True).sql(), "SELECT a FROM x")
+
     def test_replace(self):
         expression = parse_one("SELECT a, b FROM x")
         expression.find(exp.Column).replace(parse_one("c"))

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -224,9 +224,6 @@ class TestExpressions(unittest.TestCase):
         self.assertEqual(actual_expression_2.sql(dialect="presto"), "IF(c - 2 > 0, c - 2, b)")
         self.assertIs(actual_expression_2, expression)
 
-        with self.assertRaises(ValueError):
-            parse_one("a").transform(lambda n: None)
-
     def test_transform_no_infinite_recursion(self):
         expression = parse_one("a")
 
@@ -250,12 +247,31 @@ class TestExpressions(unittest.TestCase):
     def test_transform_node_removal(self):
         expression = parse_one("SELECT a, b FROM x")
 
-        def fun(node):
+        def remove_column_b(node):
             if isinstance(node, exp.Column) and node.name == "b":
                 return None
             return node
 
-        self.assertEqual(expression.transform(fun, allow_removals=True).sql(), "SELECT a FROM x")
+        self.assertEqual(expression.transform(remove_column_b).sql(), "SELECT a FROM x")
+        self.assertEqual(expression.transform(lambda _: None), None)
+
+        expression = parse_one("CAST(x AS FLOAT)")
+
+        def remove_non_list_arg(node):
+            if isinstance(node, exp.DataType):
+                return None
+            return node
+
+        self.assertEqual(expression.transform(remove_non_list_arg).sql(), "CAST(x AS )")
+
+        expression = parse_one("SELECT a, b FROM x")
+
+        def remove_all_columns(node):
+            if isinstance(node, exp.Column):
+                return None
+            return node
+
+        self.assertEqual(expression.transform(remove_all_columns).sql(), "SELECT FROM x")
 
     def test_replace(self):
         expression = parse_one("SELECT a, b FROM x")


### PR DESCRIPTION
Inspired by [this](https://github.com/tobymao/sqlglot/discussions/462) discussion.

Demo:

```python
from sqlglot import exp, parse_one

expression_tree = parse_one("SELECT a, b FROM x")

def fun(node):
    if isinstance(node, exp.Column) and node.name == "b":
        return None
    return node

transformed_tree = expression_tree.transform(fun)
transformed_tree.sql()
```

Which outputs:

```python
SELECT a FROM x
```

Allowing node deletion could certainly lead to problems, eg. removing the only condition in a where clause, although the same thing could be said about other transformations too, so this seems like a useful feature to have.
