### PR TITLE
Fix(spark): add support for RLIKE function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -242,7 +242,6 @@ class Snowflake(Dialect):
 
         FUNC_TOKENS = {
             *parser.Parser.FUNC_TOKENS,
-            TokenType.RLIKE,
             TokenType.TABLE,
         }
 

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -108,43 +108,33 @@ class Spark2(Hive):
     class Parser(Hive.Parser):
         FUNCTIONS = {
             **Hive.Parser.FUNCTIONS,
-            "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
-            "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
-            "SHIFTLEFT": lambda args: exp.BitwiseLeftShift(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-            ),
-            "SHIFTRIGHT": lambda args: exp.BitwiseRightShift(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-            ),
-            "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
-            "IIF": exp.If.from_arg_list,
             "AGGREGATE": exp.Reduce.from_arg_list,
-            "DAYOFWEEK": lambda args: exp.DayOfWeek(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "DAYOFMONTH": lambda args: exp.DayOfMonth(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "DAYOFYEAR": lambda args: exp.DayOfYear(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "WEEKOFYEAR": lambda args: exp.WeekOfYear(
-                this=exp.TsOrDsToDate(this=seq_get(args, 0)),
-            ),
-            "DATE_TRUNC": lambda args: exp.TimestampTrunc(
-                this=seq_get(args, 1),
-                unit=exp.var(seq_get(args, 0)),
-            ),
-            "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
+            "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
             "BOOLEAN": _parse_as_cast("boolean"),
             "DATE": _parse_as_cast("date"),
+            "DATE_TRUNC": lambda args: exp.TimestampTrunc(
+                this=seq_get(args, 1), unit=exp.var(seq_get(args, 0))
+            ),
+            "DAYOFMONTH": lambda args: exp.DayOfMonth(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
+            "DAYOFWEEK": lambda args: exp.DayOfWeek(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
+            "DAYOFYEAR": lambda args: exp.DayOfYear(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
             "DOUBLE": _parse_as_cast("double"),
             "FLOAT": _parse_as_cast("float"),
+            "IIF": exp.If.from_arg_list,
             "INT": _parse_as_cast("int"),
+            "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
+            "RLIKE": exp.RegexpLike.from_arg_list,
+            "SHIFTLEFT": lambda args: exp.BitwiseLeftShift(
+                this=seq_get(args, 0), expression=seq_get(args, 1)
+            ),
+            "SHIFTRIGHT": lambda args: exp.BitwiseRightShift(
+                this=seq_get(args, 0), expression=seq_get(args, 1)
+            ),
             "STRING": _parse_as_cast("string"),
             "TIMESTAMP": _parse_as_cast("timestamp"),
+            "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
+            "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),
+            "WEEKOFYEAR": lambda args: exp.WeekOfYear(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
         }
 
         FUNCTION_PARSERS = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -327,6 +327,7 @@ class Parser(metaclass=_Parser):
         TokenType.PRIMARY_KEY,
         TokenType.RANGE,
         TokenType.REPLACE,
+        TokenType.RLIKE,
         TokenType.ROW,
         TokenType.UNNEST,
         TokenType.VAR,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -386,7 +386,9 @@ class TestSnowflake(Validator):
         self.validate_all(
             "SELECT RLIKE(a, b)",
             write={
+                "hive": "SELECT a RLIKE b",
                 "snowflake": "SELECT REGEXP_LIKE(a, b)",
+                "spark": "SELECT a RLIKE b",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -233,6 +233,14 @@ TBLPROPERTIES (
         self.validate_identity("SPLIT(str, pattern, lim)")
 
         self.validate_all(
+            "SELECT RLIKE('John Doe', 'John.*')",
+            write={
+                "hive": "SELECT 'John Doe' RLIKE 'John.*'",
+                "snowflake": "SELECT REGEXP_LIKE('John Doe', 'John.*')",
+                "spark": "SELECT 'John Doe' RLIKE 'John.*'",
+            },
+        )
+        self.validate_all(
             "UNHEX(MD5(x))",
             write={
                 "bigquery": "FROM_HEX(TO_HEX(MD5(x)))",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -235,7 +235,9 @@ TBLPROPERTIES (
         self.validate_all(
             "SELECT RLIKE('John Doe', 'John.*')",
             write={
+                "bigquery": "SELECT REGEXP_CONTAINS('John Doe', 'John.*')",
                 "hive": "SELECT 'John Doe' RLIKE 'John.*'",
+                "postgres": "SELECT 'John Doe' ~ 'John.*'",
                 "snowflake": "SELECT REGEXP_LIKE('John Doe', 'John.*')",
                 "spark": "SELECT 'John Doe' RLIKE 'John.*'",
             },


### PR DESCRIPTION
Formatting changes: sorted spark functions alphabetically

References:
- https://docs.snowflake.com/en/sql-reference/functions/regexp_like
- https://spark.apache.org/docs/latest/api/sql/index.html#rlike
- https://cwiki.apache.org/confluence/display/hive/languagemanual+udf