### PR TITLE
BigQuery Fixes

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from sqlglot import exp, generator, parser, tokens
+from sqlglot import exp, generator, parser, tokens, transforms
 from sqlglot.dialects.dialect import (
     Dialect,
     datestrtodate_sql,
@@ -46,6 +46,7 @@ def _date_add_sql(data_type, kind):
 
 def _derived_table_values_to_unnest(self, expression):
     if not isinstance(expression.unnest().parent, exp.From):
+        expression = transforms.remove_precision_parameterized_types(expression)
         return self.values_sql(expression)
     rows = [tuple_exp.expressions for tuple_exp in expression.find_all(exp.Tuple)]
     structs = []
@@ -166,6 +167,7 @@ class BigQuery(Dialect):
     class Generator(generator.Generator):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,  # type: ignore
+            **transforms.REMOVE_PRECISION_PARAMETERIZED_TYPES,  # type: ignore
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.DateAdd: _date_add_sql("DATE", "ADD"),
             exp.DateSub: _date_add_sql("DATE", "SUB"),

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -47,7 +47,7 @@ def _date_add_sql(data_type, kind):
 def _derived_table_values_to_unnest(self, expression):
     if not isinstance(expression.unnest().parent, exp.From):
         return self.values_sql(expression)
-    rows = [list(tuple_exp.find_all(exp.Literal)) for tuple_exp in expression.find_all(exp.Tuple)]
+    rows = [tuple_exp.expressions for tuple_exp in expression.find_all(exp.Tuple)]
     structs = []
     for row in rows:
         aliases = [

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3785,7 +3785,7 @@ def values(
         types = list(columns.values())
         expressions[0].set(
             "expressions",
-            tuple(Cast(this=x, to=types[i]) for i, x in enumerate(expressions[0].expressions)),
+            [Cast(this=x, to=types[i]) for i, x in enumerate(expressions[0].expressions)],
         )
     return Values(
         expressions=expressions,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3754,7 +3754,7 @@ def table_(table, db=None, catalog=None, quoted=None, alias=None) -> Table:
 def values(
     values: t.Iterable[t.Tuple[t.Any, ...]],
     alias: t.Optional[str] = None,
-    columns: t.Optional[t.Iterable[str] | t.OrderedDict[str, DataType]] = None,
+    columns: t.Optional[t.Iterable[str] | t.Dict[str, DataType]] = None,
 ) -> Values:
     """Build VALUES statement.
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -87,8 +87,7 @@ def remove_precision_parameterized_types(expression: exp.Expression) -> exp.Expr
     Some dialects only allow the precision for parameterized types to be defined in the DDL and not in other expressions.
     This transforms removes the precision from parameterized types in expressions.
     """
-    expression = expression.copy()
-    expression = expression.transform(
+    return expression.transform(
         lambda node: exp.DataType(
             **{
                 **node.args,
@@ -102,8 +101,6 @@ def remove_precision_parameterized_types(expression: exp.Expression) -> exp.Expr
         if isinstance(node, exp.DataType)
         else node,
     )
-
-    return expression
 
 
 def preprocess(

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -89,10 +89,20 @@ def remove_precision_parameterized_types(expression: exp.Expression) -> exp.Expr
     """
     expression = expression.copy()
     expression = expression.transform(
-        lambda node: exp.DataType(**{**node.args, "expressions": None})
+        lambda node: exp.DataType(
+            **{
+                **node.args,
+                "expressions": [
+                    node_expression
+                    for node_expression in node.expressions
+                    if isinstance(node_expression, exp.DataType)
+                ],
+            }
+        )
         if isinstance(node, exp.DataType)
         else node,
     )
+
     return expression
 
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -136,5 +136,5 @@ def delegate(attr: str) -> t.Callable:
 UNALIAS_GROUP = {exp.Group: preprocess([unalias_group], delegate("group_sql"))}
 ELIMINATE_DISTINCT_ON = {exp.Select: preprocess([eliminate_distinct_on], delegate("select_sql"))}
 REMOVE_PRECISION_PARAMETERIZED_TYPES = {
-    exp.Select: preprocess([remove_precision_parameterized_types], delegate("select_sql"))
+    exp.Cast: preprocess([remove_precision_parameterized_types], delegate("cast_sql"))
 }

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -300,6 +300,14 @@ class TestBigQuery(Validator):
             },
         )
         self.validate_all(
+            "SELECT cola, colb, colc FROM (VALUES (1, 'test', NULL)) AS tab(cola, colb, colc)",
+            write={
+                "spark": "SELECT cola, colb, colc FROM VALUES (1, 'test', NULL) AS tab(cola, colb, colc)",
+                "bigquery": "SELECT cola, colb, colc FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb, NULL AS colc)])",
+                "snowflake": "SELECT cola, colb, colc FROM (VALUES (1, 'test', NULL)) AS tab(cola, colb, colc)",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM (SELECT a, b, c FROM test) PIVOT(SUM(b) d, COUNT(*) e FOR c IN ('x', 'y'))",
             write={
                 "bigquery": "SELECT * FROM (SELECT a, b, c FROM test) PIVOT(SUM(b) AS d, COUNT(*) AS e FOR c IN ('x', 'y'))",

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -332,3 +332,35 @@ class TestBigQuery(Validator):
             "SELECT a, GROUP_CONCAT(b) FROM table GROUP BY a",
             write={"bigquery": "SELECT a, STRING_AGG(b) FROM table GROUP BY a"},
         )
+
+    def test_remove_precision_parameterized_types(self):
+        self.validate_all(
+            "SELECT CAST(1 AS NUMERIC(10, 2))",
+            write={
+                "bigquery": "SELECT CAST(1 AS NUMERIC)",
+            },
+        )
+        self.validate_all(
+            "CREATE TABLE test (a NUMERIC(10, 2))",
+            write={
+                "bigquery": "CREATE TABLE test (a NUMERIC(10, 2))",
+            },
+        )
+        self.validate_all(
+            "SELECT CAST('1' AS STRING(10)) UNION ALL SELECT CAST('2' AS STRING(10))",
+            write={
+                "bigquery": "SELECT CAST('1' AS STRING) UNION ALL SELECT CAST('2' AS STRING)",
+            },
+        )
+        self.validate_all(
+            "SELECT cola FROM (SELECT CAST('1' AS STRING(10)) AS cola UNION ALL SELECT CAST('2' AS STRING(10)) AS cola)",
+            write={
+                "bigquery": "SELECT cola FROM (SELECT CAST('1' AS STRING) AS cola UNION ALL SELECT CAST('2' AS STRING) AS cola)",
+            },
+        )
+        self.validate_all(
+            "INSERT INTO test (cola, colb) VALUES (CAST(7 AS STRING(10)), CAST(14 AS STRING(10)))",
+            write={
+                "bigquery": "INSERT INTO test (cola, colb) VALUES (CAST(7 AS STRING), CAST(14 AS STRING))",
+            },
+        )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -85,7 +85,7 @@ class TestDialect(Validator):
         self.validate_all(
             "CAST(a AS BINARY(4))",
             write={
-                "bigquery": "CAST(a AS BINARY(4))",
+                "bigquery": "CAST(a AS BINARY)",
                 "clickhouse": "CAST(a AS BINARY(4))",
                 "drill": "CAST(a AS VARBINARY(4))",
                 "duckdb": "CAST(a AS BINARY(4))",
@@ -104,7 +104,7 @@ class TestDialect(Validator):
         self.validate_all(
             "CAST(a AS VARBINARY(4))",
             write={
-                "bigquery": "CAST(a AS VARBINARY(4))",
+                "bigquery": "CAST(a AS VARBINARY)",
                 "clickhouse": "CAST(a AS VARBINARY(4))",
                 "duckdb": "CAST(a AS VARBINARY(4))",
                 "mysql": "CAST(a AS VARBINARY(4))",
@@ -181,7 +181,7 @@ class TestDialect(Validator):
         self.validate_all(
             "CAST(a AS VARCHAR(3))",
             write={
-                "bigquery": "CAST(a AS STRING(3))",
+                "bigquery": "CAST(a AS STRING)",
                 "drill": "CAST(a AS VARCHAR(3))",
                 "duckdb": "CAST(a AS TEXT(3))",
                 "mysql": "CAST(a AS VARCHAR(3))",

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -60,7 +60,7 @@ class TestPresto(Validator):
         self.validate_all(
             "CAST(x AS TIMESTAMP(9) WITH TIME ZONE)",
             write={
-                "bigquery": "CAST(x AS TIMESTAMPTZ(9))",
+                "bigquery": "CAST(x AS TIMESTAMPTZ)",
                 "duckdb": "CAST(x AS TIMESTAMPTZ(9))",
                 "presto": "CAST(x AS TIMESTAMP(9) WITH TIME ZONE)",
                 "hive": "CAST(x AS TIMESTAMPTZ(9))",

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -646,3 +646,19 @@ FROM foo""",
                 exp.Column(this=exp.to_identifier("colb")),
             ],
         )
+
+    def test_values(self):
+        self.assertEqual(
+            exp.values([(1, 2), (3, 4)], "t", ["a", "b"]).sql(),
+            "(VALUES (1, 2), (3, 4)) AS t(a, b)",
+        )
+        self.assertEqual(
+            exp.values(
+                [(1, 2), (3, 4)],
+                "t",
+                {"a": exp.DataType.build("TEXT"), "b": exp.DataType.build("TEXT")},
+            ).sql(),
+            "(VALUES (CAST(1 AS TEXT), CAST(2 AS TEXT)), (3, 4)) AS t(a, b)",
+        )
+        with self.assertRaises(ValueError):
+            exp.values([(1, 2), (3, 4)], columns=["a"])

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,7 +1,11 @@
 import unittest
 
 from sqlglot import parse_one
-from sqlglot.transforms import eliminate_distinct_on, unalias_group
+from sqlglot.transforms import (
+    eliminate_distinct_on,
+    remove_precision_parameterized_types,
+    unalias_group,
+)
 
 
 class TestTime(unittest.TestCase):
@@ -61,4 +65,11 @@ class TestTime(unittest.TestCase):
             eliminate_distinct_on,
             "SELECT DISTINCT ON (_row_number) _row_number FROM x ORDER BY c DESC",
             'SELECT _row_number FROM (SELECT _row_number, ROW_NUMBER() OVER (PARTITION BY _row_number ORDER BY c DESC) AS _row_number_2 FROM x) WHERE "_row_number_2" = 1',
+        )
+
+    def test_remove_precision_parameterized_types(self):
+        self.validate(
+            remove_precision_parameterized_types,
+            "SELECT CAST(1 AS DECIMAL(10, 2)), CAST('13' AS VARCHAR(10))",
+            "SELECT CAST(1 AS DECIMAL), CAST('13' AS VARCHAR)",
         )


### PR DESCRIPTION
Main changes:
1. BigQuery does not allow precision on parameterized types when doing casts. Therefore added a transformer to remove these when casts are detected.
2. When doing an `UNNEST(...` (similar to `VALUES` but for BigQuery) BigQuery auto detects types from the first row of values. If one of those values are a null then it will potentially select the wrong type. Therefore updated values to accept column names and types and if types are provided then the first row is casted to the desired type to make sure type inference works correctly. 