### PR TITLE
feature: add _meta slot & meta property for more flexible annotations

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -82,7 +82,7 @@ class Expression(metaclass=_Expression):
 
     key = "expression"
     arg_types = {"this": True}
-    __slots__ = ("args", "parent", "arg_key", "comments", "_type", "meta")
+    __slots__ = ("args", "parent", "arg_key", "comments", "_type", "_meta")
 
     def __init__(self, **args: t.Any):
         self.args: t.Dict[str, t.Any] = args
@@ -90,7 +90,7 @@ class Expression(metaclass=_Expression):
         self.arg_key: t.Optional[str] = None
         self.comments: t.Optional[t.List[str]] = None
         self._type: t.Optional[DataType] = None
-        self.meta: t.Optional[t.Dict[str, t.Any]] = {}
+        self._meta: t.Optional[t.Dict[str, t.Any]] = None
 
         for arg_key, value in self.args.items():
             self._set_parent(arg_key, value)
@@ -220,8 +220,11 @@ class Expression(metaclass=_Expression):
             dtype = DataType.build(dtype)
         self._type = dtype  # type: ignore
 
-    def set_metadata(self, meta_key, meta_value):
-        self.meta[meta_key] = meta_value
+    @property
+    def meta(self):
+        if self._meta is None:
+            self._meta = {}
+        return self._meta
 
     def __deepcopy__(self, memo):
         copy = self.__class__(**deepcopy(self.args))
@@ -232,7 +235,7 @@ class Expression(metaclass=_Expression):
             copy.type = self.type.copy()
 
         if self.meta is not None:
-            copy.meta = deepcopy(self.meta)
+            copy._meta = deepcopy(self.meta)
 
         return copy
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -231,7 +231,7 @@ class Expression(metaclass=_Expression):
         if self.comments is not None:
             copy.comments = deepcopy(self.comments)
 
-        if self.type is not None:
+        if self._type is not None:
             copy._type = self._type.copy()
 
         if self._meta is not None:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -232,7 +232,7 @@ class Expression(metaclass=_Expression):
             copy.comments = deepcopy(self.comments)
 
         if self.type is not None:
-            copy.type = self.type.copy()
+            copy._type = self._type.copy()
 
         if self._meta is not None:
             copy._meta = deepcopy(self.meta)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -227,7 +227,10 @@ class Expression(metaclass=_Expression):
         copy = self.__class__(**deepcopy(self.args))
         copy.comments = self.comments
         copy.type = self.type
-        copy._meta = self.metadata
+
+        if self.meta is not None:
+            copy.meta = deepcopy(self.meta)
+
         return copy
 
     def copy(self):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -225,8 +225,11 @@ class Expression(metaclass=_Expression):
 
     def __deepcopy__(self, memo):
         copy = self.__class__(**deepcopy(self.args))
-        copy.comments = self.comments
-        copy.type = self.type
+        if self.comments is not None:
+            copy.comments = deepcopy(self.comments)
+
+        if self.type is not None:
+            copy.type = self.type.copy()
 
         if self.meta is not None:
             copy.meta = deepcopy(self.meta)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -234,7 +234,7 @@ class Expression(metaclass=_Expression):
         if self.type is not None:
             copy.type = self.type.copy()
 
-        if self.meta is not None:
+        if self._meta is not None:
             copy._meta = deepcopy(self.meta)
 
         return copy

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -82,7 +82,7 @@ class Expression(metaclass=_Expression):
 
     key = "expression"
     arg_types = {"this": True}
-    __slots__ = ("args", "parent", "arg_key", "comments", "_type")
+    __slots__ = ("args", "parent", "arg_key", "comments", "_type", "_meta")
 
     def __init__(self, **args: t.Any):
         self.args: t.Dict[str, t.Any] = args
@@ -90,6 +90,7 @@ class Expression(metaclass=_Expression):
         self.arg_key: t.Optional[str] = None
         self.comments: t.Optional[t.List[str]] = None
         self._type: t.Optional[DataType] = None
+        self._meta: t.Optional[t.Dict[str, t.Any]] = None
 
         for arg_key, value in self.args.items():
             self._set_parent(arg_key, value)
@@ -219,10 +220,21 @@ class Expression(metaclass=_Expression):
             dtype = DataType.build(dtype)
         self._type = dtype  # type: ignore
 
+    @property
+    def metadata(self) -> t.Optional[t.Dict[str, t.Any]]:
+        return self._meta
+
+    def set_metadata(self, meta_key, meta_value):
+        if not self._meta:
+            self._meta = {}
+
+        self._meta[meta_key] = meta_value
+
     def __deepcopy__(self, memo):
         copy = self.__class__(**deepcopy(self.args))
         copy.comments = self.comments
         copy.type = self.type
+        copy._meta = self.metadata
         return copy
 
     def copy(self):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -82,7 +82,7 @@ class Expression(metaclass=_Expression):
 
     key = "expression"
     arg_types = {"this": True}
