### PR TITLE
Add support for to_array (Snowflake) to array (Spark SQL)

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -161,6 +161,7 @@ class Snowflake(Dialect):
             "RLIKE": exp.RegexpLike.from_arg_list,
             "DECODE": exp.Matches.from_arg_list,
             "OBJECT_CONSTRUCT": parser.parse_var_map,
+            "TO_ARRAY": exp.Array.from_arg_list,
         }
 
         FUNCTION_PARSERS = {

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -93,10 +93,10 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
-            "TO_ARRAY(1)",
+            "SELECT TO_ARRAY(1)",
             write={
-                "snowflake": "[1]",
-                "spark": "ARRAY(1)",
+                "snowflake": "SELECT [1]",
+                "spark": "SELECT ARRAY(1)",
             },
 
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -93,10 +93,10 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
-            "SELECT TO_ARRAY(1)",
+            "TO_ARRAY(1)",
             write={
-                "spark": "SELECT ARRAY(1)",
-                "snowflake": "SELECT TO_ARRAY(1)",
+                "spark": "ARRAY(1)",
+                "snowflake": "TO_ARRAY(1)",
             },
 
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -93,6 +93,14 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
+            "SELECT TO_ARRAY(1)",
+            write={
+                "spark": "SELECT ARRAY(1)",
+                "snowflake": "SELECT TO_ARRAY(1)",
+            },
+
+        )
+        self.validate_all(
             "SELECT TO_TIMESTAMP(1659981729)",
             write={
                 "bigquery": "SELECT UNIX_TO_TIME(1659981729)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -95,8 +95,8 @@ class TestSnowflake(Validator):
         self.validate_all(
             "TO_ARRAY(1)",
             write={
+                "snowflake": "[1]",
                 "spark": "ARRAY(1)",
-                "snowflake": "TO_ARRAY(1)",
             },
 
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -95,7 +95,7 @@ class TestSnowflake(Validator):
         self.validate_all(
             "SELECT TO_ARRAY(1)",
             write={
-                "snowflake": "SELECT [1]",
+                "snowflake": "SELECT TO_ARRAY(1)",
                 "spark": "SELECT ARRAY(1)",
             },
 


### PR DESCRIPTION
1. Added TO_ARRAY -> exp.Array mapping to snowflake.py
2. Added test in test_snowflake.py
3. Did not add anything to expressions.py since exp.Array already exists
4. Did not add anything to functions.py since array() already exists