### PR TITLE
Fix: fallback to _parse_term when parsing INTERVAL values

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2604,7 +2604,7 @@ class Parser(metaclass=_Parser):
         if not self._match(TokenType.INTERVAL):
             return None
 
-        this = self._parse_primary() or self._parse_column()
+        this = self._parse_primary() or self._parse_term()
         unit = self._parse_function() or self._parse_var()
 
         # Most dialects support, e.g., the form INTERVAL '5' day, thus we try to parse

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -318,6 +318,12 @@ class TestMySQL(Validator):
 
     def test_mysql(self):
         self.validate_all(
+            "SELECT DATE(DATE_SUB(`dt`, INTERVAL DAYOFMONTH(`dt`) - 1 DAY)) AS __timestamp FROM tableT",
+            write={
+                "mysql": "SELECT DATE(DATE_SUB(`dt`, INTERVAL (DAYOFMONTH(`dt`) - 1) DAY)) AS __timestamp FROM tableT",
+            },
+        )
+        self.validate_all(
             "SELECT a FROM tbl FOR UPDATE",
             write={
                 "": "SELECT a FROM tbl",


### PR DESCRIPTION
Fixes #1478 