### PR TITLE
Add support for postgres notnull, isnull syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1536,6 +1536,14 @@ class Parser:
 
         if self._match_set(self.RANGE_PARSERS):
             this = self.RANGE_PARSERS[self._prev.token_type](self, this)
+        elif self._match(TokenType.ISNULL):
+            this = self.expression(exp.Is, this=this, expression=exp.Null())
+
+        # Postgres supports ISNULL and NOTNULL for conditions.
+        # Source: https://blog.andreiavram.ro/postgresql-null-composite-type/
+        if self._match(TokenType.NOTNULL):
+            this = self.expression(exp.Is, this=this, expression=exp.Null())
+            this = self.expression(exp.Not, this=this)
 
         if negate:
             this = self.expression(exp.Not, this=this)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -199,6 +199,7 @@ class TokenType(AutoName):
     NATURAL = auto()
     NEXT = auto()
     NO_ACTION = auto()
+    NOTNULL = auto()
     NULL = auto()
     NULLS_FIRST = auto()
     NULLS_LAST = auto()
@@ -498,6 +499,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "NEXT": TokenType.NEXT,
         "NO ACTION": TokenType.NO_ACTION,
         "NOT": TokenType.NOT,
+        "NOTNULL": TokenType.NOTNULL,
         "NULL": TokenType.NULL,
         "NULLS FIRST": TokenType.NULLS_FIRST,
         "NULLS LAST": TokenType.NULLS_LAST,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -68,6 +68,7 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT TRIM(' X' FROM ' XXX ')")
         self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ' COLLATE utf8_bin)")
         self.validate_identity("SELECT TO_TIMESTAMP(1284352323.5), TO_TIMESTAMP('05 Dec 2000', 'DD Mon YYYY')")
+        self.validate_identity("COMMENT ON TABLE mytable IS 'this'")
 
         self.validate_all(
             "CREATE TABLE x (a UUID, b BYTEA)",
@@ -163,4 +164,11 @@ class TestPostgres(Validator):
                 "postgres": "SELECT p1.id, p2.id, v1, v2 FROM polygons p1, polygons p2, LATERAL VERTICES(p1.poly) v1, LATERAL VERTICES(p2.poly) v2 WHERE (v1 <-> v2) < 10 AND p1.id != p2.id",
             },
         )
-        self.validate_identity("COMMENT ON TABLE mytable IS 'this'")
+        self.validate_all(
+            "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE NOT deleted IS NULL",
+            read={"postgres": "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE deleted NOTNULL"},
+        )
+        self.validate_all(
+            "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE NOT deleted IS NULL",
+            read={"postgres": "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE NOT deleted ISNULL"},
+        )


### PR DESCRIPTION
[This source](https://blog.andreiavram.ro/postgresql-null-composite-type/) says that the following query:

```sql
select id, email, deleted::text from users where not deleted isnull
```

behaves differently than these two:
```sql
select id, email, deleted::text from users where deleted notnull
select id, email, deleted::text from users where deleted is not null
```

Do we want to add an `IsNull` expression node and generate `.. WHERE NOT deleted ISNULL` for the first one which is the semantically correct output?

Fixes #569 