### PR TITLE
Feat!(spark): better coverage for decimals, strings, datetime, bin types

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -50,7 +50,7 @@ class Spark(Spark2):
             exp.DataType.Type.SMALLMONEY: "DECIMAL(6, 4)",
             exp.DataType.Type.VARBINARY: "BINARY",
             exp.DataType.Type.BIT: "BOOLEAN",
-            exp.DataType.Type.UNIQUEIDENTIFIER: "BINARY",
+            exp.DataType.Type.UNIQUEIDENTIFIER: "STRING",
         }
         TRANSFORMS = Spark2.Generator.TRANSFORMS.copy()
         TRANSFORMS.pop(exp.DateDiff)

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -43,9 +43,6 @@ class Spark(Spark2):
     class Generator(Spark2.Generator):
         TYPE_MAPPING = {
             **Spark2.Generator.TYPE_MAPPING,
-            exp.DataType.Type.TINYINT: "TINYINT",
-            exp.DataType.Type.SMALLINT: "SMALLINT",
-            exp.DataType.Type.BIGINT: "BIGINT",
             exp.DataType.Type.MONEY: "DECIMAL(15, 4)",
             exp.DataType.Type.SMALLMONEY: "DECIMAL(6, 4)",
             exp.DataType.Type.UNIQUEIDENTIFIER: "STRING",

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -48,8 +48,6 @@ class Spark(Spark2):
             exp.DataType.Type.BIGINT: "BIGINT",
             exp.DataType.Type.MONEY: "DECIMAL(15, 4)",
             exp.DataType.Type.SMALLMONEY: "DECIMAL(6, 4)",
-            exp.DataType.Type.VARBINARY: "BINARY",
-            exp.DataType.Type.BIT: "BOOLEAN",
             exp.DataType.Type.UNIQUEIDENTIFIER: "STRING",
         }
         TRANSFORMS = Spark2.Generator.TRANSFORMS.copy()

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -41,6 +41,17 @@ class Spark(Spark2):
         }
 
     class Generator(Spark2.Generator):
+        TYPE_MAPPING = {
+            **Spark2.Generator.TYPE_MAPPING,
+            exp.DataType.Type.TINYINT: "TINYINT",
+            exp.DataType.Type.SMALLINT: "SMALLINT",
+            exp.DataType.Type.BIGINT: "BIGINT",
+            exp.DataType.Type.MONEY: "DECIMAL(15, 4)",
+            exp.DataType.Type.SMALLMONEY: "DECIMAL(6, 4)",
+            exp.DataType.Type.VARBINARY: "BINARY",
+            exp.DataType.Type.BIT: "BOOLEAN",
+            exp.DataType.Type.UNIQUEIDENTIFIER: "BINARY",
+        }
         TRANSFORMS = Spark2.Generator.TRANSFORMS.copy()
         TRANSFORMS.pop(exp.DateDiff)
         TRANSFORMS.pop(exp.Group)

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -175,9 +175,6 @@ class Spark2(Hive):
     class Generator(Hive.Generator):
         TYPE_MAPPING = {
             **Hive.Generator.TYPE_MAPPING,
-            exp.DataType.Type.TINYINT: "BYTE",
-            exp.DataType.Type.SMALLINT: "SHORT",
-            exp.DataType.Type.BIGINT: "LONG",
         }
 
         PROPERTIES_LOCATION = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -262,7 +262,7 @@ class TestBigQuery(Validator):
                 "duckdb": "CAST(a AS BIGINT)",
                 "presto": "CAST(a AS BIGINT)",
                 "hive": "CAST(a AS BIGINT)",
