### PR TITLE
Improve values builder to support names and types

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -22,7 +22,6 @@ from sqlglot.expressions import (
     or_,
     select,
     subquery,
-    DataType,
 )
 from sqlglot.expressions import table_ as table
 from sqlglot.expressions import to_column, to_table, union

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -22,6 +22,7 @@ from sqlglot.expressions import (
     or_,
     select,
     subquery,
+    DataType,
 )
 from sqlglot.expressions import table_ as table
 from sqlglot.expressions import to_column, to_table, union

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3674,9 +3674,9 @@ def table_(table, db=None, catalog=None, quoted=None, alias=None) -> Table:
 
 
 def values(
-    values: t.Sequence[t.Tuple[str | Expression, ...]],
+    values: t.Iterable[t.Tuple[str | Expression, ...]],
     alias: t.Optional[str] = None,
-    columns_and_types: t.Optional[t.List[str | t.Tuple[str, str | DataType]]] = None,
+    columns_and_types: t.Optional[t.Iterable[str | t.Tuple[str, str | DataType]]] = None,
 ) -> Values:
     """Build VALUES statement.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3673,7 +3673,11 @@ def table_(table, db=None, catalog=None, quoted=None, alias=None) -> Table:
     )
 
 
-def values(values, alias=None) -> Values:
+def values(
+    values: t.Sequence[t.Tuple[str | Expression, ...]],
+    alias: t.Optional[str] = None,
+    columns_and_types: t.Optional[t.List[str | t.Tuple[str, str | DataType]]] = None,
+) -> Values:
     """Build VALUES statement.
 
     Example:
@@ -3681,17 +3685,45 @@ def values(values, alias=None) -> Values:
         "VALUES (1, '2')"
 
     Args:
-        values (list[tuple[str | Expression]]): values statements that will be converted to SQL
-        alias (str): optional alias
-        dialect (str): the dialect used to parse the input expression.
-        **opts: other options to use to parse the input expressions.
+        values: values statements that will be converted to SQL
+        alias: optional alias
+        columns_and_types: Optional list of ordered column names or column names and types. If types are provided,
+            they will be used to cast the values. An alias is required when providing column names.
 
     Returns:
         Values: the Values expression object
     """
+    if columns_and_types and not alias:
+        raise ValueError("Alias is required when providing columns_and_types")
+    column_names = []
+    column_types = []
+    if columns_and_types is not None:
+        for column in columns_and_types:
+            if isinstance(column, tuple):
+                column_names.append(to_identifier(column[0]))
+                if isinstance(column[1], str):
+                    column_types.append(DataType.build(column[1]))
+                else:
+                    column_types.append(column[1])
+            else:
+                column_names.append(to_identifier(column))
+    if column_types:
+        casted_rows = []
+        for row in values:
+            casted_columns = []
+            for i, value in enumerate(row):
+                casted_columns.append(Cast(this=convert(value), to=column_types[i]))
+            casted_rows.append(tuple(casted_columns))
+        values = casted_rows
+    expressions = [convert(tup) for tup in values]
+    table_alias = (
+        TableAlias(this=to_identifier(alias), columns=column_names)
+        if column_names
+        else TableAlias(this=to_identifier(alias) if alias else None)
+    )
     return Values(
-        expressions=[convert(tup) for tup in values],
-        alias=to_identifier(alias) if alias else None,
+        expressions=expressions,
+        alias=table_alias,
     )
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -478,20 +478,6 @@ class TestBuild(unittest.TestCase):
                 lambda: exp.values([("1", 2), ("2", 3)], "alias", ["col1", "col2"]),
                 "(VALUES ('1', 2), ('2', 3)) AS alias(col1, col2)",
             ),
-            (
-                lambda: exp.values(
-                    [("1", 2), ("2", 3)], "alias", [("col1", "text"), ("col2", "int")]
-                ),
-                "(VALUES (CAST('1' AS TEXT), CAST(2 AS INT)), (CAST('2' AS TEXT), CAST(3 AS INT))) AS alias(col1, col2)",
-            ),
-            (
-                lambda: exp.values(
-                    [("1", 2), ("2", 3)],
-                    "alias",
-                    [("col1", DataType.build("text")), ("col2", DataType.build("int"))],
-                ),
-                "(VALUES (CAST('1' AS TEXT), CAST(2 AS INT)), (CAST('2' AS TEXT), CAST(3 AS INT))) AS alias(col1, col2)",
-            ),
             (lambda: exp.delete("y", where="x > 1"), "DELETE FROM y WHERE x > 1"),
             (lambda: exp.delete("y", where=exp.and_("x > 1")), "DELETE FROM y WHERE x > 1"),
         ]:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -13,8 +13,8 @@ from sqlglot import (
     parse_one,
     select,
     union,
-    DataType,
 )
+from sqlglot.expressions import DataType
 
 
 class TestBuild(unittest.TestCase):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -14,7 +14,6 @@ from sqlglot import (
     select,
     union,
 )
-from sqlglot.expressions import DataType
 
 
 class TestBuild(unittest.TestCase):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -13,6 +13,7 @@ from sqlglot import (
     parse_one,
     select,
     union,
+    DataType,
 )
 
 
@@ -473,6 +474,24 @@ class TestBuild(unittest.TestCase):
             (lambda: exp.values([("1", 2)]), "VALUES ('1', 2)"),
             (lambda: exp.values([("1", 2)], "alias"), "(VALUES ('1', 2)) AS alias"),
             (lambda: exp.values([("1", 2), ("2", 3)]), "VALUES ('1', 2), ('2', 3)"),
+            (
+                lambda: exp.values([("1", 2), ("2", 3)], "alias", ["col1", "col2"]),
+                "(VALUES ('1', 2), ('2', 3)) AS alias(col1, col2)",
+            ),
+            (
+                lambda: exp.values(
+                    [("1", 2), ("2", 3)], "alias", [("col1", "text"), ("col2", "int")]
+                ),
+                "(VALUES (CAST('1' AS TEXT), CAST(2 AS INT)), (CAST('2' AS TEXT), CAST(3 AS INT))) AS alias(col1, col2)",
+            ),
+            (
+                lambda: exp.values(
+                    [("1", 2), ("2", 3)],
+                    "alias",
+                    [("col1", DataType.build("text")), ("col2", DataType.build("int"))],
+                ),
+                "(VALUES (CAST('1' AS TEXT), CAST(2 AS INT)), (CAST('2' AS TEXT), CAST(3 AS INT))) AS alias(col1, col2)",
+            ),
             (lambda: exp.delete("y", where="x > 1"), "DELETE FROM y WHERE x > 1"),
             (lambda: exp.delete("y", where=exp.and_("x > 1")), "DELETE FROM y WHERE x > 1"),
         ]:


### PR DESCRIPTION
Prior to this change the values builder would only support values with an alias. Now you can provide types and column names. This allows you to create a values expression that will match a desired table definition which includes the column names and types. 

Edit: Removed types support since it would make the expressions too long. Use a subquery if you want to type. 