### PR TITLE
Transpile DATEDIFF to postgres

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -54,7 +54,7 @@ def _date_diff_sql(self, expression):
     if factor is not None:
         return f"CAST(EXTRACT(epoch FROM {end} - {start}){factor} AS BIGINT)"
 
-    age = f"age({end}, {start})"
+    age = f"AGE({end}, {start})"
 
     if unit == "WEEK":
         extract = f"EXTRACT(year FROM {age}) * 48 + EXTRACT(month FROM {age}) * 4 + EXTRACT(day FROM {age}) / 7"

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -12,6 +12,48 @@ class TestDatabricks(Validator):
                 "databricks": "SELECT DATEDIFF(year, 'start', 'end')",
             },
         )
+        self.validate_all(
+            "SELECT DATEDIFF(microsecond, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(microsecond, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) * 1000000 AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(millisecond, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(millisecond, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) * 1000 AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(second, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(second, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(minute, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(minute, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) / 60 AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(hour, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(hour, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) / 3600 AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(day, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(day, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) / 86400 AS BIGINT)",
+            },
+        )
 
     def test_add_date(self):
         self.validate_all(

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -54,6 +54,34 @@ class TestDatabricks(Validator):
                 "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST('end' AS TIMESTAMP) - CAST('start' AS TIMESTAMP)) / 86400 AS BIGINT)",
             },
         )
+        self.validate_all(
+            "SELECT DATEDIFF(week, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(week, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 48 + EXTRACT(month FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 4 + EXTRACT(day FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) / 7 AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(month, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(month, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 12 + EXTRACT(month FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(quarter, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(quarter, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 4 + EXTRACT(month FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) / 3 AS BIGINT)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF(year, 'start', 'end')",
+            write={
+                "databricks": "SELECT DATEDIFF(year, 'start', 'end')",
+                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) AS BIGINT)",
+            },
+        )
 
     def test_add_date(self):
         self.validate_all(

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -58,28 +58,28 @@ class TestDatabricks(Validator):
             "SELECT DATEDIFF(week, 'start', 'end')",
             write={
                 "databricks": "SELECT DATEDIFF(week, 'start', 'end')",
-                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 48 + EXTRACT(month FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 4 + EXTRACT(day FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) / 7 AS BIGINT)",
+                "postgres": "SELECT CAST(EXTRACT(year FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 48 + EXTRACT(month FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 4 + EXTRACT(day FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) / 7 AS BIGINT)",
             },
         )
         self.validate_all(
             "SELECT DATEDIFF(month, 'start', 'end')",
             write={
                 "databricks": "SELECT DATEDIFF(month, 'start', 'end')",
-                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 12 + EXTRACT(month FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) AS BIGINT)",
+                "postgres": "SELECT CAST(EXTRACT(year FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 12 + EXTRACT(month FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) AS BIGINT)",
             },
         )
         self.validate_all(
             "SELECT DATEDIFF(quarter, 'start', 'end')",
             write={
                 "databricks": "SELECT DATEDIFF(quarter, 'start', 'end')",
-                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 4 + EXTRACT(month FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) / 3 AS BIGINT)",
+                "postgres": "SELECT CAST(EXTRACT(year FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) * 4 + EXTRACT(month FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) / 3 AS BIGINT)",
             },
         )
         self.validate_all(
             "SELECT DATEDIFF(year, 'start', 'end')",
             write={
                 "databricks": "SELECT DATEDIFF(year, 'start', 'end')",
-                "postgres": "SELECT CAST(EXTRACT(year FROM age(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) AS BIGINT)",
+                "postgres": "SELECT CAST(EXTRACT(year FROM AGE(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP))) AS BIGINT)",
             },
         )
 


### PR DESCRIPTION
This is a WIP -- thought I'd start a PR early to get some feedback and iterate faster. The units "week", "month", "quarter" and "year" are currently missing from the implementation, but I'll add them soon. I'm trying to figure out how to reduce code duplication as much as possible for them.

Regarding my current approach, I'm unsure whether hardcoding the mult / div operators as strings is the way to go. An alternative could be to return a tuple that contains the factor and a flag that determines whether to multiply or to divide, although it's not necessary cleaner.

cc: @tobymao 