### PR TITLE
Fix(hive, spark): improve transpilation of TABLESAMPLE clause

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -177,6 +177,7 @@ class Hive(Dialect):
         IDENTIFIERS = ["`"]
         STRING_ESCAPES = ["\\"]
         ENCODE = "utf-8"
+        IDENTIFIER_CAN_START_WITH_DIGIT = True
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
@@ -199,9 +200,8 @@ class Hive(Dialect):
             "BD": "DECIMAL",
         }
 
-        IDENTIFIER_CAN_START_WITH_DIGIT = True
-
     class Parser(parser.Parser):
+        LOG_DEFAULTS_TO_LN = True
         STRICT_CAST = False
 
         FUNCTIONS = {
@@ -255,9 +255,11 @@ class Hive(Dialect):
             ),
         }
 
-        LOG_DEFAULTS_TO_LN = True
-
     class Generator(generator.Generator):
+        LIMIT_FETCH = "LIMIT"
+        TABLESAMPLE_WITH_METHOD = False
+        TABLESAMPLE_SIZE_IS_PERCENT = True
+
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,  # type: ignore
             exp.DataType.Type.TEXT: "STRING",
@@ -340,8 +342,6 @@ class Hive(Dialect):
             exp.TableFormatProperty: exp.Properties.Location.POST_SCHEMA,
         }
 
-        LIMIT_FETCH = "LIMIT"
-
         def arrayagg_sql(self, expression: exp.ArrayAgg) -> str:
             return self.func(
                 "COLLECT_LIST",
@@ -362,4 +362,5 @@ class Hive(Dialect):
                 expression = exp.DataType.build("text")
             elif expression.this in exp.DataType.TEMPORAL_TYPES:
                 expression = exp.DataType.build(expression.this)
+
             return super().datatype_sql(expression)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -113,6 +113,12 @@ class Generator:
     # Whether or not the INTERVAL expression works only with values like '1 day'
     SINGLE_STRING_INTERVAL = False
 
+    # Whether or not the TABLESAMPLE clause supports a method name, like BERNOULLI
+    TABLESAMPLE_WITH_METHOD = True
+
+    # Whether or not to treat the number in TABLESAMPLE (50) as a percentage
+    TABLESAMPLE_SIZE_IS_PERCENT = False
+
     # Whether or not limit and fetch are supported (possible values: "ALL", "LIMIT", "FETCH")
     LIMIT_FETCH = "ALL"
 
@@ -1069,7 +1075,7 @@ class Generator:
             this = self.sql(expression, "this")
             alias = ""
         method = self.sql(expression, "method")
-        method = f"{method.upper()} " if method else ""
+        method = f"{method.upper()} " if method and self.TABLESAMPLE_WITH_METHOD else ""
         numerator = self.sql(expression, "bucket_numerator")
         denominator = self.sql(expression, "bucket_denominator")
         field = self.sql(expression, "bucket_field")
@@ -1080,6 +1086,8 @@ class Generator:
         rows = self.sql(expression, "rows")
         rows = f"{rows} ROWS" if rows else ""
         size = self.sql(expression, "size")
+        if size and self.TABLESAMPLE_SIZE_IS_PERCENT:
+            size = f"{size} PERCENT"
         seed = self.sql(expression, "seed")
         seed = f" {seed_prefix} ({seed})" if seed else ""
         kind = expression.args.get("kind", "TABLESAMPLE")

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -507,11 +507,10 @@ class TestHive(Validator):
             },
         )
         self.validate_all(
-            "SELECT * FROM x TABLESAMPLE(10) y",
+            "SELECT * FROM x TABLESAMPLE(10 PERCENT) y",
             write={
-                "presto": "SELECT * FROM x AS y TABLESAMPLE (10)",
-                "hive": "SELECT * FROM x TABLESAMPLE (10) AS y",
-                "spark": "SELECT * FROM x TABLESAMPLE (10) AS y",
+                "hive": "SELECT * FROM x TABLESAMPLE (10 PERCENT) AS y",
+                "spark": "SELECT * FROM x TABLESAMPLE (10 PERCENT) AS y",
             },
         )
         self.validate_all(
@@ -653,25 +652,13 @@ class TestHive(Validator):
             },
         )
         self.validate_all(
-            "SELECT * FROM x TABLESAMPLE (1) AS foo",
+            "SELECT * FROM x TABLESAMPLE (1 PERCENT) AS foo",
             read={
-                "presto": "SELECT * FROM x AS foo TABLESAMPLE (1)",
+                "presto": "SELECT * FROM x AS foo TABLESAMPLE BERNOULLI (1)",
             },
             write={
-                "presto": "SELECT * FROM x AS foo TABLESAMPLE (1)",
-                "hive": "SELECT * FROM x TABLESAMPLE (1) AS foo",
-                "spark": "SELECT * FROM x TABLESAMPLE (1) AS foo",
-            },
-        )
-        self.validate_all(
-            "SELECT * FROM x TABLESAMPLE (1) AS foo",
-            read={
-                "presto": "SELECT * FROM x AS foo TABLESAMPLE (1)",
-            },
-            write={
-                "presto": "SELECT * FROM x AS foo TABLESAMPLE (1)",
-                "hive": "SELECT * FROM x TABLESAMPLE (1) AS foo",
-                "spark": "SELECT * FROM x TABLESAMPLE (1) AS foo",
+                "hive": "SELECT * FROM x TABLESAMPLE (1 PERCENT) AS foo",
+                "spark": "SELECT * FROM x TABLESAMPLE (1 PERCENT) AS foo",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #1425

Note: changed some tests because they were incorrect, i.e. `SELECT * FROM x TABLESAMPLE (10)` is incorrect for hive, which also doesn't support different sampling methods like `BERNOULLI` etc.

References:
- https://cwiki.apache.org/confluence/display/hive/languagemanual+sampling
- https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-sampling.html
- https://prestodb.io/docs/current/sql/select.html#tablesample