### PR TITLE
feat: Add FLOAT(n) mappings to Hive

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -414,6 +414,16 @@ class Hive(Dialect):
             return self.properties(properties, prefix=self.seg("TBLPROPERTIES"))
 
         def datatype_sql(self, expression: exp.DataType) -> str:
+            if expression.this == (exp.DataType.Type.FLOAT):
+                # Not dealing with n>64
+                dt = expression.find(exp.DataTypeSize)
+                if dt:
+                    size = int(dt.name)
+                    if size <= 32:
+                        expression = exp.DataType.build("float")
+                    else:
+                        expression = exp.DataType.build("double")
+                        
             if (
                 expression.this in (exp.DataType.Type.VARCHAR, exp.DataType.Type.NVARCHAR)
                 and not expression.expressions

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -423,7 +423,7 @@ class Hive(Dialect):
                         expression = exp.DataType.build("float")
                     else:
                         expression = exp.DataType.build("double")
-                        
+
             if (
                 expression.this in (exp.DataType.Type.VARCHAR, exp.DataType.Type.NVARCHAR)
                 and not expression.expressions

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -204,6 +204,30 @@ class TestTSQL(Validator):
                 "tsql": "CAST(x AS FLOAT)",
             },
         )
+        
+        self.validate_all(
+            "CAST(x as FLOAT(32))",
+            write={"tsql": "CAST(x AS FLOAT(32))", "hive": "CAST(x AS FLOAT)"},
+        )
+
+        self.validate_all(
+            "CAST(x as FLOAT(64))",
+            write={"tsql": "CAST(x AS FLOAT(64))", "spark": "CAST(x AS DOUBLE)"},
+        )
+
+        self.validate_all(
+            "CAST(x as FLOAT(6))", write={"tsql": "CAST(x AS FLOAT(6))", "hive": "CAST(x AS FLOAT)"}
+        )
+
+        self.validate_all(
+            "CAST(x as FLOAT(36))",
+            write={"tsql": "CAST(x AS FLOAT(36))", "hive": "CAST(x AS DOUBLE)"},
+        )
+
+        self.validate_all(
+            "CAST(x as FLOAT(99))",
+            write={"tsql": "CAST(x AS FLOAT(99))", "hive": "CAST(x AS DOUBLE)"},
+        )
 
         self.validate_all(
             "CAST(x as DOUBLE)",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -204,7 +204,7 @@ class TestTSQL(Validator):
                 "tsql": "CAST(x AS FLOAT)",
             },
         )
-        
+
         self.validate_all(
             "CAST(x as FLOAT(32))",
             write={"tsql": "CAST(x AS FLOAT(32))", "hive": "CAST(x AS FLOAT)"},


### PR DESCRIPTION
Hive/Spark2/Spark don't support FLOAT(n) data type.
This feat maps FLOAT(n) to float if n <= 32 and double otherwise