### PR TITLE
Add table hint and support it in optimizer

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -79,14 +79,14 @@ class Spark(Hive):
 
         FUNCTION_PARSERS = {
             **Parser.FUNCTION_PARSERS,
-            "BROADCAST": lambda self: self._parse_table_hint("BROADCAST"),
-            "BROADCASTJOIN": lambda self: self._parse_table_hint("BROADCASTJOIN"),
-            "MAPJOIN": lambda self: self._parse_table_hint("MAPJOIN"),
-            "MERGE": lambda self: self._parse_table_hint("MERGE"),
-            "SHUFFLEMERGE": lambda self: self._parse_table_hint("SHUFFLEMERGE"),
-            "MERGEJOIN": lambda self: self._parse_table_hint("MERGEJOIN"),
-            "SHUFFLE_HASH": lambda self: self._parse_table_hint("SHUFFLE_HASH"),
-            "SHUFFLE_REPLICATE_NL": lambda self: self._parse_table_hint("SHUFFLE_REPLICATE_NL"),
+            "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
+            "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
+            "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),
+            "MERGE": lambda self: self._parse_join_hint("MERGE"),
+            "SHUFFLEMERGE": lambda self: self._parse_join_hint("SHUFFLEMERGE"),
+            "MERGEJOIN": lambda self: self._parse_join_hint("MERGEJOIN"),
+            "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
+            "SHUFFLE_REPLICATE_NL": lambda self: self._parse_join_hint("SHUFFLE_REPLICATE_NL"),
         }
 
     class Generator(Hive.Generator):

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -6,6 +6,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.hive import Hive
 from sqlglot.helper import list_get
+from sqlglot.parser import Parser
 
 
 def _create_sql(self, e):
@@ -74,6 +75,18 @@ class Spark(Hive):
                 length=list_get(args, 1),
             ),
             "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
+        }
+
+        FUNCTION_PARSERS = {
+            **Parser.FUNCTION_PARSERS,
+            "BROADCAST": lambda self: self._parse_table_hint("BROADCAST"),
+            "BROADCASTJOIN": lambda self: self._parse_table_hint("BROADCASTJOIN"),
+            "MAPJOIN": lambda self: self._parse_table_hint("MAPJOIN"),
+            "MERGE": lambda self: self._parse_table_hint("MERGE"),
+            "SHUFFLEMERGE": lambda self: self._parse_table_hint("SHUFFLEMERGE"),
+            "MERGEJOIN": lambda self: self._parse_table_hint("MERGEJOIN"),
+            "SHUFFLE_HASH": lambda self: self._parse_table_hint("SHUFFLE_HASH"),
+            "SHUFFLE_REPLICATE_NL": lambda self: self._parse_table_hint("SHUFFLE_REPLICATE_NL"),
         }
 
     class Generator(Hive.Generator):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -766,7 +766,7 @@ class Hint(Expression):
     arg_types = {"expressions": True}
 
 
-class TableHint(Expression):
+class JoinHint(Expression):
     arg_types = {"this": True, "expressions": True}
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -766,6 +766,10 @@ class Hint(Expression):
     arg_types = {"expressions": True}
 
 
