### PR TITLE
Feat(optimizer): optimize pivots

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -275,7 +275,7 @@ def no_tablesample_sql(self: Generator, expression: exp.TableSample) -> str:
 
 def no_pivot_sql(self: Generator, expression: exp.Pivot) -> str:
     self.unsupported("PIVOT unsupported")
-    return self.sql(expression)
+    return ""
 
 
 def no_trycast_sql(self: Generator, expression: exp.TryCast) -> str:

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -183,7 +183,7 @@ class Snowflake(Dialect):
     }
 
     class Parser(parser.Parser):
-        QUOTED_PIVOT_COLUMNS = True
+        IDENTIFY_PIVOT_STRINGS = True
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -53,7 +53,7 @@ def _unix_to_time_sql(self: Hive.Generator, expression: exp.UnixToTime) -> str:
     raise ValueError("Improper scale for timestamp")
 
 
-def _unalias_pivots(expression: exp.Expression) -> exp.Expression:
+def _unalias_pivot(expression: exp.Expression) -> exp.Expression:
     """
     Spark doesn't allow PIVOT aliases, so we need to remove them and possibly wrap a
     pivoted source in a subquery with the same alias to preserve the query's semantics.
@@ -61,7 +61,7 @@ def _unalias_pivots(expression: exp.Expression) -> exp.Expression:
     Example:
         >>> from sqlglot import parse_one
         >>> expr = parse_one("SELECT piv.x FROM tbl PIVOT (SUM(a) FOR b IN ('x')) piv")
-        >>> print(_unalias_pivots(expr).sql(dialect="spark"))
+        >>> print(_unalias_pivot(expr).sql(dialect="spark"))
         SELECT piv.x FROM (SELECT * FROM tbl PIVOT(SUM(a) FOR b IN ('x'))) AS piv
     """
     if isinstance(expression, exp.From) and expression.this.args.get("pivots"):
@@ -234,7 +234,7 @@ class Spark2(Hive):
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
             exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.FileFormatProperty: lambda self, e: f"USING {e.name.upper()}",
