### PR TITLE
TSQL format

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -284,6 +284,7 @@ class Hive(Dialect):
             exp.UnixToTime: rename_func("FROM_UNIXTIME"),
             exp.UnixToTimeStr: rename_func("FROM_UNIXTIME"),
             exp.PartitionedByProperty: lambda self, e: f"PARTITIONED BY {self.sql(e, 'value')}",
+            exp.NumberToStr: rename_func("FORMAT_NUMBER"),
         }
 
         WITH_PROPERTIES = {exp.AnonymousProperty}

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -65,11 +65,7 @@ def generate_date_delta_with_unit_sql(self, e):
 
 
 def generate_format_sql(self, e):
-    fmt = (
-        e.args["format"]
-        if isinstance(e, exp.NumberToStr)
-        else exp.Literal.string(self.format_time(e.args.get("format").name))
-    )
+    fmt = e.args["format"] if isinstance(e, exp.NumberToStr) else exp.Literal.string(self.format_time(e.text("format")))
     return f"FORMAT({self.format_args(e.this, fmt)})".replace("Y", "y")
 
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -52,7 +52,7 @@ def tsql_format_time_lambda(exp_class, full_format_mapping=None, default=None):
 
 def parse_format(args):
     fmt = list_get(args, 1)
-    number_fmt = not re.search(DATE_FMT_RE, fmt.this) or fmt.this in TRANSPILE_SAFE_NUMBER_FMT
+    number_fmt = not re.search(DATE_FMT_RE, fmt.this) or fmt.name in TRANSPILE_SAFE_NUMBER_FMT
     if number_fmt:
         return exp.NumberToStr(this=list_get(args, 0), format=fmt)
     return exp.TimeToStr(this=list_get(args, 0), format=exp.Literal.string(format_time(fmt.name, TSQL.time_mapping)))

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -28,7 +28,8 @@ DATE_DELTA_INTERVAL = {
     "d": "day",
 }
 
-DATE_FMT_RE = "([dD]{1,2})|([mM]{1,2})|([yY]{1,4})|([hH]{1,2})|([sS]{1,2})"
+
+DATE_FMT_RE = re.compile("([dD]{1,2})|([mM]{1,2})|([yY]{1,4})|([hH]{1,2})|([sS]{1,2})")
 # Current known single letter options:
 #   "d","D", "c", "C", "f","F", "g", "G", "m","o", "r", "s" ,"u","U", "T","t","Y"
 # N = Numeric, C=Currency
@@ -52,7 +53,7 @@ def tsql_format_time_lambda(exp_class, full_format_mapping=None, default=None):
 
 def parse_format(args):
     fmt = list_get(args, 1)
-    number_fmt = not re.search(DATE_FMT_RE, fmt.this) or fmt.name in TRANSPILE_SAFE_NUMBER_FMT
+    number_fmt = not DATE_FMT_RE.search(fmt.this) or fmt.name in TRANSPILE_SAFE_NUMBER_FMT
     if number_fmt:
         return exp.NumberToStr(this=list_get(args, 0), format=fmt)
     return exp.TimeToStr(this=list_get(args, 0), format=exp.Literal.string(format_time(fmt.name, TSQL.time_mapping)))
@@ -67,9 +68,7 @@ def generate_format_sql(self, e):
     fmt = (
         e.args["format"]
         if isinstance(e, exp.NumberToStr)
-        else exp.Literal.string(
-            format_time(e.args.get("format").name, {v: k.lower() for k, v in TSQL.time_mapping.items()})
-        )
+        else exp.Literal.string(format_time(e.args.get("format").name, TSQL.inversed_lower_case_time_mapping))
     )
     return f"FORMAT({self.format_args(e.this, fmt)})"
 
@@ -162,6 +161,7 @@ class TSQL(Dialect):
         "120": "%Y-%m-%d %H:%M:%S",
         "121": "%Y-%m-%d %H:%M:%S.%f",
     }
+    inversed_lower_case_time_mapping = {v: k.lower() for k, v in time_mapping.items()}
 
     class Tokenizer(Tokenizer):
         IDENTIFIERS = ['"', ("[", "]")]

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -32,7 +32,7 @@ DATE_FMT_RE = "([dD]{1,2})|([mM]{1,2})|([yY]{1,4})|([hH]{1,2})|([sS]{1,2})"
 # Current known single letter options:
 #   "d","D", "c", "C", "f","F", "g", "G", "m","o", "r", "s" ,"u","U", "T","t","Y"
 # N = Numeric, C=Currency
-TRANSPILE_SAFE_NUMBER_FMT = ("N", "C")
+TRANSPILE_SAFE_NUMBER_FMT = {"N", "C"}
 
 
 def tsql_format_time_lambda(exp_class, full_format_mapping=None, default=None):
@@ -55,10 +55,9 @@ def parse_format(args):
     number_fmt = not re.search(DATE_FMT_RE, fmt.this) or fmt.this in TRANSPILE_SAFE_NUMBER_FMT
     if number_fmt:
         return exp.NumberToStr(this=list_get(args, 0), format=fmt)
-    else:
-        return exp.TimeToStr(
-            this=list_get(args, 0), format=exp.Literal.string(format_time(fmt.name, TSQL.time_mapping))
-        )
+    return exp.TimeToStr(
+        this=list_get(args, 0), format=exp.Literal.string(format_time(fmt.name, TSQL.time_mapping))
+    )
 
 
 def generate_date_delta_with_unit_sql(self, e):
