### PR TITLE
Small comment formatting fixup

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -241,7 +241,7 @@ class Generator:
         if not NEWLINE_RE.search(comment):
             return f"{sql} --{comment.rstrip()}" if single_line else f"{sql} /*{comment}*/"
 
-        return f" /*{comment}*/" if not sql else f"/*{comment}*/\n{sql}"
+        return  f"/*{comment}*/\n{sql}" if sql else f" /*{comment}*/"
 
     def wrap(self, expression):
         this_sql = self.indent(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -241,7 +241,7 @@ class Generator:
         if not NEWLINE_RE.search(comment):
             return f"{sql} --{comment.rstrip()}" if single_line else f"{sql} /*{comment}*/"
 
-        return f"/*{comment}*/\n{sql}"
+        return f" /*{comment}*/" if not sql else f"/*{comment}*/\n{sql}"
 
     def wrap(self, expression):
         this_sql = self.indent(

--- a/tests/fixtures/pretty.sql
+++ b/tests/fixtures/pretty.sql
@@ -315,3 +315,10 @@ FROM (
   WHERE
     id = 1
 ) /* x */;
+SELECT * /* multi
+   line
+   comment */;
+SELECT
+  * /* multi
+     line
+     comment */;


### PR DESCRIPTION
This doesn't address a serious issue; it's more of a "formatting one". It aims to address examples similar to the following:

```python
>>> sql = """
... select
...   * /* multi
... line */
... """
>>> print(sqlglot.transpile(sql, pretty=True)[0])
SELECT
  */* multi
  line */
```
With this change, it's instead formatted as:
```python
SELECT
  * /* multi
  line */
```
