### PR TITLE
refactor: return more precise types from find methods

### DIFF
--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -260,7 +260,9 @@ class DataFrame:
     @classmethod
     def _get_outer_select_columns(cls, item: t.Union[exp.Expression, DataFrame]) -> t.List[Column]:
         expression = item.expression if isinstance(item, DataFrame) else item
-        return [Column(x) for x in expression.find(exp.Select).expressions]
+        select = expression.find(exp.Select)
+        assert select, "No select expression found"
+        return [Column(x) for x in select.expressions]
 
     @classmethod
     def _create_hash_from_expression(cls, expression: exp.Select):

--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -260,9 +260,7 @@ class DataFrame:
     @classmethod
     def _get_outer_select_columns(cls, item: t.Union[exp.Expression, DataFrame]) -> t.List[Column]:
         expression = item.expression if isinstance(item, DataFrame) else item
-        select = expression.find(exp.Select)
-        assert select, "No select expression found"
-        return [Column(x) for x in select.expressions]
+        return [Column(x) for x in (expression.find(exp.Select) or exp.Select()).expressions]
 
     @classmethod
     def _create_hash_from_expression(cls, expression: exp.Select):

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -360,10 +360,9 @@ def create_with_partitions_sql(self: Generator, expression: exp.Create) -> str:
     if has_schema and is_partitionable:
         expression = expression.copy()
         prop = expression.find(exp.PartitionedByProperty)
-        this = prop and prop.this
-        if prop and this and not isinstance(this, exp.Schema):
+        if prop and prop.this and not isinstance(prop.this, exp.Schema):
             schema = expression.this
-            columns = {v.name.upper() for v in this.expressions}
+            columns = {v.name.upper() for v in prop.this.expressions}
             partitions = [col for col in schema.expressions if col.name.upper() in columns]
             schema.set("expressions", [e for e in schema.expressions if e not in partitions])
             prop.replace(exp.PartitionedByProperty(this=exp.Schema(expressions=partitions)))

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -361,7 +361,7 @@ def create_with_partitions_sql(self: Generator, expression: exp.Create) -> str:
         expression = expression.copy()
         prop = expression.find(exp.PartitionedByProperty)
         this = prop and prop.this
-        if prop and not isinstance(this, exp.Schema):
+        if prop and this and not isinstance(this, exp.Schema):
             schema = expression.this
             columns = {v.name.upper() for v in this.expressions}
             partitions = [col for col in schema.expressions if col.name.upper() in columns]

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -308,7 +308,7 @@ class Expression(metaclass=_Expression):
         """
         return next(self.find_all(*expression_types, bfs=bfs), None)
 
-    def find_all(self, *expression_types: t.Type[E], bfs=True) -> t.Generator[E, None, None]:
+    def find_all(self, *expression_types: t.Type[E], bfs=True) -> t.Iterator[E]:
         """
         Returns a generator object which visits all nodes in this tree and only
         yields those that match at least one of the specified expression types.

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -337,7 +337,7 @@ class Expression(metaclass=_Expression):
         while ancestor and not isinstance(ancestor, expression_types):
             ancestor = ancestor.parent
         # ignore type because mypy doesn't know that we're checking type in the loop
-        return ancestor # type: ignore[return-value]
+        return ancestor  # type: ignore[return-value]
 
     @property
     def parent_select(self):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -35,6 +35,8 @@ from sqlglot.tokens import Token
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
 
+E = t.TypeVar("E", bound="Expression")
+
 
 class _Expression(type):
     def __new__(cls, clsname, bases, attrs):
@@ -293,7 +295,7 @@ class Expression(metaclass=_Expression):
             return self.parent.depth + 1
         return 0
 
-    def find(self, *expression_types, bfs=True):
+    def find(self, *expression_types: t.Type[E], bfs=True) -> E | None:
         """
         Returns the first node in this tree which matches at least one of
         the specified types.
@@ -306,7 +308,7 @@ class Expression(metaclass=_Expression):
         """
         return next(self.find_all(*expression_types, bfs=bfs), None)
 
-    def find_all(self, *expression_types, bfs=True):
+    def find_all(self, *expression_types: t.Type[E], bfs=True) -> t.Generator[E, None, None]:
         """
         Returns a generator object which visits all nodes in this tree and only
         yields those that match at least one of the specified expression types.
@@ -321,7 +323,7 @@ class Expression(metaclass=_Expression):
             if isinstance(expression, expression_types):
                 yield expression
 
-    def find_ancestor(self, *expression_types):
+    def find_ancestor(self, *expression_types: t.Type[E]) -> E | None:
         """
         Returns a nearest parent matching expression_types.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -336,7 +336,8 @@ class Expression(metaclass=_Expression):
         ancestor = self.parent
         while ancestor and not isinstance(ancestor, expression_types):
             ancestor = ancestor.parent
-        return ancestor
+        # ignore type because mypy doesn't know that we're checking type in the loop
+        return ancestor # type: ignore[return-value]
 
     @property
     def parent_select(self):


### PR DESCRIPTION
find methods now return the type of the expression being sought (or a union for multiple types), rather then `Any`.

this means the caller doesn't need to cast the result.

the increased precision revealed some mypy type errors, which I've fixed 
