### PR TITLE
Correction in column type retrieval in case of qualified table names

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -163,7 +163,9 @@ class MappingSchema(Schema):
         visible = _nested_get(self.visible, *zip(self.supported_table_args, args))  # type: ignore
         return [col for col in columns if col in visible]  # type: ignore
 
-    def get_column_type(self, table: exp.Table | str, column: exp.Column) -> exp.DataType.Type:
+    def get_column_type(
+        self, table: exp.Table | str, column: exp.Column | str
+    ) -> exp.DataType.Type:
         try:
             if isinstance(table, exp.Table):
                 table_args = [
@@ -176,7 +178,7 @@ class MappingSchema(Schema):
                     raise_on_missing=False,
                 )
             else:
-                schema_type = self.schema.get(table, {})
+                table_schema = self.schema.get(table, {})
 
             schema_type = table_schema.get(column if isinstance(column, str) else column.name).upper()  # type: ignore
             return self._convert_type(schema_type)

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -175,10 +175,10 @@ class MappingSchema(Schema):
                     *zip(self.supported_table_args, table_args),
                     raise_on_missing=False,
                 )
-                schema_type = table_schema.get(column.name).upper()  # type: ignore
-                return self._convert_type(schema_type)
+            else:
+                schema_type = self.schema.get(table, {})
 
-            schema_type = self.schema.get(table, {}).table_schema.get(column).upper()
+            schema_type = table_schema.get(column if isinstance(column, str) else column.name).upper()  # type: ignore
             return self._convert_type(schema_type)
         except:
             raise OptimizeError(

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -167,25 +167,24 @@ class MappingSchema(Schema):
         self, table: exp.Table | str, column: exp.Column | str
     ) -> exp.DataType.Type:
         try:
+            column_name = column if isinstance(column, str) else column.name
             if isinstance(table, exp.Table):
-                table_args = [
-                    table.text(p)
-                    for p in self.supported_table_args or self._get_table_args_from_table(table)
-                ]
+                supported_table_args = self.supported_table_args or self._get_table_args_from_table(
+                    table
+                )
+                table_args = [table.text(p) for p in supported_table_args]
                 table_schema = _nested_get(
                     self.schema,
-                    *zip(self.supported_table_args, table_args),
+                    *zip(supported_table_args, table_args),
                     raise_on_missing=False,
                 )
             else:
                 table_schema = self.schema.get(table, {})
 
-            schema_type = table_schema.get(column if isinstance(column, str) else column.name).upper()  # type: ignore
+            schema_type = table_schema.get(column_name).upper()  # type: ignore
             return self._convert_type(schema_type)
         except:
-            raise OptimizeError(
-                f"Failed to get type for column {column if isinstance(column, str) else column.sql()}"
-            )
+            raise OptimizeError(f"Failed to get type for column {column_name}")
 
     def _convert_type(self, schema_type: str) -> exp.DataType.Type:
         """

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -175,13 +175,10 @@ class MappingSchema(Schema):
                     *zip(self.supported_table_args, table_args),
                     raise_on_missing=False,
                 )
-            else:
-                table_schema = self.schema.get(table)
+                schema_type = table_schema.get(column.name).upper()  # type: ignore
+                return self._convert_type(schema_type)
 
-            schema_type = table_schema.get(
-                column if isinstance(column, str) else column.name
-            ).upper()
-
+            schema_type = self.schema.get(table, {}).table_schema.get(column).upper()
             return self._convert_type(schema_type)
         except:
             raise OptimizeError(

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sqlglot import table
+from sqlglot import exp, table
 from sqlglot.dataframe.sql import types as df_types
 from sqlglot.schema import MappingSchema, ensure_schema
 from sqlglot import exp

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,6 +3,7 @@ import unittest
 from sqlglot import table
 from sqlglot.dataframe.sql import types as df_types
 from sqlglot.schema import MappingSchema, ensure_schema
+from sqlglot import exp
 
 
 class TestSchema(unittest.TestCase):
@@ -290,3 +291,34 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(schema.column_names("test"), ["x", "y"])
         schema.add_table("test")
         self.assertEqual(schema.column_names("test"), ["x", "y"])
+
+    def test_schema_get_column_type(self):
+        schema = MappingSchema({"a": {"b": "varchar"}})
+        self.assertEqual(schema.get_column_type("a", "b"), exp.DataType.Type.VARCHAR)
+        self.assertEqual(
+            schema.get_column_type(exp.Table(this="a"), exp.Column(this="b")),
+            exp.DataType.Type.VARCHAR,
+        )
+        self.assertEqual(
+            schema.get_column_type("a", exp.Column(this="b")), exp.DataType.Type.VARCHAR
+        )
+        self.assertEqual(
+            schema.get_column_type(exp.Table(this="a"), "b"), exp.DataType.Type.VARCHAR
+        )
+        schema = MappingSchema({"a": {"b": {"c": "varchar"}}})
+        self.assertEqual(
+            schema.get_column_type(exp.Table(this="b", db="a"), exp.Column(this="c")),
+            exp.DataType.Type.VARCHAR,
+        )
+        self.assertEqual(
+            schema.get_column_type(exp.Table(this="b", db="a"), "c"), exp.DataType.Type.VARCHAR
+        )
+        schema = MappingSchema({"a": {"b": {"c": {"d": "varchar"}}}})
+        self.assertEqual(
+            schema.get_column_type(exp.Table(this="c", db="b", catalog="a"), exp.Column(this="d")),
+            exp.DataType.Type.VARCHAR,
+        )
+        self.assertEqual(
+            schema.get_column_type(exp.Table(this="c", db="b", catalog="a"), "d"),
+            exp.DataType.Type.VARCHAR,
+        )

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -3,7 +3,6 @@ import unittest
 from sqlglot import exp, table
 from sqlglot.dataframe.sql import types as df_types
 from sqlglot.schema import MappingSchema, ensure_schema
-from sqlglot import exp
 
 
 class TestSchema(unittest.TestCase):


### PR DESCRIPTION
When using qualified table names like database.table, the retrieval from the schema dictionary failed. 

I changed the way the lookup takes place by taking into account the depth of the schema.