### PR TITLE
Allow parsing strings as table references

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1759,7 +1759,7 @@ class Parser(metaclass=_Parser):
         return self.expression(exp.With, expressions=expressions, recursive=recursive)
 
     def _parse_cte(self) -> exp.Expression:
-        alias = self._parse_table_alias()
+        alias = self._parse_table_alias() or self._parse_string()
         if not alias or not alias.this:
             self.raise_error("Expected CTE to have alias")
 
@@ -2046,7 +2046,12 @@ class Parser(metaclass=_Parser):
     def _parse_table_parts(self, schema: bool = False) -> exp.Expression:
         catalog = None
         db = None
-        table = (not schema and self._parse_function()) or self._parse_id_var(any_token=False)
+
+        table = (
+            (not schema and self._parse_function())
+            or self._parse_id_var(any_token=False)
+            or self._parse_string()
+        )
 
         while self._match(TokenType.DOT):
             if catalog:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1775,9 +1775,10 @@ class Parser(metaclass=_Parser):
         self, alias_tokens: t.Optional[t.Collection[TokenType]] = None
     ) -> t.Optional[exp.Expression]:
         any_token = self._match(TokenType.ALIAS)
-        alias = self._parse_id_var(
-            any_token=any_token, tokens=alias_tokens or self.TABLE_ALIAS_TOKENS
-        ) or self._parse_string_as_identifier()
+        alias = (
+            self._parse_id_var(any_token=any_token, tokens=alias_tokens or self.TABLE_ALIAS_TOKENS)
+            or self._parse_string_as_identifier()
+        )
 
         index = self._index
         if self._match(TokenType.L_PAREN):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -110,8 +110,6 @@ class TestDuckDB(Validator):
         )
 
     def test_duckdb(self):
-        self.validate_identity("SELECT * FROM 'x.y'")
-        self.validate_identity("WITH 'x' AS (SELECT 1) SELECT * FROM x")
         self.validate_identity("SELECT {'a': 1} AS x")
         self.validate_identity("SELECT {'a': {'b': {'c': 1}}, 'd': {'e': 2}} AS x")
         self.validate_identity("SELECT {'x': 1, 'y': 2, 'z': 3}")
@@ -127,6 +125,11 @@ class TestDuckDB(Validator):
             "SELECT a['x space'] FROM (SELECT {'x space': 1, 'y': 2, 'z': 3} AS a)"
         )
 
+        self.validate_all("SELECT * FROM 'x.y'", write={"duckdb": 'SELECT * FROM "x.y"'})
+        self.validate_all(
+            "WITH 'x' AS (SELECT 1) SELECT * FROM x",
+            write={"duckdb": 'WITH "x" AS (SELECT 1) SELECT * FROM x'},
+        )
         self.validate_all(
             "CREATE TABLE IF NOT EXISTS table (cola INT, colb STRING) USING ICEBERG PARTITIONED BY (colb)",
             write={

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -110,6 +110,8 @@ class TestDuckDB(Validator):
         )
 
     def test_duckdb(self):
+        self.validate_identity("SELECT * FROM 'x.y'")
+        self.validate_identity("WITH 'x' AS (SELECT 1) SELECT * FROM x")
         self.validate_identity("SELECT {'a': 1} AS x")
         self.validate_identity("SELECT {'a': {'b': {'c': 1}}, 'd': {'e': 2}} AS x")
         self.validate_identity("SELECT {'x': 1, 'y': 2, 'z': 3}")


### PR DESCRIPTION
Apparently, DuckDB allows this:

```
>>> import duckdb
>>> duckdb.connect().execute("WITH 'x.y' AS (SELECT 1) SELECT * FROM 'x.y'").fetchdf()
   1
0  1
>>> duckdb.connect().execute("WITH 'x' AS (SELECT 1) SELECT * FROM 'x'").fetchdf()
   1
0  1
>>> duckdb.connect().execute("WITH 'x' AS (SELECT 1) SELECT * FROM x").fetchdf()
   1
0  1
```

This seems non-standard, but it felt innocuous enough to support. The places where I added `self._parse_string()` would lead to an exception without it anyway, in case we weren't able to parse a table.