### PR TITLE
Replace annotations with SQL comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,15 @@ LEFT JOIN `baz`
   ON `f`.`a` = `baz`.`a`
 ```
 
-Finally, SQLGlot tries to preserve comments when formatting SQL code using the `pretty=True` option:
+Comments are preserved in a best-effort basis when traspiling SQL code:
 
 ```python
 sql = """
-SELECT            -- comment1
+/* multi
+   line
+   comment
+*/
+SELECT
   CAST(x AS INT), -- comment2
   y               -- comment3
 FROM
@@ -135,7 +139,11 @@ print(sqlglot.transpile(sql, pretty=True)[0])
 ```
 
 ```sql
-SELECT -- comment1
+/* multi
+   line
+   comment
+*/
+SELECT
   CAST(x AS INT), -- comment2
   y -- comment3
 FROM bar

--- a/README.md
+++ b/README.md
@@ -129,13 +129,15 @@ sql = """
    comment
 */
 SELECT
-  CAST(x AS INT), -- comment2
-  y               -- comment3
+  tbl.cola /* comment 1 */ + tbl.colb /* comment 2 */,
+  CAST(x AS INT), # comment 3
+  y               -- comment 4
 FROM
-  bar
+  bar /* comment 5 */,
+  tbl #          comment 6
 """
 
-print(sqlglot.transpile(sql, pretty=True)[0])
+print(sqlglot.transpile(sql, read='mysql', pretty=True)[0])
 ```
 
 ```sql
@@ -144,9 +146,10 @@ print(sqlglot.transpile(sql, pretty=True)[0])
    comment
 */
 SELECT
-  CAST(x AS INT), -- comment2
-  y -- comment3
-FROM bar
+  tbl.cola /* comment 1 */ + tbl.colb /* comment 2 */,
+  CAST(x AS INT) /* comment 3 */,
+  y /* comment 4 */
+FROM bar /* comment 5 */, tbl /* comment 6 */
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ print(sqlglot.transpile(sql, read='mysql', pretty=True)[0])
 */
 SELECT
   tbl.cola /* comment 1 */ + tbl.colb /* comment 2 */,
-  CAST(x AS INT) /* comment 3 */,
-  y /* comment 4 */
-FROM bar /* comment 5 */, tbl /* comment 6 */
+  CAST(x AS INT), -- comment 3
+  y -- comment 4
+FROM bar /* comment 5 */, tbl /*          comment 6*/
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Contributions are very welcome in SQLGlot; read the [contribution guide](https:/
    * [Unsupported Errors](#unsupported-errors)
    * [Build and Modify SQL](#build-and-modify-sql)
    * [SQL Optimizer](#sql-optimizer)
-   * [SQL Annotations](#sql-annotations)
    * [AST Introspection](#ast-introspection)
    * [AST Diff](#ast-diff)
    * [Custom Dialects](#custom-dialects)
@@ -120,6 +119,28 @@ JOIN `bar` AS `b`
 LEFT JOIN `baz`
   ON `f`.`a` = `baz`.`a`
 ```
+
+Finally, SQLGlot tries to preserve comments when formatting SQL code using the `pretty=True` option:
+
+```python
+sql = """
+SELECT            -- comment1
+  CAST(x AS INT), -- comment2
+  y               -- comment3
+FROM
+  bar
+"""
+
+print(sqlglot.transpile(sql, pretty=True)[0])
+```
+
+```sql
+SELECT -- comment1
+  CAST(x AS INT), -- comment2
+  y -- comment3
+FROM bar
+```
+
 
 ### Metadata
 
@@ -247,17 +268,6 @@ SELECT
 FROM "x" AS "x"
 WHERE
   "x"."Z" = CAST('2021-02-01' AS DATE)
-```
-
-### SQL Annotations
-
-SQLGlot supports annotations in the sql expression. This is an experimental feature that is not part of any of the SQL standards but it can be useful when needing to annotate what a selected field is supposed to be. Below is an example:
-
-```sql
-SELECT
-  user # primary_key,
-  country
-FROM users
 ```
 
 ### AST Introspection

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -103,6 +103,7 @@ class BigQuery(Dialect):
             for quote in ["'", '"', '"""', "'''"]
             for prefix in ["", "r", "R"]
         ]
+        COMMENTS = ["--", "#", ("/*", "*/")]
         IDENTIFIERS = ["`"]
         ESCAPES = ["\\"]
         HEX_STRINGS = [("0x", ""), ("0X", "")]

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -16,6 +16,7 @@ class ClickHouse(Dialect):
     null_ordering = "nulls_are_last"
 
     class Tokenizer(tokens.Tokenizer):
+        COMMENTS = ["--", "#", "#!", ("/*", "*/")]
         IDENTIFIERS = ['"', "`"]
 
         KEYWORDS = {

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -314,7 +314,7 @@ class MySQL(Dialect):
         def _parse_show_profile_type(self):
             for type_ in self.PROFILE_TYPES:
                 if self._match_text(*type_.split(" ")):
-                    return type_
+                    return exp.Var(this=type_)
             return None
 
         def _parse_oldstyle_limit(self):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -365,6 +365,7 @@ class Expression(metaclass=_Expression):
             )
             for k, vs in self.args.items()
         }
+        args["comment"] = self.comment
         args = {k: v for k, v in args.items() if v or not hide_missing}
 
         right = ", ".join(f"{k}: {v}" for k, v in args.items())

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -135,6 +135,7 @@ class Expression(metaclass=_Expression):
     def __deepcopy__(self, memo):
         copy = self.__class__(**deepcopy(self.args))
         copy.comment = self.comment
+        copy.type = self.type
         return copy
 
     def copy(self):
@@ -366,6 +367,7 @@ class Expression(metaclass=_Expression):
             for k, vs in self.args.items()
         }
         args["comment"] = self.comment
