### PR TITLE
Add structured ParseError properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,28 @@ sqlglot.errors.ParseError: Expecting ). Line 1, Col: 13.
               ~~~~
 ```
 
+Structured syntax error details are also accessible for progammatic use:
+
+```python
+import sqlglot
+try:
+  sqlglot.transpile("SELECT foo( FROM bar")
+except sqlglot.errors.ParseError as e:
+  print(e.error_props)
+```
+
+Output:
+```python
+[{
+  'description': 'Expecting )',
+  'line': 1,
+  'col': 13,
+  'start_context': 'SELECT foo( ',
+  'highlight': 'FROM',
+  'end_context': ' bar'
+}]
+```
+
 ### Unsupported Errors
 
 Presto `APPROX_DISTINCT` supports the accuracy argument which is not supported in Hive:

--- a/README.md
+++ b/README.md
@@ -190,14 +190,14 @@ sqlglot.errors.ParseError: Expecting ). Line 1, Col: 13.
               ~~~~
 ```
 
-Structured syntax error details are also accessible for progammatic use:
+Structured syntax errors are accessible for programmatic use:
 
 ```python
 import sqlglot
 try:
-  sqlglot.transpile("SELECT foo( FROM bar")
+    sqlglot.transpile("SELECT foo( FROM bar")
 except sqlglot.errors.ParseError as e:
-  print(e.error_props)
+    print(e.errors)
 ```
 
 Output:

--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -25,26 +25,35 @@ class ParseError(SqlglotError):
     def __init__(
         self,
         message: str,
+        errors: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
+    ):
+        super().__init__(message)
+        self.errors = errors or []
+
+    @classmethod
+    def new(
+        cls,
+        message: str,
         description: t.Optional[str] = None,
         line: t.Optional[int] = None,
         col: t.Optional[int] = None,
         start_context: t.Optional[str] = None,
         highlight: t.Optional[str] = None,
         end_context: t.Optional[str] = None,
-        error_props: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
-    ):
-        super().__init__(message)
-        self.error_props = error_props or []
-        props = {
-            "description": description,
-            "line": line,
-            "col": col,
-            "start_context": start_context,
-            "highlight": highlight,
-            "end_context": end_context,
-        }
-        if any(p is not None for p in props.values()):
-            self.error_props.append(props)
+    ) -> ParseError:
+        return cls(
+            message,
+            [
+                {
+                    "description": description,
+                    "line": line,
+                    "col": col,
+                    "start_context": start_context,
+                    "highlight": highlight,
+                    "end_context": end_context,
+                }
+            ],
+        )
 
 
 class TokenError(SqlglotError):
@@ -71,5 +80,5 @@ def concat_errors(errors: t.Sequence[t.Any], maximum: int) -> str:
     return "\n\n".join(msg)
 
 
-def concat_error_props(errors: t.Sequence[ParseError], maximum: int) -> t.List[t.Dict[str, t.Any]]:
-    return [props for e in errors[:maximum] for props in e.error_props]
+def concat_struct_errors(errors: t.Sequence[ParseError]) -> t.List[t.Dict[str, t.Any]]:
+    return [e_dict for error in errors for e_dict in error.errors]

--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -21,15 +21,6 @@ class UnsupportedError(SqlglotError):
     pass
 
 
-class ParseErrorProps(t.TypedDict):
-    description: t.Optional[str]
-    line: t.Optional[int]
-    col: t.Optional[int]
-    start_context: t.Optional[str]
-    highlight: t.Optional[str]
-    end_context: t.Optional[str]
-
-
 class ParseError(SqlglotError):
     def __init__(
         self,
@@ -40,11 +31,11 @@ class ParseError(SqlglotError):
         start_context: t.Optional[str] = None,
         highlight: t.Optional[str] = None,
         end_context: t.Optional[str] = None,
-        error_props: t.Optional[t.List[ParseErrorProps]] = None,
+        error_props: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
     ):
         super().__init__(message)
         self.error_props = error_props if error_props is not None else []
