### PR TITLE
Added NULL column constraint and NVL-COALESCE mapping for Redshift

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -18,6 +18,7 @@ class Redshift(Postgres):
         FUNCTIONS = {
             **Postgres.Parser.FUNCTIONS,  # type: ignore
             "DECODE": exp.Matches.from_arg_list,
+            "NVL": exp.Coalesce.from_arg_list,
         }
 
     class Tokenizer(Postgres.Tokenizer):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -763,7 +763,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
     arg_types = {"this": True, "expression": False}
 
 
-class NullColumnConstraint(ColumnConstraintKind):
+class NotNullColumnConstraint(ColumnConstraintKind):
     arg_types = {"allow_null": False}
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -764,11 +764,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
 
 
 class NotNullColumnConstraint(ColumnConstraintKind):
-    pass
-
-
-class NullColumnConstraint(ColumnConstraintKind):
-    pass
+    arg_types = {"allow_null": False}
 
 
 class PrimaryKeyColumnConstraint(ColumnConstraintKind):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -767,6 +767,10 @@ class NotNullColumnConstraint(ColumnConstraintKind):
     pass
 
 
+class NullColumnConstraint(ColumnConstraintKind):
+    pass
+
+
 class PrimaryKeyColumnConstraint(ColumnConstraintKind):
     arg_types = {"desc": False}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -763,7 +763,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
     arg_types = {"this": True, "expression": False}
 
 
-class NotNullColumnConstraint(ColumnConstraintKind):
+class NullColumnConstraint(ColumnConstraintKind):
     arg_types = {"allow_null": False}
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -399,11 +399,8 @@ class Generator:
     ) -> str:
         return f"GENERATED {'ALWAYS' if expression.this else 'BY DEFAULT'} AS IDENTITY"
 
-    def notnullcolumnconstraint_sql(self, expression: exp.NotNullColumnConstraint) -> str:
-        allow_null = expression.args.get("allow_null")
-        if allow_null is not None:
-            return "NULL" if allow_null else "NOT NULL"
-        return "NOT NULL"
+    def nullcolumnconstraint_sql(self, expression: exp.NullColumnConstraint) -> str:
+        return f"{'' if expression.args.get('allow_null') else 'NOT '}NULL"
 
     def primarykeycolumnconstraint_sql(self, expression: exp.PrimaryKeyColumnConstraint) -> str:
         desc = expression.args.get("desc")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -399,7 +399,7 @@ class Generator:
     ) -> str:
         return f"GENERATED {'ALWAYS' if expression.this else 'BY DEFAULT'} AS IDENTITY"
 
-    def nullcolumnconstraint_sql(self, expression: exp.NullColumnConstraint) -> str:
+    def notnullcolumnconstraint_sql(self, expression: exp.NotNullColumnConstraint) -> str:
         return f"{'' if expression.args.get('allow_null') else 'NOT '}NULL"
 
     def primarykeycolumnconstraint_sql(self, expression: exp.PrimaryKeyColumnConstraint) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -399,11 +399,11 @@ class Generator:
     ) -> str:
         return f"GENERATED {'ALWAYS' if expression.this else 'BY DEFAULT'} AS IDENTITY"
 
-    def notnullcolumnconstraint_sql(self, _) -> str:
+    def notnullcolumnconstraint_sql(self, expression: exp.NotNullColumnConstraint) -> str:
+        allow_null = expression.args.get("allow_null")
+        if allow_null is not None:
+            return "NULL" if allow_null else "NOT NULL"
         return "NOT NULL"
-
-    def nullcolumnconstraint_sql(self, _) -> str:
-        return "NULL"
 
     def primarykeycolumnconstraint_sql(self, expression: exp.PrimaryKeyColumnConstraint) -> str:
         desc = expression.args.get("desc")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -402,6 +402,9 @@ class Generator:
     def notnullcolumnconstraint_sql(self, _) -> str:
         return "NOT NULL"
 
+    def nullcolumnconstraint_sql(self, _) -> str:
+        return "NULL"
+
     def primarykeycolumnconstraint_sql(self, expression: exp.PrimaryKeyColumnConstraint) -> str:
         desc = expression.args.get("desc")
         if desc is not None:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2100,9 +2100,9 @@ class Parser(metaclass=_Parser):
         elif self._match(TokenType.DEFAULT):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):
