### PR TITLE
Fix(snowflake): preserve TIME type instead of converting it to TIMESTAMP

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -153,7 +153,7 @@ class BigQuery(Dialect):
         LOG_DEFAULTS_TO_LN = True
 
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "DATE_TRUNC": lambda args: exp.DateTrunc(
                 unit=exp.Literal.string(str(seq_get(args, 1))),
                 this=seq_get(args, 0),
@@ -183,28 +183,28 @@ class BigQuery(Dialect):
         }
 
         FUNCTION_PARSERS = {
-            **parser.Parser.FUNCTION_PARSERS,  # type: ignore
+            **parser.Parser.FUNCTION_PARSERS,
             "ARRAY": lambda self: self.expression(exp.Array, expressions=[self._parse_statement()]),
         }
         FUNCTION_PARSERS.pop("TRIM")
 
         NO_PAREN_FUNCTIONS = {
-            **parser.Parser.NO_PAREN_FUNCTIONS,  # type: ignore
+            **parser.Parser.NO_PAREN_FUNCTIONS,
             TokenType.CURRENT_DATETIME: exp.CurrentDatetime,
         }
 
         NESTED_TYPE_TOKENS = {
-            *parser.Parser.NESTED_TYPE_TOKENS,  # type: ignore
+            *parser.Parser.NESTED_TYPE_TOKENS,
             TokenType.TABLE,
         }
 
         ID_VAR_TOKENS = {
-            *parser.Parser.ID_VAR_TOKENS,  # type: ignore
+            *parser.Parser.ID_VAR_TOKENS,
             TokenType.VALUES,
         }
 
         PROPERTY_PARSERS = {
-            **parser.Parser.PROPERTY_PARSERS,  # type: ignore
+            **parser.Parser.PROPERTY_PARSERS,
             "NOT DETERMINISTIC": lambda self: self.expression(
                 exp.StabilityProperty, this=exp.Literal.string("VOLATILE")
             ),
@@ -212,7 +212,7 @@ class BigQuery(Dialect):
         }
 
         CONSTRAINT_PARSERS = {
-            **parser.Parser.CONSTRAINT_PARSERS,  # type: ignore
+            **parser.Parser.CONSTRAINT_PARSERS,
             "OPTIONS": lambda self: exp.Properties(expressions=self._parse_with_property()),
         }
 
@@ -245,7 +245,7 @@ class BigQuery(Dialect):
         RENAME_TABLE_WITH_DB = False
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.AtTimeZone: lambda self, e: self.func(
@@ -288,7 +288,7 @@ class BigQuery(Dialect):
         }
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.BIGDECIMAL: "BIGNUMERIC",
             exp.DataType.Type.BIGINT: "INT64",
             exp.DataType.Type.BINARY: "BYTES",
