### PR TITLE
"decode" support in Snowflake. This function is used to decode text i…

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -81,11 +81,11 @@ def _parse_date_part(self):
     name = this.name.upper()
     if name.startswith("EPOCH"):
         if name.startswith("EPOCH_MILLISECOND"):
-            scale = 10**3
+            scale = 10 ** 3
         elif name.startswith("EPOCH_MICROSECOND"):
-            scale = 10**6
+            scale = 10 ** 6
         elif name.startswith("EPOCH_NANOSECOND"):
-            scale = 10**9
+            scale = 10 ** 9
         else:
             scale = None
 
@@ -98,6 +98,12 @@ def _parse_date_part(self):
         return to_unix
 
     return self.expression(exp.Extract, this=this, expression=expression)
+
+
+def _parse_decode(self):
+    expressions = self._parse_csv(self._parse_expression)
+
+    return self.expression(exp.DecodeConditional, expressions=expressions)
 
 
 class Snowflake(Dialect):
@@ -147,6 +153,7 @@ class Snowflake(Dialect):
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
             "DATE_PART": _parse_date_part,
+            "DECODE": _parse_decode,
         }
         FUNCTION_PARSERS.pop("TRIM")
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -81,11 +81,11 @@ def _parse_date_part(self):
     name = this.name.upper()
     if name.startswith("EPOCH"):
         if name.startswith("EPOCH_MILLISECOND"):
-            scale = 10 ** 3
+            scale = 10**3
         elif name.startswith("EPOCH_MICROSECOND"):
-            scale = 10 ** 6
+            scale = 10**6
         elif name.startswith("EPOCH_NANOSECOND"):
-            scale = 10 ** 9
+            scale = 10**9
         else:
             scale = None
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -904,9 +904,9 @@ class Literal(Condition):
 
     def __eq__(self, other):
         return (
-            isinstance(other, Literal)
-            and self.this == other.this
-            and self.args["is_string"] == other.args["is_string"]
+                isinstance(other, Literal)
+                and self.this == other.this
+                and self.args["is_string"] == other.args["is_string"]
         )
 
     def __hash__(self):
@@ -1224,14 +1224,14 @@ class Subqueryable(Unionable):
         raise NotImplementedError("Subqueryable objects must implement `named_selects`")
 
     def with_(
-        self,
-        alias,
-        as_,
-        recursive=None,
-        append=True,
-        dialect=None,
-        copy=True,
-        **opts,
+            self,
+            alias,
+            as_,
+            recursive=None,
+            append=True,
+            dialect=None,
+            copy=True,
+            **opts,
     ):
         """
         Append to or set the common table expressions.
@@ -1683,16 +1683,16 @@ class Select(Subqueryable):
         )
 
     def join(
-        self,
-        expression,
-        on=None,
-        using=None,
-        append=True,
-        join_type=None,
-        join_alias=None,
-        dialect=None,
-        copy=True,
-        **opts,
+            self,
+            expression,
+            on=None,
+            using=None,
+            append=True,
+            join_type=None,
+            join_alias=None,
+            dialect=None,
+            copy=True,
+            **opts,
     ) -> Select:
         """
         Append to or set the JOIN expressions.
@@ -2626,6 +2626,10 @@ class Decode(Func):
     arg_types = {"this": True, "charset": True}
 
 
+class DecodeConditional(Func):
+    arg_types = {"expressions": True}
+
+
 class DiToDate(Func):
     pass
 
