### PR TITLE
Implement func builder, refactor expression validation, fix bug

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4289,9 +4289,8 @@ def func(name: str, *args, dialect: t.Optional[Dialect | str] = None, **kwargs) 
     if from_args_list:
         function = from_args_list(args) if args else from_args_list.__self__(**kwargs)  # type: ignore
     else:
-        function = (
-            Anonymous(this=name, expressions=args) if args else Anonymous(this=name, **kwargs)
-        )
+        kwargs = kwargs or {"expressions": args}
+        function = Anonymous(this=name, **kwargs)
 
     for error_message in function.error_messages(args):
         raise ValueError(error_message)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -822,24 +822,8 @@ class Parser(metaclass=_Parser):
         if self.error_level == ErrorLevel.IGNORE:
             return
 
-        for k in expression.args:
-            if k not in expression.arg_types:
-                self.raise_error(f"Unexpected keyword: '{k}' for {expression.__class__}")
-        for k, mandatory in expression.arg_types.items():
-            v = expression.args.get(k)
-            if mandatory and (v is None or (isinstance(v, list) and not v)):
-                self.raise_error(f"Required keyword: '{k}' missing for {expression.__class__}")
-
-        if (
-            args
-            and isinstance(expression, exp.Func)
-            and len(args) > len(expression.arg_types)
-            and not expression.is_var_len_args
-        ):
-            self.raise_error(
-                f"The number of provided arguments ({len(args)}) is greater than "
-                f"the maximum number of supported arguments ({len(expression.arg_types)})"
-            )
+        for error_message in expression.validate(args):
+            self.raise_error(error_message)
 
     def _find_token(self, token: Token, sql: str) -> int:
         line = 1

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -822,7 +822,7 @@ class Parser(metaclass=_Parser):
         if self.error_level == ErrorLevel.IGNORE:
             return
 
-        for error_message in expression.validate(args):
+        for error_message in expression.error_messages(args):
             self.raise_error(error_message)
 
     def _find_token(self, token: Token, sql: str) -> int:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -190,21 +190,22 @@ class TestExpressions(unittest.TestCase):
         )
 
     def test_function_building(self):
-        num_arg = exp.Literal.number(1)
-        str_arg = exp.Literal.string("foo")
-
-        self.assertEqual(exp.func("bla", num_arg, str_arg).sql(), "BLA(1, 'foo')")
+        self.assertEqual(exp.func("bla", 1, "foo").sql(), "BLA(1, 'foo')")
         self.assertEqual(exp.func("COUNT", exp.Star()).sql(), "COUNT(*)")
         self.assertEqual(exp.func("bloo").sql(), "BLOO()")
+        self.assertEqual(
+            exp.func("locate", "x", "xo", dialect="hive").sql("hive"), "LOCATE('x', 'xo')"
+        )
 
-        self.assertIsInstance(exp.func("bla", num_arg, str_arg), exp.Anonymous)
+        self.assertIsInstance(exp.func("instr", "x", "b", dialect="mysql"), exp.StrPosition)
+        self.assertIsInstance(exp.func("bla", 1, "foo"), exp.Anonymous)
         self.assertIsInstance(
             exp.func("cast", this=exp.Literal.number(5), to=exp.DataType.build("DOUBLE")),
             exp.Cast,
         )
 
         with self.assertRaises(ValueError):
-            exp.func("some_func", num_arg, arg2=str_arg)
+            exp.func("some_func", 1, arg2="foo")
 
         with self.assertRaises(ValueError):
             exp.func("abs")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -189,6 +189,26 @@ class TestExpressions(unittest.TestCase):
             "SELECT * FROM (SELECT a FROM tbl1) WHERE b > 100",
         )
 
+    def test_function_building(self):
+        num_arg = exp.Literal.number(1)
+        str_arg = exp.Literal.string("foo")
+
+        self.assertEqual(exp.func("bla", num_arg, str_arg).sql(), "BLA(1, 'foo')")
+        self.assertEqual(exp.func("COUNT", exp.Star()).sql(), "COUNT(*)")
+        self.assertEqual(exp.func("bloo").sql(), "BLOO()")
+
+        self.assertIsInstance(exp.func("bla", num_arg, str_arg), exp.Anonymous)
+        self.assertIsInstance(
+            exp.func("cast", this=exp.Literal.number(5), to=exp.DataType.build("DOUBLE")),
+            exp.Cast,
+        )
+
+        with self.assertRaises(ValueError):
+            exp.func("some_func", num_arg, arg2=str_arg)
+
+        with self.assertRaises(ValueError):
+            exp.func("abs")
+
     def test_named_selects(self):
         expression = parse_one(
             "SELECT a, b AS B, c + d AS e, *, 'zz', 'zz' AS z FROM foo as bar, baz"


### PR DESCRIPTION
- Bug fixed: due to inheritance, `_sql_names` wasn't updated properly (e.g. `TryCast.sql_names` resulted in `["CAST"]`).
- Created a `validate` method in `Expression`, as it felt more natural. This led to a refactor of `validate_expression`.
- Created a helper function called `func`, which can be used for programmatically building function expressions.