### PR TITLE
Added ability to parse CREATE TABLE A LIKE B and CREATE TABLE A (LIKE B INCLUDING...)

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1075,8 +1075,10 @@ class SortKeyProperty(Property):
 class DistStyleProperty(Property):
     arg_types = {"this": True}
 
+
 class IncludingProperty(Property):
     arg_types = {"this": True}
+
 
 class LocationProperty(Property):
     arg_types = {"this": True}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1080,6 +1080,10 @@ class IncludingProperty(Property):
     arg_types = {"this": True}
 
 
+class ExcludingProperty(Property):
+    arg_types = {"this": True}
+
+
 class LocationProperty(Property):
     arg_types = {"this": True}
 
@@ -1134,6 +1138,7 @@ class Properties(Expression):
         "EXECUTE AS": ExecuteAsProperty,
         "FORMAT": FileFormatProperty,
         "INCLUDING": IncludingProperty,
+        "EXCLUDING": ExcludingProperty,
         "LANGUAGE": LanguageProperty,
         "LOCATION": LocationProperty,
         "PARTITIONED_BY": PartitionedByProperty,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -608,6 +608,7 @@ class Create(Expression):
         "this": True,
         "kind": True,
         "expression": False,
+        "like_properties": False,
         "exists": False,
         "properties": False,
         "temporary": False,
@@ -1074,6 +1075,8 @@ class SortKeyProperty(Property):
 class DistStyleProperty(Property):
     arg_types = {"this": True}
 
+class IncludingProperty(Property):
+    arg_types = {"this": True}
 
 class LocationProperty(Property):
     arg_types = {"this": True}
@@ -1128,6 +1131,7 @@ class Properties(Expression):
         "ENGINE": EngineProperty,
         "EXECUTE AS": ExecuteAsProperty,
         "FORMAT": FileFormatProperty,
+        "INCLUDING": IncludingProperty,
         "LANGUAGE": LanguageProperty,
         "LOCATION": LocationProperty,
         "PARTITIONED_BY": PartitionedByProperty,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -842,10 +842,8 @@ class Parser(metaclass=_Parser):
                 expression = self.expression(
                     exp.Like, this=this, expression=self._parse_table(schema=True)
                 )
-                
+
                 like_properties = self._parse_properties()
-                # while self._match(TokenType.INCLUDING):
-                    # bruh = self._parse_var()
 
                 self._match_r_paren()
 
@@ -854,7 +852,7 @@ class Parser(metaclass=_Parser):
             this=this,
             kind=create_token.text,
             expression=expression,
-            like_properties = like_properties,
+            like_properties=like_properties,
             exists=exists,
             properties=properties,
             temporary=temporary,
@@ -2039,7 +2037,11 @@ class Parser(metaclass=_Parser):
     def _parse_schema(self, this=None):
 
         index = self._index
-        if self._match_pair(TokenType.L_PAREN, TokenType.LIKE) or not self._match(TokenType.L_PAREN) or self._match(TokenType.SELECT):
+        if (
+            self._match_pair(TokenType.L_PAREN, TokenType.LIKE)
+            or not self._match(TokenType.L_PAREN)
+            or self._match(TokenType.SELECT)
+        ):
             self._retreat(index)
             return this
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -472,6 +472,7 @@ class Parser(metaclass=_Parser):
         TokenType.DISTSTYLE: lambda self: self._parse_property_assignment(exp.DistStyleProperty),
         TokenType.SORTKEY: lambda self: self._parse_sortkey(),
         TokenType.INCLUDING: lambda self: self._parse_property_assignment(exp.IncludingProperty),
+        TokenType.EXCLUDING: lambda self: self._parse_property_assignment(exp.ExcludingProperty),
         TokenType.RETURNS: lambda self: self._parse_returns(),
         TokenType.COLLATE: lambda self: self._parse_property_assignment(exp.CollateProperty),
         TokenType.COMMENT: lambda self: self._parse_property_assignment(exp.SchemaCommentProperty),
@@ -838,7 +839,7 @@ class Parser(metaclass=_Parser):
                     exp.Like, this=this, expression=self._parse_table(schema=True)
                 )
             elif self._match_pair(TokenType.L_PAREN, TokenType.LIKE):
-                # create table a (like b including constraints including statistics)
+                # create table a (like b including constraints excluding statistics)
                 expression = self.expression(
                     exp.Like, this=this, expression=self._parse_table(schema=True)
                 )

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -184,6 +184,7 @@ class TokenType(AutoName):
     ILIKE = auto()
     IMMUTABLE = auto()
     IN = auto()
+    INCLUDING = auto()
     INDEX = auto()
     INNER = auto()
     INSERT = auto()
@@ -501,6 +502,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "IMMUTABLE": TokenType.IMMUTABLE,
         "IGNORE NULLS": TokenType.IGNORE_NULLS,
         "IN": TokenType.IN,
+        "INCLUDING": TokenType.INCLUDING,
         "INDEX": TokenType.INDEX,
         "INNER": TokenType.INNER,
         "INSERT": TokenType.INSERT,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -159,6 +159,7 @@ class TokenType(AutoName):
     ENGINE = auto()
     ESCAPE = auto()
     EXCEPT = auto()
+    EXCLUDING = auto()
     EXECUTE = auto()
     EXISTS = auto()
     FALSE = auto()
@@ -481,6 +482,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "ENGINE": TokenType.ENGINE,
         "ESCAPE": TokenType.ESCAPE,
         "EXCEPT": TokenType.EXCEPT,
+        "EXCLUDING": TokenType.EXCLUDING,
         "EXECUTE": TokenType.EXECUTE,
         "EXISTS": TokenType.EXISTS,
         "FALSE": TokenType.FALSE,


### PR DESCRIPTION
CREATE TABLE A LIKE B is allowed in MySQL (https://dev.mysql.com/doc/refman/5.7/en/create-table-like.html) whilst CREATE TABLE A (LIKE B) is allowed in PostgreSQL (https://www.postgresql.org/docs/current/sql-createtable.html).

In Postgres you can further specify the type of deep copy you want to make, e.g. whether to include/exclude constraints, compression etc. (EXCLUDE being the default option). The syntax is then like 'CREATE TABLE A (LIKE B INCLUDING CONSTRAINTS INCLUDING COMPRESSION INCLUDING STATISTICS EXCLUDING COMMENTS)'.