-        props: ParseErrorProps = {
+        props = {
             "description": description,
             "line": line,
             "col": col,
@@ -80,5 +71,5 @@ def concat_errors(errors: t.Sequence[t.Any], maximum: int) -> str:
     return "\n\n".join(msg)
 
 
-def concat_error_props(errors: t.Sequence[ParseError], maximum: int) -> t.List[ParseErrorProps]:
+def concat_error_props(errors: t.Sequence[ParseError], maximum: int) -> t.List[t.Dict[str, t.Any]]:
     return [props for e in errors[:maximum] for props in e.error_props]

--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -34,7 +34,7 @@ class ParseError(SqlglotError):
         error_props: t.Optional[t.List[t.Dict[str, t.Any]]] = None,
     ):
         super().__init__(message)
-        self.error_props = error_props if error_props is not None else []
+        self.error_props = error_props or []
         props = {
             "description": description,
             "line": line,
@@ -43,7 +43,7 @@ class ParseError(SqlglotError):
             "highlight": highlight,
             "end_context": end_context,
         }
-        if any([p is not None for p in props.values()]):
+        if any(p is not None for p in props.values()):
             self.error_props.append(props)
 
 

--- a/sqlglot/errors.py
+++ b/sqlglot/errors.py
@@ -40,6 +40,7 @@ class ParseError(SqlglotError):
         start_context: t.Optional[str] = None,
         highlight: t.Optional[str] = None,
         end_context: t.Optional[str] = None,
+        into_expression: t.Optional[str] = None,
     ) -> ParseError:
         return cls(
             message,
@@ -51,6 +52,7 @@ class ParseError(SqlglotError):
                     "start_context": start_context,
                     "highlight": highlight,
                     "end_context": end_context,
+                    "into_expression": into_expression,
                 }
             ],
         )
@@ -72,7 +74,7 @@ class ExecuteError(SqlglotError):
     pass
 
 
-def concat_errors(errors: t.Sequence[t.Any], maximum: int) -> str:
+def concat_messages(errors: t.Sequence[t.Any], maximum: int) -> str:
     msg = [str(e) for e in errors[:maximum]]
     remaining = len(errors) - maximum
     if remaining > 0:
@@ -80,5 +82,5 @@ def concat_errors(errors: t.Sequence[t.Any], maximum: int) -> str:
     return "\n\n".join(msg)
 
 
-def concat_struct_errors(errors: t.Sequence[ParseError]) -> t.List[t.Dict[str, t.Any]]:
+def merge_errors(errors: t.Sequence[ParseError]) -> t.List[t.Dict[str, t.Any]]:
     return [e_dict for error in errors for e_dict in error.errors]

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -5,7 +5,7 @@ import re
 import typing as t
 
 from sqlglot import exp
-from sqlglot.errors import ErrorLevel, UnsupportedError, concat_errors
+from sqlglot.errors import ErrorLevel, UnsupportedError, concat_messages
 from sqlglot.helper import apply_index_offset, csv
 from sqlglot.time import format_time
 from sqlglot.tokens import TokenType
@@ -211,7 +211,7 @@ class Generator:
             for msg in self.unsupported_messages:
                 logger.warning(msg)
         elif self.unsupported_level == ErrorLevel.RAISE and self.unsupported_messages:
-            raise UnsupportedError(concat_errors(self.unsupported_messages, self.max_unsupported))
+            raise UnsupportedError(concat_messages(self.unsupported_messages, self.max_unsupported))
 
         return sql
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4,7 +4,7 @@ import logging
 import typing as t
 
 from sqlglot import exp
-from sqlglot.errors import ErrorLevel, ParseError, concat_errors, concat_struct_errors
+from sqlglot.errors import ErrorLevel, ParseError, concat_messages, merge_errors
 from sqlglot.helper import apply_index_offset, ensure_collection, seq_get
 from sqlglot.tokens import Token, Tokenizer, TokenType
 from sqlglot.trie import in_trie, new_trie
@@ -617,6 +617,7 @@ class Parser(metaclass=_Parser):
         )
 
     def parse_into(self, expression_types, raw_tokens, sql=None):
+        errors = []
         for expression_type in ensure_collection(expression_types):
             parser = self.EXPRESSION_PARSERS.get(expression_type)
             if not parser:
@@ -624,8 +625,12 @@ class Parser(metaclass=_Parser):
             try:
                 return self._parse(parser, raw_tokens, sql)
             except ParseError as e:
-                error = e
-        raise ParseError.new(f"Failed to parse into {expression_types}") from error
+                e.errors[0]["into_expression"] = expression_type
+                errors.append(e)
+        raise ParseError(
+            f"Failed to parse into {expression_types}",
+            errors=merge_errors(errors),
+        ) from errors[-1]
 
     def _parse(self, parse_method, raw_tokens, sql=None):
         self.reset()
@@ -660,8 +665,8 @@ class Parser(metaclass=_Parser):
                 logger.error(str(error))
         elif self.error_level == ErrorLevel.RAISE and self.errors:
             raise ParseError(
-                concat_errors(self.errors, self.max_errors),
-                errors=concat_struct_errors(self.errors),
+                concat_messages(self.errors, self.max_errors),
+                errors=merge_errors(self.errors),
             )
 
     def raise_error(self, message, token=None):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -15,6 +15,51 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(parse_one("int", into=exp.DataType), exp.DataType)
         self.assertIsInstance(parse_one("array<int>", into=exp.DataType), exp.DataType)
 
