### PR TITLE
Fix(clickhouse): join type/kind ordering issues

### DIFF
--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -76,6 +76,28 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "SELECT * FROM x LIMIT 10 SETTINGS max_results = 100, result_ FORMAT PrettyCompact"
         )
+        self.validate_all(
+            "SELECT * FROM foo ANY LEFT JOIN bla ON foo.c1 = bla.c2",
+            write={"clickhouse": "SELECT * FROM foo LEFT ANY JOIN bla ON foo.c1 = bla.c2"},
+        )
+        self.validate_all(
+            "SELECT * FROM foo GLOBAL ANY LEFT JOIN bla ON foo.c1 = bla.c2",
+            write={"clickhouse": "SELECT * FROM foo GLOBAL LEFT ANY JOIN bla ON foo.c1 = bla.c2"},
+        )
+        self.validate_all(
+            """
+            SELECT
+                loyalty,
+                count()
+            FROM hits SEMI LEFT JOIN users USING (UserID)
+            GROUP BY loyalty
+            ORDER BY loyalty ASC
+            """,
+            write={
+                "clickhouse": "SELECT loyalty, COUNT() FROM hits LEFT SEMI JOIN users USING (UserID)"
+                + " GROUP BY loyalty ORDER BY loyalty"
+            },
+        )
 
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")


### PR DESCRIPTION
CH can parse both `LEFT ANY JOIN` and `ANY LEFT JOIN` successfully 
But the canonical order (by the docs) is `LEFT ANY JOIN` 
This PR parses "inverted" order and produces a canonical one

Notes:
- CH uses `ASOF`, `SEMI`, `ANTI`, `ANY` as reserved words. Can be tested by doing something like: 
`FROM t semi SEMI LEFT JOIN` - fails
`FROM t "semi" SEMI LEFT JOIN` - passes
That's why I have removed them from `TABLE_ALIAS_TOKENS`
