### PR TITLE
TSQL parsing + symbol for concatenation or arithmetic operation

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -249,10 +249,9 @@ class TSQL(Dialect):
                     expressions = [term.expression]
                     this = term.this
 
-                    while isinstance(this, (exp.Add, exp.Paren)):
-                        if isinstance(this, exp.Add):
-                            expressions.insert(0, this.expression)
-                            this = this.this
+                    while isinstance(this, exp.Add):
+                        expressions.insert(0, this.expression)
+                        this = this.this
                     else:
                         expressions.insert(0, this)
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -353,4 +353,3 @@ class TestTSQL(Validator):
                 "spark": "SELECT table.col1 + table.col2 + COALESCE(table.col3, 0) AS test FROM testdb.dbo.table",
             },
         )
-

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -333,3 +333,24 @@ class TestTSQL(Validator):
                 "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL TVFTEST(t.x) y AS z",
             },
         )
+
+    def test_concat(self):
+        self.validate_all(
+            "SELECT CONCAT('test', testdb.dbo.table.column, 1) AS test FROM testdb.dbo.table",
+            write={
+                "spark": "SELECT CONCAT_WS('', 'test', testdb.dbo.table.column, 1) AS test FROM testdb.dbo.table",
+            },
+        )
+        self.validate_all(
+            "SELECT table.col1 + table.col2 + ISNULL(table.col3, 'default') AS test FROM testdb.dbo.table",
+            write={
+                "spark": "SELECT table.col1 || table.col2 || COALESCE(table.col3, 'default') AS test FROM testdb.dbo.table",
+            },
+        )
+        self.validate_all(
+            "SELECT table.col1 + table.col2 + ISNULL(table.col3, 0) AS test FROM testdb.dbo.table",
+            write={
+                "spark": "SELECT table.col1 + table.col2 + COALESCE(table.col3, 0) AS test FROM testdb.dbo.table",
+            },
+        )
+


### PR DESCRIPTION
Hi All,

Im facing quite a challenge for parsing the + symbol in T-SQL. I would love to get some help on my approach.

The problem is that there are two kind of contexts possible when using the + symbol:
- For arithmetic operations such as column1 + 234
- For string concatenations such as column1 + '234'

The problem is to identify it is either a + symbol for concatenation or not. In case of a string concatenation I managed to translate this to DPipe and is handled ok. However you would need to scan for string values in order to determine the context of string concatenation. This will never be a 100% solution as you would need the datatypes of the columns involved. However im trying a best effort approach here.

My approach is to determine the related set of literals and determine whether its a string concatenation based on that. After I would like to replace all of the exp.Add with a exp.DPipe. 

Do you guys have any good ideas on this problem?

Thanks!