### PR TITLE
Fix(spark): unqualify columns in PIVOT expressions

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -192,6 +192,7 @@ class Spark2(Hive):
             exp.LogicalAnd: rename_func("BOOL_AND"),
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.Map: _map_sql,
+            exp.Pivot: transforms.preprocess([transforms.unqualify_pivot_columns]),
             exp.Reduce: rename_func("AGGREGATE"),
             exp.StrToDate: _str_to_date,
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -244,7 +244,7 @@ def remove_within_group_for_percentiles(expression: exp.Expression) -> exp.Expre
 
 def unqualify_pivot_columns(expression: exp.Expression) -> exp.Expression:
     if isinstance(expression, exp.Pivot):
-        expression.transform(
+        expression.args["field"].transform(
             lambda node: exp.column(node.output_name) if isinstance(node, exp.Column) else node,
             copy=False,
         )

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -242,6 +242,16 @@ def remove_within_group_for_percentiles(expression: exp.Expression) -> exp.Expre
     return expression
 
 
+def unqualify_pivot_columns(expression: exp.Expression) -> exp.Expression:
+    if isinstance(expression, exp.Pivot):
+        expression.transform(
+            lambda node: exp.column(node.output_name) if isinstance(node, exp.Column) else node,
+            copy=False,
+        )
+
+    return expression
+
+
 def preprocess(
     transforms: t.List[t.Callable[[exp.Expression], exp.Expression]],
 ) -> t.Callable[[Generator, exp.Expression], str]:

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -215,13 +215,13 @@ TBLPROPERTIES (
         self.validate_identity("SPLIT(str, pattern, lim)")
 
         self.validate_all(
-            "SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))",
+            "SELECT * FROM produce PIVOT(SUM(produce.sales) FOR quarter IN ('Q1', 'Q2'))",
             read={
                 "snowflake": "SELECT * FROM produce PIVOT (SUM(produce.sales) FOR produce.quarter IN ('Q1', 'Q2'))",
             },
         )
         self.validate_all(
-            "SELECT * FROM produce AS p PIVOT(SUM(sales) AS sales FOR quarter IN ('Q1' AS Q1, 'Q2' AS Q1))",
+            "SELECT * FROM produce AS p PIVOT(SUM(p.sales) AS sales FOR quarter IN ('Q1' AS Q1, 'Q2' AS Q1))",
             read={
                 "bigquery": "SELECT * FROM produce AS p PIVOT(SUM(p.sales) AS sales FOR p.quarter IN ('Q1' AS Q1, 'Q2' AS Q1))",
             },

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -215,6 +215,18 @@ TBLPROPERTIES (
         self.validate_identity("SPLIT(str, pattern, lim)")
 
         self.validate_all(
+            "SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))",
+            read={
+                "snowflake": "SELECT * FROM produce PIVOT (SUM(produce.sales) FOR produce.quarter IN ('Q1', 'Q2'))",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM produce AS p PIVOT(SUM(sales) AS sales FOR quarter IN ('Q1' AS Q1, 'Q2' AS Q1))",
+            read={
+                "bigquery": "SELECT * FROM produce AS p PIVOT(SUM(p.sales) AS sales FOR p.quarter IN ('Q1' AS Q1, 'Q2' AS Q1))",
+            },
+        )
+        self.validate_all(
             "SELECT DATEDIFF(MONTH, '2020-01-01', '2020-03-05')",
             write={
                 "databricks": "SELECT DATEDIFF(MONTH, TO_DATE('2020-01-01'), TO_DATE('2020-03-05'))",


### PR DESCRIPTION
Spark doesn't seem to allow qualified columns inside of the `PIVOT` operator's "field" arg (i.e. `FOR .. IN (...)`):

```python
spark-sql (default)> WITH x(a, b) AS (SELECT * FROM VALUES (1, 2)) SELECT * FROM x PIVOT (SUM(a) FOR b IN (2 AS col));
col
1
Time taken: 0.411 seconds, Fetched 1 row(s)
spark-sql (default)> WITH x(a, b) AS (SELECT * FROM VALUES (1, 2)) SELECT * FROM x PIVOT (SUM(x.a) FOR x.b IN (2 AS col));

[PARSE_SYNTAX_ERROR] Syntax error at or near '.'.(line 1, pos 83)

== SQL ==
WITH x(a, b) AS (SELECT * FROM VALUES (1, 2)) SELECT * FROM x PIVOT (SUM(x.a) FOR x.b IN (2 AS col))
-----------------------------------------------------------------------------------^^^

spark-sql (default)> WITH x(a, b) AS (SELECT * FROM VALUES (1, 2)) SELECT * FROM x PIVOT (SUM(x.a) FOR b IN (2 AS col));
col
1
Time taken: 0.52 seconds, Fetched 1 row(s)
```

This may be a bug in Spark.