### PR TITLE
Fix semicolon bug in command tokenizing

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -852,8 +852,10 @@ class Tokenizer(metaclass=_Tokenizer):
 
         # If we have either a semicolon or a begin token before the command's token, we'll parse
         # whatever follows the command's token as a string
-        if token_type in self.COMMANDS and (
-            len(self.tokens) == 1 or self.tokens[-2].token_type in self.COMMAND_PREFIX_TOKENS
+        if (
+            token_type in self.COMMANDS
+            and self._peek != ";"
+            and (len(self.tokens) == 1 or self.tokens[-2].token_type in self.COMMAND_PREFIX_TOKENS)
         ):
             start = self._current
             tokens = len(self.tokens)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -30,6 +30,21 @@ class TestTokens(unittest.TestCase):
 
         self.assertEqual(tokens[-1].line, 6)
 
+    def test_command(self):
+        tokens = Tokenizer().tokenize("SHOW;")
+        self.assertEqual(tokens[0].token_type, TokenType.SHOW)
+        self.assertEqual(tokens[1].token_type, TokenType.SEMICOLON)
+
+        tokens = Tokenizer().tokenize("EXECUTE")
+        self.assertEqual(tokens[0].token_type, TokenType.EXECUTE)
+        self.assertEqual(len(tokens), 1)
+
+        tokens = Tokenizer().tokenize("FETCH;SHOW;")
+        self.assertEqual(tokens[0].token_type, TokenType.FETCH)
+        self.assertEqual(tokens[1].token_type, TokenType.SEMICOLON)
+        self.assertEqual(tokens[2].token_type, TokenType.SHOW)
+        self.assertEqual(tokens[3].token_type, TokenType.SEMICOLON)
+
     def test_jinja(self):
         tokenizer = Tokenizer()
 


### PR DESCRIPTION
Semicolon gets tokenized as a `TokenType.STRING` instead of `TokenType.SEMICOLON`:

```python
>>> import sqlglot
>>> sqlglot.tokens.Tokenizer().tokenize("show;")
[
    <Token token_type: TokenType.SHOW, text: show, line: 1, col: 1, comments: []>,
    <Token token_type: TokenType.STRING, text: ;, line: 1, col: 5, comments: []>
]
```