### PR TITLE
Fix(oracle): change the data type parser to allow type specifiers

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -45,7 +45,7 @@ class Redshift(Postgres):
                 isinstance(this, exp.DataType)
                 and this.this == exp.DataType.Type.VARCHAR
                 and this.expressions
-                and this.expressions[0] == exp.column("MAX")
+                and this.expressions[0].this == exp.column("MAX")
             ):
                 this.set("expressions", [exp.Var(this="MAX")])
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2985,7 +2985,7 @@ class Boolean(Condition):
     pass
 
 
-class DataTypeSizeSpecifier(Expression):
+class DataTypeSize(Expression):
     arg_types = {"this": True, "expression": False}
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2985,6 +2985,10 @@ class Boolean(Condition):
     pass
 
 
+class DataTypeSizeSpecifier(Expression):
+    arg_types = {"this": True, "expression": False}
+
+
 class DataType(Expression):
     arg_types = {
         "this": True,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -766,7 +766,7 @@ class Generator:
             return f"{self.byte_start}{this}{self.byte_end}"
         return this
 
-    def datatypesizespecifier_sql(self, expression: exp.DataTypeSizeSpecifier) -> str:
+    def datatypesize_sql(self, expression: exp.DataTypeSize) -> str:
         this = self.sql(expression, "this")
         specifier = self.sql(expression, "expression")
         specifier = f" {specifier}" if specifier else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -766,6 +766,12 @@ class Generator:
             return f"{self.byte_start}{this}{self.byte_end}"
         return this
 
+    def datatypesizespecifier_sql(self, expression: exp.DataTypeSizeSpecifier) -> str:
+        this = self.sql(expression, "this")
+        specifier = self.sql(expression, "expression")
+        specifier = f" {specifier}" if specifier else ""
+        return f"{this}{specifier}"
+
     def datatype_sql(self, expression: exp.DataType) -> str:
         type_value = expression.this
         type_sql = self.TYPE_MAPPING.get(type_value, type_value.value)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2811,6 +2811,12 @@ class Parser(metaclass=_Parser):
 
         return this
 
+    def _parse_type_size_specifier(self) -> t.Optional[exp.Expression]:
+        this = self._parse_conjunction()
+        if not this:
+            return None
+        return self.expression(exp.DataTypeSizeSpecifier, this=this, expression=self._parse_type())
+
     def _parse_types(self, check_func: bool = False) -> t.Optional[exp.Expression]:
         index = self._index
 
@@ -2835,7 +2841,7 @@ class Parser(metaclass=_Parser):
             elif nested:
                 expressions = self._parse_csv(self._parse_types)
             else:
-                expressions = self._parse_csv(self._parse_conjunction)
+                expressions = self._parse_csv(self._parse_type_size_specifier)
 
             if not expressions or not self._match(TokenType.R_PAREN):
                 self._retreat(index)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2811,11 +2811,14 @@ class Parser(metaclass=_Parser):
 
         return this
 
-    def _parse_type_size_specifier(self) -> t.Optional[exp.Expression]:
-        this = self._parse_conjunction()
+    def _parse_type_size(self) -> t.Optional[exp.Expression]:
+        this = self._parse_type()
         if not this:
             return None
-        return self.expression(exp.DataTypeSizeSpecifier, this=this, expression=self._parse_type())
+
+        return self.expression(
+            exp.DataTypeSize, this=this, expression=self._parse_var(any_token=True)
+        )
 
     def _parse_types(self, check_func: bool = False) -> t.Optional[exp.Expression]:
         index = self._index
@@ -2841,7 +2844,7 @@ class Parser(metaclass=_Parser):
             elif nested:
                 expressions = self._parse_csv(self._parse_types)
             else:
-                expressions = self._parse_csv(self._parse_type_size_specifier)
+                expressions = self._parse_csv(self._parse_type_size)
 
             if not expressions or not self._match(TokenType.R_PAREN):
                 self._retreat(index)

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -7,6 +7,8 @@ class TestOracle(Validator):
     def test_oracle(self):
         self.validate_identity("SELECT STANDARD_HASH('hello')")
         self.validate_identity("SELECT STANDARD_HASH('hello', 'MD5')")
+        self.validate_identity("SELECT CAST(NULL AS VARCHAR2(2328 CHAR)) AS COL1")
+        self.validate_identity("SELECT CAST(NULL AS VARCHAR2(2328 BYTE)) AS COL1")
         self.validate_identity("SELECT * FROM table_name@dblink_name.database_link_domain")
         self.validate_identity("SELECT * FROM table_name SAMPLE (25) s")
         self.validate_identity("SELECT * FROM V$SESSION")

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -405,7 +405,7 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         self.assertEqual(expression.type.this, exp.DataType.Type.TIMESTAMPTZ)
         self.assertEqual(expression.this.type.this, exp.DataType.Type.VARCHAR)
         self.assertEqual(expression.args["to"].type.this, exp.DataType.Type.TIMESTAMPTZ)
-        self.assertEqual(expression.args["to"].expressions[0].type.this, exp.DataType.Type.INT)
+        self.assertEqual(expression.args["to"].expressions[0].this.type.this, exp.DataType.Type.INT)
 
         expression = annotate_types(parse_one("ARRAY(1)::ARRAY<INT>"))
         self.assertEqual(expression.type, parse_one("ARRAY<INT>", into=exp.DataType))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -292,6 +292,7 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(parse_one("TIMESTAMP('2022-01-01')"), exp.Func)
         self.assertIsInstance(parse_one("TIMESTAMP()"), exp.Func)
         self.assertIsInstance(parse_one("map.x"), exp.Column)
+        self.assertIsInstance(parse_one("CAST(x AS CHAR(5))").to.expressions[0], exp.DataTypeSize)
 
     def test_set_expression(self):
         set_ = parse_one("SET")


### PR DESCRIPTION
Fixes #1587 

If we end up merging this, it will be a breaking change because the AST for data types like `VARCHAR(MAX)` will change.