### PR TITLE
Support for parameterized queries in the ClickHouse Dialect

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -237,7 +237,7 @@ class ClickHouse(Dialect):
             return super().cte_sql(expression)
 
         def placeholder_sql(self, expression: exp.Placeholder) -> str:
-            placeholder_type = expression.args.get("type")
-            if not placeholder_type:
+            type_sql = self.sql(expression, "type")
+            if not type_sql:
                 self.unsupported("Cannot create a placeholder without a type.")
-            return f"{{{expression.name}: {self.sql(placeholder_type)}}}"
+            return f"{{{expression.name}: {type_sql}}}"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2961,7 +2961,7 @@ class SessionParameter(Expression):
 
 
 class Placeholder(Expression):
-    arg_types = {"this": False}
+    arg_types = {"this": False, "type": False}
 
 
 class Null(Condition):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -86,3 +86,18 @@ class TestClickhouse(Validator):
                 f"pow(2, 32)::{data_type}",
                 write={"clickhouse": f"CAST(POWER(2, 32) AS {data_type})"},
             )
+
+    def test_parameterization(self):
+        # Ensure we support parameterization within the select clause
+        self.validate_all(
+            "SELECT {abc: UInt32}, {b: String}, {c: DateTime},{d: Map(String, Array(UInt8))}, {e: Tuple(UInt8, String)}",
+            write={
+                "clickhouse": "SELECT {abc: UInt32}, {b: TEXT}, {c: DateTime64}, {d: Map(TEXT, Array(UInt8))}, {e: Tuple(UInt8, String)}",
+                "": "SELECT :abc, :b, :c, :d, :e",
+            },
+        )
+        # Ensure we support parameterization for "Identity" parameters including those that can be used in a FROM clause
+        self.validate_all(
+            "SELECT * FROM {table: Identifier}",
+            write={"clickhouse": "SELECT * FROM {table: Identifier}"},
+        )


### PR DESCRIPTION
ClickHouse [supports parameterization](https://clickhouse.com/docs/en/sql-reference/syntax#defining-and-using-query-parameters) in the form of `{placeholder : type}`, this PR adds support for that using the existing `Placeholder` type.



Notes:
- This PR makes it possible to generate a query like `SELECT * FROM :identifier` which _is_ possible in ClickHouse but not in most other database engines. I couldn't figure out a way to cleanly disable this. Any insight / suggestions would be great
- There's no way to currently test something like `INSERT INTO table_map VALUES ({'key1':1, 'key2':10}), ({'key1':2,'key2':20}), ({'key1':3,'key2':30})` because this statement isn't parsed correctly. I can address that issue in another PR.