### PR TITLE
Add python type hints to parser.py

### DIFF
--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -131,7 +131,7 @@ def subclasses(
     ]
 
 
-def apply_index_offset(expressions: t.List[E], offset: int) -> t.List[E]:
+def apply_index_offset(expressions: t.List[t.Optional[E]], offset: int) -> t.List[t.Optional[E]]:
     """
     Applies an offset to a given integer literal expression.
 
@@ -148,10 +148,10 @@ def apply_index_offset(expressions: t.List[E], offset: int) -> t.List[E]:
 
     expression = expressions[0]
 
-    if expression.is_int:
+    if expression and expression.is_int:
         expression = expression.copy()
         logger.warning("Applying array index offset (%s)", offset)
-        expression.args["this"] = str(int(expression.this) + offset)
+        expression.args["this"] = str(int(expression.this) + offset)  # type: ignore
         return [expression]
 
     return expressions

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -675,8 +675,8 @@ class Parser(metaclass=_Parser):
     ) -> t.List[t.Optional[exp.Expression]]:
         """
         Parses a list of tokens into a given Expression type. If a collection of Expression
-        types is given instead, this method will try to parse the token list into one each
-        of them, stopping at the first one for which the parsing succeeds.
+        types is given instead, this method will try to parse the token list into each one
+        of them, stopping at the first for which the parsing succeeds.
 
         Args:
             expression_types: the expression type(s) to try and parse the token list into.

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -806,7 +806,7 @@ class Parser(metaclass=_Parser):
 
         Args:
             expression: the expression to validate.
-            args: an optional list of items that was used to instantiate the expression, if it's is Func.
+            args: an optional list of items that was used to instantiate the expression, if it's a Func.
         """
         if self.error_level == ErrorLevel.IGNORE:
             return

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -702,7 +702,10 @@ class Parser(metaclass=_Parser):
         ) from errors[-1]
 
     def _parse(
-        self, parse_method: t.Callable, raw_tokens: t.List[Token], sql: t.Optional[str] = None
+        self,
+        parse_method: t.Callable[[Parser], t.Optional[exp.Expression]],
+        raw_tokens: t.List[Token],
+        sql: t.Optional[str] = None,
     ) -> t.List[t.Optional[exp.Expression]]:
         self.reset()
         self.sql = sql or ""
@@ -772,7 +775,7 @@ class Parser(metaclass=_Parser):
         self.errors.append(error)
 
     def expression(
-        self, exp_class: exp._Expression, comments: t.Optional[t.List[str]] = None, **kwargs
+        self, exp_class: t.Type[exp.Expression], comments: t.Optional[t.List[str]] = None, **kwargs
     ) -> exp.Expression:
         """
         Creates a new, validated Expression.
@@ -987,7 +990,7 @@ class Parser(metaclass=_Parser):
 
         return None
 
-    def _parse_property_assignment(self, exp_class: exp._Expression) -> exp.Expression:
+    def _parse_property_assignment(self, exp_class: t.Type[exp.Expression]) -> exp.Expression:
         self._match(TokenType.EQ)
         self._match(TokenType.ALIAS)
         return self.expression(
@@ -1753,7 +1756,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_sort(
-        self, token_type: TokenType, exp_class: exp._Expression
+        self, token_type: TokenType, exp_class: t.Type[exp.Expression]
     ) -> t.Optional[exp.Expression]:
         if not self._match(token_type):
             return None


### PR DESCRIPTION
I made an attempt to add some type hints to the parser module. The "match" methods haven't been typed yet, because they cause a lot of errors. I may take another pass and see if I can type them too.

I've probably made some mistakes since there were a lot of changes involved, so please let me know if you find anything and I'll try to fix it.

On a side note: I'm not sure if the ROI is worth it for adding python types, in the end. It might be good for some other modules, but for the parser it didn't feel natural; returning the most general type "Expression" for most methods doesn't provide much information. Thoughts on this? (Besides that, it's definitely a frustrating process :-))