### PR TITLE
Support nan values in convert

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import datetime
+import math
 import numbers
 import re
 import typing as t
@@ -3795,6 +3796,8 @@ def convert(value) -> Expression:
         return Boolean(this=value)
     if isinstance(value, str):
         return Literal.string(value)
+    if isinstance(value, float) and math.isnan(value):
+        return NULL
     if isinstance(value, numbers.Number):
         return Literal.number(value)
     if isinstance(value, tuple):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 import unittest
 
 from sqlglot import alias, exp, parse_one
@@ -557,6 +558,7 @@ class TestExpressions(unittest.TestCase):
                 "TIME_STR_TO_TIME('2022-10-01 01:01:01.000000+0000')",
             ),
             (datetime.date(2022, 10, 1), "DATE_STR_TO_DATE('2022-10-01')"),
+            (math.nan, "NULL"),
         ]:
             with self.subTest(value):
                 self.assertEqual(exp.convert(value).sql(), expected)


### PR DESCRIPTION
Prior to this change `nan` values would be translated as `nan` when converted to SQL values but now they will be converted to `NULL`. 