### PR TITLE
Feat(spark): new Spark2 dialect, improve DATEDIFF sql generation BREAKING

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -70,6 +70,7 @@ from sqlglot.dialects.presto import Presto
 from sqlglot.dialects.redshift import Redshift
 from sqlglot.dialects.snowflake import Snowflake
 from sqlglot.dialects.spark import Spark
+from sqlglot.dialects.spark2 import Spark2
 from sqlglot.dialects.sqlite import SQLite
 from sqlglot.dialects.starrocks import StarRocks
 from sqlglot.dialects.tableau import Tableau

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -28,6 +28,7 @@ class Dialects(str, Enum):
     REDSHIFT = "redshift"
     SNOWFLAKE = "snowflake"
     SPARK = "spark"
+    SPARK2 = "spark2"
     SQLITE = "sqlite"
     STARROCKS = "starrocks"
     TABLEAU = "tableau"

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -81,7 +81,7 @@ def _date_diff_sql(self: generator.Generator, expression: exp.DateDiff) -> str:
     return f"{diff_sql}{multiplier_sql}"
 
 
-def _array_sort(self: generator.Generator, expression: exp.ArraySort) -> str:
+def _array_sort_sql(self: generator.Generator, expression: exp.ArraySort) -> str:
     if expression.expression:
         self.unsupported("Hive SORT_ARRAY does not support a comparator")
     return f"SORT_ARRAY({self.sql(expression, 'this')})"
@@ -91,11 +91,11 @@ def _property_sql(self: generator.Generator, expression: exp.Property) -> str:
     return f"'{expression.name}'={self.sql(expression, 'value')}"
 
 
-def _str_to_unix(self: generator.Generator, expression: exp.StrToUnix) -> str:
+def _str_to_unix_sql(self: generator.Generator, expression: exp.StrToUnix) -> str:
     return self.func("UNIX_TIMESTAMP", expression.this, _time_format(self, expression))
 
 
-def _str_to_date(self: generator.Generator, expression: exp.StrToDate) -> str:
+def _str_to_date_sql(self: generator.Generator, expression: exp.StrToDate) -> str:
     this = self.sql(expression, "this")
     time_format = self.format_time(expression)
     if time_format not in (Hive.time_format, Hive.date_format):
@@ -103,7 +103,7 @@ def _str_to_date(self: generator.Generator, expression: exp.StrToDate) -> str:
     return f"CAST({this} AS DATE)"
 
 
-def _str_to_time(self: generator.Generator, expression: exp.StrToTime) -> str:
+def _str_to_time_sql(self: generator.Generator, expression: exp.StrToTime) -> str:
     this = self.sql(expression, "this")
     time_format = self.format_time(expression)
     if time_format not in (Hive.time_format, Hive.date_format):
@@ -290,7 +290,7 @@ class Hive(Dialect):
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.ArrayConcat: rename_func("CONCAT"),
             exp.ArraySize: rename_func("SIZE"),
-            exp.ArraySort: _array_sort,
+            exp.ArraySort: _array_sort_sql,
             exp.With: no_recursive_cte_sql,
             exp.DateAdd: _add_date_sql,
             exp.DateDiff: _date_diff_sql,
@@ -319,9 +319,9 @@ class Hive(Dialect):
             exp.SetAgg: rename_func("COLLECT_SET"),
             exp.Split: lambda self, e: f"SPLIT({self.sql(e, 'this')}, CONCAT('\\\\Q', {self.sql(e, 'expression')}))",
             exp.StrPosition: strposition_to_locate_sql,
-            exp.StrToDate: _str_to_date,
-            exp.StrToTime: _str_to_time,
-            exp.StrToUnix: _str_to_unix,
+            exp.StrToDate: _str_to_date_sql,
+            exp.StrToTime: _str_to_time_sql,
+            exp.StrToUnix: _str_to_unix_sql,
             exp.StructExtract: struct_extract_sql,
             exp.TableFormatProperty: lambda self, e: f"USING {self.sql(e, 'this')}",
             exp.TimeStrToDate: rename_func("TO_DATE"),

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import typing as t
 
 from sqlglot import exp

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -1,223 +1,53 @@
-from __future__ import annotations
-
 import typing as t
 
