### PR TITLE
Add support for old (+) join syntax

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -883,7 +883,7 @@ class ByteString(Condition):
 
 
 class Column(Condition):
-    arg_types = {"this": True, "table": False, "db": False, "catalog": False}
+    arg_types = {"this": True, "table": False, "db": False, "catalog": False, "join_mark": False}
 
     @property
     def table(self) -> str:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -203,6 +203,7 @@ class TokenType(AutoName):
     IS = auto()
     ISNULL = auto()
     JOIN = auto()
+    JOIN_MARKER = auto()
     LANGUAGE = auto()
     LATERAL = auto()
     LAZY = auto()

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -7,6 +7,11 @@ class TestOracle(Validator):
     def test_oracle(self):
         self.validate_identity("SELECT * FROM V$SESSION")
 
+    def test_join_marker(self):
+        self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")
+        self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y = e2.y (+)")
+        self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y (+)")
+
     def test_xml_table(self):
         self.validate_identity("XMLTABLE('x')")
         self.validate_identity("XMLTABLE('x' RETURNING SEQUENCE BY REF)")


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/discussions/648

I only added this in `exp.Column`, because the Oracle docs suggest that it can't be used elsewhere:

> The (+) operator can appear only in the WHERE clause or, in the context of left-correlation (when specifying the TABLE clause) in the FROM clause, and can be applied only to a column of a table or view.

- https://stackoverflow.com/a/1193722
- https://stackoverflow.com/a/26484312

In the future, we could try to transform these old syntax forms into the new ones (i.e. `INNER JOIN`, `LEFT JOIN`, etc).