### PR TITLE
Ignore column references in hints

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -200,7 +200,9 @@ class Scope:
             self._columns = [
                 c
                 for c in columns + external_columns
-                if not (c.find_ancestor(exp.Qualify, exp.Order) and not c.table and c.name in named_outputs)
+                if (not c.find_ancestor(exp.Qualify, exp.Order, exp.Hint)
+                    or c.table
+                    or (c.name not in named_outputs and not c.find_ancestor(exp.Hint)))
             ]
         return self._columns
 

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -127,3 +127,11 @@ LIMIT 1;
   FROM "y" AS "y"
 )
 LIMIT 1;
+
+# dialect: spark
+SELECT /*+ BROADCAST(y) */ x.b FROM x JOIN y ON x.b = y.b;
+SELECT /*+ BROADCAST(`y`) */
+  `x`.`b` AS `b`
+FROM `x` AS `x`
+JOIN `y` AS `y`
+  ON `x`.`b` = `y`.`b`;

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -231,3 +231,10 @@ SELECT COALESCE(x.b, y.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b WHERE COALES
 
 SELECT b FROM x JOIN y USING (b) JOIN z USING (b);
 SELECT COALESCE(x.b, y.b, z.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b JOIN z AS z ON x.b = z.b;
+
+--------------------------------------
+-- Hint with table reference
+--------------------------------------
+# dialect: spark
+SELECT /*+ BROADCAST(y) */ x.b FROM x JOIN y ON x.b = y.b;
+SELECT /*+ BROADCAST(y) */ x.b AS b FROM x AS x JOIN y AS y ON x.b = y.b;


### PR DESCRIPTION
Currently if someone has a BROADCAST hint in their SQL and wants to optimize the SQL sqlglot will error since it will say that the referenced "column" does not exist. The column is actually a table. The solution in the PR is to exclude that column from the list of columns in the scope so it does not get checked as being a valid column.