### PR TITLE
Feat(optimizer): Make _expand_using more lenient in qualify columns

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -93,6 +93,7 @@ def _expand_using(scope, resolver):
                     if column not in columns:
                         columns[column] = k
 
+        source_table = ordered[-1]
         ordered.append(join_table)
         join_columns = resolver.get_source_columns(join_table)
         conditions = []
@@ -102,12 +103,13 @@ def _expand_using(scope, resolver):
             table = columns.get(identifier)
 
             if not table or identifier not in join_columns:
-                raise OptimizeError(f"Cannot automatically join: {identifier}")
+                if columns and join_columns:
+                    raise OptimizeError(f"Cannot automatically join: {identifier}")
 
             conditions.append(
                 exp.condition(
                     exp.EQ(
-                        this=exp.column(identifier, table=table),
+                        this=exp.column(identifier, table=table or source_table),
                         expression=exp.column(identifier, table=join_table),
                     )
                 )

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -106,10 +106,11 @@ def _expand_using(scope, resolver):
                 if columns and join_columns:
                     raise OptimizeError(f"Cannot automatically join: {identifier}")
 
+            table = table or source_table
             conditions.append(
                 exp.condition(
                     exp.EQ(
-                        this=exp.column(identifier, table=table or source_table),
+                        this=exp.column(identifier, table=table),
                         expression=exp.column(identifier, table=join_table),
                     )
                 )

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -317,6 +317,9 @@ SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z 
 SELECT * FROM y JOIN z USING(b, c) WHERE b = 2 AND c = 3;
 SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z ON y.b = z.b AND y.c = z.c WHERE COALESCE(y.b, z.b) = 2 AND COALESCE(y.c, z.c) = 3;
 
+-- We can safely convert `b` to `x.b` in the following two queries, because the original queries
+-- would be invalid if `b` also existed in `t`'s schema (which we don't know), due to ambiguity.
+
 # execute: false
 SELECT b FROM x JOIN t USING(a);
 SELECT x.b AS b FROM x AS x JOIN t AS t ON x.a = t.a;
@@ -324,6 +327,10 @@ SELECT x.b AS b FROM x AS x JOIN t AS t ON x.a = t.a;
 # execute: false
 SELECT b FROM t JOIN x USING(a);
 SELECT x.b AS b FROM t AS t JOIN x AS x ON t.a = x.a;
+
+# execute: false
+SELECT a FROM t1 JOIN t2 USING(a);
+SELECT COALESCE(t1.a, t2.a) AS a FROM t1 AS t1 JOIN t2 AS t2 ON t1.a = t2.a;
 
 --------------------------------------
 -- Hint with table reference

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -317,6 +317,14 @@ SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z 
 SELECT * FROM y JOIN z USING(b, c) WHERE b = 2 AND c = 3;
 SELECT COALESCE(y.b, z.b) AS b, COALESCE(y.c, z.c) AS c FROM y AS y JOIN z AS z ON y.b = z.b AND y.c = z.c WHERE COALESCE(y.b, z.b) = 2 AND COALESCE(y.c, z.c) = 3;
 
+# execute: false
+SELECT b FROM x JOIN t USING(a);
+SELECT x.b AS b FROM x AS x JOIN t AS t ON x.a = t.a;
+
+# execute: false
+SELECT b FROM t JOIN x USING(a);
+SELECT x.b AS b FROM t AS t JOIN x AS x ON t.a = x.a;
+
 --------------------------------------
 -- Hint with table reference
 --------------------------------------


### PR DESCRIPTION
An attempt to make the qualify columns more lenient.

Before:
```python
>>> from sqlglot.optimizer import optimize
>>> optimize("SELECT y FROM foo JOIN bar USING(x)", schema={"foo": {"x": "int"}}).sql()
# sqlglot.errors.OptimizeError: Cannot automatically join: x
```

After:
```python
>>> from sqlglot.optimizer import optimize
>>> optimize("SELECT y FROM foo JOIN bar USING(x)", schema={"foo": {"x": "int"}}).sql()
'SELECT "bar"."y" AS "y" FROM "foo" AS "foo" JOIN "bar" AS "bar" ON "foo"."x" = "bar"."x"'
```