+class TableHint(Expression):
+    arg_types = {"this": True, "expressions": True}
+
+
 class Identifier(Expression):
     arg_types = {"this": True, "quoted": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1187,7 +1187,7 @@ class Generator:
         kind = self.sql(expression, "kind")
         return f"{this} {kind}"
 
-    def tablehint_sql(self, expression):
+    def joinhint_sql(self, expression):
         this = self.sql(expression, "this")
         expressions = self.expressions(expression, flat=True)
         return f"{this}({expressions})"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1186,3 +1186,9 @@ class Generator:
         this = self.sql(expression, "this")
         kind = self.sql(expression, "kind")
         return f"{this} {kind}"
+
+    def tablehint_sql(self, expression):
+        this = self.sql(expression, "this")
+        expressions = self.expressions(expression, flat=True)
+        return f"{this}({expressions})"
+

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1191,4 +1191,3 @@ class Generator:
         this = self.sql(expression, "this")
         expressions = self.expressions(expression, flat=True)
         return f"{this}({expressions})"
-

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -188,8 +188,8 @@ def _merge_from(outer_scope, inner_scope, node_to_replace, alias):
         tables = table_hint.find_all(exp.Table)
         for table in tables:
             if table.alias_or_name == node_to_replace.alias_or_name:
-                new_value = new_subquery.this if isinstance(new_subquery, exp.Alias) else new_subquery
-                table.replace(new_value)
+                new_table = new_subquery.this if isinstance(new_subquery, exp.Alias) else new_subquery
+                table.set("this", exp.to_identifier(new_table.alias_or_name))
     outer_scope.remove_source(alias)
     outer_scope.add_source(new_subquery.alias_or_name, inner_scope.sources[new_subquery.alias_or_name])
 
@@ -299,7 +299,8 @@ def _merge_hints(outer_scope, inner_scope):
         return
     outer_scope_hint = outer_scope.expression.args.get("hint")
     if outer_scope_hint:
-        outer_scope_hint.args["expressions"].extend(inner_scope_hint.expressions)
+        for hint_expression in inner_scope_hint.expressions:
+            outer_scope_hint.append("expressions", hint_expression)
     else:
         outer_scope.expression.set("hint", inner_scope_hint)
 

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -184,8 +184,8 @@ def _merge_from(outer_scope, inner_scope, node_to_replace, alias):
     """
     new_subquery = inner_scope.expression.args.get("from").expressions[0]
     node_to_replace.replace(new_subquery)
-    for table_hint in outer_scope.table_hints:
-        tables = table_hint.find_all(exp.Table)
+    for join_hint in outer_scope.join_hints:
+        tables = join_hint.find_all(exp.Table)
         for table in tables:
             if table.alias_or_name == node_to_replace.alias_or_name:
                 new_table = new_subquery.this if isinstance(new_subquery, exp.Alias) else new_subquery

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -299,7 +299,7 @@ def _merge_hints(outer_scope, inner_scope):
         return
     outer_scope_hint = outer_scope.expression.args.get("hint")
     if outer_scope_hint:
-        outer_scope_hint.args['expressions'].extend(inner_scope_hint.expressions)
+        outer_scope_hint.args["expressions"].extend(inner_scope_hint.expressions)
     else:
         outer_scope.expression.set("hint", inner_scope_hint)
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -68,7 +68,7 @@ class Scope:
         self._selected_sources = None
         self._columns = None
         self._external_columns = None
-        self._table_hints = None
+        self._join_hints = None
 
     def branch(self, expression, scope_type, chain_sources=None, **kwargs):
         """Branch from the current scope to a new, inner scope"""
@@ -86,17 +86,17 @@ class Scope:
         self._subqueries = []
         self._derived_tables = []
         self._raw_columns = []
-        self._table_hints = []
+        self._join_hints = []
 
         for node, parent, _ in self.walk(bfs=False):
             if node is self.expression:
                 continue
             elif isinstance(node, exp.Column) and not isinstance(node.this, exp.Star):
                 self._raw_columns.append(node)
-            elif isinstance(node, exp.Table) and not isinstance(node.parent, exp.TableHint):
+            elif isinstance(node, exp.Table) and not isinstance(node.parent, exp.JoinHint):
                 self._tables.append(node)
-            elif isinstance(node, exp.TableHint):
-                self._table_hints.append(node)
+            elif isinstance(node, exp.JoinHint):
+                self._join_hints.append(node)
             elif isinstance(node, exp.UDTF):
                 self._derived_tables.append(node)
             elif isinstance(node, exp.CTE):
@@ -315,16 +315,16 @@ class Scope:
         return self._external_columns
 
     @property
-    def table_hints(self):
+    def join_hints(self):
         """
         Hints that exist in the scope that reference tables
 
         Returns:
-            list[exp.TableHint]: Table hints that are referenced within the scope
+            list[exp.JoinHint]: Table hints that are referenced within the scope
         """
-        if self._table_hints is None:
+        if self._join_hints is None:
             return []
-        return self._table_hints
+        return self._join_hints
 
     def source_columns(self, source_name):
         """

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -68,6 +68,7 @@ class Scope:
         self._selected_sources = None
         self._columns = None
         self._external_columns = None
+        self._table_hints = None
 
     def branch(self, expression, scope_type, chain_sources=None, **kwargs):
         """Branch from the current scope to a new, inner scope"""
@@ -85,14 +86,17 @@ class Scope:
         self._subqueries = []
         self._derived_tables = []
         self._raw_columns = []
+        self._table_hints = []
 
         for node, parent, _ in self.walk(bfs=False):
             if node is self.expression:
                 continue
             elif isinstance(node, exp.Column) and not isinstance(node.this, exp.Star):
                 self._raw_columns.append(node)
-            elif isinstance(node, exp.Table):
+            elif isinstance(node, exp.Table) and not isinstance(node.parent, exp.TableHint):
                 self._tables.append(node)
+            elif isinstance(node, exp.TableHint):
+                self._table_hints.append(node)
             elif isinstance(node, exp.UDTF):
                 self._derived_tables.append(node)
             elif isinstance(node, exp.CTE):
@@ -309,6 +313,18 @@ class Scope:
         if self._external_columns is None:
             self._external_columns = [c for c in self.columns if c.table not in self.selected_sources]
         return self._external_columns
+
+    @property
+    def table_hints(self):
+        """
+        Hints that exist in the scope that reference tables
+
+        Returns:
+            list[exp.TableHint]: Table hints that are referenced within the scope
+        """
+        if self._table_hints is None:
+            return []
+        return self._table_hints
 
     def source_columns(self, source_name):
         """

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -320,7 +320,7 @@ class Scope:
         Hints that exist in the scope that reference tables
 
         Returns:
-            list[exp.JoinHint]: Table hints that are referenced within the scope
+            list[exp.JoinHint]: Join hints that are referenced within the scope
         """
         if self._join_hints is None:
             return []

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -431,6 +431,14 @@ class Parser:
         "TRIM": lambda self: self._parse_trim(),
         "CAST": lambda self: self._parse_cast(self.STRICT_CAST),
         "TRY_CAST": lambda self: self._parse_cast(False),
+        "BROADCAST": lambda self: self._parse_table_hint("BROADCAST"),
+        "BROADCASTJOIN": lambda self: self._parse_table_hint("BROADCASTJOIN"),
+        "MAPJOIN": lambda self: self._parse_table_hint("MAPJOIN"),
+        "MERGE": lambda self: self._parse_table_hint("MERGE"),
+        "SHUFFLEMERGE": lambda self: self._parse_table_hint("SHUFFLEMERGE"),
+        "MERGEJOIN": lambda self: self._parse_table_hint("MERGEJOIN"),
+        "SHUFFLE_HASH": lambda self: self._parse_table_hint("SHUFFLE_HASH"),
+        "SHUFFLE_REPLICATE_NL": lambda self: self._parse_table_hint("SHUFFLE_REPLICATE_NL"),
     }
 
     QUERY_MODIFIER_PARSERS = {
@@ -2055,6 +2063,10 @@ class Parser:
         self.validate_expression(this, args)
 
         return this
+
+    def _parse_table_hint(self, func_name):
+        args = self._parse_csv(self._parse_table)
+        return exp.TableHint(this=func_name.upper(), expressions=args)
 
     def _parse_substring(self):
         # Postgres supports the form: substring(string [from int] [for int])

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -431,14 +431,6 @@ class Parser:
         "TRIM": lambda self: self._parse_trim(),
         "CAST": lambda self: self._parse_cast(self.STRICT_CAST),
         "TRY_CAST": lambda self: self._parse_cast(False),
-        "BROADCAST": lambda self: self._parse_table_hint("BROADCAST"),
-        "BROADCASTJOIN": lambda self: self._parse_table_hint("BROADCASTJOIN"),
-        "MAPJOIN": lambda self: self._parse_table_hint("MAPJOIN"),
-        "MERGE": lambda self: self._parse_table_hint("MERGE"),
-        "SHUFFLEMERGE": lambda self: self._parse_table_hint("SHUFFLEMERGE"),
-        "MERGEJOIN": lambda self: self._parse_table_hint("MERGEJOIN"),
-        "SHUFFLE_HASH": lambda self: self._parse_table_hint("SHUFFLE_HASH"),
-        "SHUFFLE_REPLICATE_NL": lambda self: self._parse_table_hint("SHUFFLE_REPLICATE_NL"),
     }
 
     QUERY_MODIFIER_PARSERS = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2056,9 +2056,9 @@ class Parser:
 
         return this
 
