### PR TITLE
Fix rename table expression for DuckDB

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -240,3 +240,12 @@ class DuckDB(Dialect):
             self, expression: exp.TableSample, seed_prefix: str = "SEED", sep=" AS "
         ) -> str:
             return super().tablesample_sql(expression, seed_prefix="REPEATABLE", sep=sep)
+
+        def renametable_sql(self, expression: exp.RenameTable) -> str:
+            """DuckDB only supports renaming a table in the same schema"""
+            expression = expression.copy()
+            target_table = expression.this
+            for arg in target_table.args:
+                if arg != "this":
+                    target_table.set(arg, None)
+            return super().renametable_sql(expression)

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -243,9 +243,8 @@ class DuckDB(Dialect):
 
         def renametable_sql(self, expression: exp.RenameTable) -> str:
             """DuckDB only supports renaming a table in the same schema"""
-            expression = expression.copy()
-            target_table = expression.this
-            for arg in target_table.args:
-                if arg != "this":
-                    target_table.set(arg, None)
-            return super().renametable_sql(expression)
+            return super().renametable_sql(
+                expression.transform(
+                    lambda n: exp.table_(n.this) if isinstance(n, exp.Table) else n
+                )
+            )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -481,3 +481,12 @@ class TestDuckDB(Validator):
             "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",
             write={"duckdb": "SELECT a, BOOL_OR(b) FROM table GROUP BY a"},
         )
+
+    def test_rename_table(self):
+        self.validate_all(
+            "ALTER TABLE db.t1 RENAME TO db.t2",
+            write={
+                "snowflake": "ALTER TABLE db.t1 RENAME TO db.t2",
+                "duckdb": "ALTER TABLE db.t1 RENAME TO t2",
+            },
+        )


### PR DESCRIPTION
Specifying the target table name with a schema/db causes a syntax error in DuckDB.