### PR TITLE
Feat(schema): allow passing kwargs in ensure_schema

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -382,11 +382,11 @@ class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
         return self._type_mapping_cache[schema_type]
 
 
-def ensure_schema(schema: t.Any, dialect: DialectType = None) -> Schema:
+def ensure_schema(schema: Schema | t.Optional[t.Dict], **kwargs: t.Any) -> Schema:
     if isinstance(schema, Schema):
         return schema
 
-    return MappingSchema(schema, dialect=dialect)
+    return MappingSchema(schema, **kwargs)
 
 
 def ensure_column_mapping(mapping: t.Optional[ColumnMapping]) -> t.Dict:


### PR DESCRIPTION
Minor addition: now we can specify other args besides `dialect` in `ensure_schema`. This can be useful if e.g. we want to instantiate a `MappingSchema` with `normalize=False` or `visible={...}`.