### PR TITLE
Feature!: Recursively transform children

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -536,7 +536,6 @@ class Expression(metaclass=_Expression):
             return new_node
         if new_node is not node:
             new_node.parent = node.parent
-            return new_node
 
         replace_children(new_node, lambda child: child.transform(fun, *args, copy=False, **kwargs))
         return new_node

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -406,6 +406,16 @@ class TestExpressions(unittest.TestCase):
 
         self.assertEqual(expression.transform(fun).sql(), "SELECT a, b FROM x")
 
+    def test_transform_subquery_as_child(self):
+        expression = parse_one("SELECT * FROM (SELECT * FROM x) AS y")
+
+        def fun(node):
+            if isinstance(node, exp.Star):
+                return [parse_one(c) for c in ["a", "b"]]
+            return node
+
+        self.assertEqual(expression.transform(fun).sql(), "SELECT a, b FROM (SELECT a, b FROM x) AS y")
+
     def test_transform_node_removal(self):
         expression = parse_one("SELECT a, b FROM x")
 


### PR DESCRIPTION
Perhaps I'm misunderstanding the purpose of the recursive transform method, but it seems like if we return the newly updated node immediately, we won't end up traversing the child nodes at all.