### PR TITLE
adding top for tsql

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -158,6 +158,7 @@ class TSQL(Dialect):
             "SQL_VARIANT": TokenType.VARIANT,
             "NVARCHAR(MAX)": TokenType.TEXT,
             "VARCHAR(MAX)": TokenType.TEXT,
+            "TOP": TokenType.TOP,
         }
 
     class Parser(Parser):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1531,7 +1531,11 @@ class Parser:
 
     def _parse_limit(self, this=None, top=False):
         if self._match(TokenType.TOP if top else TokenType.LIMIT):
-            return self.expression(exp.Limit, this=this, expression=self._parse_number())
+            limit_paren = self._match(TokenType.L_PAREN)
+            limit_exp = self.expression(exp.Limit, this=this, expression=self._parse_number())
+            if limit_paren:
+                self._match(TokenType.R_PAREN)
+            return limit_exp
         if self._match(TokenType.FETCH):
             direction = self._match_set((TokenType.FIRST, TokenType.NEXT))
             direction = self._prev.text if direction else "FIRST"

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -347,3 +347,17 @@ class TestTSQL(Validator):
                 "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL TVFTEST(t.x) y AS z",
             },
         )
+
+    def test_top(self):
+        self.validate_all(
+            "SELECT TOP 3 * FROM A",
+            write={
+                "spark": "SELECT * FROM A LIMIT 3",
+            },
+        )
+        self.validate_all(
+            "SELECT TOP (3) * FROM A",
+            write={
+                "spark": "SELECT * FROM A LIMIT 3",
+            },
+        )


### PR DESCRIPTION
Adding TOP for T-SQL

Added the token to the TSQL dialect because by adding it in the generic one it interfered with the transpiler test 'select TOP.x' as TOP can be a seen as a table name there. 