### PR TITLE
Fix(oracle): parsing bug in _parse_xml_table

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -7,11 +7,6 @@ from sqlglot.dialects.dialect import Dialect, no_ilike_sql, rename_func, trim_sq
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
-PASSING_TABLE_ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS - {
-    TokenType.COLUMN,
-    TokenType.RETURNING,
-}
-
 
 def _parse_xml_table(self) -> exp.XMLTable:
     this = self._parse_string()
@@ -22,9 +17,7 @@ def _parse_xml_table(self) -> exp.XMLTable:
     if self._match_text_seq("PASSING"):
         # The BY VALUE keywords are optional and are provided for semantic clarity
         self._match_text_seq("BY", "VALUE")
-        passing = self._parse_csv(
-            lambda: self._parse_table(alias_tokens=PASSING_TABLE_ALIAS_TOKENS)
-        )
+        passing = self._parse_csv(self._parse_column)
 
     by_ref = self._match_text_seq("RETURNING", "SEQUENCE", "BY", "REF")
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -99,7 +99,7 @@ FROM warehouses, XMLTABLE(
 FROM XMLTABLE(
   'ROWSET/ROW'
   PASSING
-    dbms_xmlgen.getxmltype ("SELECT table_name, column_name, data_default FROM user_tab_columns")
+    dbms_xmlgen.GETXMLTYPE('SELECT table_name, column_name, data_default FROM user_tab_columns')
   COLUMNS
     table_name VARCHAR2(128) PATH '*[1]',
     column_name VARCHAR2(128) PATH '*[2]',


### PR DESCRIPTION
Addresses https://github.com/tobymao/sqlglot/commit/bd96e9613fdcd536e50980130074d2cc9e1a004e#commitcomment-108967287.

cc: @mpf82 let me know if converting `getxmltype` to uppercase (context: `dbms_xmlgen.getxmltype(..)`) is ok. Same goes for the new AST representation, which now uses a `Dot` node instead of a `Table`:

```        
(DOT this:
  (VAR this: dbms_xmlgen), expression:
  (ANONYMOUS this: getxmltype, expressions:
    (LITERAL this: SELECT table_name, column_name, data_default FROM user_tab_columns, is_string: True))), by_ref: False))))
```