### PR TITLE
Allow type unions in optimizer.qualify_columns

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 import typing as t
 


### PR DESCRIPTION
Mypy was complaining about `dict | Schema` in Python 3.9 and older