### PR TITLE
Attach comments to tokens

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -752,7 +752,9 @@ class Tokenizer(metaclass=_Tokenizer):
 
     def _add(self, token_type, text=None):
         self._prev_token_type = token_type
-        self.tokens.append(Token(token_type, self._text if text is None else text, self._line, self._col, self._comment))
+        self.tokens.append(
+            Token(token_type, self._text if text is None else text, self._line, self._col, self._comment)
+        )
         self._comment = None
 
         if token_type in self.COMMANDS and (len(self.tokens) == 1 or self.tokens[-2].token_type == TokenType.SEMICOLON):
@@ -834,7 +836,7 @@ class Tokenizer(metaclass=_Tokenizer):
             while not self._end and self._chars(comment_end_size) != comment_end:
                 self._advance()
 
-            self._comment = self._text[comment_start_size: -comment_end_size + 1]
+            self._comment = self._text[comment_start_size : -comment_end_size + 1]
             self._advance(comment_end_size - 1)
         else:
             while not self._end and self.WHITE_SPACE.get(self._peek) != TokenType.BREAK:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -287,7 +287,8 @@ class TokenType(AutoName):
 
 
 class Token:
-    __slots__ = ("token_type", "text", "line", "col", "comment")
+    # We use "trivia" to model comments attached to tokens (& AST nodes later on, possibly)
+    __slots__ = ("token_type", "text", "line", "col", "trivia")
 
     @classmethod
     def number(cls, number):
@@ -305,12 +306,12 @@ class Token:
     def var(cls, var):
         return cls(TokenType.VAR, var)
 
-    def __init__(self, token_type, text, line=1, col=1, comment=None):
+    def __init__(self, token_type, text, line=1, col=1, trivia=None):
         self.token_type = token_type
         self.text = text
         self.line = line
         self.col = max(col - len(text), 1)
-        self.comment = comment
+        self.trivia = trivia
 
     def __repr__(self):
         attributes = ", ".join(f"{k}: {getattr(self, k)}" for k in self.__slots__)
@@ -675,10 +676,12 @@ class Tokenizer(metaclass=_Tokenizer):
         "_current",
         "_line",
         "_col",
-        "_comment",
+        "_trivia",
         "_char",
         "_end",
         "_peek",
+        "_prev_token_line",
+        "_prev_token_trivia",
         "_prev_token_type",
     )
 
@@ -696,11 +699,13 @@ class Tokenizer(metaclass=_Tokenizer):
         self._current = 0
         self._line = 1
         self._col = 1
-        self._comment = None
+        self._trivia = None
 
         self._char = None
         self._end = None
         self._peek = None
+        self._prev_token_line = -1
+        self._prev_token_trivia = None
         self._prev_token_type = None
 
     def tokenize(self, sql):
@@ -751,11 +756,11 @@ class Tokenizer(metaclass=_Tokenizer):
         return self.sql[self._start : self._current]
 
     def _add(self, token_type, text=None):
+        self._prev_token_line = self._line
+        self._prev_token_trivia = self._trivia
         self._prev_token_type = token_type
-        self.tokens.append(
-            Token(token_type, self._text if text is None else text, self._line, self._col, self._comment)
-        )
-        self._comment = None
+        self.tokens.append(Token(token_type, self._text if text is None else text, self._line, self._col, self._trivia))
+        self._trivia = None
 
         if token_type in self.COMMANDS and (len(self.tokens) == 1 or self.tokens[-2].token_type == TokenType.SEMICOLON):
             self._start = self._current
@@ -822,11 +827,11 @@ class Tokenizer(metaclass=_Tokenizer):
         self._advance(size - 1)
         self._add(self.KEYWORDS[word.upper()])
 
-    # Comments are attached to the next token, if any.
     def _scan_comment(self, comment_start):
         if comment_start not in self._COMMENTS:
             return False
 
+        comment_start_line = self._line
         comment_start_size = len(comment_start)
         comment_end = self._COMMENTS[comment_start]
 
@@ -836,12 +841,18 @@ class Tokenizer(metaclass=_Tokenizer):
             while not self._end and self._chars(comment_end_size) != comment_end:
                 self._advance()
 
-            self._comment = self._text[comment_start_size : -comment_end_size + 1]
+            self._trivia = self._text[comment_start_size : -comment_end_size + 1]
             self._advance(comment_end_size - 1)
         else:
             while not self._end and self.WHITE_SPACE.get(self._peek) != TokenType.BREAK:
                 self._advance()
-            self._comment = self._text[comment_start_size:]
+            self._trivia = self._text[comment_start_size:]
+
+        # Leading trivia is attached to the succeeding token, whilst trailing trivia to the preceding. If both
+        # types of trivia can be attached to a token, the trailing one is discarded in favour of the leading one.
+        if comment_start_line == self._prev_token_line and self._prev_token_trivia is None:
+            self.tokens[-1].trivia = self._trivia
+            self._trivia = None
 
         return True
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -287,7 +287,7 @@ class TokenType(AutoName):
 
 
 class Token:
