### PR TITLE
Fix(parser): make _parse_table_parts more lenient

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2210,20 +2210,22 @@ class Parser(metaclass=_Parser):
         catalog = None
         db = None
 
-        table = (
-            (not schema and self._parse_function())
-            or self._parse_id_var(any_token=False)
-            or self._parse_string_as_identifier()
-        )
+        def _parse_table_part() -> t.Optional[exp.Expression]:
+            return (
+                (not schema and self._parse_function())
+                or self._parse_id_var(any_token=False)
+                or self._parse_string_as_identifier()
+            )
 
+        table = _parse_table_part()
         while self._match(TokenType.DOT):
             if catalog:
                 # This allows nesting the table in arbitrarily many dot expressions if needed
-                table = self.expression(exp.Dot, this=table, expression=self._parse_id_var())
+                table = self.expression(exp.Dot, this=table, expression=_parse_table_part())
             else:
                 catalog = db
                 db = table
-                table = self._parse_id_var()
+                table = _parse_table_part()
 
         if not table:
             self.raise_error(f"Expected table name but got {self._curr}")

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -183,6 +183,7 @@ USE schema x.y
 NOT 1
 NOT NOT 1
 SELECT * FROM test
+SELECT * FROM db.FOO()
 SELECT *, 1 FROM test
 SELECT * FROM a.b
 SELECT * FROM a.b.c


### PR DESCRIPTION
This enables us to parse queries like the following (T-SQL UDF is used as a source):

```sql
select Dates from dbo.DateRange('M', '2019-01-01', getdate())
```