### PR TITLE
Stricter named_selects

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2175,15 +2175,9 @@ class Placeholder(Expression):
 class Null(Condition):
     arg_types: t.Dict[str, t.Any] = {}
 
-    @property
-    def output_name(self):
-        return self.name
-
 
 class Boolean(Condition):
-    @property
-    def output_name(self):
-        return self.name
+    pass
 
 
 class DataType(Expression):

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -306,16 +306,11 @@ def _qualify_outputs(scope):
     for i, (selection, aliased_column) in enumerate(
         itertools.zip_longest(scope.selects, scope.outer_column_list)
     ):
-        if isinstance(selection, exp.Column):
-            # convoluted setter because a simple selection.replace(alias) would require a copy
-            alias_ = alias(exp.column(""), alias=selection.name)
-            alias_.set("this", selection)
-            selection = alias_
-        elif isinstance(selection, exp.Subquery):
-            if not selection.alias:
+        if isinstance(selection, exp.Subquery):
+            if not selection.output_name:
                 selection.set("alias", exp.TableAlias(this=exp.to_identifier(f"_col_{i}")))
         elif not isinstance(selection, exp.Alias):
-            alias_ = alias(exp.column(""), f"_col_{i}")
+            alias_ = alias(exp.column(""), alias=selection.output_name or f"_col_{i}")
             alias_.set("this", selection)
             selection = alias_
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -230,7 +230,7 @@ class Scope:
                 column for scope in self.subquery_scopes for column in scope.external_columns
             ]
 
-            named_outputs = {e.alias_or_name for e in self.expression.expressions}
+            named_selects = set(self.expression.named_selects)
 
             self._columns = []
             for column in columns + external_columns:
@@ -238,7 +238,7 @@ class Scope:
                 if (
                     not ancestor
                     or column.table
-                    or (column.name not in named_outputs and not isinstance(ancestor, exp.Hint))
+                    or (column.name not in named_selects and not isinstance(ancestor, exp.Hint))
                 ):
                     self._columns.append(column)
 

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -2,7 +2,7 @@ SELECT a FROM (SELECT * FROM x);
 SELECT _q_0.a AS a FROM (SELECT x.a AS a FROM x AS x) AS _q_0;
 
 SELECT 1 FROM (SELECT * FROM x) WHERE b = 2;
-SELECT 1 AS _col_0 FROM (SELECT x.b AS b FROM x AS x) AS _q_0 WHERE _q_0.b = 2;
+SELECT 1 AS "1" FROM (SELECT x.b AS b FROM x AS x) AS _q_0 WHERE _q_0.b = 2;
 
 SELECT (SELECT c FROM y WHERE q.b = y.b) FROM (SELECT * FROM x) AS q;
 SELECT (SELECT y.c AS c FROM y AS y WHERE q.b = y.b) AS _col_0 FROM (SELECT x.b AS b FROM x AS x) AS q;

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -20,8 +20,8 @@ SELECT a AS b FROM x;
 SELECT x.a AS b FROM x AS x;
 
 # execute: false
-SELECT 1, 2 FROM x;
-SELECT 1 AS _col_0, 2 AS _col_1 FROM x AS x;
+SELECT 1, 2 + 3 FROM x;
+SELECT 1 AS "1", 2 + 3 AS _col_1 FROM x AS x;
 
 # execute: false
 SELECT a + b FROM x;
@@ -58,39 +58,8 @@ SELECT SUM(a) AS c, SUM(b) AS d FROM x ORDER BY 1, 2;
 SELECT SUM(x.a) AS c, SUM(x.b) AS d FROM x AS x ORDER BY SUM(x.a), SUM(x.b);
 
 # execute: false
