### PR TITLE
copy column during replace

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -181,7 +181,7 @@ def replace_aliases(source, predicate):
 
     def _replace_alias(column):
         if isinstance(column, exp.Column) and column.name in aliases:
-            return aliases[column.name]
+            return aliases[column.name].copy()
         return column
 
     return predicate.transform(_replace_alias)


### PR DESCRIPTION
I have a test in minerva that demonstrates why this needs to be copied, but I couldn't think of a way to do it with your existing tests. Basically the parent references are incorrect after pushing down eg
```
select a from (select a from x) x where a > 0 and a < 2
```

I can add a custom test if you'd like or if you can think of one I can add it