-    def _parse_table_hint(self, func_name):
+    def _parse_join_hint(self, func_name):
         args = self._parse_csv(self._parse_table)
-        return exp.TableHint(this=func_name.upper(), expressions=args)
+        return exp.JoinHint(this=func_name.upper(), expressions=args)
 
     def _parse_substring(self):
         # Postgres supports the form: substring(string [from int] [for int])

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -111,13 +111,71 @@ TBLPROPERTIES (
             "SELECT /*+ COALESCE(3) */ * FROM x",
             write={
                 "spark": "SELECT /*+ COALESCE(3) */ * FROM x",
+                "bigquery": "SELECT * FROM x",
             },
         )
         self.validate_all(
             "SELECT /*+ COALESCE(3), REPARTITION(1) */ * FROM x",
             write={
                 "spark": "SELECT /*+ COALESCE(3), REPARTITION(1) */ * FROM x",
+                "bigquery": "SELECT * FROM x",
             },
+        )
+        self.validate_all(
+            "SELECT /*+ BROADCAST(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ BROADCAST(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ BROADCASTJOIN(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ BROADCASTJOIN(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ MAPJOIN(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ MAPJOIN(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ MERGE(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ MERGE(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ SHUFFLEMERGE(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ SHUFFLEMERGE(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ MERGEJOIN(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ MERGEJOIN(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ SHUFFLE_HASH(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ SHUFFLE_HASH(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
+        )
+        self.validate_all(
+            "SELECT /*+ SHUFFLE_REPLICATE_NL(table) */ cola FROM table",
+            write={
+                "spark": "SELECT /*+ SHUFFLE_REPLICATE_NL(table) */ cola FROM table",
+                "bigquery": "SELECT cola FROM table",
+            }
         )
 
     def test_spark(self):

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -126,56 +126,56 @@ TBLPROPERTIES (
             write={
                 "spark": "SELECT /*+ BROADCAST(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ BROADCASTJOIN(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ BROADCASTJOIN(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ MAPJOIN(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ MAPJOIN(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ MERGE(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ MERGE(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ SHUFFLEMERGE(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ SHUFFLEMERGE(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ MERGEJOIN(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ MERGEJOIN(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ SHUFFLE_HASH(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ SHUFFLE_HASH(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
         self.validate_all(
             "SELECT /*+ SHUFFLE_REPLICATE_NL(table) */ cola FROM table",
             write={
                 "spark": "SELECT /*+ SHUFFLE_REPLICATE_NL(table) */ cola FROM table",
                 "bigquery": "SELECT cola FROM table",
-            }
+            },
         )
 
     def test_spark(self):

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -141,7 +141,7 @@ SELECT x.b AS b, y.b AS b2 FROM x AS x CROSS JOIN y AS y;
 
 # title: Broadcast hint
 # dialect: spark
-WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(n) */ m.a, n.c FROM m JOIN n ON m.b = n.b) SELECT joined.a, joined.c FROM joined;
+WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(k) */ m.a, k.c FROM m JOIN n AS k ON m.b = k.b) SELECT joined.a, joined.c FROM joined;
 SELECT /*+ BROADCAST(y) */ x.a AS a, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;
 
 # title: Broadcast hint multiple tables
