### PR TITLE
Fix(tsql): revert float-to-datetime coercions

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -180,10 +180,14 @@ def _parse_date_delta(
 
         start_date = seq_get(args, 1)
         if start_date and start_date.is_number:
-            # numeric types are valid DATETIME values
-            number = int(start_date.this) if start_date.is_int else float(start_date.this)
-            adds = DEFAULT_START_DATE + datetime.timedelta(days=number)
-            start_date = exp.Literal.string(adds.strftime("%F"))
+            # Numeric types are valid DATETIME values
+            if start_date.is_int:
+                adds = DEFAULT_START_DATE + datetime.timedelta(days=int(start_date.this))
+                start_date = exp.Literal.string(adds.strftime("%F"))
+            else:
+                # We currently don't handle float values, i.e. they're not converted to equivalent DATETIMEs.
+                # This is not a problem when generating T-SQL code, it is when transpiling to other dialects.
+                return exp_class(this=seq_get(args, 2), expression=start_date, unit=unit)
 
         return exp_class(
             this=exp.TimeStrToTime(this=seq_get(args, 2)),

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -818,6 +818,7 @@ WHERE
         )
 
     def test_date_diff(self):
+        self.validate_identity("SELECT DATEDIFF(hour, 1.5, '2021-01-01')")
         self.validate_identity(
             "SELECT DATEDIFF(year, '2020-01-01', '2021-01-01')",
             "SELECT DATEDIFF(year, CAST('2020-01-01' AS DATETIME2), CAST('2021-01-01' AS DATETIME2))",
@@ -836,14 +837,6 @@ WHERE
                 "tsql": "SELECT DATEDIFF(day, CAST('1900-01-02' AS DATETIME2), CAST('2021-01-01' AS DATETIME2))",
                 "spark": "SELECT DATEDIFF(day, CAST('1900-01-02' AS TIMESTAMP), CAST('2021-01-01' AS TIMESTAMP))",
                 "duckdb": "SELECT DATE_DIFF('day', CAST('1900-01-02' AS TIMESTAMP), CAST('2021-01-01' AS TIMESTAMP))",
-            },
-        )
-        self.validate_all(
-            "SELECT DATEDIFF(quarter, 1.5, '2021-01-01')",
-            write={
-                "tsql": "SELECT DATEDIFF(quarter, CAST('1900-01-02' AS DATETIME2), CAST('2021-01-01' AS DATETIME2))",
-                "spark": "SELECT DATEDIFF(quarter, CAST('1900-01-02' AS TIMESTAMP), CAST('2021-01-01' AS TIMESTAMP))",
-                "duckdb": "SELECT DATE_DIFF('quarter', CAST('1900-01-02' AS TIMESTAMP), CAST('2021-01-01' AS TIMESTAMP))",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Reverts the piece of logic specific to floats, introduced in #1967. Ensures that we don't break valid T-SQL code, at least.

cc: @dmoore247