### PR TITLE
Merge text property parsers with property parsers

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -556,9 +556,6 @@ class Parser(metaclass=_Parser):
         ),
         TokenType.WITH: lambda self: self._parse_wrapped_csv(self._parse_property),
         TokenType.PROPERTIES: lambda self: self._parse_wrapped_csv(self._parse_property),
-    }
-
-    PROPERTY_PARSERS_TEXT = {
         "FALLBACK": lambda self: self._parse_fallback(no=self._prev.text.upper() == "NO"),
         "WITH": lambda self: self._parse_withjournaltable()
         if self._next.text.upper() == "JOURNAL"
@@ -1063,8 +1060,8 @@ class Parser(metaclass=_Parser):
         self._match_text_seq("DUAL")
         self._match_text_seq("DEFAULT")
 
-        if self.PROPERTY_PARSERS_TEXT.get(self._curr.text.upper()):
-            return self.PROPERTY_PARSERS_TEXT[self._curr.text.upper()](self)
+        if self.PROPERTY_PARSERS.get(self._curr.text.upper()):
+            return self.PROPERTY_PARSERS[self._curr.text.upper()](self)
 
         return None
 


### PR DESCRIPTION
Addresses https://github.com/tobymao/sqlglot/pull/1033#discussion_r1092356222

I'm still thinking about https://github.com/tobymao/sqlglot/pull/1033#discussion_r1092354015, but it might be ok to use the "before" arg. If we were to only rely on `BEFORE_PROPERTIES`, I guess we'd have to check whether the first (or all?) elements in the `properties` arg appear in that set, in order to decide what to generate.

@tobymao did you have something else in mind?