### PR TITLE
Add support for Snowflake EXCLUDE & RENAME keywords

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -589,6 +589,12 @@ class Generator:
     def except_op(self, expression: exp.Except) -> str:
         return f"EXCEPT{'' if expression.args.get('distinct') else ' ALL'}"
 
+    def exclude_sql(self, expression: exp.Exclude) -> str:
+        return f" EXCLUDE {', '.join(expression.args.get('expressions'))}"
+
+    def rename_sql(self, expression: exp.Rename) -> str:
+        return f" RENAME {', '.join(expression.args.get('expressions'))}"
+
     def fetch_sql(self, expression: exp.Fetch) -> str:
         direction = expression.args.get("direction")
         direction = f" {direction.upper()}" if direction else ""
@@ -1003,6 +1009,8 @@ class Generator:
         sql = self.query_modifiers(
             expression,
             f"SELECT{hint}{distinct}{expressions}",
+            self.sql(expression, "excludes"),
+            self.sql(expression, "renames"),
             self.sql(expression, "into", comment=False),
             self.sql(expression, "from", comment=False),
         )

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -171,6 +171,7 @@ class TokenType(AutoName):
     ENGINE = auto()
     ESCAPE = auto()
     EXCEPT = auto()
+    EXCLUDE = auto()
     EXECUTE = auto()
     EXISTS = auto()
     FALSE = auto()
@@ -255,6 +256,7 @@ class TokenType(AutoName):
     QUOTE = auto()
     RANGE = auto()
     RECURSIVE = auto()
+    RENAME = auto()
     REPLACE = auto()
     RESPECT_NULLS = auto()
     REFERENCES = auto()
@@ -516,6 +518,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "ENGINE": TokenType.ENGINE,
         "ESCAPE": TokenType.ESCAPE,
         "EXCEPT": TokenType.EXCEPT,
+        "EXCLUDE": TokenType.EXCLUDE,
         "EXECUTE": TokenType.EXECUTE,
         "EXISTS": TokenType.EXISTS,
         "FALSE": TokenType.FALSE,
@@ -592,6 +595,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "RANGE": TokenType.RANGE,
         "RECURSIVE": TokenType.RECURSIVE,
         "REGEXP": TokenType.RLIKE,
+        "RENAME": TokenType.RENAME,
         "REPLACE": TokenType.REPLACE,
         "RESPECT NULLS": TokenType.RESPECT_NULLS,
         "REFERENCES": TokenType.REFERENCES,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -82,6 +82,15 @@ class TestParser(unittest.TestCase):
 
     def test_select(self):
         self.assertIsNotNone(parse_one("select 1 natural"))
+        self.assertIsNotNone(parse_one("select top 1 * from table"))
+        self.assertIsNotNone(parse_one("select top 10 distinct * from table"))
+        self.assertIsNotNone(parse_one("select top 10 distinct * exclude a, b from table"))
+        self.assertIsNotNone(parse_one("select top 10 distinct * rename a as b from table"))
+        self.assertIsNotNone(
+            parse_one(
+                "select top 10 distinct t1.* rename a as b tbl2.* exclude c from table t1, table2 t2"
+            )
+        )
         self.assertIsNotNone(parse_one("select * from (select 1) x order by x.y").args["order"])
         self.assertIsNotNone(
             parse_one("select * from x where a = (select 1) order by x.y").args["order"]


### PR DESCRIPTION
This PR adds support for `SELECT * EXCLUDE` and `SELECT * RENAME` [Snowflake syntax](https://docs.snowflake.com/en/sql-reference/sql/select.html#syntax).

Example SQL that breaks without this change:
```
from sqlglot import exp, parse_one

breaking_sql = """
SELECT DISTINCT
  TBL1.* EXCLUDE DATE_FIELD, ANOTHER_FIELD RENAME TBL1.BAD_FIELD_NAME AS GOOD_FIELD_NAME, C AS D
  TBL2.* EXCLUDE NOT_ANOTHER_FIELD RENAME A AS B
FROM DATABASE.SCHEMA.TABLE TBL1
JOIN DB.SC.TBL AS TBL2 ON TBL1.ID = TBL2.ID
WHERE INT_FIELD = 55
LIMIT 10
"""
for select in parse_one(breaking_sql, read="snowflake").find_all(exp.Select):
    for projection in select.expressions:
        print(projection.alias_or_name)
```