@@ -2983,12 +2987,12 @@ ALL_FUNCTIONS = subclasses(__name__, Func, (AggFunc, Anonymous, Func))
 
 
 def maybe_parse(
-    sql_or_expression,
-    *,
-    into=None,
-    dialect=None,
-    prefix=None,
-    **opts,
+        sql_or_expression,
+        *,
+        into=None,
+        dialect=None,
+        prefix=None,
+        **opts,
 ) -> t.Optional[Expression]:
     """Gracefully handle a possible string or expression.
 
@@ -3031,14 +3035,14 @@ def _is_wrong_expression(expression, into):
 
 
 def _apply_builder(
-    expression,
-    instance,
-    arg,
-    copy=True,
-    prefix=None,
-    into=None,
-    dialect=None,
-    **opts,
+        expression,
+        instance,
+        arg,
+        copy=True,
+        prefix=None,
+        into=None,
+        dialect=None,
+        **opts,
 ):
     if _is_wrong_expression(expression, into):
         expression = into(this=expression)
@@ -3055,16 +3059,16 @@ def _apply_builder(
 
 
 def _apply_child_list_builder(
-    *expressions,
-    instance,
-    arg,
-    append=True,
-    copy=True,
-    prefix=None,
-    into=None,
-    dialect=None,
-    properties=None,
-    **opts,
+        *expressions,
+        instance,
+        arg,
+        append=True,
+        copy=True,
+        prefix=None,
+        into=None,
+        dialect=None,
+        properties=None,
+        **opts,
 ):
     instance = _maybe_copy(instance, copy)
     parsed = []
@@ -3092,15 +3096,15 @@ def _apply_child_list_builder(
 
 
 def _apply_list_builder(
-    *expressions,
-    instance,
-    arg,
-    append=True,
-    copy=True,
-    prefix=None,
-    into=None,
-    dialect=None,
-    **opts,
+        *expressions,
+        instance,
+        arg,
+        append=True,
+        copy=True,
+        prefix=None,
+        into=None,
+        dialect=None,
+        **opts,
 ):
     inst = _maybe_copy(instance, copy)
 
@@ -3124,14 +3128,14 @@ def _apply_list_builder(
 
 
 def _apply_conjunction_builder(
-    *expressions,
-    instance,
-    arg,
-    into=None,
-    append=True,
-    copy=True,
-    dialect=None,
-    **opts,
+        *expressions,
+        instance,
+        arg,
+        into=None,
+        append=True,
+        copy=True,
+        dialect=None,
+        **opts,
 ):
     expressions = [exp for exp in expressions if exp is not None and exp != ""]
     if not expressions:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -904,9 +904,9 @@ class Literal(Condition):
 
     def __eq__(self, other):
         return (
-                isinstance(other, Literal)
-                and self.this == other.this
-                and self.args["is_string"] == other.args["is_string"]
+            isinstance(other, Literal)
+            and self.this == other.this
+            and self.args["is_string"] == other.args["is_string"]
         )
 
     def __hash__(self):
@@ -1224,14 +1224,14 @@ class Subqueryable(Unionable):
         raise NotImplementedError("Subqueryable objects must implement `named_selects`")
 
     def with_(
-            self,
-            alias,
-            as_,
-            recursive=None,
-            append=True,
-            dialect=None,
-            copy=True,
-            **opts,
+        self,
+        alias,
+        as_,
+        recursive=None,
+        append=True,
+        dialect=None,
+        copy=True,
+        **opts,
     ):
         """
         Append to or set the common table expressions.
@@ -1683,16 +1683,16 @@ class Select(Subqueryable):
         )
 
     def join(
-            self,
-            expression,
-            on=None,
-            using=None,
-            append=True,
-            join_type=None,
-            join_alias=None,
-            dialect=None,
-            copy=True,
-            **opts,
+        self,
+        expression,
+        on=None,
+        using=None,
+        append=True,
+        join_type=None,
+        join_alias=None,
+        dialect=None,
+        copy=True,
+        **opts,
     ) -> Select:
         """
         Append to or set the JOIN expressions.
@@ -2987,12 +2987,12 @@ ALL_FUNCTIONS = subclasses(__name__, Func, (AggFunc, Anonymous, Func))
 
 
 def maybe_parse(
-        sql_or_expression,
-        *,
-        into=None,
-        dialect=None,
-        prefix=None,
-        **opts,
+    sql_or_expression,
+    *,
+    into=None,
+    dialect=None,
+    prefix=None,
+    **opts,
 ) -> t.Optional[Expression]:
     """Gracefully handle a possible string or expression.
 
@@ -3035,14 +3035,14 @@ def _is_wrong_expression(expression, into):
 
 
 def _apply_builder(
-        expression,
-        instance,
-        arg,
-        copy=True,
-        prefix=None,
-        into=None,
-        dialect=None,
-        **opts,
+    expression,
+    instance,
+    arg,
+    copy=True,
+    prefix=None,
+    into=None,
+    dialect=None,
+    **opts,
 ):
     if _is_wrong_expression(expression, into):
         expression = into(this=expression)
