### PR TITLE
Fix: ensure unit is a var in parse_date_delta

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -382,7 +382,7 @@ def parse_date_delta(
         unit_based = len(args) == 3
         this = args[2] if unit_based else seq_get(args, 0)
         unit = args[0] if unit_based else exp.Literal.string("DAY")
-        unit = unit_mapping.get(unit.name.lower(), unit) if unit_mapping else unit
+        unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
         return exp_class(this=this, expression=seq_get(args, 1), unit=unit)
 
     return inner_func

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -467,6 +467,11 @@ WHERE
 
     def test_add_date(self):
         self.validate_identity("SELECT DATEADD(year, 1, '2017/08/25')")
+
+        self.validate_all(
+            "DATEADD(year, 50, '2006-07-31')",
+            write={"bigquery": "DATE_ADD('2006-07-31', INTERVAL 50 YEAR)"},
+        )
         self.validate_all(
             "SELECT DATEADD(year, 1, '2017/08/25')",
             write={"spark": "SELECT ADD_MONTHS('2017/08/25', 12)"},


### PR DESCRIPTION
Fixes the following issue:

```python
>>> import sqlglot
>>> sqlglot.transpile("DATEADD(year, 50, '2006-07-31')", read="tsql", write="bigquery")
Traceback (most recent call last):
  ...
  File "sqlglot/sqlglot/dialects/bigquery.py", line 33, in func
    unit = exp.var(unit.name.upper() if unit else "DAY")
AttributeError: 'str' object has no attribute 'name'
```