### PR TITLE
Improve handling of TSQL UDFs

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -247,6 +247,7 @@ class TSQL(Dialect):
             "DATETIME2": TokenType.DATETIME,
             "DATETIMEOFFSET": TokenType.TIMESTAMPTZ,
             "DECLARE": TokenType.COMMAND,
+            "END": TokenType.COMMAND,
             "IMAGE": TokenType.IMAGE,
             "MONEY": TokenType.MONEY,
             "NTEXT": TokenType.TEXT,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -696,7 +696,7 @@ class Show(Expression):
 
 
 class UserDefinedFunction(Expression):
-    arg_types = {"this": True, "expressions": False}
+    arg_types = {"this": True, "expressions": False, "wrapped": False}
 
 
 class UserDefinedFunctionKwarg(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1186,7 +1186,7 @@ class SchemaCommentProperty(Property):
 
 
 class ReturnsProperty(Property):
-    arg_types = {"this": True, "is_table": False}
+    arg_types = {"this": True, "is_table": False, "table": False}
 
 
 class LanguageProperty(Property):
@@ -1259,6 +1259,11 @@ class Properties(Expression):
 
 
 class Qualify(Expression):
+    pass
+
+
+# https://www.ibm.com/docs/en/ias?topic=procedures-return-statement-in-sql
+class Return(Expression):
     pass
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1561,7 +1561,10 @@ class Generator:
     def userdefinedfunction_sql(self, expression: exp.UserDefinedFunction) -> str:
         this = self.sql(expression, "this")
         expressions = self.no_identify(lambda: self.expressions(expression))
-        return f"{this}{self.wrap(expressions)}"
+        expressions = (
+            self.wrap(expressions) if expression.args.get("wrapped") else f" {expressions}"
+        )
+        return f"{this}{expressions}"
 
     def userdefinedfunctionkwarg_sql(self, expression: exp.UserDefinedFunctionKwarg) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1231,6 +1231,9 @@ class Generator:
         unit = f" {unit}" if unit else ""
         return f"INTERVAL{this}{unit}"
 
+    def return_sql(self, expression: exp.Return) -> str:
+        return f"RETURN {self.sql(expression, 'this')}"
+
     def reference_sql(self, expression: exp.Reference) -> str:
         this = self.sql(expression, "this")
         expressions = self.expressions(expression, flat=True)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1561,7 +1561,7 @@ class Generator:
     def userdefinedfunction_sql(self, expression: exp.UserDefinedFunction) -> str:
         this = self.sql(expression, "this")
         expressions = self.no_identify(lambda: self.expressions(expression))
-        return f"{this}({expressions})"
+        return f"{this}{self.wrap(expressions)}"
 
     def userdefinedfunctionkwarg_sql(self, expression: exp.UserDefinedFunctionKwarg) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -944,7 +944,11 @@ class Parser(metaclass=_Parser):
             this = self._parse_user_defined_function()
             properties = self._parse_properties()
             if self._match(TokenType.ALIAS):
+                return_ = self._match_text_seq("RETURN")
                 expression = self._parse_select_or_expression()
+
+                if return_:
+                    expression = self.expression(exp.Return, this=expression)
         elif create_token.token_type == TokenType.INDEX:
             this = self._parse_index()
         elif create_token.token_type in (
@@ -1084,7 +1088,7 @@ class Parser(metaclass=_Parser):
                 if not self._match(TokenType.GT):
                     self.raise_error("Expecting >")
             else:
-                value = self._parse_schema(exp.Literal.string("TABLE"))
+                value = self._parse_schema(exp.Var(this="TABLE"))
         else:
             value = self._parse_types()
 
@@ -2369,10 +2373,6 @@ class Parser(metaclass=_Parser):
             or self._parse_column_def(self._parse_field(any_token=True))
         )
         self._match_r_paren()
-
-        if isinstance(this, exp.Literal):
-            this = this.name
-
         return self.expression(exp.Schema, this=this, expressions=args)
 
     def _parse_column_def(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -6,6 +6,14 @@ class TestTSQL(Validator):
     dialect = "tsql"
 
     def test_tsql(self):
+        self.validate_identity("CREATE FUNCTION foo(@bar INTEGER) RETURNS TABLE AS RETURN SELECT 1")
+        self.validate_identity("CREATE FUNCTION dbo.ISOweek(@DATE DATETIME2) RETURNS INTEGER")
+        self.validate_identity(
+            "CREATE FUNCTION foo(@bar INTEGER) RETURNS @foo TABLE (x INTEGER, y NUMERIC) AS RETURN SELECT 1"
+        )
+        self.validate_identity(
+            "CREATE FUNCTION f() RETURNS @contacts TABLE (first_name VARCHAR(50), phone VARCHAR(25)) AS SELECT @fname, @phone"
+        )
         self.validate_identity("@x")
         self.validate_identity("#x")
         self.validate_identity("DECLARE @TestVariable AS VARCHAR(100)='Save Our Planet'")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -6,6 +6,7 @@ class TestTSQL(Validator):
     dialect = "tsql"
 
     def test_tsql(self):
+        self.validate_identity("END")
         self.validate_identity("@x")
         self.validate_identity("#x")
         self.validate_identity("DECLARE @TestVariable AS VARCHAR(100)='Save Our Planet'")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -332,6 +332,38 @@ class TestTSQL(Validator):
                 "spark": "SELECT CAST((SELECT x FROM y) AS STRING) AS test",
             },
         )
