### PR TITLE
Add to_table helper

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3196,6 +3196,25 @@ def to_identifier(alias, quoted=None):
     return identifier
 
 
+def to_table(sql_path, **kwargs):
+    """
+    Create a table expression from a `[catalog].[schema].[table]` sql path. Catalog and schema are optional.
+    Example:
+        >>> to_table('catalog.db.table_name').sql()
+        'catalog.db.table_name'
+
+    Args:
+        sql_path(str): `[catalog].[schema].[table]` string
+    Returns:
+        Table: A table expression
+    """
+    table_parts = sql_path.split(".")
+    catalog, db, table_name = [
+        to_identifier(x) if x is not None else x for x in [None] * (3 - len(table_parts)) + table_parts
+    ]
+    return Table(this=table_name, db=db, catalog=catalog, **kwargs)
+
+
 def alias_(expression, alias, table=False, dialect=None, quoted=None, **opts):
     """
     Create an Alias expression.

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -497,3 +497,17 @@ class TestExpressions(unittest.TestCase):
             [e.alias_or_name for e in expression.expressions],
             ["a", "B", "c", "D"],
         )
+
+    def test_to_table(self):
+        table_only = exp.to_table("table_name")
+        self.assertEqual(table_only.name, "table_name")
+        self.assertIsNone(table_only.args.get("db"))
+        self.assertIsNone(table_only.args.get("catalog"))
+        db_and_table = exp.to_table("db.table_name")
+        self.assertEqual(db_and_table.name, "table_name")
+        self.assertEqual(db_and_table.args.get("db"), exp.to_identifier("db"))
+        self.assertIsNone(db_and_table.args.get("catalog"))
+        catalog_db_and_table = exp.to_table("catalog.db.table_name")
+        self.assertEqual(catalog_db_and_table.name, "table_name")
+        self.assertEqual(catalog_db_and_table.args.get("db"), exp.to_identifier("db"))
+        self.assertEqual(catalog_db_and_table.args.get("catalog"), exp.to_identifier("catalog"))


### PR DESCRIPTION
Pulled this out of https://github.com/tobymao/sqlglot/pull/568 since I need this immediately in another project.

Given a sql table name is return a table expression.