### PR TITLE
Fix lambda variables with optimize

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -200,9 +200,9 @@ class Scope:
             self._columns = [
                 c
                 for c in columns + external_columns
-                if (not c.find_ancestor(exp.Qualify, exp.Order, exp.Hint)
+                if (not c.find_ancestor(exp.Qualify, exp.Order, exp.Hint, exp.Lambda)
                     or c.table
-                    or (c.name not in named_outputs and not c.find_ancestor(exp.Hint)))
+                    or (c.name not in named_outputs and not c.find_ancestor(exp.Hint, exp.Lambda)))
             ]
         return self._columns
 

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -135,3 +135,8 @@ SELECT /*+ BROADCAST(`y`) */
 FROM `x` AS `x`
 JOIN `y` AS `y`
   ON `x`.`b` = `y`.`b`;
+
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc) AS sum_agg FROM x;
+SELECT
+  AGGREGATE(ARRAY("x"."a", "x"."b"), 0, ("x", "acc") -> "x" + "acc") AS "sum_agg"
+FROM "x" AS "x";

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -136,7 +136,7 @@ FROM `x` AS `x`
 JOIN `y` AS `y`
   ON `x`.`b` = `y`.`b`;
 
-SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc) AS sum_agg FROM x;
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc + a) AS sum_agg FROM x;
 SELECT
-  AGGREGATE(ARRAY("x"."a", "x"."b"), 0, ("x", "acc") -> "x" + "acc") AS "sum_agg"
+  AGGREGATE(ARRAY("x"."a", "x"."b"), 0, ("x", "acc") -> "x" + "acc" + "x"."a") AS "sum_agg"
 FROM "x" AS "x";

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -69,8 +69,8 @@ SELECT ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS row_num FROM x AS x 
 SELECT x.b, x.a FROM x LEFT JOIN y ON x.b = y.b QUALIFY ROW_NUMBER() OVER(PARTITION BY x.b ORDER BY x.a DESC) = 1;
 SELECT x.b AS b, x.a AS a FROM x AS x LEFT JOIN y AS y ON x.b = y.b QUALIFY ROW_NUMBER() OVER (PARTITION BY x.b ORDER BY x.a DESC) = 1;
 
-SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc) AS sum_agg FROM x;
-SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc) AS sum_agg FROM x AS x;
+SELECT AGGREGATE(ARRAY(a, x.b), 0, (x, acc) -> x + acc + a) AS sum_agg FROM x;
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc + x.a) AS sum_agg FROM x AS x;
 
 --------------------------------------
 -- Derived tables

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -69,6 +69,9 @@ SELECT ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS row_num FROM x AS x 
 SELECT x.b, x.a FROM x LEFT JOIN y ON x.b = y.b QUALIFY ROW_NUMBER() OVER(PARTITION BY x.b ORDER BY x.a DESC) = 1;
 SELECT x.b AS b, x.a AS a FROM x AS x LEFT JOIN y AS y ON x.b = y.b QUALIFY ROW_NUMBER() OVER (PARTITION BY x.b ORDER BY x.a DESC) = 1;
 
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc) AS sum_agg FROM x;
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc) AS sum_agg FROM x AS x;
+
 --------------------------------------
 -- Derived tables
 --------------------------------------


### PR DESCRIPTION
Prior to this change lambda variables were considered columns and therefore optimize would fail since it would look for columns that didn't exist. Now those variables are excluded but any columns used within a lambda expression are still included. 