### PR TITLE
Add no schema binding

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -653,6 +653,7 @@ class Create(Expression):
         "statistics": False,
         "no_primary_index": False,
         "indexes": False,
+        "no_schema_binding": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -480,10 +480,13 @@ class Generator:
                 materialized,
             )
         )
+        no_schema_binding = (
+            " WITH NO SCHEMA BINDING" if expression.args.get("no_schema_binding") else ""
+        )
 
         post_expression_modifiers = "".join((data, statistics, no_primary_index))
 
-        expression_sql = f"CREATE{modifiers} {kind}{exists_sql} {this}{properties}{expression_sql}{post_expression_modifiers}{index_sql}"
+        expression_sql = f"CREATE{modifiers} {kind}{exists_sql} {this}{properties}{expression_sql}{post_expression_modifiers}{index_sql}{no_schema_binding}"
         return self.prepend_ctes(expression, expression_sql)
 
     def describe_sql(self, expression: exp.Describe) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -941,6 +941,7 @@ class Parser(metaclass=_Parser):
         statistics = None
         no_primary_index = None
         indexes = None
+        no_schema_binding = None
 
         if create_token.token_type in (TokenType.FUNCTION, TokenType.PROCEDURE):
             this = self._parse_user_defined_function()
@@ -979,6 +980,9 @@ class Parser(metaclass=_Parser):
                         break
                     else:
                         indexes.append(index)
+            elif create_token.token_type == TokenType.VIEW:
+                if self._match_text_seq("WITH", "NO", "SCHEMA", "BINDING"):
+                    no_schema_binding = True
 
         return self.expression(
             exp.Create,
@@ -997,6 +1001,7 @@ class Parser(metaclass=_Parser):
             statistics=statistics,
             no_primary_index=no_primary_index,
             indexes=indexes,
+            no_schema_binding=no_schema_binding,
         )
 
     def _parse_property(self) -> t.Optional[exp.Expression]:

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -174,3 +174,11 @@ class TestRedshift(Validator):
             },
             identify=True,
         )
+
+    def test_no_schema_binding(self):
+        self.validate_all(
+            "CREATE OR REPLACE VIEW v1 AS SELECT cola, colb FROM t1 WITH NO SCHEMA BINDING",
+            write={
+                "redshift": "CREATE OR REPLACE VIEW v1 AS SELECT cola, colb FROM t1 WITH NO SCHEMA BINDING",
+            },
+        )


### PR DESCRIPTION
There is a way to define views in Redshift that have `WITH NO SCHEMA BINDING` and that "unbinds" the view to underlying table(s) so that allows you to alter/drop the underlying table(s). 