### PR TITLE
Fix tokenizing of T-SQL parameters

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -269,7 +269,6 @@ class TSQL(Dialect):
 
         # TSQL allows @, # to appear as a variable/identifier prefix
         SINGLE_TOKENS = tokens.Tokenizer.SINGLE_TOKENS.copy()
-        SINGLE_TOKENS.pop("@")
         SINGLE_TOKENS.pop("#")
 
     class Parser(parser.Parser):


### PR DESCRIPTION
With this we'll now parse `@x` in `SELECT @x FROM foo` as a parameter, instead of a `Column`.

cc: @10bas10 