### PR TITLE
Add values to unnest support for bigquery

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -34,13 +34,13 @@ def _date_add_sql(data_type, kind):
 
 
 def _subquery_to_unnest_if_values(self, expression):
-    if not isinstance(expression.args.get("this"), exp.Values):
+    if not isinstance(expression.this, exp.Values):
         return self.subquery_sql(expression)
-    rows = [list(tuple_exp.find_all(exp.Literal)) for tuple_exp in expression.args["this"].find_all(exp.Tuple)]
+    rows = [list(tuple_exp.find_all(exp.Literal)) for tuple_exp in expression.this.find_all(exp.Tuple)]
     structs = []
     for row in rows:
         aliases = [
-            exp.Alias(this=value, alias=column_name)
+            exp.alias_(value, column_name)
             for value, column_name in zip(row, expression.args["alias"].args["columns"])
         ]
         structs.append(exp.Struct(expressions=aliases))

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -33,6 +33,21 @@ def _date_add_sql(data_type, kind):
     return func
 
 
+def _subquery_to_unnest_if_values(self, expression):
+    if not isinstance(expression.args.get("this"), exp.Values):
+        return self.subquery_sql(expression)
+    rows = [list(tuple_exp.find_all(exp.Literal)) for tuple_exp in expression.args["this"].find_all(exp.Tuple)]
+    structs = []
+    for row in rows:
+        aliases = [
+            exp.Alias(this=value, alias=column_name)
+            for value, column_name in zip(row, expression.args["alias"].args["columns"])
+        ]
+        structs.append(exp.Struct(expressions=aliases))
+    unnest_exp = exp.Unnest(expressions=[exp.Array(expressions=structs)])
+    return self.unnest_sql(unnest_exp)
+
+
 class BigQuery(Dialect):
     unnest_column_only = True
 
@@ -91,6 +106,7 @@ class BigQuery(Dialect):
             exp.TimestampAdd: _date_add_sql("TIMESTAMP", "ADD"),
             exp.TimestampSub: _date_add_sql("TIMESTAMP", "SUB"),
             exp.VariancePop: rename_func("VAR_POP"),
+            exp.Subquery: _subquery_to_unnest_if_values,
         }
 
         TYPE_MAPPING = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -236,3 +236,11 @@ class TestBigQuery(Validator):
                 "snowflake": "SELECT a FROM test WHERE a = 1 GROUP BY a HAVING a = 2 QUALIFY z ORDER BY a NULLS FIRST LIMIT 10",
             },
         )
+        self.validate_all(
+            "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
+            write={
+                "spark": "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
+                "bigquery": "SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)])",
+                "snowflake": "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
+            },
+        )


### PR DESCRIPTION
BigQuery doesn't support `VALUES` for statically creating a table with values but it does support the same functionality using `UNNEST` on a struct. One tricky part is that it requires that the `UNNEST` not be a subquery like what `VALUES` commonly is. Therefore on BigQuery I check if the target of a subquery is a VALUES expression and if not then I parse it like normal otherwise I convert the subquery to an `UNNEST`. 