### PR TITLE
Fix: Expand as we traverse lineage

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5064,7 +5064,7 @@ def expand(
             if source:
                 subquery = source.subquery(node.alias or name)
                 subquery.comments = [f"source: {name}"]
-                return subquery.transform(_expand, copy=copy)
+                return subquery.transform(_expand, copy=False)
         return node
 
     return expression.transform(_expand, copy=copy)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5035,13 +5035,18 @@ def replace_placeholders(expression, *args, **kwargs):
     return expression.transform(_replace_placeholders, iter(args), **kwargs)
 
 
-def expand(expression: Expression, sources: t.Dict[str, Subqueryable], copy=True) -> Expression:
+def expand(
+    expression: Expression, sources: t.Dict[str, Subqueryable], copy: bool = True
+) -> Expression:
     """Transforms an expression by expanding all referenced sources into subqueries.
 
     Examples:
         >>> from sqlglot import parse_one
         >>> expand(parse_one("select * from x AS z"), {"x": parse_one("select * from y")}).sql()
         'SELECT * FROM (SELECT * FROM y) AS z /* source: x */'
+
+        >>> expand(parse_one("select * from x AS z"), {"x": parse_one("select * from y"), "y": parse_one("select * from z")}).sql()
+        'SELECT * FROM (SELECT * FROM (SELECT * FROM z) AS y /* source: y */) AS z /* source: x */'
 
     Args:
         expression: The expression to expand.
@@ -5059,7 +5064,7 @@ def expand(expression: Expression, sources: t.Dict[str, Subqueryable], copy=True
             if source:
                 subquery = source.subquery(node.alias or name)
                 subquery.comments = [f"source: {name}"]
-                return subquery
+                return subquery.transform(_expand, copy=copy)
         return node
 
     return expression.transform(_expand, copy=copy)

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -60,10 +60,13 @@ def lineage(
     expression = maybe_parse(sql, dialect=dialect)
 
     if sources:
-        parsed_sources = {
-            k: t.cast(exp.Subqueryable, maybe_parse(v, dialect=dialect)) for k, v in sources.items()
-        }
-        expression = exp.expand(expression, parsed_sources)
+        expression = exp.expand(
+            expression,
+            {
+                k: t.cast(exp.Subqueryable, maybe_parse(v, dialect=dialect))
+                for k, v in sources.items()
+            },
+        )
 
     optimized = optimize(expression, schema=schema, rules=rules)
     scope = build_scope(optimized)
@@ -108,10 +111,6 @@ def lineage(
         for c in set(select.find_all(exp.Column)):
             table = c.table
             source = scope.sources[table]
-            if source.expression and sources:
-                expression = exp.expand(source.expression, parsed_sources)
-                optimized = optimize(expression, schema=schema, rules=rules)
-                source = build_scope(optimized)
 
             if isinstance(source, Scope):
                 to_node(

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -9,18 +9,82 @@ class TestLineage(unittest.TestCase):
     def test_lineage(self) -> None:
         node = lineage(
             "a",
-            "SELECT a FROM y",
+            "SELECT a FROM z",
+            schema={"x": {"a": "int"}},
+            sources={"y": "SELECT * FROM x", "z": "SELECT a FROM y"},
+        )
+        self.assertEqual(
+            node.source.sql(),
+            "SELECT z.a AS a FROM (SELECT y.a AS a FROM y AS y) AS z /* source: z */",
+        )
+        self.assertEqual(node.alias, "")
+
+        downstream = node.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
+            "SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y /* source: y */",
+        )
+        self.assertEqual(downstream.alias, "z")
+
+        downstream = downstream.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
+            "SELECT x.a AS a FROM x AS x",
+        )
+        self.assertEqual(downstream.alias, "y")
+        self.assertGreater(len(node.to_html()._repr_html_()), 1000)
+
+    def test_lineage_sql_with_cte(self) -> None:
+        node = lineage(
+            "a",
+            "WITH z AS (SELECT a FROM y) SELECT a FROM z",
             schema={"x": {"a": "int"}},
             sources={"y": "SELECT * FROM x"},
         )
         self.assertEqual(
             node.source.sql(),
-            "SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y /* source: y */",
+            "WITH z AS (SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y /* source: y */) SELECT z.a AS a FROM z",
         )
         self.assertEqual(node.alias, "")
+
+        # Node containing expanded CTE expression
+        downstream = node.downstream[0]
         self.assertEqual(
-            node.downstream[0].source.sql(),
+            downstream.source.sql(),
+            "SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y /* source: y */",
+        )
+        self.assertEqual(downstream.alias, "")
+
+        downstream = downstream.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
             "SELECT x.a AS a FROM x AS x",
         )
-        self.assertEqual(node.downstream[0].alias, "y")
-        self.assertGreater(len(node.to_html()._repr_html_()), 1000)
+        self.assertEqual(downstream.alias, "y")
+
+    def test_lineage_source_with_cte(self) -> None:
+        node = lineage(
+            "a",
+            "SELECT a FROM z",
+            schema={"x": {"a": "int"}},
+            sources={"z": "WITH y AS (SELECT * FROM x) SELECT a FROM y"},
+        )
+        self.assertEqual(
+            node.source.sql(),
+            "SELECT z.a AS a FROM (WITH y AS (SELECT x.a AS a FROM x AS x) SELECT y.a AS a FROM y) AS z /* source: z */",
+        )
+        self.assertEqual(node.alias, "")
+
+        downstream = node.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
+            "WITH y AS (SELECT x.a AS a FROM x AS x) SELECT y.a AS a FROM y",
+        )
+        self.assertEqual(downstream.alias, "z")
+
+        downstream = downstream.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
+            "SELECT x.a AS a FROM x AS x",
+        )
+        self.assertEqual(downstream.alias, "")

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -15,7 +15,7 @@ class TestLineage(unittest.TestCase):
         )
         self.assertEqual(
             node.source.sql(),
-            "SELECT z.a AS a FROM (SELECT y.a AS a FROM y AS y) AS z /* source: z */",
+            "SELECT z.a AS a FROM (SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y /* source: y */) AS z /* source: z */",
         )
         self.assertEqual(node.alias, "")
 


### PR DESCRIPTION
This PR
- Recursively expands expressions and extract source aliases as we traverse lineage
- Removes cache of source tables because we were losing columns when a query references multiple columns from the same source table