### PR TITLE
Add (Azure) Databricks dialect

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -1,5 +1,6 @@
 from sqlglot.dialects.bigquery import BigQuery
 from sqlglot.dialects.clickhouse import ClickHouse
+from sqlglot.dialects.databricks import Databricks
 from sqlglot.dialects.dialect import Dialect, Dialects
 from sqlglot.dialects.duckdb import DuckDB
 from sqlglot.dialects.hive import Hive

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,28 +1,9 @@
 from sqlglot import exp
+from sqlglot.dialects.dialect import generate_tsql_date_delta, parse_date_delta
 from sqlglot.dialects.spark import Spark
-from sqlglot.helper import list_get
-
-
-def generate_date_delta(self, e):
-    func = "DATEADD" if isinstance(e, exp.DateAdd) else "DATEDIFF"
-    return f"{func}({self.format_args(e.text('unit'), e.expression, e.this)})"
-
-
-def parse_date_delta(exp_class):
-    def inner_func(args):
-        spark_func = len(args) == 2
-        this = list_get(args, 0) if spark_func else list_get(args, 2)
-        expression = list_get(args, 1) if spark_func else list_get(args, 1)
-        unit = exp.Literal.string("DAY") if spark_func else list_get(args, 0)
-        return exp_class(this=this, expression=expression, unit=unit)
-
-    return inner_func
 
 
 class Databricks(Spark):
-    class Tokenizer(Spark.Tokenizer):
-        pass
-
     class Parser(Spark.Parser):
         FUNCTIONS = {
             **Spark.Parser.FUNCTIONS,
@@ -34,6 +15,6 @@ class Databricks(Spark):
     class Generator(Spark.Generator):
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: generate_date_delta(self, e),
-            exp.DateDiff: lambda self, e: generate_date_delta(self, e),
+            exp.DateAdd: lambda self, e: generate_tsql_date_delta(self, e),
+            exp.DateDiff: lambda self, e: generate_tsql_date_delta(self, e),
         }

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,0 +1,17 @@
+from sqlglot import exp
+from sqlglot.dialects.spark import Spark
+
+
+class Databricks(Spark):
+    class Tokenizer(Spark.Tokenizer):
+        pass
+
+    class Parser(Spark.Parser):
+        FUNCTIONS = {**Spark.Parser.FUNCTIONS}
+
+    class Generator(Spark.Generator):
+        TRANSFORMS = {
+            **Spark.Generator.TRANSFORMS,
+            exp.DateAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+            exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+        }

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,5 +1,6 @@
 from sqlglot import exp
 from sqlglot.dialects.spark import Spark
+from sqlglot.helper import list_get
 
 
 class Databricks(Spark):
@@ -7,11 +8,20 @@ class Databricks(Spark):
         pass
 
     class Parser(Spark.Parser):
-        FUNCTIONS = {**Spark.Parser.FUNCTIONS}
+        FUNCTIONS = {
+            **Spark.Parser.FUNCTIONS,
+            "DATEADD": lambda args: exp.DateAdd(
+                this=list_get(args, 2), expression=list_get(args, 1), unit=list_get(args, 0)
+            ),
+            "DATE_ADD": lambda args: exp.DateAdd(this=list_get(args, 2), expression=list_get(args, 1), unit="DAY"),
+            "DATEDIFF": lambda args: exp.DateDiff(
+                this=list_get(args, 2), expression=list_get(args, 1), unit=list_get(args, 0)
+            ),
+        }
 
     class Generator(Spark.Generator):
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
-            exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+            exp.DateAdd: lambda self, e: f"DATEADD({self.sql(e,'unit')}, {self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+            exp.DateDiff: lambda self, e: f"DATEDIFF({self.sql(e,'unit')}, {self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         }

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -3,6 +3,22 @@ from sqlglot.dialects.spark import Spark
 from sqlglot.helper import list_get
 
 
+def generate_date_delta(self, e):
+    func = "DATEADD" if isinstance(e, exp.DateAdd) else "DATEDIFF"
+    return f"{func}({self.format_args(e.text('unit'), e.expression, e.this)})"
+
+
+def parse_date_delta(exp_class):
+    def inner_func(args):
+        spark_func = len(args) == 2
+        this = list_get(args, 0) if spark_func else list_get(args, 2)
+        expression = list_get(args, 1) if spark_func else list_get(args, 1)
+        unit = exp.Literal.string("DAY") if spark_func else list_get(args, 0)
+        return exp_class(this=this, expression=expression, unit=unit)
+
+    return inner_func
+
+
 class Databricks(Spark):
     class Tokenizer(Spark.Tokenizer):
         pass
@@ -10,18 +26,14 @@ class Databricks(Spark):
     class Parser(Spark.Parser):
         FUNCTIONS = {
             **Spark.Parser.FUNCTIONS,
-            "DATEADD": lambda args: exp.DateAdd(
-                this=list_get(args, 2), expression=list_get(args, 1), unit=list_get(args, 0)
-            ),
-            "DATE_ADD": lambda args: exp.DateAdd(this=list_get(args, 2), expression=list_get(args, 1), unit="DAY"),
-            "DATEDIFF": lambda args: exp.DateDiff(
-                this=list_get(args, 2), expression=list_get(args, 1), unit=list_get(args, 0)
-            ),
+            "DATEADD": parse_date_delta(exp.DateAdd),
+            "DATE_ADD": parse_date_delta(exp.DateAdd),
+            "DATEDIFF": parse_date_delta(exp.DateDiff),
         }
 
     class Generator(Spark.Generator):
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: f"DATEADD({self.sql(e,'unit')}, {self.sql(e, 'this')}, {self.sql(e, 'expression')})",
-            exp.DateDiff: lambda self, e: f"DATEDIFF({self.sql(e,'unit')}, {self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+            exp.DateAdd: lambda self, e: generate_date_delta(self, e),
+            exp.DateDiff: lambda self, e: generate_date_delta(self, e),
         }

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,6 +1,7 @@
 from sqlglot import exp
