### PR TITLE
duckdb fixes

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -293,6 +293,11 @@ def no_properties_sql(self: Generator, expression: exp.Properties) -> str:
     return ""
 
 
+def no_comment_column_constraint_sql(self: Generator, expression: exp.CommentColumnConstraint) -> str:
+    self.unsupported("CommentColumnConstraint unsupported")
+    return ""
+
+
 def str_position_sql(self: Generator, expression: exp.StrPosition) -> str:
     this = self.sql(expression, "this")
     substr = self.sql(expression, "substr")

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -293,7 +293,9 @@ def no_properties_sql(self: Generator, expression: exp.Properties) -> str:
     return ""
 
 
-def no_comment_column_constraint_sql(self: Generator, expression: exp.CommentColumnConstraint) -> str:
+def no_comment_column_constraint_sql(
+    self: Generator, expression: exp.CommentColumnConstraint
+) -> str:
     self.unsupported("CommentColumnConstraint unsupported")
     return ""
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -8,6 +8,7 @@ from sqlglot.dialects.dialect import (
     arrow_json_extract_sql,
     datestrtodate_sql,
     format_time_lambda,
+    no_comment_column_constraint_sql,
     no_pivot_sql,
     no_properties_sql,
     no_safe_divide_sql,
@@ -16,14 +17,14 @@ from sqlglot.dialects.dialect import (
     str_to_time_sql,
     timestamptrunc_sql,
     timestrtotime_sql,
-    ts_or_ds_to_date_sql, no_comment_column_constraint_sql,
+    ts_or_ds_to_date_sql,
 )
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
 
 def _ts_or_ds_add(self, expression):
-    this = expression.args.get("this")
+    this = self.sql(expression, "this")
     unit = self.sql(expression, "unit").strip("'") or "DAY"
     return f"CAST({this} AS DATE) + {self.sql(exp.Interval(this=expression.expression, unit=unit))}"
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -16,7 +16,7 @@ from sqlglot.dialects.dialect import (
     str_to_time_sql,
     timestamptrunc_sql,
     timestrtotime_sql,
-    ts_or_ds_to_date_sql,
+    ts_or_ds_to_date_sql, no_comment_column_constraint_sql,
 )
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
@@ -150,6 +150,7 @@ class DuckDB(Dialect):
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArraySort: _array_sort_sql,
             exp.ArraySum: rename_func("LIST_SUM"),
+            exp.CommentColumnConstraint: no_comment_column_constraint_sql,
             exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
             exp.DayOfYear: rename_func("DAYOFYEAR"),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -149,6 +149,12 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
+            "CREATE TABLE IF NOT EXISTS table (cola INT COMMENT 'cola', colb STRING) USING ICEBERG PARTITIONED BY (colb)",
+            write={
+                "duckdb": "CREATE TABLE IF NOT EXISTS table (cola INT, colb TEXT)",
+            },
+        )
+        self.validate_all(
             "LIST_VALUE(0, 1, 2)",
             read={
                 "spark": "ARRAY(0, 1, 2)",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -345,6 +345,12 @@ class TestDuckDB(Validator):
                 "bigquery": "ARRAY_CONCAT([1, 2], [3, 4])",
             },
         )
+        self.validate_all(
+            "SELECT CAST(CAST(x AS DATE) AS DATE) + INTERVAL 1 DAY",
+            read={
+                "hive": "SELECT DATE_ADD(TO_DATE(x), 1)",
+            },
+        )
 
         with self.assertRaises(UnsupportedError):
             transpile(


### PR DESCRIPTION
- duckdb [doesn't support column comments](https://github.com/duckdb/duckdb/discussions/6290)
- ts_or_ds_add wasn't recursively generating the this arg before interpolating