### PR TITLE
Rename day of week function for duckdb

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -148,6 +148,7 @@ class DuckDB(Dialect):
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySort: _array_sort_sql,
             exp.ArraySum: rename_func("LIST_SUM"),
+            exp.DayOfWeek: rename_func("DAYOFWEEK"),
             exp.DataType: _datatype_sql,
             exp.DateAdd: _date_add,
             exp.DateDiff: lambda self, e: self.func(

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -148,7 +148,9 @@ class DuckDB(Dialect):
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySort: _array_sort_sql,
             exp.ArraySum: rename_func("LIST_SUM"),
+            exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
+            exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.DataType: _datatype_sql,
             exp.DateAdd: _date_add,
             exp.DateDiff: lambda self, e: self.func(
@@ -188,6 +190,7 @@ class DuckDB(Dialect):
             exp.UnixToStr: lambda self, e: f"STRFTIME(TO_TIMESTAMP({self.sql(e, 'this')}), {self.format_time(e)})",
             exp.UnixToTime: rename_func("TO_TIMESTAMP"),
             exp.UnixToTimeStr: lambda self, e: f"CAST(TO_TIMESTAMP({self.sql(e, 'this')}) AS TEXT)",
+            exp.WeekOfYear: rename_func("WEEKOFYEAR"),
         }
 
         TYPE_MAPPING = {

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -189,34 +189,38 @@ class TestPresto(Validator):
         )
 
         self.validate_all(
-            "DAY_OF_WEEK(timestamp '2012-08-08 01:00')",
+            "DAY_OF_WEEK(timestamp '2012-08-08 01:00:00')",
             write={
-                "spark": "DAYOFWEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_WEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))",
+                "spark": "DAYOFWEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "DAY_OF_WEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "duckdb": "DAYOFWEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
 
         self.validate_all(
-            "DAY_OF_MONTH(timestamp '2012-08-08 01:00')",
+            "DAY_OF_MONTH(timestamp '2012-08-08 01:00:00')",
             write={
-                "spark": "DAYOFMONTH(CAST('2012-08-08 01:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_MONTH(CAST('2012-08-08 01:00' AS TIMESTAMP))",
+                "spark": "DAYOFMONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "DAY_OF_MONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "duckdb": "DAYOFMONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
 
         self.validate_all(
-            "DAY_OF_YEAR(timestamp '2012-08-08 01:00')",
+            "DAY_OF_YEAR(timestamp '2012-08-08 01:00:00')",
             write={
-                "spark": "DAYOFYEAR(CAST('2012-08-08 01:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_YEAR(CAST('2012-08-08 01:00' AS TIMESTAMP))",
+                "spark": "DAYOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "DAY_OF_YEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "duckdb": "DAYOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
 
         self.validate_all(
-            "WEEK_OF_YEAR(timestamp '2012-08-08 01:00')",
+            "WEEK_OF_YEAR(timestamp '2012-08-08 01:00:00')",
             write={
-                "spark": "WEEKOFYEAR(CAST('2012-08-08 01:00' AS TIMESTAMP))",
-                "presto": "WEEK_OF_YEAR(CAST('2012-08-08 01:00' AS TIMESTAMP))",
+                "spark": "WEEKOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "WEEK_OF_YEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "duckdb": "WEEKOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -193,6 +193,7 @@ class TestPresto(Validator):
             write={
                 "spark": "DAYOFWEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))",
                 "presto": "DAY_OF_WEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))",
+                "duckdb": "DAYOFWEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))"
             },
         )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -193,7 +193,6 @@ class TestPresto(Validator):
             write={
                 "spark": "DAYOFWEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))",
                 "presto": "DAY_OF_WEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))",
-                "duckdb": "DAYOFWEEK(CAST('2012-08-08 01:00' AS TIMESTAMP))"
             },
         )
 


### PR DESCRIPTION
Currently `dayofweek()` transpiles to `day_of_week()` in duckdb but this is incorrect, it should be `dayofweek()` as stated in the [docs](https://duckdb.org/docs/sql/functions/datepart.html#part-functions).