### PR TITLE
Add `LONGVARCHAR` data type

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -665,6 +665,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "STRING": TokenType.TEXT,
         "TEXT": TokenType.TEXT,
         "CLOB": TokenType.TEXT,
+        "LONGVARCHAR": TokenType.TEXT,
         "BINARY": TokenType.BINARY,
         "BLOB": TokenType.VARBINARY,
         "BYTEA": TokenType.VARBINARY,

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -92,3 +92,9 @@ class TestSQLite(Validator):
                 "sqlite": "SELECT FIRST_VALUE(Name) OVER (PARTITION BY AlbumId ORDER BY Bytes DESC) AS LargestTrack FROM tracks"
             },
         )
+
+    def test_longvarchar_dtype(self):
+        self.validate_all(
+            "CREATE TABLE foo (bar LONGVARCHAR)",
+            write={"sqlite": "CREATE TABLE foo (bar TEXT)"},
+        )


### PR DESCRIPTION
I encountered a schema using an unsupported `LONGVARCHAR` data type. 

I have not encountered this type before, but it appears to be [a generic JDBC type](https://docs.oracle.com/javase/8/docs/api/java/sql/Types.html#LONGVARCHAR) equivalent to `TEXT`. The type appears to be possibly supported by Oracle (I don't have an installation to test) and [deprecated since 2005 in SQL-Server](https://learn.microsoft.com/en-us/sql/connect/jdbc/understanding-data-type-differences?view=sql-server-ver16).

`sqlite` trivially supports `LONGVARCHAR` as it substring matches any type containing `CHAR` as a "text affinity". 

I think it's a question for the `sqlglot` maintainers on whether this type should be supported, but I have tested this addition locally in case it should be. 

e.g. 
```python
from sqlglot import parse_one

sql = "CREATE TABLE foo (bar LONGVARCHAR);"
parse_one(sql)
```

```shell
(CREATE this: 
  (SCHEMA this: 
    (TABLE this: 
      (IDENTIFIER this: foo, quoted: False)), expressions: 
    (COLUMNDEF this: 
      (IDENTIFIER this: bar, quoted: False), kind: 
      (DATATYPE this: Type.TEXT, nested: False))), kind: TABLE, multiset: False, global_temporary: False, transient: False, external: False, no_primary_index: False)
```