### PR TITLE
change default error level to immediate

### DIFF
--- a/sqlglot/__main__.py
+++ b/sqlglot/__main__.py
@@ -40,8 +40,8 @@ parser.add_argument(
     "--error-level",
     dest="error_level",
     type=str,
-    default="RAISE",
-    help="IGNORE, WARN, RAISE (default)",
+    default="IMMEDIATE",
+    help="IGNORE, WARN, RAISE, IMMEDIATE (default)",
 )
 
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -497,7 +497,7 @@ class Parser:
         max_errors=3,
         null_ordering=None,
     ):
-        self.error_level = error_level or ErrorLevel.RAISE
+        self.error_level = error_level or ErrorLevel.IMMEDIATE
         self.error_message_context = error_message_context
         self.index_offset = index_offset
         self.unnest_column_only = unnest_column_only

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -81,7 +81,7 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(ignore.expression(exp.Hint, y=""), exp.Hint)
         self.assertIsInstance(ignore.expression(exp.Hint), exp.Hint)
 
-        default = Parser()
+        default = Parser(error_level=ErrorLevel.RAISE)
         self.assertIsInstance(default.expression(exp.Hint, expressions=[""]), exp.Hint)
         default.expression(exp.Hint, y="")
         default.expression(exp.Hint)


### PR DESCRIPTION
errorlevel.RAISE kind of sucks, i think going to immediate is better, and we're bumping version 9 tomorrow anyways, thoughts?