-from sqlglot.dialects.dialect import generate_tsql_date_delta, parse_date_delta
+from sqlglot.dialects.dialect import parse_date_delta
 from sqlglot.dialects.spark import Spark
+from sqlglot.dialects.tsql import generate_date_delta_with_unit_sql
 
 
 class Databricks(Spark):
@@ -15,6 +16,6 @@ class Databricks(Spark):
     class Generator(Spark.Generator):
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: generate_tsql_date_delta(self, e),
-            exp.DateDiff: lambda self, e: generate_tsql_date_delta(self, e),
+            exp.DateAdd: generate_date_delta_with_unit_sql,
+            exp.DateDiff: generate_date_delta_with_unit_sql,
         }

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -28,6 +28,7 @@ class Dialects(str, Enum):
     TABLEAU = "tableau"
     TRINO = "trino"
     TSQL = "tsql"
+    DATABRICKS = "databricks"
 
 
 class _Dialect(type):

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -332,3 +332,20 @@ def create_with_partitions_sql(self, expression):
             expression.set("this", schema)
 
     return self.create_sql(expression)
+
+
+def generate_tsql_date_delta(self, e):
+    func = "DATEADD" if isinstance(e, exp.DateAdd) else "DATEDIFF"
+    return f"{func}({self.format_args(e.text('unit'), e.expression, e.this)})"
+
+
+def parse_date_delta(exp_class, unit_mapping=None):
+    def inner_func(args):
+        tsql_func = len(args) == 3
+        this = list_get(args, 2) if tsql_func else list_get(args, 0)
+        expression = list_get(args, 1) if tsql_func else list_get(args, 1)
+        unit = list_get(args, 0) if tsql_func else exp.Literal.string("DAY")
+        unit = unit_mapping.get(unit.name.lower(), unit) if unit_mapping else unit
+        return exp_class(this=this, expression=expression, unit=unit)
+
+    return inner_func

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -334,17 +334,12 @@ def create_with_partitions_sql(self, expression):
     return self.create_sql(expression)
 
 
-def generate_tsql_date_delta(self, e):
-    func = "DATEADD" if isinstance(e, exp.DateAdd) else "DATEDIFF"
-    return f"{func}({self.format_args(e.text('unit'), e.expression, e.this)})"
-
-
 def parse_date_delta(exp_class, unit_mapping=None):
     def inner_func(args):
-        tsql_func = len(args) == 3
-        this = list_get(args, 2) if tsql_func else list_get(args, 0)
-        expression = list_get(args, 1) if tsql_func else list_get(args, 1)
-        unit = list_get(args, 0) if tsql_func else exp.Literal.string("DAY")
+        unit_based = len(args) == 3
+        this = list_get(args, 2) if unit_based else list_get(args, 0)
+        expression = list_get(args, 1) if unit_based else list_get(args, 1)
+        unit = list_get(args, 0) if unit_based else exp.Literal.string("DAY")
         unit = unit_mapping.get(unit.name.lower(), unit) if unit_mapping else unit
         return exp_class(this=this, expression=expression, unit=unit)
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1,5 +1,10 @@
 from sqlglot import exp
-from sqlglot.dialects.dialect import Dialect, rename_func
+from sqlglot.dialects.dialect import (
+    Dialect,
+    generate_tsql_date_delta,
+    parse_date_delta,
+    rename_func,
+)
 from sqlglot.expressions import DataType
 from sqlglot.generator import Generator
 from sqlglot.helper import list_get
