### PR TITLE
Feat!(duckdb): add support for ASOF joins

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -33,7 +33,6 @@ class ClickHouse(Dialect):
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
-            "ASOF": TokenType.ASOF,
             "ATTACH": TokenType.COMMAND,
             "DATETIME64": TokenType.DATETIME64,
             "FINAL": TokenType.FINAL,
@@ -98,7 +97,6 @@ class ClickHouse(Dialect):
 
         TABLE_ALIAS_TOKENS = {*parser.Parser.TABLE_ALIAS_TOKENS} - {
             TokenType.ANY,
-            TokenType.ASOF,
             TokenType.SEMI,
             TokenType.ANTI,
             TokenType.SETTINGS,
@@ -183,7 +181,7 @@ class ClickHouse(Dialect):
 
                 return self.expression(exp.CTE, this=statement, alias=statement and statement.this)
 
-        def _parse_join_side_and_kind(
+        def _parse_join_parts(
             self,
         ) -> t.Tuple[t.Optional[Token], t.Optional[Token], t.Optional[Token]]:
             is_global = self._match(TokenType.GLOBAL) and self._prev
@@ -202,7 +200,7 @@ class ClickHouse(Dialect):
             join = super()._parse_join(skip_join_token)
 
             if join:
-                join.set("global", join.args.pop("natural", None))
+                join.set("global", join.args.pop("method", None))
             return join
 
         def _parse_function(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1653,10 +1653,14 @@ class Join(Expression):
         "side": False,
         "kind": False,
         "using": False,
-        "natural": False,
+        "method": False,
         "global": False,
         "hint": False,
     }
+
+    @property
+    def method(self) -> str:
+        return self.text("method").upper()
 
     @property
     def kind(self) -> str:
@@ -2797,12 +2801,12 @@ class Select(Subqueryable):
         Returns:
             Select: the modified expression.
         """
-        parse_args = {"dialect": dialect, **opts}
+        parse_args: t.Dict[str, t.Any] = {"dialect": dialect, **opts}
 
         try:
-            expression = maybe_parse(expression, into=Join, prefix="JOIN", **parse_args)  # type: ignore
+            expression = maybe_parse(expression, into=Join, prefix="JOIN", **parse_args)
         except ParseError:
-            expression = maybe_parse(expression, into=(Join, Expression), **parse_args)  # type: ignore
+            expression = maybe_parse(expression, into=(Join, Expression), **parse_args)
 
         join = expression if isinstance(expression, Join) else Join(this=expression)
 
@@ -2810,14 +2814,14 @@ class Select(Subqueryable):
             join.this.replace(join.this.subquery())
 
         if join_type:
-            natural: t.Optional[Token]
+            method: t.Optional[Token]
             side: t.Optional[Token]
             kind: t.Optional[Token]
 
-            natural, side, kind = maybe_parse(join_type, into="JOIN_TYPE", **parse_args)  # type: ignore
+            method, side, kind = maybe_parse(join_type, into="JOIN_TYPE", **parse_args)  # type: ignore
 
-            if natural:
-                join.set("natural", True)
+            if method:
+                join.set("method", method.text)
             if side:
                 join.set("side", side.text)
             if kind:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1313,7 +1313,7 @@ class Generator:
         op_sql = " ".join(
             op
             for op in (
-                "NATURAL" if expression.args.get("natural") else None,
+                expression.method,
                 "GLOBAL" if expression.args.get("global") else None,
                 expression.side,
                 expression.kind,

--- a/sqlglot/optimizer/optimize_joins.py
+++ b/sqlglot/optimizer/optimize_joins.py
@@ -1,7 +1,7 @@
 from sqlglot import exp
 from sqlglot.helper import tsort
 
-JOIN_ATTRS = ("on", "side", "kind", "using", "natural")
+JOIN_ATTRS = ("on", "side", "kind", "using", "method")
 
 
 def optimize_joins(expression):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -492,6 +492,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "ANY": TokenType.ANY,
         "ASC": TokenType.ASC,
         "AS": TokenType.ALIAS,
+        "ASOF": TokenType.ASOF,
         "AUTOINCREMENT": TokenType.AUTO_INCREMENT,
         "AUTO_INCREMENT": TokenType.AUTO_INCREMENT,
         "BEGIN": TokenType.BEGIN,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -132,6 +132,7 @@ class TestDuckDB(Validator):
             parse_one("a // b", read="duckdb").assert_is(exp.IntDiv).sql(dialect="duckdb"), "a // b"
         )
 
+        self.validate_identity("SELECT * FROM foo ASOF LEFT JOIN bar ON a = b")
         self.validate_identity("PIVOT Cities ON Year USING SUM(Population)")
         self.validate_identity("PIVOT Cities ON Year USING FIRST(Population)")
         self.validate_identity("PIVOT Cities ON Year USING SUM(Population) GROUP BY Country")


### PR DESCRIPTION
Fixes #1722

Also thought of creating a `JoinParts` expression to factor out the `side`, `kind` and `method` args, but didn't end up implementing it because it seemed like a bigger breaking change.

One advantage with this is that `EXPRESSION_PARSERS` could only contain `Expression` type keys, instead of mixed with `str` (i.e. for `"JOIN_TYPE"`). We could also abstract away the accessing of these args by implementing a property that delegates to said `JoinParts` expression's properties.

The disadvantage would be in `set`ting the `JoinParts` manually, because now we can just do `e.set("kind", "foo")` and be done with it. With the `JoinParts` expression there's another expression to instantiate..