### PR TITLE
Fix Dataframe Triple Join issue

### DIFF
--- a/sqlglot/dataframe/README.md
+++ b/sqlglot/dataframe/README.md
@@ -222,36 +222,3 @@ df.show()
 # Unsupportable Operations
 
 Any operation that lacks a way to represent it in SQL cannot be supported by this tool. An example of this would be rdd operations. Since the DataFrame API though is mostly modeled around SQL concepts most operations can be supported.
-
-# Known Issues
-
-* Triple joins without a select - If you do two joins and then don't specify a select after then you could get optimizer errors. See example of what can cause this issue:
-```python
-self.df_employee
-.join(
-    self.df_store,
-    on=self.df_employee["employee_id"] == self.df_store["store_id"],
-    how="left",
-)
-.join(
-    self.df_district,
-    on=self.df_store["store_id"] == self.df_district["district_id"],
-    how="left"
-)
-```
-The workaround is to explicitly specify the columns you want to select after the joins. This is good practice anyways since without this your result can have duplicate column names and implicit behavior on how to deal with ambiguity.
-```python
-self.df_employee
-.join(
-    self.df_store, on=self.df_employee.employee_id == self.df_store.store_id
-)
-.join(self.df_district, on=self.df_store.store_id == self.df_district.district_id)
-.select(
-    self.df_employee.employee_id,
-    self.df_store.store_id,
-    self.df_district.district_id,
-    self.df_employee.fname,
-    self.df_store.store_name,
-    self.df_district.district_name,
-)
-```

--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -486,12 +486,12 @@ class DataFrame:
                 for column_name in select_column_names
                 if column_name not in [x.alias_or_name for x in join_columns]
             ]
-            join_column_names + select_column_names
+            select_column_names = join_column_names + select_column_names
         else:
             """
             Unique characteristics of join on expressions:
             * There is no deduplication of the results.
-            * The left join dataframe columns go first and left come after. No sort preference is given to join columns
+            * The left join dataframe columns go first and right come after. No sort preference is given to join columns
             """
             join_columns = self._ensure_and_normalize_cols(join_columns, join_expression)
             if len(join_columns) > 1:

--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -365,7 +365,7 @@ class DataFrame:
                     x.this for x in get_tables_from_expression_with_join(self.expression)
                 ]
                 cte_names_in_join = [x.this for x in join_table_identifiers]
-                # If we a columns resolves to multiple CTE expressions then we want to use each CTE left-to-right
+                # If we have columns that resolve to multiple CTE expressions then we want to use each CTE left-to-right
                 # and therefore we allow multiple columns with the same name in the result. This matches the behavior
                 # of Spark.
                 resolved_column_position: t.Dict[Column, int] = {col: -1 for col in ambiguous_cols}

--- a/sqlglot/dataframe/sql/dataframe.py
+++ b/sqlglot/dataframe/sql/dataframe.py
@@ -426,9 +426,9 @@ class DataFrame:
     ) -> DataFrame:
         other_df = other_df._convert_leaf_to_cte()
         join_columns = self._ensure_list_of_columns(on)
-        # We will determine actual join expression later so we provide a dummy one for now.
+        # We will determine actual "join on" expression later so we don't provide it at first
         join_expression = self.expression.join(
-            other_df.latest_cte_name, on=exp.Column(), join_type=how.replace("_", " ")
+            other_df.latest_cte_name, join_type=how.replace("_", " ")
         )
         join_expression = self._add_ctes_to_expression(join_expression, other_df.expression.ctes)
         self_columns = self._get_outer_select_columns(join_expression)

--- a/tests/dataframe/integration/test_dataframe.py
+++ b/tests/dataframe/integration/test_dataframe.py
@@ -446,23 +446,31 @@ class TestDataframeFunc(DataFrameValidator):
         self.compare_spark_with_sqlglot(df, dfs)
 
     def test_triple_join_no_select(self):
-        df = self.df_employee.join(
-            self.df_store,
-            on=self.df_employee["employee_id"] == self.df_store["store_id"],
-            how="left",
-        ).join(
-            self.df_district,
-            on=self.df_store["store_id"] == self.df_district["district_id"],
-            how="left",
+        df = (
+            self.df_employee.join(
+                self.df_store,
+                on=self.df_employee["employee_id"] == self.df_store["store_id"],
+                how="left",
+            )
+            .join(
+                self.df_district,
+                on=self.df_store["store_id"] == self.df_district["district_id"],
+                how="left",
+            )
+            .orderBy(F.col("employee_id"))
         )
-        dfs = self.dfs_employee.join(
-            self.dfs_store,
-            on=self.dfs_employee["employee_id"] == self.dfs_store["store_id"],
-            how="left",
-        ).join(
-            self.dfs_district,
-            on=self.dfs_store["store_id"] == self.dfs_district["district_id"],
-            how="left",
+        dfs = (
+            self.dfs_employee.join(
+                self.dfs_store,
+                on=self.dfs_employee["employee_id"] == self.dfs_store["store_id"],
+                how="left",
+            )
+            .join(
+                self.dfs_district,
+                on=self.dfs_store["store_id"] == self.dfs_district["district_id"],
+                how="left",
+            )
+            .orderBy(SF.col("employee_id"))
         )
         self.compare_spark_with_sqlglot(df, dfs)
 
@@ -492,16 +500,24 @@ class TestDataframeFunc(DataFrameValidator):
         self.compare_spark_with_sqlglot(df, dfs)
 
     def test_triple_join_column_name_only(self):
-        df = self.df_employee.join(
-            self.df_store,
-            on=self.df_employee["employee_id"] == self.df_store["store_id"],
-            how="left",
-        ).join(self.df_district, on="district_id", how="left")
-        dfs = self.dfs_employee.join(
-            self.dfs_store,
-            on=self.dfs_employee["employee_id"] == self.dfs_store["store_id"],
-            how="left",
-        ).join(self.dfs_district, on="district_id", how="left")
+        df = (
+            self.df_employee.join(
+                self.df_store,
+                on=self.df_employee["employee_id"] == self.df_store["store_id"],
+                how="left",
+            )
+            .join(self.df_district, on="district_id", how="left")
+            .orderBy(F.col("employee_id"))
+        )
+        dfs = (
+            self.dfs_employee.join(
+                self.dfs_store,
+                on=self.dfs_employee["employee_id"] == self.dfs_store["store_id"],
+                how="left",
+            )
+            .join(self.dfs_district, on="district_id", how="left")
+            .orderBy(SF.col("employee_id"))
+        )
         self.compare_spark_with_sqlglot(df, dfs)
 
     def test_join_select_and_select_start(self):


### PR DESCRIPTION
This also fixes an issue where the join columns were assumed to be expression in left -> right order. 

The DataFrame API will now return multiple columns with the same name if a select is not provided to make it clear which one you want. This matches Spark behavior (as proven by the tests). 

Resolves: https://github.com/tobymao/sqlglot/issues/1500