### PR TITLE
Current user, national, boolean for tsql->hive

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -282,6 +282,7 @@ class Hive(Dialect):
             exp.DataType.Type.DATETIME: "TIMESTAMP",
             exp.DataType.Type.VARBINARY: "BINARY",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
+            exp.DataType.Type.BIT: "BOOLEAN",
         }
 
         TRANSFORMS = {
@@ -345,6 +346,7 @@ class Hive(Dialect):
             exp.SerdeProperties: lambda self, e: self.properties(e, prefix="WITH SERDEPROPERTIES"),
             exp.NumberToStr: rename_func("FORMAT_NUMBER"),
             exp.LastDateOfMonth: rename_func("LAST_DAY"),
+            exp.National: lambda self, e: self.sql(e, "this"),
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -294,6 +294,8 @@ class TSQL(Dialect):
             "REPLICATE": exp.Repeat.from_arg_list,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "SYSDATETIME": exp.CurrentTimestamp.from_arg_list,
+            "SUSER_NAME": exp.CurrentUser.from_arg_list,
+            "SUSER_SNAME": exp.CurrentUser.from_arg_list,
         }
 
         VAR_LENGTH_DATATYPES = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3452,6 +3452,10 @@ class CurrentTimestamp(Func):
     arg_types = {"this": False}
 
 
+class CurrentUser(Func):
+    arg_types = {"this": False}
+
+
 class DateAdd(Func, TimeUnit):
     arg_types = {"this": True, "expression": True, "unit": False}
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -105,6 +105,7 @@ class Parser(metaclass=_Parser):
         TokenType.CURRENT_DATETIME: exp.CurrentDate,
         TokenType.CURRENT_TIME: exp.CurrentTime,
         TokenType.CURRENT_TIMESTAMP: exp.CurrentTimestamp,
+        TokenType.CURRENT_USER: exp.CurrentUser,
     }
 
     NESTED_TYPE_TOKENS = {
@@ -285,6 +286,7 @@ class Parser(metaclass=_Parser):
         TokenType.CURRENT_DATETIME,
         TokenType.CURRENT_TIMESTAMP,
         TokenType.CURRENT_TIME,
+        TokenType.CURRENT_USER,
         TokenType.FILTER,
         TokenType.FIRST,
         TokenType.FORMAT,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -163,6 +163,7 @@ class TokenType(AutoName):
     CURRENT_ROW = auto()
     CURRENT_TIME = auto()
     CURRENT_TIMESTAMP = auto()
+    CURRENT_USER = auto()
     DEFAULT = auto()
     DELETE = auto()
     DESC = auto()
@@ -506,6 +507,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "CURRENT ROW": TokenType.CURRENT_ROW,
         "CURRENT_TIME": TokenType.CURRENT_TIME,
         "CURRENT_TIMESTAMP": TokenType.CURRENT_TIMESTAMP,
+        "CURRENT_USER": TokenType.CURRENT_USER,
         "DATABASE": TokenType.DATABASE,
         "DEFAULT": TokenType.DEFAULT,
         "DELETE": TokenType.DELETE,

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -689,3 +689,11 @@ class TestHive(Validator):
         self.validate_identity("'\\z'")
         self.validate_identity("'\\\z'")
         self.validate_identity("'\\\\z'")
+
+    def test_data_type(self):
+        self.validate_all(
+            "CAST(a AS BIT)",
+            write={
+                "hive": "CAST(a AS BOOLEAN)",
+            },
+        )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -345,3 +345,13 @@ TBLPROPERTIES (
             "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",
             write={"spark": "SELECT a, BOOL_OR(b) FROM table GROUP BY a"},
         )
+
+    def test_current_user(self):
+        self.validate_all(
+            "CURRENT_USER",
+            write={"spark": "CURRENT_USER()"},
+        )
+        self.validate_all(
+            "CURRENT_USER()",
+            write={"spark": "CURRENT_USER()"},
+        )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -547,11 +547,11 @@ WHERE
     def test_string(self):
         self.validate_all(
             "SELECT N'test'",
-            write={"spark": "SELECT N'test'"},
+            write={"spark": "SELECT 'test'"},
         )
         self.validate_all(
             "SELECT n'test'",
-            write={"spark": "SELECT N'test'"},
+            write={"spark": "SELECT 'test'"},
         )
         self.validate_all(
             "SELECT '''test'''",
@@ -620,4 +620,14 @@ WHERE
             write={
                 "tsql": """SELECT "x" FROM "a"."b" FOR SYSTEM_TIME ALL AS alias""",
             },
+        )
+
+    def test_current_user(self):
+        self.validate_all(
+            "SUSER_NAME()",
+            write={"spark": "CURRENT_USER()"},
+        )
+        self.validate_all(
+            "SUSER_SNAME()",
+            write={"spark": "CURRENT_USER()"},
         )


### PR DESCRIPTION
Fixed several issues regarding tranpiling from T-SQL to Spark:
- Removed national identifier in hive and depending dialects as its not supported;
- Fixed type mapping for BIT to BOOLEAN in hive and depending dialects;
- Added support current user