### PR TITLE
expand_laterals

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 
 from sqlglot import Schema, exp, maybe_parse
 from sqlglot.optimizer import Scope, build_scope, optimize
+from sqlglot.optimizer.expand_laterals import expand_laterals
 from sqlglot.optimizer.qualify_columns import qualify_columns
 from sqlglot.optimizer.qualify_tables import qualify_tables
 
@@ -38,7 +39,7 @@ def lineage(
     sql: str | exp.Expression,
     schema: t.Optional[t.Dict | Schema] = None,
     sources: t.Optional[t.Dict[str, str | exp.Subqueryable]] = None,
-    rules: t.Sequence[t.Callable] = (qualify_tables, qualify_columns),
+    rules: t.Sequence[t.Callable] = (qualify_tables, qualify_columns, expand_laterals),
     dialect: DialectType = None,
 ) -> Node:
     """Build the lineage graph for a column of a SQL query.

--- a/sqlglot/optimizer/expand_laterals.py
+++ b/sqlglot/optimizer/expand_laterals.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import typing as t
+
+from sqlglot import exp
+
+
+def expand_laterals(expression: exp.Expression) -> exp.Expression:
+    """
+    Expand lateral column alias references.
+
+    This assumes `qualify_columns` as already run.
+
+    Example:
+        >>> import sqlglot
+        >>> sql = "SELECT x.a + 1 AS b, b + 1 AS c FROM x"
+        >>> expression = sqlglot.parse_one(sql)
+        >>> expand_laterals(expression).sql()
+        'SELECT x.a + 1 AS b, x.a + 1 + 1 AS c FROM x'
+
+    Args:
+        expression: expression to optimize
+    Returns:
+        optimized expression
+    """
+    for select in expression.find_all(exp.Select):
+        alias_to_expression: t.Dict[str, exp.Expression] = {}
+        for projection in select.expressions:
+            for column in projection.find_all(exp.Column):
+                if not column.table and column.name in alias_to_expression:
+                    column.replace(alias_to_expression[column.name].copy())
+                if isinstance(projection, exp.Alias):
+                    alias_to_expression[projection.alias] = projection.this
+    return expression

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -4,6 +4,7 @@ from sqlglot.optimizer.canonicalize import canonicalize
 from sqlglot.optimizer.eliminate_ctes import eliminate_ctes
 from sqlglot.optimizer.eliminate_joins import eliminate_joins
 from sqlglot.optimizer.eliminate_subqueries import eliminate_subqueries
+from sqlglot.optimizer.expand_laterals import expand_laterals
 from sqlglot.optimizer.expand_multi_table_selects import expand_multi_table_selects
 from sqlglot.optimizer.isolate_table_selects import isolate_table_selects
 from sqlglot.optimizer.lower_identities import lower_identities
@@ -12,7 +13,7 @@ from sqlglot.optimizer.normalize import normalize
 from sqlglot.optimizer.optimize_joins import optimize_joins
 from sqlglot.optimizer.pushdown_predicates import pushdown_predicates
 from sqlglot.optimizer.pushdown_projections import pushdown_projections
-from sqlglot.optimizer.qualify_columns import qualify_columns
+from sqlglot.optimizer.qualify_columns import qualify_columns, validate_qualify_columns
 from sqlglot.optimizer.qualify_tables import qualify_tables
 from sqlglot.optimizer.unnest_subqueries import unnest_subqueries
 from sqlglot.schema import ensure_schema
@@ -22,6 +23,8 @@ RULES = (
     qualify_tables,
     isolate_table_selects,
     qualify_columns,
+    expand_laterals,
+    validate_qualify_columns,
     pushdown_projections,
     normalize,
     unnest_subqueries,

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -47,7 +47,7 @@ def validate_qualify_columns(expression):
     for scope in traverse_scope(expression):
         if isinstance(scope.expression, exp.Select):
             unqualified_columns.extend(scope.unqualified_columns)
-            if scope.external_columns and not scope.is_udtf and not scope.is_correlated_subquery:
+            if scope.external_columns and not scope.is_correlated_subquery:
                 raise OptimizeError(f"Unknown table: {scope.external_columns[0].table}")
 
     if unqualified_columns:

--- a/tests/fixtures/optimizer/expand_laterals.sql
+++ b/tests/fixtures/optimizer/expand_laterals.sql
@@ -1,0 +1,40 @@
+# title: expand alias reference
+SELECT
+  x.a + 1 AS i,
+  i + 1 AS j,
+  j + 1 AS k
+FROM x;
+SELECT
+  x.a + 1 AS i,
+  x.a + 1 + 1 AS j,
+  x.a + 1 + 1 + 1 AS k
+FROM x;
+
+# title: noop - reference comes before alias
+SELECT
+  b + 1 AS j,
+  x.a + 1 AS i
+FROM x;
+SELECT
+  b + 1 AS j,
+  x.a + 1 AS i
+FROM x;
+
+
+# title: subquery
+SELECT
+  *
+FROM (
+  SELECT
+    x.a + 1 AS i,
+    i + 1 AS j
+  FROM x
+);
+SELECT
+  *
+FROM (
+  SELECT
+    x.a + 1 AS i,
+    x.a + 1 + 1 AS j
+  FROM x
+);

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -375,3 +375,18 @@ SELECT
 FROM "x" AS "x"
 RIGHT JOIN "y_2" AS "y"
   ON "x"."a" = "y"."b";
+
+
+# title: lateral column alias reference
+SELECT x.a + 1 AS c, c + 1 AS d FROM x;
+SELECT
+  "x"."a" + 1 AS "c",
+  "x"."a" + 2 AS "d"
+FROM "x" AS "x";
+
+# title: column reference takes priority over lateral column alias reference
+SELECT x.a + 1 AS b, b + 1 AS c FROM x;
+SELECT
+  "x"."a" + 1 AS "b",
+  "x"."b" + 1 AS "c"
+FROM "x" AS "x";

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -163,7 +163,10 @@ class TestOptimizer(unittest.TestCase):
         for sql in load_sql_fixtures("optimizer/qualify_columns__invalid.sql"):
             with self.subTest(sql):
                 with self.assertRaises((OptimizeError, SchemaError)):
-                    optimizer.qualify_columns.qualify_columns(parse_one(sql), schema=self.schema)
+                    expression = optimizer.qualify_columns.qualify_columns(
+                        parse_one(sql), schema=self.schema
+                    )
+                    optimizer.qualify_columns.validate_qualify_columns(expression)
 
     def test_lower_identities(self):
         self.check_file("lower_identities", optimizer.lower_identities.lower_identities)
@@ -189,6 +192,14 @@ class TestOptimizer(unittest.TestCase):
 
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)
+
+    def test_expand_laterals(self):
+        self.check_file(
+            "expand_laterals",
+            optimizer.expand_laterals.expand_laterals,
+            pretty=True,
+            execute=True,
+        )
 
     def test_expand_multi_table_selects(self):
         self.check_file(


### PR DESCRIPTION
Support for "lateral column alias references" (e.g. https://aws.amazon.com/about-aws/whats-new/2018/08/amazon-redshift-announces-support-for-lateral-column-alias-reference/). These are valid in snowflake, redshift, duckdb, and possibly more.

```sql
SELECT
  x.a + 1 AS i,
  i + 1 AS j,
  j + 1 AS k
FROM x;

-- to

SELECT
  x.a + 1 AS i,
  x.a + 1 + 1 AS j,
  x.a + 1 + 1 + 1 AS k
FROM x;
```

Not crazy about splitting `validate_qualify_columns` out. But this seemed like a practical way to not keep complicating `qualify_columns` logic.