@@ -3059,16 +3059,16 @@ def _apply_builder(
 
 
 def _apply_child_list_builder(
-        *expressions,
-        instance,
-        arg,
-        append=True,
-        copy=True,
-        prefix=None,
-        into=None,
-        dialect=None,
-        properties=None,
-        **opts,
+    *expressions,
+    instance,
+    arg,
+    append=True,
+    copy=True,
+    prefix=None,
+    into=None,
+    dialect=None,
+    properties=None,
+    **opts,
 ):
     instance = _maybe_copy(instance, copy)
     parsed = []
@@ -3096,15 +3096,15 @@ def _apply_child_list_builder(
 
 
 def _apply_list_builder(
-        *expressions,
-        instance,
-        arg,
-        append=True,
-        copy=True,
-        prefix=None,
-        into=None,
-        dialect=None,
-        **opts,
+    *expressions,
+    instance,
+    arg,
+    append=True,
+    copy=True,
+    prefix=None,
+    into=None,
+    dialect=None,
+    **opts,
 ):
     inst = _maybe_copy(instance, copy)
 
@@ -3128,14 +3128,14 @@ def _apply_list_builder(
 
 
 def _apply_conjunction_builder(
-        *expressions,
-        instance,
-        arg,
-        into=None,
-        append=True,
-        copy=True,
-        dialect=None,
-        **opts,
+    *expressions,
+    instance,
+    arg,
+    into=None,
+    append=True,
+    copy=True,
+    dialect=None,
+    **opts,
 ):
     expressions = [exp for exp in expressions if exp is not None and exp != ""]
     if not expressions:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -59,7 +59,8 @@ class Generator:
         exp.DateDiff: lambda self, e: f"DATEDIFF({self.format_args(e.this, e.expression)})",
         exp.TsOrDsAdd: lambda self, e: f"TS_OR_DS_ADD({self.format_args(e.this, e.expression, e.args.get('unit'))})",
         exp.VarMap: lambda self, e: f"MAP({self.format_args(e.args['keys'], e.args['values'])})",
-        exp.CharacterSetProperty: lambda self, e: f"{'DEFAULT ' if e.args['default'] else ''}CHARACTER SET={self.sql(e, 'this')}",
+        exp.CharacterSetProperty: lambda self,
+                                         e: f"{'DEFAULT ' if e.args['default'] else ''}CHARACTER SET={self.sql(e, 'this')}",
         exp.LanguageProperty: lambda self, e: self.naked_property(e),
         exp.LocationProperty: lambda self, e: self.naked_property(e),
         exp.ReturnsProperty: lambda self, e: self.naked_property(e),
@@ -136,29 +137,29 @@ class Generator:
     )
 
     def __init__(
-        self,
-        time_mapping=None,
-        time_trie=None,
-        pretty=None,
-        quote_start=None,
-        quote_end=None,
-        identifier_start=None,
-        identifier_end=None,
-        identify=False,
-        normalize=False,
-        escape=None,
-        pad=2,
-        indent=2,
-        index_offset=0,
-        unnest_column_only=False,
-        alias_post_tablesample=False,
-        normalize_functions="upper",
-        unsupported_level=ErrorLevel.WARN,
-        null_ordering=None,
-        max_unsupported=3,
-        leading_comma=False,
-        max_text_width=80,
-        comments=True,
+            self,
+            time_mapping=None,
+            time_trie=None,
+            pretty=None,
+            quote_start=None,
+            quote_end=None,
+            identifier_start=None,
+            identifier_end=None,
+            identify=False,
+            normalize=False,
+            escape=None,
+            pad=2,
+            indent=2,
+            index_offset=0,
+            unnest_column_only=False,
+            alias_post_tablesample=False,
+            normalize_functions="upper",
+            unsupported_level=ErrorLevel.WARN,
+            null_ordering=None,
+            max_unsupported=3,
+            leading_comma=False,
+            max_text_width=80,
+            comments=True,
     ):
         import sqlglot
 
@@ -839,13 +840,13 @@ class Generator:
         sort_order = " DESC" if desc else ""
         nulls_sort_change = ""
         if nulls_first and (
-            (asc and nulls_are_large) or (desc and nulls_are_small) or nulls_are_last
+                (asc and nulls_are_large) or (desc and nulls_are_small) or nulls_are_last
         ):
             nulls_sort_change = " NULLS FIRST"
         elif (
-            nulls_last
-            and ((asc and nulls_are_small) or (desc and nulls_are_large))
-            and not nulls_are_last
+                nulls_last
+                and ((asc and nulls_are_small) or (desc and nulls_are_large))
+                and not nulls_are_last
         ):
             nulls_sort_change = " NULLS LAST"
 
@@ -992,8 +993,8 @@ class Generator:
         kind = self.sql(expression, "kind")
         start = csv(self.sql(expression, "start"), self.sql(expression, "start_side"), sep=" ")
         end = (
-            csv(self.sql(expression, "end"), self.sql(expression, "end_side"), sep=" ")
-            or "CURRENT ROW"
+                csv(self.sql(expression, "end"), self.sql(expression, "end_side"), sep=" ")
+                or "CURRENT ROW"
         )
         return f"{kind} BETWEEN {start} AND {end}"
 
@@ -1397,3 +1398,7 @@ class Generator:
 
     def kwarg_sql(self, expression):
         return self.binary(expression, "=>")
+
+    def decodeconditional_sql(self, expression):
+        _expressions = self.expressions(expression, flat=True)
+        return f"DECODE({_expressions})"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -59,8 +59,7 @@ class Generator:
         exp.DateDiff: lambda self, e: f"DATEDIFF({self.format_args(e.this, e.expression)})",
         exp.TsOrDsAdd: lambda self, e: f"TS_OR_DS_ADD({self.format_args(e.this, e.expression, e.args.get('unit'))})",
         exp.VarMap: lambda self, e: f"MAP({self.format_args(e.args['keys'], e.args['values'])})",
-        exp.CharacterSetProperty: lambda self,
-                                         e: f"{'DEFAULT ' if e.args['default'] else ''}CHARACTER SET={self.sql(e, 'this')}",
+        exp.CharacterSetProperty: lambda self, e: f"{'DEFAULT ' if e.args['default'] else ''}CHARACTER SET={self.sql(e, 'this')}",
         exp.LanguageProperty: lambda self, e: self.naked_property(e),
         exp.LocationProperty: lambda self, e: self.naked_property(e),
         exp.ReturnsProperty: lambda self, e: self.naked_property(e),
@@ -137,29 +136,29 @@ class Generator:
     )
 
     def __init__(
-            self,
-            time_mapping=None,
-            time_trie=None,
-            pretty=None,
-            quote_start=None,
-            quote_end=None,
-            identifier_start=None,
-            identifier_end=None,
-            identify=False,
-            normalize=False,
-            escape=None,
-            pad=2,
-            indent=2,
-            index_offset=0,
-            unnest_column_only=False,
-            alias_post_tablesample=False,
-            normalize_functions="upper",
-            unsupported_level=ErrorLevel.WARN,
-            null_ordering=None,
-            max_unsupported=3,
-            leading_comma=False,
-            max_text_width=80,
-            comments=True,
+        self,
+        time_mapping=None,
+        time_trie=None,
+        pretty=None,
+        quote_start=None,
+        quote_end=None,
+        identifier_start=None,
+        identifier_end=None,
+        identify=False,
+        normalize=False,
+        escape=None,
+        pad=2,
+        indent=2,
+        index_offset=0,
+        unnest_column_only=False,
+        alias_post_tablesample=False,
+        normalize_functions="upper",
+        unsupported_level=ErrorLevel.WARN,
+        null_ordering=None,
+        max_unsupported=3,
+        leading_comma=False,
+        max_text_width=80,
+        comments=True,
     ):
         import sqlglot
 
@@ -840,13 +839,13 @@ class Generator:
         sort_order = " DESC" if desc else ""
         nulls_sort_change = ""
         if nulls_first and (
-                (asc and nulls_are_large) or (desc and nulls_are_small) or nulls_are_last
+            (asc and nulls_are_large) or (desc and nulls_are_small) or nulls_are_last
         ):
             nulls_sort_change = " NULLS FIRST"
         elif (
-                nulls_last
-                and ((asc and nulls_are_small) or (desc and nulls_are_large))
-                and not nulls_are_last
+            nulls_last
+            and ((asc and nulls_are_small) or (desc and nulls_are_large))
+            and not nulls_are_last
         ):
             nulls_sort_change = " NULLS LAST"
 
@@ -993,8 +992,8 @@ class Generator:
         kind = self.sql(expression, "kind")
         start = csv(self.sql(expression, "start"), self.sql(expression, "start_side"), sep=" ")
         end = (
-                csv(self.sql(expression, "end"), self.sql(expression, "end_side"), sep=" ")
-                or "CURRENT ROW"
+            csv(self.sql(expression, "end"), self.sql(expression, "end_side"), sep=" ")
+            or "CURRENT ROW"
         )
         return f"{kind} BETWEEN {start} AND {end}"
 


### PR DESCRIPTION
"decode" support in Snowflake. This function is used to decode text in postgres. However, Oracle and Snowflake implement this as a conditional.

Notes: 
1) These changes are specific to snowflake dialect.
2) It was tempting to parse the decode function into it's consituents - expression, search-replace pairs and an optional default. However, just parsed everything in a list to keep things simple.