### PR TITLE
Added ability to parse END (COMMIT equivalent in Postgres) and the CHAIN option

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2114,7 +2114,11 @@ class Transaction(Command):
 
 
 class Commit(Command):
-    arg_types = {}  # type: ignore
+    arg_types = {"chain": False}
+
+
+class End(Command):
+    arg_types = {"chain": False}
 
 
 class Rollback(Command):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1202,8 +1202,15 @@ class Generator:
     def transaction_sql(self, *_):
         return "BEGIN"
 
-    def commit_sql(self, *_):
-        return "COMMIT"
+    def commit_sql(self, expression):
+        chain = expression.args.get("chain")
+        chain = f" AND CHAIN" if chain else ""
+        return f"COMMIT{chain}"
+
+    def end_sql(self, expression):
+        chain = expression.args.get("chain")
+        chain = f" AND CHAIN" if chain else ""
+        return f"END{chain}"
 
     def rollback_sql(self, expression):
         savepoint = expression.args.get("savepoint")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -88,6 +88,7 @@ class TestPostgres(Validator):
         self.validate_identity("COMMENT ON TABLE mytable IS 'this'")
         self.validate_identity("SELECT e'\\xDEADBEEF'")
         self.validate_identity("SELECT CAST(e'\\176' AS BYTEA)")
+        self.validate_identity("END AND CHAIN")
 
         self.validate_all(
             "CREATE TABLE x (a UUID, b BYTEA)",


### PR DESCRIPTION
https://www.postgresql.org/docs/current/sql-end.html

Added a test that works (I now understand how testing works with the generator!) but maybe you want to modify the way it's parsed/shows up in the AST.