### PR TITLE
Make values Any

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3674,7 +3674,7 @@ def table_(table, db=None, catalog=None, quoted=None, alias=None) -> Table:
 
 
 def values(
-    values: t.Iterable[t.Tuple[t.Optional[str | Expression], ...]],
+    values: t.Iterable[t.Tuple[t.Any, ...]],
     alias: t.Optional[str] = None,
     columns: t.Optional[t.Iterable[str]] = None,
 ) -> Values:


### PR DESCRIPTION
We use the convert method to cast the values into their static SQL equivalent. Currently this convert function is not typed so just removing the type on this until we type the convert method. 

https://github.com/tobymao/sqlglot/blob/7e627b4c68cb453143d8eccd943efe4cc4b30d09/sqlglot/expressions.py#L3714 