### PR TITLE
clickhouse: CREATE DICTIONARY support

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -36,6 +36,7 @@ class ClickHouse(Dialect):
             "ASOF": TokenType.ASOF,
             "ATTACH": TokenType.COMMAND,
             "DATETIME64": TokenType.DATETIME64,
+            "DICTIONARY": TokenType.DICTIONARY,
             "FINAL": TokenType.FINAL,
             "FLOAT32": TokenType.FLOAT,
             "FLOAT64": TokenType.DOUBLE,
@@ -245,6 +246,13 @@ class ClickHouse(Dialect):
             self, optional: bool = False
         ) -> t.List[t.Optional[exp.Expression]]:
             return super()._parse_wrapped_id_vars(optional=True)
+
+        def _parse_primary_key(
+            self, wrapped_optional: bool = False, in_props: bool = False
+        ) -> exp.Expression:
+            if in_props:
+                return super()._parse_primary_key(wrapped_optional=True, in_props=True)
+            return super()._parse_primary_key(wrapped_optional=wrapped_optional, in_props=in_props)
 
     class Generator(generator.Generator):
         STRUCT_DELIMITER = ("(", ")")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1913,6 +1913,14 @@ class LanguageProperty(Property):
     arg_types = {"this": True}
 
 
+class DictProperty(Property):
+    arg_types = {"this": True, "kind": True, "settings": False}
+
+
+class DictRange(Property):
+    arg_types = {"this": True, "min": True, "max": True}
+
+
 class LikeProperty(Property):
     arg_types = {"this": True, "expressions": False}
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -205,6 +205,7 @@ class Parser(metaclass=_Parser):
         TokenType.SCHEMA,
         TokenType.TABLE,
         TokenType.VIEW,
+        TokenType.DICTIONARY,
     }
 
     CREATABLES = {
@@ -592,6 +593,8 @@ class Parser(metaclass=_Parser):
         ),
         "JOURNAL": lambda self, **kwargs: self._parse_journal(**kwargs),
         "LANGUAGE": lambda self: self._parse_property_assignment(exp.LanguageProperty),
+        "LAYOUT": lambda self: self._parse_dict_property(this="LAYOUT"),
+        "LIFETIME": lambda self: self._parse_dict_range(this="LIFETIME"),
         "LIKE": lambda self: self._parse_create_like(),
         "LOCATION": lambda self: self._parse_property_assignment(exp.LocationProperty),
         "LOCK": lambda self: self._parse_locking(),
@@ -606,7 +609,8 @@ class Parser(metaclass=_Parser):
         "PARTITION BY": lambda self: self._parse_partitioned_by(),
         "PARTITIONED BY": lambda self: self._parse_partitioned_by(),
         "PARTITIONED_BY": lambda self: self._parse_partitioned_by(),
-        "PRIMARY KEY": lambda self: self._parse_primary_key(),
+        "PRIMARY KEY": lambda self: self._parse_primary_key(in_props=True),
+        "RANGE": lambda self: self._parse_dict_range(this="RANGE"),
         "RETURNS": lambda self: self._parse_returns(),
         "ROW": lambda self: self._parse_row(),
         "ROW_FORMAT": lambda self: self._parse_property_assignment(exp.RowFormatProperty),
@@ -615,6 +619,7 @@ class Parser(metaclass=_Parser):
             exp.SettingsProperty, expressions=self._parse_csv(self._parse_set_item)
         ),
         "SORTKEY": lambda self: self._parse_sortkey(),
+        "SOURCE": lambda self: self._parse_dict_property(this="SOURCE"),
         "STABLE": lambda self: self.expression(
             exp.StabilityProperty, this=exp.Literal.string("STABLE")
         ),
@@ -3495,16 +3500,18 @@ class Parser(metaclass=_Parser):
             exp.ForeignKey, expressions=expressions, reference=reference, **options  # type: ignore
         )
 
-    def _parse_primary_key(self) -> exp.Expression:
+    def _parse_primary_key(
+        self, wrapped_optional: bool = False, in_props: bool = False
+    ) -> exp.Expression:
         desc = (
             self._match_set((TokenType.ASC, TokenType.DESC))
             and self._prev.token_type == TokenType.DESC
         )
 
-        if not self._match(TokenType.L_PAREN, advance=False):
+        if not in_props and not self._match(TokenType.L_PAREN, advance=False):
             return self.expression(exp.PrimaryKeyColumnConstraint, desc=desc)
 
-        expressions = self._parse_wrapped_csv(self._parse_field)
+        expressions = self._parse_wrapped_csv(self._parse_field, optional=wrapped_optional)
         options = self._parse_key_constraint_options()
         return self.expression(exp.PrimaryKey, expressions=expressions, options=options)
 
@@ -4483,6 +4490,47 @@ class Parser(metaclass=_Parser):
         text = self._find_sql(start, self._prev)
         size = len(start.text)
         return exp.Command(this=text[:size], expression=text[size:])
