### PR TITLE
Fix variable/identifier tokenization for TSQL to include @

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -263,7 +263,7 @@ class TSQL(Dialect):
             "XML": TokenType.XML,
         }
 
-        # TSQL allows @ to appear as a variable/identifier prefix
+        # TSQL allows @, # to appear as a variable/identifier prefix
         SINGLE_TOKENS = tokens.Tokenizer.SINGLE_TOKENS.copy()
         SINGLE_TOKENS.pop("@")
         SINGLE_TOKENS.pop("#")

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -266,6 +266,7 @@ class TSQL(Dialect):
         # TSQL allows @ to appear as a variable/identifier prefix
         SINGLE_TOKENS = tokens.Tokenizer.SINGLE_TOKENS.copy()
         SINGLE_TOKENS.pop("@")
+        SINGLE_TOKENS.pop("#")
 
     class Parser(parser.Parser):
         FUNCTIONS = {
@@ -296,9 +297,6 @@ class TSQL(Dialect):
             DataType.Type.CHAR,
             DataType.Type.NCHAR,
         }
-
-        # https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-tables-temporary#create-a-temporary-table
-        TABLE_PREFIX_TOKENS = {TokenType.HASH, TokenType.PARAMETER}
 
         def _parse_convert(self, strict):
             to = self._parse_types()

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -263,6 +263,10 @@ class TSQL(Dialect):
             "XML": TokenType.XML,
         }
 
+        # TSQL allows @ to appear as a variable/identifier prefix
+        SINGLE_TOKENS = tokens.Tokenizer.SINGLE_TOKENS.copy()
+        SINGLE_TOKENS.pop("@")
+
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,  # type: ignore

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -601,9 +601,6 @@ class Parser(metaclass=_Parser):
 
     WINDOW_ALIAS_TOKENS = ID_VAR_TOKENS - {TokenType.ROWS}
 
-    # allows tables to have special tokens as prefixes
-    TABLE_PREFIX_TOKENS: t.Set[TokenType] = set()
-
     STRICT_CAST = True
 
     __slots__ = (
@@ -1586,9 +1583,7 @@ class Parser(metaclass=_Parser):
 
         catalog = None
         db = None
-        table = (not schema and self._parse_function()) or self._parse_id_var(
-            any_token=False, prefix_tokens=self.TABLE_PREFIX_TOKENS
-        )
+        table = (not schema and self._parse_function()) or self._parse_id_var(any_token=False)
 
         while self._match(TokenType.DOT):
             if catalog:

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -7,6 +7,7 @@ class TestTSQL(Validator):
 
     def test_tsql(self):
         self.validate_identity("@x")
+        self.validate_identity("#x")
         self.validate_identity("DECLARE @TestVariable AS VARCHAR(100)='Save Our Planet'")
         self.validate_identity("PRINT @TestVariable")
         self.validate_identity("SELECT Employee_ID, Department_ID FROM @MyTableVar")
@@ -476,7 +477,11 @@ class TestTSQL(Validator):
         )
 
     def test_variables(self):
-        # In TSQL @ can be used as a prefix for variables/identifiers
+        # In TSQL @, # can be used as a prefix for variables/identifiers
         expr = parse_one("@x", read="tsql")
+        self.assertIsInstance(expr, exp.Column)
+        self.assertIsInstance(expr.this, exp.Identifier)
+
+        expr = parse_one("#x", read="tsql")
         self.assertIsInstance(expr, exp.Column)
         self.assertIsInstance(expr.this, exp.Identifier)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1,3 +1,4 @@
+from sqlglot import exp, parse_one
 from tests.dialects.test_dialect import Validator
 
 
@@ -5,6 +6,7 @@ class TestTSQL(Validator):
     dialect = "tsql"
 
     def test_tsql(self):
+        self.validate_identity("@x")
         self.validate_identity("DECLARE @TestVariable AS VARCHAR(100)='Save Our Planet'")
         self.validate_identity("PRINT @TestVariable")
         self.validate_identity("SELECT Employee_ID, Department_ID FROM @MyTableVar")
@@ -472,3 +474,9 @@ class TestTSQL(Validator):
             "EOMONTH(GETDATE(), -1)",
             write={"spark": "LAST_DAY(ADD_MONTHS(CURRENT_TIMESTAMP(), -1))"},
         )
+
+    def test_variables(self):
+        # In TSQL @ can be used as a prefix for variables/identifiers
+        expr = parse_one("@x", read="tsql")
+        self.assertIsInstance(expr, exp.Column)
+        self.assertIsInstance(expr.this, exp.Identifier)


### PR DESCRIPTION
This PR changes the "var" tokenizing logic for TSQL, so that the `@` is considered part of the token, instead of tokenizing it as a "parameter". This felt more natural & robust, even though we could already parse names prefixed by @ before.

Also: I don't think that adding the `PARAMETER` token to the `prefix_tokens` parameter of `_parse_id_var` would solve the problem, because there might be places in the codebase where we call `_parse_primary` first and then `_parse_id_var`, meaning that in these cases we'd parse the input as a parameter instead of an identifier.