+    def test_parse_into_error(self):
+        expected_message = "Failed to parse into [<class 'sqlglot.expressions.From'>]"
+        expected_errors = [
+            {
+                "description": "Invalid expression / Unexpected token",
+                "line": 1,
+                "col": 1,
+                "start_context": "",
+                "highlight": "SELECT",
+                "end_context": " 1;",
+                "into_expression": exp.From,
+            }
+        ]
+        with self.assertRaises(ParseError) as ctx:
+            parse_one("SELECT 1;", "sqlite", [exp.From])
+        self.assertEqual(str(ctx.exception), expected_message)
+        self.assertEqual(ctx.exception.errors, expected_errors)
+
+    def test_parse_into_errors(self):
+        expected_message = "Failed to parse into [<class 'sqlglot.expressions.From'>, <class 'sqlglot.expressions.Join'>]"
+        expected_errors = [
+            {
+                "description": "Invalid expression / Unexpected token",
+                "line": 1,
+                "col": 1,
+                "start_context": "",
+                "highlight": "SELECT",
+                "end_context": " 1;",
+                "into_expression": exp.From,
+            },
+            {
+                "description": "Invalid expression / Unexpected token",
+                "line": 1,
+                "col": 1,
+                "start_context": "",
+                "highlight": "SELECT",
+                "end_context": " 1;",
+                "into_expression": exp.Join,
+            },
+        ]
+        with self.assertRaises(ParseError) as ctx:
+            parse_one("SELECT 1;", "sqlite", [exp.From, exp.Join])
+        self.assertEqual(str(ctx.exception), expected_message)
+        self.assertEqual(ctx.exception.errors, expected_errors)
+
     def test_column(self):
         columns = parse_one("select a, ARRAY[1] b, case when 1 then 1 end").find_all(exp.Column)
         assert len(list(columns)) == 1

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -374,7 +374,7 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
             "Required keyword: 'expressions' missing for <class 'sqlglot.expressions.Aliases'>. Line 1, Col: 8.\n  x + 1. \033[4m(\033[0m",
             "Expecting ). Line 1, Col: 8.\n  x + 1. \033[4m(\033[0m",
         ]
