### PR TITLE
Chore(optimizer): fix pushdown_predicates comment example

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -10,10 +10,10 @@ def pushdown_predicates(expression):
 
     Example:
         >>> import sqlglot
-        >>> sql = "SELECT * FROM (SELECT * FROM x AS x) AS y WHERE y.a = 1"
+        >>> sql = "SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y WHERE y.a = 1"
         >>> expression = sqlglot.parse_one(sql)
         >>> pushdown_predicates(expression).sql()
-        'SELECT * FROM (SELECT * FROM x AS x WHERE y.a = 1) AS y WHERE TRUE'
+        'SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x WHERE x.a = 1) AS y WHERE TRUE'
 
     Args:
         expression (sqlglot.Expression): expression to optimize


### PR DESCRIPTION
I updated the example so that the query we call `pushdown_predicates` on is equivalent to what we get by running the optimizer up to that step, not including it.

```python
>>> import sqlglot
>>> from sqlglot.optimizer import optimize
>>> optimize("SELECT * FROM (SELECT * FROM x AS x) AS y WHERE y.a = 1", schema={"x": {"a": "int"}}).sql()
pushdown_predicates called with 'SELECT y.a AS a FROM (SELECT x.a AS a FROM x AS x) AS y WHERE y.a = 1'
'SELECT "x"."a" AS "a" FROM "x" AS "x" WHERE "x"."a" = 1'
```