+
+    def _parse_dict_property(self, this: str) -> exp.DictProperty:
+        settings = []
+
+        self._match(TokenType.L_PAREN)
+        kind = self._parse_id_var()
+        if not kind:
+            self.raise_error(f"Unexpected token: {self._curr.text}")
+        assert kind
+        wrapped = self._match(TokenType.L_PAREN)
+
+        if wrapped:
+            while True:
+                key = self._parse_id_var()
+                value = self._parse_primary()
+
+                if not key and value is None:
+                    break
+                settings.append(self.expression(exp.Property, this=key, value=value))
+            self._match(TokenType.R_PAREN)
+
+        self._match(TokenType.R_PAREN)
+
+        return self.expression(
+            exp.DictProperty,
+            this=this,
+            kind=kind.this,
+            settings=settings,
+        )
+
+    def _parse_dict_range(self, this: str) -> exp.DictRange:
+        self._match(TokenType.L_PAREN)
+        has_min = self._match_text_seq("MIN")
+        min = self._parse_var() or self._parse_primary()
+        if has_min:
+            self._match_text_seq("MAX")
+            max = self._parse_var() or self._parse_primary()
+        else:
+            max = min
+        self._match(TokenType.R_PAREN)
+        return self.expression(exp.DictRange, this=this, min=min, max=max)
 
     def _find_parser(
         self, parsers: t.Dict[str, t.Callable], trie: t.Dict

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -179,6 +179,7 @@ class TokenType(AutoName):
     DELETE = auto()
     DESC = auto()
     DESCRIBE = auto()
+    DICTIONARY = auto()
     DISTINCT = auto()
     DIV = auto()
     DROP = auto()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -398,3 +398,91 @@ SET
             },
             pretty=True,
         )
+        self.validate_all(
+            """
+            CREATE DICTIONARY discounts_dict (
+                advertiser_id UInt64,
+                discount_start_date Date,
+                discount_end_date Date,
+                amount Float64
+            )
+            PRIMARY KEY id
+            SOURCE(CLICKHOUSE(TABLE 'discounts'))
+            LIFETIME(MIN 1 MAX 1000)
+            LAYOUT(RANGE_HASHED(range_lookup_strategy 'max'))
+            RANGE(MIN discount_start_date MAX discount_end_date)
+            """,
+            write={
+                "clickhouse": """CREATE DICTIONARY discounts_dict (
+  advertiser_id UInt64,
+  discount_start_date DATE,
+  discount_end_date DATE,
+  amount Float64
+)
+PRIMARY KEY (id)
+SOURCE(CLICKHOUSE(
+  TABLE 'discounts'
+))
+LIFETIME(MIN 1 MAX 1000)
+LAYOUT(RANGE_HASHED(
+  range_lookup_strategy 'max'
+))
+RANGE(MIN discount_start_date MAX discount_end_date)""",
+            },
+            pretty=True,
+        )
+        self.validate_all(
+            """
+            CREATE DICTIONARY my_ip_trie_dictionary (
+                prefix String,
+                asn UInt32,
+                cca2 String DEFAULT '??'
+            )
+            PRIMARY KEY prefix
+            SOURCE(CLICKHOUSE(TABLE 'my_ip_addresses'))
+            LAYOUT(IP_TRIE)
+            LIFETIME(3600);
+            """,
+            write={
+                "clickhouse": """CREATE DICTIONARY my_ip_trie_dictionary (
+  prefix TEXT,
+  asn UInt32,
+  cca2 TEXT DEFAULT '??'
+)
+PRIMARY KEY (prefix)
+SOURCE(CLICKHOUSE(
+  TABLE 'my_ip_addresses'
+))
+LAYOUT(IP_TRIE())
+LIFETIME(3600)""",
+            },
+            pretty=True,
+        )
+        self.validate_all(
+            """
+            CREATE DICTIONARY polygons_test_dictionary
+            (
+                key Array(Array(Array(Tuple(Float64, Float64)))),
+                name String
+            )
+            PRIMARY KEY key
+            SOURCE(CLICKHOUSE(TABLE 'polygons_test_table'))
+            LAYOUT(POLYGON(STORE_POLYGON_KEY_COLUMN 1))
+            LIFETIME(0);
+            """,
+            write={
+                "clickhouse": """CREATE DICTIONARY polygons_test_dictionary (
+  key Array(Array(Array(Tuple(Float64, Float64)))),
+  name TEXT
+)
+PRIMARY KEY (key)
+SOURCE(CLICKHOUSE(
+  TABLE 'polygons_test_table'
+))
+LAYOUT(POLYGON(
+  STORE_POLYGON_KEY_COLUMN 1
+))
+LIFETIME(0)""",
+            },
+            pretty=True,
+        )


### PR DESCRIPTION
added all the vast Dictionary spec from [here](https://clickhouse.com/docs/en/sql-reference/dictionaries)

- bonus: fixed the unwrapped `PRIMARY KEY ident1, ident2, ident3` syntax
- bonus: fixed a typo