### PR TITLE
Add a window clause builder to Select.

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1910,9 +1910,7 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def window(
-        self, *expressions, append=True, dialect=None, copy=True, **opts
-    ) -> Select:
+    def window(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
         return _apply_list_builder(
             *expressions,
             instance=self,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1337,7 +1337,7 @@ QUERY_MODIFIERS = {
     "group": False,
     "having": False,
     "qualify": False,
-    "window": False,
+    "windows": False,
     "distribute": False,
     "sort": False,
     "cluster": False,
@@ -1905,6 +1905,20 @@ class Select(Subqueryable):
             arg="having",
             append=append,
             into=Having,
+            dialect=dialect,
+            copy=copy,
+            **opts,
+        )
+
+    def window(
+        self, *expressions, append=True, dialect=None, copy=True, **opts
+    ) -> Select:
+        return _apply_list_builder(
+            *expressions,
+            instance=self,
+            arg="windows",
+            append=append,
+            into=Window,
             dialect=dialect,
             copy=copy,
             **opts,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -402,6 +402,7 @@ class Parser(metaclass=_Parser):
         exp.Ordered: lambda self: self._parse_ordered(),
         exp.Having: lambda self: self._parse_having(),
         exp.With: lambda self: self._parse_with(),
+        exp.Window: lambda self: self._parse_named_window(),
         "JOIN_TYPE": lambda self: self._parse_join_side_and_kind(),
     }
 
@@ -550,8 +551,7 @@ class Parser(metaclass=_Parser):
         "group": lambda self: self._parse_group(),
         "having": lambda self: self._parse_having(),
         "qualify": lambda self: self._parse_qualify(),
-        "windows": lambda self: self._match(TokenType.WINDOW)
-        and self._parse_csv(lambda: self._parse_window(self._parse_id_var(), alias=True)),
+        "windows": lambda self: self._parse_window_clause(),
         "distribute": lambda self: self._parse_sort(TokenType.DISTRIBUTE_BY, exp.Distribute),
         "sort": lambda self: self._parse_sort(TokenType.SORT_BY, exp.Sort),
         "cluster": lambda self: self._parse_sort(TokenType.CLUSTER_BY, exp.Cluster),
@@ -2439,6 +2439,14 @@ class Parser(metaclass=_Parser):
             expression=expression,
             collation=collation,
         )
+
+    def _parse_window_clause(self):
+        return self._match(TokenType.WINDOW) and self._parse_csv(
+            lambda: self._parse_named_window()
+        )
+
+    def _parse_named_window(self):
+        return self._parse_window(self._parse_id_var(), alias=True)
 
     def _parse_window(self, this, alias=False):
         if self._match(TokenType.FILTER):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2441,9 +2441,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_window_clause(self):
-        return self._match(TokenType.WINDOW) and self._parse_csv(
-            lambda: self._parse_named_window()
-        )
+        return self._match(TokenType.WINDOW) and self._parse_csv(lambda: self._parse_named_window())
 
     def _parse_named_window(self):
         return self._parse_window(self._parse_id_var(), alias=True)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -482,11 +482,16 @@ class TestBuild(unittest.TestCase):
             (lambda: exp.delete("y", where="x > 1"), "DELETE FROM y WHERE x > 1"),
             (lambda: exp.delete("y", where=exp.and_("x > 1")), "DELETE FROM y WHERE x > 1"),
             (
-                lambda: select("AVG(a) OVER b").from_("table").window("b AS (PARTITION BY c ORDER BY d)"),
+                lambda: select("AVG(a) OVER b")
+                .from_("table")
+                .window("b AS (PARTITION BY c ORDER BY d)"),
                 "SELECT AVG(a) OVER b FROM table WINDOW b AS (PARTITION BY c ORDER BY d)",
             ),
             (
-                lambda: select("AVG(a) OVER b", "MIN(c) OVER d").from_("table").window("b AS (PARTITION BY e ORDER BY f)").window("d AS (PARTITION BY g ORDER BY h)"),
+                lambda: select("AVG(a) OVER b", "MIN(c) OVER d")
+                .from_("table")
+                .window("b AS (PARTITION BY e ORDER BY f)")
+                .window("d AS (PARTITION BY g ORDER BY h)"),
                 "SELECT AVG(a) OVER b, MIN(c) OVER d FROM table WINDOW b AS (PARTITION BY e ORDER BY f), d AS (PARTITION BY g ORDER BY h)",
             ),
         ]:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -481,6 +481,14 @@ class TestBuild(unittest.TestCase):
             ),
             (lambda: exp.delete("y", where="x > 1"), "DELETE FROM y WHERE x > 1"),
             (lambda: exp.delete("y", where=exp.and_("x > 1")), "DELETE FROM y WHERE x > 1"),
+            (
+                lambda: select("AVG(a) OVER b").from_("table").window("b AS (PARTITION BY c ORDER BY d)"),
+                "SELECT AVG(a) OVER b FROM table WINDOW b AS (PARTITION BY c ORDER BY d)",
+            ),
+            (
+                lambda: select("AVG(a) OVER b", "MIN(c) OVER d").from_("table").window("b AS (PARTITION BY e ORDER BY f)").window("d AS (PARTITION BY g ORDER BY h)"),
+                "SELECT AVG(a) OVER b, MIN(c) OVER d FROM table WINDOW b AS (PARTITION BY e ORDER BY f), d AS (PARTITION BY g ORDER BY h)",
+            ),
         ]:
             with self.subTest(sql):
                 self.assertEqual(expression().sql(dialect[0] if dialect else None), sql)


### PR DESCRIPTION
A few comments about this PR:

* The argument to Select used everywhere else in the code was `windows`, so I updated `QUERY_MODIFIERS` to reflect that.
* I had `window(...)` follow the same pattern as other builders of lists of expressions.
* I needed a parse function that would return one named `Window` expression.
* So I split out `_parse_named_window(...)` for that purpose -- and it's the registered parser for Window expressions. Which might be confusing -- given that window expressions can take a lot of forms.


In the future it might make sense to have `NamedWindow` as a separate expression, or `WindowClause` or something of the sort. Not sure if you want to do that now, or if this is sufficient.