-        expected_error_props = [
+        expected_errors = [
             {
                 "description": "Required keyword: 'expressions' missing for <class 'sqlglot.expressions.Aliases'>",
                 "line": 1,
@@ -400,12 +400,12 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
         with self.assertRaises(ParseError) as ctx:
             transpile(invalid, error_level=ErrorLevel.IMMEDIATE)
         self.assertEqual(str(ctx.exception), expected_messages[0])
-        self.assertEqual(ctx.exception.error_props[0], expected_error_props[0])
+        self.assertEqual(ctx.exception.errors[0], expected_errors[0])
 
         with self.assertRaises(ParseError) as ctx:
             transpile(invalid, error_level=ErrorLevel.RAISE)
         self.assertEqual(str(ctx.exception), "\n\n".join(expected_messages))
-        self.assertEqual(ctx.exception.error_props, expected_error_props)
+        self.assertEqual(ctx.exception.errors, expected_errors)
 
         more_than_max_errors = "(((("
         expected_messages = (
@@ -414,7 +414,7 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
             "Expecting ). Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
             "... and 2 more"
         )
-        expected_error_props = [
+        expected_errors = [
             {
                 "description": "Expecting )",
                 "line": 1,
@@ -439,11 +439,27 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
                 "highlight": "(",
                 "end_context": "",
             },
+            {
+                "description": "Expecting )",
+                "line": 1,
+                "col": 4,
+                "start_context": "(((",
+                "highlight": "(",
+                "end_context": "",
+            },
+            {
+                "description": "Expecting )",
+                "line": 1,
+                "col": 4,
+                "start_context": "(((",
+                "highlight": "(",
+                "end_context": "",
+            },
         ]
         with self.assertRaises(ParseError) as ctx:
             transpile(more_than_max_errors, error_level=ErrorLevel.RAISE)
         self.assertEqual(str(ctx.exception), expected_messages)
-        self.assertEqual(ctx.exception.error_props, expected_error_props)
+        self.assertEqual(ctx.exception.errors, expected_errors)
 
     @mock.patch("sqlglot.generator.logger")
     def test_unsupported_level(self, logger):

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -370,33 +370,80 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
     @mock.patch("sqlglot.parser.logger")
     def test_error_level(self, logger):
         invalid = "x + 1. ("
-        errors = [
+        expected_messages = [
             "Required keyword: 'expressions' missing for <class 'sqlglot.expressions.Aliases'>. Line 1, Col: 8.\n  x + 1. \033[4m(\033[0m",
             "Expecting ). Line 1, Col: 8.\n  x + 1. \033[4m(\033[0m",
         ]
+        expected_error_props = [
+            {
+                "description": "Required keyword: 'expressions' missing for <class 'sqlglot.expressions.Aliases'>",
+                "line": 1,
+                "col": 8,
+                "start_context": "x + 1. ",
+                "highlight": "(",
+                "end_context": "",
+            },
+            {
+                "description": "Expecting )",
+                "line": 1,
+                "col": 8,
+                "start_context": "x + 1. ",
+                "highlight": "(",
+                "end_context": "",
+            },
+        ]
 
         transpile(invalid, error_level=ErrorLevel.WARN)
-        for error in errors:
+        for error in expected_messages:
             assert_logger_contains(error, logger)
 
         with self.assertRaises(ParseError) as ctx:
             transpile(invalid, error_level=ErrorLevel.IMMEDIATE)
-        self.assertEqual(str(ctx.exception), errors[0])
+        self.assertEqual(str(ctx.exception), expected_messages[0])
+        self.assertEqual(ctx.exception.error_props[0], expected_error_props[0])
 
         with self.assertRaises(ParseError) as ctx:
             transpile(invalid, error_level=ErrorLevel.RAISE)
-        self.assertEqual(str(ctx.exception), "\n\n".join(errors))
+        self.assertEqual(str(ctx.exception), "\n\n".join(expected_messages))
+        self.assertEqual(ctx.exception.error_props, expected_error_props)
 
         more_than_max_errors = "(((("
-        expected = (
+        expected_messages = (
             "Expecting ). Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
             "Required keyword: 'this' missing for <class 'sqlglot.expressions.Paren'>. Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
             "Expecting ). Line 1, Col: 4.\n  (((\033[4m(\033[0m\n\n"
             "... and 2 more"
         )
+        expected_error_props = [
+            {
+                "description": "Expecting )",
+                "line": 1,
+                "col": 4,
+                "start_context": "(((",
+                "highlight": "(",
+                "end_context": "",
+            },
+            {
+                "description": "Required keyword: 'this' missing for <class 'sqlglot.expressions.Paren'>",
+                "line": 1,
+                "col": 4,
+                "start_context": "(((",
+                "highlight": "(",
+                "end_context": "",
+            },
+            {
+                "description": "Expecting )",
+                "line": 1,
+                "col": 4,
+                "start_context": "(((",
+                "highlight": "(",
+                "end_context": "",
+            },
+        ]
         with self.assertRaises(ParseError) as ctx:
             transpile(more_than_max_errors, error_level=ErrorLevel.RAISE)
-        self.assertEqual(str(ctx.exception), expected)
+        self.assertEqual(str(ctx.exception), expected_messages)
+        self.assertEqual(ctx.exception.error_props, expected_error_props)
 
     @mock.patch("sqlglot.generator.logger")
     def test_unsupported_level(self, logger):

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -431,31 +431,10 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
                 "highlight": "(",
                 "end_context": "",
             },
-            {
-                "description": "Expecting )",
-                "line": 1,
-                "col": 4,
-                "start_context": "(((",
-                "highlight": "(",
-                "end_context": "",
-            },
-            {
-                "description": "Expecting )",
-                "line": 1,
-                "col": 4,
-                "start_context": "(((",
-                "highlight": "(",
-                "end_context": "",
-            },
-            {
-                "description": "Expecting )",
-                "line": 1,
-                "col": 4,
-                "start_context": "(((",
-                "highlight": "(",
-                "end_context": "",
-            },
         ]
+        # Also expect three trailing structured errors that match the first
+        expected_errors += [expected_errors[0]] * 3
+
         with self.assertRaises(ParseError) as ctx:
             transpile(more_than_max_errors, error_level=ErrorLevel.RAISE)
         self.assertEqual(str(ctx.exception), expected_messages)

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -382,6 +382,7 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
                 "start_context": "x + 1. ",
                 "highlight": "(",
                 "end_context": "",
+                "into_expression": None,
             },
             {
                 "description": "Expecting )",
@@ -390,6 +391,7 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
                 "start_context": "x + 1. ",
                 "highlight": "(",
                 "end_context": "",
+                "into_expression": None,
             },
         ]
 
@@ -422,6 +424,7 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
                 "start_context": "(((",
                 "highlight": "(",
                 "end_context": "",
+                "into_expression": None,
             },
             {
                 "description": "Required keyword: 'this' missing for <class 'sqlglot.expressions.Paren'>",
@@ -430,6 +433,7 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
                 "start_context": "(((",
                 "highlight": "(",
                 "end_context": "",
+                "into_expression": None,
             },
         ]
         # Also expect three trailing structured errors that match the first


### PR DESCRIPTION
Proposing attaching structured properties to `ParseError` for convenient programmatic access and formatting for arbitrary frontends.  

First proposed `sqlglot` PR, so please let me know of any style issues or conventions I may I have overlooked.