### PR TITLE
Added introducers N (SQL-92 standard) and E (postgres)

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -168,6 +168,7 @@ class Postgres(Dialect):
             "ALWAYS": TokenType.ALWAYS,
             "BY DEFAULT": TokenType.BY_DEFAULT,
             "COMMENT ON": TokenType.COMMENT_ON,
+            "E": TokenType.INTRODUCER,
             "IDENTITY": TokenType.IDENTITY,
             "GENERATED": TokenType.GENERATED,
             "DOUBLE PRECISION": TokenType.DOUBLE,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -554,7 +554,7 @@ class Generator:
         return f"INTERSECT{'' if expression.args.get('distinct') else ' ALL'}"
 
     def introducer_sql(self, expression):
-        return f"{self.sql(expression, 'this')} {self.sql(expression, 'expression')}"
+        return f"{self.sql(expression, 'this')}{self.sql(expression, 'expression')}"
 
     def rowformat_sql(self, expression):
         fields = expression.args.get("fields")

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -500,6 +500,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "LOCATION": TokenType.LOCATION,
         "MATERIALIZED": TokenType.MATERIALIZED,
         "NATURAL": TokenType.NATURAL,
+        "N": TokenType.INTRODUCER,
         "NEXT": TokenType.NEXT,
         "NO ACTION": TokenType.NO_ACTION,
         "NOT": TokenType.NOT,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -22,12 +22,12 @@ class TestMySQL(Validator):
 
     def test_introducers(self):
         self.validate_all(
-            "_utf8mb4 'hola'",
+            "_utf8mb4'hola'",
             read={
                 "mysql": "_utf8mb4'hola'",
             },
             write={
-                "mysql": "_utf8mb4 'hola'",
+                "mysql": "_utf8mb4'hola'",
             },
         )
 


### PR DESCRIPTION
xref https://github.com/tobymao/sqlglot/pull/393

The string literal prefix N (titled introducer in sqlglot, thanks to mysql) is SQL-92 standard.

Also added he literal prefix E for postgres (bytea escape format)

removed space between introducer and literal string in generator

References:

https://www.postgresql.org/docs/9.0/datatype-binary.html
https://dev.mysql.com/doc/refman/8.0/en/string-literals.html
https://learn.microsoft.com/en-us/sql/t-sql/data-types/constants-transact-sql?view=sql-server-ver16#unicode-strings
https://www.contrib.andrew.cmu.edu/~shadow/sql/sql1992.txt

         The <key word>s NATIONAL CHARACTER are used to specify a character
         string data type with a particular implementation-defined character
         repertoire. Special syntax (N'string') is provided for representing
         literals in that character repertoire.

---

NOTE: I am well aware that this PR breaks some tests, because a stand-alone ``N`` is no longer recognized as an ``IDENTIFIER``, so while ``SELECT N'我的' AS name`` now parses, this PR breaks ``SELECT n FROM t``.

I guess, INTRODUCER parsing should be done with some kind of peek-ahead, and if a string literal is found, it's an ``INTRODUCER``, otherwise it's an ``IDENTIFIER``.

However, I have no idea how to proceed, so please feel free to modify this PR, or just close it and create a new one.

Thanks in advance.

---

Edit 2: After looking at the mysql examples for [introducers](https://dev.mysql.com/doc/refman/8.0/en/charset-introducer.html), maybe we should distinguish between introducers and literal string prefixes, such as ``E, N, X, and b``?

```sql
SELECT 'abc';
SELECT _latin1'abc';
SELECT _binary'abc';
SELECT _utf8mb4'abc' COLLATE utf8mb4_danish_ci;

SELECT _latin1 X'4D7953514C';
SELECT _utf8mb4 0x4D7953514C COLLATE utf8mb4_danish_ci;

SELECT _latin1 b'1000001';
SELECT _utf8mb4 0b1000001 COLLATE utf8mb4_danish_ci;
```