### PR TITLE
Fix transpilation example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sqlglot.transpile("SELECT EPOCH_MS(1618088028295)", read='duckdb', write='hive')
 ```
 
 ```sql
-SELECT TO_UTC_TIMESTAMP(FROM_UNIXTIME(1618088028295 / 1000, 'yyyy-MM-dd HH:mm:ss'), 'UTC')
+SELECT FROM_UNIXTIME(1618088028295 / 1000)
 ```
 
 SQLGlot can even translate custom time formats.


### PR DESCRIPTION
The README example differs from the current output of `transpile`:

```python
>>> import sqlglot
>>> sqlglot.transpile("SELECT EPOCH_MS(1618088028295)", read='duckdb', write='hive')
['SELECT FROM_UNIXTIME(1618088028295 / 1000)']
```