### PR TITLE
Add selects to union

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1202,7 +1202,11 @@ class Union(Subqueryable, Expression):
 
     @property
     def named_selects(self):
-        return self.args["this"].unnest().named_selects
+        return self.this.unnest().named_selects
+
+    @property
+    def selects(self):
+        return self.this.unnest().selects
 
     @property
     def left(self):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -511,3 +511,12 @@ class TestExpressions(unittest.TestCase):
         self.assertEqual(catalog_db_and_table.name, "table_name")
         self.assertEqual(catalog_db_and_table.args.get("db"), exp.to_identifier("db"))
         self.assertEqual(catalog_db_and_table.args.get("catalog"), exp.to_identifier("catalog"))
+
+    def test_union(self):
+        expression = parse_one(
+            "SELECT cola, colb UNION SELECT colx, coly"
+        )
+        self.assertIsInstance(expression, exp.Union)
+        self.assertEqual(expression.named_selects, ["cola", "colb"])
+        self.assertEqual(expression.selects, [exp.Column(this=exp.to_identifier("cola")),
+                                              exp.Column(this=exp.to_identifier("colb"))])


### PR DESCRIPTION
This allows someone to get the columns from a `Select` and `Union` expressions in the same way. 