### PR TITLE
Refactor!: misc. improvements in formatting, type hints, dialect class variables

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -103,8 +103,8 @@ def _unqualify_unnest(expression: exp.Expression) -> exp.Expression:
 
 
 class BigQuery(Dialect):
-    unnest_column_only = True
-    time_mapping = {
+    UNNEST_COLUMN_ONLY = True
+    TIME_MAPPING = {
         "%M": "%-M",
         "%d": "%-d",
         "%m": "%-m",

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -256,7 +256,7 @@ class ClickHouse(Dialect):
                 wrapped_optional=wrapped_optional or in_props, in_props=in_props
             )
 
-        def _parse_on_property(self) -> t.Optional[exp.Property]:
+        def _parse_on_property(self) -> t.Optional[exp.Expression]:
             index = self._index
             if self._match_text_seq("CLUSTER"):
                 this = self._parse_id_var()

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -154,15 +154,15 @@ class Dialect(metaclass=_Dialect):
     TIME_MAPPING: t.Dict[str, str] = {}
 
     # autofilled
-    tokenizer_class = None
-    parser_class = None
-    generator_class = None
+    tokenizer_class = Tokenizer
+    parser_class = Parser
+    generator_class = Generator
 
     # A trie of the time_mapping keys
     TIME_TRIE: t.Optional[t.Dict] = None
 
-    INVERSE_TIME_MAPPING: t.Optional[t.Dict[str, str]] = None
-    INVERSE_TIME_TRIE: t.Optional[t.Dict] = None
+    INVERSE_TIME_MAPPING: t.Dict[str, str] = {}
+    INVERSE_TIME_TRIE: t.Dict = {}
 
     def __eq__(self, other: t.Any) -> bool:
         return type(self) == other
@@ -220,14 +220,14 @@ class Dialect(metaclass=_Dialect):
     @property
     def tokenizer(self) -> Tokenizer:
         if not hasattr(self, "_tokenizer"):
-            self._tokenizer = t.cast(t.Type[Tokenizer], self.tokenizer_class)()
+            self._tokenizer = self.tokenizer_class()
         return self._tokenizer
 
     def parser(self, **opts) -> Parser:
-        return t.cast(t.Type[Parser], self.parser_class)(**opts)
+        return self.parser_class(**opts)
 
     def generator(self, **opts) -> Generator:
-        return t.cast(t.Type[Generator], self.generator_class)(**opts)
+        return self.generator_class(**opts)
 
 
 DialectType = t.Union[str, Dialect, t.Type[Dialect], None]

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -153,7 +153,7 @@ class Dialect(metaclass=_Dialect):
     # and the value the target time format
     TIME_MAPPING: t.Dict[str, str] = {}
 
-    # autofilled
+    # Autofilled
     tokenizer_class = Tokenizer
     parser_class = Parser
     generator_class = Generator

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -159,7 +159,7 @@ class Dialect(metaclass=_Dialect):
     generator_class = Generator
 
     # A trie of the time_mapping keys
-    TIME_TRIE: t.Optional[t.Dict] = None
+    TIME_TRIE: t.Dict = {}
 
     INVERSE_TIME_MAPPING: t.Dict[str, str] = {}
     INVERSE_TIME_TRIE: t.Dict = {}

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -126,16 +126,31 @@ class _Dialect(type):
 
 
 class Dialect(metaclass=_Dialect):
+    # Determines the base index offset for arrays
     INDEX_OFFSET = 0
+
+    # If true unnest table aliases are considered only as column aliases
     UNNEST_COLUMN_ONLY = False
+
+    # Determines whether or not the table alias comes after tablesample
     ALIAS_POST_TABLESAMPLE = False
+
+    # Determines whether or not an unquoted identifier can start with a digit
     IDENTIFIERS_CAN_START_WITH_DIGIT = False
+
+    # Determines how function names are going to be normalized
     NORMALIZE_FUNCTIONS: bool | str = "upper"
+
+    # Indicates the default null ordering method to use if not explicitly set
+    # Options are: "nulls_are_small", "nulls_are_large", "nulls_are_last"
     NULL_ORDERING = "nulls_are_small"
 
     DATE_FORMAT = "'%Y-%m-%d'"
     DATEINT_FORMAT = "'%Y%m%d'"
     TIME_FORMAT = "'%Y-%m-%d %H:%M:%S'"
+
+    # Custom time mappings in which the key represents a python time format
+    # and the value the target time format
     TIME_MAPPING: t.Dict[str, str] = {}
 
     # autofilled
@@ -143,11 +158,9 @@ class Dialect(metaclass=_Dialect):
     parser_class = None
     generator_class = None
 
-    QUOTE_START: t.Optional[str] = None
-    QUOTE_END: t.Optional[str] = None
-    IDENTIFIER_START: t.Optional[str] = None
-    IDENTIFIER_END: t.Optional[str] = None
+    # A trie of the time_mapping keys
     TIME_TRIE: t.Optional[t.Dict] = None
+
     INVERSE_TIME_MAPPING: t.Optional[t.Dict[str, str]] = None
     INVERSE_TIME_TRIE: t.Optional[t.Dict] = None
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -76,16 +76,16 @@ class _Dialect(type):
         enum = Dialects.__members__.get(clsname.upper())
         cls.classes[enum.value if enum is not None else clsname.lower()] = klass
 
-        klass.time_trie = new_trie(klass.time_mapping)
-        klass.inverse_time_mapping = {v: k for k, v in klass.time_mapping.items()}
-        klass.inverse_time_trie = new_trie(klass.inverse_time_mapping)
+        klass.TIME_TRIE = new_trie(klass.TIME_MAPPING)
+        klass.INVERSE_TIME_MAPPING = {v: k for k, v in klass.TIME_MAPPING.items()}
+        klass.INVERSE_TIME_TRIE = new_trie(klass.INVERSE_TIME_MAPPING)
 
         klass.tokenizer_class = getattr(klass, "Tokenizer", Tokenizer)
         klass.parser_class = getattr(klass, "Parser", Parser)
         klass.generator_class = getattr(klass, "Generator", Generator)
 
-        klass.quote_start, klass.quote_end = list(klass.tokenizer_class._QUOTES.items())[0]
-        klass.identifier_start, klass.identifier_end = list(
+        klass.QUOTE_START, klass.QUOTE_END = list(klass.tokenizer_class._QUOTES.items())[0]
+        klass.IDENTIFIER_START, klass.IDENTIFIER_END = list(
             klass.tokenizer_class._IDENTIFIERS.items()
         )[0]
 
@@ -99,43 +99,57 @@ class _Dialect(type):
                 (None, None),
             )
 
-        klass.bit_start, klass.bit_end = get_start_end(TokenType.BIT_STRING)
-        klass.hex_start, klass.hex_end = get_start_end(TokenType.HEX_STRING)
-        klass.byte_start, klass.byte_end = get_start_end(TokenType.BYTE_STRING)
-        klass.raw_start, klass.raw_end = get_start_end(TokenType.RAW_STRING)
+        klass.BIT_START, klass.BIT_END = get_start_end(TokenType.BIT_STRING)
+        klass.HEX_START, klass.HEX_END = get_start_end(TokenType.HEX_STRING)
+        klass.BYTE_START, klass.BYTE_END = get_start_end(TokenType.BYTE_STRING)
+        klass.RAW_START, klass.RAW_END = get_start_end(TokenType.RAW_STRING)
 
-        klass.tokenizer_class.identifiers_can_start_with_digit = (
-            klass.identifiers_can_start_with_digit
-        )
+        dialect_properties = {
+            **{
+                k: v
+                for k, v in vars(klass).items()
+                if not callable(v) and not isinstance(v, classmethod) and not k.startswith("__")
+            },
+            "STRING_ESCAPE": klass.tokenizer_class.STRING_ESCAPES[0],
+            "IDENTIFIER_ESCAPE": klass.tokenizer_class.IDENTIFIER_ESCAPES[0],
+            "TIME_MAPPING": klass.INVERSE_TIME_MAPPING,
+            "TIME_TRIE": klass.INVERSE_TIME_TRIE,
+        }
+
+        # Pass required dialect properties to the tokenizer, parser and generator classes
+        for subclass in (klass.tokenizer_class, klass.parser_class, klass.generator_class):
+            for name, value in dialect_properties.items():
+                if hasattr(subclass, name):
+                    setattr(subclass, name, value)
 
         return klass
 
 
 class Dialect(metaclass=_Dialect):
-    index_offset = 0
-    unnest_column_only = False
-    alias_post_tablesample = False
-    identifiers_can_start_with_digit = False
-    normalize_functions: t.Optional[str] = "upper"
-    null_ordering = "nulls_are_small"
+    INDEX_OFFSET = 0
+    UNNEST_COLUMN_ONLY = False
+    ALIAS_POST_TABLESAMPLE = False
+    IDENTIFIERS_CAN_START_WITH_DIGIT = False
+    NORMALIZE_FUNCTIONS: bool | str = "upper"
+    NULL_ORDERING = "nulls_are_small"
 
-    date_format = "'%Y-%m-%d'"
-    dateint_format = "'%Y%m%d'"
-    time_format = "'%Y-%m-%d %H:%M:%S'"
-    time_mapping: t.Dict[str, str] = {}
+    DATE_FORMAT = "'%Y-%m-%d'"
+    DATEINT_FORMAT = "'%Y%m%d'"
+    TIME_FORMAT = "'%Y-%m-%d %H:%M:%S'"
+    TIME_MAPPING: t.Dict[str, str] = {}
 
     # autofilled
-    quote_start = None
-    quote_end = None
-    identifier_start = None
-    identifier_end = None
-
-    time_trie = None
-    inverse_time_mapping = None
-    inverse_time_trie = None
     tokenizer_class = None
     parser_class = None
     generator_class = None
+
+    QUOTE_START: t.Optional[str] = None
+    QUOTE_END: t.Optional[str] = None
+    IDENTIFIER_START: t.Optional[str] = None
+    IDENTIFIER_END: t.Optional[str] = None
+    TIME_TRIE: t.Optional[t.Dict] = None
+    INVERSE_TIME_MAPPING: t.Optional[t.Dict[str, str]] = None
+    INVERSE_TIME_TRIE: t.Optional[t.Dict] = None
 
     def __eq__(self, other: t.Any) -> bool:
         return type(self) == other
@@ -164,20 +178,13 @@ class Dialect(metaclass=_Dialect):
     ) -> t.Optional[exp.Expression]:
         if isinstance(expression, str):
             return exp.Literal.string(
-                format_time(
-                    expression[1:-1],  # the time formats are quoted
-                    cls.time_mapping,
-                    cls.time_trie,
-                )
+                # the time formats are quoted
+                format_time(expression[1:-1], cls.TIME_MAPPING, cls.TIME_TRIE)
             )
