### PR TITLE
Fix: control whether quotes are generated for extract's date part

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -359,6 +359,7 @@ class Hive(Dialect):
         TABLE_HINTS = False
         QUERY_HINTS = False
         INDEX_ON = "ON TABLE"
+        EXTRACT_ALLOWS_QUOTES = False
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -162,6 +162,9 @@ class Generator:
     # Whether or not to generate the (+) suffix for columns used in old-style join conditions
     COLUMN_JOIN_MARKS_SUPPORTED = False
 
+    # Whether or not to generate an unquoted value for EXTRACT's date part argument
+    EXTRACT_ALLOWS_QUOTES = True
+
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
     SELECT_KINDS: t.Tuple[str, ...] = ("STRUCT", "VALUE")
 
@@ -1911,7 +1914,7 @@ class Generator:
         return f"NEXT VALUE FOR {self.sql(expression, 'this')}{order}"
 
     def extract_sql(self, expression: exp.Extract) -> str:
-        this = self.sql(expression, "this")
+        this = self.sql(expression, "this") if self.EXTRACT_ALLOWS_QUOTES else expression.this.name
         expression_sql = self.sql(expression, "expression")
         return f"EXTRACT({this} FROM {expression_sql})"
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -45,6 +45,14 @@ class TestSnowflake(Validator):
         self.validate_all("CAST(x AS CHARACTER VARYING)", write={"snowflake": "CAST(x AS VARCHAR)"})
         self.validate_all("CAST(x AS NCHAR VARYING)", write={"snowflake": "CAST(x AS VARCHAR)"})
         self.validate_all(
+            "SELECT DATE_PART('year', TIMESTAMP '2020-01-01')",
+            write={
+                "hive": "SELECT EXTRACT(year FROM CAST('2020-01-01' AS TIMESTAMP))",
+                "snowflake": "SELECT DATE_PART('year', CAST('2020-01-01' AS TIMESTAMPNTZ))",
+                "spark": "SELECT EXTRACT(year FROM CAST('2020-01-01' AS TIMESTAMP))",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM (VALUES (0) foo(bar))",
             write={"snowflake": "SELECT * FROM (VALUES (0)) AS foo(bar)"},
         )


### PR DESCRIPTION
References:
- https://cwiki.apache.org/confluence/display/hive/languagemanual+udf
- https://spark.apache.org/docs/latest/api/sql/index.html#extract