### PR TITLE
Fix(mysql): simplify LIMIT, OFFSET when their expression is complex

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -665,7 +665,7 @@ def pivot_column_names(aggregations: t.List[exp.Expression], dialect: DialectTyp
     return names
 
 
-def simplify_expression(expression: E, copy: bool = True) -> E:
+def simplify_literal(expression: E, copy: bool = True) -> E:
     if not isinstance(expression.expression, exp.Literal):
         from sqlglot.optimizer.simplify import simplify
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -669,7 +669,7 @@ def simplify_literal(expression: E, copy: bool = True) -> E:
     if not isinstance(expression.expression, exp.Literal):
         from sqlglot.optimizer.simplify import simplify
 
-        expression = exp._maybe_copy(expression, copy)
+        expression = exp.maybe_copy(expression, copy)
         simplify(expression.expression)
 
     return expression

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -665,5 +665,15 @@ def pivot_column_names(aggregations: t.List[exp.Expression], dialect: DialectTyp
     return names
 
 
+def simplify_expression(expression: E, copy: bool = True) -> E:
+    if not isinstance(expression.expression, exp.Literal):
+        from sqlglot.optimizer.simplify import simplify
+
+        expression = exp._maybe_copy(expression, copy)
+        simplify(expression.expression)
+
+    return expression
+
+
 def binary_from_function(expr_type: t.Type[B]) -> t.Callable[[t.List], B]:
     return lambda args: expr_type(this=seq_get(args, 0), expression=seq_get(args, 1))

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -18,6 +18,7 @@ from sqlglot.dialects.dialect import (
     no_trycast_sql,
     parse_date_delta_with_interval,
     rename_func,
+    simplify_expression,
     strposition_to_locate_sql,
 )
 from sqlglot.helper import seq_get
@@ -554,23 +555,13 @@ class MySQL(Dialect):
         }
 
         def limit_sql(self, expression: exp.Limit, top: bool = False) -> str:
-            if not isinstance(expression.expression, exp.Literal):
-                # MySQL requires simple literal values for its LIMIT clause.
-                from sqlglot.optimizer.simplify import simplify
-
-                expression = expression.copy()
-                simplify(expression.expression)
-
+            # MySQL requires simple literal values for its LIMIT clause.
+            expression = simplify_expression(expression)
             return super().limit_sql(expression, top=top)
 
         def offset_sql(self, expression: exp.Offset) -> str:
-            if not isinstance(expression.expression, exp.Literal):
-                # MySQL requires simple literal values for its OFFSET clause.
-                from sqlglot.optimizer.simplify import simplify
-
-                expression = expression.copy()
-                simplify(expression.expression)
-
+            # MySQL requires simple literal values for its OFFSET clause.
+            expression = simplify_expression(expression)
             return super().offset_sql(expression)
 
         def xor_sql(self, expression: exp.Xor) -> str:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -555,12 +555,23 @@ class MySQL(Dialect):
 
         def limit_sql(self, expression: exp.Limit, top: bool = False) -> str:
             if not isinstance(expression.expression, exp.Literal):
+                # MySQL requires simple literal values for its LIMIT clause.
                 from sqlglot.optimizer.simplify import simplify
 
                 expression = expression.copy()
                 simplify(expression.expression)
 
             return super().limit_sql(expression, top=top)
+
+        def offset_sql(self, expression: exp.Offset) -> str:
+            if not isinstance(expression.expression, exp.Literal):
+                # MySQL requires simple literal values for its OFFSET clause.
+                from sqlglot.optimizer.simplify import simplify
+
+                expression = expression.copy()
+                simplify(expression.expression)
+
+            return super().offset_sql(expression)
 
         def xor_sql(self, expression: exp.Xor) -> str:
             if expression.expressions:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -18,7 +18,7 @@ from sqlglot.dialects.dialect import (
     no_trycast_sql,
     parse_date_delta_with_interval,
     rename_func,
-    simplify_expression,
+    simplify_literal,
     strposition_to_locate_sql,
 )
 from sqlglot.helper import seq_get
@@ -556,12 +556,12 @@ class MySQL(Dialect):
 
         def limit_sql(self, expression: exp.Limit, top: bool = False) -> str:
             # MySQL requires simple literal values for its LIMIT clause.
-            expression = simplify_expression(expression)
+            expression = simplify_literal(expression)
             return super().limit_sql(expression, top=top)
 
         def offset_sql(self, expression: exp.Offset) -> str:
             # MySQL requires simple literal values for its OFFSET clause.
-            expression = simplify_expression(expression)
+            expression = simplify_literal(expression)
             return super().offset_sql(expression)
 
         def xor_sql(self, expression: exp.Xor) -> str:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -553,6 +553,15 @@ class MySQL(Dialect):
             exp.DataType.Type.VARCHAR: "CHAR",
         }
 
