### PR TITLE
Fix: improve parsing / generation of REGEXP_EXTRACT

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -620,7 +620,19 @@ def concat_to_dpipe_sql(self: Generator, expression: exp.Concat | exp.SafeConcat
     return self.sql(this)
 
 
-# Spark, DuckDB use (almost) the same naming scheme for the output columns of the PIVOT operator
+def regexp_extract_sql(self: Generator, expression: exp.RegexpExtract) -> str:
+    bad_args = list(filter(expression.args.get, ("position", "occurrence", "parameters")))
+    if bad_args:
+        self.unsupported(f"REGEXP_EXTRACT does not support the following arg(s): {bad_args}")
+
+    return self.func(
+        "REGEXP_EXTRACT",
+        expression.args.get("this"),
+        expression.args.get("expression"),
+        expression.args.get("group"),
+    )
+
+
 def pivot_column_names(aggregations: t.List[exp.Expression], dialect: DialectType) -> t.List[str]:
     names = []
     for agg in aggregations:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -626,10 +626,7 @@ def regexp_extract_sql(self: Generator, expression: exp.RegexpExtract) -> str:
         self.unsupported(f"REGEXP_EXTRACT does not support the following arg(s): {bad_args}")
 
     return self.func(
-        "REGEXP_EXTRACT",
-        expression.args.get("this"),
-        expression.args.get("expression"),
-        expression.args.get("group"),
+        "REGEXP_EXTRACT", expression.this, expression.expression, expression.args.get("group")
     )
 
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -144,6 +144,9 @@ class DuckDB(Dialect):
             "LIST_REVERSE_SORT": _sort_array_reverse,
             "LIST_SORT": exp.SortArray.from_arg_list,
             "LIST_VALUE": exp.Array.from_arg_list,
+            "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
+                this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
+            ),
             "REGEXP_MATCHES": exp.RegexpLike.from_arg_list,
             "STRFTIME": format_time_lambda(exp.TimeToStr, "duckdb"),
             "STRING_SPLIT": exp.Split.from_arg_list,

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -15,6 +15,7 @@ from sqlglot.dialects.dialect import (
     no_properties_sql,
     no_safe_divide_sql,
     pivot_column_names,
+    regexp_extract_sql,
     rename_func,
     str_position_sql,
     str_to_time_sql,
@@ -86,19 +87,6 @@ def _datatype_sql(self: generator.Generator, expression: exp.DataType) -> str:
     if expression.is_type("array"):
         return f"{self.expressions(expression, flat=True)}[]"
     return self.datatype_sql(expression)
-
-
-def _regexp_extract_sql(self: generator.Generator, expression: exp.RegexpExtract) -> str:
-    bad_args = list(filter(expression.args.get, ("position", "occurrence")))
-    if bad_args:
-        self.unsupported(f"REGEXP_EXTRACT does not support arg(s) {bad_args}")
-
-    return self.func(
-        "REGEXP_EXTRACT",
-        expression.args.get("this"),
-        expression.args.get("expression"),
-        expression.args.get("group"),
-    )
 
 
 def _json_format_sql(self: generator.Generator, expression: exp.JSONFormat) -> str:
@@ -227,7 +215,7 @@ class DuckDB(Dialect):
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.LogicalAnd: rename_func("BOOL_AND"),
             exp.Properties: no_properties_sql,
-            exp.RegexpExtract: _regexp_extract_sql,
+            exp.RegexpExtract: regexp_extract_sql,
             exp.RegexpLike: rename_func("REGEXP_MATCHES"),
             exp.RegexpSplit: rename_func("STR_SPLIT_REGEX"),
             exp.SafeDivide: no_safe_divide_sql,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
     no_recursive_cte_sql,
     no_safe_divide_sql,
     no_trycast_sql,
+    regexp_extract_sql,
     rename_func,
     right_to_substring_sql,
     strposition_to_locate_sql,
@@ -230,23 +231,24 @@ class Hive(Dialect):
             **parser.Parser.FUNCTIONS,
             "BASE64": exp.ToBase64.from_arg_list,
             "COLLECT_LIST": exp.ArrayAgg.from_arg_list,
+            "COLLECT_SET": exp.SetAgg.from_arg_list,
             "DATE_ADD": lambda args: exp.TsOrDsAdd(
                 this=seq_get(args, 0), expression=seq_get(args, 1), unit=exp.Literal.string("DAY")
-            ),
-            "DATEDIFF": lambda args: exp.DateDiff(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-                expression=exp.TsOrDsToDate(this=seq_get(args, 1)),
-            ),
-            "DATE_SUB": lambda args: exp.TsOrDsAdd(
-                this=seq_get(args, 0),
-                expression=exp.Mul(this=seq_get(args, 1), expression=exp.Literal.number(-1)),
-                unit=exp.Literal.string("DAY"),
             ),
             "DATE_FORMAT": lambda args: format_time_lambda(exp.TimeToStr, "hive")(
                 [
                     exp.TimeStrToTime(this=seq_get(args, 0)),
                     seq_get(args, 1),
                 ]
+            ),
+            "DATE_SUB": lambda args: exp.TsOrDsAdd(
+                this=seq_get(args, 0),
+                expression=exp.Mul(this=seq_get(args, 1), expression=exp.Literal.number(-1)),
+                unit=exp.Literal.string("DAY"),
+            ),
+            "DATEDIFF": lambda args: exp.DateDiff(
+                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
+                expression=exp.TsOrDsToDate(this=seq_get(args, 1)),
             ),
             "DAY": lambda args: exp.Day(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
             "FROM_UNIXTIME": format_time_lambda(exp.UnixToStr, "hive", True),
@@ -256,7 +258,9 @@ class Hive(Dialect):
             "MONTH": lambda args: exp.Month(this=exp.TsOrDsToDate.from_arg_list(args)),
             "PERCENTILE": exp.Quantile.from_arg_list,
             "PERCENTILE_APPROX": exp.ApproxQuantile.from_arg_list,
-            "COLLECT_SET": exp.SetAgg.from_arg_list,
+            "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
+                this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
+            ),
             "SIZE": exp.ArraySize.from_arg_list,
             "SPLIT": exp.RegexpSplit.from_arg_list,
             "TO_DATE": format_time_lambda(exp.TsOrDsToDate, "hive"),
@@ -363,6 +367,7 @@ class Hive(Dialect):
             exp.Create: create_with_partitions_sql,
             exp.Quantile: rename_func("PERCENTILE"),
             exp.ApproxQuantile: rename_func("PERCENTILE_APPROX"),
+            exp.RegexpExtract: regexp_extract_sql,
             exp.RegexpLike: lambda self, e: self.binary(e, "RLIKE"),
             exp.RegexpSplit: rename_func("SPLIT"),
             exp.Right: right_to_substring_sql,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -12,6 +12,7 @@ from sqlglot.dialects.dialect import (
     no_ilike_sql,
     no_pivot_sql,
     no_safe_divide_sql,
+    regexp_extract_sql,
     rename_func,
     right_to_substring_sql,
     struct_extract_sql,
@@ -215,6 +216,9 @@ class Presto(Dialect):
                 this=seq_get(args, 0), replace=seq_get(args, 1), charset=exp.Literal.string("utf-8")
             ),
             "NOW": exp.CurrentTimestamp.from_arg_list,
+            "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
+                this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
+            ),
             "SEQUENCE": exp.GenerateSeries.from_arg_list,
             "STRPOS": lambda args: exp.StrPosition(
                 this=seq_get(args, 0), substr=seq_get(args, 1), instance=seq_get(args, 2)
@@ -293,6 +297,7 @@ class Presto(Dialect):
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.Pivot: no_pivot_sql,
             exp.Quantile: _quantile_sql,
+            exp.RegexpExtract: regexp_extract_sql,
             exp.Right: right_to_substring_sql,
             exp.SafeBracket: lambda self, e: self.func(
                 "ELEMENT_AT", e.this, seq_get(apply_index_offset(e.this, e.expressions, 1), 0)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4420,6 +4420,7 @@ class RegexpExtract(Func):
         "expression": True,
         "position": False,
         "occurrence": False,
+        "parameters": False,
         "group": False,
     }
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -904,6 +904,7 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS f, LATERA
         self.validate_all(
             "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', group)",
             read={
+                "bigquery": "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', group)",
                 "duckdb": "REGEXP_EXTRACT(subject, pattern, group)",
                 "hive": "REGEXP_EXTRACT(subject, pattern, group)",
                 "presto": "REGEXP_EXTRACT(subject, pattern, group)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -904,6 +904,7 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS f, LATERA
         self.validate_all(
             "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', group)",
             read={
+                "duckdb": "REGEXP_EXTRACT(subject, pattern, group)",
                 "hive": "REGEXP_EXTRACT(subject, pattern, group)",
                 "presto": "REGEXP_EXTRACT(subject, pattern, group)",
                 "snowflake": "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', group)",


### PR DESCRIPTION
References:

- https://docs.snowflake.com/en/sql-reference/functions/regexp_substr
- https://spark.apache.org/docs/latest/api/sql/index.html#regexp_extract
- https://prestodb.io/docs/current/functions/regexp.html#id0
- https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_extract
- https://duckdb.org/docs/sql/functions/patternmatching.html