### PR TITLE
Allow CREATE ... TRANSIENT ... TABLE for Snowflake

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -188,7 +188,7 @@ class Snowflake(Dialect):
         }
 
     class Generator(Generator):
-        can_create_transient_table = True
+        CREATE_TRANSIENT = True
 
         TRANSFORMS = {
             **Generator.TRANSFORMS,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -188,6 +188,8 @@ class Snowflake(Dialect):
         }
 
     class Generator(Generator):
+        can_create_transient_table = True
+
         TRANSFORMS = {
             **Generator.TRANSFORMS,
             exp.ArrayConcat: rename_func("ARRAY_CAT"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -612,6 +612,7 @@ class Create(Expression):
         "exists": False,
         "properties": False,
         "temporary": False,
+        "transient": False,
         "replace": False,
         "unique": False,
         "materialized": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -65,6 +65,9 @@ class Generator:
         exp.VolatilityProperty: lambda self, e: self.sql(e.name),
     }
 
+    # whether 'CREATE ... TRANSIENT ... TABLE' is allowed
+    # can override in dialects
+    CREATE_TRANSIENT = False
     # whether or not null ordering is supported in order by
     NULL_ORDERING_SUPPORTED = True
     # always do union distinct or union all
@@ -368,11 +371,7 @@ class Generator:
         expression_sql = self.sql(expression, "expression")
         expression_sql = f"AS{self.sep()}{expression_sql}" if expression_sql else ""
         temporary = " TEMPORARY" if expression.args.get("temporary") else ""
-        transient = (
-            " TRANSIENT"
-            if expression.args.get("transient") and getattr(self, "can_create_transient_table", False)
-            else ""
-        )
+        transient = " TRANSIENT" if self.CREATE_TRANSIENT and expression.args.get("transient") else ""
         replace = " OR REPLACE" if expression.args.get("replace") else ""
         exists_sql = " IF NOT EXISTS" if expression.args.get("exists") else ""
         unique = " UNIQUE" if expression.args.get("unique") else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -368,15 +368,18 @@ class Generator:
         expression_sql = self.sql(expression, "expression")
         expression_sql = f"AS{self.sep()}{expression_sql}" if expression_sql else ""
         temporary = " TEMPORARY" if expression.args.get("temporary") else ""
+        transient = (
+            " TRANSIENT"
+            if expression.args.get("transient") and getattr(self, "can_create_transient_table", False)
+            else ""
+        )
         replace = " OR REPLACE" if expression.args.get("replace") else ""
         exists_sql = " IF NOT EXISTS" if expression.args.get("exists") else ""
         unique = " UNIQUE" if expression.args.get("unique") else ""
         materialized = " MATERIALIZED" if expression.args.get("materialized") else ""
         properties = self.sql(expression, "properties")
 
-        expression_sql = (
-            f"CREATE{replace}{temporary}{unique}{materialized} {kind}{exists_sql} {this}{properties} {expression_sql}"
-        )
+        expression_sql = f"CREATE{replace}{temporary}{transient}{unique}{materialized} {kind}{exists_sql} {this}{properties} {expression_sql}"
         return self.prepend_ctes(expression, expression_sql)
 
     def describe_sql(self, expression):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -686,6 +686,7 @@ class Parser:
     def _parse_create(self):
         replace = self._match(TokenType.OR) and self._match(TokenType.REPLACE)
         temporary = self._match(TokenType.TEMPORARY)
+        transient = self._match(TokenType.TRANSIENT)
         unique = self._match(TokenType.UNIQUE)
         materialized = self._match(TokenType.MATERIALIZED)
 
@@ -724,6 +725,7 @@ class Parser:
             exists=exists,
             properties=properties,
             temporary=temporary,
+            transient=transient,
             replace=replace,
             unique=unique,
             materialized=materialized,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -191,6 +191,7 @@ class Parser:
         TokenType.TABLE,
         TokenType.TABLE_FORMAT,
         TokenType.TEMPORARY,
+        TokenType.TRANSIENT,
         TokenType.TOP,
         TokenType.TRAILING,
         TokenType.TRUNCATE,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -257,6 +257,7 @@ class TokenType(AutoName):
     TABLE_FORMAT = auto()
     TABLE_SAMPLE = auto()
     TEMPORARY = auto()
+    TRANSIENT = auto()
     TOP = auto()
     THEN = auto()
     TRUE = auto()
@@ -561,6 +562,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "TABLESAMPLE": TokenType.TABLE_SAMPLE,
         "TEMP": TokenType.TEMPORARY,
         "TEMPORARY": TokenType.TEMPORARY,
+        "TRANSIENT": TokenType.TRANSIENT,
         "THEN": TokenType.THEN,
         "TRUE": TokenType.TRUE,
         "TRAILING": TokenType.TRAILING,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -292,7 +292,15 @@ class TestSnowflake(Validator):
         self.validate_identity(
             "CREATE TABLE a (x DATE, y BIGINT) WITH (PARTITION BY (x), integration='q', auto_refresh=TRUE, file_format=(type = parquet))"
         )
+        self.validate_identity("CREATE OR REPLACE TRANSIENT TABLE a (x DATE, y BIGINT)")
         self.validate_identity("CREATE MATERIALIZED VIEW a COMMENT='...' AS SELECT 1 FROM x")
+        self.validate_all(
+            "CREATE OR REPLACE TRANSIENT TABLE a (id INT)",
+            write={
+                "postgres": "CREATE OR REPLACE TABLE a (id INT)",
+                "mysql": "CREATE OR REPLACE TABLE a (id INT)",
+            },
+        )
 
     def test_user_defined_functions(self):
         self.validate_all(


### PR DESCRIPTION
Allow valid parsing of `CREATE ... TRANSIENT ... TABLE` statement in Snowflake.

Proposed behavior for transpiling to other dialects is to simply omit it. Did this with class attribute on the Snowflake dialect `Generator` + a janky-ish check in `generator.create_sql`. If more preferred way, happy to change.