### PR TITLE
Refactor properties

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -200,9 +200,7 @@ class BigQuery(Dialect):
             exp.VolatilityProperty,
         }
 
-        WITH_PROPERTIES = {
-            exp.AnonymousProperty,
-        }
+        WITH_PROPERTIES = {exp.Property}
 
         EXPLICIT_UNION = True
 

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -56,12 +56,12 @@ def _derived_table_values_to_unnest(self, expression):
 
 
 def _returnsproperty_sql(self, expression):
-    value = expression.args.get("value")
-    if isinstance(value, exp.Schema):
-        value = f"{value.this} <{self.expressions(value)}>"
+    this = expression.this
+    if isinstance(this, exp.Schema):
+        this = f"{this.this} <{self.expressions(this)}>"
     else:
-        value = self.sql(value)
-    return f"RETURNS {value}"
+        this = self.sql(this)
+    return f"RETURNS {this}"
 
 
 def _create_sql(self, expression):

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -336,18 +336,13 @@ def create_with_partitions_sql(self, expression):
     if has_schema and is_partitionable:
         expression = expression.copy()
         prop = expression.find(exp.PartitionedByProperty)
-        value = prop and prop.args.get("value")
-        if prop and not isinstance(value, exp.Schema):
+        this = prop and prop.this
+        if prop and not isinstance(this, exp.Schema):
             schema = expression.this
-            columns = {v.name.upper() for v in value.expressions}
+            columns = {v.name.upper() for v in this.expressions}
             partitions = [col for col in schema.expressions if col.name.upper() in columns]
-            schema.set(
-                "expressions",
-                [e for e in schema.expressions if e not in partitions],
-            )
-            prop.replace(
-                exp.PartitionedByProperty(this=prop.this, value=exp.Schema(expressions=partitions))
-            )
+            schema.set("expressions", [e for e in schema.expressions if e not in partitions])
+            prop.replace(exp.PartitionedByProperty(this=exp.Schema(expressions=partitions)))
             expression.set("this", schema)
 
     return self.create_sql(expression)

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -153,7 +153,7 @@ class Drill(Dialect):
             exp.If: if_sql,
             exp.ILike: lambda self, e: f" {self.sql(e, 'this')} `ILIKE` {self.sql(e, 'expression')}",
             exp.Levenshtein: rename_func("LEVENSHTEIN_DISTANCE"),
-            exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'value')}",
+            exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
             exp.Pivot: no_pivot_sql,
             exp.RegexpLike: rename_func("REGEXP_MATCHES"),
             exp.StrPosition: str_position_sql,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -250,7 +250,7 @@ class Hive(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             **transforms.UNALIAS_GROUP,  # type: ignore
-            exp.AnonymousProperty: _property_sql,
+            exp.Property: _property_sql,
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.ArrayAgg: rename_func("COLLECT_LIST"),
             exp.ArrayConcat: rename_func("CONCAT"),
@@ -302,7 +302,7 @@ class Hive(Dialect):
             exp.NumberToStr: rename_func("FORMAT_NUMBER"),
         }
 
