### PR TITLE
Refactor!(tokenizer): raise TokenError instead of RuntimeError

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 from enum import auto
 
+from sqlglot.errors import TokenError
 from sqlglot.helper import AutoName
 from sqlglot.trie import TrieResult, in_trie, new_trie
 
@@ -800,7 +801,7 @@ class Tokenizer(metaclass=_Tokenizer):
             start = max(self._current - 50, 0)
             end = min(self._current + 50, self.size - 1)
             context = self.sql[start:end]
-            raise ValueError(f"Error tokenizing '{context}'") from e
+            raise TokenError(f"Error tokenizing '{context}'") from e
 
         return self.tokens
 
@@ -1097,7 +1098,7 @@ class Tokenizer(metaclass=_Tokenizer):
             try:
                 int(text, base)
             except:
-                raise RuntimeError(
+                raise TokenError(
                     f"Numeric string contains invalid characters from {self._line}:{self._start}"
                 )
         else:
@@ -1140,7 +1141,7 @@ class Tokenizer(metaclass=_Tokenizer):
                 if self._current + 1 < self.size:
                     self._advance(2)
                 else:
-                    raise RuntimeError(f"Missing {delimiter} from {self._line}:{self._current}")
+                    raise TokenError(f"Missing {delimiter} from {self._line}:{self._current}")
             else:
                 if self._chars(delim_size) == delimiter:
                     if delim_size > 1:
@@ -1148,7 +1149,7 @@ class Tokenizer(metaclass=_Tokenizer):
                     break
 
                 if self._end:
-                    raise RuntimeError(f"Missing {delimiter} from {self._line}:{self._start}")
+                    raise TokenError(f"Missing {delimiter} from {self._line}:{self._start}")
 
                 current = self._current - 1
                 self._advance(alnum=True)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from sqlglot import ErrorLevel, ParseError, UnsupportedError, transpile
+from sqlglot import ErrorLevel, ParseError, TokenError, UnsupportedError, transpile
 from tests.dialects.test_dialect import Validator
 
 
@@ -8,7 +8,7 @@ class TestBigQuery(Validator):
     dialect = "bigquery"
 
     def test_bigquery(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TokenError):
             transpile("'\\'", read="bigquery")
 
         # Reference: https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#set_operators

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,6 +1,7 @@
 import unittest
 
 from sqlglot.dialects import BigQuery
+from sqlglot.errors import TokenError
 from sqlglot.tokens import Tokenizer, TokenType
 
 
@@ -65,7 +66,7 @@ x"""
         self.assertEqual(tokens[3].token_type, TokenType.SEMICOLON)
 
     def test_error_msg(self):
-        with self.assertRaisesRegex(ValueError, "Error tokenizing 'select /'"):
+        with self.assertRaisesRegex(TokenError, "Error tokenizing 'select /'"):
             Tokenizer().tokenize("select /*")
 
     def test_jinja(self):


### PR DESCRIPTION
I don't know what was the motivation behind raising a `ValueError` in the tokenizer module, but it doesn't feel right. This PR changes this to ensure consistency with the other modules.

Note how prior to this PR the `TokenError` exception type was also practically unused.