### PR TITLE
Add support for describe with kind

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -112,7 +112,7 @@ def _datatype_sql(self, expression):
 
 
 def _describe_with_kind_sql(self, expression):
-    kind_value = expression.args["kind"]
+    kind_value = expression.args.get("kind")
     kind = f" {kind_value}" if kind_value else ""
     this = f" {self.sql(expression, 'this')}"
     return f"DESCRIBE{kind}{this}"

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -296,7 +296,8 @@ class Snowflake(Dialect):
             return super().select_sql(expression)
 
         def describe_sql(self, expression: exp.Describe) -> str:
-            kind_value = expression.args.get("kind")
+            # Default to table if kind is unknown
+            kind_value = expression.args.get("kind") or "TABLE"
             kind = f" {kind_value}" if kind_value else ""
             this = f" {self.sql(expression, 'this')}"
             return f"DESCRIBE{kind}{this}"

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -111,13 +111,6 @@ def _datatype_sql(self, expression):
     return self.datatype_sql(expression)
 
 
-def _describe_with_kind_sql(self, expression):
-    kind_value = expression.args.get("kind")
-    kind = f" {kind_value}" if kind_value else ""
-    this = f" {self.sql(expression, 'this')}"
-    return f"DESCRIBE{kind}{this}"
-
-
 class Snowflake(Dialect):
     null_ordering = "nulls_are_large"
     time_format = "'yyyy-mm-dd hh24:mi:ss'"
@@ -220,7 +213,6 @@ class Snowflake(Dialect):
             exp.ArrayConcat: rename_func("ARRAY_CAT"),
             exp.DateStrToDate: datestrtodate_sql,
             exp.DataType: _datatype_sql,
-            exp.Describe: _describe_with_kind_sql,
             exp.If: rename_func("IFF"),
             exp.Map: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
@@ -302,3 +294,9 @@ class Snowflake(Dialect):
                 )
                 return self.no_identify(lambda: super(self.__class__, self).select_sql(expression))
             return super().select_sql(expression)
+
+        def describe_sql(self, expression: exp.Describe) -> str:
+            kind_value = expression.args.get("kind")
+            kind = f" {kind_value}" if kind_value else ""
+            this = f" {self.sql(expression, 'this')}"
+            return f"DESCRIBE{kind}{this}"

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -111,6 +111,13 @@ def _datatype_sql(self, expression):
     return self.datatype_sql(expression)
 
 
+def _describe_with_kind_sql(self, expression):
+    kind_value = expression.args["kind"]
+    kind = f" {kind_value}" if kind_value else ""
+    this = f" {self.sql(expression, 'this')}"
+    return f"DESCRIBE{kind}{this}"
+
+
 class Snowflake(Dialect):
     null_ordering = "nulls_are_large"
     time_format = "'yyyy-mm-dd hh24:mi:ss'"
@@ -213,6 +220,7 @@ class Snowflake(Dialect):
             exp.ArrayConcat: rename_func("ARRAY_CAT"),
             exp.DateStrToDate: datestrtodate_sql,
             exp.DataType: _datatype_sql,
+            exp.Describe: _describe_with_kind_sql,
             exp.If: rename_func("IFF"),
             exp.Map: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -635,7 +635,7 @@ class Create(Expression):
 
 
 class Describe(Expression):
-    pass
+    arg_types = {"this": True, "kind": False}
 
 
 class Set(Expression):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -419,6 +419,7 @@ class Parser(metaclass=_Parser):
         TokenType.COMMIT: lambda self: self._parse_commit_or_rollback(),
         TokenType.CREATE: lambda self: self._parse_create(),
         TokenType.DELETE: lambda self: self._parse_delete(),
+        TokenType.DESC: lambda self: self._parse_describe(),
         TokenType.DESCRIBE: lambda self: self._parse_describe(),
         TokenType.DROP: lambda self: self._parse_drop(),
         TokenType.END: lambda self: self._parse_commit_or_rollback(),
@@ -982,10 +983,8 @@ class Parser(metaclass=_Parser):
 
     def _parse_describe(self):
         kind = self._match_set(self.CREATABLES) and self._prev.text
-        this = self._parse_id_var()
+        this = self._parse_table()
 
-        while self._match(TokenType.DOT):
-            this = self.expression(exp.Dot, this=this, expression=self._parse_id_var())
         return self.expression(exp.Describe, this=this, kind=kind)
 
     def _parse_insert(self):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -981,8 +981,12 @@ class Parser(metaclass=_Parser):
         return None
 
     def _parse_describe(self):
-        self._match(TokenType.TABLE)
-        return self.expression(exp.Describe, this=self._parse_id_var())
+        kind = self._match_set(self.CREATABLES) and self._prev.text
+        this = self._parse_id_var()
+
+        while self._match(TokenType.DOT):
+            this = self.expression(exp.Dot, this=this, expression=self._parse_id_var())
+        return self.expression(exp.Describe, this=this, kind=kind)
 
     def _parse_insert(self):
         overwrite = self._match(TokenType.OVERWRITE)

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -535,8 +535,21 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS f, LATERA
         self.validate_all(
             "DESCRIBE db.table",
             write={
-                # This is invalid Snowflake SQL but the input is imprecise
-                "snowflake": "DESCRIBE db.table",
+                "snowflake": "DESCRIBE TABLE db.table",
+                "spark": "DESCRIBE db.table",
+            },
+        )
+        self.validate_all(
+            "DESC TABLE db.table",
+            write={
+                "snowflake": "DESCRIBE TABLE db.table",
+                "spark": "DESCRIBE db.table",
+            },
+        )
+        self.validate_all(
+            "DESC VIEW db.table",
+            write={
+                "snowflake": "DESCRIBE VIEW db.table",
                 "spark": "DESCRIBE db.table",
             },
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -523,3 +523,20 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS f, LATERA
                 "spark": "SELECT `c0`, `c1` FROM (VALUES (1, 2), (3, 4)) AS `t0`(`c0`, `c1`)",
             },
         )
+
+    def test_describe_table(self):
+        self.validate_all(
+            "DESCRIBE TABLE db.table",
+            write={
+                "snowflake": "DESCRIBE TABLE db.table",
+                "spark": "DESCRIBE db.table",
+            },
+        )
+        self.validate_all(
+            "DESCRIBE db.table",
+            write={
+                # This is invalid Snowflake SQL but the input is imprecise
+                "snowflake": "DESCRIBE db.table",
+                "spark": "DESCRIBE db.table",
+            },
+        )


### PR DESCRIPTION
Snowflake requires that `DESCRIBE TABLE <target>` be used instead of `DESCRIBE <target>`. Therefore I added a `kind` to describe to capture this input if provided. Prior to this change `DESCRIBE TABLE <target>` would have a parsing error. 

If kind is not provided then we will generate incorrect Snowflake SQL by generating `DESCRIBE <target>` but since kind isn't provided we would have to guess at the kind so this feels like the best option. 