@@ -40,19 +45,6 @@ def tsql_format_time_lambda(exp_class, full_format_mapping=None, default=None):
         )
 
     return _format_time
-
-
-def parse_date_delta(exp_class):
-    def inner_func(args):
-        unit = DATE_DELTA_INTERVAL.get(list_get(args, 0).name.lower(), "day")
-        return exp_class(this=list_get(args, 2), expression=list_get(args, 1), unit=unit)
-
-    return inner_func
-
-
-def generate_date_delta(self, e):
-    func = "DATEADD" if isinstance(e, exp.DateAdd) else "DATEDIFF"
-    return f"{func}({self.format_args(e.text('unit'), e.expression, e.this)})"
 
 
 class TSQL(Dialect):
@@ -173,8 +165,8 @@ class TSQL(Dialect):
             **Parser.FUNCTIONS,
             "CHARINDEX": exp.StrPosition.from_arg_list,
             "ISNULL": exp.Coalesce.from_arg_list,
-            "DATEADD": parse_date_delta(exp.DateAdd),
-            "DATEDIFF": parse_date_delta(exp.DateDiff),
+            "DATEADD": parse_date_delta(exp.DateAdd, unit_mapping=DATE_DELTA_INTERVAL),
+            "DATEDIFF": parse_date_delta(exp.DateDiff, unit_mapping=DATE_DELTA_INTERVAL),
             "DATENAME": tsql_format_time_lambda(exp.TimeToStr, full_format_mapping=True),
             "DATEPART": tsql_format_time_lambda(exp.TimeToStr),
             "GETDATE": exp.CurrentDate.from_arg_list,
@@ -238,8 +230,8 @@ class TSQL(Dialect):
 
         TRANSFORMS = {
             **Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: generate_date_delta(self, e),
-            exp.DateDiff: lambda self, e: generate_date_delta(self, e),
+            exp.DateAdd: lambda self, e: generate_tsql_date_delta(self, e),
+            exp.DateDiff: lambda self, e: generate_tsql_date_delta(self, e),
             exp.CurrentDate: rename_func("GETDATE"),
             exp.If: rename_func("IIF"),
         }

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -205,6 +205,7 @@ class TSQL(Dialect):
 
         TRANSFORMS = {
             **Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: f"DATEADD({self.format_args(e.args.get('unit'), e.expression, e.this)})",
             exp.CurrentDate: rename_func("GETDATE"),
+            exp.DateAdd: lambda self, e: f"DATEADD({self.sql(e,'unit')}, {self.sql(e, 'this')}, {self.sql(e, 'expression')})",
+            exp.DateDiff: lambda self, e: f"DATEDIFF({self.sql(e,'unit')}, {self.sql(e, 'this')}, {self.sql(e, 'expression')})",
         }

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1,10 +1,5 @@
 from sqlglot import exp
-from sqlglot.dialects.dialect import (
-    Dialect,
-    generate_tsql_date_delta,
-    parse_date_delta,
-    rename_func,
-)
+from sqlglot.dialects.dialect import Dialect, parse_date_delta, rename_func
 from sqlglot.expressions import DataType
 from sqlglot.generator import Generator
 from sqlglot.helper import list_get
@@ -45,6 +40,11 @@ def tsql_format_time_lambda(exp_class, full_format_mapping=None, default=None):
         )
 
     return _format_time
+
+
+def generate_date_delta_with_unit_sql(self, e):
+    func = "DATEADD" if isinstance(e, exp.DateAdd) else "DATEDIFF"
+    return f"{func}({self.format_args(e.text('unit'), e.expression, e.this)})"
 
 
 class TSQL(Dialect):
@@ -230,8 +230,8 @@ class TSQL(Dialect):
 
         TRANSFORMS = {
             **Generator.TRANSFORMS,
-            exp.DateAdd: lambda self, e: generate_tsql_date_delta(self, e),
-            exp.DateDiff: lambda self, e: generate_tsql_date_delta(self, e),
+            exp.DateAdd: generate_date_delta_with_unit_sql,
+            exp.DateDiff: generate_date_delta_with_unit_sql,
             exp.CurrentDate: rename_func("GETDATE"),
             exp.If: rename_func("IIF"),
         }

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -1,0 +1,8 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestDatabricks(Validator):
+    dialect = "databricks"
+
+    def test_datediff(self):
+        self.validate_all("SELECT DATEDIFF(year, 'start', 'end')", write={"tsql": "SELECT(year, 'start', 'end')"})

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -5,4 +5,11 @@ class TestDatabricks(Validator):
     dialect = "databricks"
 
     def test_datediff(self):
