### PR TITLE
Add date_trunc support for Postgres

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -255,6 +255,10 @@ class Postgres(Dialect):
             "TO_TIMESTAMP": _to_timestamp,
             "TO_CHAR": format_time_lambda(exp.TimeToStr, "postgres"),
             "GENERATE_SERIES": _generate_series,
+            "DATE_TRUNC": lambda args: exp.DateTrunc(
+                unit=exp.Literal.string(seq_get(args, 0).name),  # type: ignore
+                this=seq_get(args, 1),
+            ),
         }
 
         BITWISE = {

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -545,6 +545,7 @@ class TestDialect(Validator):
             "DATE_TRUNC('day', x)",
             write={
                 "mysql": "DATE(x)",
+                "postgres": "DATE_TRUNC('day', x)",
                 "snowflake": "DATE_TRUNC('day', x)",
             },
         )
@@ -582,6 +583,7 @@ class TestDialect(Validator):
             "DATE_TRUNC('year', x)",
             read={
                 "bigquery": "DATE_TRUNC(x, year)",
+                "postgres": "DATE_TRUNC(year, x)",
                 "snowflake": "DATE_TRUNC(year, x)",
                 "starrocks": "DATE_TRUNC('year', x)",
                 "spark": "TRUNC(x, 'year')",


### PR DESCRIPTION
Similar to 

https://github.com/tobymao/sqlglot/commit/bade19c02437129d304e543747aa8e0e310f1773

but for postgres