### PR TITLE
Fix parsing for the logarithm function

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -213,6 +213,9 @@ class BigQuery(Dialect):
             ),
         }
 
+        LOGARITHM_BASE_FIRST = False
+        LOGARITHM_DEFAULTS_TO_LN = True
+
     class Generator(generator.Generator):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,  # type: ignore

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -213,8 +213,8 @@ class BigQuery(Dialect):
             ),
         }
 
-        LOGARITHM_BASE_FIRST = False
-        LOGARITHM_DEFAULTS_TO_LN = True
+        LOG_BASE_FIRST = False
+        LOG_DEFAULTS_TO_LN = True
 
     class Generator(generator.Generator):
         TRANSFORMS = {

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -68,7 +68,7 @@ class ClickHouse(Dialect):
 
         TABLE_ALIAS_TOKENS = {*parser.Parser.TABLE_ALIAS_TOKENS} - {TokenType.ANY}  # type: ignore
 
-        LOGARITHM_DEFAULTS_TO_LN = True
+        LOG_DEFAULTS_TO_LN = True
 
         def _parse_in(
             self, this: t.Optional[exp.Expression], is_global: bool = False

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -68,6 +68,8 @@ class ClickHouse(Dialect):
 
         TABLE_ALIAS_TOKENS = {*parser.Parser.TABLE_ALIAS_TOKENS} - {TokenType.ANY}  # type: ignore
 
+        LOGARITHM_DEFAULTS_TO_LN = True
+
         def _parse_in(
             self, this: t.Optional[exp.Expression], is_global: bool = False
         ) -> exp.Expression:

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -16,7 +16,7 @@ class Databricks(Spark):
             "DATEDIFF": parse_date_delta(exp.DateDiff),
         }
 
-        LOGARITHM_DEFAULTS_TO_LN = True
+        LOG_DEFAULTS_TO_LN = True
 
     class Generator(Spark.Generator):
         TRANSFORMS = {

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -16,6 +16,8 @@ class Databricks(Spark):
             "DATEDIFF": parse_date_delta(exp.DateDiff),
         }
 
+        LOGARITHM_DEFAULTS_TO_LN = True
+
     class Generator(Spark.Generator):
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,  # type: ignore

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -101,7 +101,7 @@ class Drill(Dialect):
             "TO_CHAR": format_time_lambda(exp.TimeToStr, "drill"),
         }
 
-        LOGARITHM_DEFAULTS_TO_LN = True
+        LOG_DEFAULTS_TO_LN = True
 
     class Generator(generator.Generator):
         TYPE_MAPPING = {

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -101,6 +101,8 @@ class Drill(Dialect):
             "TO_CHAR": format_time_lambda(exp.TimeToStr, "drill"),
         }
 
+        LOGARITHM_DEFAULTS_TO_LN = True
+
     class Generator(generator.Generator):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,  # type: ignore

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -253,11 +253,6 @@ class Hive(Dialect):
             "FROM_UNIXTIME": format_time_lambda(exp.UnixToStr, "hive", True),
             "GET_JSON_OBJECT": exp.JSONExtractScalar.from_arg_list,
             "LOCATE": locate_to_strposition,
-            "LOG": (
-                lambda args: exp.Log.from_arg_list(args)
-                if len(args) > 1
-                else exp.Ln.from_arg_list(args)
-            ),
             "MAP": parse_var_map,
             "MONTH": lambda args: exp.Month(this=exp.TsOrDsToDate.from_arg_list(args)),
             "PERCENTILE": exp.Quantile.from_arg_list,
@@ -276,6 +271,8 @@ class Hive(Dialect):
                 expressions=self._parse_wrapped_csv(self._parse_property)
             ),
         }
+
+        LOG_DEFAULTS_TO_LN = True
 
     class Generator(generator.Generator):
         TYPE_MAPPING = {

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -290,7 +290,7 @@ class MySQL(Dialect):
             "SWAPS",
         }
 
-        LOGARITHM_DEFAULTS_TO_LN = True
+        LOG_DEFAULTS_TO_LN = True
 
         def _parse_show_mysql(self, this, target=False, full=None, global_=None):
             if target:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -290,6 +290,8 @@ class MySQL(Dialect):
             "SWAPS",
         }
 
+        LOGARITHM_DEFAULTS_TO_LN = True
+
         def _parse_show_mysql(self, this, target=False, full=None, global_=None):
             if target:
                 if isinstance(target, str):

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -313,6 +313,9 @@ class TSQL(Dialect):
             TokenType.END: lambda self: self._parse_command(),
         }
 
+        LOGARITHM_BASE_FIRST = False
+        LOGARITHM_DEFAULTS_TO_LN = True
+
         def _parse_system_time(self) -> t.Optional[exp.Expression]:
             if not self._match_text_seq("FOR", "SYSTEM_TIME"):
                 return None

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -313,8 +313,8 @@ class TSQL(Dialect):
             TokenType.END: lambda self: self._parse_command(),
         }
 
