### PR TITLE
Fix(spark): cast UnixToTime to TIMESTAMP BREAKING

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -42,7 +42,7 @@ def _unix_to_time_sql(self: Hive.Generator, expression: exp.UnixToTime) -> str:
     scale = expression.args.get("scale")
     timestamp = self.sql(expression, "this")
     if scale is None:
-        return f"FROM_UNIXTIME({timestamp})"
+        return f"CAST(FROM_UNIXTIME({timestamp}) AS TIMESTAMP)"
     if scale == exp.UnixToTime.SECONDS:
         return f"TIMESTAMP_SECONDS({timestamp})"
     if scale == exp.UnixToTime.MILLIS:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -24,7 +24,7 @@ class TestDuckDB(Validator):
                 "bigquery": "UNIX_TO_TIME(x / 1000)",
                 "duckdb": "TO_TIMESTAMP(x / 1000)",
                 "presto": "FROM_UNIXTIME(x / 1000)",
-                "spark": "FROM_UNIXTIME(x / 1000)",
+                "spark": "CAST(FROM_UNIXTIME(x / 1000) AS TIMESTAMP)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -134,6 +134,14 @@ class TestPresto(Validator):
         self.validate_identity("VAR_POP(a)")
 
         self.validate_all(
+            "SELECT FROM_UNIXTIME(col) FROM tbl",
+            write={
+                "presto": "SELECT FROM_UNIXTIME(col) FROM tbl",
+                "spark": "SELECT CAST(FROM_UNIXTIME(col) AS TIMESTAMP) FROM tbl",
+                "trino": "SELECT FROM_UNIXTIME(col) FROM tbl",
+            },
+        )
+        self.validate_all(
             "DATE_FORMAT(x, '%Y-%m-%d %H:%i:%S')",
             write={
                 "duckdb": "STRFTIME(x, '%Y-%m-%d %H:%M:%S')",
@@ -181,7 +189,7 @@ class TestPresto(Validator):
                 "duckdb": "TO_TIMESTAMP(x)",
                 "presto": "FROM_UNIXTIME(x)",
                 "hive": "FROM_UNIXTIME(x)",
-                "spark": "FROM_UNIXTIME(x)",
+                "spark": "CAST(FROM_UNIXTIME(x) AS TIMESTAMP)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -227,7 +227,7 @@ class TestSnowflake(Validator):
             write={
                 "bigquery": "SELECT UNIX_TO_TIME(1659981729)",
                 "snowflake": "SELECT TO_TIMESTAMP(1659981729)",
-                "spark": "SELECT FROM_UNIXTIME(1659981729)",
+                "spark": "SELECT CAST(FROM_UNIXTIME(1659981729) AS TIMESTAMP)",
             },
         )
         self.validate_all(
@@ -243,7 +243,7 @@ class TestSnowflake(Validator):
             write={
                 "bigquery": "SELECT UNIX_TO_TIME('1659981729')",
                 "snowflake": "SELECT TO_TIMESTAMP('1659981729')",
-                "spark": "SELECT FROM_UNIXTIME('1659981729')",
+                "spark": "SELECT CAST(FROM_UNIXTIME('1659981729') AS TIMESTAMP)",
             },
         )
         self.validate_all(

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -476,10 +476,12 @@ FROM v""",
             "UNIX_TIMESTAMP(x)",
             write="spark",
         )
-        self.validate("UNIX_TO_STR(123, 'y')", "FROM_UNIXTIME(123, 'y')", write="spark")
+        self.validate(
+            "UNIX_TO_STR(123, 'y')", "FROM_UNIXTIME(123, 'y')", write="spark"
+        )
         self.validate(
             "UNIX_TO_TIME(123)",
-            "FROM_UNIXTIME(123)",
+            "CAST(FROM_UNIXTIME(123) AS TIMESTAMP)",
             write="spark",
         )
         self.validate(

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -476,9 +476,7 @@ FROM v""",
             "UNIX_TIMESTAMP(x)",
             write="spark",
         )
-        self.validate(
-            "UNIX_TO_STR(123, 'y')", "FROM_UNIXTIME(123, 'y')", write="spark"
-        )
+        self.validate("UNIX_TO_STR(123, 'y')", "FROM_UNIXTIME(123, 'y')", write="spark")
         self.validate(
             "UNIX_TO_TIME(123)",
             "CAST(FROM_UNIXTIME(123) AS TIMESTAMP)",


### PR DESCRIPTION
Fixes #1545 