-                "spark": "CAST(a AS LONG)",
+                "spark": "CAST(a AS BIGINT)",
             },
         )
         self.validate_all(
@@ -412,7 +412,7 @@ class TestBigQuery(Validator):
                 "duckdb": "CREATE TABLE db.example_table (col_a STRUCT(struct_col_a BIGINT, struct_col_b STRUCT(nested_col_a TEXT, nested_col_b TEXT)))",
                 "presto": "CREATE TABLE db.example_table (col_a ROW(struct_col_a BIGINT, struct_col_b ROW(nested_col_a VARCHAR, nested_col_b VARCHAR)))",
                 "hive": "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a BIGINT, struct_col_b STRUCT<nested_col_a STRING, nested_col_b STRING>>)",
-                "spark": "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a: LONG, struct_col_b: STRUCT<nested_col_a: STRING, nested_col_b: STRING>>)",
+                "spark": "CREATE TABLE db.example_table (col_a STRUCT<struct_col_a: BIGINT, struct_col_b: STRUCT<nested_col_a: STRING, nested_col_b: STRING>>)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -218,7 +218,7 @@ class TestDialect(Validator):
                 "presto": "CAST(a AS SMALLINT)",
                 "redshift": "CAST(a AS SMALLINT)",
                 "snowflake": "CAST(a AS SMALLINT)",
-                "spark": "CAST(a AS SHORT)",
+                "spark": "CAST(a AS SMALLINT)",
                 "sqlite": "CAST(a AS INTEGER)",
                 "starrocks": "CAST(a AS SMALLINT)",
             },

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -515,7 +515,7 @@ class TestDuckDB(Validator):
                 "duckdb": "CAST(COL AS BIGINT[])",
                 "presto": "CAST(COL AS ARRAY(BIGINT))",
                 "hive": "CAST(COL AS ARRAY<BIGINT>)",
-                "spark": "CAST(COL AS ARRAY<LONG>)",
+                "spark": "CAST(COL AS ARRAY<BIGINT>)",
                 "postgres": "CAST(COL AS BIGINT[])",
                 "snowflake": "CAST(COL AS ARRAY)",
             },

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -73,7 +73,7 @@ class TestHive(Validator):
                 "duckdb": "TRY_CAST(1 AS SMALLINT)",
                 "presto": "TRY_CAST(1 AS SMALLINT)",
                 "hive": "CAST(1 AS SMALLINT)",