+
         if expression and expression.is_string:
-            return exp.Literal.string(
-                format_time(
-                    expression.this,
-                    cls.time_mapping,
-                    cls.time_trie,
-                )
-            )
+            return exp.Literal.string(format_time(expression.this, cls.TIME_MAPPING, cls.TIME_TRIE))
+
         return expression
 
     def parse(self, sql: str, **opts) -> t.List[t.Optional[exp.Expression]]:
@@ -200,48 +207,14 @@ class Dialect(metaclass=_Dialect):
     @property
     def tokenizer(self) -> Tokenizer:
         if not hasattr(self, "_tokenizer"):
-            self._tokenizer = self.tokenizer_class()  # type: ignore
+            self._tokenizer = t.cast(t.Type[Tokenizer], self.tokenizer_class)()
         return self._tokenizer
 
     def parser(self, **opts) -> Parser:
-        return self.parser_class(  # type: ignore
-            **{
-                "index_offset": self.index_offset,
-                "unnest_column_only": self.unnest_column_only,
-                "alias_post_tablesample": self.alias_post_tablesample,
-                "null_ordering": self.null_ordering,
-                **opts,
-            },
-        )
+        return t.cast(t.Type[Parser], self.parser_class)(**opts)
 
     def generator(self, **opts) -> Generator:
-        return self.generator_class(  # type: ignore
-            **{
-                "quote_start": self.quote_start,
-                "quote_end": self.quote_end,
-                "bit_start": self.bit_start,
-                "bit_end": self.bit_end,
-                "hex_start": self.hex_start,
-                "hex_end": self.hex_end,
-                "byte_start": self.byte_start,
-                "byte_end": self.byte_end,
-                "raw_start": self.raw_start,
-                "raw_end": self.raw_end,
-                "identifier_start": self.identifier_start,
-                "identifier_end": self.identifier_end,
-                "string_escape": self.tokenizer_class.STRING_ESCAPES[0],
-                "identifier_escape": self.tokenizer_class.IDENTIFIER_ESCAPES[0],
-                "index_offset": self.index_offset,
-                "time_mapping": self.inverse_time_mapping,
-                "time_trie": self.inverse_time_trie,
-                "unnest_column_only": self.unnest_column_only,
-                "alias_post_tablesample": self.alias_post_tablesample,
-                "identifiers_can_start_with_digit": self.identifiers_can_start_with_digit,
-                "normalize_functions": self.normalize_functions,
-                "null_ordering": self.null_ordering,
-                **opts,
-            }
-        )
+        return t.cast(t.Type[Generator], self.generator_class)(**opts)
 
 
 DialectType = t.Union[str, Dialect, t.Type[Dialect], None]
@@ -279,10 +252,7 @@ def inline_array_sql(self: Generator, expression: exp.Array) -> str:
 
 def no_ilike_sql(self: Generator, expression: exp.ILike) -> str:
     return self.like_sql(
-        exp.Like(
-            this=exp.Lower(this=expression.this),
-            expression=expression.args["expression"],
-        )
+        exp.Like(this=exp.Lower(this=expression.this), expression=expression.expression)
     )
 
 
