### PR TITLE
[WIP] Unquote columns in Snowflake values

### DIFF
--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -303,7 +303,8 @@ class DataFrame:
         for expression_type, select_expression in select_expressions:
             select_expression = select_expression.transform(replace_id_value, replacement_mapping)
             if optimize:
-                select_expression = optimize_func(select_expression)
+                optimize_kwargs = {"unquote_values_columns": True} if dialect == "snowflake" else {}
+                select_expression = optimize_func(select_expression, **optimize_kwargs)
             select_expression = df._replace_cte_names_with_hashes(select_expression)
             expression: t.Union[exp.Select, exp.Cache, exp.Drop]
             if expression_type == exp.Cache:

--- a/sqlglot/optimizer/quote_identities.py
+++ b/sqlglot/optimizer/quote_identities.py
@@ -22,10 +22,11 @@ def quote_identities(expression, unquote_values_columns=False):
 
     Args:
         expression (sqlglot.Expression): expression to quote
-        unquote_values_columns (bool):
+        unquote_values_columns (bool): Indicates whether to unquote values defined in a VALUES expression.
     Returns:
         sqlglot.Expression: quoted expression
     """
+
     def qualify(node):
         if isinstance(node, exp.Identifier):
             node.set("quoted", True)
@@ -37,17 +38,23 @@ def quote_identities(expression, unquote_values_columns=False):
 
     for scope in traverse_scope(quoted_expression):
         if isinstance(scope.expression, exp.Values):
-            alias = scope.expression.args.get('alias')
+            alias = scope.expression.args.get("alias")
             if not alias:
                 continue
             for column in alias.args.get("columns", []):
                 column.set("quoted", False)
         if isinstance(scope.expression, exp.Select):
-            values_scopes = [scope for scope in scope.sources.values() if isinstance(scope.expression, exp.Values)]
+            values_scopes = [
+                scope
+                for scope in scope.sources.values()
+                if isinstance(scope.expression, exp.Values)
+            ]
             values_columns = []
             for value_scope in values_scopes:
                 values_columns.extend(value_scope.outer_column_list)
-            selected_value_columns = [sel_column for sel_column in scope.columns if sel_column.name in values_columns]
+            selected_value_columns = [
+                sel_column for sel_column in scope.columns if sel_column.name in values_columns
+            ]
             for selected_value_column in selected_value_columns:
                 selected_value_column.this.set("quoted", False)
     return quoted_expression

--- a/sqlglot/optimizer/quote_identities.py
+++ b/sqlglot/optimizer/quote_identities.py
@@ -1,7 +1,8 @@
 from sqlglot import exp
+from sqlglot.optimizer.scope import traverse_scope
 
 
-def quote_identities(expression):
+def quote_identities(expression, unquote_values_columns=False):
     """
     Rewrite sqlglot AST to ensure all identities are quoted.
 
@@ -11,15 +12,42 @@ def quote_identities(expression):
         >>> quote_identities(expression).sql()
         'SELECT "x"."a" AS "a" FROM "db"."x"'
 
+    If `unquote_values_columns` is True then the columns from a derived table VALUES expression
+    are not quoted in the SELECT expression nor the VALUES alias expression:
+        >>> expression = sqlglot.parse_one("SELECT tab.a AS a FROM (VALUES (1)) AS tab(a)")
+        >>> quote_identities(expression, unquote_values_columns=True).sql()
+        'SELECT "tab".a AS "a" FROM (VALUES (1)) AS "tab"(a)'
+
+    `unquote_values_columns` is required for Snowflake.
+
     Args:
         expression (sqlglot.Expression): expression to quote
