### PR TITLE
Add support for parsing stdin in CLI

### DIFF
--- a/sqlglot/__main__.py
+++ b/sqlglot/__main__.py
@@ -1,9 +1,15 @@
 import argparse
+import sys
 
 import sqlglot
 
 parser = argparse.ArgumentParser(description="Transpile SQL")
-parser.add_argument("sql", metavar="sql", type=str, help="SQL string to transpile")
+parser.add_argument(
+    "sql",
+    metavar="sql",
+    type=str,
+    help="SQL statement(s) to transpile, or - to parse stdin.",
+)
 parser.add_argument(
     "--read",
     dest="read",
@@ -48,14 +54,20 @@ parser.add_argument(
 args = parser.parse_args()
 error_level = sqlglot.ErrorLevel[args.error_level.upper()]
 
+sql = sys.stdin.read() if args.sql == "-" else args.sql
+
 if args.parse:
     sqls = [
         repr(expression)
-        for expression in sqlglot.parse(args.sql, read=args.read, error_level=error_level)
+        for expression in sqlglot.parse(
+            sql,
+            read=args.read,
+            error_level=error_level,
+        )
     ]
 else:
     sqls = sqlglot.transpile(
-        args.sql,
+        sql,
         read=args.read,
         write=args.write,
         identify=args.identify,


### PR DESCRIPTION
Hey! The CLI is missing a way to read files or output from other tools, which is essential for my use case (statements with hundreds of LOC). My contribution is a pretty low effort way to add it.

I decided to use `-` as a sentinel value [1] to indicate that the CLI should parse the stdin instead of argv for two reasons:
1. It's an established convention in many of GNU coreutil tools [2].
2. I don't think there's a dialect for which `-` would parse successfully.

[1] https://en.wikipedia.org/wiki/Sentinel_value
[2] https://www.gnu.org/software/coreutils/manual/coreutils.html#Common-options