### PR TITLE
fix oracle subquery alias

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -142,6 +142,9 @@ class Oracle(Dialect):
         def table_sql(self, expression: exp.Table, sep: str = " ") -> str:
             return super().table_sql(expression, sep=sep)
 
+        def subquery_sql(self, expression: exp.Subquery, sep: str = " ") -> str:
+            return super().subquery_sql(expression, sep=sep)
+
         def xmltable_sql(self, expression: exp.XMLTable) -> str:
             this = self.sql(expression, "this")
             passing = self.expressions(expression, "passing")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1335,14 +1335,15 @@ class Generator:
     def placeholder_sql(self, expression: exp.Placeholder) -> str:
         return f":{expression.name}" if expression.name else "?"
 
-    def subquery_sql(self, expression: exp.Subquery) -> str:
+    def subquery_sql(self, expression: exp.Subquery, sep: str = " AS ") -> str:
         alias = self.sql(expression, "alias")
+        alias = f"{sep}{alias}" if alias else ""
 
         sql = self.query_modifiers(
             expression,
             self.wrap(expression),
             self.expressions(expression, key="pivots", sep=" "),
-            f" AS {alias}" if alias else "",
+            alias,
         )
 
         return self.prepend_ctes(expression, sql)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1280,6 +1280,16 @@ class TestDialect(Validator):
             },
         )
         self.validate_all(
+            "SELECT * FROM (SELECT * FROM my_table AS t) AS tbl",
+            write={
+                "drill": "SELECT * FROM (SELECT * FROM my_table AS t) AS tbl",
+                "hive": "SELECT * FROM (SELECT * FROM my_table AS t) AS tbl",
+                "oracle": "SELECT * FROM (SELECT * FROM my_table t) tbl",
+                "postgres": "SELECT * FROM (SELECT * FROM my_table AS t) AS tbl",
+                "sqlite": "SELECT * FROM (SELECT * FROM my_table AS t) AS tbl",
+            },
+        )
+        self.validate_all(
             "WITH cte1 AS (SELECT a, b FROM table1), cte2 AS (SELECT c, e AS d FROM table2) SELECT b, d AS dd FROM cte1 AS t JOIN cte2 WHERE cte1.a = cte2.c",
             write={
                 "hive": "WITH cte1 AS (SELECT a, b FROM table1), cte2 AS (SELECT c, e AS d FROM table2) SELECT b, d AS dd FROM cte1 AS t JOIN cte2 WHERE cte1.a = cte2.c",


### PR DESCRIPTION
oracle does not allow "AS" between subquery and alias

related issue: https://github.com/tobymao/sqlglot/pull/439

I think all other aliases are fine. I've ran the following statements against my Oracle DB, using the built-in ``dual`` table.

```sql 
-- no alias
SELECT * FROM dual; /*ok*/
SELECT dummy FROM dual; /*ok*/
-- table alias
SELECT * FROM dual tbl; /*ok*/
SELECT * FROM dual AS tbl; /*error, but sqlglot fixes this by removing AS for Oracle*/
-- column alias
SELECT dummy col FROM dual; /*ok*/
SELECT dummy AS col FROM dual; /*ok*/
-- subquery alias
SELECT * FROM (SELECT * FROM dual) tbl; /*ok, but sqlglot breaks this, by adding AS */
SELECT * FROM (SELECT * FROM dual) AS tbl; /*error, this needs fixing in sqlglot for Oracle */
-- cte
WITH tbl (SELECT * FROM dual) SELECT * FROM tbl; /*error, sqlglot actually fixes this by adding AS */
WITH tbl AS (SELECT * FROM dual) SELECT * FROM tbl; /*ok*/
WITH tbl (x) AS (SELECT dummy AS d FROM dual) SELECT * FROM tbl; /*ok*/
-- function alias
SELECT SUM(1) val FROM dual; /*ok*/
SELECT SUM(1) AS val FROM dual; /*ok*/
-- window alias
SELECT SUM(1) OVER() val FROM dual; /*ok*/
SELECT SUM(1) OVER() AS val FROM dual; /*ok*/
-- case alias
SELECT CASE dummy WHEN 'X' THEN 1 ELSE 0 END val FROM dual; /*ok*/
SELECT CASE dummy WHEN 'X' THEN 1 ELSE 0 END AS val FROM dual; /*ok*/
```

Note that the comments refer the the behavior before this PR.

``ok`` /  ``error`` in the comments refers to running the statement as-is (no sqlglot involved) against the DB.
