### PR TITLE
Generate DATE_PART instead of EXTRACT for Snowflake

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -119,6 +119,12 @@ def _parse_date_part(self: parser.Parser) -> t.Optional[exp.Expression]:
     return self.expression(exp.Extract, this=this, expression=expression)
 
 
+def _snowflake_generate_extract(self: Snowflake.Generator, expression: exp.Extract) -> str:
+    this = self.sql(expression, "this")
+    expression_sql = self.sql(expression, "expression")
+    return f"DATE_PART({this}, {expression_sql})"
+
+
 # https://docs.snowflake.com/en/sql-reference/functions/div0
 def _div0_to_if(args: t.Sequence) -> exp.Expression:
     cond = exp.EQ(this=seq_get(args, 1), expression=exp.Literal.number(0))
@@ -309,6 +315,7 @@ class Snowflake(Dialect):
             exp.DateStrToDate: datestrtodate_sql,
             exp.DataType: _datatype_sql,
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
+            exp.Extract: _snowflake_generate_extract,
             exp.If: rename_func("IFF"),
             exp.LogicalAnd: rename_func("BOOLAND_AGG"),
             exp.LogicalOr: rename_func("BOOLOR_AGG"),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -119,12 +119,6 @@ def _parse_date_part(self: parser.Parser) -> t.Optional[exp.Expression]:
     return self.expression(exp.Extract, this=this, expression=expression)
 
 
-def _snowflake_generate_extract(self: Snowflake.Generator, expression: exp.Extract) -> str:
-    this = self.sql(expression, "this")
-    expression_sql = self.sql(expression, "expression")
-    return f"DATE_PART({this}, {expression_sql})"
-
-
 # https://docs.snowflake.com/en/sql-reference/functions/div0
 def _div0_to_if(args: t.Sequence) -> exp.Expression:
     cond = exp.EQ(this=seq_get(args, 1), expression=exp.Literal.number(0))
@@ -315,7 +309,7 @@ class Snowflake(Dialect):
             exp.DateStrToDate: datestrtodate_sql,
             exp.DataType: _datatype_sql,
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
-            exp.Extract: _snowflake_generate_extract,
+            exp.Extract: rename_func("DATE_PART"),
             exp.If: rename_func("IFF"),
             exp.LogicalAnd: rename_func("BOOLAND_AGG"),
             exp.LogicalOr: rename_func("BOOLOR_AGG"),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -158,7 +158,7 @@ class TestPostgres(Validator):
             write={
                 "postgres": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
                 "redshift": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
-                "snowflake": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMPNTZ))",
+                "snowflake": "SELECT DATE_PART(minute, CAST('2023-01-04 04:05:06.789' AS TIMESTAMPNTZ))",
             },
         )
         self.validate_all(
@@ -166,7 +166,7 @@ class TestPostgres(Validator):
             write={
                 "postgres": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
                 "redshift": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
-                "snowflake": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
+                "snowflake": "SELECT DATE_PART(month, CAST('20220502' AS DATE))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -31,7 +31,7 @@ class TestRedshift(Validator):
             write={
                 "postgres": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
                 "redshift": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
-                "snowflake": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMPNTZ))",
+                "snowflake": "SELECT DATE_PART(minute, CAST('2023-01-04 04:05:06.789' AS TIMESTAMPNTZ))",
             },
         )
         self.validate_all(
@@ -39,7 +39,7 @@ class TestRedshift(Validator):
             write={
                 "postgres": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
                 "redshift": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
-                "snowflake": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
+                "snowflake": "SELECT DATE_PART(month, CAST('20220502' AS DATE))",
             },
         )
         self.validate_all("SELECT INTERVAL '5 days'", read={"": "SELECT INTERVAL '5' days"})

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -463,7 +463,7 @@ class TestSnowflake(Validator):
         )
 
     def test_timestamps(self):
-        self.validate_identity("SELECT EXTRACT(month FROM a)")
+        self.validate_identity("SELECT DATE_PART(month, a)")
 
         self.validate_all(
             "SELECT CAST(a AS TIMESTAMP)",
@@ -492,19 +492,19 @@ class TestSnowflake(Validator):
         self.validate_all(
             "SELECT EXTRACT('month', a)",
             write={
-                "snowflake": "SELECT EXTRACT('month' FROM a)",
+                "snowflake": "SELECT DATE_PART('month', a)",
             },
         )
         self.validate_all(
             "SELECT DATE_PART('month', a)",
             write={
-                "snowflake": "SELECT EXTRACT('month' FROM a)",
+                "snowflake": "SELECT DATE_PART('month', a)",
             },
         )
         self.validate_all(
             "SELECT DATE_PART(month, a::DATETIME)",
             write={
-                "snowflake": "SELECT EXTRACT(month FROM CAST(a AS DATETIME))",
+                "snowflake": "SELECT DATE_PART(month, CAST(a AS DATETIME))",
             },
         )
         self.validate_all(


### PR DESCRIPTION
This PR replaces generation of [`EXTRACT`](https://docs.snowflake.com/en/sql-reference/functions/date_part) with generation of [`DATE_PART`](https://docs.snowflake.com/en/sql-reference/functions/date_part) in the Snowflake dialect.

The motivation for this change is that, for queries using `DATE_PART` where the first argument is a string, the generated SQL is rejected by Snowflake. Taking an example from the unit tests, if I attempt to run the following on Snowflake:
```sql
SELECT EXTRACT('month' FROM a)
```
I get the following error:
```
SQL compilation error: syntax error line 1 at position 23 unexpected 'FROM'. syntax error line 1 at position 29 unexpected ')'.
```
It succeeds compilation if I remove the quotes around `'month'`.

`EXTRACT(... FROM ...)` only supports unquoted arguments. `DATE_PART(..., ...)` supports both quoted and unquoted arguments - so `DATE_PART('month', a)` and `DATE_PART(month, a)` are both valid. Unfortunately, the quoted argument forms don't appear to be documented on the Snowflake site, but I have run into the quoted forms in the wild.

My initial approach was on the parsing side, but this would only fix Snowflake -> Snowflake generation. Making this change on the generation side will generate valid SQL regardless of the source dialect.

I also considered attempting to convert the first argument to the unquoted variant on generation - that seems viable as well, but more complicated, since `DATE_PART` accepts both quoted and unquoted arguments. If that seems like a better solution I'm happy to do a rev. 