-            kind = exp.NotNullColumnConstraint(allow_null=False)
+            kind = exp.NullColumnConstraint(allow_null=False)
         elif self._match(TokenType.NULL):
-            kind = exp.NotNullColumnConstraint(allow_null=True)
+            kind = exp.NullColumnConstraint(allow_null=True)
         elif self._match(TokenType.SCHEMA_COMMENT):
             kind = self.expression(exp.CommentColumnConstraint, this=self._parse_string())
         elif self._match(TokenType.PRIMARY_KEY):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2100,9 +2100,9 @@ class Parser(metaclass=_Parser):
         elif self._match(TokenType.DEFAULT):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):
-            kind = exp.NullColumnConstraint(allow_null=False)
+            kind = exp.NotNullColumnConstraint(allow_null=False)
         elif self._match(TokenType.NULL):
-            kind = exp.NullColumnConstraint(allow_null=True)
+            kind = exp.NotNullColumnConstraint(allow_null=True)
         elif self._match(TokenType.SCHEMA_COMMENT):
             kind = self.expression(exp.CommentColumnConstraint, this=self._parse_string())
         elif self._match(TokenType.PRIMARY_KEY):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2101,6 +2101,8 @@ class Parser(metaclass=_Parser):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):
             kind = exp.NotNullColumnConstraint()
+        elif self._match(TokenType.NULL):
+            kind = exp.NullColumnConstraint()
         elif self._match(TokenType.SCHEMA_COMMENT):
             kind = self.expression(exp.CommentColumnConstraint, this=self._parse_string())
         elif self._match(TokenType.PRIMARY_KEY):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2100,9 +2100,9 @@ class Parser(metaclass=_Parser):
         elif self._match(TokenType.DEFAULT):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):
-            kind = exp.NotNullColumnConstraint()
+            kind = exp.NotNullColumnConstraint(allow_null=False)
         elif self._match(TokenType.NULL):
-            kind = exp.NullColumnConstraint()
+            kind = exp.NotNullColumnConstraint(allow_null=True)
         elif self._match(TokenType.SCHEMA_COMMENT):
             kind = self.expression(exp.CommentColumnConstraint, this=self._parse_string())
         elif self._match(TokenType.PRIMARY_KEY):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2100,7 +2100,7 @@ class Parser(metaclass=_Parser):
         elif self._match(TokenType.DEFAULT):
             kind = self.expression(exp.DefaultColumnConstraint, this=self._parse_conjunction())
         elif self._match_pair(TokenType.NOT, TokenType.NULL):
-            kind = exp.NotNullColumnConstraint(allow_null=False)
+            kind = exp.NotNullColumnConstraint()
         elif self._match(TokenType.NULL):
             kind = exp.NotNullColumnConstraint(allow_null=True)
         elif self._match(TokenType.SCHEMA_COMMENT):

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -92,5 +92,5 @@ class TestRedshift(Validator):
             "UNLOAD ('select * from venue') TO 's3://mybucket/unload/' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole'"
         )
         self.validate_identity(
-            "CREATE TABLE SOUP (SOUP1 VARCHAR(50) ENCODE ZSTD, SOUP2 VARCHAR(70) ENCODE DELTA)"
+            "CREATE TABLE SOUP (SOUP1 VARCHAR(50) NOT NULL ENCODE ZSTD, SOUP2 VARCHAR(70) NULL ENCODE DELTA)"
         )

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -64,6 +64,14 @@ class TestRedshift(Validator):
                 "snowflake": "DECODE(x, a, b, c, d)",
             },
         )
+        self.validate_all(
+            "NVL(a, b, c, d)",
+            write={
+                "redshift": "COALESCE(a, b, c, d)",
+                "mysql": "COALESCE(a, b, c, d)",
+                "postgres": "COALESCE(a, b, c, d)",
+            },
+        )
 
     def test_identity(self):
         self.validate_identity(


### PR DESCRIPTION
https://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_TABLE_NEW.html
In Redshift you can have NULL explicitly as a column constraint, as opposed to NOT NULL.


Also, NVL and COALESCE are equivalent in Redshift: Redshift NVL accepts variable length arguments as opposed to just two. So I map NVL to COALESCE, and use .from_arg_list. (both nvl and coalesce are valid in Redshift though, so I didn't use rename_func).

One thing I just wanted to clarify: is function_fall_back_sql how functions are generated in generator.py? I couldn't find anything specifically for functions like COALESCE so I guess there's a general generator for the func class.