### PR TITLE
Implement eliminate_qualify transformation

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -92,8 +92,7 @@ def _string_agg_sql(self, expression):
     this = expression.this
     if isinstance(this, exp.Order):
         if this.this:
-            this = this.this
-            this.pop()
+            this = this.this.pop()
         order = self.sql(expression.this)  # Order has a leading space
 
     return f"STRING_AGG({self.format_args(this, separator)}{order})"

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from sqlglot import exp, generator, parser, tokens
+from sqlglot import exp, generator, parser, tokens, transforms
 from sqlglot.dialects.dialect import (
     Dialect,
     arrow_json_extract_scalar_sql,
@@ -79,6 +79,7 @@ class SQLite(Dialect):
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,  # type: ignore
+            **transforms.ELIMINATE_QUALIFY,  # type: ignore
             exp.CountIf: count_if_to_sum,
             exp.CurrentDate: lambda *_: "CURRENT_DATE",
             exp.CurrentTime: lambda *_: "CURRENT_TIME",

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -117,14 +117,12 @@ def _string_agg_sql(self, e):
     if distinct:
         # exp.Distinct can appear below an exp.Order or an exp.GroupConcat expression
         self.unsupported("T-SQL STRING_AGG doesn't support DISTINCT.")
-        this = distinct.expressions[0]
-        distinct.pop()
+        this = distinct.pop().expressions[0]
 
     order = ""
     if isinstance(e.this, exp.Order):
         if e.this.this:
-            this = e.this.this
-            e.this.this.pop()
+            this = e.this.this.pop()
         order = f" WITHIN GROUP ({self.sql(e.this)[1:]})"  # Order has a leading space
 
     separator = e.args.get("separator") or exp.Literal.string(",")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -549,8 +549,12 @@ class Expression(metaclass=_Expression):
     def pop(self):
         """
         Remove this expression from its AST.
+
+        Returns:
+            The popped expression.
         """
         self.replace(None)
+        return self
 
     def assert_is(self, type_):
         """

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -18,6 +18,14 @@ class TestSnowflake(Validator):
         self.validate_identity("COMMENT IF EXISTS ON TABLE foo IS 'bar'")
 
         self.validate_all(
+            "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
+            write={
+                "": "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) = 1",
+                "snowflake": "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
+                "sqlite": "SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) AS _w_0 FROM qt) WHERE _w_0 = 1",
+            },
+        )
+        self.validate_all(
             "SELECT BOOLOR_AGG(c1), BOOLOR_AGG(c2) FROM test",
             write={
                 "": "SELECT LOGICAL_OR(c1), LOGICAL_OR(c2) FROM test",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -22,7 +22,7 @@ class TestSnowflake(Validator):
             write={
                 "": "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) = 1",
                 "snowflake": "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
-                "sqlite": "SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) AS _w FROM qt) WHERE _w = 1",
+                "sqlite": "SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) AS _w FROM qt) AS _t WHERE _w = 1",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -22,7 +22,7 @@ class TestSnowflake(Validator):
             write={
                 "": "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) = 1",
                 "snowflake": "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
-                "sqlite": "SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) AS _w_0 FROM qt) WHERE _w_0 = 1",
+                "sqlite": "SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) AS _w FROM qt) WHERE _w = 1",
             },
         )
         self.validate_all(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -3,6 +3,7 @@ import unittest
 from sqlglot import parse_one
 from sqlglot.transforms import (
     eliminate_distinct_on,
+    eliminate_qualify,
     remove_precision_parameterized_types,
     unalias_group,
 )
@@ -72,6 +73,28 @@ class TestTime(unittest.TestCase):
             eliminate_distinct_on,
             "SELECT DISTINCT ON (_row_number) _row_number FROM x ORDER BY c DESC",
             'SELECT _row_number FROM (SELECT _row_number, ROW_NUMBER() OVER (PARTITION BY _row_number ORDER BY c DESC) AS _row_number_2 FROM x) WHERE "_row_number_2" = 1',
+        )
+
+    def test_eliminate_qualify(self):
+        self.validate(
+            eliminate_qualify,
+            "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
+            "SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS _w_0 FROM qt) WHERE _w_0 = 1",
+        )
+        self.validate(
+            eliminate_qualify,
+            "SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS row_num FROM qt QUALIFY row_num = 1",
+            "SELECT i, p, o, row_num FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS row_num FROM qt) WHERE row_num = 1",
+        )
+        self.validate(
+            eliminate_qualify,
+            "SELECT * FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
+            "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS _w_0 FROM qt) WHERE _w_0 = 1",
+        )
+        self.validate(
+            eliminate_qualify,
+            "SELECT c2, SUM(c3) OVER (PARTITION BY c2) AS r FROM t1 WHERE c3 < 4 GROUP BY c2, c3 HAVING SUM(c1) > 3 QUALIFY r IN (SELECT MIN(c1) FROM test GROUP BY c2 HAVING MIN(c1) > 3)",
+            "SELECT c2, r FROM (SELECT c2, SUM(c3) OVER (PARTITION BY c2) AS r FROM t1 WHERE c3 < 4 GROUP BY c2, c3 HAVING SUM(c1) > 3) WHERE r IN (SELECT MIN(c1) FROM test GROUP BY c2 HAVING MIN(c1) > 3)",
         )
 
     def test_remove_precision_parameterized_types(self):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -78,6 +78,11 @@ class TestTransforms(unittest.TestCase):
     def test_eliminate_qualify(self):
         self.validate(
             eliminate_qualify,
+            "SELECT i, a + 1 FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p) = 1",
+            "SELECT i, _c FROM (SELECT i, a + 1 AS _c, ROW_NUMBER() OVER (PARTITION BY p) AS _w, p FROM qt) AS _t WHERE _w = 1",
+        )
+        self.validate(
+            eliminate_qualify,
             "SELECT i FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1 AND p = 0",
             "SELECT i FROM (SELECT i, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS _w, p, o FROM qt) AS _t WHERE _w = 1 AND p = 0",
         )


### PR DESCRIPTION
Reference: https://docs.snowflake.com/en/sql-reference/constructs/qualify

Tested the Snowflake example:

```sql
SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1;
```

Gives same results as what we get by transpiling it in SQLite:

```sql
SELECT i, p, o FROM (SELECT i, p, o, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o NULLS LAST) AS _w_0 FROM qt) WHERE _w_0 = 1;
```