### PR TITLE
determine order by references when qualifying columns

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -211,6 +211,23 @@ def _qualify_columns(scope, resolver):
             if column_table:
                 column.set("table", exp.to_identifier(column_table))
 
+    # Determine whether each reference in the order by clause is to a column or an alias.
+    order = scope.find(exp.Order)
+    if order is not None:
+        for column in order.find_all(exp.Column):
+            column_table = column.table
+            column_name = column.name
+
+            if column_table or isinstance(column.parent, exp.Ordered) or column.name not in resolver.all_columns:
+                continue
+
+            column_table = resolver.get_table(column_name)
+
+            if column_table is None:
+                raise OptimizeError(f"Ambiguous column: {column_name}")
+
+            column.set("table", exp.to_identifier(column_table))
+
 
 def _expand_stars(scope, resolver):
     """Expand stars to lists of column selections"""

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -212,13 +212,12 @@ def _qualify_columns(scope, resolver):
                 column.set("table", exp.to_identifier(column_table))
 
     # Determine whether each reference in the order by clause is to a column or an alias.
-    order = scope.find(exp.Order)
-    if order is not None:
-        for column in order.find_all(exp.Column):
+    for ordered in scope.find_all(exp.Ordered):
+        for column in ordered.find_all(exp.Column):
             column_table = column.table
             column_name = column.name
 
-            if column_table or isinstance(column.parent, exp.Ordered) or column.name not in resolver.all_columns:
+            if column_table or column.parent is ordered or column_name not in resolver.all_columns:
                 continue
 
             column_table = resolver.get_table(column_name)

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -72,6 +72,9 @@ SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a;
 SELECT a FROM x ORDER BY b;
 SELECT x.a AS a FROM x AS x ORDER BY x.b;
 
+SELECT SUM(a) AS a FROM x ORDER BY SUM(a);
+SELECT SUM(x.a) AS a FROM x AS x ORDER BY SUM(x.a);
+
 # dialect: bigquery
 SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS row_num FROM x QUALIFY row_num = 1;
 SELECT ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS row_num FROM x AS x QUALIFY row_num = 1;


### PR DESCRIPTION
Attempt to qualify order by references that appear to be column references and not aliases.

This helps in Minerva SQL as we need columns to be qualified to aid in rewriting queries. There is also value in doing this optimization to remove some inconsistency with how different engines handle this case of an ambiguous alias/column reference in an order by clause.