### PR TITLE
Created an generic approach to concat symbol

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -242,6 +242,7 @@ class Hive(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             **transforms.UNALIAS_GROUP,  # type: ignore
+            **transforms.ADD_TO_DPIPE,  # type: ignore
             exp.AnonymousProperty: _property_sql,
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.ArrayAgg: rename_func("COLLECT_LIST"),

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -81,3 +81,15 @@ def delegate(attr: str) -> t.Callable:
 
 
 UNALIAS_GROUP = {exp.Group: preprocess([unalias_group], delegate("group_sql"))}
+ADD_TO_DPIPE = {
+    exp.Add: lambda self, e: exp.DPipe(this=e.this, expression=e.expression)
+    if e.type
+    in [
+        exp.DataType.Type.VARCHAR,
+        exp.DataType.Type.NVARCHAR,
+        exp.DataType.Type.CHAR,
+        exp.DataType.Type.NCHAR,
+        exp.DataType.Type.TEXT,
+    ]
+    else e
+}

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -82,7 +82,7 @@ def delegate(attr: str) -> t.Callable:
 
 UNALIAS_GROUP = {exp.Group: preprocess([unalias_group], delegate("group_sql"))}
 ADD_TO_DPIPE = {
-    exp.Add: lambda self, e: exp.DPipe(this=e.this, expression=e.expression)
+    exp.Add: lambda self, e: self.dpipe_sql(e)
     if e.type
     in [
         exp.DataType.Type.VARCHAR,
@@ -91,5 +91,5 @@ ADD_TO_DPIPE = {
         exp.DataType.Type.NCHAR,
         exp.DataType.Type.TEXT,
     ]
-    else e
+    else self.add_sql(e)
 }


### PR DESCRIPTION
Because of the + symbol in T-SQL with different kind of operation methods I have implemented an approach to replace the ADD class with a DPipe class in case of the context of string concatenation.

The two cases applicable in T-SQL:
- 'test' + 'string' = 'teststring'
- 1 + 2 = 3

As @tobymao already said earlier its not really something that fits in the parser part. Also this requires to use the optimizer to assign datatypes to columns from schema. By implementing it in the transforms.py file, we are able to use this at several target dialects.