-    __slots__ = ("args", "parent", "arg_key", "comments", "_type", "_meta")
+    __slots__ = ("args", "parent", "arg_key", "comments", "_type", "meta")
 
     def __init__(self, **args: t.Any):
         self.args: t.Dict[str, t.Any] = args
@@ -90,7 +90,7 @@ class Expression(metaclass=_Expression):
         self.arg_key: t.Optional[str] = None
         self.comments: t.Optional[t.List[str]] = None
         self._type: t.Optional[DataType] = None
-        self._meta: t.Optional[t.Dict[str, t.Any]] = None
+        self.meta: t.Optional[t.Dict[str, t.Any]] = {}
 
         for arg_key, value in self.args.items():
             self._set_parent(arg_key, value)
@@ -220,15 +220,8 @@ class Expression(metaclass=_Expression):
             dtype = DataType.build(dtype)
         self._type = dtype  # type: ignore
 
-    @property
-    def metadata(self) -> t.Optional[t.Dict[str, t.Any]]:
-        return self._meta
-
     def set_metadata(self, meta_key, meta_value):
-        if not self._meta:
-            self._meta = {}
-
-        self._meta[meta_key] = meta_value
+        self.meta[meta_key] = meta_value
 
     def __deepcopy__(self, memo):
         copy = self.__class__(**deepcopy(self.args))

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -235,7 +235,7 @@ class Expression(metaclass=_Expression):
             copy._type = self._type.copy()
 
         if self._meta is not None:
-            copy._meta = deepcopy(self.meta)
+            copy._meta = deepcopy(self._meta)
 
         return copy
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -221,7 +221,7 @@ class Expression(metaclass=_Expression):
         self._type = dtype  # type: ignore
 
     @property
-    def meta(self):
+    def meta(self) -> t.Dict[str, t.Any]:
         if self._meta is None:
             self._meta = {}
         return self._meta

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -795,6 +795,4 @@ FROM foo""",
         self.assertIsNone(ast.metadata.get("some_other_meta_key"))
 
         ast.set_metadata("some_other_meta_key", "some_other_meta_value")
-        self.assertEqual(
-            ast.metadata.get("some_other_meta_key"), "some_other_meta_value"
-        )
+        self.assertEqual(ast.metadata.get("some_other_meta_key"), "some_other_meta_value")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -788,11 +788,15 @@ FROM foo""",
     def test_set_metadata(self):
         ast = parse_one("SELECT foo.col FROM foo")
 
-        self.assertIsNone(ast.metadata)
+        self.assertIsNone(ast._meta)
 
-        ast.set_metadata("some_meta_key", "some_meta_value")
-        self.assertEqual(ast.metadata.get("some_meta_key"), "some_meta_value")
-        self.assertIsNone(ast.metadata.get("some_other_meta_key"))
+        # calling ast.meta would lazily instantiate self._meta
+        self.assertEqual(ast.meta, {})
+        self.assertEqual(ast._meta, {})
 
-        ast.set_metadata("some_other_meta_key", "some_other_meta_value")
-        self.assertEqual(ast.metadata.get("some_other_meta_key"), "some_other_meta_value")
+        ast.meta["some_meta_key"] = "some_meta_value"
+        self.assertEqual(ast.meta.get("some_meta_key"), "some_meta_value")
+        self.assertEqual(ast.meta.get("some_other_meta_key"), None)
+
+        ast.meta["some_other_meta_key"] = "some_other_meta_value"
+        self.assertEqual(ast.meta.get("some_other_meta_key"), "some_other_meta_value")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -784,3 +784,17 @@ FROM foo""",
         assert parse_one("SELECT * FROM bla UNION SELECT 1 AS x")
         assert parse_one("SELECT 1 AS x UNION SELECT * FROM bla")
         assert parse_one("SELECT 1 AS x UNION SELECT 1 AS x UNION SELECT * FROM foo").is_star
+
+    def test_set_metadata(self):
+        ast = parse_one("SELECT foo.col FROM foo")
+
+        self.assertIsNone(ast.metadata)
+
+        ast.set_metadata("some_meta_key", "some_meta_value")
+        self.assertEqual(ast.metadata.get("some_meta_key"), "some_meta_value")
+        self.assertIsNone(ast.metadata.get("some_other_meta_key"))
+
+        ast.set_metadata("some_other_meta_key", "some_other_meta_value")
+        self.assertEqual(
+            ast.metadata.get("some_other_meta_key"), "some_other_meta_value"
+        )


### PR DESCRIPTION
Summary of changes
 - added `_meta` slot to `Expression`, defaults for `None`
 - added `self.metadata` property which returns `self._meta`
 - added `set_metadata(meta_key, meta_value)` method which:
   1. instantiates `self._meta = {}` if needed
   2. sets `self._meta[meta_key] = meta_value`