### PR TITLE
Feat(snowflake): add support for // comments

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -269,6 +269,7 @@ class Snowflake(Dialect):
         QUOTES = ["'", "$$"]
         STRING_ESCAPES = ["\\", "'"]
         HEX_STRINGS = [("x'", "'"), ("X'", "'")]
+        COMMENTS = ["--", "//", ("/*", "*/")]
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -392,10 +392,13 @@ class _Tokenizer(type):
 
         klass._STRING_ESCAPES = set(klass.STRING_ESCAPES)
         klass._IDENTIFIER_ESCAPES = set(klass.IDENTIFIER_ESCAPES)
-        klass._COMMENTS = dict(
-            (comment, None) if isinstance(comment, str) else (comment[0], comment[1])
-            for comment in klass.COMMENTS
-        )
+        klass._COMMENTS = {
+            **dict(
+                (comment, None) if isinstance(comment, str) else (comment[0], comment[1])
+                for comment in klass.COMMENTS
+            ),
+            "{#": "#}",  # Ensure Jinja comments are tokenized correctly in all dialects
+        }
 
         klass._KEYWORD_TRIE = new_trie(
             key.upper()
@@ -735,7 +738,7 @@ class Tokenizer(metaclass=_Tokenizer):
     NUMERIC_LITERALS: t.Dict[str, str] = {}
     ENCODE: t.Optional[str] = None
 
-    COMMENTS = ["--", ("/*", "*/"), ("{#", "#}")]
+    COMMENTS = ["--", ("/*", "*/")]
 
     __slots__ = (
         "sql",

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sqlglot.dialects import BigQuery
 from sqlglot.tokens import Tokenizer, TokenType
 
 
@@ -68,7 +69,8 @@ x"""
             Tokenizer().tokenize("select /*")
 
     def test_jinja(self):
-        tokenizer = Tokenizer()
+        # Check that {#, #} are treated as token delimiters, even though BigQuery overrides COMMENTS
+        tokenizer = BigQuery.Tokenizer()
 
         tokens = tokenizer.tokenize(
             """

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -280,6 +280,11 @@ FROM v""",
             "select * from t where ((condition = 1)/*test*/)",
             "SELECT * FROM t WHERE ((condition = 1) /* test */)",
         )
+        self.validate(
+            "SELECT 1 // hi this is a comment",
+            "SELECT 1 /* hi this is a comment */",
+            read="snowflake",
+        )
 
     def test_types(self):
         self.validate("INT 1", "CAST(1 AS INT)")


### PR DESCRIPTION
Fixes #1763 

This also fixes a tokenizer bug related to Jinja comments (`{# ... #}`). In some dialects we've overridden the `COMMENTS` tokenizer list, excluding these delimiters, but we actually want to recognize them in all dialects.

Current behavior (note that BigQuery uses `#` as a comment delimiter):

```python
>>> from sqlglot.dialects import BigQuery
>>> for tok in BigQuery.Tokenizer().tokenize("SELECT 1 {# this is a comment #}"):
...     print(tok)
...
<Token token_type: TokenType.SELECT, text: SELECT, line: 1, col: 6, start: 0, end: 5, comments: []>
<Token token_type: TokenType.NUMBER, text: 1, line: 1, col: 8, start: 7, end: 7, comments: []>
<Token token_type: TokenType.L_BRACE, text: {, line: 1, col: 10, start: 9, end: 9, comments: [' this is a comment #}']>
```

With the fix introduced in this PR:

```python
>>> from sqlglot.dialects import BigQuery
>>> for tok in BigQuery.Tokenizer().tokenize("SELECT 1 {# this is a comment #}"):
...     print(tok)
...
<Token token_type: TokenType.SELECT, text: SELECT, line: 1, col: 6, start: 0, end: 5, comments: []>
<Token token_type: TokenType.NUMBER, text: 1, line: 1, col: 8, start: 7, end: 7, comments: [' this is a comment ']>
```