### PR TITLE
Feat!(tsql): treat all identifiers as case insensitive

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -166,6 +166,7 @@ def _string_agg_sql(self: generator.Generator, expression: exp.GroupConcat) -> s
 
 
 class TSQL(Dialect):
+    RESOLVES_IDENTIFIERS_AS_UPPERCASE = None
     NULL_ORDERING = "nulls_are_small"
     TIME_FORMAT = "'yyyy-mm-dd hh:mm:ss'"
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -227,9 +227,10 @@ class TestSchema(unittest.TestCase):
         self.assertEqual(schema.column_names(exp.Table(this="x")), ["foo"])
 
         # Check that the correct dialect is used when calling schema methods
+        # Note: T-SQL is case-insensitive by default, so `fo` in clickhouse will match the normalized table name
         schema = MappingSchema(schema={"[Fo]": {"x": "int"}}, dialect="tsql")
         self.assertEqual(
-            schema.column_names("[Fo]"), schema.column_names("`Fo`", dialect="clickhouse")
+            schema.column_names("[Fo]"), schema.column_names("`fo`", dialect="clickhouse")
         )
 
         # Check that all column identifiers are normalized to lowercase for BigQuery, even quoted


### PR DESCRIPTION
Tested in SQL Fiddle:

```
CREATE TABLE "FoOOo" (id INT);
INSERT INTO foooo VALUES (1);  -- works
SELECT * FROM "foooO";  -- works
with "CtE"(foo) as (select 1) select * from cte;  -- works
```

References:
- https://learn.microsoft.com/en-us/sql/relational-databases/databases/database-identifiers?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/relational-databases/collations/collation-and-unicode-support?view=sql-server-ver16#Server-level-collations