### PR TITLE
Teradata: use MOD instead of % for modulus

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -11,7 +11,12 @@ class Teradata(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "BYTEINT": TokenType.SMALLINT,
             "SEL": TokenType.SELECT,
+            "MOD": TokenType.MOD,
         }
+
+        # teradata does not support % for modulus
+        SINGLE_TOKENS = {**tokens.Tokenizer.SINGLE_TOKENS}
+        SINGLE_TOKENS.pop("%")
 
     class Parser(parser.Parser):
         CHARSET_TRANSLATORS = {
@@ -108,3 +113,6 @@ class Teradata(Dialect):
             where_sql = self.sql(expression, "where")
             sql = f"UPDATE {this}{from_sql} SET {set_sql}{where_sql}"
             return self.prepend_ctes(expression, sql)
+
+        def mod_sql(self, expression: exp.Mod) -> str:
+            return self.binary(expression, "MOD")

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -34,3 +34,6 @@ class TestTeradata(Validator):
             "SEL a FROM b",
             write={"teradata": "SELECT a FROM b"},
         )
+
+    def test_mod(self):
+        self.validate_all("a MOD b", write={"teradata": "a MOD b", "mysql": "a % b"})


### PR DESCRIPTION
Teradata uses MOD instead of % for the modulus operator ("a MOD b" instead of "a % b").