### PR TITLE
Feat: Add Postgres user-defined type support

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3343,6 +3343,7 @@ class DataType(Expression):
         UINT128 = auto()
         UINT256 = auto()
         UNIQUEIDENTIFIER = auto()
+        USERDEFINED = "USER-DEFINED"
         UUID = auto()
         VARBINARY = auto()
         VARCHAR = auto()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -177,6 +177,7 @@ class Parser(metaclass=_Parser):
         TokenType.BIGSERIAL,
         TokenType.XML,
         TokenType.UNIQUEIDENTIFIER,
+        TokenType.USERDEFINED,
         TokenType.MONEY,
         TokenType.SMALLMONEY,
         TokenType.ROWVERSION,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -137,6 +137,7 @@ class TokenType(AutoName):
     BIGSERIAL = auto()
     XML = auto()
     UNIQUEIDENTIFIER = auto()
+    USERDEFINED = auto()
     MONEY = auto()
     SMALLMONEY = auto()
     ROWVERSION = auto()
@@ -723,6 +724,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "PREPARE": TokenType.COMMAND,
         "TRUNCATE": TokenType.COMMAND,
         "VACUUM": TokenType.COMMAND,
+        "USER-DEFINED": TokenType.USERDEFINED,
     }
 
     WHITE_SPACE: t.Dict[t.Optional[str], TokenType] = {

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -813,6 +813,7 @@ FROM foo""",
         self.assertEqual(
             exp.DataType.build("struct<x int>", dialect="spark").sql(), "STRUCT<x INT>"
         )
+        self.assertEqual(exp.DataType.build("USER-DEFINED").sql(), "USER-DEFINED")
 
     def test_rename_table(self):
         self.assertEqual(


### PR DESCRIPTION
Example from information schema: 
```
SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'table' AND table_schema = 'schema';

 id                                | bigint
 custom_col                        | USER-DEFINED
 ds                                | text
```