### PR TITLE
Have parser convert lambda variables to identifiers

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1709,6 +1709,13 @@ class Parser:
         return self._parse_window(this)
 
     def _parse_lambda(self):
+        def replace_lambda_columns_with_identifiers(node, lambda_variables):
+            if isinstance(node, exp.Column):
+                matching_lambda_var = [x for x in lambda_variables if node.name == x.name]
+                if matching_lambda_var:
+                    return matching_lambda_var[0]
+            return node
+
         index = self._index
 
         if self._match(TokenType.L_PAREN):
@@ -1733,9 +1740,10 @@ class Parser:
 
             return self._parse_alias(self._parse_limit(self._parse_order(this)))
 
+        conjunction = self._parse_conjunction().transform(replace_lambda_columns_with_identifiers, expressions)
         return self.expression(
             exp.Lambda,
-            this=self._parse_conjunction(),
+            this=conjunction,
             expressions=expressions,
         )
 

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -168,7 +168,7 @@ SELECT LEAD(a) OVER (ORDER BY b) AS a
 SELECT LEAD(a, 1) OVER (PARTITION BY a ORDER BY a) AS x
 SELECT LEAD(a, 1, b) OVER (PARTITION BY a ORDER BY a) AS x
 SELECT X((a, b) -> a + b, z -> z) AS x
-SELECT X(a -> "a" + ("z" - 1))
+SELECT X(a -> a + ("z" - 1))
 SELECT EXISTS(ARRAY(2, 3), x -> x % 2 = 0)
 SELECT test.* FROM test
 SELECT a AS b FROM test

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -135,3 +135,8 @@ SELECT /*+ BROADCAST(`y`) */
 FROM `x` AS `x`
 JOIN `y` AS `y`
   ON `x`.`b` = `y`.`b`;
+
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc + a) AS sum_agg FROM x;
+SELECT
+  AGGREGATE(ARRAY("x"."a", "x"."b"), 0, ("x", "acc") -> "x" + "acc" + "x"."a") AS "sum_agg"
+FROM "x" AS "x";

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -69,6 +69,9 @@ SELECT ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS row_num FROM x AS x 
 SELECT x.b, x.a FROM x LEFT JOIN y ON x.b = y.b QUALIFY ROW_NUMBER() OVER(PARTITION BY x.b ORDER BY x.a DESC) = 1;
 SELECT x.b AS b, x.a AS a FROM x AS x LEFT JOIN y AS y ON x.b = y.b QUALIFY ROW_NUMBER() OVER (PARTITION BY x.b ORDER BY x.a DESC) = 1;
 
+SELECT AGGREGATE(ARRAY(a, x.b), 0, (x, acc) -> x + acc + a) AS sum_agg FROM x;
+SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc + x.a) AS sum_agg FROM x AS x;
+
 --------------------------------------
 -- Derived tables
 --------------------------------------


### PR DESCRIPTION
Currently the lambda parser treats the lambda variables as columns when they really are identifiers. This issues becomes more clear when using the optimizer since it would look for the definitions of those columns in sources and the wouldn't exist. 