+        unquote_values_columns (bool):
     Returns:
         sqlglot.Expression: quoted expression
     """
-
     def qualify(node):
         if isinstance(node, exp.Identifier):
             node.set("quoted", True)
         return node
 
-    return expression.transform(qualify, copy=False)
+    quoted_expression = expression.transform(qualify, copy=False)
+    if not unquote_values_columns:
+        return quoted_expression
+
+    for scope in traverse_scope(quoted_expression):
+        if isinstance(scope.expression, exp.Values):
+            alias = scope.expression.args.get('alias')
+            if not alias:
+                continue
+            for column in alias.args.get("columns", []):
+                column.set("quoted", False)
+        if isinstance(scope.expression, exp.Select):
+            values_scopes = [scope for scope in scope.sources.values() if isinstance(scope.expression, exp.Values)]
+            values_columns = []
+            for value_scope in values_scopes:
+                values_columns.extend(value_scope.outer_column_list)
+            selected_value_columns = [sel_column for sel_column in scope.columns if sel_column.name in values_columns]
+            for selected_value_column in selected_value_columns:
+                selected_value_column.this.set("quoted", False)
+    return quoted_expression

--- a/tests/fixtures/optimizer/quote_identities.sql
+++ b/tests/fixtures/optimizer/quote_identities.sql
@@ -6,3 +6,15 @@ SELECT "a" FROM "x";
 
 SELECT x.a AS a FROM db.x;
 SELECT "x"."a" AS "a" FROM "db"."x";
+
+# unquote_values_columns: true
+SELECT x.a AS a FROM (VALUES (1)) AS x(a);
+SELECT "x".a AS "a" FROM (VALUES (1)) AS "x"(a);
+
+# unquote_values_columns: true
+SELECT y.a AS a FROM (SELECT x.a FROM (VALUES (1)) AS x(a)) y;
+SELECT "y"."a" AS "a" FROM (SELECT "x".a FROM (VALUES (1)) AS "x"(a)) AS "y";
+
+# unquote_values_columns: true
+SELECT x.a AS a, y.b AS b FROM (SELECT x.a FROM (VALUES (1)) AS x(a)) x JOIN (VALUES (1)) AS y(b) ON x.a = y.b;
+SELECT "x"."a" AS "a", "y".b AS "b" FROM (SELECT "x".a FROM (VALUES (1)) AS "x"(a)) AS "x" JOIN (VALUES (1)) AS "y"(b) ON "x"."a" = "y".b;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -80,10 +80,13 @@ class TestOptimizer(unittest.TestCase):
             title = meta.get("title") or f"{i}, {sql}"
             dialect = meta.get("dialect")
             leave_tables_isolated = meta.get("leave_tables_isolated")
+            unquote_values_columns = string_to_bool(meta.get("unquote_values_columns"))
 
             func_kwargs = {**kwargs}
             if leave_tables_isolated is not None:
                 func_kwargs["leave_tables_isolated"] = string_to_bool(leave_tables_isolated)
+            if unquote_values_columns:
+                func_kwargs["unquote_values_columns"] = unquote_values_columns
 
             with self.subTest(title):
                 optimized = func(parse_one(sql, read=dialect), **func_kwargs)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -80,13 +80,13 @@ class TestOptimizer(unittest.TestCase):
             title = meta.get("title") or f"{i}, {sql}"
             dialect = meta.get("dialect")
             leave_tables_isolated = meta.get("leave_tables_isolated")
-            unquote_values_columns = string_to_bool(meta.get("unquote_values_columns"))
+            unquote_values_columns = meta.get("unquote_values_columns")
 
             func_kwargs = {**kwargs}
             if leave_tables_isolated is not None:
                 func_kwargs["leave_tables_isolated"] = string_to_bool(leave_tables_isolated)
-            if unquote_values_columns:
-                func_kwargs["unquote_values_columns"] = unquote_values_columns
+            if unquote_values_columns is not None:
+                func_kwargs["unquote_values_columns"] = string_to_bool(unquote_values_columns)
 
             with self.subTest(title):
                 optimized = func(parse_one(sql, read=dialect), **func_kwargs)


### PR DESCRIPTION
For whatever reason, something that I researched more deeply months ago when I wrote this, Snowflake is picky about the columns being quotes in the `VALUES` expression. This breaks the DataFrame API when someone creates a DataFrame from values which can be a common use cases when running tests (less common in production). 

The fix currently in the PR involves two things:
1. Adds an argument to `quote_identities` that allows you to tell it to now quote the columns in `VALUES` expression. 
2. When the DataFrame API generates sql for the snowflake dialect is makes sure to enable not quoting those columns so that way the output is valid.

The problem though is that this approach only fixes the problem for the DataFrame API and also only fixes it when running optimize. Ideally all Snowflake generated `VALUES` SQL would be valid regardless of the context in which it was generated. Looking for feedback on the best way to do this within sqlglot. 