-        WITH_PROPERTIES = {exp.AnonymousProperty}
+        WITH_PROPERTIES = {exp.Property}
 
         ROOT_PROPERTIES = {
             exp.PartitionedByProperty,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -61,9 +61,7 @@ def _array_sort(self, expression):
 
 
 def _property_sql(self, expression):
-    key = expression.name
-    value = self.sql(expression, "value")
-    return f"'{key}'={value}"
+    return f"'{expression.name}'={self.sql(expression, 'value')}"
 
 
 def _str_to_unix(self, expression):
@@ -262,7 +260,7 @@ class Hive(Dialect):
             exp.DateStrToDate: rename_func("TO_DATE"),
             exp.DateToDi: lambda self, e: f"CAST(DATE_FORMAT({self.sql(e, 'this')}, {Hive.dateint_format}) AS INT)",
             exp.DiToDate: lambda self, e: f"TO_DATE(CAST({self.sql(e, 'this')} AS STRING), {Hive.dateint_format})",
-            exp.FileFormatProperty: lambda self, e: f"STORED AS {e.text('value').upper()}",
+            exp.FileFormatProperty: lambda self, e: f"STORED AS {e.name.upper()}",
             exp.If: if_sql,
             exp.Index: _index_sql,
             exp.ILike: no_ilike_sql,
@@ -285,7 +283,7 @@ class Hive(Dialect):
             exp.StrToTime: _str_to_time,
             exp.StrToUnix: _str_to_unix,
             exp.StructExtract: struct_extract_sql,
-            exp.TableFormatProperty: lambda self, e: f"USING {self.sql(e, 'value')}",
+            exp.TableFormatProperty: lambda self, e: f"USING {self.sql(e, 'this')}",
             exp.TimeStrToDate: rename_func("TO_DATE"),
             exp.TimeStrToTime: lambda self, e: f"CAST({self.sql(e, 'this')} AS TIMESTAMP)",
             exp.TimeStrToUnix: rename_func("UNIX_TIMESTAMP"),
@@ -298,7 +296,7 @@ class Hive(Dialect):
             exp.UnixToStr: lambda self, e: f"FROM_UNIXTIME({self.format_args(e.this, _time_format(self, e))})",
             exp.UnixToTime: rename_func("FROM_UNIXTIME"),
             exp.UnixToTimeStr: rename_func("FROM_UNIXTIME"),
-            exp.PartitionedByProperty: lambda self, e: f"PARTITIONED BY {self.sql(e, 'value')}",
+            exp.PartitionedByProperty: lambda self, e: f"PARTITIONED BY {self.sql(e, 'this')}",
             exp.NumberToStr: rename_func("FORMAT_NUMBER"),
         }
 

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -176,9 +176,9 @@ class Presto(Dialect):
         }
 
         WITH_PROPERTIES = {
+            exp.Property,
             exp.PartitionedByProperty,
             exp.FileFormatProperty,
-            exp.AnonymousProperty,
             exp.TableFormatProperty,
         }
 

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -171,16 +171,7 @@ class Presto(Dialect):
 
         STRUCT_DELIMITER = ("(", ")")
 
-        ROOT_PROPERTIES = {
-            exp.SchemaCommentProperty,
-        }
-
-        WITH_PROPERTIES = {
-            exp.Property,
-            exp.PartitionedByProperty,
-            exp.FileFormatProperty,
-            exp.TableFormatProperty,
-        }
+        ROOT_PROPERTIES = {exp.SchemaCommentProperty}
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
@@ -231,7 +222,8 @@ class Presto(Dialect):
             exp.StrToTime: _str_to_time_sql,
             exp.StrToUnix: lambda self, e: f"TO_UNIXTIME(DATE_PARSE({self.sql(e, 'this')}, {self.format_time(e)}))",
             exp.StructExtract: struct_extract_sql,
-            exp.TableFormatProperty: lambda self, e: f"TABLE_FORMAT = '{e.text('value').upper()}'",
+            exp.TableFormatProperty: lambda self, e: f"TABLE_FORMAT = '{e.name.upper()}'",
+            exp.FileFormatProperty: lambda self, e: f"FORMAT='{e.name.upper()}'",
             exp.TimeStrToDate: _date_parse_sql,
             exp.TimeStrToTime: _date_parse_sql,
             exp.TimeStrToUnix: lambda self, e: f"TO_UNIXTIME(DATE_PARSE({self.sql(e, 'this')}, {Presto.time_format}))",

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -222,7 +222,7 @@ class Presto(Dialect):
             exp.StrToTime: _str_to_time_sql,
             exp.StrToUnix: lambda self, e: f"TO_UNIXTIME(DATE_PARSE({self.sql(e, 'this')}, {self.format_time(e)}))",
             exp.StructExtract: struct_extract_sql,
-            exp.TableFormatProperty: lambda self, e: f"TABLE_FORMAT = '{e.name.upper()}'",
+            exp.TableFormatProperty: lambda self, e: f"TABLE_FORMAT='{e.name.upper()}'",
             exp.FileFormatProperty: lambda self, e: f"FORMAT='{e.name.upper()}'",
             exp.TimeStrToDate: _date_parse_sql,
             exp.TimeStrToTime: _date_parse_sql,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -35,3 +35,16 @@ class Redshift(Postgres):
             exp.DataType.Type.VARBINARY: "VARBYTE",
             exp.DataType.Type.INT: "INTEGER",
         }
