### PR TITLE
Fix(schema): ensure the correct dialect is used in schema methods

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -225,3 +225,7 @@ class TestSchema(unittest.TestCase):
         # Check that switching off the normalization logic works as expected
         schema = MappingSchema(schema={"x": {"foo": "int"}}, normalize=False, dialect="snowflake")
         self.assertEqual(schema.column_names(exp.Table(this="x")), ["foo"])
+
+        # Check that the correct dialect is used when calling schema methods
+        schema = MappingSchema(schema={"[Fo]": {"x": "int"}}, dialect="tsql")
+        self.assertEqual(schema.column_names("[Fo]"), schema.column_names("`Fo`", dialect="spark"))


### PR DESCRIPTION
This fixes a bug that I missed in https://github.com/tobymao/sqlglot/commit/12d3cca8bab004dc378f6f272be7b07a7e16eaae: `_ensure_table` used to wrap around the `dialect or self.dialect` logic, whereas in my change I just passed in `dialect` to `maybe_parse`. For this reason I reintroduced `_ensure_table`, in order to avoid doing `dialect or self.dialect` inline for every `exp.maybe_parse` call in the schema module.