### PR TITLE
Fix: skip the comment start when tokenizing a delimited comment

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -953,8 +953,10 @@ class Tokenizer(metaclass=_Tokenizer):
         comment_end = self._COMMENTS[comment_start]  # type: ignore
 
         if comment_end:
-            comment_end_size = len(comment_end)
+            # Move past the comment start (we've already consumed its first character)
+            self._advance(comment_start_size)
 
+            comment_end_size = len(comment_end)
             while not self._end and self._chars(comment_end_size) != comment_end:
                 self._advance()
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -953,7 +953,7 @@ class Tokenizer(metaclass=_Tokenizer):
         comment_end = self._COMMENTS[comment_start]  # type: ignore
 
         if comment_end:
-            # Move past the comment start (we've already consumed its first character)
+            # Skip the comment's start delimiter
             self._advance(comment_start_size)
 
             comment_end_size = len(comment_end)

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -14,6 +14,7 @@ class TestTokens(unittest.TestCase):
             ("foo", []),
             ("foo /*comment 1*/ /*comment 2*/", ["comment 1", "comment 2"]),
             ("foo\n-- comment", [" comment"]),
+            ("1 /*/2 */", ["/2 "]),
         ]
 
         for sql, comment in sql_comment:

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -87,6 +87,7 @@ class TestTranspile(unittest.TestCase):
         self.validate("SELECT 3>=3", "SELECT 3 >= 3")
 
     def test_comments(self):
+        self.validate("SELECT 1 /*/2 */", "SELECT 1 /* /2 */")
         self.validate("SELECT */*comment*/", "SELECT * /* comment */")
         self.validate(
             "SELECT * FROM table /*comment 1*/ /*comment 2*/",


### PR DESCRIPTION
Fixes #1466 