### PR TITLE
Classify Values as a Derived Table

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -20,7 +20,7 @@ from sqlglot.generator import Generator
 from sqlglot.parser import Parser
 from sqlglot.tokens import Tokenizer, TokenType
 
-__version__ = "6.2.4"
+__version__ = "6.2.5"
 
 pretty = False
 

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -33,10 +33,10 @@ def _date_add_sql(data_type, kind):
     return func
 
 
-def _subquery_to_unnest_if_values(self, expression):
-    if not isinstance(expression.this, exp.Values):
-        return self.subquery_sql(expression)
-    rows = [list(tuple_exp.find_all(exp.Literal)) for tuple_exp in expression.this.find_all(exp.Tuple)]
+def _derived_table_values_to_unnest(self, expression):
+    if not isinstance(expression.unnest().parent, exp.From):
+        return self.values_sql(expression)
+    rows = [list(tuple_exp.find_all(exp.Literal)) for tuple_exp in expression.find_all(exp.Tuple)]
     structs = []
     for row in rows:
         aliases = [
@@ -105,7 +105,7 @@ class BigQuery(Dialect):
             exp.TimestampAdd: _date_add_sql("TIMESTAMP", "ADD"),
             exp.TimestampSub: _date_add_sql("TIMESTAMP", "SUB"),
             exp.VariancePop: rename_func("VAR_POP"),
-            exp.Subquery: _subquery_to_unnest_if_values,
+            exp.Values: _derived_table_values_to_unnest,
         }
 
         TYPE_MAPPING = {

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -77,6 +77,7 @@ class Dialect(metaclass=_Dialect):
     alias_post_tablesample = False
     normalize_functions = "upper"
     null_ordering = "nulls_are_small"
+    wrapped_derived_values = True
 
     date_format = "'%Y-%m-%d'"
     dateint_format = "'%Y%m%d'"
@@ -169,6 +170,7 @@ class Dialect(metaclass=_Dialect):
                 "alias_post_tablesample": self.alias_post_tablesample,
                 "normalize_functions": self.normalize_functions,
                 "null_ordering": self.null_ordering,
+                "wrapped_derived_values": self.wrapped_derived_values,
                 **opts,
             }
         )

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -77,7 +77,7 @@ class Dialect(metaclass=_Dialect):
     alias_post_tablesample = False
     normalize_functions = "upper"
     null_ordering = "nulls_are_small"
-    wrapped_derived_values = True
+    wrap_derived_values = True
 
     date_format = "'%Y-%m-%d'"
     dateint_format = "'%Y%m%d'"
@@ -170,7 +170,7 @@ class Dialect(metaclass=_Dialect):
                 "alias_post_tablesample": self.alias_post_tablesample,
                 "normalize_functions": self.normalize_functions,
                 "null_ordering": self.null_ordering,
-                "wrapped_derived_values": self.wrapped_derived_values,
+                "wrap_derived_values": self.wrap_derived_values,
                 **opts,
             }
         )

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -47,7 +47,7 @@ def _unix_to_time(self, expression):
 
 
 class Spark(Hive):
