### PR TITLE
Parse tilde as REGEXP_MATCHES for DuckDB

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -80,6 +80,7 @@ class DuckDB(Dialect):
     class Tokenizer(tokens.Tokenizer):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
+            "~": TokenType.RLIKE,
             ":=": TokenType.EQ,
             "ATTACH": TokenType.COMMAND,
             "BINARY": TokenType.VARBINARY,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -125,6 +125,7 @@ class TestDuckDB(Validator):
             "SELECT a['x space'] FROM (SELECT {'x space': 1, 'y': 2, 'z': 3} AS a)"
         )
 
+        self.validate_all("x ~ y", write={"duckdb": "REGEXP_MATCHES(x, y)"})
         self.validate_all("SELECT * FROM 'x.y'", write={"duckdb": 'SELECT * FROM "x.y"'})
         self.validate_all(
             "WITH 'x' AS (SELECT 1) SELECT * FROM x",


### PR DESCRIPTION
Fixes #1338

This isn't complete, because `~5` is a valid expression, corresponding to the 2's complement of 5. I assume that it's not used as commonly, so maybe it's ok to leave it as is. Otherwise, happy to revisit this and try to fix parsing so that we can recognize it too. Notice that we also had this problem with postgres prior to this PR.