### PR TITLE
Fix: hive/spark identifiers can now begin with a digit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
             "black",
             "duckdb",
             "isort",
-            "mypy",
+            "mypy>=0.990",
             "pandas",
             "pyspark",
             "python-dateutil",

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -175,14 +175,6 @@ class Hive(Dialect):
         ESCAPES = ["\\"]
         ENCODE = "utf-8"
 
-        NUMERIC_LITERALS = {
-            "L": "BIGINT",
-            "S": "SMALLINT",
-            "Y": "TINYINT",
-            "D": "DOUBLE",
-            "F": "FLOAT",
-            "BD": "DECIMAL",
-        }
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "ADD ARCHIVE": TokenType.COMMAND,
@@ -193,6 +185,17 @@ class Hive(Dialect):
             "ADD JARS": TokenType.COMMAND,
             "WITH SERDEPROPERTIES": TokenType.SERDE_PROPERTIES,
         }
+
+        NUMERIC_LITERALS = {
+            "L": "BIGINT",
+            "S": "SMALLINT",
+            "Y": "TINYINT",
+            "D": "DOUBLE",
+            "F": "FLOAT",
+            "BD": "DECIMAL",
+        }
+
+        IDENTIFIER_CAN_START_WITH_DIGIT = True
 
     class Parser(parser.Parser):
         STRICT_CAST = False

--- a/sqlglot/serde.py
+++ b/sqlglot/serde.py
@@ -4,8 +4,9 @@ import typing as t
 
 from sqlglot import expressions as exp
 
-JSON = t.Union[dict, list, str, float, int, bool]
-Node = t.Union[t.List["Node"], exp.DataType.Type, exp.Expression, JSON]
+if t.TYPE_CHECKING:
+    JSON = t.Union[dict, list, str, float, int, bool]
+    Node = t.Union[t.List["Node"], exp.DataType.Type, exp.Expression, JSON]
 
 
 def dump(node: Node) -> JSON:

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -339,6 +339,12 @@ class TestHive(Validator):
 
     def test_hive(self):
         self.validate_all(
+            "SELECT A.1a AS b FROM test_a AS A",
+            write={
+                "spark": "SELECT A.1a AS b FROM test_a AS A",
+            },
+        )
+        self.validate_all(
             "PERCENTILE(x, 0.5)",
             write={
                 "duckdb": "QUANTILE(x, 0.5)",


### PR DESCRIPTION
Fixes #916 