### PR TITLE
Fix: generate ->> for JSON_EXTRACT_SCALAR (MySQL)

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlglot import exp, generator, parser, tokens
 from sqlglot.dialects.dialect import (
     Dialect,
+    arrow_json_extract_scalar_sql,
     locate_to_strposition,
     max_or_greatest,
     min_or_least,
@@ -391,6 +392,7 @@ class MySQL(Dialect):
             exp.CurrentDate: no_paren_current_date_sql,
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.ILike: no_ilike_sql,
+            exp.JSONExtractScalar: arrow_json_extract_scalar_sql,
             exp.Max: max_or_greatest,
             exp.Min: min_or_least,
             exp.TableSample: no_tablesample_sql,
@@ -404,7 +406,6 @@ class MySQL(Dialect):
             exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.WeekOfYear: rename_func("WEEKOFYEAR"),
             exp.GroupConcat: lambda self, e: f"""GROUP_CONCAT({self.sql(e, "this")} SEPARATOR {self.sql(e, "separator") or "','"})""",
-            exp.JSONExtractScalar: rename_func("JSON_EXTRACT"),
             exp.StrToDate: _str_to_date_sql,
             exp.StrToTime: _str_to_date_sql,
             exp.Trim: _trim_sql,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -832,9 +832,19 @@ class TestDialect(Validator):
                 "presto": "JSON_EXTRACT_SCALAR(x, 'y')",
             },
             write={
-                "mysql": "JSON_EXTRACT(x, 'y')",
                 "postgres": "x ->> 'y'",
                 "presto": "JSON_EXTRACT_SCALAR(x, 'y')",
+            },
+        )
+        self.validate_all(
+            "JSON_EXTRACT_SCALAR(stream_data, '$.data.results')",
+            read={
+                "hive": "GET_JSON_OBJECT(stream_data, '$.data.results')",
+                "mysql": "stream_data ->> '$.data.results'",
+            },
+            write={
+                "hive": "GET_JSON_OBJECT(stream_data, '$.data.results')",
+                "mysql": "stream_data ->> '$.data.results'",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -16,6 +16,7 @@ class TestMySQL(Validator):
         )
 
     def test_identity(self):
+        self.validate_identity("x ->> '$.name'")
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")
         self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ')")
         self.validate_identity("SELECT TRIM(TRAILING 'bla' FROM ' XXX ')")


### PR DESCRIPTION
Aims to improve https://github.com/tobymao/sqlglot/pull/1350, since MySQL directly supports `->>`, like postgres.

cc: @jerryleooo