+
+        ROOT_PROPERTIES = {
+            exp.DistKeyProperty,
+            exp.SortKeyProperty,
+            exp.DistStyleProperty,
+        }
+
+        TRANSFORMS = {
+            **Postgres.Generator.TRANSFORMS,  # type: ignore
+            exp.DistKeyProperty: lambda self, e: f"DISTKEY({e.name})",
+            exp.SortKeyProperty: lambda self, e: f"{'COMPOUND ' if e.args['compound'] else ''}SORTKEY({self.format_args(*e.this)})",
+            exp.DistStyleProperty: lambda self, e: self.naked_property(e),
+        }

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -203,7 +203,7 @@ class Snowflake(Dialect):
             exp.Array: inline_array_sql,
             exp.StrPosition: rename_func("POSITION"),
             exp.Parameter: lambda self, e: f"${self.sql(e, 'this')}",
-            exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'value')}",
+            exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
             exp.Trim: lambda self, e: f"TRIM({self.format_args(e.this, e.expression)})",
         }
 

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -98,7 +98,7 @@ class Spark(Hive):
         TRANSFORMS = {
             **Hive.Generator.TRANSFORMS,  # type: ignore
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
-            exp.FileFormatProperty: lambda self, e: f"USING {e.text('value').upper()}",
+            exp.FileFormatProperty: lambda self, e: f"USING {e.name.upper()}",
             exp.ArraySum: lambda self, e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.BitwiseLeftShift: rename_func("SHIFTLEFT"),
             exp.BitwiseRightShift: rename_func("SHIFTRIGHT"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1081,7 +1081,7 @@ class DistKeyProperty(Property):
 
 
 class SortKeyProperty(Property):
-    arg_types = {"this": True}
+    arg_types = {"this": True, "compound": False}
 
 
 class DistStyleProperty(Property):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1132,21 +1132,21 @@ class Properties(Expression):
     arg_types = {"expressions": True}
 
     NAME_TO_PROPERTY = {
-        "TABLE_FORMAT": TableFormatProperty,
-        "PARTITIONED_BY": PartitionedByProperty,
-        "FORMAT": FileFormatProperty,
-        "DISTKEY": DistKeyProperty,
-        "SORTKEY": SortKeyProperty,
-        "DISTSTYLE": DistStyleProperty,
-        "LOCATION": LocationProperty,
-        "ENGINE": EngineProperty,
         "AUTO_INCREMENT": AutoIncrementProperty,
         "CHARACTER SET": CharacterSetProperty,
         "COLLATE": CollateProperty,
         "COMMENT": SchemaCommentProperty,
-        "RETURNS": ReturnsProperty,
-        "LANGUAGE": LanguageProperty,
+        "DISTKEY": DistKeyProperty,
+        "DISTSTYLE": DistStyleProperty,
+        "ENGINE": EngineProperty,
         "EXECUTE AS": ExecuteAsProperty,
+        "FORMAT": FileFormatProperty,
+        "LANGUAGE": LanguageProperty,
+        "LOCATION": LocationProperty,
+        "PARTITIONED_BY": PartitionedByProperty,
+        "RETURNS": ReturnsProperty,
+        "SORTKEY": SortKeyProperty,
+        "TABLE_FORMAT": TableFormatProperty,
     }
 
     PROPERTY_TO_NAME = {v: k for k, v in NAME_TO_PROPERTY.items()}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1065,63 +1065,63 @@ class Property(Expression):
 
 
 class TableFormatProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class PartitionedByProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class FileFormatProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class DistKeyProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class SortKeyProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class DistStyleProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class LocationProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class EngineProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class AutoIncrementProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class CharacterSetProperty(Property):
-    arg_types = {"this": True, "value": True, "default": True}
+    arg_types = {"this": True, "default": True}
 
 
 class CollateProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class SchemaCommentProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class ReturnsProperty(Property):
-    arg_types = {"this": True, "value": True, "is_table": False}
+    arg_types = {"this": True, "is_table": False}
 
 
 class LanguageProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class ExecuteAsProperty(Property):
-    pass
+    arg_types = {"this": True}
 
 
 class VolatilityProperty(Property):
@@ -1155,8 +1155,12 @@ class Properties(Expression):
     def from_dict(cls, properties_dict) -> Properties:
         expressions = []
         for key, value in properties_dict.items():
-            property_cls = cls.NAME_TO_PROPERTY.get(key.upper(), Property)
-            expressions.append(property_cls(this=Literal.string(key), value=convert(value)))
+            property_cls = cls.NAME_TO_PROPERTY.get(key.upper())
+            if property_cls:
+                expressions.append(property_cls(this=convert(value)))
+            else:
+                expressions.append(Property(this=Literal.string(key), value=convert(value)))
+
         return cls(expressions=expressions)
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1112,10 +1112,6 @@ class SchemaCommentProperty(Property):
     pass
 
 
-class AnonymousProperty(Property):
-    pass
-
-
 class ReturnsProperty(Property):
     arg_types = {"this": True, "value": True, "is_table": False}
 
@@ -1135,26 +1131,31 @@ class VolatilityProperty(Property):
 class Properties(Expression):
     arg_types = {"expressions": True}
 
-    PROPERTY_KEY_MAPPING = {
+    NAME_TO_PROPERTY = {
+        "TABLE_FORMAT": TableFormatProperty,
+        "PARTITIONED_BY": PartitionedByProperty,
+        "FORMAT": FileFormatProperty,
+        "DISTKEY": DistKeyProperty,
+        "SORTKEY": SortKeyProperty,
+        "DISTSTYLE": DistStyleProperty,
+        "LOCATION": LocationProperty,
+        "ENGINE": EngineProperty,
         "AUTO_INCREMENT": AutoIncrementProperty,
-        "CHARACTER_SET": CharacterSetProperty,
+        "CHARACTER SET": CharacterSetProperty,
         "COLLATE": CollateProperty,
         "COMMENT": SchemaCommentProperty,
-        "ENGINE": EngineProperty,
-        "FORMAT": FileFormatProperty,
-        "LOCATION": LocationProperty,
-        "PARTITIONED_BY": PartitionedByProperty,
-        "TABLE_FORMAT": TableFormatProperty,
-        "DISTKEY": DistKeyProperty,
-        "DISTSTYLE": DistStyleProperty,
-        "SORTKEY": SortKeyProperty,
+        "RETURNS": ReturnsProperty,
+        "LANGUAGE": LanguageProperty,
+        "EXECUTE AS": ExecuteAsProperty,
     }
+
+    PROPERTY_TO_NAME = {v: k for k, v in NAME_TO_PROPERTY.items()}
 
     @classmethod
     def from_dict(cls, properties_dict) -> Properties:
         expressions = []
         for key, value in properties_dict.items():
-            property_cls = cls.PROPERTY_KEY_MAPPING.get(key.upper(), AnonymousProperty)
+            property_cls = cls.NAME_TO_PROPERTY.get(key.upper(), Property)
             expressions.append(property_cls(this=Literal.string(key), value=convert(value)))
         return cls(expressions=expressions)
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -546,36 +546,20 @@ class Generator:
 
     def root_properties(self, properties):
         if properties.expressions:
-            return self.sep() + self.expressions(
-                properties,
-                indent=False,
-                sep=" ",
-            )
+            return self.sep() + self.expressions(properties, indent=False, sep=" ")
         return ""
 
     def properties(self, properties, prefix="", sep=", "):
         if properties.expressions:
-            expressions = self.expressions(
-                properties,
-                sep=sep,
-                indent=False,
-            )
+            expressions = self.expressions(properties, sep=sep, indent=False)
             return f"{self.seg(prefix)}{' ' if prefix else ''}{self.wrap(expressions)}"
         return ""
 
     def with_properties(self, properties):
-        return self.properties(
-            properties,
-            prefix="WITH",
-        )
+        return self.properties(properties, prefix="WITH")
 
     def property_sql(self, expression):
-        if isinstance(expression.this, exp.Literal):
-            key = expression.this.this
-        else:
-            key = expression.name
-        value = self.sql(expression, "value")
-        return f"{key}={value}"
+        return f"{expression.name}={self.sql(expression, 'value')}"
 
     def insert_sql(self, expression):
         overwrite = expression.args.get("overwrite")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -58,11 +58,11 @@ class Generator:
     """
 
     TRANSFORMS = {
-        exp.CharacterSetProperty: lambda self, e: f"{'DEFAULT ' if e.args['default'] else ''}CHARACTER SET={self.sql(e, 'value')}",
         exp.DateAdd: lambda self, e: f"DATE_ADD({self.format_args(e.this, e.expression, e.args.get('unit'))})",
         exp.DateDiff: lambda self, e: f"DATEDIFF({self.format_args(e.this, e.expression)})",
         exp.TsOrDsAdd: lambda self, e: f"TS_OR_DS_ADD({self.format_args(e.this, e.expression, e.args.get('unit'))})",
         exp.VarMap: lambda self, e: f"MAP({self.format_args(e.args['keys'], e.args['values'])})",
+        exp.CharacterSetProperty: lambda self, e: f"{'DEFAULT ' if e.args['default'] else ''}CHARACTER SET={self.sql(e, 'this')}",
         exp.LanguageProperty: lambda self, e: self.naked_property(e),
         exp.LocationProperty: lambda self, e: self.naked_property(e),
         exp.ReturnsProperty: lambda self, e: self.naked_property(e),
@@ -567,7 +567,7 @@ class Generator:
         if not property_name:
             self.unsupported(f"Unsupported property {property_name}")
 
-        return f"{property_name}={self.sql(expression, 'value')}"
+        return f"{property_name}={self.sql(expression, 'this')}"
 
     def insert_sql(self, expression):
         overwrite = expression.args.get("overwrite")
@@ -1349,7 +1349,7 @@ class Generator:
         property_name = exp.Properties.PROPERTY_TO_NAME.get(expression.__class__)
         if not property_name:
             self.unsupported(f"Unsupported property {expression.__class__.__name__}")
-        return f"{property_name} {self.sql(expression, 'value')}"
+        return f"{property_name} {self.sql(expression, 'this')}"
 
     def set_operation(self, expression, op):
         this = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -830,7 +830,7 @@ class Parser(metaclass=_Parser):
             self._match(TokenType.EQ)
 
             return self.expression(
-                exp.AnonymousProperty,
+                exp.Property,
                 this=exp.Literal.string(key),
                 value=self._parse_column(),
             )
@@ -956,7 +956,7 @@ class Parser(metaclass=_Parser):
                 properties.extend(
                     self._parse_wrapped_csv(
                         lambda: self.expression(
-                            exp.AnonymousProperty,
+                            exp.Property,
                             this=self._parse_string(),
                             value=self._match(TokenType.EQ) and self._parse_string(),
                         )

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -153,6 +153,7 @@ class Parser(metaclass=_Parser):
         TokenType.COLLATE,
         TokenType.COMMAND,
         TokenType.COMMIT,
+        TokenType.COMPOUND,
         TokenType.CONSTRAINT,
         TokenType.CURRENT_TIME,
         TokenType.DEFAULT,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -822,8 +822,12 @@ class Parser(metaclass=_Parser):
     def _parse_property(self):
         if self._match_set(self.PROPERTY_PARSERS):
             return self.PROPERTY_PARSERS[self._prev.token_type](self)
+
         if self._match_pair(TokenType.DEFAULT, TokenType.CHARACTER_SET):
             return self._parse_character_set(True)
+
+        if self._match_pair(TokenType.COMPOUND, TokenType.SORTKEY):
+            return self._parse_sortkey(compound=True)
 
         if self._match_pair(TokenType.VAR, TokenType.EQ, advance=False):
             key = self._parse_var()
@@ -851,8 +855,10 @@ class Parser(metaclass=_Parser):
     def _parse_distkey(self):
         return self.expression(exp.DistKeyProperty, this=self._parse_wrapped(self._parse_var))
 
-    def _parse_sortkey(self):
-        return self.expression(exp.SortKeyProperty, this=self._parse_wrapped_csv(self._parse_var))
+    def _parse_sortkey(self, compound=False):
+        return self.expression(
+            exp.SortKeyProperty, this=self._parse_wrapped_csv(self._parse_var), compound=compound
+        )
 
     def _parse_character_set(self, default=False):
         self._match(TokenType.EQ)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -130,6 +130,7 @@ class TokenType(AutoName):
     COMMAND = auto()
     COMMENT = auto()
     COMMIT = auto()
+    COMPOUND = auto()
     CONSTRAINT = auto()
     CREATE = auto()
     CROSS = auto()
@@ -452,6 +453,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "COLLATE": TokenType.COLLATE,
         "COMMENT": TokenType.SCHEMA_COMMENT,
         "COMMIT": TokenType.COMMIT,
+        "COMPOUND": TokenType.COMPOUND,
         "CONSTRAINT": TokenType.CONSTRAINT,
         "CREATE": TokenType.CREATE,
         "CROSS": TokenType.CROSS,

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -139,7 +139,7 @@ class TestHive(Validator):
             "CREATE TABLE test STORED AS parquet TBLPROPERTIES ('x'='1', 'Z'='2') AS SELECT 1",
             write={
                 "duckdb": "CREATE TABLE test AS SELECT 1",
-                "presto": "CREATE TABLE test WITH (FORMAT='parquet', x='1', Z='2') AS SELECT 1",
+                "presto": "CREATE TABLE test WITH (FORMAT='PARQUET', x='1', Z='2') AS SELECT 1",
                 "hive": "CREATE TABLE test STORED AS PARQUET TBLPROPERTIES ('x'='1', 'Z'='2') AS SELECT 1",
                 "spark": "CREATE TABLE test USING PARQUET TBLPROPERTIES ('x'='1', 'Z'='2') AS SELECT 1",
             },

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -64,3 +64,7 @@ class TestRedshift(Validator):
         self.validate_identity(
             "SELECT COUNT(*) FROM event WHERE eventname LIKE '%Ring%' OR eventname LIKE '%Die%'"
         )
+        self.validate_identity("CREATE TABLE SOUP DISTKEY(soup1) SORTKEY(soup2) DISTSTYLE AUTO")
+        self.validate_identity(
+            "CREATE TABLE sales (salesid INTEGER NOT NULL) DISTKEY(listid) COMPOUND SORTKEY(listid, sellerid)"
+        )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -38,7 +38,7 @@ class TestSpark(Validator):
             "CREATE TABLE x USING ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
             write={
                 "duckdb": "CREATE TABLE x",
-                "presto": "CREATE TABLE x WITH (TABLE_FORMAT = 'ICEBERG', PARTITIONED_BY=ARRAY['MONTHS'])",
+                "presto": "CREATE TABLE x WITH (TABLE_FORMAT='ICEBERG', PARTITIONED_BY=ARRAY['MONTHS'])",
                 "hive": "CREATE TABLE x USING ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
                 "spark": "CREATE TABLE x USING ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
             },

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -525,22 +525,14 @@ class TestExpressions(unittest.TestCase):
             ),
             exp.Properties(
                 expressions=[
-                    exp.FileFormatProperty(
-                        this=exp.Literal.string("FORMAT"), value=exp.Literal.string("parquet")
-                    ),
+                    exp.FileFormatProperty(this=exp.Literal.string("parquet")),
                     exp.PartitionedByProperty(
-                        this=exp.Literal.string("PARTITIONED_BY"),
-                        value=exp.Tuple(
-                            expressions=[exp.to_identifier("a"), exp.to_identifier("b")]
-                        ),
+                        this=exp.Tuple(expressions=[exp.to_identifier("a"), exp.to_identifier("b")])
                     ),
                     exp.Property(this=exp.Literal.string("custom"), value=exp.Literal.number(1)),
-                    exp.TableFormatProperty(
-                        this=exp.Literal.string("TABLE_FORMAT"),
-                        value=exp.to_identifier("test_format"),
-                    ),
-                    exp.EngineProperty(this=exp.Literal.string("ENGINE"), value=exp.null()),
-                    exp.CollateProperty(this=exp.Literal.string("COLLATE"), value=exp.true()),
+                    exp.TableFormatProperty(this=exp.to_identifier("test_format")),
+                    exp.EngineProperty(this=exp.null()),
+                    exp.CollateProperty(this=exp.true()),
                 ]
             ),
         )

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -534,9 +534,7 @@ class TestExpressions(unittest.TestCase):
                             expressions=[exp.to_identifier("a"), exp.to_identifier("b")]
                         ),
                     ),
-                    exp.AnonymousProperty(
-                        this=exp.Literal.string("custom"), value=exp.Literal.number(1)
-                    ),
+                    exp.Property(this=exp.Literal.string("custom"), value=exp.Literal.number(1)),
                     exp.TableFormatProperty(
                         this=exp.Literal.string("TABLE_FORMAT"),
                         value=exp.to_identifier("test_format"),


### PR DESCRIPTION
Opening this for some early feedback. The end goal is to simplify the way properties are handled, so that we don't need to store each prop name in `this`. The parser can also be simplified because all properties are more or less parsed according to the same logic: `PROP_NAME [=] PROP_VALUE`.