### PR TITLE
Fix translating DATE_TRUNC function for spark dialect

### DIFF
--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -334,3 +334,19 @@ TBLPROPERTIES (
             "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",
             write={"spark": "SELECT a, BOOL_OR(b) FROM table GROUP BY a"},
         )
+
+    def test_date_trunc(self):
+        self.validate_all(
+            "DATE_TRUNC('day', date_col)",
+            read={
+                "spark": "DATE_TRUNC('day', date_col)",
+            },
+        )
+
+    def test__trunc(self):
+        self.validate_all(
+            "TRUNC(date_col, 'day')",
+            read={
+                "spark": "TRUNC(date_col, 'day')",
+            },
+        )


### PR DESCRIPTION
In the main branch, parsing `DATE_TRUNC('day', some_ts)` erroneously translates to `TRUNC(some_ts, 'day')`. Spark sql has a DATE_TRUNC functions since version 2.3.0. Rendering to spark dialect should preserve the `DATE_TRUNC` function.