### PR TITLE
Fix(clickhouse): make a new token for DateTime64

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -29,7 +29,7 @@ class ClickHouse(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "ASOF": TokenType.ASOF,
             "GLOBAL": TokenType.GLOBAL,
-            "DATETIME64": TokenType.DATETIME,
+            "DATETIME64": TokenType.DATETIME64,
             "FINAL": TokenType.FINAL,
             "FLOAT32": TokenType.FLOAT,
             "FLOAT64": TokenType.DOUBLE,
@@ -126,7 +126,7 @@ class ClickHouse(Dialect):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,  # type: ignore
             exp.DataType.Type.NULLABLE: "Nullable",
-            exp.DataType.Type.DATETIME: "DateTime64",
+            exp.DataType.Type.DATETIME64: "DateTime64",
             exp.DataType.Type.MAP: "Map",
             exp.DataType.Type.ARRAY: "Array",
             exp.DataType.Type.STRUCT: "Tuple",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3024,6 +3024,7 @@ class DataType(Expression):
         TIMESTAMPLTZ = auto()
         DATE = auto()
         DATETIME = auto()
+        DATETIME64 = auto()
         ARRAY = auto()
         MAP = auto()
         UUID = auto()
@@ -3079,6 +3080,7 @@ class DataType(Expression):
         Type.TIMESTAMPLTZ,
         Type.DATE,
         Type.DATETIME,
+        Type.DATETIME64,
     }
 
     @classmethod

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -158,6 +158,7 @@ class Parser(metaclass=_Parser):
         TokenType.TIMESTAMPTZ,
         TokenType.TIMESTAMPLTZ,
         TokenType.DATETIME,
+        TokenType.DATETIME64,
         TokenType.DATE,
         TokenType.DECIMAL,
         TokenType.BIGDECIMAL,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -110,6 +110,7 @@ class TokenType(AutoName):
     TIMESTAMPTZ = auto()
     TIMESTAMPLTZ = auto()
     DATETIME = auto()
+    DATETIME64 = auto()
     DATE = auto()
     UUID = auto()
     GEOGRAPHY = auto()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -25,6 +25,7 @@ class TestClickhouse(Validator):
         self.validate_identity("SELECT * FROM foo WHERE x GLOBAL IN (SELECT * FROM bar)")
         self.validate_identity("position(haystack, needle)")
         self.validate_identity("position(haystack, needle, position)")
+        self.validate_identity("CAST(x AS DateTime)")
         self.validate_identity(
             "CREATE TABLE test (id UInt8) ENGINE=AggregatingMergeTree() ORDER BY tuple()"
         )
@@ -44,9 +45,7 @@ class TestClickhouse(Validator):
         )
         self.validate_all(
             "CAST(1 AS Nullable(DateTime64(6, 'UTC')))",
-            write={
-                "clickhouse": "CAST(1 AS Nullable(DateTime64(6, 'UTC')))",
-            },
+            write={"clickhouse": "CAST(1 AS Nullable(DateTime64(6, 'UTC')))"},
         )
         self.validate_all(
             "SELECT x #! comment",

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -25,7 +25,7 @@ class TestClickhouse(Validator):
         self.validate_identity("SELECT * FROM foo WHERE x GLOBAL IN (SELECT * FROM bar)")
         self.validate_identity("position(haystack, needle)")
         self.validate_identity("position(haystack, needle, position)")
-        self.validate_identity("CAST(x AS DateTime)")
+        self.validate_identity("CAST(x AS DATETIME)")
         self.validate_identity(
             "CREATE TABLE test (id UInt8) ENGINE=AggregatingMergeTree() ORDER BY tuple()"
         )


### PR DESCRIPTION
Small fix: based on the [clickhouse docs](https://clickhouse.com/docs/en/sql-reference/data-types/datetime64), these two are not the same but SQLGlot currently transpiles `DateTime` to `DateTime64`:

```python
>>> import sqlglot
>>> sqlglot.transpile("cast(x as datetime)", "clickhouse")
['CAST(x AS DateTime64)']
```

> Unlike `DateTime`, `DateTime64` values are not converted from `String` automatically.