### PR TITLE
Fix(clickhouse): move GROUP BY, SET under TTL parser, improve generator

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -156,6 +156,7 @@ class ClickHouse(Dialect):
             exp.Map: lambda self, e: _lower_func(var_map_sql(self, e)),
             exp.Quantile: lambda self, e: f"quantile{self._param_args_sql(e, 'quantile', 'this')}",
             exp.Quantiles: lambda self, e: f"quantiles{self._param_args_sql(e, 'parameters', 'expressions')}",
+            exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
             exp.QuantileIf: lambda self, e: f"quantileIf{self._param_args_sql(e, 'parameters', 'expressions')}",
             exp.RegexpLike: lambda self, e: f"match({self.format_args(e.this, e.expression)})",
             exp.StrPosition: lambda self, e: f"position({self.format_args(e.this, e.args.get('substr'), e.args.get('position'))})",
@@ -165,6 +166,7 @@ class ClickHouse(Dialect):
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
+            exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
         }
 
         JOIN_HINTS = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1116,7 +1116,8 @@ class Comment(Expression):
     arg_types = {"this": True, "kind": True, "expression": True, "exists": False}
 
 
-class TTLAction(Expression):
+# https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#mergetree-table-ttl
+class MergeTreeTTLAction(Expression):
     arg_types = {
         "this": True,
         "delete": False,
@@ -1126,7 +1127,8 @@ class TTLAction(Expression):
     }
 
 
