### PR TITLE
Added support for expression building for DELETE

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1035,7 +1035,7 @@ class Delete(Expression):
 
     def delete(
         self,
-        table: str | Table,
+        table: str | Expression,
         dialect: DialectType = None,
         copy: bool = True,
         **opts,
@@ -1048,7 +1048,7 @@ class Delete(Expression):
             'DELETE FROM tbl'
 
         Args:
-            table (str | Table): the table from which to delete.
+            table (str | Expression): the table from which to delete.
             dialect (str): the dialect used to parse the input expression.
             copy (bool): if `False`, modify this expression instance in-place.
             opts (kwargs): other options to use to parse the input expressions.
@@ -1107,7 +1107,7 @@ class Delete(Expression):
 
     def returning(
         self,
-        expression: str | Returning,
+        expression: str | Expression,
         dialect: DialectType = None,
         copy: bool = True,
         **opts,
@@ -4245,7 +4245,7 @@ def from_(*expressions, dialect=None, **opts) -> Select:
 def update(
     table: str | Table,
     properties: dict,
-    where: str | Condition = None,
+    where: str | Expression = None,
     from_: str | Expression = None,
     dialect: DialectType = None,
     **opts,
@@ -4260,7 +4260,7 @@ def update(
     Args:
         *properties (Dict[str, Any]): dictionary of properties to set which are
             auto converted to sql objects eg None -> NULL
-        where (str|Condition): sql conditional parsed into a WHERE statement
+        where (str|Expression): sql conditional parsed into a WHERE statement
         from_ (str|Table): sql statement parsed into a FROM statement
         dialect (str): the dialect used to parse the input expressions.
         **opts: other options to use to parse the input expressions.
@@ -4293,8 +4293,8 @@ def update(
 
 def delete(
     table: str | Expression,
-    where: str | Condition = None,
-    returning: str | Returning = None,
+    where: str | Expression = None,
+    returning: str | Expression = None,
     dialect: DialectType = None,
     **opts,
 ) -> Delete:
@@ -4306,7 +4306,8 @@ def delete(
         'DELETE FROM my_table WHERE id > 1'
 
     Args:
-        where (str|Condition): sql conditional parsed into a WHERE statement
+        where (str|Expression): sql conditional parsed into a WHERE statement
+        returning (str|Expression): sql conditional parsed into a RETURNING statement
         dialect (str): the dialect used to parse the input expressions.
         **opts: other options to use to parse the input expressions.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1093,6 +1093,7 @@ class Delete(Expression):
             **opts,
         )
 
+
 class Drop(Expression):
     arg_types = {
         "this": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1050,10 +1050,10 @@ class Delete(Expression):
             'DELETE FROM tbl'
 
         Args:
-            table (str | Expression): the table from which to delete.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            table: the table from which to delete.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
             Delete: the modified expression.
@@ -1084,14 +1084,14 @@ class Delete(Expression):
             "DELETE FROM tbl WHERE x = 'a' OR x < 'b'"
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
                 Multiple expressions are combined with an AND operator.
-            append (bool): if `True`, AND the new expressions to any existing expression.
+            append: if `True`, AND the new expressions to any existing expression.
                 Otherwise, this resets the expression.
-            dialect (str): the dialect used to parse the input expressions.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expressions.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
             Delete: the modified expression.
@@ -4260,11 +4260,11 @@ def update(
         "UPDATE my_table SET x = 1, y = '2', z = NULL FROM baz WHERE id > 1"
 
     Args:
-        *properties (Dict[str, Any]): dictionary of properties to set which are
+        *properties: dictionary of properties to set which are
             auto converted to sql objects eg None -> NULL
-        where (str|Expression): sql conditional parsed into a WHERE statement
-        from_ (str|Table): sql statement parsed into a FROM statement
-        dialect (str): the dialect used to parse the input expressions.
+        where: sql conditional parsed into a WHERE statement
+        from_: sql statement parsed into a FROM statement
+        dialect: the dialect used to parse the input expressions.
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -4308,19 +4308,19 @@ def delete(
         'DELETE FROM my_table WHERE id > 1'
 
     Args:
-        where (str|Expression): sql conditional parsed into a WHERE statement
-        returning (str|Expression): sql conditional parsed into a RETURNING statement
-        dialect (str): the dialect used to parse the input expressions.
+        where: sql conditional parsed into a WHERE statement
+        returning: sql conditional parsed into a RETURNING statement
+        dialect: the dialect used to parse the input expressions.
         **opts: other options to use to parse the input expressions.
 
     Returns:
         Delete: the syntax tree for the DELETE statement.
     """
-    delete_expr = Delete().delete(table, dialect=dialect, **opts)
+    delete_expr = Delete().delete(table, dialect=dialect, copy=False, **opts)
     if where:
-        delete_expr = delete_expr.where(where, dialect=dialect, **opts)
+        delete_expr = delete_expr.where(where, dialect=dialect, copy=False, **opts)
     if returning:
-        delete_expr = delete_expr.returning(returning, dialect=dialect, **opts)
+        delete_expr = delete_expr.returning(returning, dialect=dialect, copy=False, **opts)
     return delete_expr
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1033,6 +1033,65 @@ class Constraint(Expression):
 class Delete(Expression):
     arg_types = {"with": False, "this": False, "using": False, "where": False, "returning": False}
 
+    def from_(self, expression, dialect=None, copy=True, **opts) -> Delete:
+        """
+        Set the FROM part of the DELETE expression.
+
+        Example:
+            >>> Delete().from_("tbl").sql()
+            'DELETE FROM tbl'
+
+        Args:
+            expressions (str | Expression): the SQL code strings to parse.
+            append (bool): if `True`, add to any existing expressions.
+                Otherwise, this flattens all the `From` expression into a single expression.
+            dialect (str): the dialect used to parse the input expression.
+            copy (bool): if `False`, modify this expression instance in-place.
+            opts (kwargs): other options to use to parse the input expressions.
+
+        Returns:
+            Delete: the modified expression.
+        """
+        return _apply_builder(
+            expression=expression.this if isinstance(expression, Expression) else expression,
+            instance=self,
+            arg="this",
+            dialect=dialect,
+            copy=copy,
+            **opts,
+        )
+
+    def where(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Delete:
+        """
+        Append to or set the WHERE expressions.
+
+        Example:
+            >>> Delete().from_("tbl").where("x = 'a' OR x < 'b'").sql()
+            "DELETE FROM tbl WHERE x = 'a' OR x < 'b' "
+
+        Args:
+            *expressions (str | Expression): the SQL code strings to parse.
+                If an `Expression` instance is passed, it will be used as-is.
+                Multiple expressions are combined with an AND operator.
+            append (bool): if `True`, AND the new expressions to any existing expression.
+                Otherwise, this resets the expression.
+            dialect (str): the dialect used to parse the input expressions.
+            copy (bool): if `False`, modify this expression instance in-place.
+            opts (kwargs): other options to use to parse the input expressions.
+
+        Returns:
+            Delete: the modified expression.
+        """
+        return _apply_conjunction_builder(
+            *expressions,
+            instance=self,
+            arg="where",
+            append=append,
+            into=Where,
+            dialect=dialect,
+            copy=copy,
+            **opts,
+        )
 
 class Drop(Expression):
     arg_types = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -626,6 +626,7 @@ IntoType = t.Union[
     t.Type[Expression],
     t.Collection[t.Union[str, t.Type[Expression]]],
 ]
+ExpressionType = t.Union[str, Expression, t.Type[Expression], None]
 
 
 class Condition(Expression):
@@ -4245,8 +4246,8 @@ def from_(*expressions, dialect=None, **opts) -> Select:
 def update(
     table: str | Table,
     properties: dict,
-    where: str | Expression = None,
-    from_: str | Expression = None,
+    where: ExpressionType = None,
+    from_: ExpressionType = None,
     dialect: DialectType = None,
     **opts,
 ) -> Update:
@@ -4292,9 +4293,9 @@ def update(
 
 
 def delete(
-    table: str | Expression,
-    where: str | Expression = None,
-    returning: str | Expression = None,
+    table: ExpressionType,
+    where: ExpressionType = None,
+    returning: ExpressionType = None,
     dialect: DialectType = None,
     **opts,
 ) -> Delete:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -626,7 +626,8 @@ IntoType = t.Union[
     t.Type[Expression],
     t.Collection[t.Union[str, t.Type[Expression]]],
 ]
-ExpressionType = t.Union[str, Expression, t.Type[Expression], None]
+ExpressionType = t.Union[str, Expression]
+ExpressionTypeNone = t.Union[str, Expression, None]
 
 
 class Condition(Expression):
@@ -1036,7 +1037,7 @@ class Delete(Expression):
 
     def delete(
         self,
-        table: str | Expression,
+        table: ExpressionType,
         dialect: DialectType = None,
         copy: bool = True,
         **opts,
@@ -1069,7 +1070,7 @@ class Delete(Expression):
 
     def where(
         self,
-        *expressions: str | Expression,
+        *expressions: ExpressionType,
         append: bool = True,
         dialect: DialectType = None,
         copy: bool = True,
@@ -1108,7 +1109,7 @@ class Delete(Expression):
 
     def returning(
         self,
-        expression: str | Expression,
+        expression: ExpressionType,
         dialect: DialectType = None,
         copy: bool = True,
         **opts,
@@ -1932,7 +1933,7 @@ class Union(Subqueryable):
 
     def select(
         self,
-        *expressions: str | Expression,
+        *expressions: ExpressionType,
         append: bool = True,
         dialect: DialectType = None,
         copy: bool = True,
@@ -2278,7 +2279,7 @@ class Select(Subqueryable):
 
     def select(
         self,
-        *expressions: str | Expression,
+        *expressions: ExpressionType,
         append: bool = True,
         dialect: DialectType = None,
         copy: bool = True,
@@ -3938,7 +3939,7 @@ ALL_FUNCTIONS = subclasses(__name__, Func, (AggFunc, Anonymous, Func))
 
 # Helpers
 def maybe_parse(
-    sql_or_expression: str | Expression,
+    sql_or_expression: ExpressionType,
     *,
     into: t.Optional[IntoType] = None,
     dialect: DialectType = None,
@@ -4199,7 +4200,7 @@ def except_(left, right, distinct=True, dialect=None, **opts):
     return Except(this=left, expression=right, distinct=distinct)
 
 
-def select(*expressions: str | Expression, dialect: DialectType = None, **opts) -> Select:
+def select(*expressions: ExpressionType, dialect: DialectType = None, **opts) -> Select:
     """
     Initializes a syntax tree from one or multiple SELECT expressions.
 
@@ -4246,8 +4247,8 @@ def from_(*expressions, dialect=None, **opts) -> Select:
 def update(
     table: str | Table,
     properties: dict,
-    where: ExpressionType = None,
-    from_: ExpressionType = None,
+    where: ExpressionTypeNone = None,
+    from_: ExpressionTypeNone = None,
     dialect: DialectType = None,
     **opts,
 ) -> Update:
@@ -4294,8 +4295,8 @@ def update(
 
 def delete(
     table: ExpressionType,
-    where: ExpressionType = None,
-    returning: ExpressionType = None,
+    where: ExpressionTypeNone = None,
+    returning: ExpressionTypeNone = None,
     dialect: DialectType = None,
     **opts,
 ) -> Delete:
@@ -4536,7 +4537,7 @@ def to_column(sql_path: str | Column, **kwargs) -> Column:
 
 
 def alias_(
-    expression: str | Expression,
+    expression: ExpressionType,
     alias: str | Identifier,
     table: bool | t.Sequence[str | Identifier] = False,
     quoted: t.Optional[bool] = None,
@@ -4638,7 +4639,7 @@ def column(
     )
 
 
-def cast(expression: str | Expression, to: str | DataType | DataType.Type, **opts) -> Cast:
+def cast(expression: ExpressionType, to: str | DataType | DataType.Type, **opts) -> Cast:
     """Cast an expression to a data type.
 
     Example:
@@ -4717,7 +4718,7 @@ def values(
     )
 
 
-def var(name: t.Optional[str | Expression]) -> Var:
+def var(name: t.Optional[ExpressionType]) -> Var:
     """Build a SQL variable.
 
     Example:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1067,7 +1067,7 @@ class Delete(Expression):
 
         Example:
             >>> Delete().from_("tbl").where("x = 'a' OR x < 'b'").sql()
-            "DELETE FROM tbl WHERE x = 'a' OR x < 'b' "
+            "DELETE FROM tbl WHERE x = 'a' OR x < 'b'"
 
         Args:
             *expressions (str | Expression): the SQL code strings to parse.

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -441,6 +441,7 @@ class Parser(metaclass=_Parser):
         exp.With: lambda self: self._parse_with(),
         exp.Window: lambda self: self._parse_named_window(),
         exp.Qualify: lambda self: self._parse_qualify(),
+        exp.Returning: lambda self: self._parse_returning(),
         "JOIN_TYPE": lambda self: self._parse_join_side_and_kind(),
     }
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -752,7 +752,6 @@ class TestDialect(Validator):
                 "trino": "REDUCE(x, 0, (acc, x) -> acc + x, acc -> acc)",
                 "duckdb": "REDUCE(x, 0, (acc, x) -> acc + x, acc -> acc)",
                 "hive": "REDUCE(x, 0, (acc, x) -> acc + x, acc -> acc)",
-                "presto": "REDUCE(x, 0, (acc, x) -> acc + x, acc -> acc)",
                 "spark": "AGGREGATE(x, 0, (acc, x) -> acc + x, acc -> acc)",
                 "presto": "REDUCE(x, 0, (acc, x) -> acc + x, acc -> acc)",
             },

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -510,6 +510,20 @@ class TestBuild(unittest.TestCase):
                 .qualify("row_number() OVER (PARTITION BY a ORDER BY b) = 1"),
                 "SELECT * FROM table QUALIFY ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) = 1",
             ),
+            (lambda: exp.delete("tbl", "x = 1").from_("table"), "DELETE FROM table WHERE x = 1"),
+            (
+                lambda: exp.delete("tbl", "x = 1").from_("table").where("y = 2"),
+                "DELETE FROM table WHERE x = 1 AND y = 2",
+            ),
+            (lambda: exp.Delete(this="tbl"), "DELETE FROM tbl"),
+            (lambda: exp.Delete(this="tbl").where("x = 1"), "DELETE FROM tbl WHERE x = 1"),
+            (lambda: exp.Delete().from_("tbl").where("x = 1"), "DELETE FROM tbl WHERE x = 1"),
+            (
+                lambda: exp.Delete(this="tbl").from_("tbl2").where("x = 1"),
+                "DELETE FROM tbl2 WHERE x = 1",
+            ),
+            (lambda: exp.Delete().from_(exp.From(this="tbl")), "DELETE FROM tbl"),
+            (lambda: exp.Delete().from_(exp.Table(this="tbl")), "DELETE FROM tbl"),
         ]:
             with self.subTest(sql):
                 self.assertEqual(expression().sql(dialect[0] if dialect else None), sql)


### PR DESCRIPTION
This PR aims to add support for the following methods:

Delete.from_() and Delete.where()

Examples:

``Delete(this="tbl").where("x = 1")``

> "DELETE FROM tbl WHERE x = 1"

``Delete().from_("tbl").where("x = 1")``

> "DELETE FROM tbl WHERE x = 1"

---

If this PR is fine, I'll look into doing the same for INSERT and UPDATE