### PR TITLE
added support for redshift ENCODE, fix parsing for DISTSTYLE ALL

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -19,6 +19,7 @@ class Redshift(Postgres):
         KEYWORDS = {
             **Postgres.Tokenizer.KEYWORDS,  # type: ignore
             "COPY": TokenType.COMMAND,
+            "ENCODE": TokenType.COMPRESSION,
             "GEOMETRY": TokenType.GEOMETRY,
             "GEOGRAPHY": TokenType.GEOGRAPHY,
             "HLLSKETCH": TokenType.HLLSKETCH,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -19,7 +19,7 @@ class Redshift(Postgres):
         KEYWORDS = {
             **Postgres.Tokenizer.KEYWORDS,  # type: ignore
             "COPY": TokenType.COMMAND,
-            "ENCODE": TokenType.COMPRESSION,
+            "ENCODE": TokenType.ENCODE,
             "GEOMETRY": TokenType.GEOMETRY,
             "GEOGRAPHY": TokenType.GEOGRAPHY,
             "HLLSKETCH": TokenType.HLLSKETCH,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -745,7 +745,7 @@ class DefaultColumnConstraint(ColumnConstraintKind):
 
 
 class EncodeColumnConstraint(ColumnConstraintKind):
-    arg_types = {"this": True}
+    pass
 
 
 class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -740,12 +740,12 @@ class CommentColumnConstraint(ColumnConstraintKind):
     pass
 
 
-class CompressionColumnConstraint(ColumnConstraintKind):
-    arg_types = {"this": True}
-
-
 class DefaultColumnConstraint(ColumnConstraintKind):
     pass
+
+
+class EncodeColumnConstraint(ColumnConstraintKind):
+    arg_types = {"this": True}
 
 
 class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -740,6 +740,10 @@ class CommentColumnConstraint(ColumnConstraintKind):
     pass
 
 
+class CompressionColumnConstraint(ColumnConstraintKind):
+    arg_types = {"this": True}
+
+
 class DefaultColumnConstraint(ColumnConstraintKind):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -386,9 +386,9 @@ class Generator:
         collate = self.sql(expression, "this")
         return f"COLLATE {collate}"
 
-    def compressioncolumnconstraint_sql(self, expression: exp.CompressionColumnConstraint) -> str:
-        compression = self.sql(expression, "this")
-        return f"ENCODE {compression}"
+    def encodecolumnconstraint_sql(self, expression: exp.EncodeColumnConstraint) -> str:
+        encode = self.sql(expression, "this")
+        return f"ENCODE {encode}"
 
     def defaultcolumnconstraint_sql(self, expression: exp.DefaultColumnConstraint) -> str:
         default = self.sql(expression, "this")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -386,6 +386,10 @@ class Generator:
         collate = self.sql(expression, "this")
         return f"COLLATE {collate}"
 
+    def compressioncolumnconstraint_sql(self, expression: exp.CompressionColumnConstraint) -> str:
+        compression = self.sql(expression, "this")
+        return f"ENCODE {compression}"
+
     def defaultcolumnconstraint_sql(self, expression: exp.DefaultColumnConstraint) -> str:
         default = self.sql(expression, "this")
         return f"DEFAULT {default}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -871,7 +871,10 @@ class Parser(metaclass=_Parser):
     def _parse_property_assignment(self, exp_class):
         self._match(TokenType.EQ)
         self._match(TokenType.ALIAS)
-        return self.expression(exp_class, this=self._parse_var_or_string() or self._parse_number())
+        return self.expression(
+            exp_class,
+            this=self._parse_var_or_string() or self._parse_number() or self._parse_id_var(),
+        )
 
     def _parse_partitioned_by(self):
         self._match(TokenType.EQ)
@@ -881,7 +884,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_distkey(self):
-        return self.expression(exp.DistKeyProperty, this=self._parse_wrapped(self._parse_var))
+        return self.expression(exp.DistKeyProperty, this=self._parse_wrapped(self._parse_id_var))
 
     def _parse_create_like(self):
         table = self._parse_table(schema=True)
@@ -898,7 +901,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_sortkey(self, compound=False):
         return self.expression(
-            exp.SortKeyProperty, this=self._parse_wrapped_csv(self._parse_var), compound=compound
+            exp.SortKeyProperty, this=self._parse_wrapped_csv(self._parse_id_var), compound=compound
         )
 
     def _parse_character_set(self, default=False):
@@ -2092,6 +2095,8 @@ class Parser(metaclass=_Parser):
             kind = self.expression(exp.CheckColumnConstraint, this=constraint)
         elif self._match(TokenType.COLLATE):
             kind = self.expression(exp.CollateColumnConstraint, this=self._parse_var())
+        elif self._match(TokenType.COMPRESSION):
+            kind = self.expression(exp.CompressionColumnConstraint, this=self._parse_var())
         elif self._match(TokenType.DEFAULT):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2095,8 +2095,8 @@ class Parser(metaclass=_Parser):
             kind = self.expression(exp.CheckColumnConstraint, this=constraint)
         elif self._match(TokenType.COLLATE):
             kind = self.expression(exp.CollateColumnConstraint, this=self._parse_var())
-        elif self._match(TokenType.COMPRESSION):
-            kind = self.expression(exp.CompressionColumnConstraint, this=self._parse_var())
+        elif self._match(TokenType.ENCODE):
+            kind = self.expression(exp.EncodeColumnConstraint, this=self._parse_var())
         elif self._match(TokenType.DEFAULT):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -134,6 +134,7 @@ class TokenType(AutoName):
     COMMENT = auto()
     COMMIT = auto()
     COMPOUND = auto()
+    COMPRESSION = auto()
     CONSTRAINT = auto()
     CREATE = auto()
     CROSS = auto()
@@ -458,6 +459,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "COMMENT": TokenType.SCHEMA_COMMENT,
         "COMMIT": TokenType.COMMIT,
         "COMPOUND": TokenType.COMPOUND,
+        "COMPRESSION": TokenType.COMPRESSION,
         "CONSTRAINT": TokenType.CONSTRAINT,
         "CREATE": TokenType.CREATE,
         "CROSS": TokenType.CROSS,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -134,7 +134,6 @@ class TokenType(AutoName):
     COMMENT = auto()
     COMMIT = auto()
     COMPOUND = auto()
-    COMPRESSION = auto()
     CONSTRAINT = auto()
     CREATE = auto()
     CROSS = auto()
@@ -157,6 +156,7 @@ class TokenType(AutoName):
     DIV = auto()
     DROP = auto()
     ELSE = auto()
+    ENCODE = auto()
     END = auto()
     ENGINE = auto()
     ESCAPE = auto()
@@ -459,7 +459,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "COMMENT": TokenType.SCHEMA_COMMENT,
         "COMMIT": TokenType.COMMIT,
         "COMPOUND": TokenType.COMPOUND,
-        "COMPRESSION": TokenType.COMPRESSION,
         "CONSTRAINT": TokenType.CONSTRAINT,
         "CREATE": TokenType.CREATE,
         "CROSS": TokenType.CROSS,

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -70,9 +70,9 @@ class TestRedshift(Validator):
         self.validate_identity(
             "SELECT COUNT(*) FROM event WHERE eventname LIKE '%Ring%' OR eventname LIKE '%Die%'"
         )
-        self.validate_identity("CREATE TABLE SOUP DISTKEY(soup1) SORTKEY(soup2) DISTSTYLE AUTO")
+        self.validate_identity("CREATE TABLE SOUP DISTKEY(soup1) SORTKEY(soup2) DISTSTYLE ALL")
         self.validate_identity(
-            "CREATE TABLE sales (salesid INTEGER NOT NULL) DISTKEY(listid) COMPOUND SORTKEY(listid, sellerid)"
+            "CREATE TABLE sales (salesid INTEGER NOT NULL) DISTKEY(listid) COMPOUND SORTKEY(listid, sellerid) DISTSTYLE AUTO"
         )
         self.validate_identity(
             "COPY customer FROM 's3://mybucket/customer' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole'"
@@ -80,3 +80,4 @@ class TestRedshift(Validator):
         self.validate_identity(
             "UNLOAD ('select * from venue') TO 's3://mybucket/unload/' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole'"
         )
+        self.validate_identity("CREATE TABLE SOUP (SOUP1 VARCHAR(50) ENCODE ZSTD)")

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -80,4 +80,6 @@ class TestRedshift(Validator):
         self.validate_identity(
             "UNLOAD ('select * from venue') TO 's3://mybucket/unload/' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole'"
         )
-        self.validate_identity("CREATE TABLE SOUP (SOUP1 VARCHAR(50) ENCODE ZSTD)")
+        self.validate_identity(
+            "CREATE TABLE SOUP (SOUP1 VARCHAR(50) ENCODE ZSTD, SOUP2 VARCHAR(70) ENCODE DELTA)"
+        )


### PR DESCRIPTION
https://docs.aws.amazon.com/redshift/latest/dg/c_Compression_encodings.html

Originally I thought I could just map ENCODE to TokenType.CONSTRAINT in redshift.py but that wouldn't be correct and wouldn't generate properly.

I also tried creating tokentype.ENCODE but that messes up existing parsing for ENCODE for other dialects, which is very different.

So instead I opted for creating tokentype.COMPRESSION and mapping ENCODE to COMPRESSION in redshift.py. 

https://docs.aws.amazon.com/redshift/latest/dg/c_choosing_dist_sort.html
I also made some very minor changes to how distkey, sortkey and diststyle are parsed. In particular, one of the default options for diststyle is 'all' which _parse_var can't handle, so I changed it to _parse_id_var. I decided to do the same for distkey and sortkey because something fairly innocuous like 'distkey(location)' leads to an error. 