### PR TITLE
Schema normalization: lower() column names if not quoted

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,13 +283,13 @@ print(
 ```sql
 SELECT
   (
-    "x"."A" OR "x"."B" OR "x"."C"
+    "x"."a" OR "x"."b" OR "x"."c"
   ) AND (
-    "x"."A" OR "x"."B" OR "x"."D"
+    "x"."a" OR "x"."b" OR "x"."d"
   ) AS "_col_0"
 FROM "x" AS "x"
 WHERE
-  "x"."Z" = CAST('2021-02-01' AS DATE)
+  CAST("x"."z" AS DATE) = CAST('2021-02-01' AS DATE)
 ```
 
 ### AST Introspection

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -15,7 +15,7 @@ from sqlglot.optimizer.pushdown_projections import pushdown_projections
 from sqlglot.optimizer.qualify_columns import qualify_columns
 from sqlglot.optimizer.qualify_tables import qualify_tables
 from sqlglot.optimizer.unnest_subqueries import unnest_subqueries
-from sqlglot.schema import AbstractMappingSchema, ensure_schema
+from sqlglot.schema import ensure_schema
 
 RULES = (
     lower_identities,
@@ -58,10 +58,6 @@ def optimize(expression, schema=None, db=None, catalog=None, rules=RULES, **kwar
         sqlglot.Expression: optimized expression
     """
     schema = ensure_schema(schema or sqlglot.schema)
-
-    if isinstance(schema, AbstractMappingSchema):
-        schema.normalize()
-
     possible_kwargs = {"db": db, "catalog": catalog, "schema": schema, **kwargs}
     expression = expression.copy()
     for rule in rules:

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -15,6 +15,7 @@ from sqlglot.optimizer.pushdown_projections import pushdown_projections
 from sqlglot.optimizer.qualify_columns import qualify_columns
 from sqlglot.optimizer.qualify_tables import qualify_tables
 from sqlglot.optimizer.unnest_subqueries import unnest_subqueries
+from sqlglot.schema import AbstractMappingSchema, ensure_schema
 
 RULES = (
     lower_identities,
@@ -56,7 +57,12 @@ def optimize(expression, schema=None, db=None, catalog=None, rules=RULES, **kwar
     Returns:
         sqlglot.Expression: optimized expression
     """
-    possible_kwargs = {"db": db, "catalog": catalog, "schema": schema or sqlglot.schema, **kwargs}
+    schema = ensure_schema(schema or sqlglot.schema)
+
+    if isinstance(schema, AbstractMappingSchema):
+        schema.normalize()
+
+    possible_kwargs = {"db": db, "catalog": catalog, "schema": schema, **kwargs}
     expression = expression.copy()
     for rule in rules:
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -193,7 +193,7 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
                 column = sqlglot.parse_one(column_name, read=self.dialect, into=exp.Identifier)  # type: ignore
                 assert isinstance(column, exp.Identifier)
 
-                normalized_name = column.sql()
+                normalized_name = column.sql(dialect=self.dialect)
                 if not column.quoted:
                     normalized_name = normalized_name.lower()
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -161,7 +161,7 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
         self.dialect = dialect
         self.visible = visible or {}
         self._type_mapping_cache: t.Dict[str, exp.DataType] = {}
-        super().__init__(self.normalize(schema or {}))
+        super().__init__(self._normalize(schema or {}))
 
     @classmethod
     def from_mapping_schema(cls, mapping_schema: MappingSchema) -> MappingSchema:
@@ -181,7 +181,7 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
             }
         )
 
-    def normalize(self, schema: t.Dict) -> t.Dict:
+    def _normalize(self, schema: t.Dict) -> t.Dict:
         """
         Converts all identifiers in the schema into lowercase, unless they're quoted.
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -181,7 +181,7 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
             }
         )
 
-    def normalize(self, schema: dict) -> dict:
+    def normalize(self, schema: t.Dict) -> t.Dict:
         """
         Converts all identifiers in the schema into lowercase, unless they're quoted.
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -190,7 +190,7 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
             assert columns is not None
 
             for column_name, column_type in columns.items():
-                column: exp.Identifier = sqlglot.parse_one(
+                column: t.Optional[exp.Identifier] = sqlglot.parse_one(
                     column_name, read=self.dialect, into=exp.Identifier  # type: ignore
                 )
                 assert column is not None

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -190,10 +190,8 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
             assert columns is not None
 
             for column_name, column_type in columns.items():
-                column: t.Optional[exp.Identifier] = sqlglot.parse_one(
-                    column_name, read=self.dialect, into=exp.Identifier  # type: ignore
-                )
-                assert column is not None
+                column = sqlglot.parse_one(column_name, read=self.dialect, into=exp.Identifier)  # type: ignore
+                assert isinstance(column, exp.Identifier)
 
                 normalized_name = column.sql()
                 if not column.quoted:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -187,12 +187,12 @@ class TestSchema(unittest.TestCase):
 
     def test_schema_normalization(self):
         schema = MappingSchema(
-            schema={"x": {"y": {"z": {"a": "INT", "`B`": "VARCHAR"}, "w": {"C": "INT"}}}},
+            schema={"x": {"`y`": {"Z": {"a": "INT", "`B`": "VARCHAR"}, "w": {"C": "INT"}}}},
             dialect="spark",
         )
 
-        table_z = exp.Table(this="z", db="y", catalog="x")
-        table_w = exp.Table(this="w", db="y", catalog="x")
+        table_z = exp.Table(this="z", db="`y`", catalog="x")
+        table_w = exp.Table(this="w", db="`y`", catalog="x")
 
         self.assertEqual(schema.column_names(table_z), ["a", "`B`"])
         self.assertEqual(schema.column_names(table_w), ["c"])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -191,5 +191,4 @@ class TestSchema(unittest.TestCase):
         )
         expected_mapping = {"x": {"y": {"z": {"a": "INT", '"B"': "VARCHAR"}, "w": {"c": "INT"}}}}
 
-        schema.normalize()
         self.assertEqual(schema.mapping, expected_mapping)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -186,9 +186,10 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(schema.get_column_type("foo", "bar").this, exp.DataType.Type.INT)
 
     def test_schema_normalization(self):
-        schema = ensure_schema(
-            {"x": {"y": {"z": {"a": "INT", '"B"': "VARCHAR"}, "w": {"C": "INT"}}}}
+        schema = MappingSchema(
+            schema={"x": {"y": {"z": {"a": "INT", "`B`": "VARCHAR"}, "w": {"C": "INT"}}}},
+            dialect="spark",
         )
-        expected_mapping = {"x": {"y": {"z": {"a": "INT", '"B"': "VARCHAR"}, "w": {"c": "INT"}}}}
+        expected_mapping = {"x": {"y": {"z": {"a": "INT", "`B`": "VARCHAR"}, "w": {"c": "INT"}}}}
 
         self.assertEqual(schema.mapping, expected_mapping)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -190,6 +190,6 @@ class TestSchema(unittest.TestCase):
             schema={"x": {"y": {"z": {"a": "INT", "`B`": "VARCHAR"}, "w": {"C": "INT"}}}},
             dialect="spark",
         )
-        expected_mapping = {"x": {"y": {"z": {"a": "INT", "`B`": "VARCHAR"}, "w": {"c": "INT"}}}}
 
-        self.assertEqual(schema.mapping, expected_mapping)
+        self.assertEqual(schema.column_names("z"), ["a", "`B`"])
+        self.assertEqual(schema.column_names("w"), ["c"])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -191,9 +191,12 @@ class TestSchema(unittest.TestCase):
             dialect="spark",
         )
 
