### PR TITLE
Refactor!(hive): improve transpilation of TO_JSON

### DIFF
--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -670,14 +670,25 @@ class TestPresto(Validator):
                 "spark": "TO_JSON(x)",
             },
         )
-
         self.validate_all(
-            "JSON_FORMAT(JSON 'x')",
+            """JSON_FORMAT(JSON '"x"')""",
             write={
-                "bigquery": "TO_JSON_STRING(CAST('x' AS JSON))",
-                "duckdb": "CAST(TO_JSON(CAST('x' AS JSON)) AS TEXT)",
-                "presto": "JSON_FORMAT(CAST('x' AS JSON))",
-                "spark": "TO_JSON('x')",
+                "bigquery": """TO_JSON_STRING(CAST('"x"' AS JSON))""",
+                "duckdb": """CAST(TO_JSON(CAST('"x"' AS JSON)) AS TEXT)""",
+                "presto": """JSON_FORMAT(CAST('"x"' AS JSON))""",
+                "spark": """REGEXP_EXTRACT(TO_JSON(FROM_JSON('["x"]', SCHEMA_OF_JSON('["x"]'))), '^.(.*).$', 1)""",
+            },
+        )
+        self.validate_all(
+            """SELECT JSON_FORMAT(JSON '{"a": 1, "b": "c"}')""",
+            write={
+                "spark": """SELECT REGEXP_EXTRACT(TO_JSON(FROM_JSON('[{"a": 1, "b": "c"}]', SCHEMA_OF_JSON('[{"a": 1, "b": "c"}]'))), '^.(.*).$', 1)""",
+            },
+        )
+        self.validate_all(
+            """SELECT JSON_FORMAT(JSON '[1, 2, 3]')""",
+            write={
+                "spark": "SELECT REGEXP_EXTRACT(TO_JSON(FROM_JSON('[[1, 2, 3]]', SCHEMA_OF_JSON('[[1, 2, 3]]'))), '^.(.*).$', 1)",
             },
         )
 


### PR DESCRIPTION
Related discussion: https://github.com/tobymao/sqlglot/pull/1803#discussion_r1234287657

This is a best-effort approach, so it might not be complete. The difficulty of transpiling these JSON calls correctly stems from the fact that Hive / Spark work with JSON values using only their  *string* representation, whereas Trino and Presto have native support for them, using a `JSON` type.

Note: all changed tests were previously failing in Spark. The new ones work and have the same semantics as in Trino.

References:
- https://trino.io/docs/current/functions/json.html
- https://spark.apache.org/docs/latest/api/sql/index.html#from_json
- https://spark.apache.org/docs/latest/api/sql/index.html#schema_of_json
- https://spark.apache.org/docs/latest/api/sql/index.html#to_json
- https://spark.apache.org/docs/latest/api/sql/index.html#regexp_extract