### PR TITLE
Fix mutation bug in planner

### DIFF
--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -11,7 +11,7 @@ from sqlglot.optimizer.eliminate_joins import join_condition
 
 class Plan:
     def __init__(self, expression: exp.Expression) -> None:
-        self.expression = expression
+        self.expression = expression.copy()
         self.root = Step.from_expression(self.expression)
         self._dag: t.Dict[Step, t.Set[Step]] = {}
 


### PR DESCRIPTION
Steps to reproduce bug caused by [this](https://github.com/tobymao/sqlglot/blob/main/sqlglot/planner.py#L142) line:
```python
>>> import sqlglot
>>> from sqlglot.planner import Plan
>>> sql = """
... SELECT
...   x.a,
...   SUM(x + 1)
... FROM x AS x
... JOIN y AS y
...   ON x.a = y.a
... GROUP BY x.a
... """
>>> expr = sqlglot.parse_one(sql)
>>> plan = Plan(expr)
>>> print(expr.sql(pretty=True))
SELECT
  x.a,
  SUM("_a_0")
FROM x AS x
JOIN y AS y
  ON x.a = y.a
GROUP BY
  x.a
```