### PR TITLE
feat(bigquery): support TO_JSON_STRING

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -220,6 +220,7 @@ class BigQuery(Dialect):
             "TIME_SUB": parse_date_delta_with_interval(exp.TimeSub),
             "TIMESTAMP_ADD": parse_date_delta_with_interval(exp.TimestampAdd),
             "TIMESTAMP_SUB": parse_date_delta_with_interval(exp.TimestampSub),
+            "TO_JSON_STRING": exp.JSONFormat.from_arg_list,
         }
 
         FUNCTION_PARSERS = {
@@ -308,6 +309,7 @@ class BigQuery(Dialect):
             exp.DateDiff: lambda self, e: f"DATE_DIFF({self.sql(e, 'this')}, {self.sql(e, 'expression')}, {self.sql(e.args.get('unit', 'DAY'))})",
             exp.DateStrToDate: datestrtodate_sql,
             exp.DateTrunc: lambda self, e: self.func("DATE_TRUNC", e.this, e.text("unit")),
+            exp.JSONFormat: rename_func("TO_JSON_STRING"),
             exp.GenerateSeries: rename_func("GENERATE_ARRAY"),
             exp.GroupConcat: rename_func("STRING_AGG"),
             exp.ILike: no_ilike_sql,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -486,6 +486,15 @@ class TestBigQuery(Validator):
             read={"bigquery": "GENERATE_ARRAY(1, 4)"},
             write={"duckdb": "GENERATE_SERIES(1, 4)"},
         )
+        self.validate_all(
+            "TO_JSON_STRING(x)",
+            read={"bigquery": "TO_JSON_STRING(x)"},
+            write={
+                "bigquery": "TO_JSON_STRING(x)",
+                "presto": "JSON_FORMAT(x)",
+                "spark": "TO_JSON(x)",
+            },
+        )
 
     def test_user_defined_functions(self):
         self.validate_identity(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -664,6 +664,7 @@ class TestPresto(Validator):
                 "spark": "TO_JSON(x)",
             },
             write={
+                "bigquery": "TO_JSON_STRING(x)",
                 "presto": "JSON_FORMAT(x)",
                 "spark": "TO_JSON(x)",
             },
@@ -672,6 +673,7 @@ class TestPresto(Validator):
         self.validate_all(
             "JSON_FORMAT(JSON 'x')",
             write={
+                "bigquery": "TO_JSON_STRING(CAST('x' AS JSON))",
                 "presto": "JSON_FORMAT(CAST('x' AS JSON))",
                 "spark": "TO_JSON('x')",
             },


### PR DESCRIPTION
- Accepts SQL value
- Accepts JSON value

Wasn't sure what to do about the `pretty_print` arg (does not seem compatible with the options in `exp.JSONFormat`) - let me know what you think.

---

Ref: [TO_JSON_STRING docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#to_json_string)
Ref: [TO_JSON_STRING accepted types](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_encodings)