+        args["type"] = self.type
         args = {k: v for k, v in args.items() if v or not hide_missing}
 
         right = ", ".join(f"{k}: {v}" for k, v in args.items())

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -85,9 +85,18 @@ class Expression(metaclass=_Expression):
             return field.this
         return ""
 
-    def find_comment(self, key):
+    def find_comment(self, key: str) -> str:
+        """
+        Finds the comment that is attached to specified child node.
+
+        Args:
+            key: the key of the target child node (e.g. "this", "expression", etc).
+
+        Returns:
+            The comment attached to the child node, or the empty string, if it doesn't exist.
+        """
         field = self.args.get(key)
-        return field.comment if field is not None else ""
+        return field.comment if isinstance(field, Expression) else ""
 
     @property
     def is_string(self):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -133,7 +133,9 @@ class Expression(metaclass=_Expression):
         return self.alias or self.name
 
     def __deepcopy__(self, memo):
-        return self.__class__(**deepcopy(self.args))
+        copy = self.__class__(**deepcopy(self.args))
+        copy.comment = self.comment
+        return copy
 
     def copy(self):
         new = deepcopy(self)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -85,7 +85,7 @@ class Expression(metaclass=_Expression):
             return field.this
         return ""
 
-    def comment_(self, key):
+    def find_comment(self, key):
         field = self.args.get(key)
         return field.comment if field is not None else ""
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -87,7 +87,7 @@ class Expression(metaclass=_Expression):
 
     def find_comment(self, key: str) -> str:
         """
-        Finds the comment that is attached to specified child node.
+        Finds the comment that is attached to a specified child node.
 
         Args:
             key: the key of the target child node (e.g. "this", "expression", etc).

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -85,6 +85,10 @@ class Expression(metaclass=_Expression):
             return field.this
         return ""
 
+    def comment_(self, key):
+        field = self.args.get(key)
+        return field.comment if field is not None else ""
+
     @property
     def is_string(self):
         return isinstance(self, Literal) and self.args["is_string"]

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -40,13 +40,14 @@ class Expression(metaclass=_Expression):
 
     key = None
     arg_types = {"this": True}
-    __slots__ = ("args", "parent", "arg_key", "type")
+    __slots__ = ("args", "parent", "arg_key", "type", "comment")
 
     def __init__(self, **args):
         self.args = args
         self.parent = None
         self.arg_key = None
         self.type = None
+        self.comment = None
 
         for arg_key, value in self.args.items():
             self._set_parent(arg_key, value)
@@ -577,17 +578,6 @@ class Unionable(Expression):
 
 class UDTF(DerivedTable, Unionable):
     pass
-
-
-class Annotation(Expression):
-    arg_types = {
-        "this": True,
-        "expression": True,
-    }
-
-    @property
-    def alias(self):
-        return self.expression.alias_or_name
 
 
 class Cache(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -798,7 +798,7 @@ class Generator:
         serde = f" SERDE {serde}" if serde else ""
         return f"LOAD DATA{local}{inpath}{overwrite}{this}{partition}{input_format}{serde}"
 
-    def null_sql(self, expression):
+    def null_sql(self, *_):
         return "NULL"
 
     def boolean_sql(self, expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import typing as t
 
 from sqlglot import exp
@@ -10,6 +11,8 @@ from sqlglot.time import format_time
 from sqlglot.tokens import TokenType
 
 logger = logging.getLogger("sqlglot")
+
+NEWLINE_RE = re.compile("\r\n?|\n")
 
 
 class Generator:
@@ -223,7 +226,7 @@ class Generator:
         if not comment or not self._comments:
             return sql
 
-        if not self.pretty or "\n" not in comment:
+        if not self.pretty or not NEWLINE_RE.search(comment):
             return f"{sql} /* {comment.strip()} */"
 
         return f"/*{comment}*/\n{sql}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1252,9 +1252,9 @@ class Generator:
         return f"SHOW {self.sql(expression, 'this')}"
 
     def binary(self, expression, op):
-        left = self.maybe_comment(self.sql(expression, "this"), expression.comment_("this"))
+        left = self.maybe_comment(self.sql(expression, "this"), expression.find_comment("this"))
         right = self.maybe_comment(
-            self.sql(expression, "expression"), expression.comment_("expression")
+            self.sql(expression, "expression"), expression.find_comment("expression")
         )
         return f"{left} {op} {right}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -228,18 +228,18 @@ class Generator:
             return sql
 
         comment = " " + comment if comment[0].strip() else comment
-        comment = comment.rstrip()
+        comment = comment + " " if comment[-1].strip() else comment
 
         if isinstance(expression, exp.Select):
-            return f"/*{comment} */{self.sep()}{sql}"
+            return f"/*{comment}*/{self.sep()}{sql}"
 
         if not self.pretty:
-            return f"{sql} /*{comment} */"
+            return f"{sql} /*{comment}*/"
 
         if not NEWLINE_RE.search(comment):
-            return f"{sql} --{comment}" if single_line else f"{sql} /*{comment} */"
+            return f"{sql} --{comment.rstrip()}" if single_line else f"{sql} /*{comment}*/"
 
-        return f"/*{comment} */\n{sql}"
+        return f"/*{comment}*/\n{sql}"
 
     def wrap(self, expression):
         this_sql = self.indent(
@@ -877,7 +877,7 @@ class Generator:
         sql = self.query_modifiers(
             expression,
             f"SELECT{hint}{distinct}{expressions}",
-            self.sql(expression, "from"),
+            self.sql(expression, "from", comment=False),
         )
         return self.prepend_ctes(expression, sql)
 
@@ -1308,13 +1308,11 @@ class Generator:
         result_sqls = []
         for i, e in enumerate(expressions):
             sql = self.sql(e, comment=False)
-            comment = self.maybe_comment('', e, single_line=True)
+            comment = self.maybe_comment("", e, single_line=True)
 
             if self.pretty:
                 if self._leading_comma:
-                    result_sqls.append(
-                        f"{sep if i > 0 else pad}{sql}{comment}"
-                    )
+                    result_sqls.append(f"{sep if i > 0 else pad}{sql}{comment}")
                 else:
                     result_sqls.append(f"{sql}{stripped_sep if i + 1 < num_sqls else ''}{comment}")
             else:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -677,7 +677,7 @@ class Parser(metaclass=_Parser):
 
     def _attach_comment(self, node, comment):
         if node and comment is not None:
-            node.comment = comment.strip()
+            node.comment = comment
         return node
 
     def _parse_statement(self):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -676,7 +676,7 @@ class Parser(metaclass=_Parser):
         self._advance(index - self._index)
 
     def _attach_comment(self, node, comment):
-        if node and node.comment is None and comment is not None:
+        if node and comment is not None:
             node.comment = comment
         return node
 
@@ -1876,7 +1876,7 @@ class Parser(metaclass=_Parser):
                 this = self.expression(exp.Dot, this=this, expression=field)
             this = self._parse_bracket(this)
 
-        return this
+        return self._attach_comment(this, self._prev.comment)
 
     def _parse_primary(self):
         if self._match_set(self.PRIMARY_PARSERS):
@@ -1946,7 +1946,7 @@ class Parser(metaclass=_Parser):
             ):
                 this = self.expression(subquery_predicate, this=self._parse_select())
                 self._match_r_paren()
-                return this
+                return self._attach_comment(this, self._prev.comment)
 
             if functions is None:
                 functions = self.FUNCTIONS
@@ -1959,7 +1959,7 @@ class Parser(metaclass=_Parser):
             else:
                 this = self.expression(exp.Anonymous, this=this, expressions=args)
         self._match_r_paren()
-        return self._parse_window(this)
+        return self._parse_window(self._attach_comment(this, self._prev.comment))
 
     def _parse_user_defined_function(self):
         this = self._parse_id_var()
@@ -2174,7 +2174,7 @@ class Parser(metaclass=_Parser):
         if not self._match(TokenType.R_BRACKET):
             self.raise_error("Expected ]")
 
-        return self._parse_bracket(this)
+        return self._parse_bracket(self._attach_comment(this, self._prev.comment))
 
     def _parse_case(self):
         ifs = []

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -676,10 +676,9 @@ class Parser(metaclass=_Parser):
         self._advance(index - self._index)
 
     def _attach_comment(self, node, comment):
-        try:
-            node.comment = comment
-        finally:
-            return node
+        if node and comment is not None:
+            node.comment = comment.strip()
+        return node
 
     def _parse_statement(self):
         if self._curr is None:
@@ -1030,11 +1029,13 @@ class Parser(metaclass=_Parser):
             return None
 
         def parse_values():
-            k = self._parse_var()
+            key = self._parse_var()
+            value = None
+
             if self._match(TokenType.EQ):
-                v = self._parse_string()
-                return (k, v)
-            return (k, None)
+                value = self._parse_string()
+
+            return exp.Property(this=key, value=value)
 
         self._match_l_paren()
         values = self._parse_csv(parse_values)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -40,10 +40,10 @@ class TokenType(AutoName):
     TILDA = auto()
     ARROW = auto()
     DARROW = auto()
+    HASH = auto()
     HASH_ARROW = auto()
     DHASH_ARROW = auto()
     LR_ARROW = auto()
-    ANNOTATION = auto()
     DOLLAR = auto()
     PARAMETER = auto()
 
@@ -395,13 +395,13 @@ class Tokenizer(metaclass=_Tokenizer):
         "*": TokenType.STAR,
         "~": TokenType.TILDA,
         "?": TokenType.PLACEHOLDER,
-        "#": TokenType.ANNOTATION,
         "@": TokenType.PARAMETER,
         # used for breaking a var like x'y' but nothing else
         # the token type doesn't matter
         "'": TokenType.QUOTE,
         "`": TokenType.IDENTIFIER,
         '"': TokenType.IDENTIFIER,
+        "#": TokenType.HASH,
     }
 
     QUOTES: t.List[t.Tuple[str, str] | str] = ["'"]
@@ -837,11 +837,7 @@ class Tokenizer(metaclass=_Tokenizer):
 
         if not word:
             if self._char in self.SINGLE_TOKENS:
-                token = self.SINGLE_TOKENS[self._char]  # type: ignore
-                if token == TokenType.ANNOTATION:
-                    self._scan_annotation()
-                    return
-                self._add(token)
+                self._add(self.SINGLE_TOKENS[self._char])  # type: ignore
                 return
             self._scan_var()
             return
@@ -879,16 +875,12 @@ class Tokenizer(metaclass=_Tokenizer):
 
         # Leading comment is attached to the succeeding token, whilst trailing comment to the preceding. If both
         # types of comment can be attached to a token, the trailing one is discarded in favour of the leading one.
+
         if comment_start_line == self._prev_token_line and self._prev_token_comment is None:
             self.tokens[-1].comment = self._comment
             self._comment = None
 
         return True
-
-    def _scan_annotation(self) -> None:
-        while not self._end and self.WHITE_SPACE.get(self._peek) != TokenType.BREAK and self._peek != ",":  # type: ignore
-            self._advance()
-        self._add(TokenType.ANNOTATION, self._text[1:])
 
     def _scan_number(self) -> None:
         if self._char == "0":

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -876,8 +876,10 @@ class Tokenizer(metaclass=_Tokenizer):
         # Leading comment is attached to the succeeding token, whilst trailing comment to the preceding. If both
         # types of comment can be attached to a token, the trailing one is discarded in favour of the leading one.
 
-        if comment_start_line == self._prev_token_line and self._prev_token_comment is None:
-            self.tokens[-1].comment = self._comment
+        if comment_start_line == self._prev_token_line:
+            if self._prev_token_comment is None:
+                self.tokens[-1].comment = self._comment
+
             self._comment = None
 
         return True

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -32,7 +32,5 @@ class TestClickhouse(Validator):
         )
         self.validate_all(
             "SELECT x #! comment",
-            write={
-                "": "SELECT x /* comment */",
-            },
+            write={"": "SELECT x /* comment */"},
         )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -18,7 +18,6 @@ class TestClickhouse(Validator):
                 "spark": "SELECT fname, lname, age FROM person ORDER BY age DESC NULLS FIRST, fname NULLS LAST, lname NULLS LAST",
             },
         )
-
         self.validate_all(
             "CAST(1 AS NULLABLE(Int64))",
             write={
@@ -29,5 +28,11 @@ class TestClickhouse(Validator):
             "CAST(1 AS Nullable(DateTime64(6, 'UTC')))",
             write={
                 "clickhouse": "CAST(1 AS Nullable(DateTime64(6, 'UTC')))",
+            },
+        )
+        self.validate_all(
+            "SELECT x #! comment",
+            write={
+                "": "SELECT x /* comment */",
             },
         )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -33,6 +33,6 @@ class TestClickhouse(Validator):
         self.validate_all(
             "SELECT x #! comment",
             write={
-                "": "SELECT x /* comment */",
+                "": "SELECT x /* comment*/",
             },
         )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -33,6 +33,6 @@ class TestClickhouse(Validator):
         self.validate_all(
             "SELECT x #! comment",
             write={
-                "": "SELECT x /* comment*/",
+                "": "SELECT x /* comment */",
             },
         )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1179,9 +1179,9 @@ class TestDialect(Validator):
             },
         )
         self.validate_all(
-            """SELECT -- comment1
-  x, -- comment2
-  y -- comment3""",
+            """SELECT /* comment1 */
+  x /* comment2 */,
+  y /* comment3 */""",
             read={
                 "mysql": """SELECT # comment1
   x, # comment2

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1182,7 +1182,7 @@ class TestDialect(Validator):
             """/* comment1 */
 SELECT
   x, -- comment2
-  y /* comment3 */""",
+  y -- comment3""",
             read={
                 "mysql": """SELECT # comment1
   x, # comment2

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1176,6 +1176,7 @@ class TestDialect(Validator):
             read={
                 "mysql": "SELECT 1 # arbitrary content,,, until end-of-line",
                 "bigquery": "SELECT 1 # arbitrary content,,, until end-of-line",
+                "clickhouse": "SELECT 1 #! arbitrary content,,, until end-of-line",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1172,16 +1172,17 @@ class TestDialect(Validator):
 
     def test_hash_comments(self):
         self.validate_all(
-            "SELECT 1 /* arbitrary content,,, until end-of-line*/",
+            "SELECT 1 /* arbitrary content,,, until end-of-line */",
             read={
                 "mysql": "SELECT 1 # arbitrary content,,, until end-of-line",
                 "bigquery": "SELECT 1 # arbitrary content,,, until end-of-line",
             },
         )
         self.validate_all(
-            """SELECT -- comment1
+            """/* comment1 */
+SELECT
   x, -- comment2
-  y /* comment3*/""",
+  y /* comment3 */""",
             read={
                 "mysql": """SELECT # comment1
   x, # comment2

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1181,7 +1181,7 @@ class TestDialect(Validator):
         self.validate_all(
             """SELECT -- comment1
   x, -- comment2
-  y -- comment3""",
+  y /* comment3*/""",
             read={
                 "mysql": """SELECT # comment1
   x, # comment2

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1172,16 +1172,16 @@ class TestDialect(Validator):
 
     def test_hash_comments(self):
         self.validate_all(
-            "SELECT 1 /* arbitrary content,,, until end-of-line */",
+            "SELECT 1 /* arbitrary content,,, until end-of-line*/",
             read={
                 "mysql": "SELECT 1 # arbitrary content,,, until end-of-line",
                 "bigquery": "SELECT 1 # arbitrary content,,, until end-of-line",
             },
         )
         self.validate_all(
-            """SELECT /* comment1 */
-  x /* comment2 */,
-  y /* comment3 */""",
+            """SELECT -- comment1
+  x, -- comment2
+  y -- comment3""",
             read={
                 "mysql": """SELECT # comment1
   x, # comment2

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -132,6 +132,19 @@ class TestMySQL(Validator):
                 "mysql": "SELECT 1",
             },
         )
+        self.validate_all(
+            """
+            SELECT # comment1
+              x,   # comment2
+              y    # comment3
+            """,
+            write={
+                "mysql": """SELECT -- comment1
+  x, -- comment2
+  y -- comment3"""
+            },
+            pretty=True,
+        )
 
     def test_mysql(self):
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -129,7 +129,7 @@ class TestMySQL(Validator):
         self.validate_all(
             "SELECT 1 # arbitrary content,,, until end-of-line",
             write={
-                "mysql": "SELECT 1",
+                "mysql": "SELECT 1 /* arbitrary content,,, until end-of-line */",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -125,27 +125,6 @@ class TestMySQL(Validator):
             },
         )
 
-    def test_hash_comments(self):
-        self.validate_all(
-            "SELECT 1 # arbitrary content,,, until end-of-line",
-            write={
-                "mysql": "SELECT 1 /* arbitrary content,,, until end-of-line */",
-            },
-        )
-        self.validate_all(
-            """
-            SELECT # comment1
-              x,   # comment2
-              y    # comment3
-            """,
-            write={
-                "mysql": """SELECT -- comment1
-  x, -- comment2
-  y -- comment3"""
-            },
-            pretty=True,
-        )
-
     def test_mysql(self):
         self.validate_all(
             "GROUP_CONCAT(DISTINCT x ORDER BY y DESC)",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -353,12 +353,13 @@ COMMENT='客户账户表'"""
         self.assertEqual(show.name, "PROFILE")
 
         show = self.validate_identity("SHOW PROFILE BLOCK IO")
-        self.assertEqual(show.args["types"], ["BLOCK IO"])
+        self.assertEqual(show.args["types"][0].name, "BLOCK IO")
 
         show = self.validate_identity(
             "SHOW PROFILE BLOCK IO, PAGE FAULTS FOR QUERY 1 OFFSET 2 LIMIT 3"
         )
-        self.assertEqual(show.args["types"], ["BLOCK IO", "PAGE FAULTS"])
+        self.assertEqual(show.args["types"][0].name, "BLOCK IO")
+        self.assertEqual(show.args["types"][1].name, "PAGE FAULTS")
         self.assertEqual(show.text("query"), "1")
         self.assertEqual(show.text("offset"), "2")
         self.assertEqual(show.text("limit"), "3")

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -572,11 +572,11 @@ SELECT * FROM (tbl1 JOIN tbl2 JOIN tbl3)
 SELECT * FROM (tbl1 JOIN (tbl2 JOIN tbl3) ON bla = foo)
 SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)
 SELECT CAST(x AS INT) /* comment */ FROM foo
-SELECT a /*x*/, b /*x*/
-SELECT * FROM foo /*x*/, bla /*x*/
+SELECT a /* x */, b /* x */
+SELECT * FROM foo /* x */, bla /* x */
 SELECT 1 /* comment */ + 1
-SELECT 1 /*c1*/ + 2 /*c2*/
-SELECT 1 /*c1*/ + 2 /*c2*/ + 3 /* c3 */
-SELECT 1 /*c1*/ + 2 /*c2*/, 3 /*c3*/
-SELECT x FROM a.b.c /*x*/, e.f.g /*x*/
-SELECT FOO(x /*c*/) /*FOO*/, b /*b*/
+SELECT 1 /* c1 */ + 2 /* c2 */
+SELECT 1 /* c1 */ + 2 /* c2 */ + 3 /* c3 */
+SELECT 1 /* c1 */ + 2 /* c2 */, 3 /* c3 */
+SELECT x FROM a.b.c /* x */, e.f.g /* x */
+SELECT FOO(x /* c */) /* FOO */, b /* b */

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -579,3 +579,4 @@ SELECT 1 /*c1*/ + 2 /*c2*/
 SELECT 1 /*c1*/ + 2 /*c2*/ + 3 /* c3 */
 SELECT 1 /*c1*/ + 2 /*c2*/, 3 /*c3*/
 SELECT x FROM a.b.c /*x*/, e.f.g /*x*/
+SELECT FOO(x /*c*/) /*FOO*/, b /*b*/

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -572,3 +572,10 @@ SELECT * FROM (tbl1 JOIN tbl2 JOIN tbl3)
 SELECT * FROM (tbl1 JOIN (tbl2 JOIN tbl3) ON bla = foo)
 SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)
 SELECT CAST(x AS INT) /* comment */ FROM foo
+SELECT a /*x*/, b /*x*/
+SELECT * FROM foo /*x*/, bla /*x*/
+SELECT 1 /* comment */ + 1
+SELECT 1 /*c1*/ + 2 /*c2*/
+SELECT 1 /*c1*/ + 2 /*c2*/ + 3 /* c3 */
+SELECT 1 /*c1*/ + 2 /*c2*/, 3 /*c3*/
+SELECT x FROM a.b.c /*x*/, e.f.g /*x*/

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -571,3 +571,4 @@ SELECT * FROM (tbl1 LEFT JOIN tbl2 ON 1 = 1)
 SELECT * FROM (tbl1 JOIN tbl2 JOIN tbl3)
 SELECT * FROM (tbl1 JOIN (tbl2 JOIN tbl3) ON bla = foo)
 SELECT * FROM (tbl1 JOIN LATERAL (SELECT * FROM bla) AS tbl)
+SELECT CAST(x AS INT) /* comment */ FROM foo

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -580,3 +580,4 @@ SELECT 1 /* c1 */ + 2 /* c2 */ + 3 /* c3 */
 SELECT 1 /* c1 */ + 2 /* c2 */, 3 /* c3 */
 SELECT x FROM a.b.c /* x */, e.f.g /* x */
 SELECT FOO(x /* c */) /* FOO */, b /* b */
+SELECT FOO(x /* c1 */ + y /* c2 */ + BLA(5 /* c3 */)) FROM VALUES (1 /* c4 */, "test" /* c5 */) /* c6 */

--- a/tests/fixtures/pretty.sql
+++ b/tests/fixtures/pretty.sql
@@ -304,14 +304,14 @@ FROM foo;
 SELECT x FROM a.b.c /*x*/, e.f.g /*x*/;
 SELECT
   x
-FROM a.b.c /*x*/, e.f.g /*x*/;
+FROM a.b.c /* x */, e.f.g /* x */;
 SELECT x FROM (SELECT * FROM bla /*x*/WHERE id = 1) /*x*/;
 SELECT
   x
 FROM (
   SELECT
     *
-  FROM bla /*x*/
+  FROM bla /* x */
   WHERE
     id = 1
-) /*x*/;
+) /* x */;

--- a/tests/fixtures/pretty.sql
+++ b/tests/fixtures/pretty.sql
@@ -287,3 +287,31 @@ SELECT
       "fffffff"
     )
   );
+/*
+  multi
+  line
+  comment
+*/
+SELECT * FROM foo;
+/*
+  multi
+  line
+  comment
+*/
+SELECT
+  *
+FROM foo;
+SELECT x FROM a.b.c /*x*/, e.f.g /*x*/;
+SELECT
+  x
+FROM a.b.c /*x*/, e.f.g /*x*/;
+SELECT x FROM (SELECT * FROM bla /*x*/WHERE id = 1) /*x*/;
+SELECT
+  x
+FROM (
+  SELECT
+    *
+  FROM bla /*x*/
+  WHERE
+    id = 1
+) /*x*/;

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -585,7 +585,7 @@ class TestExpressions(unittest.TestCase):
         )
         self.assertEqual(
             expression.sql(),
-            "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
+            "SELECT a, b AS B, c /*comment*/, d AS D /* another comment*/, CAST(x AS INT) /* final comment*/ FROM foo",
         )
         self.assertEqual(
             expression.sql(comments=False),
@@ -602,17 +602,13 @@ class TestExpressions(unittest.TestCase):
 FROM foo""",
         )
         self.assertEqual(
-            expression.sql(),
-            "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
-        )
-        self.assertEqual(
             expression.sql(pretty=True),
             """SELECT
   a,
   b AS B,
-  c /* comment */,
-  d AS D /* another comment */,
-  CAST(x AS INT) /* final comment */
+  c, --comment
+  d AS D, -- another comment
+  CAST(x AS INT) -- final comment
 FROM foo""",
         )
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -588,13 +588,31 @@ class TestExpressions(unittest.TestCase):
             "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
         )
         self.assertEqual(
+            expression.sql(comments=False),
+            "SELECT a, b AS B, c, d AS D, CAST(x AS INT) FROM foo",
+        )
+        self.assertEqual(
+            expression.sql(pretty=True, comments=False),
+            """SELECT
+  a,
+  b AS B,
+  c,
+  d AS D,
+  CAST(x AS INT)
+FROM foo""",
+        )
+        self.assertEqual(
+            expression.sql(),
+            "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
+        )
+        self.assertEqual(
             expression.sql(pretty=True),
             """SELECT
   a,
   b AS B,
-  c, --comment
-  d AS D, -- another comment
-  CAST(x AS INT) -- final comment
+  c /* comment */,
+  d AS D /* another comment */,
+  CAST(x AS INT) /* final comment */
 FROM foo""",
         )
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -574,7 +574,7 @@ class TestExpressions(unittest.TestCase):
             a,
             b AS B,
             c, /*comment*/
-            d AS D, -- another_comment
+            d AS D, -- another comment
             CAST(x AS INT) -- final comment
         FROM foo
         """
@@ -583,7 +583,10 @@ class TestExpressions(unittest.TestCase):
             [e.alias_or_name for e in expression.expressions],
             ["a", "B", "c", "D", "x"],
         )
-        self.assertEqual(expression.sql(), "SELECT a, b AS B, c, d AS D, CAST(x AS INT) FROM foo")
+        self.assertEqual(
+            expression.sql(),
+            "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
+        )
         self.assertEqual(
             expression.sql(pretty=True, comments=False),
             """SELECT
@@ -599,8 +602,8 @@ FROM foo""",
             """SELECT
   a,
   b AS B,
-  c, --comment
-  d AS D, -- another_comment
+  c, -- comment
+  d AS D, -- another comment
   CAST(x AS INT) -- final comment
 FROM foo""",
         )

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -585,7 +585,7 @@ class TestExpressions(unittest.TestCase):
         )
         self.assertEqual(
             expression.sql(),
-            "SELECT a, b AS B, c /*comment*/, d AS D /* another comment*/, CAST(x AS INT) /* final comment*/ FROM foo",
+            "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
         )
         self.assertEqual(
             expression.sql(comments=False),
@@ -606,7 +606,7 @@ FROM foo""",
             """SELECT
   a,
   b AS B,
-  c, --comment
+  c, -- comment
   d AS D, -- another comment
   CAST(x AS INT) -- final comment
 FROM foo""",

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -588,21 +588,11 @@ class TestExpressions(unittest.TestCase):
             "SELECT a, b AS B, c /* comment */, d AS D /* another comment */, CAST(x AS INT) /* final comment */ FROM foo",
         )
         self.assertEqual(
-            expression.sql(pretty=True, comments=False),
-            """SELECT
-  a,
-  b AS B,
-  c,
-  d AS D,
-  CAST(x AS INT)
-FROM foo""",
-        )
-        self.assertEqual(
             expression.sql(pretty=True),
             """SELECT
   a,
   b AS B,
-  c, -- comment
+  c, --comment
   d AS D, -- another comment
   CAST(x AS INT) -- final comment
 FROM foo""",

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -568,30 +568,41 @@ class TestExpressions(unittest.TestCase):
             with self.subTest(value):
                 self.assertEqual(exp.convert(value).sql(), expected)
 
-    def test_annotation_alias(self):
-        sql = "SELECT a, b AS B, c # comment, d AS D # another_comment FROM foo"
+    def test_comment_alias(self):
+        sql = """
+        SELECT
+            a,
+            b AS B,
+            c, /*comment*/
+            d AS D, -- another_comment
+            CAST(x AS INT) -- final comment
+        FROM foo
+        """
         expression = parse_one(sql)
         self.assertEqual(
             [e.alias_or_name for e in expression.expressions],
-            ["a", "B", "c", "D"],
+            ["a", "B", "c", "D", "x"],
         )
-        self.assertEqual(expression.sql(), "SELECT a, b AS B, c, d AS D")
-        self.assertEqual(expression.expressions[2].name, "comment")
+        self.assertEqual(expression.sql(), "SELECT a, b AS B, c, d AS D, CAST(x AS INT) FROM foo")
         self.assertEqual(
-            expression.sql(pretty=True, annotations=False),
+            expression.sql(pretty=True, comments=False),
             """SELECT
   a,
   b AS B,
   c,
-  d AS D""",
+  d AS D,
+  CAST(x AS INT)
+FROM foo""",
         )
         self.assertEqual(
             expression.sql(pretty=True),
             """SELECT
   a,
   b AS B,
-  c # comment,
-  d AS D # another_comment FROM foo""",
+  c, --comment
+  d AS D, -- another_comment
+  CAST(x AS INT) -- final comment
+FROM foo""",
         )
 
     def test_to_table(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -148,7 +148,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(expression.expressions[2].comment, None)
         self.assertEqual(expression.expressions[3].comment, "comment4 --foo")
         self.assertEqual(expression.expressions[4].comment, "")
-        self.assertEqual(expression.expressions[5].comment, " space")
+        self.assertEqual(expression.expressions[5].this.comment, " space")
 
     def test_pretty_config_override(self):
         self.assertEqual(parse_one("SELECT col FROM x").sql(), "SELECT col FROM x")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -148,7 +148,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(expression.expressions[2].comment, None)
         self.assertEqual(expression.expressions[3].comment, "comment4 --foo")
         self.assertEqual(expression.expressions[4].comment, "")
-        self.assertEqual(expression.expressions[5].this.comment, " space")
+        self.assertEqual(expression.expressions[5].comment, " space")
 
     def test_pretty_config_override(self):
         self.assertEqual(parse_one("SELECT col FROM x").sql(), "SELECT col FROM x")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -148,7 +148,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(expression.expressions[2].comment, None)
         self.assertEqual(expression.expressions[3].comment, "comment4 --foo")
         self.assertEqual(expression.expressions[4].comment, "")
-        self.assertEqual(expression.expressions[5].comment, "space")
+        self.assertEqual(expression.expressions[5].comment, " space")
 
     def test_pretty_config_override(self):
         self.assertEqual(parse_one("SELECT col FROM x").sql(), "SELECT col FROM x")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -148,7 +148,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(expression.expressions[2].comment, None)
         self.assertEqual(expression.expressions[3].comment, "comment4 --foo")
         self.assertEqual(expression.expressions[4].comment, "")
-        self.assertEqual(expression.expressions[5].comment, " space")
+        self.assertEqual(expression.expressions[5].comment, "space")
 
     def test_pretty_config_override(self):
         self.assertEqual(parse_one("SELECT col FROM x").sql(), "SELECT col FROM x")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -70,6 +70,8 @@ class TestTranspile(unittest.TestCase):
 
     def test_comments(self):
         self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo /* comment*/")
+        self.validate("SELECT --+5\nx FROM foo", "SELECT /* +5*/ x FROM foo")
+        self.validate("SELECT --!5\nx FROM foo", "SELECT /* !5*/ x FROM foo")
         self.validate("SELECT 1 /* comment */ + 1", "SELECT 1 /* comment */ + 1")
         self.validate(
             "SELECT 1 /* inline */ FROM foo -- comment",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -64,23 +64,40 @@ class TestTranspile(unittest.TestCase):
 
     def test_comments(self):
         self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo")
-        self.validate("SELECT 1 /* inline */ FROM foo -- comment", "SELECT 1 FROM foo")
+        self.validate("SELECT 1 /* inline */ FROM foo -- comment", "SELECT 1 /* inline */ FROM foo")
 
         self.validate(
             """
             SELECT 1 -- comment
             FROM foo -- comment
             """,
-            "SELECT 1 FROM foo",
+            "SELECT 1 /* comment */ FROM foo",
         )
-
         self.validate(
             """
             SELECT 1 /* big comment
              like this */
             FROM foo -- comment
             """,
-            "SELECT 1 FROM foo",
+            """SELECT 1 /* big comment
+             like this */ FROM foo""",
+        )
+        self.validate(
+            """
+            /*
+              multi
+              line
+              comment
+            */
+            SELECT * FROM foo
+            """,
+            """/* multi
+              line
+              comment */
+SELECT
+  *
+FROM foo""",
+            pretty=True,
         )
 
     def test_types(self):

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -91,9 +91,11 @@ class TestTranspile(unittest.TestCase):
             */
             SELECT * FROM foo
             """,
-            """/* multi
+            """/*
+              multi
               line
-              comment */
+              comment
+            */
 SELECT
   *
 FROM foo""",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -50,7 +50,7 @@ class TestTranspile(unittest.TestCase):
             pretty=True,
         )
         self.validate(
-            "SELECT FOO /*x*/, BAR /*y*/, BAZ",
+            "SELECT FOO, /*x*/\nBAR, /*y*/\nBAZ",
             "SELECT\n    FOO --x\n  , BAR --y\n  , BAZ",
             leading_comma=True,
             pretty=True,

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -63,15 +63,25 @@ class TestTranspile(unittest.TestCase):
         self.validate("SELECT 3>=3", "SELECT 3 >= 3")
 
     def test_comments(self):
-        self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo")
-        self.validate("SELECT 1 /* inline */ FROM foo -- comment", "SELECT 1 /* inline */ FROM foo")
-
+        self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo /* comment */")
+        self.validate("SELECT 1 /* comment */ + 1", "SELECT 1 /* comment */ + 1")
+        self.validate("SELECT 1 /*c1*/ + 2 /*c2*/", "SELECT 1 /* c1 */ + 2 /* c2 */")
+        self.validate(
+            "SELECT 1 /*c1*/ + 2 /*c2*/ + 3 /* c3 */", "SELECT 1 /* c1 */ + 2 /* c2 */ + 3 /* c3 */"
+        )
+        self.validate(
+            "SELECT 1 /*c1*/ + 2 /*c2*/, 3 /*c3*/", "SELECT 1 /* c1 */ + 2 /* c2 */, 3 /* c3 */"
+        )
+        self.validate(
+            "SELECT 1 /* inline */ FROM foo -- comment",
+            "SELECT 1 /* inline */ FROM foo /* comment */",
+        )
         self.validate(
             """
             SELECT 1 -- comment
             FROM foo -- comment
             """,
-            "SELECT 1 /* comment */ FROM foo",
+            "SELECT 1 /* comment */ FROM foo /* comment */",
         )
         self.validate(
             """
@@ -80,7 +90,7 @@ class TestTranspile(unittest.TestCase):
             FROM foo -- comment
             """,
             """SELECT 1 /* big comment
-             like this */ FROM foo""",
+             like this */ FROM foo /* comment */""",
         )
         self.validate(
             """
@@ -99,6 +109,34 @@ class TestTranspile(unittest.TestCase):
 SELECT
   *
 FROM foo""",
+            pretty=True,
+        )
+        self.validate(
+            "select x from foo --       x",
+            "SELECT x FROM foo /* x */",
+        )
+        self.validate(
+            "select x from a.b.c /*x*/, e.f.g /*x*/",
+            "SELECT x FROM a.b.c /* x */, e.f.g /* x */",
+        )
+        self.validate(
+            "select x from a.b.c /*x*/, e.f.g /*x*/",
+            """SELECT
+  x
+FROM a.b.c /* x */, e.f.g /* x */""",
+            pretty=True,
+        )
+        self.validate(
+            "select x from (select * from bla /*x*/where id=1) /*x*/",
+            """SELECT
+  x
+FROM (
+  SELECT
+    *
+  FROM bla /* x */
+  WHERE
+    id = 1
+) /* x */""",
             pretty=True,
         )
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -72,7 +72,6 @@ class TestTranspile(unittest.TestCase):
         self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo /* comment */")
         self.validate("SELECT --+5\nx FROM foo", "/* +5 */ SELECT x FROM foo")
         self.validate("SELECT --!5\nx FROM foo", "/* !5 */ SELECT x FROM foo")
-        self.validate("SELECT 1 /* comment */ + 1", "SELECT 1 /* comment */ + 1")
         self.validate(
             "SELECT 1 /* inline */ FROM foo -- comment",
             "SELECT 1 /* inline */ FROM foo /* comment */",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -51,7 +51,7 @@ class TestTranspile(unittest.TestCase):
         )
         self.validate(
             "SELECT FOO, /*x*/\nBAR, /*y*/\nBAZ",
-            "SELECT\n    FOO --x\n  , BAR --y\n  , BAZ",
+            "SELECT\n    FOO -- x\n  , BAR -- y\n  , BAZ",
             leading_comma=True,
             pretty=True,
         )
@@ -69,23 +69,23 @@ class TestTranspile(unittest.TestCase):
         self.validate("SELECT 3>=3", "SELECT 3 >= 3")
 
     def test_comments(self):
-        self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo /* comment*/")
-        self.validate("SELECT --+5\nx FROM foo", "SELECT /* +5*/ x FROM foo")
-        self.validate("SELECT --!5\nx FROM foo", "SELECT /* !5*/ x FROM foo")
+        self.validate("SELECT 1 FROM foo -- comment", "SELECT 1 FROM foo /* comment */")
+        self.validate("SELECT --+5\nx FROM foo", "/* +5 */ SELECT x FROM foo")
+        self.validate("SELECT --!5\nx FROM foo", "/* !5 */ SELECT x FROM foo")
         self.validate("SELECT 1 /* comment */ + 1", "SELECT 1 /* comment */ + 1")
         self.validate(
             "SELECT 1 /* inline */ FROM foo -- comment",
-            "SELECT 1 /* inline */ FROM foo /* comment*/",
+            "SELECT 1 /* inline */ FROM foo /* comment */",
         )
         self.validate(
-            "SELECT FUN(x) /*x*/, [1,2,3] /*y*/", "SELECT FUN(x) /*x*/, ARRAY(1, 2, 3) /*y*/"
+            "SELECT FUN(x) /*x*/, [1,2,3] /*y*/", "SELECT FUN(x) /* x */, ARRAY(1, 2, 3) /* y */"
         )
         self.validate(
             """
             SELECT 1 -- comment
             FROM foo -- comment
             """,
-            "SELECT 1 /* comment*/ FROM foo /* comment*/",
+            "SELECT 1 /* comment */ FROM foo /* comment */",
         )
         self.validate(
             """
@@ -94,11 +94,11 @@ class TestTranspile(unittest.TestCase):
             FROM foo -- comment
             """,
             """SELECT 1 /* big comment
-             like this */ FROM foo /* comment*/""",
+             like this */ FROM foo /* comment */""",
         )
         self.validate(
             "select x from foo --       x",
-            "SELECT x FROM foo /*       x*/",
+            "SELECT x FROM foo /*       x */",
         )
         self.validate(
             """
@@ -122,7 +122,7 @@ SELECT
   tbl.cola /* comment 1 */ + tbl.colb /* comment 2 */,
   CAST(x AS INT), -- comment 3
   y -- comment 4
-FROM bar /* comment 5 */, tbl /*          comment 6*/""",
+FROM bar /* comment 5 */, tbl /*          comment 6 */""",
             read="mysql",
             pretty=True,
         )


### PR DESCRIPTION
- [x] Fix `PARTITION` so that it doesn't store tuples for its arguments.
- [x] Handle multi-line comments.
- [x] Always output comments regardless of `pretty` mode or not (or discard them if corresponding flag is set).
- [x] Investigate whether all dialects support `--` and `/**/`.
- [x] Try to make the following work: 
  - `select 1 /* comment */ + 1`.
  - `select * from x --comment`.
- [x] Change the tokenizer's logic so that we can have leading comments in the same line (e.g. /* comment */ foo).
- [x] Make sure we don't transpile comments into hints.
- [x] Try to simplify parser logic so that we don't call `_attach_comment` in many places.
