### PR TITLE
add: transpile ifnull from bigquery to coalesce

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -145,6 +145,7 @@ class BigQuery(Dialect):
             "PARSE_TIMESTAMP": lambda args: exp.StrToTime(
                 this=seq_get(args, 1), format=seq_get(args, 0)
             ),
+            "IFNULL": exp.Coalesce.from_arg_list,
         }
 
         FUNCTION_PARSERS = {

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -256,6 +256,14 @@ FROM bar /* comment 5 */, tbl /*          comment 6 */""",
         )
         self.validate("SELECT IF(a > 1, 1) FROM foo", "SELECT CASE WHEN a > 1 THEN 1 END FROM foo")
 
+    def test_if_null(self):
+        self.validate(
+            "SELECT IFNULL(1, NULL) FROM foo",
+            "SELECT COALESCE(1, NULL) FROM foo",
+            read="bigquery",
+            write="redshift",
+        )
+
     def test_ignore_nulls(self):
         self.validate("SELECT COUNT(x RESPECT NULLS)", "SELECT COUNT(x)")
 


### PR DESCRIPTION
### Add new translation

this pull request adds the IFNULL function conversion to Coalesce Function.

IFNULL Function hasn't a direct correspondent, but it does the same thing as the coalesce and NVL

**OBS**: is my first PR in repo, please tell me if i did something wrong :)