### PR TITLE
improve comment parsing

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -103,7 +103,7 @@ class Generator:
         exp.TableFormatProperty,
     }
 
-    WITH_SEPARATED_COMMENTS = (exp.Select,)
+    WITH_SEPARATED_COMMENTS = (exp.Select, exp.From, exp.Where, exp.Binary)
 
     __slots__ = (
         "time_mapping",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import logging
 import typing as t
 
@@ -1227,8 +1226,9 @@ class Parser(metaclass=_Parser):
     def _parse_from(self):
         if not self._match(TokenType.FROM):
             return None
-        this = self.expression(exp.From, comments=self._prev_comments, expressions=self._parse_csv(self._parse_table))
-        return this
+        return self.expression(
+            exp.From, comments=self._prev_comments, expressions=self._parse_csv(self._parse_table)
+        )
 
     def _parse_lateral(self):
         outer_apply = self._match_pair(TokenType.OUTER, TokenType.APPLY)
@@ -1491,7 +1491,9 @@ class Parser(metaclass=_Parser):
     def _parse_where(self, skip_where_token=False):
         if not skip_where_token and not self._match(TokenType.WHERE):
             return None
-        return self.expression(exp.Where, comments=self._prev_comments, this=self._parse_conjunction())
+        return self.expression(
+            exp.Where, comments=self._prev_comments, this=self._parse_conjunction()
+        )
 
     def _parse_group(self, skip_group_by_token=False):
         if not skip_group_by_token and not self._match(TokenType.GROUP_BY):
@@ -2500,7 +2502,10 @@ class Parser(metaclass=_Parser):
 
         while self._match_set(expressions):
             this = self.expression(
-                expressions[self._prev.token_type], this=this, comments=self._prev_comments, expression=parse_method()
+                expressions[self._prev.token_type],
+                this=this,
+                comments=self._prev_comments,
+                expression=parse_method(),
             )
 
         return this

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1223,8 +1223,10 @@ class Parser(metaclass=_Parser):
     def _parse_from(self):
         if not self._match(TokenType.FROM):
             return None
-
-        return self.expression(exp.From, expressions=self._parse_csv(self._parse_table))
+        comments = self._prev_comments
+        this = self.expression(exp.From, expressions=self._parse_csv(self._parse_table))
+        this.comments = comments
+        return this
 
     def _parse_lateral(self):
         outer_apply = self._match_pair(TokenType.OUTER, TokenType.APPLY)
@@ -2495,9 +2497,11 @@ class Parser(metaclass=_Parser):
         this = parse_method()
 
         while self._match_set(expressions):
+            comments = self._prev_comments
             this = self.expression(
                 expressions[self._prev.token_type], this=this, expression=parse_method()
             )
+            this.comments = comments
 
         return this
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -692,8 +692,7 @@ class Parser(metaclass=_Parser):
             raise error
         self.errors.append(error)
 
-    def expression(self, exp_class, **kwargs):
-        comments = kwargs.pop("comments", None)
+    def expression(self, exp_class, comments=None, **kwargs):
         instance = exp_class(**kwargs)
         if self._prev_comments:
             instance.comments = self._prev_comments

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import logging
 import typing as t
 
@@ -693,10 +694,13 @@ class Parser(metaclass=_Parser):
         self.errors.append(error)
 
     def expression(self, exp_class, **kwargs):
+        comments = kwargs.pop("comments", None)
         instance = exp_class(**kwargs)
         if self._prev_comments:
             instance.comments = self._prev_comments
             self._prev_comments = None
+        if comments:
+            instance.comments = comments
         self.validate_expression(instance)
         return instance
 
@@ -1223,9 +1227,7 @@ class Parser(metaclass=_Parser):
     def _parse_from(self):
         if not self._match(TokenType.FROM):
             return None
-        comments = self._prev_comments
-        this = self.expression(exp.From, expressions=self._parse_csv(self._parse_table))
-        this.comments = comments
+        this = self.expression(exp.From, comments=self._prev_comments, expressions=self._parse_csv(self._parse_table))
         return this
 
     def _parse_lateral(self):
@@ -1489,7 +1491,7 @@ class Parser(metaclass=_Parser):
     def _parse_where(self, skip_where_token=False):
         if not skip_where_token and not self._match(TokenType.WHERE):
             return None
-        return self.expression(exp.Where, this=self._parse_conjunction())
+        return self.expression(exp.Where, comments=self._prev_comments, this=self._parse_conjunction())
 
     def _parse_group(self, skip_group_by_token=False):
         if not skip_group_by_token and not self._match(TokenType.GROUP_BY):
@@ -2497,11 +2499,9 @@ class Parser(metaclass=_Parser):
         this = parse_method()
 
         while self._match_set(expressions):
-            comments = self._prev_comments
             this = self.expression(
-                expressions[self._prev.token_type], this=this, expression=parse_method()
+                expressions[self._prev.token_type], this=this, comments=self._prev_comments, expression=parse_method()
             )
-            this.comments = comments
 
         return this
 


### PR DESCRIPTION
Now comments after "FROM" or "=" will no longer be discarded, though the order is currently messed up.

```sql
/*a*/SELECT/*b*/*/*c*/FROM/*d*/tbl/*e*/WHERE/*f*/1/*g*/=/*h*/2/*i*/--j
```

would previously translate to

``/* a */ /* b */ SELECT * /* c */ FROM tbl /* e */ WHERE 1 /* g */ = 2 /* i */ /* j */  ``

missing comments ``d, f, and h``

with this PR the above SQL parses and translates to

```
(SELECT expressions:
  (STAR comments: ['c']), from:
  (FROM expressions:
    (TABLE this:
      (IDENTIFIER this: tbl, quoted: False), comments: ['e']), comments: ['d']), where:
  (WHERE this:
    (EQ this:
      (LITERAL this: 1, is_string: False, comments: ['g']), expression:
      (LITERAL this: 2, is_string: False, comments: ['i', 'j']), comments: ['h'])), comments: ['a', 'b'])
/* a */ /* b */ SELECT * /* c */ FROM tbl /* e */ /* d */ WHERE 1 /* g */ = 2 /* i */ /* j */ /* h */    
```

Now only missing comment ``f``, but notice that comments ``d and h`` are added after the expression, not after the token.

That's because currenlty, the generator creates the expression and then appends (or prepends in case of SELECT) the comments in ``self.maybe_comment``.

Maybe someone has a better idea to do this, that's why I'm creating this PR as a draft.

cc: @GeorgeSittas 