@@ -158,3 +158,13 @@ SELECT /*+ BROADCAST(x), MERGE(x, y) */ x.a AS a, y.c AS c FROM x AS x JOIN y AS
 # dialect: spark
 WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(m), MERGE(m, n) */ m.a, n.c FROM m JOIN n ON m.b = n.b) SELECT /*+ COALESCE(3) */ joined.a, joined.c FROM joined;
 SELECT /*+ COALESCE(3), BROADCAST(x), MERGE(x, y) */ x.a AS a, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;
+
+# title: Hint Subquery
+# dialect: spark
+SELECT
+    subquery.a,
+    subquery.c
+FROM (
+    SELECT /*+ BROADCAST(m), MERGE(m, n) */ m.a, n.c FROM (SELECT x.a, x.b FROM x) AS m JOIN (SELECT y.b, y.c FROM y) AS n ON m.b = n.b
+) AS subquery;
+SELECT /*+ BROADCAST(x), MERGE(x, y) */ x.a AS a, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -168,3 +168,22 @@ FROM (
     SELECT /*+ BROADCAST(m), MERGE(m, n) */ m.a, n.c FROM (SELECT x.a, x.b FROM x) AS m JOIN (SELECT y.b, y.c FROM y) AS n ON m.b = n.b
 ) AS subquery;
 SELECT /*+ BROADCAST(x), MERGE(x, y) */ x.a AS a, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;
