### PR TITLE
Only match on property texts, remove some prop tokens

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -169,6 +169,13 @@ class BigQuery(Dialect):
             TokenType.VALUES,
         }
 
+        PROPERTY_PARSERS = {
+            **parser.Parser.PROPERTY_PARSERS,  # type: ignore
+            "NOT DETERMINISTIC": lambda self: self.expression(
+                exp.VolatilityProperty, this=exp.Literal.string("VOLATILE")
+            ),
+        }
+
     class Generator(generator.Generator):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,  # type: ignore

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -251,7 +251,7 @@ class Hive(Dialect):
 
         PROPERTY_PARSERS = {
             **parser.Parser.PROPERTY_PARSERS,  # type: ignore
-            TokenType.SERDE_PROPERTIES: lambda self: exp.SerdeProperties(
+            "WITH SERDEPROPERTIES": lambda self: exp.SerdeProperties(
                 expressions=self._parse_wrapped_csv(self._parse_property)
             ),
         }

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -202,7 +202,7 @@ class MySQL(Dialect):
 
         PROPERTY_PARSERS = {
             **parser.Parser.PROPERTY_PARSERS,  # type: ignore
-            TokenType.ENGINE: lambda self: self._parse_property_assignment(exp.EngineProperty),
+            "ENGINE": lambda self: self._parse_property_assignment(exp.EngineProperty),
         }
 
         STATEMENT_PARSERS = {

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -178,11 +178,6 @@ class Snowflake(Dialect):
             ),
         }
 
-        PROPERTY_PARSERS = {
-            **parser.Parser.PROPERTY_PARSERS,
-            TokenType.PARTITION_BY: lambda self: self._parse_partitioned_by(),
-        }
-
     class Tokenizer(tokens.Tokenizer):
         QUOTES = ["'", "$$"]
         ESCAPES = ["\\", "'"]

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -175,13 +175,9 @@ class Parser(metaclass=_Parser):
         TokenType.DEFAULT,
         TokenType.DELETE,
         TokenType.DESCRIBE,
-        TokenType.DETERMINISTIC,
         TokenType.DIV,
-        TokenType.DISTKEY,
-        TokenType.DISTSTYLE,
         TokenType.END,
         TokenType.EXECUTE,
-        TokenType.ENGINE,
         TokenType.ESCAPE,
         TokenType.FALSE,
         TokenType.FIRST,
@@ -194,13 +190,10 @@ class Parser(metaclass=_Parser):
         TokenType.IF,
         TokenType.INDEX,
         TokenType.ISNULL,
-        TokenType.IMMUTABLE,
         TokenType.INTERVAL,
         TokenType.LAZY,
-        TokenType.LANGUAGE,
         TokenType.LEADING,
         TokenType.LOCAL,
-        TokenType.LOCATION,
         TokenType.MATERIALIZED,
         TokenType.MERGE,
         TokenType.NATURAL,
@@ -209,13 +202,11 @@ class Parser(metaclass=_Parser):
         TokenType.ONLY,
         TokenType.OPTIONS,
         TokenType.ORDINALITY,
-        TokenType.PARTITIONED_BY,
         TokenType.PERCENT,
         TokenType.PIVOT,
         TokenType.PRECEDING,
         TokenType.RANGE,
         TokenType.REFERENCES,
-        TokenType.RETURNS,
         TokenType.ROW,
         TokenType.ROWS,
         TokenType.SCHEMA,
@@ -225,10 +216,7 @@ class Parser(metaclass=_Parser):
         TokenType.SET,
         TokenType.SHOW,
         TokenType.SORTKEY,
-        TokenType.STABLE,
-        TokenType.STORED,
         TokenType.TABLE,
-        TokenType.TABLE_FORMAT,
         TokenType.TEMPORARY,
         TokenType.TOP,
         TokenType.TRAILING,
@@ -237,7 +225,6 @@ class Parser(metaclass=_Parser):
         TokenType.UNIQUE,
         TokenType.UNLOGGED,
         TokenType.UNPIVOT,
-        TokenType.PROPERTIES,
         TokenType.PROCEDURE,
         TokenType.VIEW,
         TokenType.VOLATILE,
