### PR TITLE
fix missing concat type annotating

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -108,6 +108,7 @@ class TypeAnnotator:
         exp.If: lambda self, expr: self._annotate_by_args(expr, "true", "false"),
         exp.Coalesce: lambda self, expr: self._annotate_by_args(expr, "this", "expressions"),
         exp.IfNull: lambda self, expr: self._annotate_by_args(expr, "this", "expression"),
+        exp.Concat: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.VARCHAR),
         exp.ConcatWs: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.VARCHAR),
         exp.GroupConcat: lambda self, expr: self._annotate_with_type(
             expr, exp.DataType.Type.VARCHAR

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -578,6 +578,10 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
             )
             self.assertEqual(expression.expressions[0].type.this, target_type)
 
+    def test_concat_annotation(self):
+        expression = annotate_types(parse_one("CONCAT('A', 'B')"))
+        self.assertEqual(expression.type.this, exp.DataType.Type.VARCHAR)
+
     def test_recursive_cte(self):
         query = parse_one(
             """


### PR DESCRIPTION
## Purpose
There was existing logic for type annotating the other concat methods, however the standard `CONCAT` was missed out

## Description of changes
- Implemented string type for `CONCAT`
- Added unit test to cover it