### PR TITLE
Add Spark's timestamp function to Parser.FUNCTIONS

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -94,6 +94,10 @@ class Spark(Hive):
                 unit=exp.var(seq_get(args, 0)),
             ),
             "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
+            "TIMESTAMP": lambda args: exp.Cast(
+                this=seq_get(args, 0),
+                to="timestamp",
+            ),
         }
 
         FUNCTION_PARSERS = {

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -94,10 +94,7 @@ class Spark(Hive):
                 unit=exp.var(seq_get(args, 0)),
             ),
             "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
-            "TIMESTAMP": lambda args: exp.Cast(
-                this=seq_get(args, 0),
-                to="timestamp",
-            ),
+            "TIMESTAMP": lambda args: exp.cast(seq_get(args, 0), "timestamp"),
         }
 
         FUNCTION_PARSERS = {

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -94,7 +94,9 @@ class Spark(Hive):
                 unit=exp.var(seq_get(args, 0)),
             ),
             "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
-            "TIMESTAMP": lambda args: exp.cast(seq_get(args, 0), "timestamp"),
+            "TIMESTAMP": lambda args: exp.Cast(
+                this=seq_get(args, 0), to=exp.DataType.build("timestamp")
+            ),
         }
 
         FUNCTION_PARSERS = {


### PR DESCRIPTION
From https://spark.apache.org/docs/latest/api/sql/index.html#timestamp:

> Casts the value `expr` to the target data type `timestamp`.