### PR TITLE
Parse MATCH_RECOGNIZE in Presto/Trino

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -201,6 +201,7 @@ class Presto(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "START": TokenType.BEGIN,
+            "MATCH_RECOGNIZE": TokenType.MATCH_RECOGNIZE,
             "ROW": TokenType.STRUCT,
         }
 


### PR DESCRIPTION
To be able to parse MATCH_RECOGNIZE in Presto/Trino

Doc is https://trino.io/docs/current/sql/match-recognize.html
