### PR TITLE
`123::CHARACTER VARYING` should parse in DuckDB.

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -83,6 +83,7 @@ class DuckDB(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             ":=": TokenType.EQ,
+            "CHARACTER VARYING": TokenType.VARCHAR,
         }
 
     class Parser(parser.Parser):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -305,3 +305,11 @@ class TestDuckDB(Validator):
 
     def test_array(self):
         self.validate_identity("ARRAY(SELECT id FROM t)")
+
+    def test_cast(self):
+        self.validate_all(
+            "123::CHARACTER VARYING",
+            write={
+                "duckdb": "CAST(123 AS TEXT)",
+            },
+        )


### PR DESCRIPTION
Porting Postgres fix for https://github.com/tobymao/sqlglot/issues/838 to DuckDB.