-                "spark": "CAST(1 AS SHORT)",
+                "spark": "CAST(1 AS SMALLINT)",
             },
         )
         self.validate_all(
@@ -82,7 +82,7 @@ class TestHive(Validator):
                 "duckdb": "TRY_CAST(1 AS SMALLINT)",
                 "presto": "TRY_CAST(1 AS SMALLINT)",
                 "hive": "CAST(1 AS SMALLINT)",
-                "spark": "CAST(1 AS SHORT)",
+                "spark": "CAST(1 AS SMALLINT)",
             },
         )
         self.validate_all(
@@ -91,7 +91,7 @@ class TestHive(Validator):
                 "duckdb": "TRY_CAST(1 AS TINYINT)",
                 "presto": "TRY_CAST(1 AS TINYINT)",
                 "hive": "CAST(1 AS TINYINT)",
-                "spark": "CAST(1 AS BYTE)",
+                "spark": "CAST(1 AS TINYINT)",
             },
         )
         self.validate_all(
@@ -100,7 +100,7 @@ class TestHive(Validator):
                 "duckdb": "TRY_CAST(1 AS BIGINT)",
                 "presto": "TRY_CAST(1 AS BIGINT)",
                 "hive": "CAST(1 AS BIGINT)",
-                "spark": "CAST(1 AS LONG)",
+                "spark": "CAST(1 AS BIGINT)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -65,7 +65,7 @@ class TestPresto(Validator):
                 "bigquery": "CAST([1, 2] AS ARRAY<INT64>)",
                 "duckdb": "CAST(LIST_VALUE(1, 2) AS BIGINT[])",
                 "presto": "CAST(ARRAY[1, 2] AS ARRAY(BIGINT))",
-                "spark": "CAST(ARRAY(1, 2) AS ARRAY<LONG>)",
+                "spark": "CAST(ARRAY(1, 2) AS ARRAY<BIGINT>)",
                 "snowflake": "CAST([1, 2] AS ARRAY)",
             },
         )

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -92,7 +92,7 @@ class TestSQLite(Validator):
             "SELECT CAST([a].[b] AS SMALLINT) FROM foo",
             write={
                 "sqlite": 'SELECT CAST("a"."b" AS INTEGER) FROM foo',
-                "spark": "SELECT CAST(`a`.`b` AS SHORT) FROM foo",
+                "spark": "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -31,7 +31,7 @@ class TestTSQL(Validator):
             "SELECT CAST([a].[b] AS SMALLINT) FROM foo",
             write={
                 "tsql": 'SELECT CAST("a"."b" AS SMALLINT) FROM foo',
-                "spark": "SELECT CAST(`a`.`b` AS SHORT) FROM foo",
+                "spark": "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
             },
         )
         self.validate_all(
@@ -72,7 +72,7 @@ class TestTSQL(Validator):
             "SELECT CAST([a].[b] AS SMALLINT) FROM foo",
             write={
                 "tsql": 'SELECT CAST("a"."b" AS SMALLINT) FROM foo',
-                "spark": "SELECT CAST(`a`.`b` AS SHORT) FROM foo",
+                "spark": "SELECT CAST(`a`.`b` AS SMALLINT) FROM foo",
             },
         )
         self.validate_all(
@@ -140,6 +140,203 @@ class TestTSQL(Validator):
             "CAST(x AS DATETIME2(6))",
             write={
                 "hive": "CAST(x AS TIMESTAMP)",
+            },
+        )
+        
+    def test__types_ints(self):
+        self.validate_all(
+            "CAST(X AS INT)",
+            write={
+                "spark" :"CAST(X AS INT)",
+                "tsql"  :"CAST(X AS INTEGER)"
+            },
+        )
+        
+        self.validate_all(
+            "CAST(X AS BIGINT)",
+            write={
+                "spark" :"CAST(X AS BIGINT)",
+                "tsql"  :"CAST(X AS BIGINT)"
+            },
+        )
+         
+        self.validate_all(
+            "CAST(X AS SMALLINT)",
+            write={
+                "spark" :"CAST(X AS SMALLINT)",
+                "tsql"  :"CAST(X AS SMALLINT)"
+            },
+        )
+        
+        self.validate_all(
+            "CAST(X AS TINYINT)",
+            write={
+                "spark" :"CAST(X AS TINYINT)",
+                "tsql"  :"CAST(X AS TINYINT)"
+            },
+        )
+        
+    def test_types_decimals(self):
+        self.validate_all(
+            "CAST(x as FLOAT)",
+            write={
+                "spark":"CAST(x AS FLOAT)",
+                "tsql" :"CAST(x AS FLOAT)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as DOUBLE)",
+            write={
+                "spark":"CAST(x AS DOUBLE)",
+                "tsql" :"CAST(x AS DOUBLE)",
+            },
+        )
+
+        self.validate_all(
+            "CAST(x as DECIMAL(15, 4))",
+            write={
+                "spark":"CAST(x AS DECIMAL(15, 4))",
+                "tsql" :"CAST(x AS NUMERIC(15, 4))",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as NUMERIC(13,3))",
+            write={
+                "spark":"CAST(x AS DECIMAL(13, 3))",
+                "tsql" :"CAST(x AS NUMERIC(13, 3))",
+            },
+        )
+         
+        self.validate_all(
+            "CAST(x as MONEY)",
+            write={
+                "spark":"CAST(x AS DECIMAL(15, 4))",
+                "tsql" :"CAST(x AS MONEY)",
+            },
+        )
+         
+        self.validate_all(
+            "CAST(x as SMALLMONEY)",
+            write={
+                "spark":"CAST(x AS DECIMAL(6, 4))",
+                "tsql" :"CAST(x AS SMALLMONEY)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as REAL)",
+            write={
+                "spark":"CAST(x AS FLOAT)",
+                "tsql" :"CAST(x AS FLOAT)",
+            },
+        )
+
+    def test_types_string(self):
+        self.validate_all(
+            "CAST(x as CHAR(1))",
+            write={
+                "spark":"CAST(x AS CHAR(1))",
+                "tsql" :"CAST(x AS CHAR(1))",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as VARCHAR(2))",
+            write={
+                "spark":"CAST(x AS VARCHAR(2))",
+                "tsql" :"CAST(x AS VARCHAR(2))",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as NCHAR(1))",
+            write={
+                "spark":"CAST(x AS CHAR(1))",
+                "tsql" :"CAST(x AS CHAR(1))",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as NVARCHAR(2))",
+            write={
+                "spark":"CAST(x AS VARCHAR(2))",
+                "tsql" :"CAST(x AS VARCHAR(2))",
+            },
+        )
+    
+    def test_types_date(self):
+        self.validate_all(
+            "CAST(x as DATE)",
+            write={
+                "spark":"CAST(x AS DATE)",
+                "tsql" :"CAST(x AS DATE)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as DATE)",
+            write={
+                "spark":"CAST(x AS DATETIME)",
+                "tsql" :"CAST(x AS DATETIME)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as TIME(4))",
+            write={
+                "spark":"CAST(x AS TIMESTAMP)",
+                "tsql" :"CAST(x AS TIMESTAMP(4))",
+            },
+        )
+
+        self.validate_all(
+            "CAST(x as DATETIME2)",
+            write={
+                "spark":"CAST(x AS TIMESTAMP)",
+                "tsql" :"CAST(x AS DATETIME2)",
+            },
+        )
+
+        self.validate_all(
+            "CAST(x as DATETIMEOFFSET)",
+            write={
+                "spark":"CAST(x AS TIMESTAMP)",
+                "tsql" :"CAST(x AS TIMESTAMPTZ)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as SMALLDATETIME)",
+            write={
+                "spark":"CAST(x AS TIMESTAMP)",
+                "tsql" :"CAST(x AS DATETIME2)",
+            },
+        )
+        
+    def test_types_bin(self):
+        self.validate_all(
+            "CAST(x as BIT)",
+            write={
+                "spark":"CAST(x AS BOOLEAN)",
+                "tsql" :"CAST(x AS BIT)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as UNIQUEIDENTIFIER)",
+            write={
+                "spark":"CAST(x AS BINARY)",
+                "tsql" :"CAST(x AS UNIQUEIDENTIFIER)",
+            },
+        )
+        
+        self.validate_all(
+            "CAST(x as VARBINARY)",
+            write={
+                "spark":"CAST(x AS BINARY)",
+                "tsql" :"CAST(x AS VARBINARY)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -278,8 +278,8 @@ class TestTSQL(Validator):
         self.validate_all(
             "CAST(x as DATE)",
             write={
-                "spark":"CAST(x AS DATETIME)",
-                "tsql" :"CAST(x AS DATETIME)",
+                "spark":"CAST(x AS DATE)",
+                "tsql" :"CAST(x AS DATE)",
             },
         )
         

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -315,7 +315,7 @@ class TestTSQL(Validator):
         self.validate_all(
             "CAST(x as UNIQUEIDENTIFIER)",
             write={
-                "spark": "CAST(x AS BINARY)",
+                "spark": "CAST(x AS STRING)",
                 "tsql": "CAST(x AS UNIQUEIDENTIFIER)",
             },
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -142,94 +142,82 @@ class TestTSQL(Validator):
                 "hive": "CAST(x AS TIMESTAMP)",
             },
         )
-        
+
     def test__types_ints(self):
         self.validate_all(
             "CAST(X AS INT)",
-            write={
-                "spark" :"CAST(X AS INT)",
-                "tsql"  :"CAST(X AS INTEGER)"
-            },
+            write={"spark": "CAST(X AS INT)", "tsql": "CAST(X AS INTEGER)"},
         )
-        
+
         self.validate_all(
             "CAST(X AS BIGINT)",
-            write={
-                "spark" :"CAST(X AS BIGINT)",
-                "tsql"  :"CAST(X AS BIGINT)"
-            },
+            write={"spark": "CAST(X AS BIGINT)", "tsql": "CAST(X AS BIGINT)"},
         )
-         
+
         self.validate_all(
             "CAST(X AS SMALLINT)",
-            write={
-                "spark" :"CAST(X AS SMALLINT)",
-                "tsql"  :"CAST(X AS SMALLINT)"
-            },
+            write={"spark": "CAST(X AS SMALLINT)", "tsql": "CAST(X AS SMALLINT)"},
         )
-        
+
         self.validate_all(
             "CAST(X AS TINYINT)",
-            write={
-                "spark" :"CAST(X AS TINYINT)",
-                "tsql"  :"CAST(X AS TINYINT)"
-            },
+            write={"spark": "CAST(X AS TINYINT)", "tsql": "CAST(X AS TINYINT)"},
         )
-        
+
     def test_types_decimals(self):
         self.validate_all(
             "CAST(x as FLOAT)",
             write={
-                "spark":"CAST(x AS FLOAT)",
-                "tsql" :"CAST(x AS FLOAT)",
+                "spark": "CAST(x AS FLOAT)",
+                "tsql": "CAST(x AS FLOAT)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as DOUBLE)",
             write={
-                "spark":"CAST(x AS DOUBLE)",
-                "tsql" :"CAST(x AS DOUBLE)",
+                "spark": "CAST(x AS DOUBLE)",
+                "tsql": "CAST(x AS DOUBLE)",
             },
         )
 
         self.validate_all(
             "CAST(x as DECIMAL(15, 4))",
             write={
-                "spark":"CAST(x AS DECIMAL(15, 4))",
-                "tsql" :"CAST(x AS NUMERIC(15, 4))",
+                "spark": "CAST(x AS DECIMAL(15, 4))",
+                "tsql": "CAST(x AS NUMERIC(15, 4))",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as NUMERIC(13,3))",
             write={
-                "spark":"CAST(x AS DECIMAL(13, 3))",
-                "tsql" :"CAST(x AS NUMERIC(13, 3))",
+                "spark": "CAST(x AS DECIMAL(13, 3))",
+                "tsql": "CAST(x AS NUMERIC(13, 3))",
             },
         )
-         
+
         self.validate_all(
             "CAST(x as MONEY)",
             write={
-                "spark":"CAST(x AS DECIMAL(15, 4))",
-                "tsql" :"CAST(x AS MONEY)",
+                "spark": "CAST(x AS DECIMAL(15, 4))",
+                "tsql": "CAST(x AS MONEY)",
             },
         )
-         
+
         self.validate_all(
             "CAST(x as SMALLMONEY)",
             write={
-                "spark":"CAST(x AS DECIMAL(6, 4))",
-                "tsql" :"CAST(x AS SMALLMONEY)",
+                "spark": "CAST(x AS DECIMAL(6, 4))",
+                "tsql": "CAST(x AS SMALLMONEY)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as REAL)",
             write={
-                "spark":"CAST(x AS FLOAT)",
-                "tsql" :"CAST(x AS FLOAT)",
+                "spark": "CAST(x AS FLOAT)",
+                "tsql": "CAST(x AS FLOAT)",
             },
         )
 
@@ -237,106 +225,106 @@ class TestTSQL(Validator):
         self.validate_all(
             "CAST(x as CHAR(1))",
             write={
-                "spark":"CAST(x AS CHAR(1))",
-                "tsql" :"CAST(x AS CHAR(1))",
+                "spark": "CAST(x AS CHAR(1))",
+                "tsql": "CAST(x AS CHAR(1))",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as VARCHAR(2))",
             write={
-                "spark":"CAST(x AS VARCHAR(2))",
-                "tsql" :"CAST(x AS VARCHAR(2))",
+                "spark": "CAST(x AS VARCHAR(2))",
+                "tsql": "CAST(x AS VARCHAR(2))",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as NCHAR(1))",
             write={
-                "spark":"CAST(x AS CHAR(1))",
-                "tsql" :"CAST(x AS CHAR(1))",
+                "spark": "CAST(x AS CHAR(1))",
+                "tsql": "CAST(x AS CHAR(1))",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as NVARCHAR(2))",
             write={
-                "spark":"CAST(x AS VARCHAR(2))",
-                "tsql" :"CAST(x AS VARCHAR(2))",
+                "spark": "CAST(x AS VARCHAR(2))",
+                "tsql": "CAST(x AS VARCHAR(2))",
             },
         )
-    
+
     def test_types_date(self):
         self.validate_all(
             "CAST(x as DATE)",
             write={
-                "spark":"CAST(x AS DATE)",
-                "tsql" :"CAST(x AS DATE)",
+                "spark": "CAST(x AS DATE)",
+                "tsql": "CAST(x AS DATE)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as DATE)",
             write={
-                "spark":"CAST(x AS DATE)",
-                "tsql" :"CAST(x AS DATE)",
+                "spark": "CAST(x AS DATE)",
+                "tsql": "CAST(x AS DATE)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as TIME(4))",
             write={
-                "spark":"CAST(x AS TIMESTAMP)",
-                "tsql" :"CAST(x AS TIMESTAMP(4))",
+                "spark": "CAST(x AS TIMESTAMP)",
+                "tsql": "CAST(x AS TIMESTAMP(4))",
             },
         )
 
         self.validate_all(
             "CAST(x as DATETIME2)",
             write={
-                "spark":"CAST(x AS TIMESTAMP)",
-                "tsql" :"CAST(x AS DATETIME2)",
+                "spark": "CAST(x AS TIMESTAMP)",
+                "tsql": "CAST(x AS DATETIME2)",
             },
         )
 
         self.validate_all(
             "CAST(x as DATETIMEOFFSET)",
             write={
-                "spark":"CAST(x AS TIMESTAMP)",
-                "tsql" :"CAST(x AS TIMESTAMPTZ)",
+                "spark": "CAST(x AS TIMESTAMP)",
+                "tsql": "CAST(x AS TIMESTAMPTZ)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as SMALLDATETIME)",
             write={
-                "spark":"CAST(x AS TIMESTAMP)",
-                "tsql" :"CAST(x AS DATETIME2)",
+                "spark": "CAST(x AS TIMESTAMP)",
+                "tsql": "CAST(x AS DATETIME2)",
             },
         )
-        
+
     def test_types_bin(self):
         self.validate_all(
             "CAST(x as BIT)",
             write={
-                "spark":"CAST(x AS BOOLEAN)",
-                "tsql" :"CAST(x AS BIT)",
+                "spark": "CAST(x AS BOOLEAN)",
+                "tsql": "CAST(x AS BIT)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as UNIQUEIDENTIFIER)",
             write={
-                "spark":"CAST(x AS BINARY)",
-                "tsql" :"CAST(x AS UNIQUEIDENTIFIER)",
+                "spark": "CAST(x AS BINARY)",
+                "tsql": "CAST(x AS UNIQUEIDENTIFIER)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as VARBINARY)",
             write={
-                "spark":"CAST(x AS BINARY)",
-                "tsql" :"CAST(x AS VARBINARY)",
+                "spark": "CAST(x AS BINARY)",
+                "tsql": "CAST(x AS VARBINARY)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -146,22 +146,42 @@ class TestTSQL(Validator):
     def test__types_ints(self):
         self.validate_all(
             "CAST(X AS INT)",
-            write={"spark": "CAST(X AS INT)", "tsql": "CAST(X AS INTEGER)"},
+            write={
+                "hive": "CAST(X AS INT)",
+                "spark2": "CAST(X AS INT)",
+                "spark": "CAST(X AS INT)",
+                "tsql": "CAST(X AS INTEGER)",
+            },
         )
 
         self.validate_all(
             "CAST(X AS BIGINT)",
-            write={"spark": "CAST(X AS BIGINT)", "tsql": "CAST(X AS BIGINT)"},
+            write={
+                "hive": "CAST(X AS BIGINT)",
+                "spark2": "CAST(X AS BIGINT)",
+                "spark": "CAST(X AS BIGINT)",
+                "tsql": "CAST(X AS BIGINT)",
+            },
         )
 
         self.validate_all(
             "CAST(X AS SMALLINT)",
-            write={"spark": "CAST(X AS SMALLINT)", "tsql": "CAST(X AS SMALLINT)"},
+            write={
+                "hive": "CAST(X AS SMALLINT)",
+                "spark2": "CAST(X AS SMALLINT)",
+                "spark": "CAST(X AS SMALLINT)",
+                "tsql": "CAST(X AS SMALLINT)",
+            },
         )
 
         self.validate_all(
             "CAST(X AS TINYINT)",
-            write={"spark": "CAST(X AS TINYINT)", "tsql": "CAST(X AS TINYINT)"},
+            write={
+                "hive": "CAST(X AS TINYINT)",
+                "spark2": "CAST(X AS TINYINT)",
+                "spark": "CAST(X AS TINYINT)",
+                "tsql": "CAST(X AS TINYINT)",
+            },
         )
 
     def test_types_decimals(self):


### PR DESCRIPTION
Update test coverage, update tsql to spark mappings for more 1-to-1 mappings on INT, TINYINT, BIGINT etc.