### PR TITLE
Feat(duckdb): add support for simplified pivot syntax

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -148,9 +148,7 @@ class ClickHouse(Dialect):
 
             return self.expression(exp.Placeholder, this=this, kind=kind)
 
-        def _parse_in(
-            self, this: t.Optional[exp.Expression], is_global: bool = False
-        ) -> exp.Expression:
+        def _parse_in(self, this: t.Optional[exp.Expression], is_global: bool = False) -> exp.In:
             this = super()._parse_in(this)
             this.set("is_global", is_global)
             return this

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -108,6 +108,7 @@ class DuckDB(Dialect):
             "INT1": TokenType.TINYINT,
             "LOGICAL": TokenType.BOOLEAN,
             "NUMERIC": TokenType.DOUBLE,
+            "PIVOT_WIDER": TokenType.PIVOT,
             "SIGNED": TokenType.INT,
             "STRING": TokenType.VARCHAR,
             "UBIGINT": TokenType.UBIGINT,
@@ -153,6 +154,12 @@ class DuckDB(Dialect):
             TokenType.UINT,
             TokenType.USMALLINT,
             TokenType.UTINYINT,
+        }
+
+        STATEMENT_PARSERS = {
+            **parser.Parser.STATEMENT_PARSERS,
+            TokenType.FROM: lambda self: self._parse_from(skip_from_token=True),
+            TokenType.PIVOT: lambda self: self._parse_simplified_pivot(),
         }
 
         def _pivot_column_names(self, aggregations: t.List[exp.Expression]) -> t.List[str]:

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -159,7 +159,7 @@ class DuckDB(Dialect):
         STATEMENT_PARSERS = {
             **parser.Parser.STATEMENT_PARSERS,
             TokenType.FROM: lambda self: exp.select("*").from_(
-                self._parse_from(skip_from_token=True)
+                t.cast(exp.From, self._parse_from(skip_from_token=True))
             ),
             TokenType.PIVOT: lambda self: self._parse_simplified_pivot(),
         }

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -156,14 +156,6 @@ class DuckDB(Dialect):
             TokenType.UTINYINT,
         }
 
-        STATEMENT_PARSERS = {
-            **parser.Parser.STATEMENT_PARSERS,
-            TokenType.FROM: lambda self: exp.select("*").from_(
-                t.cast(exp.From, self._parse_from(skip_from_token=True))
-            ),
-            TokenType.PIVOT: lambda self: self._parse_simplified_pivot(),
-        }
-
         def _pivot_column_names(self, aggregations: t.List[exp.Expression]) -> t.List[str]:
             if len(aggregations) == 1:
                 return super()._pivot_column_names(aggregations)

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -158,7 +158,9 @@ class DuckDB(Dialect):
 
         STATEMENT_PARSERS = {
             **parser.Parser.STATEMENT_PARSERS,
-            TokenType.FROM: lambda self: self._parse_from(skip_from_token=True),
+            TokenType.FROM: lambda self: exp.select("*").from_(
+                self._parse_from(skip_from_token=True)
+            ),
             TokenType.PIVOT: lambda self: self._parse_simplified_pivot(),
         }
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3120,12 +3120,17 @@ class Tag(Expression):
     }
 
 
+# Represents both the standard SQL PIVOT operator and DuckDB's "simplified" PIVOT syntax
+# https://duckdb.org/docs/sql/statements/pivot
 class Pivot(Expression):
     arg_types = {
+        "this": False,
         "alias": False,
         "expressions": True,
-        "field": True,
-        "unpivot": True,
+        "field": False,
+        "unpivot": False,
+        "using": False,
+        "group": False,
         "columns": False,
     }
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1220,11 +1220,20 @@ class Generator:
         return f"{this} {kind} {method}({bucket}{percent}{rows}{size}){seed}{alias}"
 
     def pivot_sql(self, expression: exp.Pivot) -> str:
+        expressions = self.expressions(expression, flat=True)
+
+        if expression.this:
+            this = self.sql(expression, "this")
+            on = f"{self.seg('ON')} {expressions}"
+            using = self.expressions(expression, "using", flat=True)
+            using = f"{self.seg('USING')} {using}" if using else ""
+            group = self.sql(expression, "group")
+            return f"PIVOT {this}{on}{using}{group}"
+
         alias = self.sql(expression, "alias")
         alias = f" AS {alias}" if alias else ""
         unpivot = expression.args.get("unpivot")
         direction = "UNPIVOT" if unpivot else "PIVOT"
-        expressions = self.expressions(expression, flat=True)
         field = self.sql(expression, "field")
         return f"{direction}({expressions} FOR {field}){alias}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1225,7 +1225,7 @@ class Generator:
         if expression.this:
             this = self.sql(expression, "this")
             on = f"{self.seg('ON')} {expressions}"
-            using = self.expressions(expression, "using", flat=True)
+            using = self.expressions(expression, key="using", flat=True)
             using = f"{self.seg('USING')} {using}" if using else ""
             group = self.sql(expression, "group")
             return f"PIVOT {this}{on}{using}{group}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1897,7 +1897,7 @@ class Parser(metaclass=_Parser):
                 expressions=self._parse_csv(self._parse_value),
                 alias=self._parse_table_alias(),
             )
