### PR TITLE
Fix(presto, spark): remove WITHIN GROUP when transpiling percentile_[cont|disc]

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -348,3 +348,13 @@ class Presto(Dialect):
             modes = expression.args.get("modes")
             modes = f" {', '.join(modes)}" if modes else ""
             return f"START TRANSACTION{modes}"
+
+        def withingroup_sql(self, expression: exp.WithinGroup) -> str:
+            if isinstance(expression.this, (exp.PercentileCont, exp.PercentileDisc)) and isinstance(
+                expression.expression, exp.Order
+            ):
+                # Unwrap an Order > Ordered > obj expression into just obj (e.g. a Column)
+                input_value = expression.expression.expressions[0].this
+                return self.func("APPROX_PERCENTILE", input_value, expression.this.this)
+
+            return super().withingroup_sql(expression)

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -135,6 +135,7 @@ class TestPostgres(Validator):
         self.validate_all(
             "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount)",
             write={
+                "databricks": "SELECT PERCENTILE_APPROX(amount, 0.5)",
                 "presto": "SELECT APPROX_PERCENTILE(amount, 0.5)",
                 "spark": "SELECT PERCENTILE_APPROX(amount, 0.5)",
                 "trino": "SELECT APPROX_PERCENTILE(amount, 0.5)",

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -418,12 +418,6 @@ class TestPresto(Validator):
         self.validate_all("(5 * INTERVAL '7' day)", read={"": "INTERVAL '5' week"})
         self.validate_all("(5 * INTERVAL '7' day)", read={"": "INTERVAL '5' WEEKS"})
         self.validate_all(
-            "SELECT APPROX_PERCENTILE(amount, 0.5)",
-            read={
-                "postgres": "SELECT PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY amount)",
-            },
-        )
-        self.validate_all(
             "SELECT JSON_OBJECT(KEY 'key1' VALUE 1, KEY 'key2' VALUE TRUE)",
             write={
                 "presto": "SELECT JSON_OBJECT('key1': 1, 'key2': TRUE)",

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -420,12 +420,6 @@ class TestPresto(Validator):
         self.validate_all(
             "SELECT APPROX_PERCENTILE(amount, 0.5)",
             read={
-                "postgres": "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount)",
-            },
-        )
-        self.validate_all(
-            "SELECT APPROX_PERCENTILE(amount, 0.5)",
-            read={
                 "postgres": "SELECT PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY amount)",
             },
         )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -418,6 +418,18 @@ class TestPresto(Validator):
         self.validate_all("(5 * INTERVAL '7' day)", read={"": "INTERVAL '5' week"})
         self.validate_all("(5 * INTERVAL '7' day)", read={"": "INTERVAL '5' WEEKS"})
         self.validate_all(
+            "SELECT APPROX_PERCENTILE(amount, 0.5)",
+            read={
+                "postgres": "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount)",
+            },
+        )
+        self.validate_all(
+            "SELECT APPROX_PERCENTILE(amount, 0.5)",
+            read={
+                "postgres": "SELECT PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY amount)",
+            },
+        )
+        self.validate_all(
             "SELECT JSON_OBJECT(KEY 'key1' VALUE 1, KEY 'key2' VALUE TRUE)",
             write={
                 "presto": "SELECT JSON_OBJECT('key1': 1, 'key2': TRUE)",


### PR DESCRIPTION
Example usage:

```python
>>> sqlglot.transpile("WITH sales(amount) AS (SELECT * FROM (VALUES (100), (200), (300), (400), (500), (600), (700), (800), (900), (1000)) sales(amount)) SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount) AS median FROM sales", "postgres", "trino")[0]
'WITH sales(amount) AS (SELECT * FROM (VALUES (100), (200), (300), (400), (500), (600), (700), (800), (900), (1000)) AS sales(amount)) SELECT APPROX_PERCENTILE(amount, 0.5) AS median FROM sales'
```

In Postgres:
```python
georgesittas=# WITH sales(amount) AS (SELECT * FROM (VALUES (100), (200), (300), (400), (500), (600), (700), (800), (900), (1000)) sales(amount)) SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY amount) AS median FROM sales;
 median
--------
    550
(1 row)
```

In Trino:
```python
trino> WITH sales(amount) AS (SELECT * FROM (VALUES (100), (200), (300), (400), (500), (600), (700), (800), (900), (1000)) AS sales(amount)) SELECT APPROX_PERCENTILE(amount, 0.5) AS median FROM sales;
 median 
--------
    600 
(1 row)
```

From what I can see, there's no exact percentile function in Presto / Trino, hence the different column value. Not sure if we can do something better than what's proposed in this PR.

cc: @vegarsti

References:
- https://trino.io/docs/current/functions/aggregate.html
- https://www.postgresql.org/docs/15/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE
- https://docs.databricks.com/sql/language-manual/functions/percentile_approx.html
- https://spark.apache.org/docs/latest/sql-ref-functions-builtin.html