### PR TITLE
Enable table aliasing for UPDATE

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1188,12 +1188,12 @@ class Parser(metaclass=_Parser):
 
     def _parse_table_alias(self, is_update=False):
         any_token = self._match(TokenType.ALIAS)
-        if is_update:
-            alias = self._parse_id_var(
-                any_token=any_token, tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}
-            )
-        else:
-            alias = self._parse_id_var(any_token=any_token, tokens=self.TABLE_ALIAS_TOKENS)
+        alias = self._parse_id_var(
+            any_token=any_token,
+            tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}
+            if is_update
+            else self.TABLE_ALIAS_TOKENS,
+        )
         columns = None
 
         if self._match(TokenType.L_PAREN):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1035,7 +1035,7 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.Update,
             **{
-                "this": self._parse_table(),
+                "this": self._parse_table(is_update=True),
                 "expressions": self._match(TokenType.SET) and self._parse_csv(self._parse_equality),
                 "from": self._parse_from(),
                 "where": self._parse_where(),
@@ -1186,9 +1186,9 @@ class Parser(metaclass=_Parser):
             alias=alias,
         )
 
-    def _parse_table_alias(self):
+    def _parse_table_alias(self, is_update=False):
         any_token = self._match(TokenType.ALIAS)
-        if self._tokens[self._index - 2].token_type == TokenType.UPDATE:
+        if is_update:
             alias = self._parse_id_var(
                 any_token=any_token, tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}
             )
@@ -1345,7 +1345,7 @@ class Parser(metaclass=_Parser):
             columns=self._parse_expression(),
         )
 
-    def _parse_table(self, schema=False):
+    def _parse_table(self, schema=False, is_update=False):
         lateral = self._parse_lateral()
 
         if lateral:
@@ -1392,7 +1392,7 @@ class Parser(metaclass=_Parser):
         if self.alias_post_tablesample:
             table_sample = self._parse_table_sample()
 
-        alias = self._parse_table_alias()
+        alias = self._parse_table_alias(is_update=is_update)
 
         if alias:
             this.set("alias", alias)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -229,6 +229,8 @@ class Parser(metaclass=_Parser):
 
     TABLE_ALIAS_TOKENS = ID_VAR_TOKENS - {TokenType.NATURAL, TokenType.APPLY}
 
+    UPDATE_ALIAS_TOKENS = TABLE_ALIAS_TOKENS - {TokenType.SET}
+
     TRIM_TYPES = {TokenType.LEADING, TokenType.TRAILING, TokenType.BOTH}
 
     FUNC_TOKENS = {
@@ -1035,7 +1037,7 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.Update,
             **{
-                "this": self._parse_table(alias_tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}),
+                "this": self._parse_table(alias_tokens=self.UPDATE_ALIAS_TOKENS),
                 "expressions": self._match(TokenType.SET) and self._parse_csv(self._parse_equality),
                 "from": self._parse_from(),
                 "where": self._parse_where(),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -203,7 +203,6 @@ class Parser(metaclass=_Parser):
         TokenType.SCHEMA_COMMENT,
         TokenType.SEED,
         TokenType.SEMI,
-        TokenType.SET,
         TokenType.SHOW,
         TokenType.SORTKEY,
         TokenType.STABLE,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1035,7 +1035,7 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.Update,
             **{
-                "this": self._parse_table(is_update=True),
+                "this": self._parse_table(alias_tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}),
                 "expressions": self._match(TokenType.SET) and self._parse_csv(self._parse_equality),
                 "from": self._parse_from(),
                 "where": self._parse_where(),
@@ -1186,13 +1186,10 @@ class Parser(metaclass=_Parser):
             alias=alias,
         )
 
-    def _parse_table_alias(self, is_update=False):
+    def _parse_table_alias(self, alias_tokens=None):
         any_token = self._match(TokenType.ALIAS)
         alias = self._parse_id_var(
-            any_token=any_token,
-            tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}
-            if is_update
-            else self.TABLE_ALIAS_TOKENS,
+            any_token=any_token, tokens=alias_tokens or self.TABLE_ALIAS_TOKENS
         )
         columns = None
 