+
+# title: Subquery Test
+# dialect: spark
+SELECT /*+ BROADCAST(x) */
+  x.a,
+  x.c
+FROM (
+  SELECT
+    x.a,
+    x.c
+  FROM (
+    SELECT
+      x.a,
+      COUNT(1) AS c
+    FROM x
+    GROUP BY x.a
+  ) AS x
+) AS x;
+SELECT /*+ BROADCAST(x) */ x.a AS a, x.c AS c FROM (SELECT x.a AS a, COUNT(1) AS c FROM x AS x GROUP BY x.a) AS x;

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -218,7 +218,26 @@ WHERE
 
 # title: Broadcast hint
 # dialect: spark
-WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(n) */ m.a, n.c FROM m JOIN n ON m.b = n.b) SELECT joined.a, joined.c FROM joined;
+WITH m AS (
+  SELECT
+    x.a,
+    x.b
+  FROM x
+), n AS (
+  SELECT
+    y.b,
+    y.c
+  FROM y
+), joined as (
+  SELECT /*+ BROADCAST(n) */
+    m.a,
+    n.c
+  FROM m JOIN n ON m.b = n.b
+)
+SELECT
+  joined.a,
+  joined.c
+FROM joined;
 SELECT /*+ BROADCAST(`y`) */
   `x`.`a` AS `a`,
   `y`.`c` AS `c`
@@ -228,7 +247,27 @@ JOIN `y` AS `y`
 
 # title: Mix Table and Column Hints
 # dialect: spark
-WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(m), MERGE(m, n) */ m.a, n.c FROM m JOIN n ON m.b = n.b) SELECT /*+ COALESCE(3) */ joined.a, joined.c FROM joined;
+WITH m AS (
+  SELECT
+    x.a,
+    x.b
+  FROM x
+), n AS (
+  SELECT
+    y.b,
+    y.c
+  FROM y
+), joined as (
+  SELECT /*+ BROADCAST(m), MERGE(m, n) */
+    m.a,
+    n.c
+  FROM m JOIN n ON m.b = n.b
+)
+SELECT
+  /*+ COALESCE(3) */
+  joined.a,
+  joined.c
+FROM joined;
 SELECT /*+ COALESCE(3),
   BROADCAST(`x`),
   MERGE(`x`, `y`) */

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -215,3 +215,25 @@ JOIN "n" AS "n2"
   ON "n"."a" = "n2"."a"
 WHERE
   "o"."b" > 0;
+
+# title: Broadcast hint
+# dialect: spark
+WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(n) */ m.a, n.c FROM m JOIN n ON m.b = n.b) SELECT joined.a, joined.c FROM joined;
+SELECT /*+ BROADCAST(`y`) */
+  `x`.`a` AS `a`,
+  `y`.`c` AS `c`
+FROM `x` AS `x`
+JOIN `y` AS `y`
+  ON `x`.`b` = `y`.`b`;
+
+# title: Mix Table and Column Hints
+# dialect: spark
+WITH m AS (SELECT x.a, x.b FROM x), n AS (SELECT y.b, y.c FROM y), joined as (SELECT /*+ BROADCAST(m), MERGE(m, n) */ m.a, n.c FROM m JOIN n ON m.b = n.b) SELECT /*+ COALESCE(3) */ joined.a, joined.c FROM joined;
+SELECT /*+ COALESCE(3),
+  BROADCAST(`x`),
+  MERGE(`x`, `y`) */
+  `x`.`a` AS `a`,
+  `y`.`c` AS `c`
+FROM `x` AS `x`
+JOIN `y` AS `y`
+  ON `x`.`b` = `y`.`b`;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -97,7 +97,7 @@ class TestOptimizer(unittest.TestCase):
     def test_optimize(self):
         schema = {
             "x": {"a": "INT", "b": "INT"},
-            "y": {"a": "INT", "b": "INT"},
+            "y": {"b": "INT", "c": "INT"},
             "z": {"a": "INT", "c": "INT"},
         }
 


### PR DESCRIPTION
Prior to this change hints that contain tables would actually parse them into a column instead of a table. The initial change here is to have them properly parse into tables. The next change is in the optimizer where we tell the `merge_subqueries` rule that it can merge hints and then provided a function to do that merge. 

Hints that are not "JoinHints" are left untouched in this PR since they parse into columns and are handled correctly by default. 