### PR TITLE
Fix eliminate_subqueries on unions

### DIFF
--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -114,7 +114,7 @@ def _eliminate_union(scope, existing_ctes, taken):
     taken[alias] = scope
 
     # Try to maintain the selections
-    expressions = scope.expression.args.get("expressions")
+    expressions = scope.selects
     selects = [
         exp.alias_(exp.column(e.alias_or_name, table=alias), alias=e.alias_or_name)
         for e in expressions

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -300,7 +300,7 @@ class Scope:
             list[exp.Expression]: expressions
         """
         if isinstance(self.expression, exp.Union):
-            return []
+            return self.expression.unnest().selects
         return self.expression.selects
 
     @property

--- a/tests/fixtures/optimizer/eliminate_subqueries.sql
+++ b/tests/fixtures/optimizer/eliminate_subqueries.sql
@@ -50,6 +50,10 @@ WITH cte AS (SELECT 1 AS x, 2 AS y) SELECT cte.x AS x, cte.y AS y FROM cte AS ct
 (SELECT a FROM (SELECT b FROM x)) UNION (SELECT a FROM (SELECT b FROM y));
 WITH cte AS (SELECT b FROM x), cte_2 AS (SELECT a FROM cte AS cte), cte_3 AS (SELECT b FROM y), cte_4 AS (SELECT a FROM cte_3 AS cte_3) (SELECT cte_2.a AS a FROM cte_2 AS cte_2) UNION (SELECT cte_4.a AS a FROM cte_4 AS cte_4);
 
+-- Three unions
+SELECT a FROM x UNION ALL SELECT a FROM y UNION ALL SELECT a FROM z;
+WITH cte AS (SELECT a FROM x), cte_2 AS (SELECT a FROM y), cte_3 AS (SELECT a FROM z), cte_4 AS (SELECT cte_2.a AS a FROM cte_2 AS cte_2 UNION ALL SELECT cte_3.a AS a FROM cte_3 AS cte_3) SELECT cte.a AS a FROM cte AS cte UNION ALL SELECT cte_4.a AS a FROM cte_4 AS cte_4;
+
 -- Subquery
 SELECT a FROM x WHERE b = (SELECT y.c FROM y);
 SELECT a FROM x WHERE b = (SELECT y.c FROM y);


### PR DESCRIPTION
fixes https://github.com/tobymao/sqlglot/issues/1093

This still leaves a pretty ugly result:
```python
from sqlglot import parse_one
from sqlglot.optimizer import optimize

sql = """
select test_col from test_table
union all select test_col from test_table_1
union all select test_col from test_table_2
"""
schema = {
    "test_table": {"test_col": "INT"},
    "test_table_1": {"test_col": "INT"},
    "test_table_2": {"test_col": "INT"}
}
ast = parse_one(sql)
ast = optimize(ast, schema=schema)
print(ast.sql(pretty=True))
```
```sql
WITH "cte_4" AS (
  SELECT
    "test_table_1"."test_col" AS "test_col"
  FROM "test_table_1" AS "test_table_1"
  UNION ALL
  SELECT
    "test_table_2"."test_col" AS "test_col"
  FROM "test_table_2" AS "test_table_2"
)
SELECT
  "test_table"."test_col" AS "test_col"
FROM "test_table" AS "test_table"
UNION ALL
SELECT
  "cte_4"."test_col" AS "test_col"
FROM "cte_4" AS "cte_4"
```

But at least it's valid.