### PR TITLE
Fix: dont expand bq pseudocolumns in optimizer star expansion

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -336,7 +336,9 @@ def _expand_stars(
             # https://cloud.google.com/bigquery/docs/querying-partitioned-tables#query_an_ingestion-time_partitioned_table
             if resolver.schema.dialect == "bigquery":
                 columns = [
-                    name for name in columns if name not in ("_PARTITIONTIME", "_PARTITIONDATE")
+                    name
+                    for name in columns
+                    if name.upper() not in ("_PARTITIONTIME", "_PARTITIONDATE")
                 ]
 
             if columns and "*" not in columns:


### PR DESCRIPTION
Bigquery has pseudocolumns for time ingestion partitioned tables. These pseudocolumns are `_PARTITIONTIME` and `PARTITIONDATE`. Both of these are reserved identifiers, furthermore neither are returned in * expansion by bigquery. So we should respect that during the optimizer's star expansion. To not do so would break a valid query (by adding reserved idents to the projection).