### PR TITLE
transform fetch to limit for sqlite

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -13,6 +13,10 @@ from sqlglot.dialects.dialect import (
 from sqlglot.tokens import TokenType
 
 
+def _fetch_sql(self, expression):
+    return self.limit_sql(exp.Limit(expression=expression.args.get("count")))
+
+
 # https://www.sqlite.org/lang_aggfunc.html#group_concat
 def _group_concat_sql(self, expression):
     this = expression.this
@@ -80,6 +84,7 @@ class SQLite(Dialect):
             exp.TableSample: no_tablesample_sql,
             exp.TryCast: no_trycast_sql,
             exp.GroupConcat: _group_concat_sql,
+            exp.Fetch: _fetch_sql,
         }
 
         def transaction_sql(self, expression):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1120,6 +1120,7 @@ class TestDialect(Validator):
         self.validate_all(
             "SELECT x FROM y OFFSET 10 FETCH FIRST 3 ROWS ONLY",
             write={
+                "sqlite": "SELECT x FROM y LIMIT 3 OFFSET 10",
                 "oracle": "SELECT x FROM y OFFSET 10 ROWS FETCH FIRST 3 ROWS ONLY",
             },
         )


### PR DESCRIPTION
sqlite does not support the sql 2008 standard "FETCH FIRST" syntax, thus "FETCH" must be transformed to LIMIT.