### PR TITLE
Transpile current date/time/timestamp correctly for sqlite

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -144,7 +144,6 @@ class BigQuery(Dialect):
             "BEGIN": TokenType.COMMAND,
             "BEGIN TRANSACTION": TokenType.BEGIN,
             "CURRENT_DATETIME": TokenType.CURRENT_DATETIME,
-            "CURRENT_TIME": TokenType.CURRENT_TIME,
             "DECLARE": TokenType.COMMAND,
             "GEOGRAPHY": TokenType.GEOGRAPHY,
             "FLOAT64": TokenType.DOUBLE,
@@ -194,7 +193,6 @@ class BigQuery(Dialect):
         NO_PAREN_FUNCTIONS = {
             **parser.Parser.NO_PAREN_FUNCTIONS,  # type: ignore
             TokenType.CURRENT_DATETIME: exp.CurrentDatetime,
-            TokenType.CURRENT_TIME: exp.CurrentTime,
         }
 
         NESTED_TYPE_TOKENS = {

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -80,6 +80,9 @@ class SQLite(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,  # type: ignore
             exp.CountIf: count_if_to_sum,
+            exp.CurrentDate: lambda *_: "CURRENT_DATE",
+            exp.CurrentTime: lambda *_: "CURRENT_TIME",
+            exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.DateAdd: _date_add_sql,
             exp.DateStrToDate: lambda self, e: self.sql(e, "this"),
             exp.GroupConcat: _group_concat_sql,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -96,6 +96,7 @@ class Parser(metaclass=_Parser):
     NO_PAREN_FUNCTIONS = {
         TokenType.CURRENT_DATE: exp.CurrentDate,
         TokenType.CURRENT_DATETIME: exp.CurrentDate,
+        TokenType.CURRENT_TIME: exp.CurrentTime,
         TokenType.CURRENT_TIMESTAMP: exp.CurrentTimestamp,
     }
 
@@ -198,7 +199,6 @@ class Parser(metaclass=_Parser):
         TokenType.COMMIT,
         TokenType.COMPOUND,
         TokenType.CONSTRAINT,
-        TokenType.CURRENT_TIME,
         TokenType.DEFAULT,
         TokenType.DELETE,
         TokenType.DESCRIBE,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -502,6 +502,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "CUBE": TokenType.CUBE,
         "CURRENT_DATE": TokenType.CURRENT_DATE,
         "CURRENT ROW": TokenType.CURRENT_ROW,
+        "CURRENT_TIME": TokenType.CURRENT_TIME,
         "CURRENT_TIMESTAMP": TokenType.CURRENT_TIMESTAMP,
         "DATABASE": TokenType.DATABASE,
         "DEFAULT": TokenType.DEFAULT,

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -57,6 +57,27 @@ class TestSQLite(Validator):
 
     def test_sqlite(self):
         self.validate_all(
+            "CURRENT_DATE",
+            read={
+                "": "CURRENT_DATE",
+                "snowflake": "CURRENT_DATE()",
+            },
+        )
+        self.validate_all(
+            "CURRENT_TIME",
+            read={
+                "": "CURRENT_TIME",
+                "snowflake": "CURRENT_TIME()",
+            },
+        )
+        self.validate_all(
+            "CURRENT_TIMESTAMP",
+            read={
+                "": "CURRENT_TIMESTAMP",
+                "snowflake": "CURRENT_TIMESTAMP()",
+            },
+        )
+        self.validate_all(
             "SELECT CAST([a].[b] AS SMALLINT) FROM foo",
             write={
                 "sqlite": 'SELECT CAST("a"."b" AS INTEGER) FROM foo',


### PR DESCRIPTION
Even though the SQLite docs don't mention `current_time`, `current_date` and `current_timestamp` as valid functions, in my system they work just fine (SQLite version 3.37.0 2021-12-09 01:34:53). The "official" way to write the first two of them is `TIME()` and `DATE()`. I didn't find a function as simple as these for timestamp.

- https://www.sqlite.org/lang_datefunc.html