### PR TITLE
Use full uuid value

### DIFF
--- a/sqlglot/dataframe/sql/session.py
+++ b/sqlglot/dataframe/sql/session.py
@@ -129,7 +129,7 @@ class SparkSession:
 
     @property
     def _random_name(self) -> str:
-        return f"a{str(uuid.uuid4())[:8]}"
+        return f"r{str(uuid.uuid4()).replace('-', '')}"
 
     @property
     def _random_branch_id(self) -> str:


### PR DESCRIPTION
Just to rule out the possibility of collisions as the reason for flaky tests. also I changed the `a` prefix to `r` since `r` will just represent random (either is somewhat arbitrary so just making things potentially a little clearer). 