-        LOGARITHM_BASE_FIRST = False
-        LOGARITHM_DEFAULTS_TO_LN = True
+        LOG_BASE_FIRST = False
+        LOG_DEFAULTS_TO_LN = True
 
         def _parse_system_time(self) -> t.Optional[exp.Expression]:
             if not self._match_text_seq("FOR", "SYSTEM_TIME"):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -734,8 +734,8 @@ class Parser(metaclass=_Parser):
 
     CONVERT_TYPE_FIRST = False
 
-    LOGARITHM_BASE_FIRST = True
-    LOGARITHM_DEFAULTS_TO_LN = False
+    LOG_BASE_FIRST = True
+    LOG_DEFAULTS_TO_LN = False
 
     __slots__ = (
         "error_level",
@@ -3390,12 +3390,12 @@ class Parser(metaclass=_Parser):
         args = self._parse_csv(self._parse_range)
 
         if len(args) > 1:
-            if not self.LOGARITHM_BASE_FIRST:
+            if not self.LOG_BASE_FIRST:
                 args.reverse()
             return exp.Log.from_arg_list(args)
 
         return self.expression(
-            exp.Ln if self.LOGARITHM_DEFAULTS_TO_LN else exp.Log, this=seq_get(args, 0)
+            exp.Ln if self.LOG_DEFAULTS_TO_LN else exp.Log, this=seq_get(args, 0)
         )
 
     def _parse_position(self, haystack_first: bool = False) -> exp.Expression:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1511,6 +1511,45 @@ SELECT
             },
         )
 
+    def test_logarithm(self):
+        self.validate_all(
+            "LOG(x)",
+            read={
+                "duckdb": "LOG(x)",
+                "postgres": "LOG(x)",
+                "redshift": "LOG(x)",
+                "sqlite": "LOG(x)",
+                "teradata": "LOG(x)",
+            },
+        )
+        self.validate_all(
+            "LN(x)",
+            read={
+                "bigquery": "LOG(x)",
+                "clickhouse": "LOG(x)",
+                "databricks": "LOG(x)",
+                "drill": "LOG(x)",
+                "mysql": "LOG(x)",
+                "tsql": "LOG(x)",
+            },
+        )
+        self.validate_all(
+            "LOG(b, n)",
+            read={
+                "bigquery": "LOG(n, b)",
+                "databricks": "LOG(b, n)",
+                "drill": "LOG(b, n)",
+                "hive": "LOG(b, n)",
+                "mysql": "LOG(b, n)",
+                "oracle": "LOG(b, n)",
+                "postgres": "LOG(b, n)",
+                "snowflake": "LOG(b, n)",
+                "spark": "LOG(b, n)",
+                "sqlite": "LOG(b, n)",
+                "tsql": "LOG(n, b)",
+            },
+        )
+
     def test_count_if(self):
         self.validate_identity("COUNT_IF(DISTINCT cond)")
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1529,6 +1529,7 @@ SELECT
                 "clickhouse": "LOG(x)",
                 "databricks": "LOG(x)",
                 "drill": "LOG(x)",
+                "hive": "LOG(x)",
                 "mysql": "LOG(x)",
                 "tsql": "LOG(x)",
             },


### PR DESCRIPTION
Fixes #1360

References:
- https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#log
- https://clickhouse.com/docs/en/sql-reference/functions/math-functions
- https://docs.databricks.com/sql/language-manual/functions/log.html
- https://duckdb.org/docs/sql/functions/numeric.html
- https://cwiki.apache.org/confluence/display/hive/languagemanual+udf
- https://dev.mysql.com/doc/refman/8.0/en/mathematical-functions.html#function_log
- https://docs.oracle.com/cd/B13789_01/server.101/b10759/functions070.htm
- https://www.postgresql.org/docs/9.1/functions-math.html
- https://prestodb.io/docs/current/functions/math.html
- https://docs.aws.amazon.com/redshift/latest/dg/r_LOG.html
- https://docs.aws.amazon.com/redshift/latest/dg/r_LOG.html
- https://docs.snowflake.com/en/sql-reference/functions/log
- https://spark.apache.org/docs/2.3.0/api/sql/index.html
- https://www.sqlite.org/lang_mathfunc.html#log
- https://docs.teradata.com/r/Teradata-Database-SQL-Functions-Operators-Expressions-and-Predicates/March-2017/Arithmetic-Trigonometric-Hyperbolic-Operators/Functions/LOG-Function
- https://learn.microsoft.com/en-us/sql/t-sql/functions/log-transact-sql?view=sql-server-ver16
- https://drill.apache.org/docs/math-and-trig/