@@ -1345,7 +1342,7 @@ class Parser(metaclass=_Parser):
             columns=self._parse_expression(),
         )
 
-    def _parse_table(self, schema=False, is_update=False):
+    def _parse_table(self, schema=False, alias_tokens=None):
         lateral = self._parse_lateral()
 
         if lateral:
@@ -1392,7 +1389,7 @@ class Parser(metaclass=_Parser):
         if self.alias_post_tablesample:
             table_sample = self._parse_table_sample()
 
-        alias = self._parse_table_alias(is_update=is_update)
+        alias = self._parse_table_alias(alias_tokens=alias_tokens or self.TABLE_ALIAS_TOKENS)
 
         if alias:
             this.set("alias", alias)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -203,6 +203,7 @@ class Parser(metaclass=_Parser):
         TokenType.SCHEMA_COMMENT,
         TokenType.SEED,
         TokenType.SEMI,
+        TokenType.SET,
         TokenType.SHOW,
         TokenType.SORTKEY,
         TokenType.STABLE,
@@ -1187,7 +1188,12 @@ class Parser(metaclass=_Parser):
 
     def _parse_table_alias(self):
         any_token = self._match(TokenType.ALIAS)
-        alias = self._parse_id_var(any_token=any_token, tokens=self.TABLE_ALIAS_TOKENS)
+        if self._tokens[self._index - 2].token_type == TokenType.UPDATE:
+            alias = self._parse_id_var(
+                any_token=any_token, tokens=self.TABLE_ALIAS_TOKENS - {TokenType.SET}
+            )
+        else:
+            alias = self._parse_id_var(any_token=any_token, tokens=self.TABLE_ALIAS_TOKENS)
         columns = None
 
         if self._match(TokenType.L_PAREN):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1035,7 +1035,7 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.Update,
             **{
-                "this": self._parse_table(schema=True),
+                "this": self._parse_table(),
                 "expressions": self._match(TokenType.SET) and self._parse_csv(self._parse_equality),
                 "from": self._parse_from(),
                 "where": self._parse_where(),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -94,7 +94,6 @@ class TestPostgres(Validator):
         self.validate_identity("COMMENT ON TABLE mytable IS 'this'")
         self.validate_identity("SELECT e'\\xDEADBEEF'")
         self.validate_identity("SELECT CAST(e'\\176' AS BYTEA)")
-        self.validate_identity("UPDATE MYTABLE AS T1 SET T1.COL = 13")
 
         self.validate_all(
             "END WORK AND NO CHAIN",
@@ -256,4 +255,8 @@ class TestPostgres(Validator):
         self.validate_all(
             "SELECT $$Dianne's horse$$",
             write={"postgres": "SELECT 'Dianne''s horse'"},
+        )
+        self.validate_all(
+            "UPDATE MYTABLE T1 SET T1.COL = 13",
+            write={"postgres": "UPDATE MYTABLE AS T1 SET T1.COL = 13"},
         )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -94,6 +94,7 @@ class TestPostgres(Validator):
         self.validate_identity("COMMENT ON TABLE mytable IS 'this'")
         self.validate_identity("SELECT e'\\xDEADBEEF'")
         self.validate_identity("SELECT CAST(e'\\176' AS BYTEA)")
+        self.validate_identity("UPDATE MYTABLE AS T1 SET T1.COL = 13")
 
         self.validate_all(
             "END WORK AND NO CHAIN",


### PR DESCRIPTION
https://www.postgresql.org/docs/current/sql-update.html

This seems like a Postgres exclusive feature that allows the syntax 'UPDATE TABLE1 T1 SET T1.SOME_COL = SOME_VALUE'.
Schema = True was preventing the alias from ever getting parsed. I don't think the schema is ever an argument for UPDATE in any dialects (correct me if I'm wrong) 

Just one other thing: what does the line `table = (not schema and self._parse_function()) or self._parse_id_var(False)` mean? In particular, what actually does id_var represent?