### PR TITLE
Support regex function in Starrocks

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -34,6 +34,7 @@ class StarRocks(MySQL):
             exp.JSONExtractScalar: arrow_json_extract_sql,
             exp.JSONExtract: arrow_json_extract_sql,
             exp.DateDiff: rename_func("DATEDIFF"),
+            exp.RegexpLike: rename_func("REGEXP"),
             exp.StrToUnix: lambda self, e: f"UNIX_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TimestampTrunc: lambda self, e: self.func(
                 "DATE_TRUNC", exp.Literal.string(e.text("unit")), e.this

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -15,6 +15,6 @@ class TestMySQL(Validator):
         self.validate_all(
             "SELECT REGEXP_LIKE(abc, '%foo%')",
             write={
-                "starrocks":"SELECT REGEXP(abc, '%foo%')",
+                "starrocks": "SELECT REGEXP(abc, '%foo%')",
             },
         )

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -10,3 +10,11 @@ class TestMySQL(Validator):
 
     def test_time(self):
         self.validate_identity("TIMESTAMP('2022-01-01')")
+
+    def test_regex(self):
+        self.validate_all(
+            "SELECT REGEXP_LIKE(abc, '%foo%')",
+            write={
+                "starrocks":"SELECT REGEXP(abc, '%foo%')",
+            },
+        )


### PR DESCRIPTION
Support regex in Starrocks

Function is documented at https://docs.starrocks.io/en-us/2.4/sql-reference/sql-functions/like_predicate-functions/regexp

MySQL uses `REGEXP_LIKE`
https://dev.mysql.com/doc/refman/8.0/en/regexp.html