-            exp.From: transforms.preprocess([_unalias_pivots]),
+            exp.From: transforms.preprocess([_unalias_pivot]),
             exp.Hint: lambda self, e: f" /*+ {self.expressions(e).strip()} */",
             exp.LogicalAnd: rename_func("BOOL_AND"),
             exp.LogicalOr: rename_func("BOOL_OR"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2953,7 +2953,6 @@ class Tag(Expression):
 
 class Pivot(Expression):
     arg_types = {
-        "this": False,
         "alias": False,
         "expressions": True,
         "field": True,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2026,10 +2026,10 @@ class Subqueryable(Unionable):
             Alias: the subquery
         """
         instance = _maybe_copy(self, copy)
-        return Subquery(
-            this=instance,
-            alias=TableAlias(this=to_identifier(alias)) if alias else None,
-        )
+        if not isinstance(alias, Expression):
+            alias = TableAlias(this=to_identifier(alias)) if alias else None
+
+        return Subquery(this=instance, alias=alias)
 
     def limit(self, expression, dialect=None, copy=True, **opts) -> Select:
         raise NotImplementedError

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1158,9 +1158,10 @@ class Generator:
 
         alias = self.sql(expression, "alias")
         alias = f"{sep}{alias}" if alias else ""
-        hints = self.expressions(expression, key="hints", sep=", ", flat=True)
+        hints = self.expressions(expression, key="hints", flat=True)
         hints = f" WITH ({hints})" if hints and self.TABLE_HINTS else ""
-        pivots = self.expressions(expression, key="pivots", sep="")
+        pivots = self.expressions(expression, key="pivots", sep=" ", flat=True)
+        pivots = f" {pivots}" if pivots else ""
         joins = self.expressions(expression, key="joins", sep="")
         laterals = self.expressions(expression, key="laterals", sep="")
         system_time = expression.args.get("system_time")
@@ -1197,14 +1198,13 @@ class Generator:
         return f"{this} {kind} {method}({bucket}{percent}{rows}{size}){seed}{alias}"
 
     def pivot_sql(self, expression: exp.Pivot) -> str:
-        this = self.sql(expression, "this")
         alias = self.sql(expression, "alias")
         alias = f" AS {alias}" if alias else ""
         unpivot = expression.args.get("unpivot")
         direction = "UNPIVOT" if unpivot else "PIVOT"
-        expressions = self.expressions(expression, key="expressions")
+        expressions = self.expressions(expression, flat=True)
         field = self.sql(expression, "field")
-        return f"{this} {direction}({expressions} FOR {field}){alias}"
+        return f"{direction}({expressions} FOR {field}){alias}"
 
     def tuple_sql(self, expression: exp.Tuple) -> str:
         return f"({self.expressions(expression, flat=True)})"
@@ -1562,13 +1562,10 @@ class Generator:
         alias = self.sql(expression, "alias")
         alias = f"{sep}{alias}" if alias else ""
 
-        sql = self.query_modifiers(
-            expression,
-            self.wrap(expression),
-            alias,
-            self.expressions(expression, key="pivots", sep=" "),
-        )
+        pivots = self.expressions(expression, key="pivots", sep=" ", flat=True)
+        pivots = f" {pivots}" if pivots else ""
 
+        sql = self.query_modifiers(expression, self.wrap(expression), alias, pivots)
         return self.prepend_ctes(expression, sql)
 
     def qualify_sql(self, expression: exp.Qualify) -> str:

--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -133,6 +133,10 @@ def _eliminate_union(scope, existing_ctes, taken):
 
 
 def _eliminate_derived_table(scope, existing_ctes, taken):
+    # This ensures we don't drop the "pivot" arg from a pivoted subquery
+    if scope.parent.pivots:
+        return None
+
     parent = scope.expression.parent
     name, cte = _new_cte(scope, existing_ctes, taken)
 

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -167,6 +167,7 @@ def _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join):
         and isinstance(inner_select, exp.Select)
         and not any(inner_select.args.get(arg) for arg in UNMERGABLE_ARGS)
         and inner_select.args.get("from")
+        and not outer_scope.pivots
         and not any(e.find(exp.AggFunc, exp.Select) for e in inner_select.expressions)
         and not (leave_tables_isolated and len(outer_scope.selected_sources) > 1)
         and not (

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -79,6 +79,7 @@ def optimize(
     schema = ensure_schema(schema or sqlglot.schema, dialect=dialect)
     possible_kwargs = {"db": db, "catalog": catalog, "schema": schema, **kwargs}
     expression = exp.maybe_parse(expression, dialect=dialect, copy=True)
+
     for rule in rules:
         # Find any additional rule parameters, beyond `expression`
         rule_params = rule.__code__.co_varnames
@@ -86,4 +87,5 @@ def optimize(
             param: possible_kwargs[param] for param in rule_params if param in possible_kwargs
         }
         expression = rule(expression, **rule_kwargs)
+
     return expression

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -39,8 +39,9 @@ def pushdown_projections(expression, schema=None, remove_unused_selections=True)
     for scope in reversed(traverse_scope(expression)):
         parent_selections = referenced_columns.get(scope, {SELECT_ALL})
 
-        if scope.expression.args.get("distinct"):
-            # We can't remove columns SELECT DISTINCT nor UNION DISTINCT
+        if scope.expression.args.get("distinct") or scope.parent and scope.parent.pivots:
+            # We can't remove columns SELECT DISTINCT nor UNION DISTINCT. The same holds if
+            # we select from a pivoted source in the parent scope.
             parent_selections = {SELECT_ALL}
 
         if isinstance(scope.expression, exp.Union):

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -6,7 +6,6 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.errors import OptimizeError
 from sqlglot.helper import seq_get
-from sqlglot.optimizer.expand_laterals import expand_laterals as _expand_laterals
 from sqlglot.optimizer.scope import Scope, traverse_scope, walk_in_scope
 from sqlglot.schema import Schema, ensure_schema
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -302,7 +302,6 @@ def _expand_stars(scope, resolver, using_column_tables):
 
     has_pivoted_source = pivot and not pivot.args.get("unpivot")
     if has_pivoted_source:
-        # We're using a dictionary here in order to preserve order
         pivot_columns = set(col.output_name for col in pivot.find_all(exp.Column))
 
         pivot_output_columns = [col.output_name for col in pivot.args.get("columns", [])]

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -253,7 +253,7 @@ def _qualify_columns(scope, resolver):
             if scope.pivots and not column.find_ancestor(exp.Pivot):
                 # If the column is under the Pivot expression, we need to qualify it
                 # using the name of the pivoted source instead of the pivot's alias
-                column.set("table", scope.pivots[0].args["alias"])
+                column.set("table", exp.to_identifier(scope.pivots[0].alias))
                 continue
 
             column_table = resolver.get_table(column_name)

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -5,6 +5,8 @@ import typing as t
 
 from sqlglot import alias, exp
 from sqlglot.errors import OptimizeError
+from sqlglot.helper import seq_get
+from sqlglot.optimizer.expand_laterals import expand_laterals as _expand_laterals
 from sqlglot.optimizer.scope import Scope, traverse_scope, walk_in_scope
 from sqlglot.schema import Schema, ensure_schema
 
@@ -65,7 +67,7 @@ def validate_qualify_columns(expression):
     for scope in traverse_scope(expression):
         if isinstance(scope.expression, exp.Select):
             unqualified_columns.extend(scope.unqualified_columns)
-            if scope.external_columns and not scope.is_correlated_subquery:
+            if scope.external_columns and not scope.is_correlated_subquery and not scope.pivots:
                 column = scope.external_columns[0]
                 raise OptimizeError(
                     f"""Column '{column}' could not be resolved{f" for table: '{column.table}'" if column.table else ''}"""
@@ -249,6 +251,12 @@ def _qualify_columns(scope, resolver):
                 raise OptimizeError(f"Unknown column: {column_name}")
 
         if not column_table:
+            if scope.pivots and not column.find_ancestor(exp.Pivot):
+                # If the column is under the Pivot expression, we need to qualify it
+                # using the name of the pivoted source instead of the pivot's alias
+                column.set("table", scope.pivots[0].args["alias"])
+                continue
+
             column_table = resolver.get_table(column_name)
 
             # column_table can be a '' because bigquery unnest has no table alias
@@ -272,6 +280,13 @@ def _qualify_columns(scope, resolver):
             if column_table:
                 column.replace(exp.Dot.build([exp.column(root, table=column_table), *parts]))
 
+    for pivot in scope.pivots:
+        for column in pivot.find_all(exp.Column):
+            if not column.table and column.name in resolver.all_columns:
+                column_table = resolver.get_table(column.name)
+                if column_table:
+                    column.set("table", column_table)
+
 
 def _expand_stars(scope, resolver, using_column_tables):
     """Expand stars to lists of column selections"""
@@ -280,6 +295,9 @@ def _expand_stars(scope, resolver, using_column_tables):
     except_columns = {}
     replace_columns = {}
     coalesced_columns = set()
+
+    # TODO: handle optimization of multiple PIVOTs (and possibly UNPIVOTs) in the future
+    pivot = seq_get(scope.pivots, 0)
 
     for expression in scope.selects:
         if isinstance(expression, exp.Star):
@@ -297,9 +315,14 @@ def _expand_stars(scope, resolver, using_column_tables):
         for table in tables:
             if table not in scope.sources:
                 raise OptimizeError(f"Unknown table: {table}")
+
             columns = resolver.get_source_columns(table, only_visible=True)
 
             if columns and "*" not in columns:
+                if pivot and not pivot.args.get("unpivot"):
+                    _add_pivot_columns(pivot, columns, new_selections)
+                    continue
+
                 table_id = id(table)
                 for name in columns:
                     if name in using_column_tables and table in using_column_tables[name]:
@@ -319,12 +342,13 @@ def _expand_stars(scope, resolver, using_column_tables):
                         )
                     elif name not in except_columns.get(table_id, set()):
                         alias_ = replace_columns.get(table_id, {}).get(name, name)
-                        column = exp.column(name, table)
+                        column = exp.column(name, table=table)
                         new_selections.append(
                             alias(column, alias_, copy=False) if alias_ != name else column
                         )
             else:
                 return
+
     scope.expression.set("expressions", new_selections)
 
 
@@ -350,6 +374,22 @@ def _add_replace_columns(expression, tables, replace_columns):
 
     for table in tables:
         replace_columns[id(table)] = columns
+
+
+def _add_pivot_columns(pivot, source_columns, columns):
+    pivot_output_columns = [col.output_name for col in pivot.args.get("columns", [])]
+    if not pivot_output_columns:
+        pivot_output_columns = [col.alias_or_name for col in pivot.expressions]
+
+    pivot_columns = set(column.output_name for column in pivot.find_all(exp.Column))
+    implicit_columns = list(set(source_columns) - pivot_columns)
+
+    columns.extend(
+        [
+            exp.alias_(exp.column(name, table=pivot.alias), name)
+            for name in implicit_columns + pivot_output_columns
+        ]
+    )
 
 
 def _qualify_outputs(scope):

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -302,7 +302,8 @@ def _expand_stars(scope, resolver, using_column_tables):
 
     has_pivoted_source = pivot and not pivot.args.get("unpivot")
     if has_pivoted_source:
-        pivot_columns = set(column.output_name for column in pivot.find_all(exp.Column))
+        # We're using a dictionary here in order to preserve order
+        pivot_columns = set(col.output_name for col in pivot.find_all(exp.Column))
 
         pivot_output_columns = [col.output_name for col in pivot.args.get("columns", [])]
         if not pivot_output_columns:
@@ -329,12 +330,10 @@ def _expand_stars(scope, resolver, using_column_tables):
 
             if columns and "*" not in columns:
                 if has_pivoted_source:
-                    implicit_columns = list(set(columns) - pivot_columns)
+                    implicit_columns = [col for col in columns if col not in pivot_columns]
                     new_selections.extend(
-                        [
-                            exp.alias_(exp.column(name, table=pivot.alias), name, copy=False)
-                            for name in implicit_columns + pivot_output_columns
-                        ]
+                        exp.alias_(exp.column(name, table=pivot.alias), name, copy=False)
+                        for name in implicit_columns + pivot_output_columns
                     )
                     continue
 

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -48,14 +48,11 @@ def qualify_tables(expression, db=None, catalog=None, schema=None):
                 derived_table.set("alias", exp.TableAlias(this=exp.to_identifier(alias_)))
                 scope.rename_source(None, alias_)
 
-            # TODO: handle optimization of multiple PIVOTs (and possibly UNPIVOTs) in the future
             pivots = derived_table.args.get("pivots")
-            if pivots:
-                pivot = pivots[0]
-                if not pivot.alias:
-                    pivot.set(
-                        "alias", exp.TableAlias(this=exp.to_identifier(f"_q_{next(sequence)}"))
-                    )
+            if pivots and not pivots[0].alias:
+                pivots[0].set(
+                    "alias", exp.TableAlias(this=exp.to_identifier(f"_q_{next(sequence)}"))
+                )
 
         for name, source in scope.sources.items():
             if isinstance(source, exp.Table):

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -44,15 +44,13 @@ def qualify_tables(expression, db=None, catalog=None, schema=None):
                     derived_table.this.replace(exp.select("*").from_(unnested.copy(), copy=False))
 
             if not derived_table.args.get("alias"):
-                alias_ = f"_q_{next(sequence)}"
+                alias_ = next_name()
                 derived_table.set("alias", exp.TableAlias(this=exp.to_identifier(alias_)))
                 scope.rename_source(None, alias_)
 
             pivots = derived_table.args.get("pivots")
             if pivots and not pivots[0].alias:
-                pivots[0].set(
-                    "alias", exp.TableAlias(this=exp.to_identifier(f"_q_{next(sequence)}"))
-                )
+                pivots[0].set("alias", exp.TableAlias(this=exp.to_identifier(next_name())))
 
         for name, source in scope.sources.items():
             if isinstance(source, exp.Table):
@@ -74,7 +72,7 @@ def qualify_tables(expression, db=None, catalog=None, schema=None):
 
                 pivots = source.args.get("pivots")
                 if pivots and not pivots[0].alias:
-                    pivots[0].set("alias", exp.to_identifier(next_name()))
+                    pivots[0].set("alias", exp.TableAlias(this=exp.to_identifier(next_name())))
 
                 if schema and isinstance(source.this, exp.ReadCSV):
                     with csv_reader(source.this) as reader:

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -64,7 +64,7 @@ def qualify_tables(expression, db=None, catalog=None, schema=None):
                     source = source.replace(
                         alias(
                             source,
-                            name if name else next_name(),
+                            name or source.name or next_name(),
                             copy=True,
                             table=True,
                         )

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -379,7 +379,7 @@ class Scope:
             self._pivots = [
                 pivot
                 for node in self.tables + self.derived_tables
-                for pivot in node.args.get("pivots", [])
+                for pivot in node.args.get("pivots") or []
             ]
 
         return self._pivots

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -83,6 +83,7 @@ class Scope:
         self._columns = None
         self._external_columns = None
         self._join_hints = None
+        self._pivots = None
 
     def branch(self, expression, scope_type, chain_sources=None, **kwargs):
         """Branch from the current scope to a new, inner scope"""
@@ -371,6 +372,17 @@ class Scope:
         if self._join_hints is None:
             return []
         return self._join_hints
+
+    @property
+    def pivots(self):
+        if not self._pivots:
+            self._pivots = [
+                pivot
+                for node in self.tables + self.derived_tables
+                for pivot in node.args.get("pivots", [])
+            ]
+
+        return self._pivots
 
     def source_columns(self, source_name):
         """

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -615,8 +615,13 @@ def _traverse_tables(scope):
             source_name = expression.alias_or_name
 
             if table_name in scope.sources:
-                # This is a reference to a parent source (e.g. a CTE), not an actual table.
-                sources[source_name] = scope.sources[table_name]
+                # This is a reference to a parent source (e.g. a CTE), not an actual table, unless
+                # it is pivoted, because then we get back a new table and hence a new source.
+                pivots = expression.args.get("pivots")
+                if pivots:
+                    sources[pivots[0].alias] = expression
+                else:
+                    sources[source_name] = scope.sources[table_name]
             elif source_name in sources:
                 sources[find_new_name(sources, table_name)] = expression
             else:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -777,8 +777,8 @@ class Parser(metaclass=_Parser):
 
     CONVERT_TYPE_FIRST = False
 
-    QUOTED_PIVOT_COLUMNS: t.Optional[bool] = None
     PREFIXED_PIVOT_COLUMNS = False
+    IDENTIFY_PIVOT_STRINGS = False
 
     LOG_BASE_FIRST = True
     LOG_DEFAULTS_TO_LN = False
@@ -2465,14 +2465,15 @@ class Parser(metaclass=_Parser):
             names = self._pivot_column_names(t.cast(t.List[exp.Expression], expressions))
 
             columns: t.List[exp.Expression] = []
-            for col in pivot.args["field"].expressions:
+            for fld in pivot.args["field"].expressions:
+                field_name = fld.sql() if self.IDENTIFY_PIVOT_STRINGS else fld.alias_or_name
                 for name in names:
                     if self.PREFIXED_PIVOT_COLUMNS:
-                        name = f"{name}_{col.alias_or_name}" if name else col.alias_or_name
+                        name = f"{name}_{field_name}" if name else field_name
                     else:
-                        name = f"{col.alias_or_name}_{name}" if name else col.alias_or_name
+                        name = f"{field_name}_{name}" if name else field_name
 
-                    columns.append(exp.to_identifier(name, quoted=self.QUOTED_PIVOT_COLUMNS))
+                    columns.append(exp.to_identifier(name))
 
             pivot.set("columns", columns)
 

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -215,6 +215,18 @@ TBLPROPERTIES (
         self.validate_identity("SPLIT(str, pattern, lim)")
 
         self.validate_all(
+            "SELECT piv.Q1 FROM (SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))) AS piv",
+            read={
+                "snowflake": "SELECT piv.Q1 FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2')) piv",
+            },
+        )
+        self.validate_all(
+            "SELECT piv.Q1 FROM (SELECT * FROM (SELECT * FROM produce) PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))) AS piv",
+            read={
+                "snowflake": "SELECT piv.Q1 FROM (SELECT * FROM produce) PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2')) piv",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM produce PIVOT(SUM(produce.sales) FOR quarter IN ('Q1', 'Q2'))",
             read={
                 "snowflake": "SELECT * FROM produce PIVOT (SUM(produce.sales) FOR produce.quarter IN ('Q1', 'Q2'))",

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -502,3 +502,55 @@ WHERE
   "unioned"."source_system" = 'bamboohr' OR "unioned"."source_system" = 'workday'
 QUALIFY
   ROW_NUMBER() OVER (PARTITION BY "unioned"."unique_filter_key" ORDER BY "unioned"."sort_order" DESC, 1) = 1;
+
+# title: pivoted source with explicit selections
+# execute: false
+SELECT * FROM (SELECT a, b, c FROM sc.tb) PIVOT (SUM(c) FOR b IN ('x','y','z'));
+SELECT
+  "_q_1"."a" AS "a",
+  "_q_1"."x" AS "x",
+  "_q_1"."y" AS "y",
+  "_q_1"."z" AS "z"
+FROM (
+  SELECT
+    "tb"."a" AS "a",
+    "tb"."b" AS "b",
+    "tb"."c" AS "c"
+  FROM "sc"."tb" AS "tb"
+) AS "_q_0"   PIVOT(  SUM("_q_0"."c") FOR "_q_0"."b" IN ('x', 'y', 'z')) AS "_q_1";
+
+# title: pivoted source with implicit selections
+# execute: false
+SELECT * FROM (SELECT * FROM u) PIVOT (SUM(f) FOR h IN ('x', 'y'));
+SELECT
+  "_q_1"."g" AS "g",
+  "_q_1"."x" AS "x",
+  "_q_1"."y" AS "y"
+FROM (
+  SELECT
+    "u"."f" AS "f",
+    "u"."g" AS "g",
+    "u"."h" AS "h"
+  FROM "u" AS "u"
+) AS "_q_0"   PIVOT(  SUM("_q_0"."f") FOR "_q_0"."h" IN ('x', 'y')) AS "_q_1";
+
+# title: selecting explicit qualified columns from pivoted source with explicit selections
+# execute: false
+SELECT piv.x, piv.y FROM (SELECT f, h FROM u) PIVOT (SUM(f) FOR h IN ('x', 'y')) AS piv;
+SELECT
+  "piv"."x" AS "x",
+  "piv"."y" AS "y"
+FROM (
+  SELECT
+    "u"."f" AS "f",
+    "u"."h" AS "h"
+  FROM "u" AS "u"
+) AS "_q_0"   PIVOT(  SUM("_q_0"."f") FOR "_q_0"."h" IN ('x', 'y')) AS "piv";
+
+# title: selecting explicit unqualified columns from pivoted source with implicit selections
+# execute: false
+SELECT x, y FROM u PIVOT (SUM(f) FOR h IN ('x', 'y'));
+SELECT
+  "_q_0"."x" AS "x",
+  "_q_0"."y" AS "y"
+FROM "u" AS "u"   PIVOT(  SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -517,7 +517,7 @@ FROM (
     "tb"."b" AS "b",
     "tb"."c" AS "c"
   FROM "sc"."tb" AS "tb"
-) AS "_q_0"   PIVOT(  SUM("_q_0"."c") FOR "_q_0"."b" IN ('x', 'y', 'z')) AS "_q_1";
+) AS "_q_0" PIVOT(SUM("_q_0"."c") FOR "_q_0"."b" IN ('x', 'y', 'z')) AS "_q_1";
 
 # title: pivoted source with implicit selections
 # execute: false
@@ -532,7 +532,7 @@ FROM (
     "u"."g" AS "g",
     "u"."h" AS "h"
   FROM "u" AS "u"
-) AS "_q_0"   PIVOT(  SUM("_q_0"."f") FOR "_q_0"."h" IN ('x', 'y')) AS "_q_1";
+) AS "_q_0" PIVOT(SUM("_q_0"."f") FOR "_q_0"."h" IN ('x', 'y')) AS "_q_1";
 
 # title: selecting explicit qualified columns from pivoted source with explicit selections
 # execute: false
@@ -545,7 +545,7 @@ FROM (
     "u"."f" AS "f",
     "u"."h" AS "h"
   FROM "u" AS "u"
-) AS "_q_0"   PIVOT(  SUM("_q_0"."f") FOR "_q_0"."h" IN ('x', 'y')) AS "piv";
+) AS "_q_0" PIVOT(SUM("_q_0"."f") FOR "_q_0"."h" IN ('x', 'y')) AS "piv";
 
 # title: selecting explicit unqualified columns from pivoted source with implicit selections
 # execute: false
@@ -553,4 +553,4 @@ SELECT x, y FROM u PIVOT (SUM(f) FOR h IN ('x', 'y'));
 SELECT
   "_q_0"."x" AS "x",
   "_q_0"."y" AS "y"
-FROM "u" AS "u"   PIVOT(  SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";
+FROM "u" AS "u" PIVOT(SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -554,3 +554,13 @@ SELECT
   "_q_0"."x" AS "x",
   "_q_0"."y" AS "y"
 FROM "u" AS "u" PIVOT(SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";
+
+# title: selecting all columns from a pivoted source and generating snowflake
+# execute: false
+# dialect: snowflake
+SELECT * FROM u PIVOT (SUM(f) FOR h IN ('x', 'y'));
+SELECT
+  "_q_0"."g" AS "g",
+  "_q_0"."'x'" AS "'x'",
+  "_q_0"."'y'" AS "'y'"
+FROM "u" AS "u" PIVOT(SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -581,3 +581,18 @@ SELECT
   "_q_0"."'x'" AS "'x'",
   "_q_0"."'y'" AS "'y'"
 FROM "u" AS "u" PIVOT(SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";
+
+# title: selecting all columns from a pivoted source and generating spark
+# note: spark doesn't allow pivot aliases or qualified columns for the pivot's "field" (`h`)
+# execute: false
+# dialect: spark
+SELECT * FROM u PIVOT (SUM(f) FOR h IN ('x', 'y'));
+SELECT
+  `_q_0`.`g` AS `g`,
+  `_q_0`.`x` AS `x`,
+  `_q_0`.`y` AS `y`
+FROM (
+  SELECT
+    *
+  FROM `u` AS `u` PIVOT(SUM(`u`.`f`) FOR `h` IN ('x', 'y'))
+) AS `_q_0`;

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -555,6 +555,23 @@ SELECT
   "_q_0"."y" AS "y"
 FROM "u" AS "u" PIVOT(SUM("u"."f") FOR "u"."h" IN ('x', 'y')) AS "_q_0";
 
+# title: selecting all columns from a pivoted CTE source, using alias for the aggregation and generating bigquery
+# execute: false
+# dialect: bigquery
+WITH u_cte(f, g, h) AS (SELECT * FROM u) SELECT * FROM u_cte PIVOT(SUM(f) AS sum FOR h IN ('x', 'y'));
+WITH `u_cte` AS (
+  SELECT
+    `u`.`f` AS `f`,
+    `u`.`g` AS `g`,
+    `u`.`h` AS `h`
+  FROM `u` AS `u`
+)
+SELECT
+  `_q_0`.`g` AS `g`,
+  `_q_0`.`sum_x` AS `sum_x`,
+  `_q_0`.`sum_y` AS `sum_y`
+FROM `u_cte` AS `u_cte` PIVOT(SUM(`u_cte`.`f`) AS `sum` FOR `u_cte`.`h` IN ('x', 'y')) AS `_q_0`;
+
 # title: selecting all columns from a pivoted source and generating snowflake
 # execute: false
 # dialect: snowflake

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -16,9 +16,12 @@ WITH a AS (SELECT 1 FROM c.db.z AS z) SELECT 1 FROM a;
 SELECT (SELECT y.c FROM y AS y) FROM x;
 SELECT (SELECT y.c FROM c.db.y AS y) FROM c.db.x AS x;
 
--------------------------
+SELECT * FROM x PIVOT (SUM(a) FOR b IN ('a', 'b'));
+SELECT * FROM c.db.x AS x PIVOT(SUM(a) FOR b IN ('a', 'b')) AS _q_0;
+
+----------------------------
 -- Expand join constructs
--------------------------
+----------------------------
 
 -- This is valid in Trino, so we treat the (tbl AS tbl) as a "join construct" per postgres' terminology.
 SELECT * FROM (tbl AS tbl) AS _q_0;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -145,6 +145,7 @@ class TestOptimizer(unittest.TestCase):
             "x": {"a": "INT", "b": "INT"},
             "y": {"b": "INT", "c": "INT"},
             "z": {"a": "INT", "c": "INT"},
+            "u": {"f": "INT", "g": "INT", "h": "TEXT"},
         }
 
         self.check_file(

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -426,7 +426,7 @@ class TestParser(unittest.TestCase):
             nothing_aliased: {
                 "bigquery": ["prop", "rudder"],
                 "redshift": ["prop", "rudder"],
-                "snowflake": ['"prop"', '"rudder"'],
+                "snowflake": ['''"'prop'"''', '''"'rudder'"'''],
                 "spark": ["prop", "rudder"],
             },
             everything_aliased: {


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/discussions/1449

This PR introduces optimizer logic for handling the PIVOT operator, i.e. explode & qualify the columns of the table it produces where necessary. It's a first draft towards the general solution, which is more difficult because we may have multiple JOINs and / or PIVOTs, UNPIVOTs chained together in non-trivial ways.

We could also try to transform PIVOT operators using `exp.Case` expressions. This seems a bit less straightforward to me if we want to get it right in all cases. For example:

1. What do we `GROUP BY` if there are additional columns besides what's referenced in the `exp.Pivot` expression? 
2. Can we always map the aggregations trivially into projections? How would we handle stuff like `COUNT(*)`?
3. How does this transformation behave when there are JOINs and / or other (UN)PIVOT operators applied?

The major advantage of this approach, though, would be that we'd get back a canonical query without `PIVOT`s.

References:
- https://docs.aws.amazon.com/redshift/latest/dg/r_FROM_clause-pivot-unpivot-examples.html
- https://stackoverflow.com/questions/5846007/sql-query-to-pivot-a-column-using-case-when
- https://www.phind.com/search?cache=5b176c80-4468-4d71-8b33-f3bd9bb37578