### PR TITLE
Feat!(mysql, oracle): improve parsing of lock syntax

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2162,7 +2162,7 @@ QUERY_MODIFIERS = {
     "order": False,
     "limit": False,
     "offset": False,
-    "lock": False,
+    "locks": False,
     "sample": False,
     "settings": False,
     "format": False,
@@ -2343,10 +2343,10 @@ class Schema(Expression):
     arg_types = {"this": False, "expressions": False}
 
 
-# Used to represent the FOR UPDATE and FOR SHARE locking read types.
-# https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html
+# https://dev.mysql.com/doc/refman/8.0/en/select.html
+# https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SELECT.html
 class Lock(Expression):
-    arg_types = {"update": True}
+    arg_types = {"update": True, "expressions": False, "wait": False}
 
 
 class Select(Subqueryable):
@@ -2922,7 +2922,7 @@ class Select(Subqueryable):
         """
 
         inst = _maybe_copy(self, copy)
-        inst.set("lock", Lock(update=update))
+        inst.set("locks", [Lock(update=update)])
 
         return inst
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -231,6 +231,7 @@ class TokenType(AutoName):
     LIMIT = auto()
     LOAD_DATA = auto()
     LOCAL = auto()
+    LOCK = auto()
     MAP = auto()
     MATCH_RECOGNIZE = auto()
     MATERIALIZED = auto()
@@ -580,6 +581,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "LIMIT": TokenType.LIMIT,
         "LOAD DATA": TokenType.LOAD_DATA,
         "LOCAL": TokenType.LOCAL,
+        "LOCK": TokenType.LOCK,
         "MATERIALIZED": TokenType.MATERIALIZED,
         "MERGE": TokenType.MERGE,
         "NATURAL": TokenType.NATURAL,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -47,8 +47,11 @@ class TestMySQL(Validator):
         self.validate_identity("SELECT TRIM(BOTH 'bla' FROM ' XXX ')")
         self.validate_identity("SELECT TRIM('bla' FROM ' XXX ')")
         self.validate_identity("@@GLOBAL.max_connections")
-
         self.validate_identity("CREATE TABLE A LIKE B")
+        self.validate_identity("SELECT * FROM t1, t2 FOR SHARE OF t1, t2 SKIP LOCKED")
+        self.validate_identity(
+            "SELECT * FROM t1, t2, t3 FOR SHARE OF t1 NOWAIT FOR UPDATE OF t2, t3 SKIP LOCKED"
+        )
 
         # SET Commands
         self.validate_identity("SET @var_name = expr")
@@ -368,6 +371,9 @@ class TestMySQL(Validator):
         self.validate_identity("TIME_STR_TO_UNIX(x)", "UNIX_TIMESTAMP(x)")
 
     def test_mysql(self):
+        self.validate_all(
+            "SELECT * FROM t LOCK IN SHARE MODE", write={"mysql": "SELECT * FROM t FOR SHARE"}
+        )
         self.validate_all(
             "SELECT DATE(DATE_SUB(`dt`, INTERVAL DAYOFMONTH(`dt`) - 1 DAY)) AS __timestamp FROM tableT",
             write={

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -5,6 +5,13 @@ class TestOracle(Validator):
     dialect = "oracle"
 
     def test_oracle(self):
+        self.validate_identity("SELECT * FROM t FOR UPDATE")
+        self.validate_identity("SELECT * FROM t FOR UPDATE WAIT 5")
+        self.validate_identity("SELECT * FROM t FOR UPDATE NOWAIT")
+        self.validate_identity("SELECT * FROM t FOR UPDATE SKIP LOCKED")
+        self.validate_identity("SELECT * FROM t FOR UPDATE OF s.t.c, s.t.v")
+        self.validate_identity("SELECT * FROM t FOR UPDATE OF s.t.c, s.t.v NOWAIT")
+        self.validate_identity("SELECT * FROM t FOR UPDATE OF s.t.c, s.t.v SKIP LOCKED")
         self.validate_identity("SELECT STANDARD_HASH('hello')")
         self.validate_identity("SELECT STANDARD_HASH('hello', 'MD5')")
         self.validate_identity("SELECT CAST(NULL AS VARCHAR2(2328 CHAR)) AS COL1")


### PR DESCRIPTION
Fixes #1641

This is a breaking change because the arguments of the `exp.Lock` expression were changed.

cc: @mpf82