### PR TITLE
Teradata CAST DATE FORMAT to DATE_FORMAT()

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -29,12 +29,6 @@ class Databricks(Spark):
 
         PARAMETER_TOKEN = "$"
 
-        def cast_sql(self, expression: exp.Cast) -> str:
-            if expression.to.is_type(exp.DataType.Type.DATE) and expression.to.args.get("format"):
-                return self.func("DATE_FORMAT", expression.this, expression.to.args.get("format"))
-
-            return super(Spark.Generator, self).cast_sql(expression)
-
     class Tokenizer(Spark.Tokenizer):
         SINGLE_TOKENS = {
             **Spark.Tokenizer.SINGLE_TOKENS,

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -29,6 +29,16 @@ class Databricks(Spark):
 
         PARAMETER_TOKEN = "$"
 
+        def cast_sql(self, expression: exp.Cast) -> str:
+            if (
+                isinstance(expression, exp.Cast)
+                and expression.to.is_type(exp.DataType.Type.DATE)
+                and expression.to.args.get("format")
+            ):
+                return self.func("DATE_FORMAT", expression.this, expression.to.args.get("format"))
+
+            return super(Spark.Generator, self).cast_sql(expression)
+
     class Tokenizer(Spark.Tokenizer):
         SINGLE_TOKENS = {
             **Spark.Tokenizer.SINGLE_TOKENS,

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -30,11 +30,7 @@ class Databricks(Spark):
         PARAMETER_TOKEN = "$"
 
         def cast_sql(self, expression: exp.Cast) -> str:
-            if (
-                isinstance(expression, exp.Cast)
-                and expression.to.is_type(exp.DataType.Type.DATE)
-                and expression.to.args.get("format")
-            ):
+            if expression.to.is_type(exp.DataType.Type.DATE) and expression.to.args.get("format"):
                 return self.func("DATE_FORMAT", expression.this, expression.to.args.get("format"))
 
             return super(Spark.Generator, self).cast_sql(expression)

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -479,7 +479,11 @@ class MySQL(Dialect):
             return ""
 
         def cast_sql(self, expression: exp.Cast) -> str:
-            if expression.to.is_type(exp.DataType.Type.DATE) and expression.to.args.get("format"):
+            if (
+                isinstance(expression.to, exp.DataType)
+                and expression.to.is_type(exp.DataType.Type.DATE)
+                and expression.to.args.get("format")
+            ):
                 return self.func("DATE_FORMAT", expression.this, expression.to.args.get("format"))
 
             return super().cast_sql(expression)

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -477,3 +477,9 @@ class MySQL(Dialect):
                 limit_offset = f"{offset}, {limit}" if offset else limit
                 return f" LIMIT {limit_offset}"
             return ""
+
+        def cast_sql(self, expression: exp.Cast) -> str:
+            if expression.to.is_type(exp.DataType.Type.DATE) and expression.to.args.get("format"):
+                return self.func("DATE_FORMAT", expression.this, expression.to.args.get("format"))
+
+            return super().cast_sql(expression)

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -179,8 +179,11 @@ class Spark(Hive):
             ):
                 schema = f"'{self.sql(expression, 'to')}'"
                 return self.func("FROM_JSON", expression.this.this, schema)
+
             if expression.to.is_type(exp.DataType.Type.JSON):
                 return self.func("TO_JSON", expression.this)
+            elif expression.to.is_type(exp.DataType.Type.DATE) and expression.to.args.get("format"):
+                return self.func("DATE_FORMAT", expression.this, expression.to.args.get("format"))
 
             return super(Spark.Generator, self).cast_sql(expression)
 

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -161,13 +161,3 @@ class Teradata(Dialect):
             each_sql = f" EACH {each_sql}" if each_sql else ""
 
             return f"RANGE_N({this} BETWEEN {expressions_sql}{each_sql})"
-
-        def cast_sql(self, expression: exp.Cast) -> str:
-            if (
-                isinstance(expression, exp.Cast)
-                and isinstance(expression.to, exp.DataType)
-                and expression.to.is_type(exp.DataType.Type.DATE)
-                and expression.to.args.get("format")
-            ):
-                return f"CAST({self.sql(expression, 'this')} AS {self.sql(expression, 'to')} FORMAT {self.sql(expression.to, 'format')})"
-            return super().cast_sql(expression)

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -116,6 +116,8 @@ class Teradata(Dialect):
             return self.expression(exp.RangeN, this=this, expressions=expressions, each=each)
 
     class Generator(generator.Generator):
+        DATE_DATATYPE_FORMAT = True
+
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,  # type: ignore
             exp.DataType.Type.GEOMETRY: "ST_GEOMETRY",

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -161,3 +161,13 @@ class Teradata(Dialect):
             each_sql = f" EACH {each_sql}" if each_sql else ""
 
             return f"RANGE_N({this} BETWEEN {expressions_sql}{each_sql})"
+
+        def cast_sql(self, expression: exp.Cast) -> str:
+            if (
+                isinstance(expression, exp.Cast)
+                and isinstance(expression.to, exp.DataType)
+                and expression.to.is_type(exp.DataType.Type.DATE)
+                and expression.to.args.get("format")
+            ):
+                return f"CAST({self.sql(expression, 'this')} AS {self.sql(expression, 'to')} FORMAT {self.sql(expression.to, 'format')})"
+            return super().cast_sql(expression)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2807,6 +2807,7 @@ class DataType(Expression):
         "nested": False,
         "values": False,
         "prefix": False,
+        "format": False,
     }
 
     class Type(AutoName):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -727,6 +727,8 @@ class Generator:
                 if expression.args.get("values") is not None:
                     delimiters = ("[", "]") if type_value == exp.DataType.Type.ARRAY else ("(", ")")
                     values = f"{delimiters[0]}{self.expressions(expression, key='values')}{delimiters[1]}"
