### PR TITLE
Optimizer: fix star expansion when USING clause is present

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -295,7 +295,6 @@ def _expand_stars(scope, resolver, using_column_tables):
                             continue
 
                         coalesced_columns.add(name)
-
                         tables = using_column_tables[name]
                         coalesce = [exp.column(name, table=table) for table in tables]
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -282,6 +282,27 @@ SELECT COALESCE(x.b, y.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b WHERE COALES
 SELECT b FROM x JOIN y USING (b) JOIN z USING (b);
 SELECT COALESCE(x.b, y.b, z.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b JOIN z AS z ON x.b = z.b;
 
+SELECT * FROM x JOIN y USING(b);
+SELECT x.a AS a, COALESCE(x.b, y.b) AS b, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;
+
+SELECT * FROM x LEFT JOIN y USING(b);
+SELECT x.a AS a, COALESCE(x.b, y.b) AS b, y.c AS c FROM x AS x LEFT JOIN y AS y ON x.b = y.b;
+
+SELECT b FROM x JOIN y USING(b);
+SELECT COALESCE(x.b, y.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b;
+
+SELECT b, c FROM x JOIN y USING(b);
+SELECT COALESCE(x.b, y.b) AS b, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;
+
+SELECT b, c FROM y JOIN z USING(b, c);
+SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z ON y.b = z.b AND y.c = z.c;
+
+SELECT * FROM y JOIN z USING(b, c);
+SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z ON y.b = z.b AND y.c = z.c;
+
+SELECT * FROM y JOIN z USING(b, c) WHERE b = 2 AND c = 3;
+SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z ON y.b = z.b AND y.c = z.c WHERE COALESCE(y.b, z.b) = 2 AND COALESCE(y.c, z.c) = 3;
+
 --------------------------------------
 -- Hint with table reference
 --------------------------------------

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -285,6 +285,9 @@ SELECT COALESCE(x.b, y.b, z.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b JOIN z 
 SELECT * FROM x JOIN y USING(b);
 SELECT x.a AS a, COALESCE(x.b, y.b) AS b, y.c AS c FROM x AS x JOIN y AS y ON x.b = y.b;
 
+SELECT x.* FROM x JOIN y USING(b);
+SELECT x.a AS a, COALESCE(x.b, y.b) AS b FROM x AS x JOIN y AS y ON x.b = y.b;
+
 SELECT * FROM x LEFT JOIN y USING(b);
 SELECT x.a AS a, COALESCE(x.b, y.b) AS b, y.c AS c FROM x AS x LEFT JOIN y AS y ON x.b = y.b;
 


### PR DESCRIPTION
Before:

```python
>>> from sqlglot.optimizer import optimize
>>>
>>> optimize("SELECT * FROM x JOIN y USING(id)", schema={"x": {"id": "int"}, "y": {"id": "int"}}).sql()
'SELECT "x"."id" AS "id", "y"."id" AS "id" FROM "x" AS "x" JOIN "y" AS "y" ON "x"."id" = "y"."id"'
```

This transformation doesn't preserve the semantics of the `USING` clause, because it expands `id` into two columns, both named `"id"`, instead of merging them into a single one. For example, in Postgres SQL:

```sql
-- Tables x and y both have a single column named "id", with values 1, 2 and 3.
georgesittas=# SELECT * FROM x JOIN y USING(id);
 id
----
  1
  2
  3
(3 rows)
```

After:

```python
>>> from sqlglot.optimizer import optimize
>>>
>>> optimize("SELECT * FROM x JOIN y USING(id)", schema={"x": {"id": "int"}, "y": {"id": "int"}}).sql()
'SELECT COALESCE("x"."id", "y"."id") AS "id" FROM "x" AS "x" JOIN "y" AS "y" ON "x"."id" = "y"."id"'
```

Notice that this matches the behavior of Postgres and is aligned with the current `_expand_using` [behavior](https://github.com/tobymao/sqlglot/blob/main/sqlglot/optimizer/qualify_columns.py#L129):

```sql
georgesittas=# SELECT COALESCE(x.id, y.id) AS id FROM x AS x JOIN y AS y ON x.id = y.id'
 id
----
  1
  2
  3
(3 rows)
```

Some more examples I tried (including left and right joins) can be found [here](https://user-images.githubusercontent.com/46752250/227366023-44d24fb9-45ad-46a3-8bcd-5911509d5850.png).
