### PR TITLE
Use STRING_AGG instead of GROUP_CONCAT in BigQuery.

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -168,6 +168,7 @@ class BigQuery(Dialect):
             exp.DatetimeAdd: _date_add_sql("DATETIME", "ADD"),
             exp.DatetimeSub: _date_add_sql("DATETIME", "SUB"),
             exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')}, {self.sql(e.args.get('unit', 'DAY'))})",
+            exp.GroupConcat: rename_func("STRING_AGG"),
             exp.ILike: no_ilike_sql,
             exp.IntDiv: rename_func("DIV"),
             exp.StrToTime: lambda self, e: f"PARSE_TIMESTAMP({self.format_time(e)}, {self.sql(e, 'this')})",

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -1,3 +1,5 @@
+"""Supports BigQuery Standard SQL."""
+
 from __future__ import annotations
 
 from sqlglot import exp, generator, parser, tokens

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -318,3 +318,9 @@ class TestBigQuery(Validator):
         self.validate_identity(
             "CREATE TABLE FUNCTION a(x INT64) RETURNS TABLE <q STRING, r INT64> AS SELECT s, t"
         )
+
+    def test_group_concat(self):
+        self.validate_all(
+            "SELECT a, GROUP_CONCAT(b) FROM table GROUP BY a",
+            write={"bigquery": "SELECT a, STRING_AGG(b) FROM table GROUP BY a"},
+        )


### PR DESCRIPTION
For posterity: I added a docstring to the `bigquery` dialect module stating that it is meant to support Standard SQL.

`GROUP_CONCAT` is only supported in BigQuery's Legacy SQL.