@@ -311,7 +311,7 @@ class BigQuery(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -57,7 +57,7 @@ class ClickHouse(Dialect):
 
     class Parser(parser.Parser):
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "ANY": exp.AnyValue.from_arg_list,
             "MAP": parse_var_map,
             "MATCH": exp.RegexpLike.from_arg_list,
@@ -249,7 +249,7 @@ class ClickHouse(Dialect):
         STRUCT_DELIMITER = ("(", ")")
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.ARRAY: "Array",
             exp.DataType.Type.BIGINT: "Int64",
             exp.DataType.Type.DATETIME64: "DateTime64",
@@ -272,7 +272,7 @@ class ClickHouse(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.AnyValue: rename_func("any"),
             exp.ApproxDistinct: rename_func("uniq"),
             exp.Array: inline_array_sql,
@@ -289,7 +289,7 @@ class ClickHouse(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
             exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
         }

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -25,7 +25,7 @@ class Databricks(Spark):
 
     class Generator(Spark.Generator):
         TRANSFORMS = {
-            **Spark.Generator.TRANSFORMS,  # type: ignore
+            **Spark.Generator.TRANSFORMS,
             exp.DateAdd: generate_date_delta_with_unit_sql,
             exp.DateDiff: generate_date_delta_with_unit_sql,
             exp.JSONExtract: lambda self, e: self.binary(e, ":"),

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -95,7 +95,7 @@ class Drill(Dialect):
         STRICT_CAST = False
 
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "DATE_FORMAT": format_time_lambda(exp.TimeToStr, "drill"),
             "TO_TIMESTAMP": exp.TimeStrToTime.from_arg_list,
             "TO_CHAR": format_time_lambda(exp.TimeToStr, "drill"),
@@ -108,7 +108,7 @@ class Drill(Dialect):
         TABLE_HINTS = False
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.INT: "INTEGER",
             exp.DataType.Type.SMALLINT: "INTEGER",
             exp.DataType.Type.TINYINT: "INTEGER",
@@ -121,13 +121,13 @@ class Drill(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.ArrayContains: rename_func("REPEATED_CONTAINS"),
             exp.ArraySize: rename_func("REPEATED_COUNT"),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -117,7 +117,7 @@ class DuckDB(Dialect):
 
     class Parser(parser.Parser):
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "ARRAY_LENGTH": exp.ArraySize.from_arg_list,
             "ARRAY_SORT": exp.SortArray.from_arg_list,
             "ARRAY_REVERSE_SORT": _sort_array_reverse,
@@ -240,7 +240,7 @@ class DuckDB(Dialect):
         STAR_MAPPING = {**generator.Generator.STAR_MAPPING, "except": "EXCLUDE"}
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -225,7 +225,7 @@ class Hive(Dialect):
         STRICT_CAST = False
 
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "BASE64": exp.ToBase64.from_arg_list,
             "COLLECT_LIST": exp.ArrayAgg.from_arg_list,
             "DATE_ADD": lambda args: exp.TsOrDsAdd(
@@ -270,7 +270,7 @@ class Hive(Dialect):
         }
 
         PROPERTY_PARSERS = {
-            **parser.Parser.PROPERTY_PARSERS,  # type: ignore
+            **parser.Parser.PROPERTY_PARSERS,
             "WITH SERDEPROPERTIES": lambda self: exp.SerdeProperties(
                 expressions=self._parse_wrapped_csv(self._parse_property)
             ),
@@ -291,7 +291,7 @@ class Hive(Dialect):
         TABLE_HINTS = False
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.TEXT: "STRING",
             exp.DataType.Type.DATETIME: "TIMESTAMP",
             exp.DataType.Type.VARBINARY: "BINARY",
@@ -300,7 +300,7 @@ class Hive(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.Group: transforms.preprocess([transforms.unalias_group]),
             exp.Select: transforms.preprocess(
                 [
@@ -372,7 +372,7 @@ class Hive(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.FileFormatProperty: exp.Properties.Location.POST_SCHEMA,
             exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -176,10 +176,10 @@ class MySQL(Dialect):
         COMMANDS = tokens.Tokenizer.COMMANDS - {TokenType.SHOW}
 
     class Parser(parser.Parser):
-        FUNC_TOKENS = {*parser.Parser.FUNC_TOKENS, TokenType.SCHEMA, TokenType.DATABASE}  # type: ignore
+        FUNC_TOKENS = {*parser.Parser.FUNC_TOKENS, TokenType.SCHEMA, TokenType.DATABASE}
 
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "DATE_ADD": parse_date_delta_with_interval(exp.DateAdd),
             "DATE_FORMAT": format_time_lambda(exp.TimeToStr, "mysql"),
             "DATE_SUB": parse_date_delta_with_interval(exp.DateSub),
@@ -192,7 +192,7 @@ class MySQL(Dialect):
         }
 
         FUNCTION_PARSERS = {
-            **parser.Parser.FUNCTION_PARSERS,  # type: ignore
+            **parser.Parser.FUNCTION_PARSERS,
             "GROUP_CONCAT": lambda self: self.expression(
                 exp.GroupConcat,
                 this=self._parse_lambda(),
@@ -201,7 +201,7 @@ class MySQL(Dialect):
         }
 
         STATEMENT_PARSERS = {
-            **parser.Parser.STATEMENT_PARSERS,  # type: ignore
+            **parser.Parser.STATEMENT_PARSERS,
             TokenType.SHOW: lambda self: self._parse_show(),
         }
 
@@ -382,7 +382,7 @@ class MySQL(Dialect):
         TABLE_HINTS = False
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.CurrentDate: no_paren_current_date_sql,
             exp.DateDiff: lambda self, e: self.func("DATEDIFF", e.this, e.expression),
             exp.DateAdd: _date_add_sql("ADD"),
@@ -419,7 +419,7 @@ class MySQL(Dialect):
         TYPE_MAPPING.pop(exp.DataType.Type.LONGBLOB)
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.TransientProperty: exp.Properties.Location.UNSUPPORTED,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -66,7 +66,7 @@ class Oracle(Dialect):
         WINDOW_BEFORE_PAREN_TOKENS = {TokenType.OVER, TokenType.KEEP}
 
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
         }
 
@@ -107,7 +107,7 @@ class Oracle(Dialect):
         TABLE_HINTS = False
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.TINYINT: "NUMBER",
             exp.DataType.Type.SMALLINT: "NUMBER",
             exp.DataType.Type.INT: "NUMBER",
@@ -122,7 +122,7 @@ class Oracle(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.DateStrToDate: lambda self, e: self.func(
                 "TO_DATE", e.this, exp.Literal.string("YYYY-MM-DD")
             ),
@@ -143,7 +143,7 @@ class Oracle(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -256,7 +256,7 @@ class Postgres(Dialect):
         STRICT_CAST = False
 
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "DATE_TRUNC": lambda args: exp.TimestampTrunc(
                 this=seq_get(args, 1), unit=seq_get(args, 0)
             ),
@@ -272,7 +272,7 @@ class Postgres(Dialect):
         }
 
         BITWISE = {
-            **parser.Parser.BITWISE,  # type: ignore
+            **parser.Parser.BITWISE,
             TokenType.HASH: exp.BitwiseXor,
         }
 
@@ -281,7 +281,7 @@ class Postgres(Dialect):
         }
 
         RANGE_PARSERS = {
-            **parser.Parser.RANGE_PARSERS,  # type: ignore
+            **parser.Parser.RANGE_PARSERS,
             TokenType.DAMP: binary_range_parser(exp.ArrayOverlaps),
             TokenType.AT_GT: binary_range_parser(exp.ArrayContains),
             TokenType.LT_AT: binary_range_parser(exp.ArrayContained),
@@ -311,7 +311,7 @@ class Postgres(Dialect):
         PARAMETER_TOKEN = "$"
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.TINYINT: "SMALLINT",
             exp.DataType.Type.FLOAT: "REAL",
             exp.DataType.Type.DOUBLE: "DOUBLE PRECISION",
@@ -321,7 +321,7 @@ class Postgres(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.BitwiseXor: lambda self, e: self.binary(e, "#"),
             exp.ColumnDef: transforms.preprocess(
                 [
@@ -371,7 +371,7 @@ class Postgres(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.TransientProperty: exp.Properties.Location.UNSUPPORTED,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -184,8 +184,8 @@ def _unnest_sequence(expression: exp.Expression) -> exp.Expression:
 class Presto(Dialect):
     index_offset = 1
     null_ordering = "nulls_are_last"
-    time_format = MySQL.time_format  # type: ignore
-    time_mapping = MySQL.time_mapping  # type: ignore
+    time_format = MySQL.time_format
+    time_mapping = MySQL.time_mapping
 
     class Tokenizer(tokens.Tokenizer):
         KEYWORDS = {
@@ -197,7 +197,7 @@ class Presto(Dialect):
 
     class Parser(parser.Parser):
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "APPROX_DISTINCT": exp.ApproxDistinct.from_arg_list,
             "APPROX_PERCENTILE": _approx_percentile,
             "CARDINALITY": exp.ArraySize.from_arg_list,
@@ -243,13 +243,13 @@ class Presto(Dialect):
         STRUCT_DELIMITER = ("(", ")")
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.LocationProperty: exp.Properties.Location.UNSUPPORTED,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.INT: "INTEGER",
             exp.DataType.Type.FLOAT: "REAL",
             exp.DataType.Type.BINARY: "VARBINARY",
@@ -259,7 +259,7 @@ class Presto(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.ApproxDistinct: _approx_distinct_sql,
             exp.ApproxQuantile: rename_func("APPROX_PERCENTILE"),
             exp.Array: lambda self, e: f"ARRAY[{self.expressions(e, flat=True)}]",

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -15,14 +15,14 @@ def _json_sql(self, e) -> str:
 class Redshift(Postgres):
     time_format = "'YYYY-MM-DD HH:MI:SS'"
     time_mapping = {
-        **Postgres.time_mapping,  # type: ignore
+        **Postgres.time_mapping,
         "MON": "%b",
         "HH": "%H",
     }
 
     class Parser(Postgres.Parser):
         FUNCTIONS = {
-            **Postgres.Parser.FUNCTIONS,  # type: ignore
+            **Postgres.Parser.FUNCTIONS,
             "DATEADD": lambda args: exp.DateAdd(
                 this=seq_get(args, 2),
                 expression=seq_get(args, 1),
@@ -57,7 +57,7 @@ class Redshift(Postgres):
         STRING_ESCAPES = ["\\"]
 
         KEYWORDS = {
-            **Postgres.Tokenizer.KEYWORDS,  # type: ignore
+            **Postgres.Tokenizer.KEYWORDS,
             "HLLSKETCH": TokenType.HLLSKETCH,
             "SUPER": TokenType.SUPER,
             "SYSDATE": TokenType.CURRENT_TIMESTAMP,
@@ -77,19 +77,19 @@ class Redshift(Postgres):
         RENAME_TABLE_WITH_DB = False
 
         TYPE_MAPPING = {
-            **Postgres.Generator.TYPE_MAPPING,  # type: ignore
+            **Postgres.Generator.TYPE_MAPPING,
             exp.DataType.Type.BINARY: "VARBYTE",
             exp.DataType.Type.VARBINARY: "VARBYTE",
             exp.DataType.Type.INT: "INTEGER",
         }
 
         PROPERTIES_LOCATION = {
-            **Postgres.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **Postgres.Generator.PROPERTIES_LOCATION,
             exp.LikeProperty: exp.Properties.Location.POST_WITH,
         }
 
         TRANSFORMS = {
-            **Postgres.Generator.TRANSFORMS,  # type: ignore
+            **Postgres.Generator.TRANSFORMS,
             exp.CurrentTimestamp: lambda self, e: "SYSDATE",
             exp.DateAdd: lambda self, e: self.func(
                 "DATEADD", exp.var(e.text("unit") or "day"), e.expression, e.this

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -231,7 +231,7 @@ class Snowflake(Dialect):
         }
 
         COLUMN_OPERATORS = {
-            **parser.Parser.COLUMN_OPERATORS,  # type: ignore
+            **parser.Parser.COLUMN_OPERATORS,
             TokenType.COLON: lambda self, this, path: self.expression(
                 exp.Bracket,
                 this=this,
@@ -239,14 +239,16 @@ class Snowflake(Dialect):
             ),
         }
 
+        TIMESTAMPS = parser.Parser.TIMESTAMPS.copy() - {TokenType.TIME}
+
         RANGE_PARSERS = {
-            **parser.Parser.RANGE_PARSERS,  # type: ignore
+            **parser.Parser.RANGE_PARSERS,
             TokenType.LIKE_ANY: binary_range_parser(exp.LikeAny),
             TokenType.ILIKE_ANY: binary_range_parser(exp.ILikeAny),
         }
 
         ALTER_PARSERS = {
-            **parser.Parser.ALTER_PARSERS,  # type: ignore
+            **parser.Parser.ALTER_PARSERS,
             "UNSET": lambda self: self._parse_alter_table_set_tag(unset=True),
             "SET": lambda self: self._parse_alter_table_set_tag(),
         }
@@ -295,7 +297,7 @@ class Snowflake(Dialect):
         TABLE_HINTS = False
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.Array: inline_array_sql,
             exp.ArrayConcat: rename_func("ARRAY_CAT"),
             exp.ArrayJoin: rename_func("ARRAY_TO_STRING"),
@@ -337,7 +339,7 @@ class Snowflake(Dialect):
         }
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.TIMESTAMP: "TIMESTAMPNTZ",
         }
 
@@ -347,7 +349,7 @@ class Snowflake(Dialect):
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.SetProperty: exp.Properties.Location.UNSUPPORTED,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -36,7 +36,7 @@ def _parse_datediff(args: t.Sequence) -> exp.Expression:
 class Spark(Spark2):
     class Parser(Spark2.Parser):
         FUNCTIONS = {
-            **Spark2.Parser.FUNCTIONS,  # type: ignore
+            **Spark2.Parser.FUNCTIONS,
             "DATEDIFF": _parse_datediff,
         }
 

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -107,7 +107,7 @@ def _unqualify_pivot_columns(expression: exp.Expression) -> exp.Expression:
 class Spark2(Hive):
     class Parser(Hive.Parser):
         FUNCTIONS = {
-            **Hive.Parser.FUNCTIONS,  # type: ignore
+            **Hive.Parser.FUNCTIONS,
             "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
             "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
             "LEFT": lambda args: exp.Substring(
@@ -161,7 +161,7 @@ class Spark2(Hive):
         }
 
         FUNCTION_PARSERS = {
-            **parser.Parser.FUNCTION_PARSERS,  # type: ignore
+            **parser.Parser.FUNCTION_PARSERS,
             "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
             "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
             "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),
@@ -189,14 +189,14 @@ class Spark2(Hive):
 
     class Generator(Hive.Generator):
         TYPE_MAPPING = {
-            **Hive.Generator.TYPE_MAPPING,  # type: ignore
+            **Hive.Generator.TYPE_MAPPING,
             exp.DataType.Type.TINYINT: "BYTE",
             exp.DataType.Type.SMALLINT: "SHORT",
             exp.DataType.Type.BIGINT: "LONG",
         }
 
         PROPERTIES_LOCATION = {
-            **Hive.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **Hive.Generator.PROPERTIES_LOCATION,
             exp.EngineProperty: exp.Properties.Location.UNSUPPORTED,
             exp.AutoIncrementProperty: exp.Properties.Location.UNSUPPORTED,
             exp.CharacterSetProperty: exp.Properties.Location.UNSUPPORTED,
@@ -204,7 +204,7 @@ class Spark2(Hive):
         }
 
         TRANSFORMS = {
-            **Hive.Generator.TRANSFORMS,  # type: ignore
+            **Hive.Generator.TRANSFORMS,
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ArraySum: lambda self, e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.AtTimeZone: lambda self, e: f"FROM_UTC_TIMESTAMP({self.sql(e, 'this')}, {self.sql(e, 'zone')})",

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -68,7 +68,7 @@ class SQLite(Dialect):
 
     class Parser(parser.Parser):
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "EDITDIST3": exp.Levenshtein.from_arg_list,
         }
 
@@ -77,7 +77,7 @@ class SQLite(Dialect):
         TABLE_HINTS = False
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.BOOLEAN: "INTEGER",
             exp.DataType.Type.TINYINT: "INTEGER",
             exp.DataType.Type.SMALLINT: "INTEGER",
@@ -99,7 +99,7 @@ class SQLite(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.CountIf: count_if_to_sum,
             exp.Create: transforms.preprocess([_transform_create]),
             exp.CurrentDate: lambda *_: "CURRENT_DATE",

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -11,7 +11,7 @@ from sqlglot.helper import seq_get
 
 
 class StarRocks(MySQL):
-    class Parser(MySQL.Parser):  # type: ignore
+    class Parser(MySQL.Parser):
         FUNCTIONS = {
             **MySQL.Parser.FUNCTIONS,
             "DATE_TRUNC": lambda args: exp.TimestampTrunc(
@@ -19,16 +19,16 @@ class StarRocks(MySQL):
             ),
         }
 
-    class Generator(MySQL.Generator):  # type: ignore
+    class Generator(MySQL.Generator):
         TYPE_MAPPING = {
-            **MySQL.Generator.TYPE_MAPPING,  # type: ignore
+            **MySQL.Generator.TYPE_MAPPING,
             exp.DataType.Type.TEXT: "STRING",
             exp.DataType.Type.TIMESTAMP: "DATETIME",
             exp.DataType.Type.TIMESTAMPTZ: "DATETIME",
         }
 
         TRANSFORMS = {
-            **MySQL.Generator.TRANSFORMS,  # type: ignore
+            **MySQL.Generator.TRANSFORMS,
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.JSONExtractScalar: arrow_json_extract_sql,
             exp.JSONExtract: arrow_json_extract_sql,

--- a/sqlglot/dialects/tableau.py
+++ b/sqlglot/dialects/tableau.py
@@ -4,41 +4,38 @@ from sqlglot import exp, generator, parser, transforms
 from sqlglot.dialects.dialect import Dialect
 
 
-def _if_sql(self, expression):
-    return f"IF {self.sql(expression, 'this')} THEN {self.sql(expression, 'true')} ELSE {self.sql(expression, 'false')} END"
-
-
-def _coalesce_sql(self, expression):
-    return f"IFNULL({self.sql(expression, 'this')}, {self.expressions(expression)})"
-
-
-def _count_sql(self, expression):
-    this = expression.this
-    if isinstance(this, exp.Distinct):
-        return f"COUNTD({self.expressions(this, flat=True)})"
-    return f"COUNT({self.sql(expression, 'this')})"
-
-
 class Tableau(Dialect):
     class Generator(generator.Generator):
         JOIN_HINTS = False
         TABLE_HINTS = False
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
-            exp.If: _if_sql,
-            exp.Coalesce: _coalesce_sql,
-            exp.Count: _count_sql,
+            **generator.Generator.TRANSFORMS,
             exp.Select: transforms.preprocess([transforms.eliminate_distinct_on]),
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
+        def if_sql(self, expression: exp.If) -> str:
+            this = self.sql(expression, "this")
+            true = self.sql(expression, "true")
+            false = self.sql(expression, "false")
+            return f"IF {this} THEN {true} ELSE {false} END"
+
+        def coalesce_sql(self, expression: exp.Coalesce) -> str:
+            return f"IFNULL({self.sql(expression, 'this')}, {self.expressions(expression)})"
+
+        def count_sql(self, expression: exp.Count) -> str:
+            this = expression.this
+            if isinstance(this, exp.Distinct):
+                return f"COUNTD({self.expressions(this, flat=True)})"
+            return f"COUNT({self.sql(expression, 'this')})"
+
     class Parser(parser.Parser):
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "COUNTD": lambda args: exp.Count(this=exp.Distinct(expressions=args)),
         }

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -75,12 +75,12 @@ class Teradata(Dialect):
         FUNC_TOKENS.remove(TokenType.REPLACE)
 
         STATEMENT_PARSERS = {
-            **parser.Parser.STATEMENT_PARSERS,  # type: ignore
+            **parser.Parser.STATEMENT_PARSERS,
             TokenType.REPLACE: lambda self: self._parse_create(),
         }
 
         FUNCTION_PARSERS = {
-            **parser.Parser.FUNCTION_PARSERS,  # type: ignore
+            **parser.Parser.FUNCTION_PARSERS,
             "RANGE_N": lambda self: self._parse_rangen(),
             "TRANSLATE": lambda self: self._parse_translate(self.STRICT_CAST),
         }
@@ -135,12 +135,12 @@ class Teradata(Dialect):
         TABLE_HINTS = False
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.GEOMETRY: "ST_GEOMETRY",
         }
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.OnCommitProperty: exp.Properties.Location.POST_INDEX,
             exp.PartitionedByProperty: exp.Properties.Location.POST_INDEX,
             exp.StabilityProperty: exp.Properties.Location.POST_CREATE,

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -7,7 +7,7 @@ from sqlglot.dialects.presto import Presto
 class Trino(Presto):
     class Generator(Presto.Generator):
         TRANSFORMS = {
-            **Presto.Generator.TRANSFORMS,  # type: ignore
+            **Presto.Generator.TRANSFORMS,
             exp.ArraySum: lambda self, e: f"REDUCE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
         }
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -292,7 +292,7 @@ class TSQL(Dialect):
 
     class Parser(parser.Parser):
         FUNCTIONS = {
-            **parser.Parser.FUNCTIONS,  # type: ignore
+            **parser.Parser.FUNCTIONS,
             "CHARINDEX": lambda args: exp.StrPosition(
                 this=seq_get(args, 1),
                 substr=seq_get(args, 0),
@@ -332,13 +332,13 @@ class TSQL(Dialect):
             DataType.Type.NCHAR,
         }
 
-        RETURNS_TABLE_TOKENS = parser.Parser.ID_VAR_TOKENS - {  # type: ignore
+        RETURNS_TABLE_TOKENS = parser.Parser.ID_VAR_TOKENS - {
             TokenType.TABLE,
-            *parser.Parser.TYPE_TOKENS,  # type: ignore
+            *parser.Parser.TYPE_TOKENS,
         }
 
         STATEMENT_PARSERS = {
-            **parser.Parser.STATEMENT_PARSERS,  # type: ignore
+            **parser.Parser.STATEMENT_PARSERS,
             TokenType.END: lambda self: self._parse_command(),
         }
 
@@ -450,7 +450,7 @@ class TSQL(Dialect):
         LOCKING_READS_SUPPORTED = True
 
         TYPE_MAPPING = {
-            **generator.Generator.TYPE_MAPPING,  # type: ignore
+            **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.INT: "INTEGER",
             exp.DataType.Type.DECIMAL: "NUMERIC",
             exp.DataType.Type.DATETIME: "DATETIME2",
@@ -458,7 +458,7 @@ class TSQL(Dialect):
         }
 
         TRANSFORMS = {
-            **generator.Generator.TRANSFORMS,  # type: ignore
+            **generator.Generator.TRANSFORMS,
             exp.DateAdd: generate_date_delta_with_unit_sql,
             exp.DateDiff: generate_date_delta_with_unit_sql,
             exp.CurrentDate: rename_func("GETDATE"),
@@ -480,7 +480,7 @@ class TSQL(Dialect):
         TRANSFORMS.pop(exp.ReturnsProperty)
 
         PROPERTIES_LOCATION = {
-            **generator.Generator.PROPERTIES_LOCATION,  # type: ignore
+            **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -464,6 +464,7 @@ class TestSnowflake(Validator):
         )
 
     def test_timestamps(self):
+        self.validate_identity("SELECT CAST('12:00:00' AS TIME)")
         self.validate_identity("SELECT DATE_PART(month, a)")
 
         self.validate_all(


### PR DESCRIPTION
Fixes #1682

Got rid of several `type: ignore` comments because mypy seems to no longer complain.

The line of interest for #1682 is the following (inside Snowflake's parser):

```python
TIMESTAMPS = parser.Parser.TIMESTAMPS.copy() - {TokenType.TIME}
```

Also moved some `_sql` methods inside of the `Tableau` class instead of having them in `TRANSFORMS`.