### PR TITLE
Export everything in __init__.py explicitly using aliases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
         require_serial: true
         files: ^(sqlglot/|tests/|setup.py)
       - id: isort
+        args: [--combine-as]
         name: isort
         entry: isort
         language: system

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -9,33 +9,40 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import expressions as exp
-from sqlglot.dialects import Dialect, Dialects
-from sqlglot.diff import diff
-from sqlglot.errors import ErrorLevel, ParseError, TokenError, UnsupportedError
-from sqlglot.expressions import Expression
-from sqlglot.expressions import alias_ as alias
-from sqlglot.expressions import (
-    and_,
-    column,
-    condition,
-    except_,
-    from_,
-    intersect,
-    maybe_parse,
-    not_,
-    or_,
-    select,
-    subquery,
+from sqlglot.dialects.dialect import Dialect as Dialect, Dialects as Dialects
+from sqlglot.diff import diff as diff
+from sqlglot.errors import (
+    ErrorLevel as ErrorLevel,
+    ParseError as ParseError,
+    TokenError as TokenError,
+    UnsupportedError as UnsupportedError,
 )
-from sqlglot.expressions import table_ as table
-from sqlglot.expressions import to_column, to_table, union
-from sqlglot.generator import Generator
-from sqlglot.parser import Parser
-from sqlglot.schema import MappingSchema, Schema
-from sqlglot.tokens import Tokenizer, TokenType
+from sqlglot.expressions import (
+    Expression as Expression,
+    alias_ as alias,
+    and_ as and_,
+    column as column,
+    condition as condition,
+    except_ as except_,
+    from_ as from_,
+    intersect as intersect,
+    maybe_parse as maybe_parse,
+    not_ as not_,
+    or_ as or_,
+    select as select,
+    subquery as subquery,
+    table_ as table,
+    to_column as to_column,
+    to_table as to_table,
+    union as union,
+)
+from sqlglot.generator import Generator as Generator
+from sqlglot.parser import Parser as Parser
+from sqlglot.schema import MappingSchema as MappingSchema, Schema as Schema
+from sqlglot.tokens import Tokenizer as Tokenizer, TokenType as TokenType
 
 if t.TYPE_CHECKING:
-    from sqlglot.dialects.dialect import DialectType
+    from sqlglot.dialects.dialect import DialectType as DialectType
 
     T = t.TypeVar("T", bound=Expression)
 

--- a/sqlglot/dataframe/sql/functions.py
+++ b/sqlglot/dataframe/sql/functions.py
@@ -4,8 +4,7 @@ import typing as t
 
 from sqlglot import exp as expression
 from sqlglot.dataframe.sql.column import Column
-from sqlglot.helper import ensure_list
-from sqlglot.helper import flatten as _flatten
+from sqlglot.helper import ensure_list, flatten as _flatten
 
 if t.TYPE_CHECKING:
     from sqlglot.dataframe.sql._typing import ColumnOrLiteral, ColumnOrName

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -11,8 +11,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from heapq import heappop, heappush
 
-from sqlglot import Dialect
-from sqlglot import expressions as exp
+from sqlglot import Dialect, expressions as exp
 from sqlglot.helper import ensure_collection
 
 

--- a/tests/dataframe/unit/test_functions.py
+++ b/tests/dataframe/unit/test_functions.py
@@ -2,8 +2,7 @@ import datetime
 import inspect
 import unittest
 
-from sqlglot import expressions as exp
-from sqlglot import parse_one
+from sqlglot import expressions as exp, parse_one
 from sqlglot.dataframe.sql import functions as SF
 from sqlglot.errors import ErrorLevel
 

--- a/tests/dataframe/unit/test_session.py
+++ b/tests/dataframe/unit/test_session.py
@@ -1,8 +1,7 @@
 from unittest import mock
 
 import sqlglot
-from sqlglot.dataframe.sql import functions as F
-from sqlglot.dataframe.sql import types
+from sqlglot.dataframe.sql import functions as F, types
 from sqlglot.dataframe.sql.session import SparkSession
 from sqlglot.schema import MappingSchema
 from tests.dataframe.unit.dataframe_sql_validator import DataFrameSQLValidator


### PR DESCRIPTION
fixes #1203

Can do this for other packages too if we want consistency.