### PR TITLE
Fix(teradata): improve post index property parsing

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -141,7 +141,9 @@ class Teradata(Dialect):
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            exp.OnCommitProperty: exp.Properties.Location.POST_INDEX,
             exp.PartitionedByProperty: exp.Properties.Location.POST_INDEX,
+            exp.StabilityProperty: exp.Properties.Location.POST_CREATE,
         }
 
         TRANSFORMS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1896,7 +1896,7 @@ class NoPrimaryIndexProperty(Property):
 
 
 class OnCommitProperty(Property):
-    arg_type = {"this": False}
+    arg_type = {"delete": False}
 
 
 class PartitionedByProperty(Property):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -76,7 +76,7 @@ class Generator:
         exp.LogProperty: lambda self, e: f"{'NO ' if e.args.get('no') else ''}LOG",
         exp.MaterializedProperty: lambda self, e: "MATERIALIZED",
         exp.NoPrimaryIndexProperty: lambda self, e: "NO PRIMARY INDEX",
-        exp.OnCommitProperty: lambda self, e: "ON COMMIT PRESERVE ROWS",
+        exp.OnCommitProperty: lambda self, e: f"ON COMMIT {'DELETE' if e.args.get('delete') else 'PRESERVE'} ROWS",
         exp.ReturnsProperty: lambda self, e: self.naked_property(e),
         exp.SetProperty: lambda self, e: f"{'MULTI' if e.args.get('multi') else ''}SET",
         exp.SettingsProperty: lambda self, e: f"SETTINGS{self.seg('')}{(self.expressions(e))}",

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -25,6 +25,12 @@ class TestTeradata(Validator):
     def test_create(self):
         self.validate_identity("CREATE TABLE x (y INT) PRIMARY INDEX (y) PARTITION BY y INDEX (y)")
         self.validate_identity(
+            "CREATE MULTISET VOLATILE TABLE my_table (id INT) PRIMARY INDEX (id) ON COMMIT PRESERVE ROWS"
+        )
+        self.validate_identity(
+            "CREATE SET VOLATILE TABLE my_table (id INT) PRIMARY INDEX (id) ON COMMIT DELETE ROWS"
+        )
+        self.validate_identity(
             "CREATE TABLE a (b INT) PRIMARY INDEX (y) PARTITION BY RANGE_N(b BETWEEN 'a', 'b' AND 'c' EACH '1')"
         )
         self.validate_identity(
@@ -35,10 +41,20 @@ class TestTeradata(Validator):
         )
 
         self.validate_all(
+            """
+            CREATE SET TABLE test, NO FALLBACK, NO BEFORE JOURNAL, NO AFTER JOURNAL,
+            CHECKSUM = DEFAULT (x INT, y INT, z CHAR(30), a INT, b DATE, e INT)
+            PRIMARY INDEX (a),
+            INDEX(x, y)
+            """,
+            write={
+                "teradata": "CREATE SET TABLE test, NO FALLBACK, NO BEFORE JOURNAL, NO AFTER JOURNAL, CHECKSUM=DEFAULT (x INT, y INT, z CHAR(30), a INT, b DATE, e INT) PRIMARY INDEX (a) INDEX (x, y)",
+            },
+        )
+        self.validate_all(
             "REPLACE VIEW a AS (SELECT b FROM c)",
             write={"teradata": "CREATE OR REPLACE VIEW a AS (SELECT b FROM c)"},
         )
-
         self.validate_all(
             "CREATE VOLATILE TABLE a",
             write={


### PR DESCRIPTION
Fixes #1674

References:
- https://www.geeksforgeeks.org/how-to-create-volatile-table-in-teradata/
- https://docs.teradata.com/r/SQL-Data-Definition-Language-Syntax-and-Examples/September-2015/Table-Statements/CREATE-TABLE/Examples/Example-AS-...-WITH-DATA-With-a-Nonunique-Secondary-Index