### PR TITLE
Parse Oracle SQL hints as raw strings

### DIFF
--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -12,6 +12,24 @@ class TestOracle(Validator):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y = e2.y (+)")
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y (+)")
 
+    def test_hints(self):
+        self.validate_identity("SELECT /*+ USE_NL(A B) */ A.COL_TEST FROM TABLE_A A, TABLE_B B")
+        self.validate_identity(
+            "SELECT /*+ INDEX(v.j jhist_employee_ix (employee_id start_date)) */ * FROM v"
+        )
+        self.validate_identity(
+            "SELECT /*+ USE_NL(A B C) */ A.COL_TEST FROM TABLE_A A, TABLE_B B, TABLE_C C"
+        )
+        self.validate_identity(
+            "SELECT /*+ NO_INDEX(employees emp_empid) */ employee_id FROM employees WHERE employee_id > 200"
+        )
+        self.validate_identity(
+            "SELECT /*+ NO_INDEX_FFS(items item_order_ix) */ order_id FROM order_items items"
+        )
+        self.validate_identity(
+            "SELECT /*+ LEADING(e j) */ * FROM employees e, departments d, job_history j WHERE e.department_id = d.department_id AND e.hire_date = j.start_date"
+        )
+
     def test_xml_table(self):
         self.validate_identity("XMLTABLE('x')")
         self.validate_identity("XMLTABLE('x' RETURNING SEQUENCE BY REF)")


### PR DESCRIPTION
Fixes #1327 

Due to Oracle's weird syntax, I opted to parsing hints as raw strings. If needed, we can refactor this in the future, but there are some tricky cases where spaces are used as value separators when we expect commas, e.g. in:

```sql
-- Both function arguments and tuple values are separated by spaces here
SELECT /*+ INDEX(v.j jhist_employee_ix (employee_id start_date)) */ * FROM v;
```