### PR TITLE
Change name of lineage root Table node to refer to column name

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -113,7 +113,7 @@ def lineage(
                 )
             else:
                 if table not in tables:
-                    tables[table] = Node(name=str(c.this), source=source, expression=source)
+                    tables[table] = Node(name=str(c), source=source, expression=source)
                 node.downstream.append(tables[table])
 
         return node

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -113,7 +113,7 @@ def lineage(
                 )
             else:
                 if table not in tables:
-                    tables[table] = Node(name=table, source=source, expression=source)
+                    tables[table] = Node(name=str(c.this), source=source, expression=source)
                 node.downstream.append(tables[table])
 
         return node

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -113,7 +113,7 @@ def lineage(
                 )
             else:
                 if table not in tables:
-                    tables[table] = Node(name=str(c), source=source, expression=source)
+                    tables[table] = Node(name=c.sql(), source=source, expression=source)
                 node.downstream.append(tables[table])
 
         return node


### PR DESCRIPTION
Suggested fix for #1199. Changed the name of the root Table node to `c.sql()` instead of `c.table`

```python
 if table not in tables:
     tables[table] = Node(name=c.sql(), source=source, expression=source)
     node.downstream.append(tables[table])
```
![image](https://user-images.githubusercontent.com/59633236/219850022-786e434d-2d44-4b90-9612-d3b6abeda90a.png)