+            elif expression.args.get("format"):
+                nested = f" FORMAT {self.sql(expression, 'format')}"
             else:
                 nested = f"({interior})"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -730,10 +730,11 @@ class Generator:
                 if expression.args.get("values") is not None:
                     delimiters = ("[", "]") if type_value == exp.DataType.Type.ARRAY else ("(", ")")
                     values = f"{delimiters[0]}{self.expressions(expression, key='values')}{delimiters[1]}"
-            elif expression.args.get("format"):
-                nested = f" FORMAT {self.sql(expression, 'format')}"
             else:
                 nested = f"({interior})"
+        else:
+            if expression.args.get("format"):
+                nested = f" FORMAT {self.sql(expression, 'format')}"
 
         return f"{type_sql}{nested}{values}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -127,7 +127,7 @@ class Generator:
     LIMIT_FETCH = "ALL"
 
     # Whether or not DATE datatype formats (e.g., "CAST('01/1999' as DATE FORMAT 'yyyy-mm')") are supported
-    DATE_DATATYPE_FORMAT = False
+    DATE_DATATYPE_FORMAT = True
 
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -126,6 +126,9 @@ class Generator:
     # Whether or not limit and fetch are supported (possible values: "ALL", "LIMIT", "FETCH")
     LIMIT_FETCH = "ALL"
 
+    # Whether or not DATE datatype formats (e.g., "CAST('01/1999' as DATE FORMAT 'yyyy-mm')") are supported
+    DATE_DATATYPE_FORMAT = False
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -733,7 +736,7 @@ class Generator:
             else:
                 nested = f"({interior})"
         else:
-            if expression.args.get("format"):
+            if self.DATE_DATATYPE_FORMAT and expression.args.get("format"):
                 nested = f" FORMAT {self.sql(expression, 'format')}"
 
         return f"{type_sql}{nested}{values}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3361,6 +3361,9 @@ class Parser(metaclass=_Parser):
         elif to.this == exp.DataType.Type.CHAR:
             if self._match(TokenType.CHARACTER_SET):
                 to = self.expression(exp.CharacterSet, this=self._parse_var_or_string())
+        elif to.this == exp.DataType.Type.DATE:
+            if self._match(TokenType.FORMAT):
+                to.set("format", self._parse_conjunction())
 
         return self.expression(exp.Cast if strict else exp.TryCast, this=this, to=to)
 

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -71,3 +71,12 @@ class TestTeradata(Validator):
         )
 
         self.validate_identity("CREATE TABLE z (a SYSUDTLIB.INT)")
+
+    def test_cast(self):
+        self.validate_all(
+            "CAST('1992-01' AS DATE FORMAT 'YYYY-DD')",
+            write={
+                "teradata": "CAST('1992-01' AS DATE FORMAT 'YYYY-DD')",
+                "databricks": "DATE_FORMAT('1992-01', 'YYYY-DD')",
+            },
+        )

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -78,5 +78,8 @@ class TestTeradata(Validator):
             write={
                 "teradata": "CAST('1992-01' AS DATE FORMAT 'YYYY-DD')",
                 "databricks": "DATE_FORMAT('1992-01', 'YYYY-DD')",
+                "mysql": "DATE_FORMAT('1992-01', 'YYYY-DD')",
+                "spark": "DATE_FORMAT('1992-01', 'YYYY-DD')",
+                "": "CAST('1992-01' AS DATE)",
             },
         )


### PR DESCRIPTION
Transpile Teradata's `CAST('1/1999' as DATE FORMAT 'yyyy-mm')` to `DATE_FORMAT('1/1999', 'yyyy-mm')` for spark, databricks, and mysql