### PR TITLE
LOGICAL_OR is BOOL_OR in Spark SQL.

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -124,6 +124,7 @@ class Spark(Hive):
             exp.TimestampTrunc: lambda self, e: f"DATE_TRUNC({self.sql(e, 'unit')}, {self.sql(e, 'this')})",
             exp.VariancePop: rename_func("VAR_POP"),
             exp.DateFromParts: rename_func("MAKE_DATE"),
+            exp.LogicalOr: rename_func("BOOL_OR"),
         }
         TRANSFORMS.pop(exp.ArraySort)
         TRANSFORMS.pop(exp.ILike)

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -307,5 +307,12 @@ TBLPROPERTIES (
 
     def test_iif(self):
         self.validate_all(
-            "SELECT IIF(cond, 'True', 'False')", write={"spark": "SELECT IF(cond, 'True', 'False')"}
+            "SELECT IIF(cond, 'True', 'False')",
+            write={"spark": "SELECT IF(cond, 'True', 'False')"},
+        )
+
+    def test_bool_or(self):
+        self.validate_all(
+            "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",
+            write={"duckdb": "SELECT a, BOOL_OR(b) FROM table GROUP BY a"},
         )


### PR DESCRIPTION
Write out `bool_or` instead of `logical_or` when generating Spark SQL.