### PR TITLE
Fix alias builder for window expressions

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3150,7 +3150,7 @@ def alias_(expression, alias, table=False, dialect=None, quoted=None, **opts):
     alias = to_identifier(alias, quoted=quoted)
     alias = TableAlias(this=alias) if table else alias
 
-    if "alias" in exp.arg_types:
+    if "alias" in exp.arg_types and not isinstance(exp, Window):
         exp = exp.copy()
         exp.set("alias", alias)
         return exp

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -153,6 +153,10 @@ class TestBigQuery(Validator):
         )
 
         self.validate_identity(
+            "SELECT item, purchases, LAST_VALUE(item) OVER (item_window ROWS BETWEEN 2 PRECEDING AND 2 FOLLOWING) AS most_popular FROM Produce WINDOW item_window AS (ORDER BY purchases)"
+        )
+
+        self.validate_identity(
             "SELECT LAST_VALUE(a IGNORE NULLS) OVER y FROM x WINDOW y AS (PARTITION BY CATEGORY)",
         )
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,6 +1,7 @@
 import unittest
 
 from sqlglot import (
+    alias,
     and_,
     condition,
     except_,
@@ -363,6 +364,14 @@ class TestBuild(unittest.TestCase):
             (
                 lambda: parse_one("(SELECT * FROM foo)").union("SELECT * FROM bla", distinct=False),
                 "(SELECT * FROM foo) UNION ALL SELECT * FROM bla",
+            ),
+            (
+                lambda: alias(parse_one("LAG(x) OVER (PARTITION BY y ORDER BY z)"), "a"),
+                "LAG(x) OVER (PARTITION BY y ORDER BY z) AS a",
+            ),
+            (
+                lambda: alias(parse_one("LAG(x) OVER ()"), "a"),
+                "LAG(x) OVER () AS a",
             ),
         ]:
             with self.subTest(sql):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -366,6 +366,14 @@ class TestBuild(unittest.TestCase):
                 "(SELECT * FROM foo) UNION ALL SELECT * FROM bla",
             ),
             (
+                lambda: alias(parse_one("LAG(x) OVER (PARTITION BY y)"), "a"),
+                "LAG(x) OVER (PARTITION BY y) AS a",
+            ),
+            (
+                lambda: alias(parse_one("LAG(x) OVER (ORDER BY z)"), "a"),
+                "LAG(x) OVER (ORDER BY z) AS a",
+            ),
+            (
                 lambda: alias(parse_one("LAG(x) OVER (PARTITION BY y ORDER BY z)"), "a"),
                 "LAG(x) OVER (PARTITION BY y ORDER BY z) AS a",
             ),


### PR DESCRIPTION
Not sure if this is the correct approach for this, but the idea was to follow the parser's output:

```python
>>> sqlglot.parse_one("RANK() OVER (y PARTITION BY a, b ORDER BY x DESC) AS foo")
(ALIAS this: # <~~~~ For the AS <alias_name> form, we get an ALIAS node
  (WINDOW this:
    (ANONYMOUS this: RANK), partition_by:
    (COLUMN this:
      (IDENTIFIER this: a, quoted: False)),
    (COLUMN this:
      (IDENTIFIER this: b, quoted: False)), order:
    (ORDER expressions:
      (ORDERED this:
        (COLUMN this:
          (IDENTIFIER this: x, quoted: False)), desc: True, nulls_first: False)), alias:
    (IDENTIFIER this: y, quoted: False)), alias: # <~~~~ For a named_window alias, we get the IDENTIFIER node
  (IDENTIFIER this: foo, quoted: False))
```

I think that we only use the alias inside the parentheses (here: y) for the BigQuery dialect, so the tradeoff of this change is:
- We can't set this alias using the `alias_` builder function.
- We add the ALIAS node by default for all window expressions when using the builder, which seems more "standard".

Happy to follow another direction if this isn't the right approach. See [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/window-function-calls) for the `named_window` syntax.

Fixes #558 