-        elif self._match_texts({"PIVOT", "PIVOT_WIDER"}):
+        elif self._match(TokenType.PIVOT):
             this = self._parse_simplified_pivot()
         else:
             this = None

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1899,6 +1899,8 @@ class Parser(metaclass=_Parser):
             )
         elif self._match(TokenType.PIVOT):
             this = self._parse_simplified_pivot()
+        elif self._match(TokenType.FROM):
+            this = exp.select("*").from_(t.cast(exp.From, self._parse_from(skip_from_token=True)))
         else:
             this = None
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2011,7 +2011,7 @@ class Parser(metaclass=_Parser):
     def _parse_from(
         self, modifiers: bool = False, skip_from_token: bool = False
     ) -> t.Optional[exp.From]:
-        if not self._match(TokenType.FROM) and not skip_from_token:
+        if not skip_from_token and not self._match(TokenType.FROM):
             return None
 
         comments = self._prev_comments

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -132,7 +132,6 @@ class TestDuckDB(Validator):
             parse_one("a // b", read="duckdb").assert_is(exp.IntDiv).sql(dialect="duckdb"), "a // b"
         )
 
-        self.validate_identity("FROM tbl")
         self.validate_identity("PIVOT Cities ON Year USING SUM(Population)")
         self.validate_identity("PIVOT Cities ON Year USING FIRST(Population)")
         self.validate_identity("PIVOT Cities ON Year USING SUM(Population) GROUP BY Country")
@@ -166,6 +165,7 @@ class TestDuckDB(Validator):
             "SELECT * FROM (PIVOT Cities ON Year USING SUM(Population) GROUP BY Country) AS pivot_alias"
         )
 
+        self.validate_all("FROM tbl", write={"duckdb": "SELECT * FROM tbl"})
         self.validate_all("0b1010", write={"": "0 AS b1010"})
         self.validate_all("0x1010", write={"": "0 AS x1010"})
         self.validate_all("x ~ y", write={"duckdb": "REGEXP_MATCHES(x, y)"})
@@ -173,6 +173,10 @@ class TestDuckDB(Validator):
         self.validate_all(
             "PIVOT_WIDER Cities ON Year USING SUM(Population)",
             write={"duckdb": "PIVOT Cities ON Year USING SUM(Population)"},
+        )
+        self.validate_all(
+            "WITH t AS (SELECT 1) FROM t",
+            write={"duckdb": "WITH t AS (SELECT 1) SELECT * FROM t"}
         )
         self.validate_all(
             """SELECT DATEDIFF('day', t1."A", t1."B") FROM "table" AS t1""",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -165,6 +165,7 @@ class TestDuckDB(Validator):
             "SELECT * FROM (PIVOT Cities ON Year USING SUM(Population) GROUP BY Country) AS pivot_alias"
         )
 
+        self.validate_all("FROM (FROM tbl)", write={"duckdb": "SELECT * FROM (SELECT * FROM tbl)"})
         self.validate_all("FROM tbl", write={"duckdb": "SELECT * FROM tbl"})
         self.validate_all("0b1010", write={"": "0 AS b1010"})
         self.validate_all("0x1010", write={"": "0 AS x1010"})
@@ -175,8 +176,11 @@ class TestDuckDB(Validator):
             write={"duckdb": "PIVOT Cities ON Year USING SUM(Population)"},
         )
         self.validate_all(
-            "WITH t AS (SELECT 1) FROM t",
-            write={"duckdb": "WITH t AS (SELECT 1) SELECT * FROM t"}
+            "WITH t AS (SELECT 1) FROM t", write={"duckdb": "WITH t AS (SELECT 1) SELECT * FROM t"}
+        )
+        self.validate_all(
+            "WITH t AS (SELECT 1) SELECT * FROM (FROM t)",
+            write={"duckdb": "WITH t AS (SELECT 1) SELECT * FROM (SELECT * FROM t)"},
         )
         self.validate_all(
             """SELECT DATEDIFF('day', t1."A", t1."B") FROM "table" AS t1""",


### PR DESCRIPTION
Fixes #1712

Also added support for the standalone `FROM tbl` expression (see example below) which is used in DuckDB's pivot examples. This is essentially a shorthand for `SELECT * FROM tbl` and it seems useful to support in the base parser. We could also improve the `from_` helper to allow `from_(..., star=True)` as a way to dry up `exp.select("*").from_(...)`. @tobymao thoughts on this?

```python
>>> import duckdb
>>> duckdb.connect().execute("with t as (select 1) select * from (from t)").fetchdf()
   1
0  1
>>> duckdb.connect().execute("with t as (select 1) from (from t)").fetchdf()
   1
0  1
```


References:
- https://duckdb.org/docs/sql/statements/pivot
- https://duckdb.org/docs/sql/query_syntax/from#examples