### PR TITLE
Fix(clickhouse): use _parse_expression in _parse_if to allow ternaries

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3532,7 +3532,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_if(self) -> t.Optional[exp.Expression]:
         if self._match(TokenType.L_PAREN):
-            args = self._parse_csv(self._parse_conjunction)
+            args = self._parse_csv(self._parse_expression)
             this = exp.If.from_arg_list(args)
             self.validate_expression(this, args)
             self._match_r_paren()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -121,6 +121,12 @@ class TestClickhouse(Validator):
     def test_ternary(self):
         self.validate_all("x ? 1 : 2", write={"clickhouse": "CASE WHEN x THEN 1 ELSE 2 END"})
         self.validate_all(
+            "IF(BAR(col), sign > 0 ? FOO() : 0, 1)",
+            write={
+                "clickhouse": "CASE WHEN BAR(col) THEN CASE WHEN sign > 0 THEN FOO() ELSE 0 END ELSE 1 END"
+            },
+        )
+        self.validate_all(
             "x AND FOO() > 3 + 2 ? 1 : 2",
             write={"clickhouse": "CASE WHEN x AND FOO() > 3 + 2 THEN 1 ELSE 2 END"},
         )


### PR DESCRIPTION
Fixes #1645 