-from sqlglot import exp, parser
-from sqlglot.dialects.dialect import create_with_partitions_sql, rename_func, trim_sql
-from sqlglot.dialects.hive import Hive
+from sqlglot import exp
+from sqlglot.dialects.spark2 import Spark2
 from sqlglot.helper import seq_get
 
 
-def _create_sql(self: Hive.Generator, e: exp.Create) -> str:
-    kind = e.args["kind"]
-    properties = e.args.get("properties")
+def _parse_datediff(args: t.Sequence) -> exp.Expression:
+    """
+    Although Spark docs don't mention the "unit" argument, Spark3 does support it.
+    Databricks also supports it and documents the 3 argument version accordingly.
 
-    if kind.upper() == "TABLE" and any(
-        isinstance(prop, exp.TemporaryProperty)
-        for prop in (properties.expressions if properties else [])
-    ):
-        return f"CREATE TEMPORARY VIEW {self.sql(e, 'this')} AS {self.sql(e, 'expression')}"
-    return create_with_partitions_sql(self, e)
+    For example, in spark-sql (v3.3.1):
+    - SELECT DATEDIFF('2020-01-01', '2020-01-05') results in -4
+    - SELECT DATEDIFF(day, '2020-01-01', '2020-01-05') results in 4
 
+    See also:
+    - https://docs.databricks.com/sql/language-manual/functions/datediff3.html
+    - https://docs.databricks.com/sql/language-manual/functions/datediff.html
+    """
+    unit = None
+    this = seq_get(args, 0)
+    expression = seq_get(args, 1)
 
-def _map_sql(self: Hive.Generator, expression: exp.Map) -> str:
-    keys = self.sql(expression.args["keys"])
-    values = self.sql(expression.args["values"])
-    return f"MAP_FROM_ARRAYS({keys}, {values})"
+    if len(args) == 3:
+        unit = this
+        this = args[2]
 
