### PR TITLE
ARRAY(SELECT ...]) shouldn't use the LIST_VALUE alias for DuckDB.

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -121,7 +121,9 @@ class DuckDB(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,  # type: ignore
             exp.ApproxDistinct: approx_count_distinct_sql,
-            exp.Array: rename_func("LIST_VALUE"),
+            exp.Array: lambda self, e: f"{self.normalize_func('ARRAY')}({self.sql(e.expressions[0])})"
+            if isinstance(seq_get(e.expressions, 0), exp.Select)
+            else rename_func("LIST_VALUE")(self, e),
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySort: _array_sort_sql,
             exp.ArraySum: rename_func("LIST_SUM"),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -302,3 +302,6 @@ class TestDuckDB(Validator):
                 read="duckdb",
                 unsupported_level=ErrorLevel.IMMEDIATE,
             )
+
+    def test_array(self):
+        self.validate_identity("ARRAY(SELECT id FROM t)")


### PR DESCRIPTION
DuckDB's alias for ARRAY is `LIST_VALUE`, *except* when the argument to ARRAY is a `SELECT` expression.

---

#847 fixed the parse error, but this error remained. To demonstrate:

**Passing a SELECT expression:**

```
D WITH t AS (SELECT 1 AS id UNION ALL SELECT 2)
> SELECT ARRAY(SELECT id FROM t);
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (SELECT CASE  WHEN ((array_agg(__subquery.__arr_element) IS NULL)) THEN (list_value()) ELSE array_agg(__subquery.__arr_element) END FROM (SELECT id FROM t) AS __subquery(__arr_element)) │
│                                                                                          int32[]                                                                                          │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ [2, 1]                                                                                                                                                                                    │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
D WITH t AS (SELECT 1 AS id UNION ALL SELECT 2)
> SELECT LIST_VALUE(SELECT id FROM t);
Error: Parser Error: syntax error at or near "SELECT"
LINE 2: SELECT LIST_VALUE(SELECT id FROM t);
```

**Passing a list of args:**

```
D SELECT ARRAY(1, 2, 3);
Error: Parser Error: syntax error at or near "1"
LINE 1: SELECT ARRAY(1, 2, 3);
                     ^
D SELECT LIST_VALUE(1, 2, 3);
┌─────────────────────┐
│ list_value(1, 2, 3) │
│       int32[]       │
├─────────────────────┤
│ [1, 2, 3]           │
└─────────────────────┘
```

