### PR TITLE
Fix(Postgres): Correct operator precedence for ^ inline power operator

### DIFF
--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -175,6 +175,13 @@ class TestPostgres(Validator):
             },
         )
         self.validate_all(
+            "x / y ^ z",
+            write={
+                "": "x / POWER(y, z)",
+                "postgres": "x / y ^ z",
+            },
+        )
+        self.validate_all(
             "x # y",
             write={
                 "": "x ^ y",


### PR DESCRIPTION
To fix https://github.com/tobymao/sqlglot/issues/1555