### PR TITLE
Remove dependency on local path settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ style:
 check: style test
 
 docs:
-	pdoc/cli.py -o pdoc/docs
+	python pdoc/cli.py -o pdoc/docs
 
 docs-serve:
-	pdoc/cli.py
+	python pdoc/cli.py


### PR DESCRIPTION
On my machine ```make docs``` fails because Python is not on the local PATH.

```make test``` works fine because the reference to ```python``` is explicit.

So this pull request adds explicit reference to python where currently implicit.