-class TTL(Expression):
+# https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#mergetree-table-ttl
+class MergeTreeTTL(Expression):
     arg_types = {
         "expressions": True,
         "where": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1116,8 +1116,23 @@ class Comment(Expression):
     arg_types = {"this": True, "kind": True, "expression": True, "exists": False}
 
 
+class TTLAction(Expression):
+    arg_types = {
+        "this": True,
+        "delete": False,
+        "recompress": False,
+        "to_disk": False,
+        "to_volume": False,
+    }
+
+
 class TTL(Expression):
-    pass
+    arg_types = {
+        "expressions": True,
+        "where": False,
+        "group": False,
+        "aggregates": False,
+    }
 
 
 class ColumnConstraint(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -216,7 +216,7 @@ class Generator:
         exp.TableFormatProperty: exp.Properties.Location.POST_WITH,
         exp.TemporaryProperty: exp.Properties.Location.POST_CREATE,
         exp.TransientProperty: exp.Properties.Location.POST_CREATE,
-        exp.TTL: exp.Properties.Location.POST_SCHEMA,
+        exp.MergeTreeTTL: exp.Properties.Location.POST_SCHEMA,
         exp.VolatileProperty: exp.Properties.Location.POST_CREATE,
         exp.WithDataProperty: exp.Properties.Location.POST_EXPRESSION,
         exp.WithJournalTableProperty: exp.Properties.Location.POST_NAME,
@@ -1917,7 +1917,7 @@ class Generator:
         expression_sql = self.sql(expression, "expression")
         return f"COMMENT{exists_sql}ON {kind} {this} IS {expression_sql}"
 
-    def ttlaction_sql(self, expression: exp.TTLAction) -> str:
+    def mergetreettlaction_sql(self, expression: exp.MergeTreeTTLAction) -> str:
         this = self.sql(expression, "this")
         delete = " DELETE" if expression.args.get("delete") else ""
         recompress = self.sql(expression, "recompress")
@@ -1928,7 +1928,7 @@ class Generator:
         to_volume = f" TO VOLUME {to_volume}" if to_volume else ""
         return f"{this}{delete}{recompress}{to_disk}{to_volume}"
 
-    def ttl_sql(self, expression: exp.TTL) -> str:
+    def mergetreettl_sql(self, expression: exp.MergeTreeTTL) -> str:
         where = self.sql(expression, "where")
         group = self.sql(expression, "group")
         aggregates = self.expressions(expression, key="aggregates")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -79,7 +79,7 @@ class Generator:
         exp.OnCommitProperty: lambda self, e: "ON COMMIT PRESERVE ROWS",
         exp.ReturnsProperty: lambda self, e: self.naked_property(e),
         exp.SetProperty: lambda self, e: f"{'MULTI' if e.args.get('multi') else ''}SET",
-        exp.SettingsProperty: lambda self, e: f"SETTINGS {self.expressions(e)}",
+        exp.SettingsProperty: lambda self, e: f"SETTINGS{self.seg('')}{(self.expressions(e))}",
         exp.SqlSecurityProperty: lambda self, e: f"SQL SECURITY {'DEFINER' if e.args.get('definer') else 'INVOKER'}",
         exp.TemporaryProperty: lambda self, e: f"{'GLOBAL ' if e.args.get('global_') else ''}TEMPORARY",
         exp.TransientProperty: lambda self, e: "TRANSIENT",
@@ -186,7 +186,6 @@ class Generator:
         exp.FallbackProperty: exp.Properties.Location.POST_NAME,
         exp.FileFormatProperty: exp.Properties.Location.POST_WITH,
         exp.FreespaceProperty: exp.Properties.Location.POST_NAME,
-        exp.Group: exp.Properties.Location.POST_SCHEMA,
         exp.IsolatedLoadingProperty: exp.Properties.Location.POST_NAME,
         exp.JournalProperty: exp.Properties.Location.POST_NAME,
         exp.LanguageProperty: exp.Properties.Location.POST_SCHEMA,
@@ -1918,8 +1917,27 @@ class Generator:
         expression_sql = self.sql(expression, "expression")
         return f"COMMENT{exists_sql}ON {kind} {this} IS {expression_sql}"
 
+    def ttlaction_sql(self, expression: exp.TTLAction) -> str:
+        this = self.sql(expression, "this")
+        delete = " DELETE" if expression.args.get("delete") else ""
+        recompress = self.sql(expression, "recompress")
+        recompress = f" RECOMPRESS {recompress}" if recompress else ""
+        to_disk = self.sql(expression, "to_disk")
+        to_disk = f" TO DISK {to_disk}" if to_disk else ""
+        to_volume = self.sql(expression, "to_volume")
+        to_volume = f" TO VOLUME {to_volume}" if to_volume else ""
+        return f"{this}{delete}{recompress}{to_disk}{to_volume}"
+
     def ttl_sql(self, expression: exp.TTL) -> str:
-        return f"TTL {self.sql(expression, 'this')}"
+        where = self.sql(expression, "where")
+        group = self.sql(expression, "group")
+        aggregates = self.expressions(expression, key="aggregates")
+        aggregates = self.seg("SET") + self.seg(aggregates) if aggregates else ""
+
+        if not (where or group or aggregates) and len(expression.expressions) == 1:
+            return f"TTL {self.expressions(expression, flat=True)}"
+
+        return f"TTL{self.seg(self.expressions(expression))}{where}{group}{aggregates}"
 
     def transaction_sql(self, expression: exp.Transaction) -> str:
         return "BEGIN"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1054,7 +1054,7 @@ class Parser(metaclass=_Parser):
 
     # https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#mergetree-table-ttl
     def _parse_ttl(self) -> exp.Expression:
-        def _parse_delete_recompress() -> t.Optional[exp.Expression]:
+        def _parse_ttl_action() -> t.Optional[exp.Expression]:
             this = self._parse_bitwise()
 
             if self._match_text_seq("DELETE"):
@@ -1068,7 +1068,7 @@ class Parser(metaclass=_Parser):
 
             return this
 
-        expressions = self._parse_csv(_parse_delete_recompress)
+        expressions = self._parse_csv(_parse_ttl_action)
         where = self._parse_where()
         group = self._parse_group()
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -687,7 +687,7 @@ class Parser(metaclass=_Parser):
         "TITLE": lambda self: self.expression(
             exp.TitleColumnConstraint, this=self._parse_var_or_string()
         ),
-        "TTL": lambda self: self.expression(exp.TTL, expressions=[self._parse_bitwise()]),
+        "TTL": lambda self: self.expression(exp.MergeTreeTTL, expressions=[self._parse_bitwise()]),
         "UNIQUE": lambda self: self._parse_unique(),
         "UPPERCASE": lambda self: self.expression(exp.UppercaseColumnConstraint),
     }
@@ -1058,13 +1058,19 @@ class Parser(metaclass=_Parser):
             this = self._parse_bitwise()
 
             if self._match_text_seq("DELETE"):
-                return self.expression(exp.TTLAction, this=this, delete=True)
+                return self.expression(exp.MergeTreeTTLAction, this=this, delete=True)
             if self._match_text_seq("RECOMPRESS"):
-                return self.expression(exp.TTLAction, this=this, recompress=self._parse_bitwise())
+                return self.expression(
+                    exp.MergeTreeTTLAction, this=this, recompress=self._parse_bitwise()
+                )
             if self._match_text_seq("TO", "DISK"):
-                return self.expression(exp.TTLAction, this=this, to_disk=self._parse_string())
+                return self.expression(
+                    exp.MergeTreeTTLAction, this=this, to_disk=self._parse_string()
+                )
             if self._match_text_seq("TO", "VOLUME"):
-                return self.expression(exp.TTLAction, this=this, to_volume=self._parse_string())
+                return self.expression(
+                    exp.MergeTreeTTLAction, this=this, to_volume=self._parse_string()
+                )
 
             return this
 
@@ -1077,7 +1083,7 @@ class Parser(metaclass=_Parser):
             aggregates = self._parse_csv(self._parse_set_item)
 
         return self.expression(
-            exp.TTL,
+            exp.MergeTreeTTL,
             expressions=expressions,
             where=where,
             group=group,


### PR DESCRIPTION
Addresses https://github.com/tobymao/sqlglot/pull/1593#issuecomment-1544487194 and improves parsing according to:

```
TTL expr
    [DELETE|RECOMPRESS codec_name1|TO DISK 'xxx'|TO VOLUME 'xxx'][, DELETE|RECOMPRESS codec_name2|TO DISK 'aaa'|TO VOLUME 'bbb'] ...
    [WHERE conditions]
    [GROUP BY key_expr [SET v1 = aggr_func(v1) [, v2 = aggr_func(v2) ...]] ]
```

All examples using TTL from Clickhouse's documentation page are now parseable / pretty-printable even!

Reference: https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#mergetree-table-ttl