### PR TITLE
Handle non-select expressions in lineage

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -104,12 +104,17 @@ def lineage(
         if not select:
             raise ValueError(f"Could not find {column_name} in {scope.expression}")
 
-        # For better ergonomics in our node labels, replace the full select with a version that
-        # has only the column we care about.
-        #   "x", SELECT x, y FROM foo
-        #     => "x", SELECT x FROM foo
-        source = optimize(scope.expression.select(select, append=False), schema=schema, rules=rules)
-        select = source.selects[0]
+        if isinstance(scope.expression, exp.Select):
+            # For better ergonomics in our node labels, replace the full select with
+            # a version that has only the column we care about.
+            #   "x", SELECT x, y FROM foo
+            #     => "x", SELECT x FROM foo
+            source = optimize(
+                scope.expression.select(select, append=False), schema=schema, rules=rules
+            )
+            select = source.selects[0]
+        else:
+            source = scope.expression
 
         # Create the node for this step in the lineage chain, and attach it to the previous one.
         node = Node(


### PR DESCRIPTION
Currently, lineage raises an exception when it encounters non-select expressions in a scope. For example,
```python
lineage(
    "a",
    "SELECT a FROM y",
    sources={"y": "SELECT a FROM (VALUES (1), (2)) AS t (a)"},
)
```
results in the following error
```
File lib/python3.10/site-packages/sqlglot/lineage.py:111, in lineage.<locals>.to_node(column_name, scope, scope_name, upstream, alias)
    105     raise ValueError(f"Could not find {column_name} in {scope.expression}")
    107 # For better ergonomics in our node labels, replace the full select with a version that
    108 # has only the column we care about.
    109 #   "x", SELECT x, y FROM foo
    110 #     => "x", SELECT x FROM foo
--> 111 source = optimize(scope.expression.select(select, append=False), schema=schema, rules=rules)
    112 select = source.selects[0]
    114 # Create the node for this step in the lineage chain, and attach it to the previous one.

AttributeError: 'Values' object has no attribute 'select'
```