### PR TITLE
Add Converter for Drill Dialect for DATE_FORMAT

### DIFF
--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -97,6 +97,7 @@ class Drill(Dialect):
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,  # type: ignore
+            "DATE_FORMAT": format_time_lambda(exp.TimeToStr, "drill"),
             "TO_TIMESTAMP": exp.TimeStrToTime.from_arg_list,
             "TO_CHAR": format_time_lambda(exp.TimeToStr, "drill"),
         }


### PR DESCRIPTION
This PR adds a function converter to convert the `DATE_FORMAT` function to Drill's native but not intuitive `TO_CHAR` function.  