### PR TITLE
Feat(duckdb): support TO_JSON

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -85,6 +85,21 @@ def _regexp_extract_sql(self: generator.Generator, expression: exp.RegexpExtract
     )
 
 
+def _json_format_sql(self: generator.Generator, expression: exp.JSONFormat) -> str:
+    this = expression.this
+    if not this.type:
+        from sqlglot.optimizer.annotate_types import annotate_types
+
+        annotate_types(this)
+
+    if this.type.is_type("json"):
+        sql = self.sql(this)
+    else:
+        sql = self.func("TO_JSON", this, expression.args.get("options"))
+
+    return f"CAST({sql} AS TEXT)"
+
+
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
 
@@ -195,6 +210,7 @@ class DuckDB(Dialect):
             exp.IntDiv: lambda self, e: self.binary(e, "//"),
             exp.JSONExtract: arrow_json_extract_sql,
             exp.JSONExtractScalar: arrow_json_extract_scalar_sql,
+            exp.JSONFormat: _json_format_sql,
             exp.JSONBExtract: arrow_json_extract_sql,
             exp.JSONBExtractScalar: arrow_json_extract_scalar_sql,
             exp.LogicalOr: rename_func("BOOL_OR"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -491,6 +491,7 @@ class TestBigQuery(Validator):
             read={"bigquery": "TO_JSON_STRING(x)"},
             write={
                 "bigquery": "TO_JSON_STRING(x)",
+                "duckdb": "CAST(TO_JSON(x) AS TEXT)",
                 "presto": "JSON_FORMAT(x)",
                 "spark": "TO_JSON(x)",
             },

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -665,6 +665,7 @@ class TestPresto(Validator):
             },
             write={
                 "bigquery": "TO_JSON_STRING(x)",
+                "duckdb": "CAST(TO_JSON(x) AS TEXT)",
                 "presto": "JSON_FORMAT(x)",
                 "spark": "TO_JSON(x)",
             },
@@ -674,6 +675,7 @@ class TestPresto(Validator):
             "JSON_FORMAT(JSON 'x')",
             write={
                 "bigquery": "TO_JSON_STRING(CAST('x' AS JSON))",
+                "duckdb": "CAST(CAST('x' AS JSON) AS TEXT)",
                 "presto": "JSON_FORMAT(CAST('x' AS JSON))",
                 "spark": "TO_JSON('x')",
             },


### PR DESCRIPTION
Only added `write=duckdb`. I think we would need something like an `exp.JSONParse` to support `read=duckdb`, since `TO_JSON` returns a JSON type instead of TEXT.

Ref: [DuckDB - JSON Creation Functions](https://duckdb.org/docs/extensions/json#json-creation-functions)