-    __slots__ = ("token_type", "text", "line", "col")
+    __slots__ = ("token_type", "text", "line", "col", "comment")
 
     @classmethod
     def number(cls, number):
@@ -305,11 +305,12 @@ class Token:
     def var(cls, var):
         return cls(TokenType.VAR, var)
 
-    def __init__(self, token_type, text, line=1, col=1):
+    def __init__(self, token_type, text, line=1, col=1, comment=None):
         self.token_type = token_type
         self.text = text
         self.line = line
         self.col = max(col - len(text), 1)
+        self.comment = comment
 
     def __repr__(self):
         attributes = ", ".join(f"{k}: {getattr(self, k)}" for k in self.__slots__)
@@ -674,6 +675,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "_current",
         "_line",
         "_col",
+        "_comment",
         "_char",
         "_end",
         "_peek",
@@ -694,6 +696,7 @@ class Tokenizer(metaclass=_Tokenizer):
         self._current = 0
         self._line = 1
         self._col = 1
+        self._comment = None
 
         self._char = None
         self._end = None
@@ -749,7 +752,8 @@ class Tokenizer(metaclass=_Tokenizer):
 
     def _add(self, token_type, text=None):
         self._prev_token_type = token_type
-        self.tokens.append(Token(token_type, self._text if text is None else text, self._line, self._col))
+        self.tokens.append(Token(token_type, self._text if text is None else text, self._line, self._col, self._comment))
+        self._comment = None
 
         if token_type in self.COMMANDS and (len(self.tokens) == 1 or self.tokens[-2].token_type == TokenType.SEMICOLON):
             self._start = self._current
@@ -816,10 +820,12 @@ class Tokenizer(metaclass=_Tokenizer):
         self._advance(size - 1)
         self._add(self.KEYWORDS[word.upper()])
 
+    # Comments are attached to the next token, if any.
     def _scan_comment(self, comment_start):
         if comment_start not in self._COMMENTS:
             return False
 
+        comment_start_size = len(comment_start)
         comment_end = self._COMMENTS[comment_start]
 
         if comment_end:
@@ -827,10 +833,14 @@ class Tokenizer(metaclass=_Tokenizer):
 
             while not self._end and self._chars(comment_end_size) != comment_end:
                 self._advance()
+
+            self._comment = self._text[comment_start_size: -comment_end_size + 1]
             self._advance(comment_end_size - 1)
         else:
             while not self._end and self.WHITE_SPACE.get(self._peek) != TokenType.BREAK:
                 self._advance()
+            self._comment = self._text[comment_start_size:]
+
         return True
 
     def _scan_annotation(self):

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,0 +1,14 @@
+import unittest
+
+from sqlglot.tokens import Tokenizer
+
+
+class TestTokens(unittest.TestCase):
+    def test_comment_attachment(self):
+        tokenizer = Tokenizer()
+
+        sqls = ["/*comment*/ foo", "/*comment*/ foo --test", "--comment\nfoo --test", "foo --comment", "foo"]
+        comments = ["comment", "comment", "comment", "comment", None]
+
+        for sql, comment in zip(sqls, comments):
+            self.assertEqual(tokenizer.tokenize(sql)[0].comment, comment)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -6,9 +6,13 @@ from sqlglot.tokens import Tokenizer
 class TestTokens(unittest.TestCase):
     def test_comment_attachment(self):
         tokenizer = Tokenizer()
+        sql_comment = [
+            ("/*comment*/ foo", "comment"),
+            ("/*comment*/ foo --test", "comment"),
+            ("--comment\nfoo --test", "comment"),
+            ("foo --comment", "comment"),
+            ("foo", None),
+        ]
 
-        sqls = ["/*comment*/ foo", "/*comment*/ foo --test", "--comment\nfoo --test", "foo --comment", "foo"]
-        comments = ["comment", "comment", "comment", "comment", None]
-
-        for sql, comment in zip(sqls, comments):
+        for sql, comment in sql_comment:
             self.assertEqual(tokenizer.tokenize(sql)[0].comment, comment)


### PR DESCRIPTION
This PR aims to pave the way for changing how we handle comments; instead of discarding them, keep them so that maybe they can be used later on meaningfully.

One such example is trying to preserve comments during SQL formatting. Ideally, we'd like to support the following:
```python
>>> import sqlglot
>>>
>>> sql = """
... SELECT -- comment
...   x, -- comment
...   y, -- comment
... FROM foo"""
>>>
>>> print(sqlglot.transpile(sql, pretty=True)[0])
SELECT -- comment
  x, -- comment
  y, -- comment
FROM foo
```

The problem of handling comments correctly after we parse SQL into an AST is not a simple one, but we may manage to come up with some heuristics / best-effort approaches that work fine for our needs. Feedback is very welcome!

Sources:
- https://stackoverflow.com/questions/7456933/python-ast-with-preserved-comments/32372075
- https://hisham.hm/2020/12/28/parsing-and-preserving-teal-comments/
- https://github.com/terrajobst/minsk/blob/master/docs/episode-24.md