-
-def _str_to_date(self: Hive.Generator, expression: exp.StrToDate) -> str:
-    this = self.sql(expression, "this")
-    time_format = self.format_time(expression)
-    if time_format == Hive.date_format:
-        return f"TO_DATE({this})"
-    return f"TO_DATE({this}, {time_format})"
-
-
-def _unix_to_time_sql(self: Hive.Generator, expression: exp.UnixToTime) -> str:
-    scale = expression.args.get("scale")
-    timestamp = self.sql(expression, "this")
-    if scale is None:
-        return f"FROM_UNIXTIME({timestamp})"
-    if scale == exp.UnixToTime.SECONDS:
-        return f"TIMESTAMP_SECONDS({timestamp})"
-    if scale == exp.UnixToTime.MILLIS:
-        return f"TIMESTAMP_MILLIS({timestamp})"
-    if scale == exp.UnixToTime.MICROS:
-        return f"TIMESTAMP_MICROS({timestamp})"
-
-    raise ValueError("Improper scale for timestamp")
+    return exp.DateDiff(
+        this=exp.TsOrDsToDate(this=this), expression=exp.TsOrDsToDate(this=expression), unit=unit
+    )
 
 
-class Spark(Hive):
-    class Parser(Hive.Parser):
+class Spark(Spark2):
+    class Parser(Spark2.Parser):
         FUNCTIONS = {
-            **Hive.Parser.FUNCTIONS,  # type: ignore
-            "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
-            "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
-            "LEFT": lambda args: exp.Substring(
-                this=seq_get(args, 0),
-                start=exp.Literal.number(1),
-                length=seq_get(args, 1),
-            ),
-            "SHIFTLEFT": lambda args: exp.BitwiseLeftShift(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-            ),
-            "SHIFTRIGHT": lambda args: exp.BitwiseRightShift(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-            ),
-            "RIGHT": lambda args: exp.Substring(
-                this=seq_get(args, 0),
-                start=exp.Sub(
-                    this=exp.Length(this=seq_get(args, 0)),
-                    expression=exp.Add(this=seq_get(args, 1), expression=exp.Literal.number(1)),
-                ),
-                length=seq_get(args, 1),
-            ),
-            "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
-            "BOOLEAN": lambda args: exp.Cast(
-                this=seq_get(args, 0), to=exp.DataType.build("boolean")
-            ),
-            "IIF": exp.If.from_arg_list,
-            "INT": lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build("int")),
-            "AGGREGATE": exp.Reduce.from_arg_list,
-            "DAYOFWEEK": lambda args: exp.DayOfWeek(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "DAYOFMONTH": lambda args: exp.DayOfMonth(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "DAYOFYEAR": lambda args: exp.DayOfYear(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "WEEKOFYEAR": lambda args: exp.WeekOfYear(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "DATE": lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build("date")),
-            "DATE_TRUNC": lambda args: exp.TimestampTrunc(
-                this=seq_get(args, 1),
-                unit=exp.var(seq_get(args, 0)),
-            ),
-            "STRING": lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build("string")),
-            "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
-            "TIMESTAMP": lambda args: exp.Cast(
-                this=seq_get(args, 0), to=exp.DataType.build("timestamp")
-            ),
+            **Spark2.Parser.FUNCTIONS,  # type: ignore
+            "DATEDIFF": _parse_datediff,
         }
 
-        FUNCTION_PARSERS = {
-            **parser.Parser.FUNCTION_PARSERS,  # type: ignore
-            "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
-            "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
-            "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),
-            "MERGE": lambda self: self._parse_join_hint("MERGE"),
-            "SHUFFLEMERGE": lambda self: self._parse_join_hint("SHUFFLEMERGE"),
-            "MERGEJOIN": lambda self: self._parse_join_hint("MERGEJOIN"),
-            "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
-            "SHUFFLE_REPLICATE_NL": lambda self: self._parse_join_hint("SHUFFLE_REPLICATE_NL"),
-        }
+    class Generator(Spark2.Generator):
+        TRANSFORMS = Spark2.Generator.TRANSFORMS.copy()
+        TRANSFORMS.pop(exp.DateDiff)
 
-        def _parse_add_column(self) -> t.Optional[exp.Expression]:
-            return self._match_text_seq("ADD", "COLUMNS") and self._parse_schema()
+        def datediff_sql(self, expression: exp.DateDiff) -> str:
+            unit = self.sql(expression, "unit")
+            end = self.sql(expression, "this")
+            start = self.sql(expression, "expression")
 
-        def _parse_drop_column(self) -> t.Optional[exp.Expression]:
-            return self._match_text_seq("DROP", "COLUMNS") and self.expression(
-                exp.Drop,
-                this=self._parse_schema(),
-                kind="COLUMNS",
-            )
+            if unit:
+                return self.func("DATEDIFF", unit, start, end)
 
-        def _pivot_column_names(self, pivot_columns: t.List[exp.Expression]) -> t.List[str]:
-            # Spark doesn't add a suffix to the pivot columns when there's a single aggregation
-            if len(pivot_columns) == 1:
-                return [""]
-
-            names = []
-            for agg in pivot_columns:
-                if isinstance(agg, exp.Alias):
-                    names.append(agg.alias)
-                else:
-                    """
-                    This case corresponds to aggregations without aliases being used as suffixes
-                    (e.g. col_avg(foo)). We need to unquote identifiers because they're going to
-                    be quoted in the base parser's `_parse_pivot` method, due to `to_identifier`.
-                    Otherwise, we'd end up with `col_avg(`foo`)` (notice the double quotes).
-
-                    Moreover, function names are lowercased in order to mimic Spark's naming scheme.
-                    """
-                    agg_all_unquoted = agg.transform(
-                        lambda node: exp.Identifier(this=node.name, quoted=False)
-                        if isinstance(node, exp.Identifier)
-                        else node
-                    )
-                    names.append(agg_all_unquoted.sql(dialect="spark", normalize_functions="lower"))
-
-            return names
-
-    class Generator(Hive.Generator):
-        TYPE_MAPPING = {
-            **Hive.Generator.TYPE_MAPPING,  # type: ignore
-            exp.DataType.Type.TINYINT: "BYTE",
-            exp.DataType.Type.SMALLINT: "SHORT",
-            exp.DataType.Type.BIGINT: "LONG",
-        }
-
-        PROPERTIES_LOCATION = {
-            **Hive.Generator.PROPERTIES_LOCATION,  # type: ignore
-            exp.EngineProperty: exp.Properties.Location.UNSUPPORTED,
-            exp.AutoIncrementProperty: exp.Properties.Location.UNSUPPORTED,
-            exp.CharacterSetProperty: exp.Properties.Location.UNSUPPORTED,
-            exp.CollateProperty: exp.Properties.Location.UNSUPPORTED,
-        }
-
-        TRANSFORMS = {
-            **Hive.Generator.TRANSFORMS,  # type: ignore
-            exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
-            exp.FileFormatProperty: lambda self, e: f"USING {e.name.upper()}",
-            exp.ArraySum: lambda self, e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
-            exp.BitwiseLeftShift: rename_func("SHIFTLEFT"),
-            exp.BitwiseRightShift: rename_func("SHIFTRIGHT"),
-            exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, e.args.get("unit")),
-            exp.Hint: lambda self, e: f" /*+ {self.expressions(e).strip()} */",
-            exp.StrToDate: _str_to_date,
-            exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
-            exp.UnixToTime: _unix_to_time_sql,
-            exp.Create: _create_sql,
-            exp.Map: _map_sql,
-            exp.Reduce: rename_func("AGGREGATE"),
-            exp.StructKwarg: lambda self, e: f"{self.sql(e, 'this')}: {self.sql(e, 'expression')}",
-            exp.TimestampTrunc: lambda self, e: self.func(
-                "DATE_TRUNC", exp.Literal.string(e.text("unit")), e.this
-            ),
-            exp.Trim: trim_sql,
-            exp.VariancePop: rename_func("VAR_POP"),
-            exp.DateFromParts: rename_func("MAKE_DATE"),
-            exp.LogicalOr: rename_func("BOOL_OR"),
-            exp.LogicalAnd: rename_func("BOOL_AND"),
-            exp.DayOfWeek: rename_func("DAYOFWEEK"),
-            exp.DayOfMonth: rename_func("DAYOFMONTH"),
-            exp.DayOfYear: rename_func("DAYOFYEAR"),
-            exp.WeekOfYear: rename_func("WEEKOFYEAR"),
-            exp.AtTimeZone: lambda self, e: f"FROM_UTC_TIMESTAMP({self.sql(e, 'this')}, {self.sql(e, 'zone')})",
-        }
-        TRANSFORMS.pop(exp.ArraySort)
-        TRANSFORMS.pop(exp.ILike)
-
-        WRAP_DERIVED_VALUES = False
-        CREATE_FUNCTION_RETURN_AS = False
-
-        def cast_sql(self, expression: exp.Cast) -> str:
-            if isinstance(expression.this, exp.Cast) and expression.this.is_type(
-                exp.DataType.Type.JSON
-            ):
-                schema = f"'{self.sql(expression, 'to')}'"
-                return self.func("FROM_JSON", expression.this.this, schema)
-            if expression.to.is_type(exp.DataType.Type.JSON):
-                return self.func("TO_JSON", expression.this)
-
-            return super(Spark.Generator, self).cast_sql(expression)
-
-    class Tokenizer(Hive.Tokenizer):
-        HEX_STRINGS = [("X'", "'")]
+            return self.func("DATEDIFF", end, start)

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -7,8 +7,8 @@ from sqlglot.helper import seq_get
 
 def _parse_datediff(args: t.Sequence) -> exp.Expression:
     """
-    Although Spark docs don't mention the "unit" argument, Spark3 does support it.
-    Databricks also supports it and documents the 3 argument version accordingly.
+    Although Spark docs don't mention the "unit" argument, Spark3 added support for
+    it at some point. Databricks also supports this variation (see below).
 
     For example, in spark-sql (v3.3.1):
     - SELECT DATEDIFF('2020-01-01', '2020-01-05') results in -4

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import typing as t
+
+from sqlglot import exp, parser
+from sqlglot.dialects.dialect import create_with_partitions_sql, rename_func, trim_sql
+from sqlglot.dialects.hive import Hive
+from sqlglot.helper import seq_get
+
+
+def _create_sql(self: Hive.Generator, e: exp.Create) -> str:
+    kind = e.args["kind"]
+    properties = e.args.get("properties")
+
+    if kind.upper() == "TABLE" and any(
+        isinstance(prop, exp.TemporaryProperty)
+        for prop in (properties.expressions if properties else [])
+    ):
+        return f"CREATE TEMPORARY VIEW {self.sql(e, 'this')} AS {self.sql(e, 'expression')}"
+    return create_with_partitions_sql(self, e)
+
+
+def _map_sql(self: Hive.Generator, expression: exp.Map) -> str:
+    keys = self.sql(expression.args["keys"])
+    values = self.sql(expression.args["values"])
+    return f"MAP_FROM_ARRAYS({keys}, {values})"
+
+
+def _str_to_date(self: Hive.Generator, expression: exp.StrToDate) -> str:
+    this = self.sql(expression, "this")
+    time_format = self.format_time(expression)
+    if time_format == Hive.date_format:
+        return f"TO_DATE({this})"
+    return f"TO_DATE({this}, {time_format})"
+
+
+def _unix_to_time_sql(self: Hive.Generator, expression: exp.UnixToTime) -> str:
+    scale = expression.args.get("scale")
+    timestamp = self.sql(expression, "this")
+    if scale is None:
+        return f"FROM_UNIXTIME({timestamp})"
+    if scale == exp.UnixToTime.SECONDS:
+        return f"TIMESTAMP_SECONDS({timestamp})"
+    if scale == exp.UnixToTime.MILLIS:
+        return f"TIMESTAMP_MILLIS({timestamp})"
+    if scale == exp.UnixToTime.MICROS:
+        return f"TIMESTAMP_MICROS({timestamp})"
+
+    raise ValueError("Improper scale for timestamp")
+
+
+class Spark2(Hive):
+    class Parser(Hive.Parser):
+        FUNCTIONS = {
+            **Hive.Parser.FUNCTIONS,  # type: ignore
+            "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
+            "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
+            "LEFT": lambda args: exp.Substring(
+                this=seq_get(args, 0),
+                start=exp.Literal.number(1),
+                length=seq_get(args, 1),
+            ),
+            "SHIFTLEFT": lambda args: exp.BitwiseLeftShift(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+            ),
+            "SHIFTRIGHT": lambda args: exp.BitwiseRightShift(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+            ),
+            "RIGHT": lambda args: exp.Substring(
+                this=seq_get(args, 0),
+                start=exp.Sub(
+                    this=exp.Length(this=seq_get(args, 0)),
+                    expression=exp.Add(this=seq_get(args, 1), expression=exp.Literal.number(1)),
+                ),
+                length=seq_get(args, 1),
+            ),
+            "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
+            "BOOLEAN": lambda args: exp.Cast(
+                this=seq_get(args, 0), to=exp.DataType.build("boolean")
+            ),
+            "IIF": exp.If.from_arg_list,
+            "INT": lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build("int")),
+            "AGGREGATE": exp.Reduce.from_arg_list,
+            "DAYOFWEEK": lambda args: exp.DayOfWeek(
+                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
+            ),
+            "DAYOFMONTH": lambda args: exp.DayOfMonth(
+                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
+            ),
+            "DAYOFYEAR": lambda args: exp.DayOfYear(
+                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
+            ),
+            "WEEKOFYEAR": lambda args: exp.WeekOfYear(
+                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
+            ),
+            "DATE": lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build("date")),
+            "DATE_TRUNC": lambda args: exp.TimestampTrunc(
+                this=seq_get(args, 1),
+                unit=exp.var(seq_get(args, 0)),
+            ),
+            "STRING": lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build("string")),
+            "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
+            "TIMESTAMP": lambda args: exp.Cast(
+                this=seq_get(args, 0), to=exp.DataType.build("timestamp")
+            ),
+        }
+
+        FUNCTION_PARSERS = {
+            **parser.Parser.FUNCTION_PARSERS,  # type: ignore
+            "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
+            "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
+            "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),
+            "MERGE": lambda self: self._parse_join_hint("MERGE"),
+            "SHUFFLEMERGE": lambda self: self._parse_join_hint("SHUFFLEMERGE"),
+            "MERGEJOIN": lambda self: self._parse_join_hint("MERGEJOIN"),
+            "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
+            "SHUFFLE_REPLICATE_NL": lambda self: self._parse_join_hint("SHUFFLE_REPLICATE_NL"),
+        }
+
+        def _parse_add_column(self) -> t.Optional[exp.Expression]:
+            return self._match_text_seq("ADD", "COLUMNS") and self._parse_schema()
+
+        def _parse_drop_column(self) -> t.Optional[exp.Expression]:
+            return self._match_text_seq("DROP", "COLUMNS") and self.expression(
+                exp.Drop,
+                this=self._parse_schema(),
+                kind="COLUMNS",
+            )
+
+        def _pivot_column_names(self, pivot_columns: t.List[exp.Expression]) -> t.List[str]:
+            # Spark doesn't add a suffix to the pivot columns when there's a single aggregation
+            if len(pivot_columns) == 1:
+                return [""]
+
+            names = []
+            for agg in pivot_columns:
+                if isinstance(agg, exp.Alias):
+                    names.append(agg.alias)
+                else:
+                    """
+                    This case corresponds to aggregations without aliases being used as suffixes
+                    (e.g. col_avg(foo)). We need to unquote identifiers because they're going to
+                    be quoted in the base parser's `_parse_pivot` method, due to `to_identifier`.
+                    Otherwise, we'd end up with `col_avg(`foo`)` (notice the double quotes).
+
+                    Moreover, function names are lowercased in order to mimic Spark's naming scheme.
+                    """
+                    agg_all_unquoted = agg.transform(
+                        lambda node: exp.Identifier(this=node.name, quoted=False)
+                        if isinstance(node, exp.Identifier)
+                        else node
+                    )
+                    names.append(agg_all_unquoted.sql(dialect="spark", normalize_functions="lower"))
+
+            return names
+
+    class Generator(Hive.Generator):
+        TYPE_MAPPING = {
+            **Hive.Generator.TYPE_MAPPING,  # type: ignore
+            exp.DataType.Type.TINYINT: "BYTE",
+            exp.DataType.Type.SMALLINT: "SHORT",
+            exp.DataType.Type.BIGINT: "LONG",
+        }
+
+        PROPERTIES_LOCATION = {
+            **Hive.Generator.PROPERTIES_LOCATION,  # type: ignore
+            exp.EngineProperty: exp.Properties.Location.UNSUPPORTED,
+            exp.AutoIncrementProperty: exp.Properties.Location.UNSUPPORTED,
+            exp.CharacterSetProperty: exp.Properties.Location.UNSUPPORTED,
+            exp.CollateProperty: exp.Properties.Location.UNSUPPORTED,
+        }
+
+        TRANSFORMS = {
+            **Hive.Generator.TRANSFORMS,  # type: ignore
+            exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
+            exp.FileFormatProperty: lambda self, e: f"USING {e.name.upper()}",
+            exp.ArraySum: lambda self, e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
+            exp.BitwiseLeftShift: rename_func("SHIFTLEFT"),
+            exp.BitwiseRightShift: rename_func("SHIFTRIGHT"),
+            exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, e.args.get("unit")),
+            exp.Hint: lambda self, e: f" /*+ {self.expressions(e).strip()} */",
+            exp.StrToDate: _str_to_date,
+            exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
+            exp.UnixToTime: _unix_to_time_sql,
+            exp.Create: _create_sql,
+            exp.Map: _map_sql,
+            exp.Reduce: rename_func("AGGREGATE"),
+            exp.StructKwarg: lambda self, e: f"{self.sql(e, 'this')}: {self.sql(e, 'expression')}",
+            exp.TimestampTrunc: lambda self, e: self.func(
+                "DATE_TRUNC", exp.Literal.string(e.text("unit")), e.this
+            ),
+            exp.Trim: trim_sql,
+            exp.VariancePop: rename_func("VAR_POP"),
+            exp.DateFromParts: rename_func("MAKE_DATE"),
+            exp.LogicalOr: rename_func("BOOL_OR"),
+            exp.LogicalAnd: rename_func("BOOL_AND"),
+            exp.DayOfWeek: rename_func("DAYOFWEEK"),
+            exp.DayOfMonth: rename_func("DAYOFMONTH"),
+            exp.DayOfYear: rename_func("DAYOFYEAR"),
+            exp.WeekOfYear: rename_func("WEEKOFYEAR"),
+            exp.AtTimeZone: lambda self, e: f"FROM_UTC_TIMESTAMP({self.sql(e, 'this')}, {self.sql(e, 'zone')})",
+        }
+        TRANSFORMS.pop(exp.ArraySort)
+        TRANSFORMS.pop(exp.ILike)
+
+        WRAP_DERIVED_VALUES = False
+        CREATE_FUNCTION_RETURN_AS = False
+
+        def cast_sql(self, expression: exp.Cast) -> str:
+            if isinstance(expression.this, exp.Cast) and expression.this.is_type(
+                exp.DataType.Type.JSON
+            ):
+                schema = f"'{self.sql(expression, 'to')}'"
+                return self.func("FROM_JSON", expression.this.this, schema)
+            if expression.to.is_type(exp.DataType.Type.JSON):
+                return self.func("TO_JSON", expression.this)
+
+            return super(Hive.Generator, self).cast_sql(expression)
+
+    class Tokenizer(Hive.Tokenizer):
+        HEX_STRINGS = [("X'", "'")]

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -215,6 +215,17 @@ TBLPROPERTIES (
         self.validate_identity("SPLIT(str, pattern, lim)")
 
         self.validate_all(
+            "SELECT DATEDIFF(MONTH, '2020-01-01', '2020-03-05')",
+            write={
+                "databricks": "SELECT DATEDIFF(MONTH, TO_DATE('2020-01-01'), TO_DATE('2020-03-05'))",
+                "hive": "SELECT MONTHS_BETWEEN(TO_DATE('2020-03-05'), TO_DATE('2020-01-01'))",
+                "presto": "SELECT DATE_DIFF('MONTH', CAST(SUBSTR(CAST('2020-01-01' AS VARCHAR), 1, 10) AS DATE), CAST(SUBSTR(CAST('2020-03-05' AS VARCHAR), 1, 10) AS DATE))",
+                "spark": "SELECT DATEDIFF(MONTH, TO_DATE('2020-01-01'), TO_DATE('2020-03-05'))",
+                "spark2": "SELECT MONTHS_BETWEEN(TO_DATE('2020-03-05'), TO_DATE('2020-01-01'))",
+                "trino": "SELECT DATE_DIFF('MONTH', CAST(SUBSTR(CAST('2020-01-01' AS VARCHAR), 1, 10) AS DATE), CAST(SUBSTR(CAST('2020-03-05' AS VARCHAR), 1, 10) AS DATE))",
+            },
+        )
+        self.validate_all(
             "BOOLEAN(x)",
             write={
                 "": "CAST(x AS BOOLEAN)",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -485,26 +485,30 @@ WHERE
 
     def test_date_diff(self):
         self.validate_identity("SELECT DATEDIFF(year, '2020/01/01', '2021/01/01')")
+
         self.validate_all(
             "SELECT DATEDIFF(year, '2020/01/01', '2021/01/01')",
             write={
                 "tsql": "SELECT DATEDIFF(year, '2020/01/01', '2021/01/01')",
-                "spark": "SELECT MONTHS_BETWEEN('2021/01/01', '2020/01/01') / 12",
+                "spark": "SELECT DATEDIFF(year, '2020/01/01', '2021/01/01')",
+                "spark2": "SELECT MONTHS_BETWEEN('2021/01/01', '2020/01/01') / 12",
             },
         )
         self.validate_all(
             "SELECT DATEDIFF(mm, 'start','end')",
             write={
-                "spark": "SELECT MONTHS_BETWEEN('end', 'start')",
-                "tsql": "SELECT DATEDIFF(month, 'start', 'end')",
                 "databricks": "SELECT DATEDIFF(month, 'start', 'end')",
+                "spark2": "SELECT MONTHS_BETWEEN('end', 'start')",
+                "tsql": "SELECT DATEDIFF(month, 'start', 'end')",
             },
         )
         self.validate_all(
             "SELECT DATEDIFF(quarter, 'start', 'end')",
             write={
-                "spark": "SELECT MONTHS_BETWEEN('end', 'start') / 3",
                 "databricks": "SELECT DATEDIFF(quarter, 'start', 'end')",
+                "spark": "SELECT DATEDIFF(quarter, 'start', 'end')",
+                "spark2": "SELECT MONTHS_BETWEEN('end', 'start') / 3",
+                "tsql": "SELECT DATEDIFF(quarter, 'start', 'end')",
             },
         )
 


### PR DESCRIPTION
This PR originally aimed to improve the transpilation of `DATEDIFF` for Spark and Databricks, which both inherit from Hive. It turns out that this function can also receive a "unit" argument in (at least) v3.3.1 Spark, similar to other dialects. This isn't documented in Spark's docs (it is in Databricks'), but one can easily test this using for example `spark-sql`:

```
spark-sql> SELECT DATEDIFF(MONTH, '2020-01-01', '2020-03-05'); -- v3.3.1
timestampdiff(MONTH, 2020-01-01, 2020-03-05)
2
Time taken: 0.143 seconds, Fetched 1 row(s)
```

Note that this is **NOT** supported in v2 Spark. So, if we just parsed the unit correctly, without changing the generation logic of `DATEDIFF`, we'd get the following query after transpiling to the current Hive / Spark / Databricks dialects:

```sql
SELECT MONTHS_BETWEEN(TO_DATE('2020-03-05'), TO_DATE('2020-01-01'));
```

However, this transformation results in different semantics, compared to the previous query:

```
spark-sql> SELECT MONTHS_BETWEEN(TO_DATE('2020-03-05'), TO_DATE('2020-01-01')); -- v3.3.1
months_between(to_date(2020-03-05), to_date(2020-01-01), true)
2.12903226
Time taken: 0.169 seconds, Fetched 1 row(s)
```

I discussed this with Toby and we decided to introduce a Spark2 dialect, equivalent to our current Spark dialect, which in turn was changed to 1) inherit from Spark2 and 2) override the sql generation of `DATEDIFF`.

xref: https://github.com/duneanalytics/harmonizer/issues/39