### PR TITLE
Fix(clickhouse): `USING`, `[PRIMARY|FOREIGN] KEY` allows unwrapped col list

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -195,6 +195,11 @@ class ClickHouse(Dialect):
                 return self.expression(exp.Quantile, this=params[0], quantile=this)
             return self.expression(exp.Quantile, this=this, quantile=exp.Literal.number(0.5))
 
+        def _parse_wrapped_id_vars(
+            self, optional: bool = False
+        ) -> t.List[t.Optional[exp.Expression]]:
+            return super()._parse_wrapped_id_vars(optional=True)
+
     class Generator(generator.Generator):
         STRUCT_DELIMITER = ("(", ")")
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4070,18 +4070,23 @@ class Parser(metaclass=_Parser):
 
         return this
 
-    def _parse_wrapped_id_vars(self) -> t.List[t.Optional[exp.Expression]]:
-        return self._parse_wrapped_csv(self._parse_id_var)
+    def _parse_wrapped_id_vars(self, optional: bool = False) -> t.List[t.Optional[exp.Expression]]:
+        return self._parse_wrapped_csv(self._parse_id_var, optional=optional)
 
     def _parse_wrapped_csv(
-        self, parse_method: t.Callable, sep: TokenType = TokenType.COMMA
+        self, parse_method: t.Callable, sep: TokenType = TokenType.COMMA, optional: bool = False
     ) -> t.List[t.Optional[exp.Expression]]:
-        return self._parse_wrapped(lambda: self._parse_csv(parse_method, sep=sep))
+        return self._parse_wrapped(
+            lambda: self._parse_csv(parse_method, sep=sep), optional=optional
+        )
 
-    def _parse_wrapped(self, parse_method: t.Callable) -> t.Any:
-        self._match_l_paren()
+    def _parse_wrapped(self, parse_method: t.Callable, optional: bool = False) -> t.Any:
+        wrapped = self._match(TokenType.L_PAREN)
+        if not wrapped and not optional:
+            self.raise_error("Expecting (")
         parse_result = parse_method()
-        self._match_r_paren()
+        if wrapped:
+            self._match_r_paren()
         return parse_result
 
     def _parse_select_or_expression(self) -> t.Optional[exp.Expression]:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -76,6 +76,10 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "SELECT * FROM x LIMIT 10 SETTINGS max_results = 100, result_ FORMAT PrettyCompact"
         )
+        self.validate_all(
+            "SELECT * FROM foo JOIN bar USING id, name",
+            write={"clickhouse": "SELECT * FROM foo JOIN bar USING (id, name)"},
+        )
 
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")


### PR DESCRIPTION
I.e. both `USING a, b, c` and `USING (a, b, c)` are allowed 
Although the wrapped variant is a canonical one (see docs)
https://clickhouse.com/docs/en/sql-reference/statements/select/join#examples

Unwrapped columns and expression lists are allowed in other places too. Will update later.