+        self.validate_all(
+            """
+            CREATE FUNCTION udfProductInYear (
+                @model_year INT
+            )
+            RETURNS TABLE
+            AS
+            RETURN
+                SELECT
+                    product_name,
+                    model_year,
+                    list_price
+                FROM
+                    production.products
+                WHERE
+                    model_year = @model_year
+            """,
+            write={
+                "tsql": """CREATE FUNCTION udfProductInYear(
+    @model_year INTEGER
+)
+RETURNS TABLE AS
+RETURN SELECT
+  product_name,
+  model_year,
+  list_price
+FROM production.products
+WHERE
+  model_year = @model_year""",
+            },
+            pretty=True,
+        )
 
     def test_add_date(self):
         self.validate_identity("SELECT DATEADD(year, 1, '2017/08/25')")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -92,6 +92,14 @@ class TestTSQL(Validator):
         )
 
     def test_udf(self):
+        self.validate_identity(
+            "CREATE PROCEDURE foo @a INTEGER, @b INTEGER AS SELECT @a = SUM(bla) FROM baz AS bar"
+        )
+        self.validate_identity(
+            "CREATE PROC foo @ID INTEGER, @AGE INTEGER AS SELECT DB_NAME(@ID) AS ThatDB"
+        )
+        self.validate_identity("CREATE PROC foo AS SELECT BAR() AS baz")
+        self.validate_identity("CREATE PROCEDURE foo AS SELECT BAR() AS baz")
         self.validate_identity("CREATE FUNCTION foo(@bar INTEGER) RETURNS TABLE AS RETURN SELECT 1")
         self.validate_identity("CREATE FUNCTION dbo.ISOweek(@DATE DATETIME2) RETURNS INTEGER")
 


### PR DESCRIPTION
Fixes (partially) #970

Main items addressed in this PR:

1. Fix the `RETURNS` property, so that it can parse the following forms (some previously unsupported):
  - `RETURNS return_data_type`,
  - `RETURNS TABLE`,
  - `RETURNS @return_variable TABLE`.

2. Modify the `_parse_user_defined_function` parser so that it can consume a `CREATE [PROCEDURE | PROC]` statement which has an unwrapped csv argument list (see tests).

3. Add support for the `RETURN` statement.

4. Refactor `_match` so that it expects an optional `advance` argument.

References:
- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-procedure-transact-sql?view=sql-server-ver16#examples

Outstanding items (for either this or later PRs):

- [ ] Fix the command parsing, so that we can have UDFs of the form:

```sql
CREATE PROCEDURE HumanResources.uspGetAllEmployees
AS
    SET NOCOUNT ON;
    SELECT LastName, FirstName, JobTitle, Department
    FROM HumanResources.vEmployeeDepartment;
GO

SELECT * FROM HumanResources.vEmployeeDepartment;
```

The problem with this is that we can't parse `SET NOCOUNT ON;` as a command with `NOCOUNT ON` being a string, because the tokenizer logic expects the token before `SET` to be a semicolon to interpret all following characters as a string. I'm not sure how we can fix this.

- [ ] Improve UDF argument parsing so that additional options can be recognized:

```
[ VARYING ] [ NULL ] [ = default ] [ OUT | OUTPUT | [READONLY]
```

- [ ] Improve parsing and sql generating for `CREATE FUNCTION`: some forms require the use of the `BEGIN` keyword, which doesn't currently exist in the exp.Create state in order to generate it. This may also be the case for the `CREATE PROCEDURE` statement, when we have a block instead of a single expression as the return value.

