### PR TITLE
Fix rename table expression for BigQuery

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -333,3 +333,11 @@ class BigQuery(Dialect):
 
         def with_properties(self, properties: exp.Properties) -> str:
             return self.properties(properties, prefix=self.seg("OPTIONS"))
+
+        def renametable_sql(self, expression: exp.RenameTable) -> str:
+            """BigQuery only supports renaming a table in the same schema"""
+            return super().renametable_sql(
+                expression.transform(
+                    lambda n: exp.table_(n.this) if isinstance(n, exp.Table) else n
+                )
+            )

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -470,3 +470,12 @@ class TestBigQuery(Validator):
                 "snowflake": "MERGE INTO dataset.Inventory AS T USING dataset.NewArrivals AS S ON FALSE WHEN NOT MATCHED AND product LIKE '%a%' THEN DELETE WHEN NOT MATCHED AND product LIKE '%b%' THEN DELETE",
             },
         )
+
+    def test_rename_table(self):
+        self.validate_all(
+            "ALTER TABLE db.t1 RENAME TO db.t2",
+            write={
+                "snowflake": "ALTER TABLE db.t1 RENAME TO db.t2",
+                "bigquery": "ALTER TABLE db.t1 RENAME TO t2",
+            },
+        )


### PR DESCRIPTION
```sql
ALTER TABLE mydataset.mytable
RENAME TO mydataset.mynewtable;
```
causes the following error in BigQuery:
`name "mydataset.mynewtable" cannot contain dot.`