@@ -359,6 +329,7 @@ def var_map_sql(
     for key, value in zip(keys.expressions, values.expressions):
         args.append(self.sql(key))
         args.append(self.sql(value))
+
     return self.func(map_func_name, *args)
 
 
@@ -381,7 +352,7 @@ def format_time_lambda(
             this=seq_get(args, 0),
             format=Dialect[dialect].format_time(
                 seq_get(args, 1)
-                or (Dialect[dialect].time_format if default is True else default or None)
+                or (Dialect[dialect].TIME_FORMAT if default is True else default or None)
             ),
         )
 
@@ -462,9 +433,7 @@ def timestamptrunc_sql(self: Generator, expression: exp.TimestampTrunc) -> str:
 
 def locate_to_strposition(args: t.List) -> exp.Expression:
     return exp.StrPosition(
-        this=seq_get(args, 1),
-        substr=seq_get(args, 0),
-        position=seq_get(args, 2),
+        this=seq_get(args, 1), substr=seq_get(args, 0), position=seq_get(args, 2)
     )
 
 
@@ -546,7 +515,7 @@ def ts_or_ds_to_date_sql(dialect: str) -> t.Callable:
     def _ts_or_ds_to_date_sql(self: Generator, expression: exp.TsOrDsToDate) -> str:
         _dialect = Dialect.get_or_raise(dialect)
         time_format = self.format_time(expression)
-        if time_format and time_format not in (_dialect.time_format, _dialect.date_format):
+        if time_format and time_format not in (_dialect.TIME_FORMAT, _dialect.DATE_FORMAT):
             return f"CAST({str_to_time_sql(self, expression)} AS DATE)"
         return f"CAST({self.sql(expression, 'this')} AS DATE)"
 

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -16,17 +16,6 @@ from sqlglot.dialects.dialect import (
 )
 
 
-def _str_to_time_sql(self: generator.Generator, expression: exp.TsOrDsToDate) -> str:
-    return f"STRPTIME({self.sql(expression, 'this')}, {self.format_time(expression)})"
-
-
-def _ts_or_ds_to_date_sql(self: generator.Generator, expression: exp.TsOrDsToDate) -> str:
-    time_format = self.format_time(expression)
-    if time_format and time_format not in (Drill.TIME_FORMAT, Drill.DATE_FORMAT):
-        return f"CAST({_str_to_time_sql(self, expression)} AS DATE)"
-    return f"CAST({self.sql(expression, 'this')} AS DATE)"
-
-
 def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | exp.DateSub], str]:
     def func(self: generator.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -22,7 +22,7 @@ def _str_to_time_sql(self: generator.Generator, expression: exp.TsOrDsToDate) ->
 
 def _ts_or_ds_to_date_sql(self: generator.Generator, expression: exp.TsOrDsToDate) -> str:
     time_format = self.format_time(expression)
-    if time_format and time_format not in (Drill.time_format, Drill.date_format):
+    if time_format and time_format not in (Drill.TIME_FORMAT, Drill.DATE_FORMAT):
         return f"CAST({_str_to_time_sql(self, expression)} AS DATE)"
     return f"CAST({self.sql(expression, 'this')} AS DATE)"
 
@@ -30,7 +30,7 @@ def _ts_or_ds_to_date_sql(self: generator.Generator, expression: exp.TsOrDsToDat
 def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | exp.DateSub], str]:
     def func(self: generator.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
         this = self.sql(expression, "this")
-        unit = exp.Var(this=expression.text("unit").upper() or "DAY")
+        unit = exp.var(expression.text("unit").upper() or "DAY")
         return (
             f"DATE_{kind}({this}, {self.sql(exp.Interval(this=expression.expression, unit=unit))})"
         )
@@ -41,19 +41,19 @@ def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | e
 def _str_to_date(self: generator.Generator, expression: exp.StrToDate) -> str:
     this = self.sql(expression, "this")
     time_format = self.format_time(expression)
-    if time_format == Drill.date_format:
+    if time_format == Drill.DATE_FORMAT:
         return f"CAST({this} AS DATE)"
     return f"TO_DATE({this}, {time_format})"
 
 
 class Drill(Dialect):
-    normalize_functions = None
-    null_ordering = "nulls_are_last"
-    date_format = "'yyyy-MM-dd'"
-    dateint_format = "'yyyyMMdd'"
-    time_format = "'yyyy-MM-dd HH:mm:ss'"
+    NORMALIZE_FUNCTIONS: bool | str = False
+    NULL_ORDERING = "nulls_are_last"
+    DATE_FORMAT = "'yyyy-MM-dd'"
+    DATEINT_FORMAT = "'yyyyMMdd'"
+    TIME_FORMAT = "'yyyy-MM-dd HH:mm:ss'"
 
-    time_mapping = {
+    TIME_MAPPING = {
         "y": "%Y",
         "Y": "%Y",
         "YYYY": "%Y",
@@ -135,8 +135,8 @@ class Drill(Dialect):
             exp.DateAdd: _date_add_sql("ADD"),
             exp.DateStrToDate: datestrtodate_sql,
             exp.DateSub: _date_add_sql("SUB"),
-            exp.DateToDi: lambda self, e: f"CAST(TO_DATE({self.sql(e, 'this')}, {Drill.dateint_format}) AS INT)",
-            exp.DiToDate: lambda self, e: f"TO_DATE(CAST({self.sql(e, 'this')} AS VARCHAR), {Drill.dateint_format})",
+            exp.DateToDi: lambda self, e: f"CAST(TO_DATE({self.sql(e, 'this')}, {Drill.DATEINT_FORMAT}) AS INT)",
+            exp.DiToDate: lambda self, e: f"TO_DATE(CAST({self.sql(e, 'this')} AS VARCHAR), {Drill.DATEINT_FORMAT})",
             exp.If: lambda self, e: f"`IF`({self.format_args(e.this, e.args.get('true'), e.args.get('false'))})",
             exp.ILike: lambda self, e: f" {self.sql(e, 'this')} `ILIKE` {self.sql(e, 'expression')}",
             exp.Levenshtein: rename_func("LEVENSHTEIN_DISTANCE"),
@@ -154,7 +154,7 @@ class Drill(Dialect):
             exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
             exp.TryCast: no_trycast_sql,
-            exp.TsOrDsAdd: lambda self, e: f"DATE_ADD(CAST({self.sql(e, 'this')} AS DATE), {self.sql(exp.Interval(this=e.expression, unit=exp.Var(this='DAY')))})",
+            exp.TsOrDsAdd: lambda self, e: f"DATE_ADD(CAST({self.sql(e, 'this')} AS DATE), {self.sql(exp.Interval(this=e.expression, unit=exp.var('DAY')))})",
             exp.TsOrDsToDate: ts_or_ds_to_date_sql("drill"),
             exp.TsOrDiToDi: lambda self, e: f"CAST(SUBSTR(REPLACE(CAST({self.sql(e, 'this')} AS VARCHAR), '-', ''), 1, 8) AS INT)",
         }

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -56,11 +56,7 @@ def _sort_array_reverse(args: t.List) -> exp.Expression:
 
 
 def _parse_date_diff(args: t.List) -> exp.Expression:
-    return exp.DateDiff(
-        this=seq_get(args, 2),
-        expression=seq_get(args, 1),
-        unit=seq_get(args, 0),
-    )
+    return exp.DateDiff(this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0))
 
 
 def _struct_sql(self: generator.Generator, expression: exp.Struct) -> str:
@@ -90,7 +86,7 @@ def _regexp_extract_sql(self: generator.Generator, expression: exp.RegexpExtract
 
 
 class DuckDB(Dialect):
-    null_ordering = "nulls_are_last"
+    NULL_ORDERING = "nulls_are_last"
 
     class Tokenizer(tokens.Tokenizer):
         KEYWORDS = {
@@ -127,10 +123,7 @@ class DuckDB(Dialect):
             "DATE_DIFF": _parse_date_diff,
             "EPOCH": exp.TimeToUnix.from_arg_list,
             "EPOCH_MS": lambda args: exp.UnixToTime(
-                this=exp.Div(
-                    this=seq_get(args, 0),
-                    expression=exp.Literal.number(1000),
-                )
+                this=exp.Div(this=seq_get(args, 0), expression=exp.Literal.number(1000))
             ),
             "LIST_REVERSE_SORT": _sort_array_reverse,
             "LIST_SORT": exp.SortArray.from_arg_list,
@@ -191,8 +184,8 @@ class DuckDB(Dialect):
                 "DATE_DIFF", f"'{e.args.get('unit', 'day')}'", e.expression, e.this
             ),
             exp.DateStrToDate: datestrtodate_sql,
-            exp.DateToDi: lambda self, e: f"CAST(STRFTIME({self.sql(e, 'this')}, {DuckDB.dateint_format}) AS INT)",
-            exp.DiToDate: lambda self, e: f"CAST(STRPTIME(CAST({self.sql(e, 'this')} AS TEXT), {DuckDB.dateint_format}) AS DATE)",
+            exp.DateToDi: lambda self, e: f"CAST(STRFTIME({self.sql(e, 'this')}, {DuckDB.DATEINT_FORMAT}) AS INT)",
+            exp.DiToDate: lambda self, e: f"CAST(STRPTIME(CAST({self.sql(e, 'this')} AS TEXT), {DuckDB.DATEINT_FORMAT}) AS DATE)",
             exp.Explode: rename_func("UNNEST"),
             exp.IntDiv: lambda self, e: self.binary(e, "//"),
             exp.JSONExtract: arrow_json_extract_sql,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -94,10 +94,10 @@ def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | e
 
 
 class MySQL(Dialect):
-    time_format = "'%Y-%m-%d %T'"
+    TIME_FORMAT = "'%Y-%m-%d %T'"
 
     # https://prestodb.io/docs/current/functions/datetime.html#mysql-date-functions
-    time_mapping = {
+    TIME_MAPPING = {
         "%M": "%B",
         "%c": "%-m",
         "%e": "%-d",
@@ -372,12 +372,7 @@ class MySQL(Dialect):
             else:
                 collate = None
 
-            return self.expression(
-                exp.SetItem,
-                this=charset,
-                collate=collate,
-                kind="NAMES",
-            )
+            return self.expression(exp.SetItem, this=charset, collate=collate, kind="NAMES")
 
     class Generator(generator.Generator):
         LOCKING_READS_SUPPORTED = True
@@ -472,9 +467,7 @@ class MySQL(Dialect):
 
         def _prefixed_sql(self, prefix: str, expression: exp.Expression, arg: str) -> str:
             sql = self.sql(expression, arg)
-            if not sql:
-                return ""
-            return f" {prefix} {sql}"
+            return f" {prefix} {sql}" if sql else ""
 
         def _oldstyle_limit_sql(self, expression: exp.Show) -> str:
             limit = self.sql(expression, "limit")

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -183,9 +183,9 @@ def _to_timestamp(args: t.List) -> exp.Expression:
 
 
 class Postgres(Dialect):
-    null_ordering = "nulls_are_large"
-    time_format = "'YYYY-MM-DD HH24:MI:SS'"
-    time_mapping = {
+    NULL_ORDERING = "nulls_are_large"
+    TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
+    TIME_MAPPING = {
         "AM": "%p",
         "PM": "%p",
         "D": "%u",  # 1-based day of week
@@ -303,7 +303,7 @@ class Postgres(Dialect):
             value = self._parse_bitwise()
 
             if part and part.is_string:
-                part = exp.Var(this=part.name)
+                part = exp.var(part.name)
 
             return self.expression(exp.Extract, this=part, expression=value)
 

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -227,7 +227,7 @@ class Presto(Dialect):
         INTERVAL_ALLOWS_PLURAL_FORM = False
         JOIN_HINTS = False
         TABLE_HINTS = False
-        IS_BOOLEAN_ALLOWED = False
+        IS_BOOL_ALLOWED = False
         STRUCT_DELIMITER = ("(", ")")
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -102,7 +102,7 @@ def _str_to_time_sql(
 
 def _ts_or_ds_to_date_sql(self: generator.Generator, expression: exp.TsOrDsToDate) -> str:
     time_format = self.format_time(expression)
-    if time_format and time_format not in (Presto.time_format, Presto.date_format):
+    if time_format and time_format not in (Presto.TIME_FORMAT, Presto.DATE_FORMAT):
         return f"CAST({_str_to_time_sql(self, expression)} AS DATE)"
     return f"CAST(SUBSTR(CAST({self.sql(expression, 'this')} AS VARCHAR), 1, 10) AS DATE)"
 
@@ -119,7 +119,7 @@ def _ts_or_ds_add_sql(self: generator.Generator, expression: exp.TsOrDsAdd) -> s
                 exp.Literal.number(1),
                 exp.Literal.number(10),
             ),
-            Presto.date_format,
+            Presto.DATE_FORMAT,
         )
 
     return self.func(
@@ -145,9 +145,7 @@ def _approx_percentile(args: t.List) -> exp.Expression:
         )
     if len(args) == 3:
         return exp.ApproxQuantile(
-            this=seq_get(args, 0),
-            quantile=seq_get(args, 1),
-            accuracy=seq_get(args, 2),
+            this=seq_get(args, 0), quantile=seq_get(args, 1), accuracy=seq_get(args, 2)
         )
     return exp.ApproxQuantile.from_arg_list(args)
 
@@ -160,10 +158,8 @@ def _from_unixtime(args: t.List) -> exp.Expression:
             minutes=seq_get(args, 2),
         )
     if len(args) == 2:
-        return exp.UnixToTime(
-            this=seq_get(args, 0),
-            zone=seq_get(args, 1),
-        )
+        return exp.UnixToTime(this=seq_get(args, 0), zone=seq_get(args, 1))
+
     return exp.UnixToTime.from_arg_list(args)
 
 
@@ -173,21 +169,16 @@ def _unnest_sequence(expression: exp.Expression) -> exp.Expression:
             unnest = exp.Unnest(expressions=[expression.this])
 
             if expression.alias:
-                return exp.alias_(
-                    unnest,
-                    alias="_u",
-                    table=[expression.alias],
-                    copy=False,
-                )
+                return exp.alias_(unnest, alias="_u", table=[expression.alias], copy=False)
             return unnest
     return expression
 
 
 class Presto(Dialect):
-    index_offset = 1
-    null_ordering = "nulls_are_last"
-    time_format = MySQL.time_format
-    time_mapping = MySQL.time_mapping
+    INDEX_OFFSET = 1
+    NULL_ORDERING = "nulls_are_last"
+    TIME_FORMAT = MySQL.TIME_FORMAT
+    TIME_MAPPING = MySQL.TIME_MAPPING
 
     class Tokenizer(tokens.Tokenizer):
         KEYWORDS = {
@@ -205,14 +196,10 @@ class Presto(Dialect):
             "CARDINALITY": exp.ArraySize.from_arg_list,
             "CONTAINS": exp.ArrayContains.from_arg_list,
             "DATE_ADD": lambda args: exp.DateAdd(
-                this=seq_get(args, 2),
-                expression=seq_get(args, 1),
-                unit=seq_get(args, 0),
+                this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0)
             ),
             "DATE_DIFF": lambda args: exp.DateDiff(
-                this=seq_get(args, 2),
-                expression=seq_get(args, 1),
-                unit=seq_get(args, 0),
+                this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0)
             ),
             "DATE_FORMAT": format_time_lambda(exp.TimeToStr, "presto"),
             "DATE_PARSE": format_time_lambda(exp.StrToTime, "presto"),
@@ -225,9 +212,7 @@ class Presto(Dialect):
             "NOW": exp.CurrentTimestamp.from_arg_list,
             "SEQUENCE": exp.GenerateSeries.from_arg_list,
             "STRPOS": lambda args: exp.StrPosition(
-                this=seq_get(args, 0),
-                substr=seq_get(args, 1),
-                instance=seq_get(args, 2),
+                this=seq_get(args, 0), substr=seq_get(args, 1), instance=seq_get(args, 2)
             ),
             "TO_UNIXTIME": exp.TimeToUnix.from_arg_list,
             "TO_HEX": exp.Hex.from_arg_list,
@@ -242,7 +227,7 @@ class Presto(Dialect):
         INTERVAL_ALLOWS_PLURAL_FORM = False
         JOIN_HINTS = False
         TABLE_HINTS = False
-        IS_BOOL = False
+        IS_BOOLEAN_ALLOWED = False
         STRUCT_DELIMITER = ("(", ")")
 
         PROPERTIES_LOCATION = {
@@ -284,10 +269,10 @@ class Presto(Dialect):
             exp.DateDiff: lambda self, e: self.func(
                 "DATE_DIFF", exp.Literal.string(e.text("unit") or "day"), e.expression, e.this
             ),
-            exp.DateStrToDate: lambda self, e: f"CAST(DATE_PARSE({self.sql(e, 'this')}, {Presto.date_format}) AS DATE)",
-            exp.DateToDi: lambda self, e: f"CAST(DATE_FORMAT({self.sql(e, 'this')}, {Presto.dateint_format}) AS INT)",
+            exp.DateStrToDate: lambda self, e: f"CAST(DATE_PARSE({self.sql(e, 'this')}, {Presto.DATE_FORMAT}) AS DATE)",
+            exp.DateToDi: lambda self, e: f"CAST(DATE_FORMAT({self.sql(e, 'this')}, {Presto.DATEINT_FORMAT}) AS INT)",
             exp.Decode: _decode_sql,
-            exp.DiToDate: lambda self, e: f"CAST(DATE_PARSE(CAST({self.sql(e, 'this')} AS VARCHAR), {Presto.dateint_format}) AS DATE)",
+            exp.DiToDate: lambda self, e: f"CAST(DATE_PARSE(CAST({self.sql(e, 'this')} AS VARCHAR), {Presto.DATEINT_FORMAT}) AS DATE)",
             exp.Encode: _encode_sql,
             exp.FileFormatProperty: lambda self, e: f"FORMAT='{e.name.upper()}'",
             exp.Group: transforms.preprocess([transforms.unalias_group]),
@@ -322,7 +307,7 @@ class Presto(Dialect):
             exp.TimestampTrunc: timestamptrunc_sql,
             exp.TimeStrToDate: timestrtotime_sql,
             exp.TimeStrToTime: timestrtotime_sql,
-            exp.TimeStrToUnix: lambda self, e: f"TO_UNIXTIME(DATE_PARSE({self.sql(e, 'this')}, {Presto.time_format}))",
+            exp.TimeStrToUnix: lambda self, e: f"TO_UNIXTIME(DATE_PARSE({self.sql(e, 'this')}, {Presto.TIME_FORMAT}))",
             exp.TimeToStr: lambda self, e: f"DATE_FORMAT({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TimeToUnix: rename_func("TO_UNIXTIME"),
             exp.TryCast: transforms.preprocess([transforms.epoch_cast_to_ts]),
@@ -367,9 +352,9 @@ class Presto(Dialect):
                 to = target_type.copy()
 
                 if target_type is start.to:
-                    end = exp.Cast(this=end, to=to)
+                    end = exp.cast(end, to)
                 else:
-                    start = exp.Cast(this=start, to=to)
+                    start = exp.cast(start, to)
 
             return self.func("SEQUENCE", start, end, step)
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -14,9 +14,9 @@ def _json_sql(self: Postgres.Generator, expression: exp.JSONExtract | exp.JSONEx
 
 
 class Redshift(Postgres):
-    time_format = "'YYYY-MM-DD HH:MI:SS'"
-    time_mapping = {
-        **Postgres.time_mapping,
+    TIME_FORMAT = "'YYYY-MM-DD HH:MI:SS'"
+    TIME_MAPPING = {
+        **Postgres.TIME_MAPPING,
         "MON": "%b",
         "HH": "%H",
     }
@@ -51,7 +51,7 @@ class Redshift(Postgres):
                 and this.expressions
                 and this.expressions[0].this == exp.column("MAX")
             ):
-                this.set("expressions", [exp.Var(this="MAX")])
+                this.set("expressions", [exp.var("MAX")])
 
             return this
 
@@ -170,6 +170,6 @@ class Redshift(Postgres):
                 precision = expression.args.get("expressions")
 
                 if not precision:
-                    expression.append("expressions", exp.Var(this="MAX"))
+                    expression.append("expressions", exp.var("MAX"))
 
             return super().datatype_sql(expression)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -167,10 +167,10 @@ def _parse_convert_timezone(args: t.List) -> exp.Expression:
 
 
 class Snowflake(Dialect):
-    null_ordering = "nulls_are_large"
-    time_format = "'yyyy-mm-dd hh24:mi:ss'"
+    NULL_ORDERING = "nulls_are_large"
+    TIME_FORMAT = "'yyyy-mm-dd hh24:mi:ss'"
 
-    time_mapping = {
+    TIME_MAPPING = {
         "YYYY": "%Y",
         "yyyy": "%Y",
         "YY": "%y",
@@ -210,14 +210,10 @@ class Snowflake(Dialect):
             "CONVERT_TIMEZONE": _parse_convert_timezone,
             "DATE_TRUNC": date_trunc_to_time,
             "DATEADD": lambda args: exp.DateAdd(
-                this=seq_get(args, 2),
-                expression=seq_get(args, 1),
-                unit=seq_get(args, 0),
+                this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0)
             ),
             "DATEDIFF": lambda args: exp.DateDiff(
-                this=seq_get(args, 2),
-                expression=seq_get(args, 1),
-                unit=seq_get(args, 0),
+                this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0)
             ),
             "DIV0": _div0_to_if,
             "IFF": exp.If.from_arg_list,
@@ -246,9 +242,7 @@ class Snowflake(Dialect):
         COLUMN_OPERATORS = {
             **parser.Parser.COLUMN_OPERATORS,
             TokenType.COLON: lambda self, this, path: self.expression(
-                exp.Bracket,
-                this=this,
-                expressions=[path],
+                exp.Bracket, this=this, expressions=[path]
             ),
         }
 

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -38,7 +38,7 @@ def _parse_as_cast(to_type: str) -> t.Callable[[t.List], exp.Expression]:
 def _str_to_date(self: Hive.Generator, expression: exp.StrToDate) -> str:
     this = self.sql(expression, "this")
     time_format = self.format_time(expression)
-    if time_format == Hive.date_format:
+    if time_format == Hive.DATE_FORMAT:
         return f"TO_DATE({this})"
     return f"TO_DATE({this}, {time_format})"
 
@@ -162,11 +162,9 @@ class Spark2(Hive):
         def _parse_add_column(self) -> t.Optional[exp.Expression]:
             return self._match_text_seq("ADD", "COLUMNS") and self._parse_schema()
 
-        def _parse_drop_column(self) -> t.Optional[exp.Expression]:
+        def _parse_drop_column(self) -> t.Optional[exp.Drop | exp.Command]:
             return self._match_text_seq("DROP", "COLUMNS") and self.expression(
-                exp.Drop,
-                this=self._parse_schema(),
-                kind="COLUMNS",
+                exp.Drop, this=self._parse_schema(), kind="COLUMNS"
             )
 
         def _pivot_column_names(self, aggregations: t.List[exp.Expression]) -> t.List[str]:

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -62,10 +62,6 @@ class SQLite(Dialect):
         IDENTIFIERS = ['"', ("[", "]"), "`"]
         HEX_STRINGS = [("x'", "'"), ("X'", "'"), ("0x", ""), ("0X", "")]
 
-        KEYWORDS = {
-            **tokens.Tokenizer.KEYWORDS,
-        }
-
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/tableau.py
+++ b/sqlglot/dialects/tableau.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sqlglot import exp, generator, parser, transforms
-from sqlglot.dialects.dialect import Dialect
+from sqlglot.dialects.dialect import Dialect, rename_func
 
 
 class Tableau(Dialect):
@@ -11,6 +11,7 @@ class Tableau(Dialect):
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
+            exp.Coalesce: rename_func("IFNULL"),
             exp.Select: transforms.preprocess([transforms.eliminate_distinct_on]),
         }
 
@@ -24,9 +25,6 @@ class Tableau(Dialect):
             true = self.sql(expression, "true")
             false = self.sql(expression, "false")
             return f"IF {this} THEN {true} ELSE {false} END"
-
-        def coalesce_sql(self, expression: exp.Coalesce) -> str:
-            return f"IFNULL({self.sql(expression, 'this')}, {self.expressions(expression)})"
 
         def count_sql(self, expression: exp.Count) -> str:
             this = expression.this

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -31,7 +31,7 @@ class Teradata(Dialect):
             "ST_GEOMETRY": TokenType.GEOMETRY,
         }
 
-        # teradata does not support % for modulus
+        # Teradata does not support % as a modulo operator
         SINGLE_TOKENS = {**tokens.Tokenizer.SINGLE_TOKENS}
         SINGLE_TOKENS.pop("%")
 
@@ -101,7 +101,7 @@ class Teradata(Dialect):
 
         # FROM before SET in Teradata UPDATE syntax
         # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/Teradata-VantageTM-SQL-Data-Manipulation-Language-17.20/Statement-Syntax/UPDATE/UPDATE-Syntax-Basic-Form-FROM-Clause
-        def _parse_update(self) -> exp.Expression:
+        def _parse_update(self) -> exp.Update:
             return self.expression(
                 exp.Update,
                 **{  # type: ignore

--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -159,7 +159,6 @@ ENV = {
     "EXTRACT": null_if_any(lambda this, e: getattr(e, this)),
     "GT": null_if_any(lambda this, e: this > e),
     "GTE": null_if_any(lambda this, e: this >= e),
-    "IFNULL": lambda e, alt: alt if e is None else e,
     "IF": lambda predicate, true, false: true if predicate else false,
     "INTDIV": null_if_any(lambda e, this: e // this),
     "INTERVAL": interval,

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -394,7 +394,7 @@ def _lambda_sql(self, e: exp.Lambda) -> str:
     names = {e.name.lower() for e in e.expressions}
 
     e = e.transform(
-        lambda n: exp.Var(this=n.name)
+        lambda n: exp.var(n.name)
         if isinstance(n, exp.Identifier) and n.name.lower() in names
         else n
     )

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3913,6 +3913,7 @@ class Ceil(Func):
 class Coalesce(Func):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True
+    _sql_names = ["COALESCE", "IFNULL", "NVL"]
 
 
 class Concat(Func):
@@ -4109,11 +4110,6 @@ class Hex(Func):
 
 class If(Func):
     arg_types = {"this": True, "true": True, "false": False}
-
-
-class IfNull(Func):
-    arg_types = {"this": True, "expression": False}
-    _sql_names = ["IFNULL", "NVL"]
 
 
 class Initcap(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -38,7 +38,7 @@ class Generator:
         max_unsupported: Maximum number of unsupported messages to include in a raised UnsupportedError.
             This is only relevant if unsupported_level is ErrorLevel.RAISE.
             Default: 3
-        leading_comma: Determines whether the comma is leading or trailing in select expressions.
+        leading_comma: Determines whether or not the comma is leading or trailing in select expressions.
             This is only relevant when generating in pretty mode.
             Default: False
         max_text_width: The max number of characters in a segment before creating new lines in pretty mode.

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -14,47 +14,32 @@ logger = logging.getLogger("sqlglot")
 
 class Generator:
     """
-    Generator interprets the given syntax tree and produces a SQL string as an output.
+    Generator converts a given syntax tree to the corresponding SQL string.
 
     Args:
-        time_mapping (dict): the dictionary of custom time mappings in which the key
-            represents a python time format and the output the target time format
-        time_trie (trie): a trie of the time_mapping keys
-        pretty (bool): if set to True the returned string will be formatted. Default: False.
-        quote_start (str): specifies which starting character to use to delimit quotes. Default: '.
-        quote_end (str): specifies which ending character to use to delimit quotes. Default: '.
-        identifier_start (str): specifies which starting character to use to delimit identifiers. Default: ".
-        identifier_end (str): specifies which ending character to use to delimit identifiers. Default: ".
-        bit_start (str): specifies which starting character to use to delimit bit literals. Default: None.
-        bit_end (str): specifies which ending character to use to delimit bit literals. Default: None.
-        hex_start (str): specifies which starting character to use to delimit hex literals. Default: None.
-        hex_end (str): specifies which ending character to use to delimit hex literals. Default: None.
-        byte_start (str): specifies which starting character to use to delimit byte literals. Default: None.
-        byte_end (str): specifies which ending character to use to delimit byte literals. Default: None.
-        raw_start (str): specifies which starting character to use to delimit raw literals. Default: None.
-        raw_end (str): specifies which ending character to use to delimit raw literals. Default: None.
-        identify (bool | str): 'always': always quote, 'safe': quote identifiers if they don't contain an upcase, True defaults to always.
-        normalize (bool): if set to True all identifiers will lower cased
-        string_escape (str): specifies a string escape character. Default: '.
-        identifier_escape (str): specifies an identifier escape character. Default: ".
-        pad (int): determines padding in a formatted string. Default: 2.
-        indent (int): determines the size of indentation in a formatted string. Default: 4.
-        unnest_column_only (bool): if true unnest table aliases are considered only as column aliases
-        normalize_functions (str): normalize function names, "upper", "lower", or None
-            Default: "upper"
-        alias_post_tablesample (bool): if the table alias comes after tablesample
-            Default: False
-        identifiers_can_start_with_digit (bool): if an unquoted identifier can start with digit
-            Default: False
-        unsupported_level (ErrorLevel): determines the generator's behavior when it encounters
-            unsupported expressions. Default ErrorLevel.WARN.
-        null_ordering (str): Indicates the default null ordering method to use if not explicitly set.
-            Options are "nulls_are_small", "nulls_are_large", "nulls_are_last".
-            Default: "nulls_are_small"
-        max_unsupported (int): Maximum number of unsupported messages to include in a raised UnsupportedError.
+        pretty: Whether or not to format the produced SQL string.
+            Default: False.
+        identify: Determines when an identifier should be quoted. Possible values are:
+            False (default): Never quote, except in cases where it's mandatory by the dialect.
+            True or 'always': Always quote.
+            'safe': Only quote identifiers that are case insensitive.
+        normalize: Whether or not to normalize identifiers to lowercase.
+            Default: False.
+        pad: Determines the pad size in a formatted string.
+            Default: 2.
+        indent: Determines the indentation size in a formatted string.
+            Default: 2.
+        normalize_functions: Whether or not to normalize all function names. Possible values are:
+            "upper" or True (default): Convert names to uppercase.
+            "lower": Convert names to lowercase.
+            False: Disables function name normalization.
+        unsupported_level: Determines the generator's behavior when it encounters unsupported expressions.
+            Default ErrorLevel.WARN.
+        max_unsupported: Maximum number of unsupported messages to include in a raised UnsupportedError.
             This is only relevant if unsupported_level is ErrorLevel.RAISE.
             Default: 3
-        leading_comma (bool): if the the comma is leading or trailing in select statements
+        leading_comma: Determines whether the comma is leading or trailing in select expressions.
+            This is only relevant when generating in pretty mode.
             Default: False
         max_text_width: The max number of characters in a segment before creating new lines in pretty mode.
             The default is on the smaller end because the length only represents a segment and not the true
@@ -139,14 +124,23 @@ class Generator:
     # Whether or not limit and fetch are supported (possible values: "ALL", "LIMIT", "FETCH")
     LIMIT_FETCH = "ALL"
 
-    # Whether a table is allowed to be renamed with a db
+    # Whether or not a table is allowed to be renamed with a db
     RENAME_TABLE_WITH_DB = True
 
     # The separator for grouping sets and rollups
     GROUPINGS_SEP = ","
 
-    # The string used for creating index on a table
+    # The string used for creating an index on a table
     INDEX_ON = "ON"
+
+    # Whether or not join hints should be generated
+    JOIN_HINTS = True
+
+    # Whether or not table hints should be generated
+    TABLE_HINTS = True
+
+    # Whether or not comparing against booleans (e.g. x IS TRUE) is supported 
+    IS_BOOLEAN_ALLOWED = True
 
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
@@ -237,128 +231,94 @@ class Generator:
         exp.WithJournalTableProperty: exp.Properties.Location.POST_NAME,
     }
 
-    JOIN_HINTS = True
-    TABLE_HINTS = True
-    IS_BOOL = True
-
+    # Keywords that can't be used as unquoted identifier names
     RESERVED_KEYWORDS: t.Set[str] = set()
+
     WITH_SEPARATED_COMMENTS = (exp.Select, exp.From, exp.Where, exp.With)
+
     UNWRAPPED_INTERVAL_VALUES = (exp.Column, exp.Literal, exp.Neg, exp.Paren)
 
     SENTINEL_LINE_BREAK = "__SQLGLOT__LB__"
 
+    # Autofilled
+    TIME_MAPPING: t.Dict[str, str] = {}
+    TIME_TRIE: t.Dict = {}
+    QUOTE_START = "'"
+    QUOTE_END = "'"
+    IDENTIFIER_START = '"'
+    IDENTIFIER_END = '"'
+    STRING_ESCAPE = "'"
+    IDENTIFIER_ESCAPE = '"'
+    INDEX_OFFSET = 0
+    UNNEST_COLUMN_ONLY = False
+    ALIAS_POST_TABLESAMPLE = False
+    IDENTIFIERS_CAN_START_WITH_DIGIT = False
+    NORMALIZE_FUNCTIONS: bool | str = "upper"
+    NULL_ORDERING = "nulls_are_small"
+
+    BIT_START: t.Optional[str] = None
+    BIT_END: t.Optional[str] = None
+    HEX_START: t.Optional[str] = None
+    HEX_END: t.Optional[str] = None
+    BYTE_START: t.Optional[str] = None
+    BYTE_END: t.Optional[str] = None
+    RAW_START: t.Optional[str] = None
+    RAW_END: t.Optional[str] = None
+
     __slots__ = (
-        "time_mapping",
-        "time_trie",
         "pretty",
-        "quote_start",
-        "quote_end",
-        "identifier_start",
-        "identifier_end",
-        "bit_start",
-        "bit_end",
-        "hex_start",
-        "hex_end",
-        "byte_start",
-        "byte_end",
-        "raw_start",
-        "raw_end",
         "identify",
         "normalize",
-        "string_escape",
-        "identifier_escape",
         "pad",
-        "index_offset",
-        "unnest_column_only",
-        "alias_post_tablesample",
-        "identifiers_can_start_with_digit",
+        "_indent",
         "normalize_functions",
         "unsupported_level",
-        "unsupported_messages",
-        "null_ordering",
         "max_unsupported",
-        "_indent",
+        "leading_comma",
+        "max_text_width",
+        "comments",
+        "unsupported_messages",
         "_escaped_quote_end",
         "_escaped_identifier_end",
-        "_leading_comma",
-        "_max_text_width",
-        "_comments",
         "_cache",
     )
 
     def __init__(
         self,
-        time_mapping=None,
-        time_trie=None,
-        pretty=None,
-        quote_start=None,
-        quote_end=None,
-        identifier_start=None,
-        identifier_end=None,
-        bit_start=None,
-        bit_end=None,
-        hex_start=None,
-        hex_end=None,
-        byte_start=None,
-        byte_end=None,
-        raw_start=None,
-        raw_end=None,
-        identify=False,
-        normalize=False,
-        string_escape=None,
-        identifier_escape=None,
-        pad=2,
-        indent=2,
-        index_offset=0,
-        unnest_column_only=False,
-        alias_post_tablesample=False,
-        identifiers_can_start_with_digit=False,
-        normalize_functions="upper",
-        unsupported_level=ErrorLevel.WARN,
-        null_ordering=None,
-        max_unsupported=3,
-        leading_comma=False,
-        max_text_width=80,
-        comments=True,
+        pretty: t.Optional[bool] = None,
+        identify: str | bool = False,
+        normalize: bool = False,
+        pad: int = 2,
+        indent: int = 2,
+        normalize_functions: t.Optional[str | bool] = None,
+        unsupported_level: ErrorLevel = ErrorLevel.WARN,
+        max_unsupported: int = 3,
+        leading_comma: bool = False,
+        max_text_width: int = 80,
+        comments: bool = True,
     ):
         import sqlglot
 
-        self.time_mapping = time_mapping or {}
-        self.time_trie = time_trie
         self.pretty = pretty if pretty is not None else sqlglot.pretty
-        self.quote_start = quote_start or "'"
-        self.quote_end = quote_end or "'"
-        self.identifier_start = identifier_start or '"'
-        self.identifier_end = identifier_end or '"'
-        self.bit_start = bit_start
-        self.bit_end = bit_end
-        self.hex_start = hex_start
-        self.hex_end = hex_end
-        self.byte_start = byte_start
-        self.byte_end = byte_end
-        self.raw_start = raw_start
-        self.raw_end = raw_end
         self.identify = identify
         self.normalize = normalize
-        self.string_escape = string_escape or "'"
-        self.identifier_escape = identifier_escape or '"'
         self.pad = pad
-        self.index_offset = index_offset
-        self.unnest_column_only = unnest_column_only
-        self.alias_post_tablesample = alias_post_tablesample
-        self.identifiers_can_start_with_digit = identifiers_can_start_with_digit
-        self.normalize_functions = normalize_functions
-        self.unsupported_level = unsupported_level
-        self.unsupported_messages = []
-        self.max_unsupported = max_unsupported
-        self.null_ordering = null_ordering
         self._indent = indent
-        self._escaped_quote_end = self.string_escape + self.quote_end
-        self._escaped_identifier_end = self.identifier_escape + self.identifier_end
-        self._leading_comma = leading_comma
-        self._max_text_width = max_text_width
-        self._comments = comments
-        self._cache = None
+        self.unsupported_level = unsupported_level
+        self.max_unsupported = max_unsupported
+        self.leading_comma = leading_comma
+        self.max_text_width = max_text_width
+        self.comments = comments
+
+        # This is both a Dialect property and a generator argument, so we prioritize the latter
+        self.normalize_functions = (
+            self.NORMALIZE_FUNCTIONS if normalize_functions is None else normalize_functions
+        )
+
+        self.unsupported_messages: t.List[str] = []
+        self._escaped_quote_end: str = self.STRING_ESCAPE + self.QUOTE_END
+        self._escaped_identifier_end: str = self.IDENTIFIER_ESCAPE + self.IDENTIFIER_END
+        self._cache: t.Optional[t.Dict[int, str]] = None
 
     def generate(
         self,
@@ -366,17 +326,19 @@ class Generator:
         cache: t.Optional[t.Dict[int, str]] = None,
     ) -> str:
         """
-        Generates a SQL string by interpreting the given syntax tree.
+        Generates the SQL string corresponding to the given syntax tree.
 
-        Args
-            expression: the syntax tree.
-            cache: an optional sql string cache. this leverages the hash of an expression which is slow, so only use this if you set _hash on each node.
+        Args:
+            expression: The syntax tree.
+            cache: An optional sql string cache. This leverages the hash of an Expression
+                which can be slow to compute, so only use it if you set _hash on each node.
 
-        Returns
-            the SQL string.
+        Returns:
+            The SQL string corresponding to `expression`.
         """
         if cache is not None:
             self._cache = cache
+
         self.unsupported_messages = []
         sql = self.sql(expression).strip()
         self._cache = None
@@ -416,7 +378,11 @@ class Generator:
         expression: t.Optional[exp.Expression] = None,
         comments: t.Optional[t.List[str]] = None,
     ) -> str:
-        comments = ((expression and expression.comments) if comments is None else comments) if self._comments else None  # type: ignore
+        comments = (
+            ((expression and expression.comments) if comments is None else comments)  # type: ignore
+            if self.comments
+            else None
+        )
 
         if not comments or isinstance(expression, exp.Binary):
             return sql
@@ -456,7 +422,7 @@ class Generator:
         return result
 
     def normalize_func(self, name: str) -> str:
-        if self.normalize_functions == "upper":
+        if self.normalize_functions == "upper" or self.normalize_functions is True:
             return name.upper()
         if self.normalize_functions == "lower":
             return name.lower()
@@ -524,7 +490,7 @@ class Generator:
         else:
             raise ValueError(f"Expected an Expression. Received {type(expression)}: {expression}")
 
-        sql = self.maybe_comment(sql, expression) if self._comments and comment else sql
+        sql = self.maybe_comment(sql, expression) if self.comments and comment else sql
 
         if self._cache is not None:
             self._cache[expression_id] = sql
@@ -772,25 +738,25 @@ class Generator:
 
     def bitstring_sql(self, expression: exp.BitString) -> str:
         this = self.sql(expression, "this")
-        if self.bit_start:
-            return f"{self.bit_start}{this}{self.bit_end}"
+        if self.BIT_START:
+            return f"{self.BIT_START}{this}{self.BIT_END}"
         return f"{int(this, 2)}"
 
     def hexstring_sql(self, expression: exp.HexString) -> str:
         this = self.sql(expression, "this")
-        if self.hex_start:
-            return f"{self.hex_start}{this}{self.hex_end}"
+        if self.HEX_START:
+            return f"{self.HEX_START}{this}{self.HEX_END}"
         return f"{int(this, 16)}"
 
     def bytestring_sql(self, expression: exp.ByteString) -> str:
         this = self.sql(expression, "this")
-        if self.byte_start:
-            return f"{self.byte_start}{this}{self.byte_end}"
+        if self.BYTE_START:
+            return f"{self.BYTE_START}{this}{self.BYTE_END}"
         return this
 
     def rawstring_sql(self, expression: exp.RawString) -> str:
-        if self.raw_start:
-            return f"{self.raw_start}{expression.name}{self.raw_end}"
+        if self.RAW_START:
+            return f"{self.RAW_START}{expression.name}{self.RAW_END}"
         return self.sql(exp.Literal.string(expression.name.replace("\\", "\\\\")))
 
     def datatypesize_sql(self, expression: exp.DataTypeSize) -> str:
@@ -898,14 +864,14 @@ class Generator:
         text = expression.name
         lower = text.lower()
         text = lower if self.normalize and not expression.quoted else text
-        text = text.replace(self.identifier_end, self._escaped_identifier_end)
+        text = text.replace(self.IDENTIFIER_END, self._escaped_identifier_end)
         if (
             expression.quoted
             or should_identify(text, self.identify)
             or lower in self.RESERVED_KEYWORDS
-            or (not self.identifiers_can_start_with_digit and text[:1].isdigit())
+            or (not self.IDENTIFIERS_CAN_START_WITH_DIGIT and text[:1].isdigit())
         ):
-            text = f"{self.identifier_start}{text}{self.identifier_end}"
+            text = f"{self.IDENTIFIER_START}{text}{self.IDENTIFIER_END}"
         return text
 
     def inputoutputformat_sql(self, expression: exp.InputOutputFormat) -> str:
@@ -1202,7 +1168,7 @@ class Generator:
     def tablesample_sql(
         self, expression: exp.TableSample, seed_prefix: str = "SEED", sep=" AS "
     ) -> str:
-        if self.alias_post_tablesample and expression.this.alias:
+        if self.ALIAS_POST_TABLESAMPLE and expression.this.alias:
             table = expression.this.copy()
             table.set("alias", None)
             this = self.sql(table)
@@ -1423,10 +1389,10 @@ class Generator:
     def literal_sql(self, expression: exp.Literal) -> str:
         text = expression.this or ""
         if expression.is_string:
-            text = text.replace(self.quote_end, self._escaped_quote_end)
+            text = text.replace(self.QUOTE_END, self._escaped_quote_end)
             if self.pretty:
                 text = text.replace("\n", self.SENTINEL_LINE_BREAK)
-            text = f"{self.quote_start}{text}{self.quote_end}"
+            text = f"{self.QUOTE_START}{text}{self.QUOTE_END}"
         return text
 
     def loaddata_sql(self, expression: exp.LoadData) -> str:
@@ -1468,9 +1434,9 @@ class Generator:
 
         nulls_first = expression.args.get("nulls_first")
         nulls_last = not nulls_first
-        nulls_are_large = self.null_ordering == "nulls_are_large"
-        nulls_are_small = self.null_ordering == "nulls_are_small"
-        nulls_are_last = self.null_ordering == "nulls_are_last"
+        nulls_are_large = self.NULL_ORDERING == "nulls_are_large"
+        nulls_are_small = self.NULL_ORDERING == "nulls_are_small"
+        nulls_are_last = self.NULL_ORDERING == "nulls_are_last"
 
         sort_order = " DESC" if desc else ""
         nulls_sort_change = ""
@@ -1646,7 +1612,7 @@ class Generator:
     def unnest_sql(self, expression: exp.Unnest) -> str:
         args = self.expressions(expression, flat=True)
         alias = expression.args.get("alias")
-        if alias and self.unnest_column_only:
+        if alias and self.UNNEST_COLUMN_ONLY:
             columns = alias.columns
             alias = self.sql(columns[0]) if columns else ""
         else:
@@ -1709,7 +1675,7 @@ class Generator:
         return f"{this} BETWEEN {low} AND {high}"
 
     def bracket_sql(self, expression: exp.Bracket) -> str:
-        expressions = apply_index_offset(expression.this, expression.expressions, self.index_offset)
+        expressions = apply_index_offset(expression.this, expression.expressions, self.INDEX_OFFSET)
         expressions_sql = ", ".join(self.sql(e) for e in expressions)
 
         return f"{self.sql(expression, 'this')}[{expressions_sql}]"
@@ -1741,7 +1707,7 @@ class Generator:
 
         statements.append("END")
 
-        if self.pretty and self.text_width(statements) > self._max_text_width:
+        if self.pretty and self.text_width(statements) > self.max_text_width:
             return self.indent("\n".join(statements), skip_first=True, skip_last=True)
 
         return " ".join(statements)
@@ -1942,7 +1908,7 @@ class Generator:
             for i, e in enumerate(expression.flatten(unnest=False))
         )
 
-        sep = "\n" if self.text_width(sqls) > self._max_text_width else " "
+        sep = "\n" if self.text_width(sqls) > self.max_text_width else " "
         return f"{sep}{op} ".join(sqls)
 
     def bitwiseand_sql(self, expression: exp.BitwiseAnd) -> str:
@@ -2139,7 +2105,7 @@ class Generator:
         return self.binary(expression, "ILIKE ANY")
 
     def is_sql(self, expression: exp.Is) -> str:
-        if not self.IS_BOOL and isinstance(expression.expression, exp.Boolean):
+        if not self.IS_BOOLEAN_ALLOWED and isinstance(expression.expression, exp.Boolean):
             return self.sql(
                 expression.this if expression.expression.this else exp.not_(expression.this)
             )
@@ -2214,7 +2180,7 @@ class Generator:
 
     def format_args(self, *args: t.Optional[str | exp.Expression]) -> str:
         arg_sqls = tuple(self.sql(arg) for arg in args if arg is not None)
-        if self.pretty and self.text_width(arg_sqls) > self._max_text_width:
+        if self.pretty and self.text_width(arg_sqls) > self.max_text_width:
             return self.indent("\n" + f",\n".join(arg_sqls) + "\n", skip_first=True, skip_last=True)
         return ", ".join(arg_sqls)
 
@@ -2222,7 +2188,7 @@ class Generator:
         return sum(len(arg) for arg in args)
 
     def format_time(self, expression: exp.Expression) -> t.Optional[str]:
-        return format_time(self.sql(expression, "format"), self.time_mapping, self.time_trie)
+        return format_time(self.sql(expression, "format"), self.TIME_MAPPING, self.TIME_TRIE)
 
     def expressions(
         self,
@@ -2254,7 +2220,7 @@ class Generator:
             comments = self.maybe_comment("", e) if isinstance(e, exp.Expression) else ""
 
             if self.pretty:
-                if self._leading_comma:
+                if self.leading_comma:
                     result_sqls.append(f"{sep if i > 0 else pad}{prefix}{sql}{comments}")
                 else:
                     result_sqls.append(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -140,7 +140,7 @@ class Generator:
     TABLE_HINTS = True
 
     # Whether or not comparing against booleans (e.g. x IS TRUE) is supported
-    IS_BOOLEAN_ALLOWED = True
+    IS_BOOL_ALLOWED = True
 
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
@@ -2105,7 +2105,7 @@ class Generator:
         return self.binary(expression, "ILIKE ANY")
 
     def is_sql(self, expression: exp.Is) -> str:
-        if not self.IS_BOOLEAN_ALLOWED and isinstance(expression.expression, exp.Boolean):
+        if not self.IS_BOOL_ALLOWED and isinstance(expression.expression, exp.Boolean):
             return self.sql(
                 expression.this if expression.expression.this else exp.not_(expression.this)
             )

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -310,7 +310,7 @@ class Generator:
         self.max_text_width = max_text_width
         self.comments = comments
 
-        # This is both a Dialect property and a generator argument, so we prioritize the latter
+        # This is both a Dialect property and a Generator argument, so we prioritize the latter
         self.normalize_functions = (
             self.NORMALIZE_FUNCTIONS if normalize_functions is None else normalize_functions
         )

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -139,7 +139,7 @@ class Generator:
     # Whether or not table hints should be generated
     TABLE_HINTS = True
 
-    # Whether or not comparing against booleans (e.g. x IS TRUE) is supported 
+    # Whether or not comparing against booleans (e.g. x IS TRUE) is supported
     IS_BOOLEAN_ALLOWED = True
 
     TYPE_MAPPING = {

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -243,12 +243,6 @@ class Generator:
     # Autofilled
     TIME_MAPPING: t.Dict[str, str] = {}
     TIME_TRIE: t.Dict = {}
-    QUOTE_START = "'"
-    QUOTE_END = "'"
-    IDENTIFIER_START = '"'
-    IDENTIFIER_END = '"'
-    STRING_ESCAPE = "'"
-    IDENTIFIER_ESCAPE = '"'
     INDEX_OFFSET = 0
     UNNEST_COLUMN_ONLY = False
     ALIAS_POST_TABLESAMPLE = False
@@ -256,6 +250,15 @@ class Generator:
     NORMALIZE_FUNCTIONS: bool | str = "upper"
     NULL_ORDERING = "nulls_are_small"
 
+    # Delimiters for quotes, identifiers and the corresponding escape characters
+    QUOTE_START = "'"
+    QUOTE_END = "'"
+    IDENTIFIER_START = '"'
+    IDENTIFIER_END = '"'
+    STRING_ESCAPE = "'"
+    IDENTIFIER_ESCAPE = '"'
+
+    # Delimiters for bit, hex, byte and raw literals
     BIT_START: t.Optional[str] = None
     BIT_END: t.Optional[str] = None
     HEX_START: t.Optional[str] = None

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -107,7 +107,6 @@ class TypeAnnotator:
         exp.Case: lambda self, expr: self._annotate_by_args(expr, "default", "ifs"),
         exp.If: lambda self, expr: self._annotate_by_args(expr, "true", "false"),
         exp.Coalesce: lambda self, expr: self._annotate_by_args(expr, "this", "expressions"),
-        exp.IfNull: lambda self, expr: self._annotate_by_args(expr, "this", "expression"),
         exp.Concat: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.VARCHAR),
         exp.ConcatWs: lambda self, expr: self._annotate_with_type(expr, exp.DataType.Type.VARCHAR),
         exp.GroupConcat: lambda self, expr: self._annotate_with_type(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3812,8 +3812,8 @@ class Parser(metaclass=_Parser):
             needle = seq_get(args, 0)
             haystack = seq_get(args, 1)
 
-        return self.validate_expression(
-            exp.StrPosition(this=haystack, substr=needle, position=seq_get(args, 2)), args
+        return self.expression(
+            exp.StrPosition, this=haystack, substr=needle, position=seq_get(args, 2)
         )
 
     def _parse_join_hint(self, func_name: str) -> exp.JoinHint:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1566,7 +1566,7 @@ class Parser(metaclass=_Parser):
             return exp.NoPrimaryIndexProperty()
         return None
 
-    def _parse_on_property(self) -> t.Optional[exp.OnCommitProperty]:
+    def _parse_on_property(self) -> t.Optional[exp.Expression]:
         if self._match_text_seq("COMMIT", "PRESERVE", "ROWS"):
             return exp.OnCommitProperty()
         elif self._match_text_seq("COMMIT", "DELETE", "ROWS"):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3740,7 +3740,7 @@ class Parser(metaclass=_Parser):
             encoding=encoding,
         )
 
-    def _parse_logarithm(self) -> exp.Log | exp.Ln:
+    def _parse_logarithm(self) -> exp.Func:
         # Default argument order is base, expression
         args = self._parse_csv(self._parse_range)
 
@@ -3749,9 +3749,8 @@ class Parser(metaclass=_Parser):
                 args.reverse()
             return exp.Log.from_arg_list(args)
 
-        return t.cast(
-            exp.Log | exp.Ln,
-            self.expression(exp.Ln if self.LOG_DEFAULTS_TO_LN else exp.Log, this=seq_get(args, 0)),
+        return self.expression(
+            exp.Ln if self.LOG_DEFAULTS_TO_LN else exp.Log, this=seq_get(args, 0)
         )
 
     def _parse_match_against(self) -> exp.MatchAgainst:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3506,7 +3506,9 @@ class Parser(metaclass=_Parser):
         bracket_kind = self._prev.token_type
 
         if self._match(TokenType.COLON):
-            expressions = [self.expression(exp.Slice, expression=self._parse_conjunction())]
+            expressions: t.List[t.Optional[exp.Expression]] = [
+                self.expression(exp.Slice, expression=self._parse_conjunction())
+            ]
         else:
             expressions = self._parse_csv(lambda: self._parse_slice(self._parse_conjunction()))
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -467,7 +467,7 @@ class Tokenizer(metaclass=_Tokenizer):
     _STRING_ESCAPES: t.Set[str] = set()
     _KEYWORD_TRIE: t.Dict = {}
 
-    KEYWORDS: t.Dict[t.Optional[str], TokenType] = {
+    KEYWORDS: t.Dict[str, TokenType] = {
         **{f"{{%{postfix}": TokenType.BLOCK_START for postfix in ("", "+", "-")},
         **{f"{prefix}%}}": TokenType.BLOCK_END for prefix in ("", "+", "-")},
         **{f"{{{{{postfix}": TokenType.BLOCK_START for postfix in ("+", "-")},
@@ -1013,7 +1013,7 @@ class Tokenizer(metaclass=_Tokenizer):
                     literal += self._peek.upper()
                     self._advance()
 
-                token_type = self.KEYWORDS.get(self.NUMERIC_LITERALS.get(literal))
+                token_type = self.KEYWORDS.get(self.NUMERIC_LITERALS.get(literal, ""))
 
                 if token_type:
                     self._add(TokenType.NUMBER, number_text)

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -26,8 +26,8 @@ class TestOracle(Validator):
         self.validate_all(
             "NVL(NULL, 1)",
             write={
+                "": "COALESCE(NULL, 1)",
                 "oracle": "NVL(NULL, 1)",
-                "": "IFNULL(NULL, 1)",
             },
         )
         self.validate_all(

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -590,7 +590,7 @@ class TestExpressions(unittest.TestCase):
         unit = parse_one("timestamp_trunc(current_timestamp, week(thursday))")
         self.assertIsNotNone(unit.find(exp.CurrentTimestamp))
         week = unit.find(exp.Week)
-        self.assertEqual(week.this, exp.Var(this="thursday"))
+        self.assertEqual(week.this, exp.var("thursday"))
 
     def test_identifier(self):
         self.assertTrue(exp.to_identifier('"x"').quoted)
@@ -601,7 +601,7 @@ class TestExpressions(unittest.TestCase):
     def test_function_normalizer(self):
         self.assertEqual(parse_one("HELLO()").sql(normalize_functions="lower"), "hello()")
         self.assertEqual(parse_one("hello()").sql(normalize_functions="upper"), "HELLO()")
-        self.assertEqual(parse_one("heLLO()").sql(normalize_functions=None), "heLLO()")
+        self.assertEqual(parse_one("heLLO()").sql(normalize_functions=False), "heLLO()")
         self.assertEqual(parse_one("SUM(x)").sql(normalize_functions="lower"), "sum(x)")
         self.assertEqual(parse_one("sum(x)").sql(normalize_functions="upper"), "SUM(x)")
 


### PR DESCRIPTION
- Dialect properties like `time_mapping` have been converted to uppercase for consistency, i.e. `TIME_MAPPING`.
- Dialect properties removed from constructors; they're now set using metaprogramming in the `_Dialect` class.
- Generator `normalize_functions` arg has changed: now `False` means "don't normalize", `True` is equiv. to `"upper"`.
- Removed the `IfNull` expression in favor of adding `IFNULL` as a `_sql_name` in `Coalesce`.
- Renamed `IS_BOOL` generator flag to `IS_BOOL_ALLOWED` for clarity.
- Tried to replace some Expression constructors with the corresponding helpers in some places.
- Did some manual formatting by adding whitespace to reduce visual noise, unwrapped some multi-line expressions.
- Improved type hints in the Parser.
- Cleaned up some comments.
- Made `validate_expression` return its argument, to improve composability.