-        self.validate_all("SELECT DATEDIFF(year, 'start', 'end')", write={"tsql": "SELECT(year, 'start', 'end')"})
+        self.validate_all(
+            "SELECT DATEDIFF(year, 'start', 'end')", write={"tsql": "SELECT DATEDIFF(year, 'start', 'end')"}
+        )
+
+    def test_add_date(self):
+        self.validate_all(
+            "SELECT DATEADD(year, 1, '2020-01-01')", write={"tsql": "SELECT DATEADD(year, 1, '2020-01-01')"}
+        )

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -6,10 +6,28 @@ class TestDatabricks(Validator):
 
     def test_datediff(self):
         self.validate_all(
-            "SELECT DATEDIFF(year, 'start', 'end')", write={"tsql": "SELECT DATEDIFF(year, 'start', 'end')"}
+            "SELECT DATEDIFF(year, 'start', 'end')",
+            write={
+                "tsql": "SELECT DATEDIFF(year, 'start', 'end')",
+                "databricks": "SELECT DATEDIFF(year, 'start', 'end')",
+            },
         )
 
     def test_add_date(self):
         self.validate_all(
-            "SELECT DATEADD(year, 1, '2020-01-01')", write={"tsql": "SELECT DATEADD(year, 1, '2020-01-01')"}
+            "SELECT DATEADD(year, 1, '2020-01-01')",
+            write={
+                "tsql": "SELECT DATEADD(year, 1, '2020-01-01')",
+                "databricks": "SELECT DATEADD(year, 1, '2020-01-01')",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF('end', 'start')", write={"databricks": "SELECT DATEDIFF(DAY, 'start', 'end')"}
+        )
+        self.validate_all(
+            "SELECT DATE_ADD('2020-01-01', 1)",
+            write={
+                "tsql": "SELECT DATEADD(DAY, 1, '2020-01-01')",
+                "databricks": "SELECT DATEADD(DAY, 1, '2020-01-01')",
+            },
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -267,7 +267,10 @@ class TestTSQL(Validator):
             "SELECT DATEADD(year, 1, '2017/08/25')", write={"spark": "SELECT ADD_MONTHS('2017/08/25', 12)"}
         )
         self.validate_all("SELECT DATEADD(qq, 1, '2017/08/25')", write={"spark": "SELECT ADD_MONTHS('2017/08/25', 3)"})
-        self.validate_all("SELECT DATEADD(wk, 1, '2017/08/25')", write={"spark": "SELECT DATE_ADD('2017/08/25', 7)"})
+        self.validate_all(
+            "SELECT DATEADD(wk, 1, '2017/08/25')",
+            write={"spark": "SELECT DATE_ADD('2017/08/25', 7)", "databricks": "SELECT DATEADD(week, 1, '2017/08/25')"},
+        )
 
     def test_date_diff(self):
         self.validate_identity("SELECT DATEDIFF(year, '2020/01/01', '2021/01/01')")
@@ -279,11 +282,19 @@ class TestTSQL(Validator):
             },
         )
         self.validate_all(
-            "SELECT DATEDIFF(month, 'start','end')",
-            write={"spark": "SELECT MONTHS_BETWEEN('end', 'start')", "tsql": "SELECT DATEDIFF(month, 'start', 'end')"},
+            "SELECT DATEDIFF(mm, 'start','end')",
+            write={
+                "spark": "SELECT MONTHS_BETWEEN('end', 'start')",
+                "tsql": "SELECT DATEDIFF(month, 'start', 'end')",
+                "databricks": "SELECT DATEDIFF(month, 'start', 'end')",
+            },
         )
         self.validate_all(
-            "SELECT DATEDIFF(quarter, 'start', 'end')", write={"spark": "SELECT MONTHS_BETWEEN('end', 'start') / 3"}
+            "SELECT DATEDIFF(quarter, 'start', 'end')",
+            write={
+                "spark": "SELECT MONTHS_BETWEEN('end', 'start') / 3",
+                "databricks": "SELECT DATEDIFF(quarter, 'start', 'end')",
+            },
         )
 
     def test_iif(self):


### PR DESCRIPTION
I'm currently trying to go towards databricks and while dealing with datediff and date_add noticed that databricks is not limited to just the spark sql language.
It has implemented some functions in the TSQL style. DATEDIFF(unit, int, datetime) and DATEDIFF(datetime, datetime) both exist in databricks. As well as DATE_ADD(datetime, int) and DATEADD(unit, int, datetime). 

The spark transpiler should not deal with this since the TSQL like functions do not exist in spark (as far as I am aware of).
Spark Date functions : https://spark.apache.org/docs/2.3.0/api/sql/search.html?q=date
Databricks TSQL DATEDIFF: https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/functions/datediff3
Datebricks spark DATEDIFF: https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/functions/datediff