### PR TITLE
fix exp.func bug

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1860,7 +1860,7 @@ class Generator:
     def function_fallback_sql(self, expression: exp.Func) -> str:
         args = []
         for arg_value in expression.args.values():
-            if isinstance(arg_value, list):
+            if isinstance(arg_value, (list, tuple)):
                 for value in arg_value:
                     args.append(value)
             else:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -205,6 +205,7 @@ class TestExpressions(unittest.TestCase):
         self.assertEqual(
             exp.func("locate", "x", "xo", dialect="hive").sql("hive"), "LOCATE('x', 'xo')"
         )
+        self.assertEqual(exp.func("MIN", 1).sql(), "MIN(1)")
 
         self.assertIsInstance(exp.func("instr", "x", "b", dialect="mysql"), exp.StrPosition)
         self.assertIsInstance(exp.func("bla", 1, "foo"), exp.Anonymous)


### PR DESCRIPTION
[This PR](https://github.com/tobymao/sqlglot/pull/1261) introduced a little bug in `exp.func`:

```python
exp.func("MIN", 1).sql() == 'MIN(1, )'
```