### PR TITLE
DataFrame: Fix literal after join

### DIFF
--- a/sqlglot/dataframe/sql/column.py
+++ b/sqlglot/dataframe/sql/column.py
@@ -176,7 +176,7 @@ class Column:
         return isinstance(self.expression, exp.Column)
 
     @property
-    def column_expression(self) -> exp.Column:
+    def column_expression(self) -> t.Union[exp.Column, exp.Literal]:
         return self.expression.unalias()
 
     @property

--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -355,7 +355,11 @@ class DataFrame:
         cols = self._ensure_and_normalize_cols(cols)
         kwargs["append"] = kwargs.get("append", False)
         if self.expression.args.get("joins"):
-            ambiguous_cols = [col for col in cols if not col.column_expression.table]
+            ambiguous_cols = [
+                col
+                for col in cols
+                if isinstance(col.column_expression, exp.Column) and not col.column_expression.table
+            ]
             if ambiguous_cols:
                 join_table_identifiers = [
                     x.this for x in get_tables_from_expression_with_join(self.expression)

--- a/tests/dataframe/integration/test_dataframe.py
+++ b/tests/dataframe/integration/test_dataframe.py
@@ -276,6 +276,7 @@ class TestDataframeFunc(DataFrameValidator):
             self.df_spark_employee.store_id,
             self.df_spark_store.store_name,
             self.df_spark_store["num_sales"],
+            F.lit("literal_value"),
         )
         dfs_joined = self.df_sqlglot_employee.join(
             self.df_sqlglot_store,
@@ -289,6 +290,7 @@ class TestDataframeFunc(DataFrameValidator):
             self.df_sqlglot_employee.store_id,
             self.df_sqlglot_store.store_name,
             self.df_sqlglot_store["num_sales"],
+            SF.lit("literal_value"),
         )
         self.compare_spark_with_sqlglot(df_joined, dfs_joined)
 


### PR DESCRIPTION
We check for ambiguous columns after a join and currently we assume all objects in the select are column expressions when they can also be literal expressions. Literals can't be ambiguous so we remove them from the check. 