### PR TITLE
Use DATETIME2 in TSQL as default timestamp type

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -18,6 +18,7 @@ class TSQL(Dialect):
             "REAL": TokenType.FLOAT,
             "NTEXT": TokenType.TEXT,
             "SMALLDATETIME": TokenType.DATETIME,
+            "DATETIME2": TokenType.DATETIME,
             "DATETIMEOFFSET": TokenType.TIMESTAMPTZ,
             "TIME": TokenType.TIMESTAMP,
             "VARBINARY": TokenType.BINARY,
@@ -43,5 +44,6 @@ class TSQL(Dialect):
             exp.DataType.Type.BOOLEAN: "BIT",
             exp.DataType.Type.INT: "INTEGER",
             exp.DataType.Type.DECIMAL: "NUMERIC",
+            exp.DataType.Type.DATETIME: "DATETIME2",
             exp.DataType.Type.VARIANT: "SQL_VARIANT",
         }

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -32,3 +32,5 @@ class TestTSQL(Validator):
         self.validate_identity("CAST(x AS IMAGE)")
         self.validate_identity("CAST(x AS SQL_VARIANT)")
         self.validate_identity("CAST(x AS BIT)")
+        self.validate("CAST(x AS DATETIME)", "CAST(x AS DATETIME2)", write="tsql")
+        self.validate("CAST(x AS DATETIME2)", "CAST(x AS DATETIME)", read="tsql", write="mysql")


### PR DESCRIPTION
It is the flavor of datetime which "aligns with the SQL Standard".

Docs: https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=azure-sqldw-latest&preserve-view=true