### PR TITLE
Fix: Replace columns in replace_tables

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5297,7 +5297,7 @@ def replace_tables(expression, mapping):
 
     def _replace_columns(node):
         if isinstance(node, Column) and node.table:
-            # Find the table name in the mapping
+            # Find node's table name in mapping. It may be `db.tbl` or it may be `tbl`.
             to_replace = None
             for name in mapping.keys():
                 if name == node.table or name.endswith(f".{node.table}"):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -190,6 +190,13 @@ class TestExpressions(unittest.TestCase):
             ).sql(),
             "SELECT * FROM a1 AS a JOIN b.a JOIN c.a2 JOIN d2 JOIN e.a",
         )
+        self.assertEqual(
+            exp.replace_tables(
+                parse_one("select tbl.col, c from db.tbl, db.tbl_2"),
+                {"db.tbl": "new_db.new_tbl", "db.tbl_2": "new_db.new_tbl_2"},
+            ).sql(),
+            "SELECT new_tbl.col, c FROM new_db.new_tbl, new_db.new_tbl_2",
+        )
 
     def test_replace_placeholders(self):
         self.assertEqual(


### PR DESCRIPTION
This PR adds a `_replace_columns` transform inside `replace_tables`, which ensures `table.name` column names in an expression are also replaced when calling `replace_tables`. I'm sure I'm missing something or doing something weird with this, so please let me know what to fix/improve.

Fixes #1622.