### PR TITLE
Fix(snowflake): Handle form of CONVERT_TIMEZONE with a source TZ

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -17,7 +17,7 @@ from sqlglot.dialects.dialect import (
     ts_or_ds_to_date_sql,
     var_map_sql,
 )
-from sqlglot.expressions import Literal, maybe_parse
+from sqlglot.expressions import Literal
 from sqlglot.helper import flatten, seq_get
 from sqlglot.parser import binary_range_parser
 from sqlglot.tokens import TokenType
@@ -145,10 +145,8 @@ def _datatype_sql(self: generator.Generator, expression: exp.DataType) -> str:
 
 def _parse_convert_timezone(args: t.Sequence) -> exp.Expression:
     if len(args) == 3:
-        converted: t.List[exp.Expression] = [maybe_parse(arg, dialect=Snowflake) for arg in args]
-        return exp.Anonymous(this="CONVERT_TIMEZONE", expressions=converted)
-    else:
-        return exp.AtTimeZone(this=seq_get(args, 1), zone=seq_get(args, 0))
+        return exp.Anonymous(this="CONVERT_TIMEZONE", expressions=args)
+    return exp.AtTimeZone(this=seq_get(args, 1), zone=seq_get(args, 0))
 
 
 class Snowflake(Dialect):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -25,6 +25,7 @@ class TestSnowflake(Validator):
             'COPY INTO NEW_TABLE ("foo", "bar") FROM (SELECT $1, $2, $3, $4 FROM @%old_table)'
         )
         self.validate_identity("COMMENT IF EXISTS ON TABLE foo IS 'bar'")
+        self.validate_identity("SELECT CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', col)")
 
         self.validate_all(
             "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",


### PR DESCRIPTION
Snowflake's [CONVERT_TIMEZONE](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone) has two forms:

```sql
CONVERT_TIMEZONE( <target_tz> , <source_timestamp> )
-- and
CONVERT_TIMEZONE( <source_tz> , <target_tz> , <source_timestamp_ntz> )
```

The second is required if the timestamp doesn't have timezone information. Currently, parsing
```sql
CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', tzcolumn)
```
produces
```sql
CONVERT_TIMEZONE('UTC', 'America/Los_Angeles')
```
when re-rendered, which is invalid. This PR still treats the target-only case as `exp.AtTimeZone`, but parses the source-and-target case as `exp.Anonymous` so that rendering back to Snowflake will be correct.