### PR TITLE
Map Snowflake EXCLUDE and RENAME keywords

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2948,13 +2948,16 @@ class Parser(metaclass=_Parser):
     def _parse_except(self) -> t.Optional[t.List[t.Optional[exp.Expression]]]:
         if not self._match(TokenType.EXCEPT):
             return None
-
-        return self._parse_wrapped_id_vars()
+        if self._match(TokenType.L_PAREN, advance=False):
+            return self._parse_wrapped_id_vars()
+        return self._parse_csv(self._parse_expression)
 
     def _parse_replace(self) -> t.Optional[t.List[t.Optional[exp.Expression]]]:
         if not self._match(TokenType.REPLACE):
             return None
-        return self._parse_wrapped_csv(lambda: self._parse_alias(self._parse_expression()))
+        if self._match(TokenType.L_PAREN, advance=False):
+            return self._parse_wrapped_csv(lambda: self._parse_alias(self._parse_expression()))
+        return self._parse_csv(lambda: self._parse_alias(self._parse_expression()))
 
     def _parse_csv(
         self, parse_method: t.Callable, sep: TokenType = TokenType.COMMA

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -13,6 +13,24 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
+            "SELECT * EXCLUDE a, b FROM xxx",
+            write={
+                "snowflake": "SELECT * EXCLUDE (a, b) FROM xxx",
+            },
+        )
+        self.validate_all(
+            "SELECT * RENAME a AS b, c AS d FROM xxx",
+            write={
+                "snowflake": "SELECT * RENAME (a AS b, c AS d) FROM xxx",
+            },
+        )
+        self.validate_all(
+            "SELECT * EXCLUDE a, b RENAME (c AS d, E as F) FROM xxx",
+            write={
+                "snowflake": "SELECT * EXCLUDE (a, b) RENAME (c AS d, E AS F) FROM xxx",
+            },
+        )
+        self.validate_all(
             'x:a:"b c"',
             write={
                 "duckdb": "x['a']['b c']",

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -378,10 +378,13 @@ SELECT * FROM ((SELECT 1) AS a(b))
 SELECT * FROM ((SELECT 1) UNION (SELECT 2) UNION (SELECT 3))
 SELECT * FROM x AS y(a, b)
 SELECT * EXCEPT (a, b)
+SELECT * EXCEPT (a, b) FROM y
 SELECT * REPLACE (a AS b, b AS C)
 SELECT * REPLACE (a + 1 AS b, b AS C)
 SELECT * EXCEPT (a, b) REPLACE (a AS b, b AS C)
+SELECT * EXCEPT (a, b) REPLACE (a AS b, b AS C) FROM y
 SELECT a.* EXCEPT (a, b), b.* REPLACE (a AS b, b AS C)
+SELECT a.* EXCEPT (a, b), b.* REPLACE (a AS b, b AS C) FROM x
 SELECT zoo, animals FROM (VALUES ('oakland', ARRAY('a', 'b')), ('sf', ARRAY('b', 'c'))) AS t(zoo, animals)
 SELECT zoo, animals FROM UNNEST(ARRAY(STRUCT('oakland' AS zoo, ARRAY('a', 'b') AS animals), STRUCT('sf' AS zoo, ARRAY('b', 'c') AS animals))) AS t(zoo, animals)
 WITH a AS (SELECT 1) SELECT 1 UNION ALL SELECT 2


### PR DESCRIPTION
This PR maps Snowflake's proprietary EXCLUDE and RENAME keywords to standard EXCEPT and REPLACE keywords.

It supports parsing these keywords only when Snowflake is the specified dialect. It does not support using them in sql construction.

example code to test:
```
from sqlglot import exp, parse_one

sql = """
SELECT DISTINCT
  TBL1.* EXCLUDE DATE_FIELD, ANOTHER_FIELD RENAME TBL1.BAD_NAME AS GOOD_NAME, C AS D
FROM DATABASE.SCHEMA.TABLE TBL1
JOIN DB.SC.TBL AS TBL2 ON TBL1.ID = TBL2.ID
WHERE INT_FIELD = 55
LIMIT 10
"""

parse_one(sql, read="snowflake")
parse_one(sql, read="snowflake").sql("snowflake")
transpile(sql, read="snowflake", write="snowflake")
```