### PR TITLE
Feat(hive): add support for the query TRANSFORM clause

### DIFF
--- a/sqlglot/dataframe/sql/functions.py
+++ b/sqlglot/dataframe/sql/functions.py
@@ -1200,7 +1200,9 @@ def transform(
     f: t.Union[t.Callable[[Column], Column], t.Callable[[Column, Column], Column]],
 ) -> Column:
     f_expression = _get_lambda_from_func(f)
-    return Column.invoke_anonymous_function(col, "TRANSFORM", Column(f_expression))
+    return Column.invoke_expression_over_column(
+        col, expression.Transform, expression=Column(f_expression)
+    )
 
 
 def exists(col: ColumnOrName, f: t.Callable[[Column], Column]) -> Column:

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -284,7 +284,7 @@ class Hive(Dialect):
             ),
         }
 
-        def _parse_query_transform(self) -> exp.Anonymous | exp.QueryTransform:
+        def _parse_query_transform(self) -> exp.Transform | exp.QueryTransform:
             args = self._parse_csv(self._parse_lambda)
 
             index = self._index
@@ -298,7 +298,7 @@ class Hive(Dialect):
 
             if not self._match(TokenType.USING):
                 self._retreat(index)
-                return self.expression(exp.Anonymous, this="TRANSFORM", expressions=args)
+                return exp.Transform.from_arg_list(args)
 
             command_script = self._parse_string()
 

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -286,8 +286,6 @@ class Hive(Dialect):
 
         def _parse_query_transform(self) -> exp.Transform | exp.QueryTransform:
             args = self._parse_csv(self._parse_lambda)
-
-            index = self._index
             self._match_r_paren()
 
             row_format_before = self._parse_row_format(match_row=True)
@@ -297,7 +295,6 @@ class Hive(Dialect):
                 record_writer = self._parse_string()
 
             if not self._match(TokenType.USING):
-                self._retreat(index)
                 return exp.Transform.from_arg_list(args)
 
             command_script = self._parse_string()

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -274,7 +274,7 @@ class Hive(Dialect):
 
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
-            "TRANSFORM": lambda self: self._parse_query_transform(),
+            "TRANSFORM": lambda self: self._parse_transform(),
         }
 
         PROPERTY_PARSERS = {
@@ -284,7 +284,7 @@ class Hive(Dialect):
             ),
         }
 
-        def _parse_query_transform(self) -> exp.Transform | exp.QueryTransform:
+        def _parse_transform(self) -> exp.Transform | exp.QueryTransform:
             args = self._parse_csv(self._parse_lambda)
             self._match_r_paren()
 

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp, parser, transforms
+from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
     create_with_partitions_sql,
     format_time_lambda,
@@ -142,7 +142,7 @@ class Spark2(Hive):
         }
 
         FUNCTION_PARSERS = {
-            **parser.Parser.FUNCTION_PARSERS,
+            **Hive.Parser.FUNCTION_PARSERS,
             "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
             "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
             "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3889,6 +3889,11 @@ class Abs(Func):
     pass
 
 
+# https://spark.apache.org/docs/latest/api/sql/index.html#transform
+class Transform(Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class Anonymous(Func):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2031,7 +2031,20 @@ class RowFormatDelimitedProperty(Property):
 
 
 class RowFormatSerdeProperty(Property):
-    arg_types = {"this": True}
+    arg_types = {"this": True, "serde_properties": False}
+
+
+# https://spark.apache.org/docs/3.1.2/sql-ref-syntax-qry-select-transform.html
+class QueryTransform(Expression):
+    arg_types = {
+        "expressions": True,
+        "command_script": True,
+        "schema": False,
+        "row_format_before": False,
+        "record_writer": False,
+        "row_format_after": False,
+        "record_reader": False,
+    }
 
 
 class SchemaCommentProperty(Property):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2508,6 +2508,21 @@ class Generator:
 
         return self.func("ANY_VALUE", this)
 
+    def querytransform_sql(self, expression: exp.QueryTransform) -> str:
+        transform = self.func("TRANSFORM", *expression.expressions)
+        row_format_before = self.sql(expression, "row_format_before")
+        row_format_before = f" {row_format_before}" if row_format_before else ""
+        record_writer = self.sql(expression, "record_writer")
+        record_writer = f" RECORDWRITER {record_writer}" if record_writer else ""
+        using = f" USING {self.sql(expression, 'command_script')}"
+        schema = self.sql(expression, "schema")
+        schema = f" AS {schema}" if schema else ""
+        row_format_after = self.sql(expression, "row_format_after")
+        row_format_after = f" {row_format_after}" if row_format_after else ""
+        record_reader = self.sql(expression, "record_reader")
+        record_reader = f" RECORDREADER {record_reader}" if record_reader else ""
+        return f"{transform}{row_format_before}{record_writer}{using}{schema}{row_format_after}{record_reader}"
+
 
 def cached_generator(
     cache: t.Optional[t.Dict[int, str]] = None

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -556,6 +556,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("HEX(foo)"), exp.Hex)
         self.assertIsInstance(parse_one("TO_HEX(foo)", read="bigquery"), exp.Hex)
         self.assertIsInstance(parse_one("TO_HEX(MD5(foo))", read="bigquery"), exp.MD5)
+        self.assertIsInstance(parse_one("TRANSFORM(a, b)", read="spark"), exp.Transform)
 
     def test_column(self):
         column = parse_one("a.b.c.d")


### PR DESCRIPTION
Fixes #1933

References:
- https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Transform
- https://spark.apache.org/docs/3.1.2/sql-ref-syntax-qry-select-transform.html
- https://spark.apache.org/docs/3.1.2/sql-ref-syntax-hive-format.html
- https://spark.apache.org/docs/latest/api/sql/index.html#transform