-    wrapped_derived_values = False
+    wrap_derived_values = False
 
     class Parser(Hive.Parser):
         FUNCTIONS = {

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -47,6 +47,8 @@ def _unix_to_time(self, expression):
 
 
 class Spark(Hive):
+    wrapped_derived_values = False
+
     class Parser(Hive.Parser):
         FUNCTIONS = {
             **Hive.Parser.FUNCTIONS,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -506,6 +506,10 @@ class DerivedTable(Expression):
         return [select.alias_or_name for select in self.selects]
 
 
+class SelectlessDerivedTable(DerivedTable):
+    pass
+
+
 class Annotation(Expression):
     arg_types = {
         "this": True,
@@ -827,7 +831,7 @@ class Join(Expression):
         return join
 
 
-class Lateral(DerivedTable):
+class Lateral(SelectlessDerivedTable):
     arg_types = {"this": True, "outer": False, "alias": False}
 
 
@@ -1098,7 +1102,7 @@ class Intersect(Union):
     pass
 
 
-class Unnest(DerivedTable):
+class Unnest(SelectlessDerivedTable):
     arg_types = {
         "expressions": True,
         "ordinality": False,
@@ -1116,7 +1120,7 @@ class Update(Expression):
     }
 
 
-class Values(DerivedTable):
+class Values(SelectlessDerivedTable):
     arg_types = {
         "expressions": True,
         "ordinality": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2095,6 +2095,7 @@ class Array(Func):
 
 class NamelessArray(Array):
     _sql_names = ["NamelessArray"]
+
     @classmethod
     def sql_name(cls):
         return ""

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -506,7 +506,7 @@ class DerivedTable(Expression):
         return [select.alias_or_name for select in self.selects]
 
 
-class SelectlessDerivedTable(DerivedTable):
+class UDTF(DerivedTable):
     pass
 
 
@@ -831,7 +831,7 @@ class Join(Expression):
         return join
 
 
-class Lateral(SelectlessDerivedTable):
+class Lateral(UDTF):
     arg_types = {"this": True, "outer": False, "alias": False}
 
 
@@ -1102,7 +1102,7 @@ class Intersect(Union):
     pass
 
 
-class Unnest(SelectlessDerivedTable):
+class Unnest(UDTF):
     arg_types = {
         "expressions": True,
         "ordinality": False,
@@ -1120,7 +1120,7 @@ class Update(Expression):
     }
 
 
-class Values(SelectlessDerivedTable):
+class Values(UDTF):
     arg_types = {
         "expressions": True,
         "ordinality": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1115,8 +1115,12 @@ class Update(Expression):
     }
 
 
-class Values(Expression):
-    arg_types = {"expressions": True}
+class Values(DerivedTable):
+    arg_types = {
+        "expressions": True,
+        "ordinality": False,
+        "alias": False,
+    }
 
 
 class Var(Expression):
@@ -2087,6 +2091,13 @@ class ApproxDistinct(AggFunc):
 class Array(Func):
     arg_types = {"expressions": False}
     is_var_len_args = True
+
+
+class NamelessArray(Array):
+    _sql_names = ["NamelessArray"]
+    @classmethod
+    def sql_name(cls):
+        return ""
 
 
 class ArrayAgg(AggFunc):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2093,14 +2093,6 @@ class Array(Func):
     is_var_len_args = True
 
 
-class NamelessArray(Array):
-    _sql_names = ["NamelessArray"]
-
-    @classmethod
-    def sql_name(cls):
-        return ""
-
-
 class ArrayAgg(AggFunc):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -99,7 +99,7 @@ class Generator:
         "unsupported_messages",
         "null_ordering",
         "max_unsupported",
-        "wrapped_derived_values",
+        "wrap_derived_values",
         "_indent",
         "_replace_backslash",
         "_escaped_quote_end",
@@ -128,7 +128,7 @@ class Generator:
         null_ordering=None,
         max_unsupported=3,
         leading_comma=False,
-        wrapped_derived_values=True,
+        wrap_derived_values=True,
     ):
         import sqlglot
 
@@ -152,7 +152,7 @@ class Generator:
         self.unsupported_messages = []
         self.max_unsupported = max_unsupported
         self.null_ordering = null_ordering
-        self.wrapped_derived_values = wrapped_derived_values
+        self.wrap_derived_values = wrap_derived_values
         self._indent = indent
         self._replace_backslash = self.escape == "\\"
         self._escaped_quote_end = self.escape + self.quote_end
@@ -591,7 +591,7 @@ class Generator:
         if not alias:
             return f"VALUES{self.seg('')}{args}"
         alias = f" AS {alias}" if alias else alias
-        if self.wrapped_derived_values:
+        if self.wrap_derived_values:
             return f"(VALUES{self.seg('')}{args}){alias}"
         return f"VALUES{self.seg('')}{args}{alias}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -588,8 +588,8 @@ class Generator:
             return f"VALUES{self.seg('')}{args}"
         alias = f" AS {alias}" if alias else alias
         if self.wrapped_derived_values:
-            return f"(VALUES {args}){alias}"
-        return f"VALUES {args}{alias}"
+            return f"(VALUES{self.seg('')}{args}){alias}"
+        return f"VALUES{self.seg('')}{args}{alias}"
 
     def var_sql(self, expression):
         return self.sql(expression, "this")
@@ -808,7 +808,6 @@ class Generator:
         alias = f" AS {alias}" if alias else alias
         ordinality = " WITH ORDINALITY" if expression.args.get("ordinality") else ""
         return f"UNNEST({args}){ordinality}{alias}"
-
 
     def where_sql(self, expression):
         this = self.indent(self.sql(expression, "this"))
@@ -1161,7 +1160,6 @@ class Generator:
 
     def token_sql(self, token_type):
         return self.TOKEN_MAPPING.get(token_type, token_type.name)
-
 
     def userdefinedfunction_sql(self, expression):
         this = self.sql(expression, "this")

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -5,7 +5,7 @@ from sqlglot.errors import OptimizeError
 from sqlglot.optimizer.schema import ensure_schema
 from sqlglot.optimizer.scope import traverse_scope
 
-SKIP_QUALIFY = (exp.Unnest, exp.Lateral)
+SKIP_QUALIFY = (exp.Unnest, exp.Lateral, exp.Values)
 
 
 def qualify_columns(expression, schema):

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -5,8 +5,6 @@ from sqlglot.errors import OptimizeError
 from sqlglot.optimizer.schema import ensure_schema
 from sqlglot.optimizer.scope import traverse_scope
 
-SKIP_QUALIFY = exp.SelectlessDerivedTable
-
 
 def qualify_columns(expression, schema):
     """
@@ -35,7 +33,7 @@ def qualify_columns(expression, schema):
         _expand_group_by(scope, resolver)
         _expand_order_by(scope)
         _qualify_columns(scope, resolver)
-        if not isinstance(scope.expression, SKIP_QUALIFY):
+        if not isinstance(scope.expression, exp.UDTF):
             _expand_stars(scope, resolver)
             _qualify_outputs(scope)
         _check_unknown_tables(scope)
@@ -50,7 +48,7 @@ def _pop_table_column_aliases(derived_tables):
     (e.g. SELECT ... FROM (SELECT ...) AS foo(col1, col2)
     """
     for derived_table in derived_tables:
-        if isinstance(derived_table, SKIP_QUALIFY):
+        if isinstance(derived_table, exp.UDTF):
             continue
         table_alias = derived_table.args.get("alias")
         if table_alias:
@@ -202,7 +200,7 @@ def _qualify_columns(scope, resolver):
         if not column_table:
             column_table = resolver.get_table(column_name)
 
-            if not scope.is_subquery and not scope.is_unnest:
+            if not scope.is_subquery and not scope.is_udtf:
                 if column_name not in resolver.all_columns:
                     raise OptimizeError(f"Unknown column: {column_name}")
 
@@ -296,7 +294,7 @@ def _qualify_outputs(scope):
 
 
 def _check_unknown_tables(scope):
-    if scope.external_columns and not scope.is_unnest and not scope.is_correlated_subquery:
+    if scope.external_columns and not scope.is_udtf and not scope.is_correlated_subquery:
         raise OptimizeError(f"Unknown table: {scope.external_columns[0].text('table')}")
 
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -5,7 +5,7 @@ from sqlglot.errors import OptimizeError
 from sqlglot.optimizer.schema import ensure_schema
 from sqlglot.optimizer.scope import traverse_scope
 
-SKIP_QUALIFY = (exp.Unnest, exp.Lateral, exp.Values)
+SKIP_QUALIFY = exp.SelectlessDerivedTable
 
 
 def qualify_columns(expression, schema):

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -103,7 +103,7 @@ class Scope:
                 self._raw_columns.append(node)
             elif isinstance(node, exp.Table):
                 self._tables.append(node)
-            elif isinstance(node, (exp.Unnest, exp.Lateral)):
+            elif isinstance(node, (exp.Unnest, exp.Lateral, exp.Values)):
                 self._derived_tables.append(node)
             elif isinstance(node, exp.CTE):
                 self._ctes.append(node)
@@ -399,7 +399,7 @@ def _traverse_scope(scope):
         yield from _traverse_select(scope)
     elif isinstance(scope.expression, exp.Union):
         yield from _traverse_union(scope)
-    elif isinstance(scope.expression, (exp.Lateral, exp.Unnest)):
+    elif isinstance(scope.expression, (exp.Lateral, exp.Unnest, exp.Values)):
         pass
     elif isinstance(scope.expression, exp.Subquery):
         yield from _traverse_subqueries(scope)
@@ -437,10 +437,10 @@ def _traverse_derived_tables(derived_tables, scope, scope_type):
         top = None
         for child_scope in _traverse_scope(
             scope.branch(
-                derived_table if isinstance(derived_table, (exp.Unnest, exp.Lateral)) else derived_table.this,
+                derived_table if isinstance(derived_table, (exp.Unnest, exp.Lateral, exp.Values)) else derived_table.this,
                 add_sources=sources if scope_type == ScopeType.CTE else None,
                 outer_column_list=derived_table.alias_column_names,
-                scope_type=ScopeType.UNNEST if isinstance(derived_table, exp.Unnest) else scope_type,
+                scope_type=ScopeType.UNNEST if isinstance(derived_table, (exp.Unnest, exp.Values)) else scope_type,
             )
         ):
             yield child_scope

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -314,7 +314,7 @@ class Scope:
 
     @property
     def is_unnest(self):
-        """Determine if this scope is an unnest"""
+        """Determine if this scope is a selectless derived"""
         return self.scope_type == ScopeType.SELECTLESS_DERIVED
 
     @property

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -437,7 +437,9 @@ def _traverse_derived_tables(derived_tables, scope, scope_type):
         top = None
         for child_scope in _traverse_scope(
             scope.branch(
-                derived_table if isinstance(derived_table, (exp.Unnest, exp.Lateral, exp.Values)) else derived_table.this,
+                derived_table
+                if isinstance(derived_table, (exp.Unnest, exp.Lateral, exp.Values))
+                else derived_table.this,
                 add_sources=sources if scope_type == ScopeType.CTE else None,
                 outer_column_list=derived_table.alias_column_names,
                 scope_type=ScopeType.UNNEST if isinstance(derived_table, (exp.Unnest, exp.Values)) else scope_type,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2229,12 +2229,12 @@ class Parser:
         self._match_r_paren()
         return columns
 
-    def _parse_csv(self, parse, *args, **kwargs):
-        parse_result = parse(*args, **kwargs)
+    def _parse_csv(self, parse):
+        parse_result = parse()
         items = [parse_result] if parse_result is not None else []
 
         while self._match(TokenType.COMMA):
-            parse_result = parse(*args, **kwargs)
+            parse_result = parse()
             if parse_result is not None:
                 items.append(parse_result)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1192,11 +1192,11 @@ class Parser:
         )
 
     def _parse_derived_table_values(self):
-        is_derived = self._curr is not None and self._curr.token_type == TokenType.L_PAREN
-        if not self._match(TokenType.VALUES) and not self._match_pair(TokenType.L_PAREN, TokenType.VALUES):
+        is_derived = self._match_pair(TokenType.L_PAREN, TokenType.VALUES)
+        if not is_derived and not self._match(TokenType.VALUES):
             return None
 
-        expressions = self._parse_csv(self._parse_paren_enclosed_csv, self._parse_column)
+        expressions = self._parse_csv(self._parse_value)
 
         if is_derived:
             self._match_r_paren()
@@ -2253,13 +2253,6 @@ class Parser:
         expressions = self._parse_csv(self._parse_id_var)
         self._match_r_paren()
         return expressions
-
-    def _parse_paren_enclosed_csv(self, parse):
-        if not self._match(TokenType.L_PAREN):
-            return
-        expressions = self._parse_csv(parse)
-        self._match_r_paren()
-        return exp.Tuple(expressions=expressions)
 
     def _parse_select_or_expression(self):
         return self._parse_select() or self._parse_expression()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2235,9 +2235,7 @@ class Parser:
             return
         expressions = self._parse_csv(parse)
         self._match_r_paren()
-        return exp.Tuple(
-            expressions=expressions
-        )
+        return exp.Tuple(expressions=expressions)
 
     def _match(self, token_type):
         if not self._curr:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -239,7 +239,7 @@ class TestBigQuery(Validator):
         self.validate_all(
             "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
             write={
-                "spark": "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
+                "spark": "SELECT cola, colb FROM VALUES (1, 'test') AS tab(cola, colb)",
                 "bigquery": "SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)])",
                 "snowflake": "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
             },

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1009,7 +1009,7 @@ class TestDialect(Validator):
         self.validate_all(
             "SELECT * FROM VALUES ('x'), ('y') AS t(z)",
             write={
-                "spark": "SELECT * FROM (VALUES ('x'), ('y')) AS t(z)",
+                "spark": "SELECT * FROM VALUES ('x'), ('y') AS t(z)",
             },
         )
         self.validate_all(

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -357,6 +357,7 @@ SELECT * REPLACE (a + 1 AS b, b AS C)
 SELECT * EXCEPT (a, b) REPLACE (a AS b, b AS C)
 SELECT a.* EXCEPT (a, b), b.* REPLACE (a AS b, b AS C)
 SELECT zoo, animals FROM (VALUES ('oakland', ARRAY('a', 'b')), ('sf', ARRAY('b', 'c'))) AS t(zoo, animals)
+SELECT zoo, animals FROM UNNEST(ARRAY(STRUCT('oakland' AS zoo, ARRAY('a', 'b') AS animals), STRUCT('sf' AS zoo, ARRAY('b', 'c') AS animals))) AS t(zoo, animals)
 WITH a AS (SELECT 1) SELECT 1 UNION ALL SELECT 2
 WITH a AS (SELECT 1) SELECT 1 UNION SELECT 2
 WITH a AS (SELECT 1) SELECT 1 INTERSECT SELECT 2

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -137,3 +137,16 @@ SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc + a) AS sum_agg FROM x;
 SELECT
   AGGREGATE(ARRAY("x"."a", "x"."b"), 0, ("x", "acc") -> "x" + "acc" + "x"."a") AS "sum_agg"
 FROM "x" AS "x";
+
+SELECT cola, colb FROM (VALUES (1, 'test'), (2, 'test2')) AS tab(cola, colb);
+SELECT
+  "tab"."cola" AS "cola",
+  "tab"."colb" AS "colb"
+FROM (VALUES (1, 'test'), (2, 'test2')) AS "tab"("cola", "colb");
+
+# dialect: spark
+SELECT cola, colb FROM (VALUES (1, 'test'), (2, 'test2')) AS tab(cola, colb);
+SELECT
+  `tab`.`cola` AS `cola`,
+  `tab`.`colb` AS `colb`
+FROM VALUES (1, 'test'), (2, 'test2') AS `tab`(`cola`, `colb`);

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -142,11 +142,15 @@ SELECT cola, colb FROM (VALUES (1, 'test'), (2, 'test2')) AS tab(cola, colb);
 SELECT
   "tab"."cola" AS "cola",
   "tab"."colb" AS "colb"
-FROM (VALUES (1, 'test'), (2, 'test2')) AS "tab"("cola", "colb");
+FROM (VALUES
+  (1, 'test'),
+  (2, 'test2')) AS "tab"("cola", "colb");
 
 # dialect: spark
 SELECT cola, colb FROM (VALUES (1, 'test'), (2, 'test2')) AS tab(cola, colb);
 SELECT
   `tab`.`cola` AS `cola`,
   `tab`.`colb` AS `colb`
-FROM VALUES (1, 'test'), (2, 'test2') AS `tab`(`cola`, `colb`);
+FROM VALUES
+  (1, 'test'),
+  (2, 'test2') AS `tab`(`cola`, `colb`);

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -39,3 +39,15 @@ SELECT "_q_0".b AS b FROM (SELECT SUM(x.b) AS b FROM x AS x GROUP BY x.a) AS "_q
 
 SELECT b FROM (SELECT a, SUM(b) AS b FROM x ORDER BY a);
 SELECT "_q_0".b AS b FROM (SELECT x.a AS a, SUM(x.b) AS b FROM x AS x ORDER BY a) AS "_q_0";
+
+SELECT x FROM (VALUES(1, 2)) AS q(x, y);
+SELECT q.x AS x FROM (VALUES (1, 2)) AS q(x, y);
+
+SELECT x FROM UNNEST([1, 2]) AS q(x, y);
+SELECT q.x AS x FROM UNNEST(ARRAY(1, 2)) AS q(x, y);
+
+WITH t1 AS (SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)]) AS "q"("cola", "colb")) SELECT cola FROM t1;
+WITH t1 AS (SELECT q.cola AS cola FROM UNNEST(ARRAY(STRUCT(1 AS cola, 'test' AS colb))) AS "q"("cola", "colb")) SELECT t1.cola AS cola FROM t1;
+
+SELECT x FROM VALUES(1, 2) AS q(x, y);
+SELECT q.x AS x FROM (VALUES (1, 2)) AS q(x, y);


### PR DESCRIPTION
Some naunces about values that I figured out while working on this:

### Spark
Values with parenthesis around them is valid but the tab alias assigned cannot be used in the select expression if you have the parentheses around them. It does work correctly though if there is no parentheses around values so we remove them by default now.

### Snowflake
You cannot put double quotes around the column names in `tab(<col>)` alias and they cannot have quotes in the select expression. There will be a follow up PR to ensure snowflake doesn't do that when using optimize to add the quotes. 