### PR TITLE
Fix transpilation of casting to date in sqlite

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -58,7 +58,6 @@ class SQLite(Dialect):
             exp.CurrentDate: lambda *_: "CURRENT_DATE",
             exp.CurrentTime: lambda *_: "CURRENT_TIME",
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
-            exp.DateAdd: _date_add_sql,
             exp.DateStrToDate: lambda self, e: self.sql(e, "this"),
             exp.ILike: no_ilike_sql,
             exp.JSONExtract: arrow_json_extract_sql,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1668,7 +1668,7 @@ class Generator:
         expression_sql = self.sql(expression, "expression")
         return f"COMMENT{exists_sql}ON {kind} {this} IS {expression_sql}"
 
-    def transaction_sql(self, *_) -> str:
+    def transaction_sql(self, expression: exp.Transaction) -> str:
         return "BEGIN"
 
     def commit_sql(self, expression: exp.Commit) -> str:

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -75,6 +75,12 @@ class TestSQLite(Validator):
             read={
                 "": "CURRENT_TIMESTAMP",
                 "snowflake": "CURRENT_TIMESTAMP()",
+            }
+        )
+        self.validate_all(
+            "SELECT DATE('2020-01-01 16:03:05')",
+            read={
+                "snowflake": "SELECT CAST('2020-01-01 16:03:05' AS DATE)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -75,7 +75,7 @@ class TestSQLite(Validator):
             read={
                 "": "CURRENT_TIMESTAMP",
                 "snowflake": "CURRENT_TIMESTAMP()",
-            }
+            },
         )
         self.validate_all(
             "SELECT DATE('2020-01-01 16:03:05')",


### PR DESCRIPTION
The change is that `CAST(x AS DATE)` becomes `DATE(x)` for SQLite, since it has no `DATE` type.

In Snowflake, `select cast('2020-03-01 16:03:05' as date)` outputs `2020-03-01`, same as using `DATE(..)` instead of `CAST` for SQLite. I'm not sure if this transformation is generally correct, but for timestamp strings it seems legit. 🤞 

- https://www.sqlite.org/datatype3.html