### PR TITLE
Add docs for expressions, minor cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # PyCharm
 .idea/
+
+# Visual Studio Code
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.linting.pylintEnabled": true
-}

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SQLGlot is a no dependency Python SQL parser, transpiler, and optimizer. It can be used to format SQL or translate between different dialects like [DuckDB](https://duckdb.org/), [Presto](https://prestodb.io/), [Spark](https://spark.apache.org/), [Snowflake](https://www.snowflake.com/en/), and [BigQuery](https://cloud.google.com/bigquery/). It aims to read a wide variety of SQL inputs and output syntactically correct SQL in the targeted dialects.
 
-It is a very comprehensive generic SQL parser with a robust [test suite](tests). It is also quite [performant](#benchmarks) while being written purely in Python.
+It is a very comprehensive generic SQL parser with a robust [test suite](https://github.com/tobymao/sqlglot/blob/main/tests/). It is also quite [performant](#benchmarks) while being written purely in Python.
 
 You can easily [customize](#custom-dialects) the parser, [analyze](#metadata) queries, traverse expression trees, and programmatically [build](#build-and-modify-sql) SQL.
 
@@ -272,7 +272,7 @@ transformed_tree.sql()
 
 ### SQL Optimizer
 
-SQLGlot can rewrite queries into an "optimized" form. It performs a variety of [techniques](sqlglot/optimizer/optimizer.py) to create a new canonical AST. This AST can be used to standardize queries or provide the foundations for implementing an actual engine. For example:
+SQLGlot can rewrite queries into an "optimized" form. It performs a variety of [techniques](https://github.com/tobymao/sqlglot/blob/main/sqlglot/optimizer/optimizer.py) to create a new canonical AST. This AST can be used to standardize queries or provide the foundations for implementing an actual engine. For example:
 
 ```python
 import sqlglot
@@ -290,7 +290,7 @@ print(
 )
 ```
 
-```
+```sql
 SELECT
   (
     "x"."A" OR "x"."B" OR "x"."C"
@@ -349,9 +349,11 @@ diff(parse_one("SELECT a + b, c, d"), parse_one("SELECT c, a - b, d"))
 ]
 ```
 
+See also: [Semantic Diff for SQL](https://github.com/tobymao/sqlglot/blob/main/posts/sql_diff.md).
+
 ### Custom Dialects
 
-[Dialects](sqlglot/dialects) can be added by subclassing `Dialect`:
+[Dialects](https://github.com/tobymao/sqlglot/tree/main/sqlglot/dialects) can be added by subclassing `Dialect`:
 
 ```python
 from sqlglot import exp
@@ -389,7 +391,7 @@ class Custom(Dialect):
 print(Dialect["custom"])
 ```
 
-```python
+```
 <class '__main__.Custom'>
 ```
 
@@ -442,7 +444,7 @@ user_id price
 
 ## Benchmarks
 
-[Benchmarks](benchmarks) run on Python 3.10.5 in seconds.
+[Benchmarks](https://github.com/tobymao/sqlglot/blob/main/benchmarks/bench.py) run on Python 3.10.5 in seconds.
 
 |           Query |         sqlglot |        sqlfluff |         sqltree |        sqlparse |  moz_sql_parser |        sqloxide |
 | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- | --------------- |

--- a/pdoc/docs/expressions.md
+++ b/pdoc/docs/expressions.md
@@ -1,0 +1,41 @@
+# Expressions
+
+Every AST node in SQLGlot is represented by a subclass of `Expression`. Each such expression encapsulates any necessary context, such as its child expressions, their names, or arg keys, and whether each child expression is optional or not.
+
+Furthermore, the following attributes are common across all expressions:
+
+#### key
+
+A unique key for each class in the `Expression` hierarchy. This is useful for hashing and representing expressions as strings.
+
+#### args
+
+A dictionary used for mapping child arg keys, to the corresponding expressions. A value in this mapping is usually either a single or a list of `Expression` instances, but SQLGlot doesn't impose any constraints on the actual type of the value.
+
+#### arg_types
+
+A dictionary used for mapping arg keys to booleans that determine whether the corresponding expressions are optional or not. Consider the following example:
+
+```python
+class Limit(Expression):
+    arg_types = {"this": False, "expression": True}
+
+```
+
+Here, `Limit` declares that it expects to have one optional and one required child expression, which can be referenced through `this` and `expression`, correspondingly. The arg keys are generally arbitrary, but there are helper methods for keys like `this`, `expression` and `expressions` that abstract away dictionary lookups and related checks. For this reason, these keys are common throughout SQLGlot's codebase.
+
+#### parent
+
+A reference to the parent expression (may be `None`).
+
+#### arg_key
+
+The arg key an expression is associated with, i.e. the name its parent expression uses to refer to it.
+
+#### comments
+
+A list of comments that are associated with a given expression. This is used in order to preserve comments when transpiling SQL code.
+
+#### type
+
+The data type of an expression, as inferred by SQLGlot's optimizer.

--- a/pdoc/docs/expressions.md
+++ b/pdoc/docs/expressions.md
@@ -22,7 +22,7 @@ class Limit(Expression):
 
 ```
 
-Here, `Limit` declares that it expects to have one optional and one required child expression, which can be referenced through `this` and `expression`, correspondingly. The arg keys are generally arbitrary, but there are helper methods for keys like `this`, `expression` and `expressions` that abstract away dictionary lookups and related checks. For this reason, these keys are common throughout SQLGlot's codebase.
+Here, `Limit` declares that it expects to have one optional and one required child expression, which can be referenced through `this` and `expression`, respectively. The arg keys are generally arbitrary, but there are helper methods for keys like `this`, `expression` and `expressions` that abstract away dictionary lookups and related checks. For this reason, these keys are common throughout SQLGlot's codebase.
 
 #### parent
 

--- a/sqlglot/dataframe/__init__.py
+++ b/sqlglot/dataframe/__init__.py
@@ -1,0 +1,3 @@
+"""
+.. include:: ./README.md
+"""

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -1,3 +1,7 @@
+"""
+.. include:: ../posts/sql_diff.md
+"""
+
 from __future__ import annotations
 
 import typing as t

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1,3 +1,7 @@
+"""
+.. include:: ../pdoc/docs/expressions.md
+"""
+
 from __future__ import annotations
 
 import datetime

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -6,7 +6,7 @@ from sqlglot.optimizer.scope import Scope, traverse_scope
 # Sentinel value that means an outer query selecting ALL columns
 SELECT_ALL = object()
 
-# SELECTION TO USE IF SELECTION LIST IS EMPTY
+# Selection to use if selection list is empty
 DEFAULT_SELECTION = alias("1", "_")
 
 


### PR DESCRIPTION
Wrote a first draft about sqlglot's expressions & did some minor fixes here and there, mostly related to the README.

The idea is to create an index for helper expression methods in a later PR.