-        self.assertEqual(schema.column_names("z"), ["a", "`B`"])
-        self.assertEqual(schema.column_names("w"), ["c"])
+        table_z = exp.Table(this="z", db="y", catalog="x")
+        table_w = exp.Table(this="w", db="y", catalog="x")
+
+        self.assertEqual(schema.column_names(table_z), ["a", "`B`"])
+        self.assertEqual(schema.column_names(table_w), ["c"])
 
         # Clickhouse supports both `` and "" for identifier quotes; sqlglot uses "" when generating sql
         schema = MappingSchema(schema={"x": {"`y`": "INT"}}, dialect="clickhouse")
-        self.assertEqual(schema.column_names("x"), ['"y"'])
+        self.assertEqual(schema.column_names(exp.Table(this="x")), ['"y"'])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -184,3 +184,12 @@ class TestSchema(unittest.TestCase):
 
         schema = MappingSchema({"foo": {"bar": parse_one("INT", into=exp.DataType)}})
         self.assertEqual(schema.get_column_type("foo", "bar").this, exp.DataType.Type.INT)
+
+    def test_schema_normalization(self):
+        schema = ensure_schema(
+            {"x": {"y": {"z": {"a": "INT", '"B"': "VARCHAR"}, "w": {"C": "INT"}}}}
+        )
+        expected_mapping = {"x": {"y": {"z": {"a": "INT", '"B"': "VARCHAR"}, "w": {"c": "INT"}}}}
+
+        schema.normalize()
+        self.assertEqual(schema.mapping, expected_mapping)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -193,3 +193,7 @@ class TestSchema(unittest.TestCase):
 
         self.assertEqual(schema.column_names("z"), ["a", "`B`"])
         self.assertEqual(schema.column_names("w"), ["c"])
+
+        # Clickhouse supports both `` and "" for identifier quotes; sqlglot uses "" when generating sql
+        schema = MappingSchema(schema={"x": {"`y`": "INT"}}, dialect="clickhouse")
+        self.assertEqual(schema.column_names("x"), ['"y"'])


### PR DESCRIPTION
This PR introduces a way to normalize schemas, by converting their column's names to lowercase, unless they're quoted. The problem it aims to fix is the following:

In the current main branch, the optimizer fails for the query below due to the inconsistency between schema column names and those produced by the `lower_identities` rule in the optimizer.

```python
import sqlglot
from sqlglot.optimizer import optimize

print(
    optimize(
        sqlglot.parse_one("""
            SELECT A OR (B OR (C AND D))
            FROM x
            WHERE Z = date '2021-01-01' + INTERVAL '1' month OR 1 = 0
        """),
        schema={"x": {"A": "INT", "B": "INT", "C": "INT", "D": "INT", "Z": "STRING"}}
    ).sql(pretty=True)
)
```