### PR TITLE
Remove extra function

### DIFF
--- a/sqlglot/dataframe/sql/functions.py
+++ b/sqlglot/dataframe/sql/functions.py
@@ -420,7 +420,7 @@ def randn(seed: t.Optional[ColumnOrLiteral] = None) -> Column:
 
 def round(col: ColumnOrName, scale: t.Optional[int] = None) -> Column:
     if scale is not None:
-        return Column.invoke_expression_over_column(col, glotexp.Round, decimals=glotexp.convert(scale))
+        return Column.invoke_expression_over_column(col, glotexp.Round, decimals=scale)
     return Column.invoke_expression_over_column(col, glotexp.Round)
 
 


### PR DESCRIPTION
We don't need to do the convert here since it will be converted later as the value is cast to a DataFrame column.