### PR TITLE
Redshift Improvements

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -299,6 +299,7 @@ class Postgres(Dialect):
             exp.StrPosition: str_position_sql,
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.Substring: _substring_sql,
+            exp.TimeStrToTime: lambda self, e: f"CAST({self.sql(e, 'this')} AS TIMESTAMP)",
             exp.TimeToStr: lambda self, e: f"TO_CHAR({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TableSample: no_tablesample_sql,
             exp.Trim: trim_sql,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -75,13 +75,16 @@ class Redshift(Postgres):
             """
             if not isinstance(expression.unnest().parent, exp.From):
                 return super().values_sql(expression)
-            rows = [tuple_exp.expressions for tuple_exp in expression.find_all(exp.Tuple)]
+            rows = [tuple_exp.expressions for tuple_exp in expression.expressions]
             selects = []
             for i, row in enumerate(rows):
-                columns = [
-                    exp.alias_(value, column_name) if i == 0 else value
-                    for value, column_name in zip(row, expression.args["alias"].args["columns"])
-                ]
+                if i == 0:
+                    columns = [
+                        exp.alias_(value, column_name)
+                        for value, column_name in zip(row, expression.args["alias"].args["columns"])
+                    ]
+                else:
+                    columns = row
                 selects.append(exp.Select(expressions=columns))
             subquery_expression = selects[0]
             if len(selects) > 1:

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -52,6 +52,10 @@ class Redshift(Postgres):
             exp.DistStyleProperty,
         }
 
+        WITH_PROPERTIES = {
+            exp.LikeProperty,
+        }
+
         TRANSFORMS = {
             **Postgres.Generator.TRANSFORMS,  # type: ignore
             **transforms.ELIMINATE_DISTINCT_ON,  # type: ignore
@@ -60,3 +64,55 @@ class Redshift(Postgres):
             exp.DistStyleProperty: lambda self, e: self.naked_property(e),
             exp.Matches: rename_func("DECODE"),
         }
+
+        def values_sql(self, expression: exp.Values) -> str:
+            """
+            Converts `VALUES...` expression into a series of unions.
+
+            Note: If you have a lot of unions then this will result in a large number of recursive statements to
+            evaluate the expression. You may need to increase `sys.setrecursionlimit` to run and it can also be
+            very slow.
+            """
+            if not isinstance(expression.unnest().parent, exp.From):
+                return super().values_sql(expression)
+            rows = [tuple_exp.expressions for tuple_exp in expression.find_all(exp.Tuple)]
+            selects = []
+            for i, row in enumerate(rows):
+                columns = [
+                    exp.alias_(value, column_name) if i == 0 else value
+                    for value, column_name in zip(row, expression.args["alias"].args["columns"])
+                ]
+                selects.append(exp.Select(expressions=columns))
+            subquery_expression = selects[0]
+            if len(selects) > 1:
+                for select in selects[1:]:
+                    subquery_expression = exp.union(subquery_expression, select, distinct=False)
+            return self.subquery_sql(subquery_expression.subquery(expression.alias))
+
+        def with_properties(self, properties: exp.Properties) -> str:
+            """Redshift doesn't have `WITH` as part of their with_properties so we remove it"""
+            return self.properties(properties, prefix=" ", suffix="")
+
+        def renametable_sql(self, expression: exp.RenameTable) -> str:
+            """Redshift only supports defining the table name itself (not the db) when renaming tables"""
+            target_table = expression.this
+            for arg in target_table.args:
+                if arg != "this":
+                    target_table.set(arg, None)
+            this = self.sql(expression, "this")
+            return f"RENAME TO {this}"
+
+        def datatype_sql(self, expression: exp.DataType) -> str:
+            """
+            Redshift converts the `TEXT` data type to `VARCHAR(255)` by default when people more generally mean
+            VARCHAR of max length which is `VARCHAR(max)` in Redshift. Therefore if we get a `TEXT` data type
+            without precision we convert it to `VARCHAR(max)` and if it does have precision then we just convert
+            `TEXT` to `VARCHAR`.
+            """
+            if expression.this == exp.DataType.Type.TEXT:
+                expression = expression.copy()
+                expression.set("this", exp.DataType.Type.VARCHAR)
+                precision = expression.args.get("expressions")
+                if not precision:
+                    expression.set("expressions", [exp.to_identifier("max")])
+            return super().datatype_sql(expression)

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -95,6 +95,7 @@ class Redshift(Postgres):
 
         def renametable_sql(self, expression: exp.RenameTable) -> str:
             """Redshift only supports defining the table name itself (not the db) when renaming tables"""
