### PR TITLE
Refactor(executor): get rid of 'running' set

### DIFF
--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -19,7 +19,6 @@ class PythonExecutor:
         self.tables = tables or {}
 
     def execute(self, plan):
-        running = set()
         finished = set()
         queue = set(plan.leaves)
         contexts = {}
@@ -34,7 +33,6 @@ class PythonExecutor:
                         for name, table in contexts[dep].tables.items()
                     }
                 )
-                running.add(node)
 
                 if isinstance(node, planner.Scan):
                     contexts[node] = self.scan(node, context)
@@ -49,11 +47,10 @@ class PythonExecutor:
                 else:
                     raise NotImplementedError
 
-                running.remove(node)
                 finished.add(node)
 
                 for dep in node.dependents:
-                    if dep not in running and all(d in contexts for d in dep.dependencies):
+                    if all(d in contexts for d in dep.dependencies):
                         queue.add(dep)
 
                 for dep in node.dependencies:


### PR DESCRIPTION
Notice how `running` isn't mutated anywhere besides the main executor loop (it's not passed by reference anywhere):

```python
                running.add(node)

                if isinstance(node, planner.Scan):
                    contexts[node] = self.scan(node, context)
                elif isinstance(node, planner.Aggregate):
                    contexts[node] = self.aggregate(node, context)
                elif isinstance(node, planner.Join):
                    contexts[node] = self.join(node, context)
                elif isinstance(node, planner.Sort):
                    contexts[node] = self.sort(node, context)
                elif isinstance(node, planner.SetOperation):
                    contexts[node] = self.set_operation(node, context)
                else:
                    raise NotImplementedError

                running.remove(node)
```

This means that it will always be empty after the `remove` call, and so the condition `dep not in running` will be trivially true. Hence, `running` is not actually needed in the current implementation of the executor.

Another way to phrase / understand this: you can't have a `node` run before its dependencies have been fully computed, so the above condition doesn't really make sense.