### PR TITLE
Parse db.table syntax in MySQL's SHOW INDEX statement

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -303,7 +303,13 @@ class MySQL(Dialect):
                 db = None
             else:
                 position = None
-                db = self._parse_id_var() if self._match_text_seq("FROM") else None
+                db = None
+
+                if self._match(TokenType.FROM):
+                    db = self._parse_id_var()
+                elif self._match(TokenType.DOT):
+                    db = target_id
+                    target_id = self._parse_id_var()
 
             channel = self._parse_id_var() if self._match_text_seq("FOR", "CHANNEL") else None
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -424,6 +424,10 @@ COMMENT='客户账户表'"""
         show = self.validate_identity("SHOW INDEX FROM foo FROM bar")
         self.assertEqual(show.text("db"), "bar")
 
+        self.validate_all(
+            "SHOW INDEX FROM bar.foo", write={"mysql": "SHOW INDEX FROM foo FROM bar"}
+        )
+
     def test_show_db_like_or_where_sql(self):
         for key in [
             "OPEN TABLES",


### PR DESCRIPTION
Fixes #1315

>  An alternative to tbl_name FROM db_name syntax is db_name.tbl_name. These two statements are equivalent:

```sql
SHOW INDEX FROM mytable FROM mydb;
SHOW INDEX FROM mydb.mytable;
```

- https://dev.mysql.com/doc/refman/8.0/en/show-index.html