+            expression = expression.copy()
             target_table = expression.this
             for arg in target_table.args:
                 if arg != "this":
@@ -114,5 +115,5 @@ class Redshift(Postgres):
                 expression.set("this", exp.DataType.Type.VARCHAR)
                 precision = expression.args.get("expressions")
                 if not precision:
-                    expression.set("expressions", [exp.to_identifier("max")])
+                    expression.append("expressions", exp.to_identifier("max"))
             return super().datatype_sql(expression)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -770,6 +770,10 @@ class AlterColumn(Expression):
     }
 
 
+class RenameTable(Expression):
+    pass
+
+
 class ColumnConstraint(Expression):
     arg_types = {"this": False, "kind": True}
 
@@ -1266,7 +1270,7 @@ class Tuple(Expression):
 
 
 class Subqueryable(Unionable):
-    def subquery(self, alias=None, copy=True):
+    def subquery(self, alias=None, copy=True) -> Subquery:
         """
         Convert this expression to an aliased expression that can be used as a Subquery.
 
@@ -3866,6 +3870,26 @@ def values(
     return Values(
         expressions=expressions,
         alias=table_alias,
+    )
+
+
+def rename_table(old_name: str | Table, new_name: str | Table) -> AlterTable:
+    """Build ALTER TABLE... RENAME... expression
+
+    Args:
+        old_name: The old name of the table
+        new_name: The new name of the table
+
+    Returns:
+        Alter table expression
+    """
+    old_table = to_table(old_name)
+    new_table = to_table(new_name)
+    return AlterTable(
+        this=old_table,
+        actions=[
+            RenameTable(this=new_table),
+        ],
     )
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -631,10 +631,14 @@ class Generator:
             return self.sep() + self.expressions(properties, indent=False, sep=" ")
         return ""
 
-    def properties(self, properties: exp.Properties, prefix: str = "", sep: str = ", ") -> str:
+    def properties(
+        self, properties: exp.Properties, prefix: str = "", sep: str = ", ", suffix: str = ""
+    ) -> str:
         if properties.expressions:
             expressions = self.expressions(properties, sep=sep, indent=False)
-            return f"{prefix}{' ' if prefix else ''}{self.wrap(expressions)}"
+            return (
+                f"{prefix}{' ' if prefix and prefix != ' ' else ''}{self.wrap(expressions)}{suffix}"
+            )
         return ""
 
     def with_properties(self, properties: exp.Properties) -> str:
@@ -1329,6 +1333,10 @@ class Generator:
 
         return f"ALTER COLUMN {this} DROP DEFAULT"
 
+    def renametable_sql(self, expression: exp.RenameTable) -> str:
+        this = self.sql(expression, "this")
+        return f"RENAME TO {this}"
+
     def altertable_sql(self, expression: exp.AlterTable) -> str:
         actions = expression.args["actions"]
 
@@ -1338,7 +1346,7 @@ class Generator:
             actions = self.expressions(expression, "actions", prefix="ADD COLUMNS ")
         elif isinstance(actions[0], exp.Drop):
             actions = self.expressions(expression, "actions")
-        elif isinstance(actions[0], exp.AlterColumn):
+        elif isinstance(actions[0], (exp.AlterColumn, exp.RenameTable)):
             actions = self.sql(actions[0])
         else:
             self.unsupported(f"Unsupported ALTER TABLE action {actions[0].__class__.__name__}")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3018,6 +3018,8 @@ class Parser(metaclass=_Parser):
             actions = self._parse_csv(self._parse_add_column)
         elif self._match_text_seq("DROP", advance=False):
             actions = self._parse_csv(self._parse_drop_column)
+        elif self._match_text_seq("RENAME", "TO"):
+            actions = self.expression(exp.RenameTable, this=self._parse_table(schema=True))
         elif self._match_text_seq("ALTER"):
             self._match(TokenType.COLUMN)
             column = self._parse_field(any_token=True)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -76,7 +76,7 @@ class TestDialect(Validator):
                 "oracle": "CAST(a AS CLOB)",
                 "postgres": "CAST(a AS TEXT)",
                 "presto": "CAST(a AS VARCHAR)",
-                "redshift": "CAST(a AS TEXT)",
+                "redshift": "CAST(a AS VARCHAR(max))",
                 "snowflake": "CAST(a AS TEXT)",
                 "spark": "CAST(a AS STRING)",
                 "starrocks": "CAST(a AS STRING)",
@@ -155,7 +155,7 @@ class TestDialect(Validator):
                 "oracle": "CAST(a AS CLOB)",
                 "postgres": "CAST(a AS TEXT)",
                 "presto": "CAST(a AS VARCHAR)",
-                "redshift": "CAST(a AS TEXT)",
+                "redshift": "CAST(a AS VARCHAR(max))",
                 "snowflake": "CAST(a AS TEXT)",
                 "spark": "CAST(a AS STRING)",
                 "starrocks": "CAST(a AS STRING)",
@@ -373,7 +373,7 @@ class TestDialect(Validator):
                 "duckdb": "CAST(x AS TEXT)",
                 "hive": "CAST(x AS STRING)",
                 "presto": "CAST(x AS VARCHAR)",
-                "redshift": "CAST(x AS TEXT)",
+                "redshift": "CAST(x AS VARCHAR(max))",
             },
         )
         self.validate_all(
@@ -1199,7 +1199,7 @@ class TestDialect(Validator):
                 "oracle": "CREATE TABLE t (b1 BLOB, b2 BLOB(1024), c1 CLOB, c2 CLOB(1024))",
                 "postgres": "CREATE TABLE t (b1 BYTEA, b2 BYTEA(1024), c1 TEXT, c2 TEXT(1024))",
                 "sqlite": "CREATE TABLE t (b1 BLOB, b2 BLOB(1024), c1 TEXT, c2 TEXT(1024))",
-                "redshift": "CREATE TABLE t (b1 VARBYTE, b2 VARBYTE(1024), c1 TEXT, c2 TEXT(1024))",
+                "redshift": "CREATE TABLE t (b1 VARBYTE, b2 VARBYTE(1024), c1 VARCHAR(max), c2 VARCHAR(1024))",
             },
         )
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -715,3 +715,9 @@ FROM foo""",
         self.assertEqual(exp.DataType.build("OBJECT").sql(), "OBJECT")
         self.assertEqual(exp.DataType.build("NULL").sql(), "NULL")
         self.assertEqual(exp.DataType.build("UNKNOWN").sql(), "UNKNOWN")
+
+    def test_rename_table(self):
+        self.assertEqual(
+            exp.rename_table("t1", "t2").sql(),
+            "ALTER TABLE t1 RENAME TO t2",
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -325,3 +325,9 @@ class TestParser(unittest.TestCase):
             "Expected table name",
             logger,
         )
+
+    def test_rename_table(self):
+        self.assertEqual(
+            parse_one("ALTER TABLE foo RENAME TO bar").sql(),
+            "ALTER TABLE foo RENAME TO bar",
+        )


### PR DESCRIPTION
Key changes:
1. Redshift doesn't support values outside of an `INSERT INTO` expression. Therefore we convert this to a union and have a warning about the poor performance with unioning a lot of values
2. This adds support for `ALTER TABLE ... RENAME TO...`. Some engines support a more direct `RENAME TABLE` syntax but I didn't tackle that here
3. Redshift puts the `LIKE` expression in paranthesis and the rest at root. I handle this by having `WITH` properties drop list (`WITH` isn't supported by Redshift).
4. Redshift converts `TEXT` to `VARCHAR(255)` which is strange since the max size is much larger. So we override this to make `TEXT` be `VARCHAR(max)`. That is generally what is meant by other engines when they say `TEXT`/`STRING` without precision.