-SELECT SUM(a), SUM(b) AS c FROM x ORDER BY 1, 2;
-SELECT SUM(x.a) AS _col_0, SUM(x.b) AS c FROM x AS x ORDER BY SUM(x.a), SUM(x.b);
-
-SELECT a AS j, b FROM x GROUP BY j, b;
-SELECT x.a AS j, x.b AS b FROM x AS x GROUP BY x.a, x.b;
-
-SELECT a, b FROM x GROUP BY 1, 2;
-SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY x.a, x.b;
-
-SELECT a, b FROM x ORDER BY 1, 2;
-SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY x.a, x.b;
-
-# execute: false
-SELECT DATE(a), DATE(b) AS c FROM x GROUP BY 1, 2;
-SELECT DATE(x.a) AS _col_0, DATE(x.b) AS c FROM x AS x GROUP BY DATE(x.a), DATE(x.b);
-
-SELECT SUM(x.a) AS c FROM x JOIN y ON x.b = y.b GROUP BY c;
-SELECT SUM(x.a) AS c FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY y.c;
-
-SELECT COALESCE(x.a) AS d FROM x JOIN y ON x.b = y.b GROUP BY d;
-SELECT COALESCE(x.a) AS d FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY COALESCE(x.a);
-
-SELECT a AS a, b FROM x ORDER BY a;
-SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a;
-
-SELECT a, b FROM x ORDER BY a;
-SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a;
-
-SELECT a FROM x ORDER BY b;
-SELECT x.a AS a FROM x AS x ORDER BY x.b;
-
-SELECT SUM(a) AS a FROM x ORDER BY SUM(a);
-SELECT SUM(x.a) AS a FROM x AS x ORDER BY SUM(x.a);
+SELECT CAST(a AS INT) FROM x ORDER BY a;
+SELECT CAST(x.a AS INT) AS a FROM x AS x ORDER BY a;
 
 # dialect: bigquery
 SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS row_num FROM x QUALIFY row_num = 1;

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -61,6 +61,41 @@ SELECT SUM(x.a) AS c, SUM(x.b) AS d FROM x AS x ORDER BY SUM(x.a), SUM(x.b);
 SELECT CAST(a AS INT) FROM x ORDER BY a;
 SELECT CAST(x.a AS INT) AS a FROM x AS x ORDER BY a;
 
+# execute: false
+SELECT SUM(a), SUM(b) AS c FROM x ORDER BY 1, 2;
+SELECT SUM(x.a) AS _col_0, SUM(x.b) AS c FROM x AS x ORDER BY SUM(x.a), SUM(x.b);
+
+SELECT a AS j, b FROM x GROUP BY j, b;
+SELECT x.a AS j, x.b AS b FROM x AS x GROUP BY x.a, x.b;
+
+SELECT a, b FROM x GROUP BY 1, 2;
+SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY x.a, x.b;
+
+SELECT a, b FROM x ORDER BY 1, 2;
+SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY x.a, x.b;
+
+# execute: false
+SELECT DATE(a), DATE(b) AS c FROM x GROUP BY 1, 2;
+SELECT DATE(x.a) AS _col_0, DATE(x.b) AS c FROM x AS x GROUP BY DATE(x.a), DATE(x.b);
+
+SELECT SUM(x.a) AS c FROM x JOIN y ON x.b = y.b GROUP BY c;
+SELECT SUM(x.a) AS c FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY y.c;
+
+SELECT COALESCE(x.a) AS d FROM x JOIN y ON x.b = y.b GROUP BY d;
+SELECT COALESCE(x.a) AS d FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY COALESCE(x.a);
+
+SELECT a AS a, b FROM x ORDER BY a;
+SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a;
+
+SELECT a, b FROM x ORDER BY a;
+SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a;
+
+SELECT a FROM x ORDER BY b;
+SELECT x.a AS a FROM x AS x ORDER BY x.b;
+
+SELECT SUM(a) AS a FROM x ORDER BY SUM(a);
+SELECT SUM(x.a) AS a FROM x AS x ORDER BY SUM(x.a);
+
 # dialect: bigquery
 SELECT ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS row_num FROM x QUALIFY row_num = 1;
 SELECT ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS row_num FROM x AS x QUALIFY row_num = 1;

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -481,11 +481,11 @@ class TestExecutor(unittest.TestCase):
 
     def test_static_queries(self):
         for sql, cols, rows in [
-            ("SELECT 1", ["_col_0"], [(1,)]),
+            ("SELECT 1", ["1"], [(1,)]),
             ("SELECT 1 + 2 AS x", ["x"], [(3,)]),
             ("SELECT CONCAT('a', 'b') AS x", ["x"], [("ab",)]),
             ("SELECT 1 AS x, 2 AS y", ["x", "y"], [(1, 2)]),
-            ("SELECT 'foo' LIMIT 1", ["_col_0"], [("foo",)]),
+            ("SELECT 'foo' LIMIT 1", ["foo"], [("foo",)]),
             (
                 "SELECT SUM(x), COUNT(x) FROM (SELECT 1 AS x WHERE FALSE)",
                 ["_col_0", "_col_1"],


### PR DESCRIPTION
fixes https://github.com/tobymao/sqlglot/issues/999

`Expression.alias_or_name` is a bit too lenient in many cases:

```python
parse_one("1 + 2").alias_or_name
# '1'
```

So this introduces yet another concept - "output_name". 
I'm not crazy about adding a new method. But this seems safer than mucking with `Expression.alias_or_name`. Happy to hear opinions here.

@tobymao @GeorgeSittas 