### PR TITLE
Disable execution of lateral column tests

### DIFF
--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -378,6 +378,7 @@ RIGHT JOIN "y_2" AS "y"
 
 
 # title: lateral column alias reference
+# execute: false
 SELECT x.a + 1 AS c, c + 1 AS d FROM x;
 SELECT
   "x"."a" + 1 AS "c",

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -198,7 +198,7 @@ class TestOptimizer(unittest.TestCase):
             "expand_laterals",
             optimizer.expand_laterals.expand_laterals,
             pretty=True,
-            execute=True,
+            execute=False,
         )
 
     def test_expand_multi_table_selects(self):


### PR DESCRIPTION
Seems like a DuckDB update broke these tests in main:

```python
ERROR: test_expand_laterals (tests.test_optimizer.TestOptimizer) [(execute) expand alias reference]
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../sqlglot/tests/test_optimizer.py", line 101, in check_file
    df1 = self.conn.execute(
duckdb.BinderException: Binder Error: Referenced column "i" not found in FROM clause!
Candidate bindings: "x.a", "x.b"
LINE 1: SELECT x.a + 1 AS i, i + 1 AS j, j + 1 AS k FROM x
                             ^

======================================================================
ERROR: test_expand_laterals (tests.test_optimizer.TestOptimizer) [(execute) subquery]
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../sqlglot/tests/test_optimizer.py", line 101, in check_file
    df1 = self.conn.execute(
duckdb.BinderException: Binder Error: Referenced column "i" not found in FROM clause!
Candidate bindings: "x.a", "x.b"

======================================================================
ERROR: test_optimize (tests.test_optimizer.TestOptimizer) [(execute) lateral column alias reference]
----------------------------------------------------------------------
Traceback (most recent call last):
  File ".../sqlglot/tests/test_optimizer.py", line 101, in check_file
    df1 = self.conn.execute(
duckdb.BinderException: Binder Error: Referenced column "c" not found in FROM clause!
Candidate bindings: "x.a", "x.b"
LINE 1: SELECT x.a + 1 AS c, c + 1 AS d FROM x
                             ^

----------------------------------------------------------------------
Ran 814 tests in 66.553s

FAILED (errors=3)
make: *** [test] Error 1
```