@@ -68,13 +67,12 @@ def generate_date_delta_with_unit_sql(self, e):
 
 def generate_format_sql(self, e):
     fmt = (
-        e.args.get("format")
+        e.args["format"]
         if isinstance(e, exp.NumberToStr)
         else exp.Literal.string(
             format_time(e.args.get("format").name, {v: k.lower() for k, v in TSQL.time_mapping.items()})
         )
     )
-    print(self.sql(e, "format"))
     return f"FORMAT({self.format_args(e.this, fmt)})"
 
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -55,9 +55,7 @@ def parse_format(args):
     number_fmt = not re.search(DATE_FMT_RE, fmt.this) or fmt.this in TRANSPILE_SAFE_NUMBER_FMT
     if number_fmt:
         return exp.NumberToStr(this=list_get(args, 0), format=fmt)
-    return exp.TimeToStr(
-        this=list_get(args, 0), format=exp.Literal.string(format_time(fmt.name, TSQL.time_mapping))
-    )
+    return exp.TimeToStr(this=list_get(args, 0), format=exp.Literal.string(format_time(fmt.name, TSQL.time_mapping)))
 
 
 def generate_date_delta_with_unit_sql(self, e):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2673,6 +2673,10 @@ class StrToUnix(Func):
     arg_types = {"this": True, "format": True}
 
 
+class NumberToStr(Func):
+    arg_types = {"this": True, "format": True}
+
+
 class Struct(Func):
     arg_types = {"expressions": True}
     is_var_len_args = True

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -23,6 +23,7 @@ def format_time(string, mapping, trie=None):
     current = trie
     chunks = []
     sym = None
+
     while end <= size:
         chars = string[start:end]
         result, current = in_trie(current, chars[-1])

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -23,7 +23,6 @@ def format_time(string, mapping, trie=None):
     current = trie
     chunks = []
     sym = None
-
     while end <= size:
         chars = string[start:end]
         result, current = in_trie(current, chars[-1])

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -43,5 +43,4 @@ def format_time(string, mapping, trie=None):
 
         if result and end > size:
             chunks.append(chars)
-
     return "".join(mapping.get(chars, chars) for chars in chunks)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -361,3 +361,22 @@ class TestTSQL(Validator):
                 "spark": "SELECT * FROM A LIMIT 3",
             },
         )
+
+    def test_format(self):
+        self.validate_identity("SELECT FORMAT('01-01-1991', 'dd.mm.yyyy')")
+        self.validate_identity("SELECT FORMAT(12345, '###.###.###')")
+        self.validate_identity("SELECT FORMAT(1234567, 'f')")
+        self.validate_all(
+            "SELECT FORMAT(1000000.01,'###,###.###')",
+            write={"spark": "SELECT FORMAT_NUMBER(1000000.01, '###,###.###')"},
+        )
+        self.validate_all("SELECT FORMAT(1234567, 'f')", write={"spark": "SELECT FORMAT_NUMBER(1234567, 'f')"})
+        self.validate_all(
+            "SELECT FORMAT('01-01-1991', 'dd.mm.yyyy')",
+            write={"spark": "SELECT DATE_FORMAT('01-01-1991', 'dd.mm.yyyy')"},
+        )
+        self.validate_all(
+            "SELECT FORMAT(date_col, 'dd.mm.yyyy')", write={"spark": "SELECT DATE_FORMAT(date_col, 'dd.mm.yyyy')"}
+        )
+        self.validate_all("SELECT FORMAT(date_col, 'm')", write={"spark": "SELECT DATE_FORMAT(date_col, 'm')"})
+        self.validate_all("SELECT FORMAT(num_col, 'c')", write={"spark": "SELECT FORMAT_NUMBER(num_col, 'c')"})

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -363,7 +363,7 @@ class TestTSQL(Validator):
         )
 
     def test_format(self):
-        self.validate_identity("SELECT FORMAT('01-01-1991', 'dd.mm.yyyy')")
+        self.validate_identity("SELECT FORMAT('01-01-1991', 'd.mm.yyyy')")
         self.validate_identity("SELECT FORMAT(12345, '###.###.###')")
         self.validate_identity("SELECT FORMAT(1234567, 'f')")
         self.validate_all(
@@ -378,5 +378,5 @@ class TestTSQL(Validator):
         self.validate_all(
             "SELECT FORMAT(date_col, 'dd.mm.yyyy')", write={"spark": "SELECT DATE_FORMAT(date_col, 'dd.mm.yyyy')"}
         )
-        self.validate_all("SELECT FORMAT(date_col, 'm')", write={"spark": "SELECT DATE_FORMAT(date_col, 'm')"})
+        self.validate_all("SELECT FORMAT(date_col, 'm')", write={"spark": "SELECT DATE_FORMAT(date_col, 'MMMM d')"})
         self.validate_all("SELECT FORMAT(num_col, 'c')", write={"spark": "SELECT FORMAT_NUMBER(num_col, 'c')"})


### PR DESCRIPTION
Attempt at TSQL format, format is quite versatile in that it can format any input type.
I am not fond of the regex but it does the trick in sort of safely switching between number formatting and date formatting.
The switch is needed since most target dialects will not have a versatile format like TSQL.