### PR TITLE
optionally check whether value is a function when parsing data type

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1820,8 +1820,15 @@ class Parser(metaclass=_Parser):
                     this=exp.DataType.Type.TIMESTAMPLTZ,
                     expressions=expressions,
                 )
-            else:
-                self._match(TokenType.WITHOUT_TIME_ZONE)
+            elif self._match(TokenType.WITHOUT_TIME_ZONE):
+                value = exp.DataType(
+                    this=exp.DataType.Type.TIMESTAMP,
+                    expressions=expressions,
+                )
+
+            maybe_func = maybe_func and value is None
+
+            if value is None:
                 value = exp.DataType(
                     this=exp.DataType.Type.TIMESTAMP,
                     expressions=expressions,
@@ -1829,7 +1836,7 @@ class Parser(metaclass=_Parser):
 
         if maybe_func and check_func:
             index2 = self._index
-            peek = self._parse_column()
+            peek = self._parse_string()
 
             if not peek:
                 self._retreat(index)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1746,7 +1746,7 @@ class Parser(metaclass=_Parser):
             )
 
         index = self._index
-        type_token = self._parse_types()
+        type_token = self._parse_types(check_func=True)
         this = self._parse_column()
 
         if type_token:
@@ -1759,7 +1759,7 @@ class Parser(metaclass=_Parser):
 
         return this
 
-    def _parse_types(self):
+    def _parse_types(self, check_func=False):
         index = self._index
 
         if not self._match_set(self.TYPE_TOKENS):
@@ -1769,6 +1769,7 @@ class Parser(metaclass=_Parser):
         nested = type_token in self.NESTED_TYPE_TOKENS
         is_struct = type_token == TokenType.STRUCT
         expressions = None
+        maybe_func = False
 
         if not nested and self._match_pair(TokenType.L_BRACKET, TokenType.R_BRACKET):
             return exp.DataType(
@@ -1794,6 +1795,7 @@ class Parser(metaclass=_Parser):
                 return None
 
             self._match_r_paren()
+            maybe_func = True
 
         if nested and self._match(TokenType.LT):
             if is_struct:
@@ -1804,27 +1806,39 @@ class Parser(metaclass=_Parser):
             if not self._match(TokenType.GT):
                 self.raise_error("Expecting >")
 
+        value = None
         if type_token in self.TIMESTAMPS:
-            tz = self._match(TokenType.WITH_TIME_ZONE) or type_token == TokenType.TIMESTAMPTZ
-            if tz:
-                return exp.DataType(
+            if self._match(TokenType.WITH_TIME_ZONE) or type_token == TokenType.TIMESTAMPTZ:
+                value = exp.DataType(
                     this=exp.DataType.Type.TIMESTAMPTZ,
                     expressions=expressions,
                 )
-            ltz = (
+            elif (
                 self._match(TokenType.WITH_LOCAL_TIME_ZONE) or type_token == TokenType.TIMESTAMPLTZ
-            )
-            if ltz:
-                return exp.DataType(
+            ):
+                value = exp.DataType(
                     this=exp.DataType.Type.TIMESTAMPLTZ,
                     expressions=expressions,
                 )
-            self._match(TokenType.WITHOUT_TIME_ZONE)
+            else:
+                self._match(TokenType.WITHOUT_TIME_ZONE)
+                value = exp.DataType(
+                    this=exp.DataType.Type.TIMESTAMP,
+                    expressions=expressions,
+                )
 
-            return exp.DataType(
-                this=exp.DataType.Type.TIMESTAMP,
-                expressions=expressions,
-            )
+        if maybe_func and check_func:
+            index2 = self._index
+            peek = self._parse_column()
+
+            if not peek:
+                self._retreat(index)
+                return None
+
+            self._retreat(index2)
+
+        if value:
+            return value
 
         return exp.DataType(
             this=exp.DataType.Type[type_token.value.upper()],

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -590,6 +590,22 @@ class TestDialect(Validator):
                 "spark": "DATE_ADD(CAST('2020-01-01' AS DATE), 1)",
             },
         )
+        self.validate_all(
+            "TIMESTAMP '2022-01-01'",
+            write={
+                "mysql": "CAST('2022-01-01' AS TIMESTAMP)",
+                "starrocks": "CAST('2022-01-01' AS DATETIME)",
+                "hive": "CAST('2022-01-01' AS TIMESTAMP)",
+            },
+        )
+        self.validate_all(
+            "TIMESTAMP('2022-01-01')",
+            write={
+                "mysql": "TIMESTAMP('2022-01-01')",
+                "starrocks": "TIMESTAMP('2022-01-01')",
+                "hive": "TIMESTAMP('2022-01-01')",
+            },
+        )
 
         for unit in ("DAY", "MONTH", "YEAR"):
             self.validate_all(

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -6,3 +6,6 @@ class TestMySQL(Validator):
 
     def test_identity(self):
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")
+
+    def test_time(self):
+        self.validate_identity("TIMESTAMP('2022-01-01')")


### PR DESCRIPTION
the current implementation is overly permissive for what it parses as a data type. this change tries to further disambiguate type literals of the form `TIMESTAMP(3) '2022-01-01'` | `DATE(1) '2022-01-01'` from functions `TIMESTAMP('2022-01-01')` | `DATE('2022-01-01')` | `BOOLEAN(1)` etc.