### PR TITLE
Fix duckdb array type

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -71,8 +71,7 @@ def _struct_pack_sql(self, expression):
 def _datatype_sql(self, expression):
     type_value = expression.this
     if type_value == exp.DataType.Type.ARRAY:
-        interior = self.expressions(expression, flat=True)
-        return f"{interior}[]"
+        return f"{self.expressions(expression, flat=True)}[]"
     else:
         return self.datatype_sql(expression)
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -68,6 +68,15 @@ def _struct_pack_sql(self, expression):
     return f"STRUCT_PACK({', '.join(args)})"
 
 
+def _datatype_sql(self, expression):
+    type_value = expression.this
+    if type_value == exp.DataType.Type.ARRAY:
+        interior = self.expressions(expression, flat=True)
+        return f"{interior}[]"
+    else:
+        return self.datatype_sql(expression)
+
+
 class DuckDB(Dialect):
     class Tokenizer(Tokenizer):
         KEYWORDS = {
@@ -113,6 +122,7 @@ class DuckDB(Dialect):
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySort: _array_sort_sql,
             exp.ArraySum: rename_func("LIST_SUM"),
+            exp.DataType: _datatype_sql,
             exp.DateAdd: _date_add,
             exp.DateDiff: lambda self, e: f"""DATE_DIFF({self.sql(e, 'unit') or "'day'"}, {self.sql(e, 'expression')}, {self.sql(e, 'this')})""",
             exp.DateStrToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE)",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1676,6 +1676,11 @@ class Parser:
         is_struct = type_token == TokenType.STRUCT
         expressions = None
 
+        if not nested and self._match_pair(TokenType.L_BRACKET, TokenType.R_BRACKET):
+            return exp.DataType(
+                this=exp.DataType.Type.ARRAY, expressions=[exp.DataType.build(type_token.value.upper())], nested=True
+            )
+
         if self._match(TokenType.L_BRACKET):
             self._retreat(index)
             return None

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1678,7 +1678,7 @@ class Parser:
 
         if not nested and self._match_pair(TokenType.L_BRACKET, TokenType.R_BRACKET):
             return exp.DataType(
-                this=exp.DataType.Type.ARRAY, expressions=[exp.DataType.build(type_token.value.upper())], nested=True
+                this=exp.DataType.Type.ARRAY, expressions=[exp.DataType.build(type_token.value)], nested=True
             )
 
         if self._match(TokenType.L_BRACKET):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -66,6 +66,16 @@ class TestDuckDB(Validator):
 
     def test_duckdb(self):
         self.validate_all(
+            "COL::BIGINT[]",
+            write={
+                "duckdb": "CAST(COL AS BIGINT[])",
+                "presto": "CAST(COL AS ARRAY(BIGINT))",
+                "hive": "CAST(COL AS ARRAY<BIGINT>)",
+                "spark": "CAST(COL AS ARRAY<LONG>)",
+            },
+        )
+
+        self.validate_all(
             "LIST_VALUE(0, 1, 2)",
             read={
                 "spark": "ARRAY(0, 1, 2)",

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -10,7 +10,7 @@ class TestPresto(Validator):
             "CAST(a AS ARRAY(INT))",
             write={
                 "bigquery": "CAST(a AS ARRAY<INT64>)",
-                "duckdb": "CAST(a AS ARRAY<INT>)",
+                "duckdb": "CAST(a AS INT[])",
                 "presto": "CAST(a AS ARRAY(INTEGER))",
                 "spark": "CAST(a AS ARRAY<INT>)",
             },
@@ -28,7 +28,7 @@ class TestPresto(Validator):
             "CAST(ARRAY[1, 2] AS ARRAY(BIGINT))",
             write={
                 "bigquery": "CAST([1, 2] AS ARRAY<INT64>)",
-                "duckdb": "CAST(LIST_VALUE(1, 2) AS ARRAY<BIGINT>)",
+                "duckdb": "CAST(LIST_VALUE(1, 2) AS BIGINT[])",
                 "presto": "CAST(ARRAY[1, 2] AS ARRAY(BIGINT))",
                 "spark": "CAST(ARRAY(1, 2) AS ARRAY<LONG>)",
             },
@@ -47,7 +47,7 @@ class TestPresto(Validator):
             "CAST(MAP(ARRAY['a','b','c'], ARRAY[ARRAY[1], ARRAY[2], ARRAY[3]]) AS MAP(VARCHAR, ARRAY(INT)))",
             write={
                 "bigquery": "CAST(MAP(['a', 'b', 'c'], [[1], [2], [3]]) AS MAP<STRING, ARRAY<INT64>>)",
-                "duckdb": "CAST(MAP(LIST_VALUE('a', 'b', 'c'), LIST_VALUE(LIST_VALUE(1), LIST_VALUE(2), LIST_VALUE(3))) AS MAP<TEXT, ARRAY<INT>>)",
+                "duckdb": "CAST(MAP(LIST_VALUE('a', 'b', 'c'), LIST_VALUE(LIST_VALUE(1), LIST_VALUE(2), LIST_VALUE(3))) AS MAP<TEXT, INT[]>)",
                 "presto": "CAST(MAP(ARRAY['a', 'b', 'c'], ARRAY[ARRAY[1], ARRAY[2], ARRAY[3]]) AS MAP(VARCHAR, ARRAY(INTEGER)))",
                 "hive": "CAST(MAP('a', ARRAY(1), 'b', ARRAY(2), 'c', ARRAY(3)) AS MAP<STRING, ARRAY<INT>>)",
                 "spark": "CAST(MAP_FROM_ARRAYS(ARRAY('a', 'b', 'c'), ARRAY(ARRAY(1), ARRAY(2), ARRAY(3))) AS MAP<STRING, ARRAY<INT>>)",


### PR DESCRIPTION
https://duckdb.org/docs/sql/data_types/overview

DuckDB expects that array are declared using `INTERIOR[]` instead of `ARRAY<INTERIOR>`. 