@@ -520,49 +507,41 @@ class Parser(metaclass=_Parser):
     }
 
     PROPERTY_PARSERS = {
-        TokenType.AUTO_INCREMENT: lambda self: self._parse_property_assignment(
-            exp.AutoIncrementProperty
-        ),
-        TokenType.CHARACTER_SET: lambda self: self._parse_character_set(),
-        TokenType.LOCATION: lambda self: self._parse_property_assignment(exp.LocationProperty),
-        TokenType.PARTITIONED_BY: lambda self: self._parse_partitioned_by(),
-        TokenType.SCHEMA_COMMENT: lambda self: self._parse_property_assignment(
-            exp.SchemaCommentProperty
-        ),
-        TokenType.STORED: lambda self: self._parse_property_assignment(exp.FileFormatProperty),
-        TokenType.DISTKEY: lambda self: self._parse_distkey(),
-        TokenType.DISTSTYLE: lambda self: self._parse_property_assignment(exp.DistStyleProperty),
-        TokenType.SORTKEY: lambda self: self._parse_sortkey(),
-        TokenType.LIKE: lambda self: self._parse_create_like(),
-        TokenType.RETURNS: lambda self: self._parse_returns(),
-        TokenType.ROW: lambda self: self._parse_row(),
-        TokenType.COLLATE: lambda self: self._parse_property_assignment(exp.CollateProperty),
-        TokenType.COMMENT: lambda self: self._parse_property_assignment(exp.SchemaCommentProperty),
-        TokenType.FORMAT: lambda self: self._parse_property_assignment(exp.FileFormatProperty),
-        TokenType.TABLE_FORMAT: lambda self: self._parse_property_assignment(
-            exp.TableFormatProperty
-        ),
-        TokenType.USING: lambda self: self._parse_property_assignment(exp.TableFormatProperty),
-        TokenType.LANGUAGE: lambda self: self._parse_property_assignment(exp.LanguageProperty),
-        TokenType.EXECUTE: lambda self: self._parse_property_assignment(exp.ExecuteAsProperty),
-        TokenType.DETERMINISTIC: lambda self: self.expression(
+        "AUTO_INCREMENT": lambda self: self._parse_property_assignment(exp.AutoIncrementProperty),
+        "CHARACTER SET": lambda self: self._parse_character_set(),
+        "LOCATION": lambda self: self._parse_property_assignment(exp.LocationProperty),
+        "PARTITION BY": lambda self: self._parse_partitioned_by(),
+        "PARTITIONED BY": lambda self: self._parse_partitioned_by(),
+        "PARTITIONED_BY": lambda self: self._parse_partitioned_by(),
+        "COMMENT": lambda self: self._parse_property_assignment(exp.SchemaCommentProperty),
+        "STORED": lambda self: self._parse_property_assignment(exp.FileFormatProperty),
+        "DISTKEY": lambda self: self._parse_distkey(),
+        "DISTSTYLE": lambda self: self._parse_property_assignment(exp.DistStyleProperty),
+        "SORTKEY": lambda self: self._parse_sortkey(),
+        "LIKE": lambda self: self._parse_create_like(),
+        "RETURNS": lambda self: self._parse_returns(),
+        "ROW": lambda self: self._parse_row(),
+        "COLLATE": lambda self: self._parse_property_assignment(exp.CollateProperty),
+        "FORMAT": lambda self: self._parse_property_assignment(exp.FileFormatProperty),
+        "TABLE_FORMAT": lambda self: self._parse_property_assignment(exp.TableFormatProperty),
+        "USING": lambda self: self._parse_property_assignment(exp.TableFormatProperty),
+        "LANGUAGE": lambda self: self._parse_property_assignment(exp.LanguageProperty),
+        "EXECUTE": lambda self: self._parse_property_assignment(exp.ExecuteAsProperty),
+        "DETERMINISTIC": lambda self: self.expression(
             exp.VolatilityProperty, this=exp.Literal.string("IMMUTABLE")
         ),
-        TokenType.IMMUTABLE: lambda self: self.expression(
+        "IMMUTABLE": lambda self: self.expression(
             exp.VolatilityProperty, this=exp.Literal.string("IMMUTABLE")
         ),
-        TokenType.STABLE: lambda self: self.expression(
+        "STABLE": lambda self: self.expression(
             exp.VolatilityProperty, this=exp.Literal.string("STABLE")
         ),
-        TokenType.VOLATILE: lambda self: self.expression(
+        "VOLATILE": lambda self: self.expression(
             exp.VolatilityProperty, this=exp.Literal.string("VOLATILE")
         ),
-        TokenType.WITH: lambda self: self._parse_wrapped_csv(self._parse_property),
-        TokenType.PROPERTIES: lambda self: self._parse_wrapped_csv(self._parse_property),
+        "WITH": lambda self: self._parse_with_property(),
+        "TBLPROPERTIES": lambda self: self._parse_wrapped_csv(self._parse_property),
         "FALLBACK": lambda self: self._parse_fallback(no=self._prev.text.upper() == "NO"),
-        "WITH": lambda self: self._parse_withjournaltable()
-        if self._next.text.upper() == "JOURNAL"
-        else self._parse_withisolatedloading(),
         "LOG": lambda self: self._parse_log(no=self._prev.text.upper() == "NO"),
         "BEFORE": lambda self: self._parse_journal(
             no=self._prev.text.upper() == "NO", dual=self._prev.text.upper() == "DUAL"
@@ -1069,8 +1048,8 @@ class Parser(metaclass=_Parser):
         return None
 
     def _parse_property(self) -> t.Optional[exp.Expression]:
-        if self._match_set(self.PROPERTY_PARSERS):
-            return self.PROPERTY_PARSERS[self._prev.token_type](self)
+        if self._match_texts(self.PROPERTY_PARSERS):
+            return self.PROPERTY_PARSERS[self._prev.text.upper()](self)
 
         if self._match_pair(TokenType.DEFAULT, TokenType.CHARACTER_SET):
             return self._parse_character_set(True)
@@ -1122,6 +1101,20 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.FallbackProperty, no=no, protection=self._match_text_seq("PROTECTION")
         )
+
+    def _parse_with_property(
+        self,
+    ) -> t.Union[t.Optional[exp.Expression], t.List[t.Optional[exp.Expression]]]:
+        if self._match(TokenType.L_PAREN, advance=False):
+            return self._parse_wrapped_csv(self._parse_property)
+
+        if not self._next:
+            return None
+
+        if self._next.text.upper() == "JOURNAL":
+            return self._parse_withjournaltable()
+
+        return self._parse_withisolatedloading()
 
     def _parse_withjournaltable(self) -> exp.Expression:
         self._match_text_seq("WITH", "JOURNAL", "TABLE")

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -158,18 +158,14 @@ class TokenType(AutoName):
     DELETE = auto()
     DESC = auto()
     DESCRIBE = auto()
-    DETERMINISTIC = auto()
     DISTINCT = auto()
     DISTINCT_FROM = auto()
-    DISTKEY = auto()
     DISTRIBUTE_BY = auto()
-    DISTSTYLE = auto()
     DIV = auto()
     DROP = auto()
     ELSE = auto()
     ENCODE = auto()
     END = auto()
-    ENGINE = auto()
     ESCAPE = auto()
     EXCEPT = auto()
     EXECUTE = auto()
@@ -197,7 +193,6 @@ class TokenType(AutoName):
     IF = auto()
     IGNORE_NULLS = auto()
     ILIKE = auto()
-    IMMUTABLE = auto()
     IN = auto()
     INDEX = auto()
     INNER = auto()
@@ -219,7 +214,6 @@ class TokenType(AutoName):
     LIMIT = auto()
     LOAD_DATA = auto()
     LOCAL = auto()
-    LOCATION = auto()
     MAP = auto()
     MATCH_RECOGNIZE = auto()
     MATERIALIZED = auto()
@@ -245,7 +239,6 @@ class TokenType(AutoName):
     OVERWRITE = auto()
     PARTITION = auto()
     PARTITION_BY = auto()
-    PARTITIONED_BY = auto()
     PERCENT = auto()
     PIVOT = auto()
     PLACEHOLDER = auto()
@@ -261,7 +254,6 @@ class TokenType(AutoName):
     REPLACE = auto()
     RESPECT_NULLS = auto()
     REFERENCES = auto()
-    RETURNS = auto()
     RIGHT = auto()
     RLIKE = auto()
     ROLLBACK = auto()
@@ -280,10 +272,7 @@ class TokenType(AutoName):
     SOME = auto()
     SORTKEY = auto()
     SORT_BY = auto()
-    STABLE = auto()
-    STORED = auto()
     STRUCT = auto()
-    TABLE_FORMAT = auto()
     TABLE_SAMPLE = auto()
     TEMPORARY = auto()
     TOP = auto()
@@ -509,17 +498,13 @@ class Tokenizer(metaclass=_Tokenizer):
         "DELETE": TokenType.DELETE,
         "DESC": TokenType.DESC,
         "DESCRIBE": TokenType.DESCRIBE,
-        "DETERMINISTIC": TokenType.DETERMINISTIC,
         "DISTINCT": TokenType.DISTINCT,
         "DISTINCT FROM": TokenType.DISTINCT_FROM,
-        "DISTKEY": TokenType.DISTKEY,
         "DISTRIBUTE BY": TokenType.DISTRIBUTE_BY,
-        "DISTSTYLE": TokenType.DISTSTYLE,
         "DIV": TokenType.DIV,
         "DROP": TokenType.DROP,
         "ELSE": TokenType.ELSE,
         "END": TokenType.END,
-        "ENGINE": TokenType.ENGINE,
         "ESCAPE": TokenType.ESCAPE,
         "EXCEPT": TokenType.EXCEPT,
         "EXECUTE": TokenType.EXECUTE,
@@ -543,7 +528,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "IDENTITY": TokenType.IDENTITY,
         "IF": TokenType.IF,
         "ILIKE": TokenType.ILIKE,
-        "IMMUTABLE": TokenType.IMMUTABLE,
         "IGNORE NULLS": TokenType.IGNORE_NULLS,
         "IN": TokenType.IN,
         "INDEX": TokenType.INDEX,
@@ -555,7 +539,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "IS": TokenType.IS,
         "ISNULL": TokenType.ISNULL,
         "JOIN": TokenType.JOIN,
-        "LANGUAGE": TokenType.LANGUAGE,
         "LATERAL": TokenType.LATERAL,
         "LAZY": TokenType.LAZY,
         "LEADING": TokenType.LEADING,
@@ -564,7 +547,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "LIMIT": TokenType.LIMIT,
         "LOAD DATA": TokenType.LOAD_DATA,
         "LOCAL": TokenType.LOCAL,
-        "LOCATION": TokenType.LOCATION,
         "MATERIALIZED": TokenType.MATERIALIZED,
         "MERGE": TokenType.MERGE,
         "NATURAL": TokenType.NATURAL,
@@ -589,8 +571,8 @@ class Tokenizer(metaclass=_Tokenizer):
         "OVERWRITE": TokenType.OVERWRITE,
         "PARTITION": TokenType.PARTITION,
         "PARTITION BY": TokenType.PARTITION_BY,
-        "PARTITIONED BY": TokenType.PARTITIONED_BY,
-        "PARTITIONED_BY": TokenType.PARTITIONED_BY,
+        "PARTITIONED BY": TokenType.PARTITION_BY,
+        "PARTITIONED_BY": TokenType.PARTITION_BY,
         "PERCENT": TokenType.PERCENT,
         "PIVOT": TokenType.PIVOT,
         "PRECEDING": TokenType.PRECEDING,
@@ -603,7 +585,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "REPLACE": TokenType.REPLACE,
         "RESPECT NULLS": TokenType.RESPECT_NULLS,
         "REFERENCES": TokenType.REFERENCES,
-        "RETURNS": TokenType.RETURNS,
         "RIGHT": TokenType.RIGHT,
         "RLIKE": TokenType.RLIKE,
         "ROLLBACK": TokenType.ROLLBACK,
@@ -620,11 +601,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "SOME": TokenType.SOME,
         "SORTKEY": TokenType.SORTKEY,
         "SORT BY": TokenType.SORT_BY,
-        "STABLE": TokenType.STABLE,
-        "STORED": TokenType.STORED,
         "TABLE": TokenType.TABLE,
-        "TABLE_FORMAT": TokenType.TABLE_FORMAT,
-        "TBLPROPERTIES": TokenType.PROPERTIES,
         "TABLESAMPLE": TokenType.TABLE_SAMPLE,
         "TEMP": TokenType.TEMPORARY,
         "TEMPORARY": TokenType.TEMPORARY,


### PR DESCRIPTION
Tried to clean up `PROPERTY_PARSERS` once again, so that we now only use strings instead of mixing them up with tokens.