### PR TITLE
Fix: allow column values in INTERVAL expressions

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -212,6 +212,8 @@ class Generator:
 
     WITH_SEPARATED_COMMENTS = (exp.Select, exp.From, exp.Where, exp.With)
 
+    UNWRAPPED_INTERVAL_VALUES = (exp.Literal, exp.Paren, exp.Column)
+
     SENTINEL_LINE_BREAK = "__SQLGLOT__LB__"
 
     __slots__ = (
@@ -1704,15 +1706,10 @@ class Generator:
             this = expression.this.name if expression.this else ""
             return f"INTERVAL '{this}{unit}'"
 
-        this = expression.this
+        this = self.sql(expression, "this")
         if this:
-            this = (
-                f" {this}"
-                if isinstance(this, exp.Literal) or isinstance(this, exp.Paren)
-                else f" ({this})"
-            )
-        else:
-            this = ""
+            unwrapped = isinstance(expression.this, self.UNWRAPPED_INTERVAL_VALUES)
+            this = f" {this}" if unwrapped else f" ({this})"
 
         return f"INTERVAL{this}{unit}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2589,12 +2589,12 @@ class Parser(metaclass=_Parser):
         if not self._match(TokenType.INTERVAL):
             return None
 
-        this = self._parse_primary()
+        this = self._parse_primary() or self._parse_column()
         unit = self._parse_function() or self._parse_var()
 
         # Most dialects support, e.g., the form INTERVAL '5' day, thus we try to parse
         # each INTERVAL expression into this canonical form so it's easy to transpile
-        if this:
+        if this and isinstance(this, exp.Literal):
             if this.is_number:
                 this = exp.Literal.string(this.name)
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -5,6 +5,7 @@ class TestClickhouse(Validator):
     dialect = "clickhouse"
 
     def test_clickhouse(self):
+        self.validate_identity("SELECT INTERVAL t.days day")
         self.validate_identity("SELECT match('abc', '([a-z]+)')")
         self.validate_identity("dictGet(x, 'y')")
         self.validate_identity("SELECT * FROM x FINAL")


### PR DESCRIPTION
Fixes #1469 