### PR TITLE
support alternate implementation of DateTrunc function

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -23,6 +23,13 @@ def _date_add(expression_class):
     return func
 
 
+def _date_trunc(args):
+    unit = seq_get(args, 1)
+    if isinstance(unit, exp.Column):
+        unit = exp.Var(this=unit.name)
+    return exp.DateTrunc(this=seq_get(args, 0), expression=unit)
+
+
 def _date_add_sql(data_type, kind):
     def func(self, expression):
         this = self.sql(expression, "this")
@@ -117,6 +124,7 @@ class BigQuery(Dialect):
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            "DATE_TRUNC": _date_trunc,
             "DATE_ADD": _date_add(exp.DateAdd),
             "DATETIME_ADD": _date_add(exp.DatetimeAdd),
             "DIV": lambda args: exp.IntDiv(this=seq_get(args, 0), expression=seq_get(args, 1)),

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -15,28 +15,28 @@ from sqlglot.tokens import TokenType
 
 
 def _date_trunc_sql(self, expression):
-    unit = expression.text("unit").lower()
+    unit = expression.name.lower()
 
-    this = self.sql(expression.this)
+    expr = self.sql(expression.expression)
 
     if unit == "day":
-        return f"DATE({this})"
+        return f"DATE({expr})"
 
     if unit == "week":
-        concat = f"CONCAT(YEAR({this}), ' ', WEEK({this}, 1), ' 1')"
+        concat = f"CONCAT(YEAR({expr}), ' ', WEEK({expr}, 1), ' 1')"
         date_format = "%Y %u %w"
     elif unit == "month":
-        concat = f"CONCAT(YEAR({this}), ' ', MONTH({this}), ' 1')"
+        concat = f"CONCAT(YEAR({expr}), ' ', MONTH({expr}), ' 1')"
         date_format = "%Y %c %e"
     elif unit == "quarter":
-        concat = f"CONCAT(YEAR({this}), ' ', QUARTER({this}) * 3 - 2, ' 1')"
+        concat = f"CONCAT(YEAR({expr}), ' ', QUARTER({expr}) * 3 - 2, ' 1')"
         date_format = "%Y %c %e"
     elif unit == "year":
-        concat = f"CONCAT(YEAR({this}), ' 1 1')"
+        concat = f"CONCAT(YEAR({expr}), ' 1 1')"
         date_format = "%Y %c %e"
     else:
         self.unsupported("Unexpected interval unit: {unit}")
-        return f"DATE({this})"
+        return f"DATE({expr})"
 
     return f"STR_TO_DATE({concat}, '{date_format}')"
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2419,8 +2419,8 @@ class DateDiff(Func, TimeUnit):
     arg_types = {"this": True, "expression": True, "unit": False}
 
 
-class DateTrunc(Func, TimeUnit):
-    arg_types = {"this": True, "unit": True, "zone": False}
+class DateTrunc(Func):
+    arg_types = {"this": True, "expression": True, "zone": False}
 
 
 class DatetimeAdd(Func, TimeUnit):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -474,48 +474,57 @@ class TestDialect(Validator):
             },
         )
         self.validate_all(
-            "DATE_TRUNC(x, 'day')",
+            "DATE_TRUNC('day', x)",
             write={
                 "mysql": "DATE(x)",
             },
         )
         self.validate_all(
-            "DATE_TRUNC('day', x)",
-            read={
-                "starrocks": "DATE_TRUNC('day', x)",
-            },
-            write={
-                "starrocks": "DATE_TRUNC('day', x)",
-            },
-        )
-        self.validate_all(
-            "DATE_TRUNC(x, 'week')",
+            "DATE_TRUNC('week', x)",
             write={
                 "mysql": "STR_TO_DATE(CONCAT(YEAR(x), ' ', WEEK(x, 1), ' 1'), '%Y %u %w')",
             },
         )
         self.validate_all(
-            "DATE_TRUNC(x, 'month')",
+            "DATE_TRUNC('month', x)",
             write={
                 "mysql": "STR_TO_DATE(CONCAT(YEAR(x), ' ', MONTH(x), ' 1'), '%Y %c %e')",
             },
         )
         self.validate_all(
-            "DATE_TRUNC(x, 'quarter')",
+            "DATE_TRUNC('quarter', x)",
             write={
                 "mysql": "STR_TO_DATE(CONCAT(YEAR(x), ' ', QUARTER(x) * 3 - 2, ' 1'), '%Y %c %e')",
             },
         )
         self.validate_all(
-            "DATE_TRUNC(x, 'year')",
+            "DATE_TRUNC('year', x)",
             write={
                 "mysql": "STR_TO_DATE(CONCAT(YEAR(x), ' 1 1'), '%Y %c %e')",
             },
         )
         self.validate_all(
-            "DATE_TRUNC(x, 'millenium')",
+            "DATE_TRUNC('millenium', x)",
             write={
                 "mysql": UnsupportedError,
+            },
+        )
+        self.validate_all(
+            "DATE_TRUNC('year', x)",
+            read={
+                "starrocks": "DATE_TRUNC('year', x)",
+            },
+            write={
+                "starrocks": "DATE_TRUNC('year', x)",
+            },
+        )
+        self.validate_all(
+            "DATE_TRUNC(x, year)",
+            read={
+                "bigquery": "DATE_TRUNC(x, year)",
+            },
+            write={
+                "bigquery": "DATE_TRUNC(x, year)",
             },
         )
         self.validate_all(

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -104,6 +104,16 @@ SELECT x.b AS b, x.a AS a FROM x AS x LEFT JOIN y AS y ON x.b = y.b QUALIFY ROW_
 SELECT AGGREGATE(ARRAY(a, x.b), 0, (x, acc) -> x + acc + a) AS sum_agg FROM x;
 SELECT AGGREGATE(ARRAY(x.a, x.b), 0, (x, acc) -> x + acc + x.a) AS sum_agg FROM x AS x;
 
+# dialect: starrocks
+# execute: false
+SELECT DATE_TRUNC('week', a) AS a FROM x;
+SELECT DATE_TRUNC('week', x.a) AS a FROM x AS x;
+
+# dialect: bigquery
+# execute: false
+SELECT DATE_TRUNC(a, MONTH) AS a FROM x;
+SELECT DATE_TRUNC(x.a, MONTH) AS a FROM x AS x;
+
 --------------------------------------
 -- Derived tables
 --------------------------------------


### PR DESCRIPTION
The current sqlglot implementation of DATE_TRUNC assumes the timestamp is the first argument, but many dialects implement a version where the arguments are reversed as well as having the "unit" argument being just a string.

Since only bigquery uses the existing signature, we will use the new signature format as the default and implement a custom parser for bigquery where the arguments are reversed.