### PR TITLE
Have snowflake generate values columns without quotes

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -115,7 +115,7 @@ def _values_sql(self, expression: exp.Values) -> str:
     if alias:
         for column in alias.args.get("columns", []):
             column.set("quoted", False)
-    return self.values_sql(expression)
+    return self.no_identify(lambda: self.values_sql(expression))
 
 
 def _select_sql(self, expression: exp.Select) -> str:
@@ -136,7 +136,7 @@ def _select_sql(self, expression: exp.Select) -> str:
     for identifier in all_identifiers:
         if identifier in values_identifiers:
             identifier.set("quoted", False)
-    return self.select_sql(expression)
+    return self.no_identify(lambda: self.select_sql(expression))
 
 
 class Snowflake(Dialect):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -278,10 +278,8 @@ class Snowflake(Dialect):
             values_expressions = expression.find_all(exp.Values)
             values_identifiers = set(
                 flatten(
-                    [
-                        v.args.get("alias", exp.Alias()).args.get("columns", [])
-                        for v in values_expressions
-                    ]
+                    v.args.get("alias", exp.Alias()).args.get("columns", [])
+                    for v in values_expressions
                 )
             )
             if values_identifiers:

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -509,3 +509,11 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS f, LATERA
                 "snowflake": "SELECT 1 MINUS SELECT 1",
             },
         )
+
+    def test_values(self):
+        self.validate_all(
+            'SELECT c0, c1 FROM (VALUES (1, 2), (3, 4)) AS "t0"(c0, c1)',
+            read={
+                "spark": "SELECT `c0`, `c1` FROM (VALUES (1, 2), (3, 4)) AS `t0`(`c0`, `c1`)",
+            },
+        )


### PR DESCRIPTION
Snowflake has a bug (I created a ticket) where it can't execute table aliases for VALUES expressions that have quotes around the column names. Since the usage of quotes has to be consistent that also means you can't quote these columns when you reference them throughout your query.

This PR changes the Snowflake generator so that way it properly unquotes these columns.