### PR TITLE
Fix transpilation of generate_series for trino

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -29,7 +29,7 @@ DATE_DIFF_FACTOR = {
 }
 
 # This pattern is used to capture valid postgres string intervals like '  15  days '
-INTERVAL_STRING_RE = re.compile("([0-9]+)([a-zA-Z]+)")
+INTERVAL_STRING_RE = re.compile(r"\s*([0-9]+)\s*([a-zA-Z]+)\s*")
 
 
 def _date_add_sql(kind):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3964,9 +3964,15 @@ def to_identifier(alias, quoted=None) -> t.Optional[Identifier]:
 INTERVAL_STRING_RE = re.compile(r"\s*([0-9]+)\s*([a-zA-Z]+)\s*")
 
 
-def to_interval(interval: str) -> Interval:
+def to_interval(interval: str | Literal) -> Interval:
     """Builds an interval expression from a string like '1 day' or '5 months'."""
-    interval_parts = INTERVAL_STRING_RE.match(interval)
+    if isinstance(interval, Literal):
+        if not interval.is_string:
+            raise ValueError("Invalid interval string.")
+
+        interval = interval.this
+
+    interval_parts = INTERVAL_STRING_RE.match(interval)  # type: ignore
 
     if not interval_parts:
         raise ValueError("Invalid interval string.")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3961,6 +3961,22 @@ def to_identifier(alias, quoted=None) -> t.Optional[Identifier]:
     return identifier
 
 
+INTERVAL_STRING_RE = re.compile(r"\s*([0-9]+)\s*([a-zA-Z]+)\s*")
+
+
+def to_interval(interval: str) -> Interval:
+    """Builds an interval expression from a string like '1 day' or '5 months'."""
+    interval_parts = INTERVAL_STRING_RE.match(interval)
+
+    if not interval_parts:
+        raise ValueError("Invalid interval string.")
+
+    return Interval(
+        this=Literal.string(interval_parts.group(1)),
+        unit=Var(this=interval_parts.group(2)),
+    )
+
+
 @t.overload
 def to_table(sql_path: str | Table, **kwargs) -> Table:
     ...

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -113,11 +113,11 @@ class TestPostgres(Validator):
         self.validate_identity("x ~* 'y'")
 
         self.validate_all(
-            "GENERATE_SERIES(a, b, c)",
+            "GENERATE_SERIES(a, b, '  2   days  ')",
             write={
-                "postgres": "GENERATE_SERIES(a, b, c)",
-                "presto": "SEQUENCE(a, b, c)",
-                "trino": "SEQUENCE(a, b, c)",
+                "postgres": "GENERATE_SERIES(a, b, INTERVAL '2' days)",
+                "presto": "SEQUENCE(a, b, INTERVAL '2' days)",
+                "trino": "SEQUENCE(a, b, INTERVAL '2' days)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -121,6 +121,14 @@ class TestPostgres(Validator):
             },
         )
         self.validate_all(
+            "GENERATE_SERIES('2019-01-01'::TIMESTAMP, NOW(), '1day')",
+            write={
+                "postgres": "GENERATE_SERIES(CAST('2019-01-01' AS TIMESTAMP), CURRENT_TIMESTAMP, INTERVAL '1' day)",
+                "presto": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP AS TIMESTAMP), INTERVAL '1' day)",
+                "trino": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP AS TIMESTAMP), INTERVAL '1' day)",
+            },
+        )
+        self.validate_all(
             "END WORK AND NO CHAIN",
             write={"postgres": "COMMIT AND NO CHAIN"},
         )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -314,6 +314,11 @@ class TestPresto(Validator):
 
     def test_presto(self):
         self.validate_identity("SELECT BOOL_OR(a > 10) FROM asd AS T(a)")
+        self.validate_identity("SELECT * FROM (VALUES (1))")
+        self.validate_identity("START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE")
+        self.validate_identity("START TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        self.validate_identity("APPROX_PERCENTILE(a, b, c, d)")
+
         self.validate_all(
             'SELECT a."b" FROM "foo"',
             write={
@@ -455,10 +460,6 @@ class TestPresto(Validator):
                 "spark": UnsupportedError,
             },
         )
-        self.validate_identity("SELECT * FROM (VALUES (1))")
-        self.validate_identity("START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE")
-        self.validate_identity("START TRANSACTION ISOLATION LEVEL REPEATABLE READ")
-        self.validate_identity("APPROX_PERCENTILE(a, b, c, d)")
 
     def test_encode_decode(self):
         self.validate_all(

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -637,6 +637,13 @@ FROM foo""",
         with self.assertRaises(ValueError):
             exp.to_interval("bla")
 
+        self.assertEqual(exp.to_interval(exp.Literal.string("1day")).sql(), "INTERVAL '1' day")
+        self.assertEqual(
+            exp.to_interval(exp.Literal.string("  5   months")).sql(), "INTERVAL '5' months"
+        )
+        with self.assertRaises(ValueError):
+            exp.to_interval(exp.Literal.string("bla"))
+
     def test_to_table(self):
         table_only = exp.to_table("table_name")
         self.assertEqual(table_only.name, "table_name")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -631,6 +631,12 @@ FROM foo""",
 FROM foo""",
         )
 
+    def test_to_interval(self):
+        self.assertEqual(exp.to_interval("1day").sql(), "INTERVAL '1' day")
+        self.assertEqual(exp.to_interval("  5     months").sql(), "INTERVAL '5' months")
+        with self.assertRaises(ValueError):
+            exp.to_interval("bla")
+
     def test_to_table(self):
         table_only = exp.to_table("table_name")
         self.assertEqual(table_only.name, "table_name")


### PR DESCRIPTION
Completed the remaining tasks for https://github.com/tobymao/sqlglot/pull/1081

Fixes #1077 

Note: for the time being, I only handled casting to `timestamp` (if needed). This can be easily refined in the future if we want to include other cases too.