### PR TITLE
Move SET parsing/generating logic from MySQL to base

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -809,7 +809,7 @@ class Describe(Expression):
 
 
 class Set(Expression):
-    arg_types = {"expressions": True}
+    arg_types = {"expressions": False}
 
 
 class SetItem(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1176,6 +1176,19 @@ class Generator:
         this = self.sql(expression, "this")
         return f"{this}{self.seg('OFFSET')} {self.sql(expression, 'expression')}"
 
+    def setitem_sql(self, expression: exp.SetItem) -> str:
+        kind = self.sql(expression, "kind")
+        kind = f"{kind} " if kind else ""
+        this = self.sql(expression, "this")
+        expressions = self.expressions(expression)
+        collate = self.sql(expression, "collate")
+        collate = f" COLLATE {collate}" if collate else ""
+        global_ = "GLOBAL " if expression.args.get("global") else ""
+        return f"{global_}{kind}{this}{expressions}{collate}"
+
+    def set_sql(self, expression: exp.Set) -> str:
+        return f"SET {self.expressions(expression)}"
+
     def lock_sql(self, expression: exp.Lock) -> str:
         if self.LOCKING_READS_SUPPORTED:
             lock_type = "UPDATE" if expression.args["update"] else "SHARE"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1187,7 +1187,8 @@ class Generator:
         return f"{global_}{kind}{this}{expressions}{collate}"
 
     def set_sql(self, expression: exp.Set) -> str:
-        return f"SET {self.expressions(expression)}"
+        expressions = f" {self.expressions(expression)}" if expression.expressions else ""
+        return f"SET{expressions}"
 
     def lock_sql(self, expression: exp.Lock) -> str:
         if self.LOCKING_READS_SUPPORTED:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3879,7 +3879,7 @@ class Parser(metaclass=_Parser):
 
         left = self._parse_primary() or self._parse_id_var()
 
-        if not self._match(TokenType.EQ):
+        if not self._match_texts(("=", "TO")):
             self._retreat(index)
             return None
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -726,7 +726,6 @@ class Tokenizer(metaclass=_Tokenizer):
         TokenType.COMMAND,
         TokenType.EXECUTE,
         TokenType.FETCH,
-        TokenType.SET,
         TokenType.SHOW,
     }
 

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -161,6 +161,10 @@ CAST('2025-11-20 00:00:00+00' AS TIMESTAMP) AT TIME ZONE 'Africa/Cairo'
 SET x = 1
 SET -v
 SET x = ';'
+SET variable = value
+SET GLOBAL variable = value
+SET LOCAL variable = value
+SET @user OFF
 COMMIT
 USE db
 USE role x

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -300,6 +300,11 @@ class TestParser(unittest.TestCase):
 
         self.assertEqual(set_item.args.get("kind"), "SESSION")
 
+        set_to = parse_one("SET x TO 1")
+
+        self.assertEqual(set_to.sql(), "SET x = 1")
+        self.assertIsInstance(set_to, exp.Set)
+
         set_as_command = parse_one("SET DEFAULT ROLE ALL TO USER")
 
         self.assertEqual(set_as_command.sql(), "SET DEFAULT ROLE ALL TO USER")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -281,6 +281,11 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(parse_one("map.x"), exp.Column)
 
     def test_set_expression(self):
+        set_ = parse_one("SET")
+
+        self.assertEqual(set_.sql(), "SET")
+        self.assertIsInstance(set_, exp.Set)
+
         set_session = parse_one("SET SESSION x = 1")
 
         self.assertEqual(set_session.sql(), "SET SESSION x = 1")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -280,6 +280,29 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(parse_one("TIMESTAMP()"), exp.Func)
         self.assertIsInstance(parse_one("map.x"), exp.Column)
 
+    def test_set_expression(self):
+        set_session = parse_one("SET SESSION x = 1")
+
+        self.assertEqual(set_session.sql(), "SET SESSION x = 1")
+        self.assertIsInstance(set_session, exp.Set)
+
+        set_item = set_session.expressions[0]
+
+        self.assertIsInstance(set_item, exp.SetItem)
+        self.assertIsInstance(set_item.this, exp.EQ)
+        self.assertIsInstance(set_item.this.this, exp.Identifier)
+        self.assertIsInstance(set_item.this.expression, exp.Literal)
+
+        self.assertEqual(set_item.args.get("kind"), "SESSION")
+
+        set_as_command = parse_one("SET DEFAULT ROLE ALL TO USER")
+
+        self.assertEqual(set_as_command.sql(), "SET DEFAULT ROLE ALL TO USER")
+
+        self.assertIsInstance(set_as_command, exp.Command)
+        self.assertEqual(set_as_command.this, "SET")
+        self.assertEqual(set_as_command.expression, " DEFAULT ROLE ALL TO USER")
+
     def test_pretty_config_override(self):
         self.assertEqual(parse_one("SELECT col FROM x").sql(), "SELECT col FROM x")
         with patch("sqlglot.pretty", True):


### PR DESCRIPTION
- Moved a subset of the logic we use for parsing / generating SET statements to the base classes, so that we can parse statements like `SET variable = value` with finer granularity.
- When the base `_parse_set` method fails, the parser will fallback to parsing the input as a command.

cc: @joocer @tobymao @barakalon 

Fixes #1225 