+        def limit_sql(self, expression: exp.Limit, top: bool = False) -> str:
+            if not isinstance(expression.expression, exp.Literal):
+                from sqlglot.optimizer.simplify import simplify
+
+                expression = expression.copy()
+                simplify(expression.expression)
+
+            return super().limit_sql(expression, top=top)
+
         def xor_sql(self, expression: exp.Xor) -> str:
             if expression.expressions:
                 return self.expressions(expression, sep=" XOR ")

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -41,14 +41,14 @@ def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | e
     def func(self: generator.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
         from sqlglot.optimizer.simplify import simplify
 
+        expression = expression.copy()
         this = self.sql(expression, "this")
         unit = expression.args.get("unit")
-        expression = simplify(expression.args["expression"])
 
+        expression = simplify(expression.expression)
         if not isinstance(expression, exp.Literal):
             self.unsupported("Cannot add non literal")
 
-        expression = expression.copy()
         expression.args["is_string"] = True
         return f"{this} {kind} {self.sql(exp.Interval(this=expression, unit=unit))}"
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -17,7 +17,7 @@ from sqlglot.dialects.dialect import (
     no_tablesample_sql,
     no_trycast_sql,
     rename_func,
-    simplify_expression,
+    simplify_literal,
     str_position_sql,
     timestamptrunc_sql,
     timestrtotime_sql,
@@ -43,7 +43,7 @@ def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | e
         this = self.sql(expression, "this")
         unit = expression.args.get("unit")
 
-        expression = simplify_expression(expression.copy(), copy=False).expression
+        expression = simplify_literal(expression.copy(), copy=False).expression
         if not isinstance(expression, exp.Literal):
             self.unsupported("Cannot add non literal")
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
     no_tablesample_sql,
     no_trycast_sql,
     rename_func,
+    simplify_expression,
     str_position_sql,
     timestamptrunc_sql,
     timestrtotime_sql,
@@ -39,13 +40,10 @@ DATE_DIFF_FACTOR = {
 
 def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | exp.DateSub], str]:
     def func(self: generator.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
-        from sqlglot.optimizer.simplify import simplify
-
-        expression = expression.copy()
         this = self.sql(expression, "this")
         unit = expression.args.get("unit")
 
-        expression = simplify(expression.expression)
+        expression = simplify_expression(expression.copy(), copy=False).expression
         if not isinstance(expression, exp.Literal):
             self.unsupported("Cannot add non literal")
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -767,7 +767,7 @@ class Condition(Expression):
         **opts,
     ) -> In:
         return In(
-            this=_maybe_copy(self, copy),
+            this=maybe_copy(self, copy),
             expressions=[convert(e, copy=copy) for e in expressions],
             query=maybe_parse(query, copy=copy, **opts) if query else None,
             unnest=Unnest(
@@ -781,7 +781,7 @@ class Condition(Expression):
 
     def between(self, low: t.Any, high: t.Any, copy: bool = True, **opts) -> Between:
         return Between(
-            this=_maybe_copy(self, copy),
+            this=maybe_copy(self, copy),
             low=convert(low, copy=copy, **opts),
             high=convert(high, copy=copy, **opts),
         )
@@ -2200,7 +2200,7 @@ class Tuple(Expression):
         **opts,
     ) -> In:
         return In(
-            this=_maybe_copy(self, copy),
+            this=maybe_copy(self, copy),
             expressions=[convert(e, copy=copy) for e in expressions],
             query=maybe_parse(query, copy=copy, **opts) if query else None,
             unnest=Unnest(
@@ -2230,7 +2230,7 @@ class Subqueryable(Unionable):
         Returns:
             Alias: the subquery
         """
-        instance = _maybe_copy(self, copy)
+        instance = maybe_copy(self, copy)
         if not isinstance(alias, Expression):
             alias = TableAlias(this=to_identifier(alias)) if alias else None
 
@@ -3111,7 +3111,7 @@ class Select(Subqueryable):
         Returns:
             Select: the modified expression.
         """
-        instance = _maybe_copy(self, copy)
+        instance = maybe_copy(self, copy)
         on = Tuple(expressions=[maybe_parse(on, copy=copy) for on in ons if on]) if ons else None
         instance.set("distinct", Distinct(on=on) if distinct else None)
         return instance
@@ -3142,7 +3142,7 @@ class Select(Subqueryable):
         Returns:
             The new Create expression.
         """
-        instance = _maybe_copy(self, copy)
+        instance = maybe_copy(self, copy)
         table_expression = maybe_parse(
             table,
             into=Table,
@@ -3178,7 +3178,7 @@ class Select(Subqueryable):
         Returns:
             The modified expression.
         """
-        inst = _maybe_copy(self, copy)
+        inst = maybe_copy(self, copy)
         inst.set("locks", [Lock(update=update)])
 
         return inst
@@ -3200,7 +3200,7 @@ class Select(Subqueryable):
         Returns:
             The modified expression.
         """
-        inst = _maybe_copy(self, copy)
+        inst = maybe_copy(self, copy)
         inst.set(
             "hint", Hint(expressions=[maybe_parse(h, copy=copy, dialect=dialect) for h in hints])
         )
@@ -4008,7 +4008,7 @@ class Case(Func):
     arg_types = {"this": False, "ifs": True, "default": False}
 
     def when(self, condition: ExpOrStr, then: ExpOrStr, copy: bool = True, **opts) -> Case:
-        instance = _maybe_copy(self, copy)
+        instance = maybe_copy(self, copy)
         instance.append(
             "ifs",
             If(
@@ -4019,7 +4019,7 @@ class Case(Func):
         return instance
 
     def else_(self, condition: ExpOrStr, copy: bool = True, **opts) -> Case:
-        instance = _maybe_copy(self, copy)
+        instance = maybe_copy(self, copy)
         instance.set("default", maybe_parse(condition, copy=copy, **opts))
         return instance
 
@@ -4834,7 +4834,7 @@ def maybe_parse(
     return sqlglot.parse_one(sql, read=dialect, into=into, **opts)
 
 
-def _maybe_copy(instance: E, copy: bool = True) -> E:
+def maybe_copy(instance: E, copy: bool = True) -> E:
     return instance.copy() if copy else instance
 
 
@@ -4854,7 +4854,7 @@ def _apply_builder(
 ):
     if _is_wrong_expression(expression, into):
         expression = into(this=expression)
-    instance = _maybe_copy(instance, copy)
+    instance = maybe_copy(instance, copy)
     expression = maybe_parse(
         sql_or_expression=expression,
         prefix=prefix,
@@ -4878,7 +4878,7 @@ def _apply_child_list_builder(
     properties=None,
     **opts,
 ):
-    instance = _maybe_copy(instance, copy)
+    instance = maybe_copy(instance, copy)
     parsed = []
     for expression in expressions:
         if expression is not None:
@@ -4917,7 +4917,7 @@ def _apply_list_builder(
     dialect=None,
     **opts,
 ):
-    inst = _maybe_copy(instance, copy)
+    inst = maybe_copy(instance, copy)
 
     expressions = [
         maybe_parse(
@@ -4953,7 +4953,7 @@ def _apply_conjunction_builder(
     if not expressions:
         return instance
 
-    inst = _maybe_copy(instance, copy)
+    inst = maybe_copy(instance, copy)
 
     existing = inst.args.get(arg)
     if append and existing is not None:
@@ -5428,7 +5428,7 @@ def to_identifier(name, quoted=None, copy=True):
         return None
 
     if isinstance(name, Identifier):
-        identifier = _maybe_copy(name, copy)
+        identifier = maybe_copy(name, copy)
     elif isinstance(name, str):
         identifier = Identifier(
             this=name,
@@ -5765,7 +5765,7 @@ def convert(value: t.Any, copy: bool = False) -> Expression:
         Expression: the equivalent expression object.
     """
     if isinstance(value, Expression):
-        return _maybe_copy(value, copy)
+        return maybe_copy(value, copy)
     if isinstance(value, str):
         return Literal.string(value)
     if isinstance(value, bool):

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -448,12 +448,11 @@ class TestMySQL(Validator):
         self.validate_identity("TIME_STR_TO_UNIX(x)", "UNIX_TIMESTAMP(x)")
 
     def test_mysql(self):
-        self.validate_all("SELECT 1 LIMIT 1", write={"mysql": "SELECT 1 LIMIT 1"})
         self.validate_all(
-            "SELECT * FROM test LIMIT 0 + 1",
+            "SELECT * FROM test LIMIT 0 + 1, 0 + 1",
             write={
-                "mysql": "SELECT * FROM test LIMIT 1",
-                "postgres": "SELECT * FROM test LIMIT 0 + 1",
+                "mysql": "SELECT * FROM test LIMIT 1 OFFSET 1",
+                "postgres": "SELECT * FROM test LIMIT 0 + 1 OFFSET 0 + 1",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -448,6 +448,14 @@ class TestMySQL(Validator):
         self.validate_identity("TIME_STR_TO_UNIX(x)", "UNIX_TIMESTAMP(x)")
 
     def test_mysql(self):
+        self.validate_all("SELECT 1 LIMIT 1", write={"mysql": "SELECT 1 LIMIT 1"})
+        self.validate_all(
+            "SELECT * FROM test LIMIT 0 + 1",
+            write={
+                "mysql": "SELECT * FROM test LIMIT 1",
+                "postgres": "SELECT * FROM test LIMIT 0 + 1",
+            },
+        )
         self.validate_all(
             "CAST(x AS TEXT)",
             write={


### PR DESCRIPTION
MySQL prohibits complex expressions in the `LIMIT` and `OFFSET` clauses, so we need to simplify them.

For example, the following query is invalid in MySQL:

```sql
SELECT 1 LIMIT 0 + 1
```

