### PR TITLE
[fix] edge cases for lineage node generation

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -101,7 +101,7 @@ def lineage(
             if maybe_select.alias_or_name == column_name:
                 # If we get an exact match, stop searching.
                 select = maybe_select
-                break           
+                break
             if isinstance(maybe_select, exp.Star):
                 # If we get a `*`, make a note but keep moving. This means we will prefer
                 # an exact match if both a `*` and an exact match exist:

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -130,18 +130,15 @@ def lineage(
             source = scope.sources.get(table)
 
             if isinstance(source, Scope):
-                # If the table itself came from a scope, recurse into that one using the unaliased column name.
+                # The table itself came from a more specific scope. Recurse into that one using the unaliased column name.
                 to_node(
                     c.name, scope=source, scope_name=table, upstream=node, alias=aliases.get(table)
                 )
-            elif source:
-                # Else, if we found a source that's not a scope, we've reached the end of the line.
-                node.downstream.append(Node(name=c.sql(), source=source, expression=source))
             else:
-                # If a source is not found, we can't go any further - this column's lineage is
-                # unknown. This can happen if the definition of a source used in a query is
-                # not passed into the `sources` map.
-                source = exp.Placeholder()
+                # The source is not a scope - we've reached the end of the line. At this point, if a source is not found
+                # it means this column's lineage is unknown. This can happen if the definition of a source used in a query
+                # is not passed into the `sources` map.
+                source = source or exp.Placeholder()
                 node.downstream.append(Node(name=c.sql(), source=source, expression=source))
 
         return node

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -103,14 +103,18 @@ def lineage(
                 select = maybe_select
                 break
             elif isinstance(maybe_select, exp.Star):
-                # If we get a `*`, make a note but keep moving.
+                # If we get a `*`, make a note but keep moving. This means we will prefer
+                # an exact match if both a `*` and an exact match exist:
+                #   "x", WITH foo AS (SELECT *, x FROM bar) SELECT x from foo
+                #     => SELECT x FROM bar
                 select = maybe_select
         if not select:
             raise ValueError(f"Could not find {column_name} in {scope.expression.sql()}")
 
         # For better ergonomics in our node labels, replace the full select with a version that
         # has only the column we care about.
-        #   "x", SELECT x, y FROM foo => "x", SELECT x FROM foo
+        #   "x", SELECT x, y FROM foo
+        #     => "x", SELECT x FROM foo
         source = optimize(scope.expression.select(select, append=False), schema=schema, rules=rules)
         select = source.selects[0]
 

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -101,8 +101,8 @@ def lineage(
             if maybe_select.alias_or_name == column_name:
                 # If we get an exact match, stop searching.
                 select = maybe_select
-                break
-            elif isinstance(maybe_select, exp.Star):
+                break           
+            if isinstance(maybe_select, exp.Star):
                 # If we get a `*`, make a note but keep moving. This means we will prefer
                 # an exact match if both a `*` and an exact match exist:
                 #   "x", WITH foo AS (SELECT *, x FROM bar) SELECT x from foo

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -108,3 +108,9 @@ class TestLineage(unittest.TestCase):
             "SELECT * FROM x AS x",
         )
         self.assertEqual(downstream.alias, "")
+
+    def test_lineage_external_col(self) -> None:
+        lineage(
+            "a",
+            "WITH y AS (SELECT * FROM x) SELECT a FROM y JOIN z USING (uid)",
+        )

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -110,7 +110,19 @@ class TestLineage(unittest.TestCase):
         self.assertEqual(downstream.alias, "")
 
     def test_lineage_external_col(self) -> None:
-        lineage(
+        node = lineage(
             "a",
             "WITH y AS (SELECT * FROM x) SELECT a FROM y JOIN z USING (uid)",
         )
+        self.assertEqual(
+            node.source.sql(),
+            "WITH y AS (SELECT * FROM x AS x) SELECT a AS a FROM y JOIN z AS z ON y.uid = z.uid",
+        )
+        self.assertEqual(node.alias, "")
+
+        downstream = node.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
+            "?",
+        )
+        self.assertEqual(downstream.alias, "")

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from sqlglot.lineage import lineage
@@ -86,5 +88,23 @@ class TestLineage(unittest.TestCase):
         self.assertEqual(
             downstream.source.sql(),
             "SELECT x.a AS a FROM x AS x",
+        )
+        self.assertEqual(downstream.alias, "")
+
+    def test_lineage_source_with_star(self) -> None:
+        node = lineage(
+            "a",
+            "WITH y AS (SELECT * FROM x) SELECT a FROM y",
+        )
+        self.assertEqual(
+            node.source.sql(),
+            "WITH y AS (SELECT * FROM x AS x) SELECT y.a AS a FROM y",
+        )
+        self.assertEqual(node.alias, "")
+
+        downstream = node.downstream[0]
+        self.assertEqual(
+            downstream.source.sql(),
+            "SELECT * FROM x AS x",
         )
         self.assertEqual(downstream.alias, "")


### PR DESCRIPTION
This PR fixes a couple of issues with `lineage.py:to_node`. Specifically, it handles two edge cases:
* If the lineage maps to a CTE with a `SELECT *`, the node is correctly generated
* If the lineage maps to an external source _not specified_ in the `sources` map, the node gracefully falls back to a placeholder value

While I was here, I also added some inline comments to help grok the code.

### Details
If the last node came from a CTE with a `SELECT *`, the function failed with
```
pytest -vv tests/test_lineage.py -k test_lineage_source_with_star
...
>       select = next(select for select in scope.selects if select.alias_or_name == column_name)
E       StopIteration

sqlglot/lineage.py:97: StopIteration
```
This is now handled correctly.

If the lineage involves a source that was not specified in the `sources` map, the function failed with
```
pytest -vv tests/test_lineage.py -k test_lineage_external_col
...
        for c in set(select.find_all(exp.Column)):
            table = c.table
>           source = scope.sources[table]
E           KeyError: ''

sqlglot/lineage.py:113: KeyError
```
This is now gracefully handled by falling back to the placeholder expression `?` as the source.