### PR TITLE
Qualified lateral functions

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -250,6 +250,7 @@ class Hive(Dialect):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.TEXT: "STRING",
+            exp.DataType.Type.DATETIME: "TIMESTAMP",
             exp.DataType.Type.VARBINARY: "BINARY",
         }
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -244,7 +244,7 @@ class Postgres(Dialect):
 
     class Parser(parser.Parser):
         STRICT_CAST = False
-        TREAT_LAT_FUNC_AS_LAT_VIEW = True
+        LATERAL_FUNCTION_AS_VIEW = True
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -244,6 +244,7 @@ class Postgres(Dialect):
 
     class Parser(parser.Parser):
         STRICT_CAST = False
+        TREAT_LAT_FUNC_AS_LAT_VIEW = True
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -224,6 +224,12 @@ class TSQL(Dialect):
     class Tokenizer(tokens.Tokenizer):
         IDENTIFIERS = ['"', ("[", "]")]
 
+        QUOTES = [
+            (prefix + quote, quote) if prefix else quote
+            for quote in ["'", '"']
+            for prefix in ["", "n", "N"]
+        ]
+
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "BIT": TokenType.BOOLEAN,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -795,14 +795,16 @@ class Generator:
 
         alias = expression.args["alias"]
         table = alias.name
-        table = f" {table}" if table else table
         columns = self.expressions(alias, key="columns", flat=True)
-        columns = f" AS {columns}" if columns else ""
 
         if expression.args.get("view"):
+            table = f" {table}" if table else table
+            columns = f" AS {columns}" if columns else ""
             op_sql = self.seg(f"LATERAL VIEW{' OUTER' if expression.args.get('outer') else ''}")
             return f"{op_sql}{self.sep()}{this}{table}{columns}"
 
+        table = f" AS {table}" if table else table
+        columns = f"({columns})" if columns else ""
         return f"LATERAL {this}{table}{columns}"
 
     def limit_sql(self, expression: exp.Limit) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -891,8 +891,8 @@ class Generator:
     def query_modifiers(self, expression: exp.Expression, *sqls: str) -> str:
         return csv(
             *sqls,
-            *[self.sql(sql) for sql in expression.args.get("laterals", [])],
             *[self.sql(sql) for sql in expression.args.get("joins", [])],
+            *[self.sql(sql) for sql in expression.args.get("laterals", [])],
             self.sql(expression, "where"),
             self.sql(expression, "group"),
             self.sql(expression, "having"),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1287,7 +1287,9 @@ class Parser(metaclass=_Parser):
             return None
 
         if not this:
-            this = self._parse_function()
+            this = self._parse_function() or self._parse_id_var(False)
+            while self._match(TokenType.DOT):
+                this = exp.Dot(this=this, expression=self._parse_function() or self._parse_id_var())
 
         table_alias = self._parse_id_var(any_token=False)
 
@@ -1303,7 +1305,11 @@ class Parser(metaclass=_Parser):
             this=this,
             view=view,
             outer=outer,
-            alias=self.expression(exp.TableAlias, this=table_alias, columns=columns),
+            alias=self.expression(
+                exp.TableAlias,
+                this=table_alias,
+                columns=columns,
+            ),
         )
 
         if outer_apply or cross_apply:

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -496,7 +496,7 @@ FROM cs.telescope.dag_report, TABLE(FLATTEN(input => SPLIT(operators, ','))) AS 
   f.value AS "Contact",
   f1.value['type'] AS "Type",
   f1.value['content'] AS "Details"
-FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') f, LATERAL FLATTEN(input => f.value['business']) f1""",
+FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS f, LATERAL FLATTEN(input => f.value['business']) AS f1""",
             },
             pretty=True,
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -380,6 +380,12 @@ class TestTSQL(Validator):
                 "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL TVFTEST(t.x) y AS z",
             },
         )
+        self.validate_all(
+            "SELECT t.x, y.z FROM x OUTER APPLY a.b.tvfTest(t.x)y(z)",
+            write={
+                "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL a.b.TVFTEST(t.x) y AS z",
+            },
+        )
 
     def test_top(self):
         self.validate_all(

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -371,19 +371,19 @@ class TestTSQL(Validator):
         self.validate_all(
             "SELECT t.x, y.z FROM x CROSS APPLY tvfTest(t.x)y(z)",
             write={
-                "spark": "SELECT t.x, y.z FROM x JOIN LATERAL TVFTEST(t.x) y AS z",
+                "spark": "SELECT t.x, y.z FROM x JOIN LATERAL TVFTEST(t.x) AS y(z)",
             },
         )
         self.validate_all(
             "SELECT t.x, y.z FROM x OUTER APPLY tvfTest(t.x)y(z)",
             write={
-                "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL TVFTEST(t.x) y AS z",
+                "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL TVFTEST(t.x) AS y(z)",
             },
         )
         self.validate_all(
             "SELECT t.x, y.z FROM x OUTER APPLY a.b.tvfTest(t.x)y(z)",
             write={
-                "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL a.b.TVFTEST(t.x) y AS z",
+                "spark": "SELECT t.x, y.z FROM x LEFT JOIN LATERAL a.b.TVFTEST(t.x) AS y(z)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -427,3 +427,17 @@ class TestTSQL(Validator):
         self.validate_all(
             "SELECT FORMAT(num_col, 'c')", write={"spark": "SELECT FORMAT_NUMBER(num_col, 'c')"}
         )
+
+    def test_string(self):
+        self.validate_all(
+            "SELECT N'test'",
+            write={"spark": "SELECT 'test'"},
+        )
+        self.validate_all(
+            "SELECT n'test'",
+            write={"spark": "SELECT 'test'"},
+        )
+        self.validate_all(
+            "SELECT '''test'''",
+            write={"spark": r"SELECT '\'test\''"},
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -85,7 +85,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(len(parse_one("select * from (select 1) x cross join y").args["joins"]), 1)
         self.assertEqual(
             parse_one("""SELECT * FROM x CROSS JOIN y, z LATERAL VIEW EXPLODE(y)""").sql(),
-            """SELECT * FROM x, z LATERAL VIEW EXPLODE(y) CROSS JOIN y""",
+            """SELECT * FROM x, z CROSS JOIN y LATERAL VIEW EXPLODE(y)""",
         )
 
     def test_command(self):


### PR DESCRIPTION
Added a class variable at the parser class to make a distinction between dialects on parsing table or column aliases. This is due to the fact that at postgresql in case of a lateral join on a function, no table alias is expected.

Also changed the order of query modifiers in order to have columns available which can be used at laterals. This also required a fix in a test case in test_parser.py

Also added support for unicode literal strings at T-SQL along with a type translation for DATETIME to TIMESTAMP in Hive.