### PR TITLE
Chore!: improve python type hints

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -46,9 +46,8 @@ from sqlglot.schema import MappingSchema as MappingSchema, Schema as Schema
 from sqlglot.tokens import Tokenizer as Tokenizer, TokenType as TokenType
 
 if t.TYPE_CHECKING:
+    from sqlglot._typing import E
     from sqlglot.dialects.dialect import DialectType as DialectType
-
-    T = t.TypeVar("T", bound=Expression)
 
 logger = logging.getLogger("sqlglot")
 
@@ -88,9 +87,9 @@ def parse(sql: str, read: DialectType = None, **opts) -> t.List[t.Optional[Expre
 def parse_one(
     sql: str,
     read: None = None,
-    into: t.Type[T] = ...,
+    into: t.Type[E] = ...,
     **opts,
-) -> T:
+) -> E:
     ...
 
 
@@ -98,9 +97,9 @@ def parse_one(
 def parse_one(
     sql: str,
     read: DialectType,
-    into: t.Type[T],
+    into: t.Type[E],
     **opts,
-) -> T:
+) -> E:
     ...
 
 

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import sqlglot
 import typing as t
+
+import sqlglot
 
 E = t.TypeVar("E", bound="sqlglot.exp.Expression")
 T = t.TypeVar("T")

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+import sqlglot
+import typing as t
+
+E = t.TypeVar("E", bound="sqlglot.exp.Expression")
+T = t.TypeVar("T")

--- a/sqlglot/_typing.pyi
+++ b/sqlglot/_typing.pyi
@@ -1,6 +1,0 @@
-import typing as t
-
-from sqlglot.expressions import Expression
-
-E = t.TypeVar("E", bound=Expression)
-T = t.TypeVar("T")

--- a/sqlglot/_typing.pyi
+++ b/sqlglot/_typing.pyi
@@ -1,0 +1,6 @@
+import typing as t
+
+from sqlglot.expressions import Expression
+
+E = t.TypeVar("E", bound=Expression)
+T = t.TypeVar("T")

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -19,7 +19,8 @@ from sqlglot.dialects.dialect import (
 from sqlglot.helper import seq_get, split_num_words
 from sqlglot.tokens import TokenType
 
-E = t.TypeVar("E", bound=exp.Expression)
+if t.TYPE_CHECKING:
+    pass
 
 
 def _date_add_sql(

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -19,9 +19,6 @@ from sqlglot.dialects.dialect import (
 from sqlglot.helper import seq_get, split_num_words
 from sqlglot.tokens import TokenType
 
-if t.TYPE_CHECKING:
-    pass
-
 
 def _date_add_sql(
     data_type: str, kind: str

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -1,5 +1,3 @@
-"""Supports BigQuery Standard SQL."""
-
 from __future__ import annotations
 
 import re

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -305,7 +305,7 @@ class ClickHouse(Dialect):
 
             return super().cte_sql(expression)
 
-        def after_limit_modifiers(self, expression):
+        def after_limit_modifiers(self, expression: exp.Expression) -> t.List[str]:
             return super().after_limit_modifiers(expression) + [
                 self.seg("SETTINGS ") + self.expressions(expression, key="settings", flat=True)
                 if expression.args.get("settings")

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -347,7 +347,7 @@ def var_map_sql(
 
 def format_time_lambda(
     exp_class: t.Type[E], dialect: str, default: t.Optional[bool | str] = None
-) -> t.Callable[[t.Sequence], E]:
+) -> t.Callable[[t.List], E]:
     """Helper used for time expressions.
 
     Args:
@@ -359,7 +359,7 @@ def format_time_lambda(
         A callable that can be used to return the appropriately formatted time expression.
     """
 
-    def _format_time(args: t.Sequence):
+    def _format_time(args: t.List):
         return exp_class(
             this=seq_get(args, 0),
             format=Dialect[dialect].format_time(
@@ -396,8 +396,8 @@ def create_with_partitions_sql(self: Generator, expression: exp.Create) -> str:
 
 def parse_date_delta(
     exp_class: t.Type[E], unit_mapping: t.Optional[t.Dict[str, str]] = None
-) -> t.Callable[[t.Sequence], E]:
-    def inner_func(args: t.Sequence) -> E:
+) -> t.Callable[[t.List], E]:
+    def inner_func(args: t.List) -> E:
         unit_based = len(args) == 3
         this = args[2] if unit_based else seq_get(args, 0)
         unit = args[0] if unit_based else exp.Literal.string("DAY")
@@ -409,8 +409,8 @@ def parse_date_delta(
 
 def parse_date_delta_with_interval(
     expression_class: t.Type[E],
-) -> t.Callable[[t.Sequence], t.Optional[E]]:
-    def func(args: t.Sequence) -> t.Optional[E]:
+) -> t.Callable[[t.List], t.Optional[E]]:
+    def func(args: t.List) -> t.Optional[E]:
         if len(args) < 2:
             return None
 
@@ -428,7 +428,7 @@ def parse_date_delta_with_interval(
     return func
 
 
-def date_trunc_to_time(args: t.Sequence) -> exp.DateTrunc | exp.TimestampTrunc:
+def date_trunc_to_time(args: t.List) -> exp.DateTrunc | exp.TimestampTrunc:
     unit = seq_get(args, 0)
     this = seq_get(args, 1)
 
@@ -443,7 +443,7 @@ def timestamptrunc_sql(self: Generator, expression: exp.TimestampTrunc) -> str:
     )
 
 
-def locate_to_strposition(args: t.Sequence) -> exp.Expression:
+def locate_to_strposition(args: t.List) -> exp.Expression:
     return exp.StrPosition(
         this=seq_get(args, 1),
         substr=seq_get(args, 0),
@@ -502,7 +502,7 @@ def trim_sql(self: Generator, expression: exp.Trim) -> str:
     return f"TRIM({trim_type}{remove_chars}{from_part}{target}{collation})"
 
 
-def str_to_time_sql(self, expression: exp.Expression) -> str:
+def str_to_time_sql(self: Generator, expression: exp.Expression) -> str:
     return self.func("STRPTIME", expression.this, self.format_time(expression))
 
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -11,7 +11,8 @@ from sqlglot.time import format_time
 from sqlglot.tokens import Token, Tokenizer
 from sqlglot.trie import new_trie
 
-E = t.TypeVar("E", bound=exp.Expression)
+if t.TYPE_CHECKING:
+    from sqlglot._typing import E
 
 
 class Dialects(str, Enum):

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -50,11 +50,11 @@ def _sort_array_sql(self: generator.Generator, expression: exp.SortArray) -> str
     return f"ARRAY_SORT({this})"
 
 
-def _sort_array_reverse(args: t.Sequence) -> exp.Expression:
+def _sort_array_reverse(args: t.List) -> exp.Expression:
     return exp.SortArray(this=seq_get(args, 0), asc=exp.false())
 
 
-def _parse_date_diff(args: t.Sequence) -> exp.Expression:
+def _parse_date_diff(args: t.List) -> exp.Expression:
     return exp.DateDiff(
         this=seq_get(args, 2),
         expression=seq_get(args, 1),
@@ -245,6 +245,6 @@ class DuckDB(Dialect):
         }
 
         def tablesample_sql(
-            self, expression: exp.TableSample, seed_prefix: str = "SEED", sep=" AS "
+            self, expression: exp.TableSample, seed_prefix: str = "SEED", sep: str = " AS "
         ) -> str:
             return super().tablesample_sql(expression, seed_prefix="REPEATABLE", sep=sep)

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -401,7 +401,7 @@ class Hive(Dialect):
 
             return super().datatype_sql(expression)
 
-        def after_having_modifiers(self, expression):
+        def after_having_modifiers(self, expression: exp.Expression) -> t.List[str]:
             return super().after_having_modifiers(expression) + [
                 self.sql(expression, "distribute"),
                 self.sql(expression, "sort"),

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -24,8 +24,8 @@ from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
 
-def _show_parser(*args: t.Any, **kwargs: t.Any) -> t.Callable[[parser.Parser], exp.Show]:
-    def _parse(self) -> exp.Show:
+def _show_parser(*args: t.Any, **kwargs: t.Any) -> t.Callable[[MySQL.Parser], exp.Show]:
+    def _parse(self: MySQL.Parser) -> exp.Show:
         return self._parse_show_mysql(*args, **kwargs)
 
     return _parse

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -8,7 +8,7 @@ from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
 
-def _parse_xml_table(self) -> exp.XMLTable:
+def _parse_xml_table(self: parser.Parser) -> exp.XMLTable:
     this = self._parse_string()
 
     passing = None

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -133,7 +133,7 @@ def _ensure_utf8(charset: exp.Literal) -> None:
         raise UnsupportedError(f"Unsupported charset {charset}")
 
 
-def _approx_percentile(args: t.Sequence) -> exp.Expression:
+def _approx_percentile(args: t.List) -> exp.Expression:
     if len(args) == 4:
         return exp.ApproxQuantile(
             this=seq_get(args, 0),
@@ -150,7 +150,7 @@ def _approx_percentile(args: t.Sequence) -> exp.Expression:
     return exp.ApproxQuantile.from_arg_list(args)
 
 
-def _from_unixtime(args: t.Sequence) -> exp.Expression:
+def _from_unixtime(args: t.List) -> exp.Expression:
     if len(args) == 3:
         return exp.UnixToTime(
             this=seq_get(args, 0),

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -8,8 +8,8 @@ from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
 
-def _json_sql(self, e) -> str:
-    return f'{self.sql(e, "this")}."{e.expression.name}"'
+def _json_sql(self: Postgres.Generator, expression: exp.JSONExtract | exp.JSONExtractScalar) -> str:
+    return f'{self.sql(expression, "this")}."{expression.expression.name}"'
 
 
 class Redshift(Postgres):
@@ -140,7 +140,7 @@ class Redshift(Postgres):
 
                 selects.append(exp.Select(expressions=row))
 
-            subquery_expression = selects[0]
+            subquery_expression: exp.Select | exp.Union = selects[0]
             if len(selects) > 1:
                 for select in selects[1:]:
                     subquery_expression = exp.union(subquery_expression, select, distinct=False)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -30,7 +30,7 @@ def _check_int(s: str) -> bool:
 
 
 # from https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html
-def _snowflake_to_timestamp(args: t.Sequence) -> t.Union[exp.StrToTime, exp.UnixToTime]:
+def _snowflake_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime]:
     if len(args) == 2:
         first_arg, second_arg = args
         if second_arg.is_string:
@@ -120,7 +120,7 @@ def _parse_date_part(self: parser.Parser) -> t.Optional[exp.Expression]:
 
 
 # https://docs.snowflake.com/en/sql-reference/functions/div0
-def _div0_to_if(args: t.Sequence) -> exp.Expression:
+def _div0_to_if(args: t.List) -> exp.Expression:
     cond = exp.EQ(this=seq_get(args, 1), expression=exp.Literal.number(0))
     true = exp.Literal.number(0)
     false = exp.Div(this=seq_get(args, 0), expression=seq_get(args, 1))
@@ -128,13 +128,13 @@ def _div0_to_if(args: t.Sequence) -> exp.Expression:
 
 
 # https://docs.snowflake.com/en/sql-reference/functions/zeroifnull
-def _zeroifnull_to_if(args: t.Sequence) -> exp.Expression:
+def _zeroifnull_to_if(args: t.List) -> exp.Expression:
     cond = exp.Is(this=seq_get(args, 0), expression=exp.Null())
     return exp.If(this=cond, true=exp.Literal.number(0), false=seq_get(args, 0))
 
 
 # https://docs.snowflake.com/en/sql-reference/functions/zeroifnull
-def _nullifzero_to_if(args: t.Sequence) -> exp.Expression:
+def _nullifzero_to_if(args: t.List) -> exp.Expression:
     cond = exp.EQ(this=seq_get(args, 0), expression=exp.Literal.number(0))
     return exp.If(this=cond, true=exp.Null(), false=seq_get(args, 0))
 
@@ -147,7 +147,7 @@ def _datatype_sql(self: generator.Generator, expression: exp.DataType) -> str:
     return self.datatype_sql(expression)
 
 
-def _parse_convert_timezone(args: t.Sequence) -> exp.Expression:
+def _parse_convert_timezone(args: t.List) -> exp.Expression:
     if len(args) == 3:
         return exp.Anonymous(this="CONVERT_TIMEZONE", expressions=args)
     return exp.AtTimeZone(this=seq_get(args, 1), zone=seq_get(args, 0))

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -7,10 +7,10 @@ from sqlglot.dialects.spark2 import Spark2
 from sqlglot.helper import seq_get
 
 
-def _parse_datediff(args: t.Sequence) -> exp.Expression:
+def _parse_datediff(args: t.List) -> exp.Expression:
     """
     Although Spark docs don't mention the "unit" argument, Spark3 added support for
-    it at some point. Databricks also supports this variation (see below).
+    it at some point. Databricks also supports this variant (see below).
 
     For example, in spark-sql (v3.3.1):
     - SELECT DATEDIFF('2020-01-01', '2020-01-05') results in -4

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -31,7 +31,7 @@ def _map_sql(self: Hive.Generator, expression: exp.Map) -> str:
     return f"MAP_FROM_ARRAYS({keys}, {values})"
 
 
-def _parse_as_cast(to_type: str) -> t.Callable[[t.Sequence], exp.Expression]:
+def _parse_as_cast(to_type: str) -> t.Callable[[t.List], exp.Expression]:
     return lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.build(to_type))
 
 

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -15,7 +15,7 @@ from sqlglot.dialects.dialect import (
 from sqlglot.tokens import TokenType
 
 
-def _date_add_sql(self, expression):
+def _date_add_sql(self: generator.Generator, expression: exp.DateAdd) -> str:
     modifier = expression.expression
     modifier = modifier.name if modifier.is_string else self.sql(modifier)
     unit = expression.args.get("unit")
@@ -165,12 +165,15 @@ class SQLite(Dialect):
             return f"CAST({sql} AS INTEGER)"
 
         # https://www.sqlite.org/lang_aggfunc.html#group_concat
-        def groupconcat_sql(self, expression):
+        def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
             this = expression.this
             distinct = expression.find(exp.Distinct)
+
             if distinct:
                 this = distinct.expressions[0]
-                distinct = "DISTINCT "
+                distinct_sql = "DISTINCT "
+            else:
+                distinct_sql = ""
 
             if isinstance(expression.this, exp.Order):
                 self.unsupported("SQLite GROUP_CONCAT doesn't support ORDER BY.")
@@ -178,7 +181,7 @@ class SQLite(Dialect):
                     this = expression.this.this
 
             separator = expression.args.get("separator")
-            return f"GROUP_CONCAT({distinct or ''}{self.format_args(this, separator)})"
+            return f"GROUP_CONCAT({distinct_sql}{self.format_args(this, separator)})"
 
         def least_sql(self, expression: exp.Least) -> str:
             if len(expression.expressions) > 1:

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -42,4 +42,5 @@ class StarRocks(MySQL):
             exp.UnixToStr: lambda self, e: f"FROM_UNIXTIME({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.UnixToTime: rename_func("FROM_UNIXTIME"),
         }
+
         TRANSFORMS.pop(exp.DateTrunc)

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -16,7 +16,8 @@ from sqlglot.helper import seq_get
 from sqlglot.time import format_time
 from sqlglot.tokens import TokenType
 
-E = t.TypeVar("E", bound="exp.Expression")
+if t.TYPE_CHECKING:
+    from sqlglot._typing import E
 
 FULL_FORMAT_TIME_MAPPING = {
     "weekday": "%A",

--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -53,7 +53,8 @@ class Keep:
 
 
 if t.TYPE_CHECKING:
-    T = t.TypeVar("T")
+    from sqlglot._typing import T
+
     Edit = t.Union[Insert, Remove, Move, Update, Keep]
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -21,6 +21,7 @@ from collections import deque
 from copy import deepcopy
 from enum import auto
 
+from sqlglot._typing import E
 from sqlglot.errors import ParseError
 from sqlglot.helper import (
     AutoName,
@@ -33,7 +34,6 @@ from sqlglot.helper import (
 from sqlglot.tokens import Token
 
 if t.TYPE_CHECKING:
-    from sqlglot._typing import E
     from sqlglot.dialects.dialect import DialectType
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4711,14 +4711,16 @@ def _apply_cte_builder(
 
 
 def _combine(
-    expressions: t.Sequence[ExpOrStr],
+    expressions: t.Sequence[t.Optional[ExpOrStr]],
     operator: t.Type[Connector],
     dialect: DialectType = None,
     copy: bool = True,
     **opts,
 ) -> Expression:
     conditions = [
-        condition(expression, dialect=dialect, copy=copy, **opts) for expression in expressions
+        condition(expression, dialect=dialect, copy=copy, **opts)
+        for expression in expressions
+        if expression
     ]
 
     this, *rest = conditions
@@ -5027,7 +5029,7 @@ def condition(
 
 
 def and_(
-    *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+    *expressions: t.Optional[ExpOrStr], dialect: DialectType = None, copy: bool = True, **opts
 ) -> Expression:
     """
     Combine multiple conditions with an AND logical operator.
@@ -5050,7 +5052,7 @@ def and_(
 
 
 def or_(
-    *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+    *expressions: t.Optional[ExpOrStr], dialect: DialectType = None, copy: bool = True, **opts
 ) -> Expression:
     """
     Combine multiple conditions with an OR logical operator.

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -586,7 +586,7 @@ class Expression(metaclass=_Expression):
         self.replace(None)
         return self
 
-    def assert_is(self: E, type_: t.Type[E]) -> E:
+    def assert_is(self: Expression, type_: t.Type[E]) -> E:
         """
         Assert that this `Expression` is an instance of `type_`.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -586,7 +586,7 @@ class Expression(metaclass=_Expression):
         self.replace(None)
         return self
 
-    def assert_is(self: Expression, type_: t.Type[E]) -> E:
+    def assert_is(self, type_: t.Type[E]) -> E:
         """
         Assert that this `Expression` is an instance of `type_`.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -33,9 +33,8 @@ from sqlglot.helper import (
 from sqlglot.tokens import Token
 
 if t.TYPE_CHECKING:
+    from sqlglot._typing import E
     from sqlglot.dialects.dialect import DialectType
-
-E = t.TypeVar("E", bound="Expression")
 
 
 class _Expression(type):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -199,11 +199,11 @@ class Expression(metaclass=_Expression):
         return self.text("this")
 
     @property
-    def alias_or_name(self):
+    def alias_or_name(self) -> str:
         return self.alias or self.name
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         """
         Name of the output column if this expression is a selection.
 
@@ -263,7 +263,7 @@ class Expression(metaclass=_Expression):
         if comments:
             self.comments.extend(comments)
 
-    def append(self, arg_key, value):
+    def append(self, arg_key: str, value: t.Any) -> None:
         """
         Appends value to arg_key if it's a list or sets it as a new list.
 
@@ -276,7 +276,7 @@ class Expression(metaclass=_Expression):
         self.args[arg_key].append(value)
         self._set_parent(arg_key, value)
 
-    def set(self, arg_key, value):
+    def set(self, arg_key: str, value: t.Any) -> None:
         """
         Sets `arg_key` to `value`.
 
@@ -287,7 +287,7 @@ class Expression(metaclass=_Expression):
         self.args[arg_key] = value
         self._set_parent(arg_key, value)
 
-    def _set_parent(self, arg_key, value):
+    def _set_parent(self, arg_key: str, value: t.Any) -> None:
         if hasattr(value, "parent"):
             value.parent = self
             value.arg_key = arg_key
@@ -298,7 +298,7 @@ class Expression(metaclass=_Expression):
                     v.arg_key = arg_key
 
     @property
-    def depth(self):
+    def depth(self) -> int:
         """
         Returns the depth of this tree.
         """
@@ -361,14 +361,14 @@ class Expression(metaclass=_Expression):
         return t.cast(E, ancestor)
 
     @property
-    def parent_select(self):
+    def parent_select(self) -> t.Optional[Select]:
         """
         Returns the parent select statement.
         """
         return self.find_ancestor(Select)
 
     @property
-    def same_parent(self):
+    def same_parent(self) -> bool:
         """Returns if the parent is the same class as itself."""
         return type(self.parent) is self.__class__
 
@@ -468,10 +468,10 @@ class Expression(metaclass=_Expression):
             if not type(node) is self.__class__:
                 yield node.unnest() if unnest else node
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.sql()
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return self._to_s()
 
     def sql(self, dialect: DialectType = None, **opts) -> str:
@@ -540,6 +540,14 @@ class Expression(metaclass=_Expression):
         replace_children(new_node, lambda child: child.transform(fun, *args, copy=False, **kwargs))
         return new_node
 
+    @t.overload
+    def replace(self, expression: E) -> E:
+        ...
+
+    @t.overload
+    def replace(self, expression: None) -> None:
+        ...
+
     def replace(self, expression):
         """
         Swap out this expression with a new expression.
@@ -553,7 +561,7 @@ class Expression(metaclass=_Expression):
             'SELECT y FROM tbl'
 
         Args:
-            expression (Expression|None): new node
+            expression: new node
 
         Returns:
             The new expression or expressions.
@@ -567,7 +575,7 @@ class Expression(metaclass=_Expression):
         replace_children(parent, lambda child: expression if child is self else child)
         return expression
 
-    def pop(self):
+    def pop(self: E) -> E:
         """
         Remove this expression from its AST.
 
@@ -577,7 +585,7 @@ class Expression(metaclass=_Expression):
         self.replace(None)
         return self
 
-    def assert_is(self, type_):
+    def assert_is(self: E, type_: t.Type[E]) -> E:
         """
         Assert that this `Expression` is an instance of `type_`.
 
@@ -655,7 +663,9 @@ ExpOrStr = t.Union[str, Expression]
 
 
 class Condition(Expression):
-    def and_(self, *expressions, dialect=None, copy=True, **opts):
+    def and_(
+        self, *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+    ) -> Expression:
         """
         AND this condition with one or multiple expressions.
 
@@ -664,18 +674,20 @@ class Condition(Expression):
             'x = 1 AND y = 1'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): whether or not to copy the involved expressions (only applies to Expressions).
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: whether or not to copy the involved expressions (only applies to Expressions).
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            And: the new condition.
+            The new And condition.
         """
         return and_(self, *expressions, dialect=dialect, copy=copy, **opts)
 
-    def or_(self, *expressions, dialect=None, copy=True, **opts):
+    def or_(
+        self, *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+    ) -> Expression:
         """
         OR this condition with one or multiple expressions.
 
@@ -684,18 +696,18 @@ class Condition(Expression):
             'x = 1 OR y = 1'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): whether or not to copy the involved expressions (only applies to Expressions).
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: whether or not to copy the involved expressions (only applies to Expressions).
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Or: the new condition.
+            The new Or condition.
         """
         return or_(self, *expressions, dialect=dialect, copy=copy, **opts)
 
-    def not_(self, copy=True):
+    def not_(self, copy: bool = True):
         """
         Wrap this condition with NOT.
 
@@ -737,7 +749,7 @@ class Condition(Expression):
         )
 
     def isin(
-        self, *expressions: t.Any, query: t.Optional[ExpOrStr] = None, copy=True, **opts
+        self, *expressions: t.Any, query: t.Optional[ExpOrStr] = None, copy: bool = True, **opts
     ) -> In:
         return In(
             this=_maybe_copy(self, copy),
@@ -745,7 +757,7 @@ class Condition(Expression):
             query=maybe_parse(query, copy=copy, **opts) if query else None,
         )
 
-    def between(self, low: t.Any, high: t.Any, copy=True, **opts) -> Between:
+    def between(self, low: t.Any, high: t.Any, copy: bool = True, **opts) -> Between:
         return Between(
             this=_maybe_copy(self, copy),
             low=convert(low, copy=copy, **opts),
@@ -849,7 +861,7 @@ class Predicate(Condition):
 
 class DerivedTable(Expression):
     @property
-    def alias_column_names(self):
+    def alias_column_names(self) -> t.List[str]:
         table_alias = self.args.get("alias")
         if not table_alias:
             return []
@@ -866,7 +878,9 @@ class DerivedTable(Expression):
 
 
 class Unionable(Expression):
-    def union(self, expression, distinct=True, dialect=None, **opts):
+    def union(
+        self, expression: ExpOrStr, distinct: bool = True, dialect: DialectType = None, **opts
+    ) -> Unionable:
         """
         Builds a UNION expression.
 
@@ -876,17 +890,20 @@ class Unionable(Expression):
             'SELECT * FROM foo UNION SELECT * FROM bla'
 
         Args:
-            expression (str | Expression): the SQL code string.
+            expression: the SQL code string.
                 If an `Expression` instance is passed, it will be used as-is.
-            distinct (bool): set the DISTINCT flag if and only if this is true.
-            dialect (str): the dialect used to parse the input expression.
-            opts (kwargs): other options to use to parse the input expressions.
+            distinct: set the DISTINCT flag if and only if this is true.
+            dialect: the dialect used to parse the input expression.
+            opts: other options to use to parse the input expressions.
+
         Returns:
-            Union: the Union expression.
+            The new Union expression.
         """
         return union(left=self, right=expression, distinct=distinct, dialect=dialect, **opts)
 
-    def intersect(self, expression, distinct=True, dialect=None, **opts):
+    def intersect(
+        self, expression: ExpOrStr, distinct: bool = True, dialect: DialectType = None, **opts
+    ) -> Unionable:
         """
         Builds an INTERSECT expression.
 
@@ -896,17 +913,20 @@ class Unionable(Expression):
             'SELECT * FROM foo INTERSECT SELECT * FROM bla'
 
         Args:
-            expression (str | Expression): the SQL code string.
+            expression: the SQL code string.
                 If an `Expression` instance is passed, it will be used as-is.
-            distinct (bool): set the DISTINCT flag if and only if this is true.
-            dialect (str): the dialect used to parse the input expression.
-            opts (kwargs): other options to use to parse the input expressions.
+            distinct: set the DISTINCT flag if and only if this is true.
+            dialect: the dialect used to parse the input expression.
+            opts: other options to use to parse the input expressions.
+
         Returns:
-            Intersect: the Intersect expression
+            The new Intersect expression.
         """
         return intersect(left=self, right=expression, distinct=distinct, dialect=dialect, **opts)
 
-    def except_(self, expression, distinct=True, dialect=None, **opts):
+    def except_(
+        self, expression: ExpOrStr, distinct: bool = True, dialect: DialectType = None, **opts
+    ) -> Unionable:
         """
         Builds an EXCEPT expression.
 
@@ -916,13 +936,14 @@ class Unionable(Expression):
             'SELECT * FROM foo EXCEPT SELECT * FROM bla'
 
         Args:
-            expression (str | Expression): the SQL code string.
+            expression: the SQL code string.
                 If an `Expression` instance is passed, it will be used as-is.
-            distinct (bool): set the DISTINCT flag if and only if this is true.
-            dialect (str): the dialect used to parse the input expression.
-            opts (kwargs): other options to use to parse the input expressions.
+            distinct: set the DISTINCT flag if and only if this is true.
+            dialect: the dialect used to parse the input expression.
+            opts: other options to use to parse the input expressions.
+
         Returns:
-            Except: the Except expression
+            The new Except expression.
         """
         return except_(left=self, right=expression, distinct=distinct, dialect=dialect, **opts)
 
@@ -1453,7 +1474,7 @@ class Identifier(Expression):
     arg_types = {"this": True, "quoted": False}
 
     @property
-    def quoted(self):
+    def quoted(self) -> bool:
         return bool(self.args.get("quoted"))
 
     @property
@@ -1463,7 +1484,7 @@ class Identifier(Expression):
         return self.this.lower()
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         return self.name
 
 
@@ -1612,7 +1633,7 @@ class Literal(Condition):
         return cls(this=str(string), is_string=True)
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         return self.name
 
 
@@ -1629,22 +1650,29 @@ class Join(Expression):
     }
 
     @property
-    def kind(self):
+    def kind(self) -> str:
         return self.text("kind").upper()
 
     @property
-    def side(self):
+    def side(self) -> str:
         return self.text("side").upper()
 
     @property
-    def hint(self):
+    def hint(self) -> str:
         return self.text("hint").upper()
 
     @property
-    def alias_or_name(self):
+    def alias_or_name(self) -> str:
         return self.this.alias_or_name
 
-    def on(self, *expressions, append=True, dialect=None, copy=True, **opts):
+    def on(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Join:
         """
         Append to or set the ON expressions.
 
@@ -1654,17 +1682,17 @@ class Join(Expression):
             'JOIN x ON y = 1'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
                 Multiple expressions are combined with an AND operator.
-            append (bool): if `True`, AND the new expressions to any existing expression.
+            append: if `True`, AND the new expressions to any existing expression.
                 Otherwise, this resets the expression.
-            dialect (str): the dialect used to parse the input expressions.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expressions.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Join: the modified join expression.
+            The modified Join expression.
         """
         join = _apply_conjunction_builder(
             *expressions,
@@ -1681,7 +1709,14 @@ class Join(Expression):
 
         return join
 
-    def using(self, *expressions, append=True, dialect=None, copy=True, **opts):
+    def using(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Join:
         """
         Append to or set the USING expressions.
 
@@ -1691,16 +1726,16 @@ class Join(Expression):
             'JOIN x USING (foo, bla)'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
-            append (bool): if `True`, concatenate the new expressions to the existing "using" list.
+            append: if `True`, concatenate the new expressions to the existing "using" list.
                 Otherwise, this resets the expression.
-            dialect (str): the dialect used to parse the input expressions.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expressions.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Join: the modified join expression.
+            The modified Join expression.
         """
         join = _apply_list_builder(
             *expressions,
@@ -2033,7 +2068,7 @@ class Properties(Expression):
         UNSUPPORTED = auto()
 
     @classmethod
-    def from_dict(cls, properties_dict) -> Properties:
+    def from_dict(cls, properties_dict: t.Dict) -> Properties:
         expressions = []
         for key, value in properties_dict.items():
             property_cls = cls.NAME_TO_PROPERTY.get(key.upper())
@@ -2062,7 +2097,7 @@ class Tuple(Expression):
     arg_types = {"expressions": False}
 
     def isin(
-        self, *expressions: t.Any, query: t.Optional[ExpOrStr] = None, copy=True, **opts
+        self, *expressions: t.Any, query: t.Optional[ExpOrStr] = None, copy: bool = True, **opts
     ) -> In:
         return In(
             this=_maybe_copy(self, copy),
@@ -2072,7 +2107,7 @@ class Tuple(Expression):
 
 
 class Subqueryable(Unionable):
-    def subquery(self, alias=None, copy=True) -> Subquery:
+    def subquery(self, alias: t.Optional[ExpOrStr] = None, copy: bool = True) -> Subquery:
         """
         Convert this expression to an aliased expression that can be used as a Subquery.
 
@@ -2094,7 +2129,9 @@ class Subqueryable(Unionable):
 
         return Subquery(this=instance, alias=alias)
 
-    def limit(self, expression, dialect=None, copy=True, **opts) -> Select:
+    def limit(
+        self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
+    ) -> Select:
         raise NotImplementedError
 
     @property
@@ -2221,7 +2258,9 @@ class Union(Subqueryable):
         **QUERY_MODIFIERS,
     }
 
-    def limit(self, expression, dialect=None, copy=True, **opts) -> Select:
+    def limit(
+        self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
+    ) -> Select:
         """
         Set the LIMIT expression.
 
@@ -2230,16 +2269,16 @@ class Union(Subqueryable):
             'SELECT * FROM (SELECT 1 UNION SELECT 1) AS _l_0 LIMIT 1'
 
         Args:
-            expression (str | int | Expression): the SQL code string to parse.
+            expression: the SQL code string to parse.
                 This can also be an integer.
                 If a `Limit` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `Limit`.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: The limited subqueryable.
+            The limited subqueryable.
         """
         return (
             select("*")
@@ -2385,7 +2424,7 @@ class Select(Subqueryable):
             opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_builder(
             expression=expression,
@@ -2398,7 +2437,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def group_by(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def group_by(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Set the GROUP BY expression.
 
@@ -2407,18 +2453,18 @@ class Select(Subqueryable):
             'SELECT x, COUNT(1) FROM tbl GROUP BY x'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If a `Group` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `Group`.
                 If nothing is passed in then a group by is not applied to the expression
-            append (bool): if `True`, add to any existing expressions.
+            append: if `True`, add to any existing expressions.
                 Otherwise, this flattens all the `Group` expression into a single expression.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         if not expressions:
             return self if not copy else self.copy()
@@ -2434,7 +2480,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def order_by(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def order_by(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Set the ORDER BY expression.
 
@@ -2443,17 +2496,17 @@ class Select(Subqueryable):
             'SELECT x FROM tbl ORDER BY x DESC'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If a `Group` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `Order`.
-            append (bool): if `True`, add to any existing expressions.
+            append: if `True`, add to any existing expressions.
                 Otherwise, this flattens all the `Order` expression into a single expression.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_child_list_builder(
             *expressions,
@@ -2467,7 +2520,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def sort_by(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def sort_by(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Set the SORT BY expression.
 
@@ -2476,17 +2536,17 @@ class Select(Subqueryable):
             'SELECT x FROM tbl SORT BY x DESC'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If a `Group` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `SORT`.
-            append (bool): if `True`, add to any existing expressions.
+            append: if `True`, add to any existing expressions.
                 Otherwise, this flattens all the `Order` expression into a single expression.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_child_list_builder(
             *expressions,
@@ -2500,7 +2560,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def cluster_by(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def cluster_by(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Set the CLUSTER BY expression.
 
@@ -2509,17 +2576,17 @@ class Select(Subqueryable):
             'SELECT x FROM tbl CLUSTER BY x DESC'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If a `Group` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `Cluster`.
-            append (bool): if `True`, add to any existing expressions.
+            append: if `True`, add to any existing expressions.
                 Otherwise, this flattens all the `Order` expression into a single expression.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_child_list_builder(
             *expressions,
@@ -2533,7 +2600,9 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def limit(self, expression, dialect=None, copy=True, **opts) -> Select:
+    def limit(
+        self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
+    ) -> Select:
         """
         Set the LIMIT expression.
 
@@ -2542,13 +2611,13 @@ class Select(Subqueryable):
             'SELECT x FROM tbl LIMIT 10'
 
         Args:
-            expression (str | int | Expression): the SQL code string to parse.
+            expression: the SQL code string to parse.
                 This can also be an integer.
                 If a `Limit` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `Limit`.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
             Select: the modified expression.
@@ -2564,7 +2633,9 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def offset(self, expression, dialect=None, copy=True, **opts) -> Select:
+    def offset(
+        self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
+    ) -> Select:
         """
         Set the OFFSET expression.
 
@@ -2573,16 +2644,16 @@ class Select(Subqueryable):
             'SELECT x FROM tbl OFFSET 10'
 
         Args:
-            expression (str | int | Expression): the SQL code string to parse.
+            expression: the SQL code string to parse.
                 This can also be an integer.
                 If a `Offset` instance is passed, this is used as-is.
                 If another `Expression` instance is passed, it will be wrapped in a `Offset`.
-            dialect (str): the dialect used to parse the input expression.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expression.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_builder(
             expression=expression,
@@ -2620,7 +2691,7 @@ class Select(Subqueryable):
             opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_list_builder(
             *expressions,
@@ -2632,7 +2703,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def lateral(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def lateral(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Append to or set the LATERAL expressions.
 
@@ -2641,16 +2719,16 @@ class Select(Subqueryable):
             'SELECT x FROM tbl LATERAL VIEW OUTER EXPLODE(y) tbl2 AS z'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
-            append (bool): if `True`, add to any existing expressions.
+            append: if `True`, add to any existing expressions.
                 Otherwise, this resets the expressions.
-            dialect (str): the dialect used to parse the input expressions.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expressions.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_list_builder(
             *expressions,
@@ -2759,7 +2837,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def where(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def where(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Append to or set the WHERE expressions.
 
@@ -2768,14 +2853,14 @@ class Select(Subqueryable):
             "SELECT x FROM tbl WHERE x = 'a' OR x < 'b'"
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
                 Multiple expressions are combined with an AND operator.
-            append (bool): if `True`, AND the new expressions to any existing expression.
+            append: if `True`, AND the new expressions to any existing expression.
                 Otherwise, this resets the expression.
-            dialect (str): the dialect used to parse the input expressions.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expressions.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
             Select: the modified expression.
@@ -2791,7 +2876,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def having(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def having(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         """
         Append to or set the HAVING expressions.
 
@@ -2800,17 +2892,17 @@ class Select(Subqueryable):
             'SELECT x, COUNT(y) FROM tbl GROUP BY x HAVING COUNT(y) > 3'
 
         Args:
-            *expressions (str | Expression): the SQL code strings to parse.
+            *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
                 Multiple expressions are combined with an AND operator.
-            append (bool): if `True`, AND the new expressions to any existing expression.
+            append: if `True`, AND the new expressions to any existing expression.
                 Otherwise, this resets the expression.
-            dialect (str): the dialect used to parse the input expressions.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input expressions.
+            dialect: the dialect used to parse the input expressions.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input expressions.
 
         Returns:
-            Select: the modified expression.
+            The modified Select expression.
         """
         return _apply_conjunction_builder(
             *expressions,
@@ -2823,7 +2915,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def window(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def window(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         return _apply_list_builder(
             *expressions,
             instance=self,
@@ -2835,7 +2934,14 @@ class Select(Subqueryable):
             **opts,
         )
 
-    def qualify(self, *expressions, append=True, dialect=None, copy=True, **opts) -> Select:
+    def qualify(
+        self,
+        *expressions: ExpOrStr,
+        append: bool = True,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Select:
         return _apply_conjunction_builder(
             *expressions,
             instance=self,
@@ -2868,7 +2974,14 @@ class Select(Subqueryable):
         instance.set("distinct", Distinct(on=on) if distinct else None)
         return instance
 
-    def ctas(self, table, properties=None, dialect=None, copy=True, **opts) -> Create:
+    def ctas(
+        self,
+        table: ExpOrStr,
+        properties: t.Optional[t.Dict] = None,
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
+    ) -> Create:
         """
         Convert this expression to a CREATE TABLE AS statement.
 
@@ -2877,15 +2990,15 @@ class Select(Subqueryable):
             'CREATE TABLE x AS SELECT * FROM tbl'
 
         Args:
-            table (str | Expression): the SQL code string to parse as the table name.
+            table: the SQL code string to parse as the table name.
                 If another `Expression` instance is passed, it will be used as-is.
-            properties (dict): an optional mapping of table properties
-            dialect (str): the dialect used to parse the input table.
-            copy (bool): if `False`, modify this expression instance in-place.
-            opts (kwargs): other options to use to parse the input table.
+            properties: an optional mapping of table properties
+            dialect: the dialect used to parse the input table.
+            copy: if `False`, modify this expression instance in-place.
+            opts: other options to use to parse the input table.
 
         Returns:
-            Create: the CREATE TABLE AS expression
+            The new Create expression.
         """
         instance = _maybe_copy(self, copy)
         table_expression = maybe_parse(
@@ -2964,7 +3077,7 @@ class Subquery(DerivedTable, Unionable):
         return self.this.is_star
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         return self.alias
 
 
@@ -3037,7 +3150,7 @@ class Star(Expression):
         return "*"
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         return self.name
 
 
@@ -3458,7 +3571,7 @@ class Alias(Expression):
     arg_types = {"this": True, "alias": False}
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         return self.alias
 
 
@@ -3706,11 +3819,11 @@ class Cast(Func):
         return self.this.name
 
     @property
-    def to(self):
+    def to(self) -> DataType:
         return self.args["to"]
 
     @property
-    def output_name(self):
+    def output_name(self) -> str:
         return self.name
 
     def is_type(self, dtype: DataType.Type) -> bool:
@@ -4586,25 +4699,34 @@ def _apply_cte_builder(
     )
 
 
-def _combine(expressions, operator, dialect=None, copy=True, **opts):
+def _combine(
+    expressions: t.Sequence[ExpOrStr],
+    operator: t.Type[Connector],
+    dialect: DialectType = None,
+    copy: bool = True,
+    **opts,
+) -> Expression:
     expressions = [
         condition(expression, dialect=dialect, copy=copy, **opts) for expression in expressions
     ]
-    this = expressions[0]
+    this = t.cast(Expression, expressions[0])
     if expressions[1:]:
         this = _wrap(this, Connector)
     for expression in expressions[1:]:
         this = operator(this=this, expression=_wrap(expression, Connector))
+
     return this
 
 
-def _wrap(expression: E, kind: t.Type[Expression]) -> E | Paren:
+def _wrap(expression, kind):
     if isinstance(expression, kind):
         return Paren(this=expression)
     return expression
 
 
-def union(left, right, distinct=True, dialect=None, **opts):
+def union(
+    left: ExpOrStr, right: ExpOrStr, distinct: bool = True, dialect: DialectType = None, **opts
+) -> Union:
     """
     Initializes a syntax tree from one UNION expression.
 
@@ -4613,15 +4735,16 @@ def union(left, right, distinct=True, dialect=None, **opts):
         'SELECT * FROM foo UNION SELECT * FROM bla'
 
     Args:
-        left (str | Expression): the SQL code string corresponding to the left-hand side.
+        left: the SQL code string corresponding to the left-hand side.
             If an `Expression` instance is passed, it will be used as-is.
-        right (str | Expression): the SQL code string corresponding to the right-hand side.
+        right: the SQL code string corresponding to the right-hand side.
             If an `Expression` instance is passed, it will be used as-is.
-        distinct (bool): set the DISTINCT flag if and only if this is true.
-        dialect (str): the dialect used to parse the input expression.
-        opts (kwargs): other options to use to parse the input expressions.
+        distinct: set the DISTINCT flag if and only if this is true.
+        dialect: the dialect used to parse the input expression.
+        opts: other options to use to parse the input expressions.
+
     Returns:
-        Union: the syntax tree for the UNION expression.
+        The new Union instance.
     """
     left = maybe_parse(sql_or_expression=left, dialect=dialect, **opts)
     right = maybe_parse(sql_or_expression=right, dialect=dialect, **opts)
@@ -4629,7 +4752,9 @@ def union(left, right, distinct=True, dialect=None, **opts):
     return Union(this=left, expression=right, distinct=distinct)
 
 
-def intersect(left, right, distinct=True, dialect=None, **opts):
+def intersect(
+    left: ExpOrStr, right: ExpOrStr, distinct: bool = True, dialect: DialectType = None, **opts
+) -> Intersect:
     """
     Initializes a syntax tree from one INTERSECT expression.
 
@@ -4638,15 +4763,16 @@ def intersect(left, right, distinct=True, dialect=None, **opts):
         'SELECT * FROM foo INTERSECT SELECT * FROM bla'
 
     Args:
-        left (str | Expression): the SQL code string corresponding to the left-hand side.
+        left: the SQL code string corresponding to the left-hand side.
             If an `Expression` instance is passed, it will be used as-is.
-        right (str | Expression): the SQL code string corresponding to the right-hand side.
+        right: the SQL code string corresponding to the right-hand side.
             If an `Expression` instance is passed, it will be used as-is.
-        distinct (bool): set the DISTINCT flag if and only if this is true.
-        dialect (str): the dialect used to parse the input expression.
-        opts (kwargs): other options to use to parse the input expressions.
+        distinct: set the DISTINCT flag if and only if this is true.
+        dialect: the dialect used to parse the input expression.
+        opts: other options to use to parse the input expressions.
+
     Returns:
-        Intersect: the syntax tree for the INTERSECT expression.
+        The new Intersect instance.
     """
     left = maybe_parse(sql_or_expression=left, dialect=dialect, **opts)
     right = maybe_parse(sql_or_expression=right, dialect=dialect, **opts)
@@ -4654,7 +4780,9 @@ def intersect(left, right, distinct=True, dialect=None, **opts):
     return Intersect(this=left, expression=right, distinct=distinct)
 
 
-def except_(left, right, distinct=True, dialect=None, **opts):
+def except_(
+    left: ExpOrStr, right: ExpOrStr, distinct: bool = True, dialect: DialectType = None, **opts
+) -> Except:
     """
     Initializes a syntax tree from one EXCEPT expression.
 
@@ -4663,15 +4791,16 @@ def except_(left, right, distinct=True, dialect=None, **opts):
         'SELECT * FROM foo EXCEPT SELECT * FROM bla'
 
     Args:
-        left (str | Expression): the SQL code string corresponding to the left-hand side.
+        left: the SQL code string corresponding to the left-hand side.
             If an `Expression` instance is passed, it will be used as-is.
-        right (str | Expression): the SQL code string corresponding to the right-hand side.
+        right: the SQL code string corresponding to the right-hand side.
             If an `Expression` instance is passed, it will be used as-is.
-        distinct (bool): set the DISTINCT flag if and only if this is true.
-        dialect (str): the dialect used to parse the input expression.
-        opts (kwargs): other options to use to parse the input expressions.
+        distinct: set the DISTINCT flag if and only if this is true.
+        dialect: the dialect used to parse the input expression.
+        opts: other options to use to parse the input expressions.
+
     Returns:
-        Except: the syntax tree for the EXCEPT statement.
+        The new Except instance.
     """
     left = maybe_parse(sql_or_expression=left, dialect=dialect, **opts)
     right = maybe_parse(sql_or_expression=right, dialect=dialect, **opts)
@@ -4848,7 +4977,9 @@ def insert(
     return Insert(this=this, expression=expr, overwrite=overwrite)
 
 
-def condition(expression, dialect=None, copy=True, **opts) -> Condition:
+def condition(
+    expression: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+) -> Condition:
     """
     Initialize a logical condition expression.
 
@@ -4863,18 +4994,18 @@ def condition(expression, dialect=None, copy=True, **opts) -> Condition:
         'SELECT * FROM tbl WHERE x = 1 AND y = 1'
 
     Args:
-        *expression (str | Expression): the SQL code string to parse.
+        *expression: the SQL code string to parse.
             If an Expression instance is passed, this is used as-is.
-        dialect (str): the dialect used to parse the input expression (in the case that the
+        dialect: the dialect used to parse the input expression (in the case that the
             input expression is a SQL string).
-        copy (bool): Whether or not to copy `expression` (only applies to expressions).
+        copy: Whether or not to copy `expression` (only applies to expressions).
         **opts: other options to use to parse the input expressions (again, in the case
             that the input expression is a SQL string).
 
     Returns:
-        Condition: the expression
+        The new Condition instance
     """
-    return maybe_parse(  # type: ignore
+    return maybe_parse(
         expression,
         into=Condition,
         dialect=dialect,
@@ -4883,7 +5014,9 @@ def condition(expression, dialect=None, copy=True, **opts) -> Condition:
     )
 
 
-def and_(*expressions, dialect=None, copy=True, **opts) -> And:
+def and_(
+    *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+) -> Expression:
     """
     Combine multiple conditions with an AND logical operator.
 
@@ -4892,10 +5025,10 @@ def and_(*expressions, dialect=None, copy=True, **opts) -> And:
         'x = 1 AND (y = 1 AND z = 1)'
 
     Args:
-        *expressions (str | Expression): the SQL code strings to parse.
+        *expressions: the SQL code strings to parse.
             If an Expression instance is passed, this is used as-is.
-        dialect (str): the dialect used to parse the input expression.
-        copy (bool): whether or not to copy `expressions` (only applies to Expressions).
+        dialect: the dialect used to parse the input expression.
+        copy: whether or not to copy `expressions` (only applies to Expressions).
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -4904,7 +5037,9 @@ def and_(*expressions, dialect=None, copy=True, **opts) -> And:
     return _combine(expressions, And, dialect, copy=copy, **opts)
 
 
-def or_(*expressions, dialect=None, copy=True, **opts) -> Or:
+def or_(
+    *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+) -> Expression:
     """
     Combine multiple conditions with an OR logical operator.
 
@@ -4913,10 +5048,10 @@ def or_(*expressions, dialect=None, copy=True, **opts) -> Or:
         'x = 1 OR (y = 1 OR z = 1)'
 
     Args:
-        *expressions (str | Expression): the SQL code strings to parse.
+        *expressions: the SQL code strings to parse.
             If an Expression instance is passed, this is used as-is.
-        dialect (str): the dialect used to parse the input expression.
-        copy (bool): whether or not to copy `expressions` (only applies to Expressions).
+        dialect: the dialect used to parse the input expression.
+        copy: whether or not to copy `expressions` (only applies to Expressions).
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -4925,7 +5060,7 @@ def or_(*expressions, dialect=None, copy=True, **opts) -> Or:
     return _combine(expressions, Or, dialect, copy=copy, **opts)
 
 
-def not_(expression, dialect=None, copy=True, **opts) -> Not:
+def not_(expression: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts) -> Not:
     """
     Wrap a condition with a NOT operator.
 
@@ -4934,13 +5069,14 @@ def not_(expression, dialect=None, copy=True, **opts) -> Not:
         "NOT this_suit = 'black'"
 
     Args:
-        expression (str | Expression): the SQL code strings to parse.
+        expression: the SQL code string to parse.
             If an Expression instance is passed, this is used as-is.
-        dialect (str): the dialect used to parse the input expression.
+        dialect: the dialect used to parse the input expression.
+        copy: whether to copy the expression or not.
         **opts: other options to use to parse the input expressions.
 
     Returns:
-        Not: the new condition
+        The new condition.
     """
     this = condition(
         expression,
@@ -4951,8 +5087,23 @@ def not_(expression, dialect=None, copy=True, **opts) -> Not:
     return Not(this=_wrap(this, Connector))
 
 
-def paren(expression, copy=True) -> Paren:
-    return Paren(this=_maybe_copy(expression, copy))
+def paren(expression: ExpOrStr, copy: bool = True) -> Paren:
+    """
+    Wrap an expression in parentheses.
+
+    Example:
+        >>> paren("5 + 3").sql()
+        '(5 + 3)'
+
+    Args:
+        expression: the SQL code string to parse.
+            If an Expression instance is passed, this is used as-is.
+        copy: whether to copy the expression or not.
+
+    Returns:
+        The wrapped expression.
+    """
+    return Paren(this=maybe_parse(expression, copy=copy))
 
 
 SAFE_IDENTIFIER_RE = re.compile(r"^[_a-zA-Z][\w]*$")
@@ -5132,7 +5283,12 @@ def alias_(
     return Alias(this=exp, alias=alias)
 
 
-def subquery(expression, alias=None, dialect=None, **opts):
+def subquery(
+    expression: ExpOrStr,
+    alias: t.Optional[Identifier | str] = None,
+    dialect: DialectType = None,
+    **opts,
+) -> Select:
     """
     Build a subquery expression.
 
@@ -5141,14 +5297,14 @@ def subquery(expression, alias=None, dialect=None, **opts):
         'SELECT x FROM (SELECT x FROM tbl) AS bar'
 
     Args:
-        expression (str | Expression): the SQL code strings to parse.
+        expression: the SQL code strings to parse.
             If an Expression instance is passed, this is used as-is.
-        alias (str | Expression): the alias name to use.
-        dialect (str): the dialect used to parse the input expression.
+        alias: the alias name to use.
+        dialect: the dialect used to parse the input expression.
         **opts: other options to use to parse the input expressions.
 
     Returns:
-        Select: a new select with the subquery expression included
+        A new Select instance with the subquery expression included.
     """
 
     expression = maybe_parse(expression, dialect=dialect, **opts).subquery(alias)
@@ -5166,13 +5322,14 @@ def column(
     Build a Column.
 
     Args:
-        col: column name
-        table: table name
-        db: db name
-        catalog: catalog name
-        quoted: whether or not to force quote each part
+        col: Column name.
+        table: Table name.
+        db: Database name.
+        catalog: Catalog name.
+        quoted: Whether to force quotes on the column's identifiers.
+
     Returns:
-        Column: column instance
+        The new Column instance.
     """
     return Column(
         this=to_identifier(col, quoted=quoted),
@@ -5194,22 +5351,30 @@ def cast(expression: ExpOrStr, to: str | DataType | DataType.Type, **opts) -> Ca
         to: The datatype to cast to.
 
     Returns:
-        A cast node.
+        The new Cast instance.
     """
     expression = maybe_parse(expression, **opts)
     return Cast(this=expression, to=DataType.build(to, **opts))
 
 
-def table_(table, db=None, catalog=None, quoted=None, alias=None) -> Table:
+def table_(
+    table: Identifier | str,
+    db: t.Optional[Identifier | str] = None,
+    catalog: t.Optional[Identifier | str] = None,
+    quoted: t.Optional[bool] = None,
+    alias: t.Optional[Identifier | str] = None,
+) -> Table:
     """Build a Table.
 
     Args:
-        table (str | Expression): column name
-        db (str | Expression): db name
-        catalog (str | Expression): catalog name
+        table: Table name.
+        db: Database name.
+        catalog: Catalog name.
+        quote: Whether to force quotes on the table's identifiers.
+        alias: Table's alias.
 
     Returns:
-        Table: table instance
+        The new Table instance.
     """
     return Table(
         this=to_identifier(table, quoted=quoted),
@@ -5338,7 +5503,7 @@ def convert(value: t.Any, copy: bool = False) -> Expression:
     raise ValueError(f"Cannot convert {value}")
 
 
-def replace_children(expression, fun, *args, **kwargs):
+def replace_children(expression: Expression, fun: t.Callable, *args, **kwargs) -> None:
     """
     Replace children of an expression with the result of a lambda fun(child) -> exp.
     """
@@ -5360,7 +5525,7 @@ def replace_children(expression, fun, *args, **kwargs):
         expression.args[k] = new_child_nodes if is_list_arg else seq_get(new_child_nodes, 0)
 
 
-def column_table_names(expression):
+def column_table_names(expression: Expression) -> t.List[str]:
     """
     Return all table names referenced through columns in an expression.
 
@@ -5370,19 +5535,19 @@ def column_table_names(expression):
         ['c', 'a']
 
     Args:
-        expression (sqlglot.Expression): expression to find table names
+        expression: expression to find table names.
 
     Returns:
-        list: A list of unique names
+        A list of unique names.
     """
     return list(dict.fromkeys(column.table for column in expression.find_all(Column)))
 
 
-def table_name(table) -> str:
+def table_name(table: Table | str) -> str:
     """Get the full name of a table as a string.
 
     Args:
-        table (exp.Table | str): table expression node or string.
+        table: table expression node or string.
 
     Examples:
         >>> from sqlglot import exp, parse_one
@@ -5398,23 +5563,15 @@ def table_name(table) -> str:
     if not table:
         raise ValueError(f"Cannot parse {table}")
 
-    return ".".join(
-        part
-        for part in (
-            table.text("catalog"),
-            table.text("db"),
-            table.name,
-        )
-        if part
-    )
+    return ".".join(part for part in (table.text("catalog"), table.text("db"), table.name) if part)
 
 
-def replace_tables(expression, mapping):
+def replace_tables(expression: E, mapping: t.Dict[str, str]) -> E:
     """Replace all tables in expression according to the mapping.
 
     Args:
-        expression (sqlglot.Expression): expression node to be transformed and replaced.
-        mapping (Dict[str, str]): mapping of table names.
+        expression: expression node to be transformed and replaced.
+        mapping: mapping of table names.
 
     Examples:
         >>> from sqlglot import exp, parse_one
@@ -5425,7 +5582,7 @@ def replace_tables(expression, mapping):
         The mapped expression.
     """
 
-    def _replace_tables(node):
+    def _replace_tables(node: Expression) -> Expression:
         if isinstance(node, Table):
             new_name = mapping.get(table_name(node))
             if new_name:
@@ -5438,11 +5595,11 @@ def replace_tables(expression, mapping):
     return expression.transform(_replace_tables)
 
 
-def replace_placeholders(expression, *args, **kwargs):
+def replace_placeholders(expression: Expression, *args, **kwargs) -> Expression:
     """Replace placeholders in an expression.
 
     Args:
-        expression (sqlglot.Expression): expression node to be transformed and replaced.
+        expression: expression node to be transformed and replaced.
         args: positional names that will substitute unnamed placeholders in the given order.
         kwargs: keyword arguments that will substitute named placeholders.
 
@@ -5458,7 +5615,7 @@ def replace_placeholders(expression, *args, **kwargs):
         The mapped expression.
     """
 
-    def _replace_placeholders(node, args, **kwargs):
+    def _replace_placeholders(node: Expression, args, **kwargs) -> Expression:
         if isinstance(node, Placeholder):
             if node.name:
                 new_name = kwargs.get(node.name)
@@ -5556,21 +5713,21 @@ def func(name: str, *args, dialect: DialectType = None, **kwargs) -> Func:
     return function
 
 
-def true():
+def true() -> Boolean:
     """
     Returns a true Boolean expression.
     """
     return Boolean(this=True)
 
 
-def false():
+def false() -> Boolean:
     """
     Returns a false Boolean expression.
     """
     return Boolean(this=False)
 
 
-def null():
+def null() -> Null:
     """
     Returns a Null expression.
     """

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -665,7 +665,11 @@ ExpOrStr = t.Union[str, Expression]
 
 class Condition(Expression):
     def and_(
-        self, *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+        self,
+        *expressions: t.Optional[ExpOrStr],
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
     ) -> Expression:
         """
         AND this condition with one or multiple expressions.
@@ -687,7 +691,11 @@ class Condition(Expression):
         return and_(self, *expressions, dialect=dialect, copy=copy, **opts)
 
     def or_(
-        self, *expressions: ExpOrStr, dialect: DialectType = None, copy: bool = True, **opts
+        self,
+        *expressions: t.Optional[ExpOrStr],
+        dialect: DialectType = None,
+        copy: bool = True,
+        **opts,
     ) -> Expression:
         """
         OR this condition with one or multiple expressions.

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4657,7 +4657,7 @@ def _apply_list_builder(
             **opts,
         )
         for expression in expressions
-        if expression
+        if expression is not None
     ]
 
     existing_expressions = inst.args.get(arg)
@@ -4728,7 +4728,7 @@ def _combine(
     conditions = [
         condition(expression, dialect=dialect, copy=copy, **opts)
         for expression in expressions
-        if expression
+        if expression is not None
     ]
 
     this, *rest = conditions

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4740,10 +4740,8 @@ def _combine(
     return this
 
 
-def _wrap(expression: Expression, kind: t.Type[Expression]):
-    if isinstance(expression, kind):
-        return Paren(this=expression)
-    return expression
+def _wrap(expression: E, kind: t.Type[Expression]) -> E | Paren:
+    return Paren(this=expression) if isinstance(expression, kind) else expression
 
 
 def union(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1529,7 +1529,7 @@ class Generator:
             sep="",
         )
 
-    def after_having_modifiers(self, expression):
+    def after_having_modifiers(self, expression: exp.Expression) -> t.List[str]:
         return [
             self.sql(expression, "qualify"),
             self.seg("WINDOW ") + self.expressions(expression, key="windows", flat=True)
@@ -1537,7 +1537,7 @@ class Generator:
             else "",
         ]
 
-    def after_limit_modifiers(self, expression):
+    def after_limit_modifiers(self, expression: exp.Expression) -> t.List[str]:
         locks = self.expressions(expression, key="locks", sep=" ")
         locks = f" {locks}" if locks else ""
         return [locks, self.sql(expression, "sample")]

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -92,7 +92,7 @@ def ensure_collection(value):
     )
 
 
-def csv(*args, sep: str = ", ") -> str:
+def csv(*args: str, sep: str = ", ") -> str:
     """
     Formats any number of string arguments as CSV.
 

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -12,10 +12,8 @@ from enum import Enum
 
 if t.TYPE_CHECKING:
     from sqlglot import exp
+    from sqlglot._typing import E, T
     from sqlglot.expressions import Expression
-
-    T = t.TypeVar("T")
-    E = t.TypeVar("E", bound=Expression)
 
 CAMEL_CASE_PATTERN = re.compile("(?<!^)(?=[A-Z])")
 PYTHON_VERSION = sys.version_info[:2]

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -10,9 +10,10 @@ from sqlglot.helper import apply_index_offset, ensure_collection, ensure_list, s
 from sqlglot.tokens import Token, Tokenizer, TokenType
 from sqlglot.trie import in_trie, new_trie
 
-logger = logging.getLogger("sqlglot")
+if t.TYPE_CHECKING:
+    from sqlglot._typing import E
 
-E = t.TypeVar("E", bound=exp.Expression)
+logger = logging.getLogger("sqlglot")
 
 
 def parse_var_map(args: t.List) -> exp.Expression:

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -303,7 +303,7 @@ class Join(Step):
         for join in joins:
             source_key, join_key, condition = join_condition(join)
             step.joins[join.this.alias_or_name] = {
-                "side": join.side,
+                "side": join.side,  # type: ignore
                 "join_key": join_key,
                 "source_key": source_key,
                 "condition": condition,

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -10,14 +10,13 @@ from sqlglot.helper import dict_depth
 from sqlglot.trie import in_trie, new_trie
 
 if t.TYPE_CHECKING:
+    from sqlglot._typing import T
     from sqlglot.dataframe.sql.types import StructType
     from sqlglot.dialects.dialect import DialectType
 
     ColumnMapping = t.Union[t.Dict, str, StructType, t.List]
 
 TABLE_ARGS = ("this", "db", "catalog")
-
-T = t.TypeVar("T")
 
 
 class Schema(abc.ABC):

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -5,12 +5,12 @@ import typing as t
 
 import sqlglot
 from sqlglot import expressions as exp
+from sqlglot._typing import T
 from sqlglot.errors import ParseError, SchemaError
 from sqlglot.helper import dict_depth
 from sqlglot.trie import in_trie, new_trie
 
 if t.TYPE_CHECKING:
-    from sqlglot._typing import T
     from sqlglot.dataframe.sql.types import StructType
     from sqlglot.dialects.dialect import DialectType
 


### PR DESCRIPTION
I did a sweep in the codebase to clean up the type hints. All files under `sqlglot/dialects` should be now fully typed.

This is still a WIP, gonna continue iterating on it tomorrow to do any remaining fixes.