### PR TITLE
Type inheritance for functions based on args

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -96,10 +96,10 @@ class TypeAnnotator:
         exp.DiToDate: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.DATE),
         exp.Exp: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.DOUBLE),
         exp.Floor: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.INT),
-        exp.Case: lambda self, expr: self._annotate_custom(expr, "default", "ifs"),
-        exp.If: lambda self, expr: self._annotate_custom(expr, "true", "false"),
-        exp.Coalesce: lambda self, expr: self._annotate_custom(expr, "this", "expressions"),
-        exp.IfNull: lambda self, expr: self._annotate_custom(expr, "this", "expression"),
+        exp.Case: lambda self, expr: self._annotate_by_args(expr, "default", "ifs"),
+        exp.If: lambda self, expr: self._annotate_by_args(expr, "true", "false"),
+        exp.Coalesce: lambda self, expr: self._annotate_by_args(expr, "this", "expressions"),
+        exp.IfNull: lambda self, expr: self._annotate_by_args(expr, "this", "expression"),
         exp.ConcatWs: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.VARCHAR),
         exp.GroupConcat: lambda self, expr: self._annotate_with_type(
             expr, exp.DataType.Type.VARCHAR
@@ -340,7 +340,7 @@ class TypeAnnotator:
         expression.type = target_type
         return self._annotate_args(expression)
 
-    def _annotate_custom(self, expression, *kwargs):
+    def _annotate_by_args(self, expression, *kwargs):
         self._annotate_args(expression)
         expressions = []
         for arg in kwargs:

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -1,5 +1,5 @@
 from sqlglot import exp
-from sqlglot.helper import ensure_collection, subclasses
+from sqlglot.helper import ensure_collection, ensure_list, subclasses
 from sqlglot.optimizer.scope import Scope, traverse_scope
 from sqlglot.schema import ensure_schema
 
@@ -345,10 +345,7 @@ class TypeAnnotator:
         expressions = []
         for arg in args:
             arg_expr = expression.args.get(arg)
-            if isinstance(arg_expr, list):
-                expressions.extend(expr for expr in arg_expr if expr)
-            elif arg_expr:
-                expressions.append(arg_expr)
+            expressions.extend(expr for expr in ensure_list(arg_expr) if expr)
 
         last_datatype = None
         for expr in expressions:

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -344,21 +344,15 @@ class TypeAnnotator:
         self._annotate_args(expression)
         expressions = []
         for arg in args:
-            if isinstance(arg, list):
-                expressions += arg
-            elif isinstance(arg, str):
-                arg_expr = expression.args.get(arg)
-                if isinstance(arg_expr, list):
-                    expressions += arg_expr
-                else:
-                    expressions.append(arg_expr)
-            else:
-                expressions.append(arg)
+            arg_expr = expression.args.get(arg)
+            if isinstance(arg_expr, list):
+                expressions += (expr for expr in arg_expr if expr)
+            elif arg_expr:
+                expressions.append(arg_expr)
 
         last_datatype = None
         for expr in expressions:
-            if expr:
-                last_datatype = self._maybe_coerce(last_datatype or expr.type, expr.type)
+            last_datatype = self._maybe_coerce(last_datatype or expr.type, expr.type)
 
         expression.type = last_datatype or exp.DataType.Type.UNKNOWN
         return expression

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -340,13 +340,13 @@ class TypeAnnotator:
         expression.type = target_type
         return self._annotate_args(expression)
 
-    def _annotate_by_args(self, expression, *kwargs):
+    def _annotate_by_args(self, expression, *args):
         self._annotate_args(expression)
         expressions = []
-        for arg in kwargs:
+        for arg in args:
             if isinstance(arg, list):
                 expressions += arg
-            if isinstance(arg, str):
+            elif isinstance(arg, str):
                 arg_expr = expression.args.get(arg)
                 if isinstance(arg_expr, list):
                     expressions += arg_expr
@@ -354,13 +354,11 @@ class TypeAnnotator:
                     expressions.append(arg_expr)
             else:
                 expressions.append(arg)
+
         last_datatype = None
-
         for expr in expressions:
-            if hasattr(expr, "type"):
-                last_datatype = self._maybe_coerce(
-                    last_datatype if last_datatype else expr.type, expr.type
-                )
+            if expr:
+                last_datatype = self._maybe_coerce(last_datatype or expr.type, expr.type)
 
-        expression.type = last_datatype if last_datatype else exp.DataType.Type.UNKNOWN
+        expression.type = last_datatype or exp.DataType.Type.UNKNOWN
         return expression

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -346,7 +346,7 @@ class TypeAnnotator:
         for arg in args:
             arg_expr = expression.args.get(arg)
             if isinstance(arg_expr, list):
-                expressions += (expr for expr in arg_expr if expr)
+                expressions.extend(expr for expr in arg_expr if expr)
             elif arg_expr:
                 expressions.append(arg_expr)
 


### PR DESCRIPTION
Made a new function to support type inheritance for specific functions that should only inherit from specific attributes. The function allows one of the following parameters:

- A string and that will refer to an entry within the args dictionary, the array of expressions or its single expression will be included in the inheritance of datatypes;
- An expression;
- An list of expressions.

From the list of expressions applicable, the datatype will be inherited.