### PR TITLE
revert _parse_cache changes

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1027,7 +1027,12 @@ class Parser(metaclass=_Parser):
         options = []
 
         if self._match(TokenType.OPTIONS):
-            options = self._parse_wrapped_csv(self._parse_string, sep=TokenType.EQ)
+            self._match_l_paren()
+            k = self._parse_string()
+            self._match(TokenType.EQ)
+            v = self._parse_string()
+            options = [k, v]
+            self._match_r_paren()
 
         self._match(TokenType.ALIAS)
         return self.expression(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -94,6 +94,13 @@ TBLPROPERTIES (
             pretty=True,
         )
 
+        self.validate_all(
+            "CACHE TABLE testCache OPTIONS ('storageLevel' 'DISK_ONLY') SELECT * FROM testData",
+            write={
+                "spark": "CACHE TABLE testCache OPTIONS('storageLevel' = 'DISK_ONLY') AS SELECT * FROM testData"
+            },
+        )
+
     def test_to_date(self):
         self.validate_all(
             "TO_DATE(x, 'yyyy-MM-dd')",


### PR DESCRIPTION
I'm pretty sure this is meant to handle Spark's [CACHE TABLE](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-aux-cache-cache-table.html) statement.

The "=" is optional. This is causing some breakages in our CI, so I'm simply reverting the refactor for now.