### PR TITLE
Fix!(clickhouse): preserve original function names instead of uppercasing

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -225,7 +225,6 @@ class ClickHouse(Dialect):
             anonymous: bool = False,
             optional_parens: bool = True,
         ) -> t.Optional[exp.Expression]:
-            name = self._curr and self._curr.text
             func = super()._parse_function(
                 functions=functions, anonymous=anonymous, optional_parens=optional_parens
             )
@@ -240,9 +239,6 @@ class ClickHouse(Dialect):
                         expressions=func.expressions,
                         params=params,
                     )
-
-            if func and name:
-                func.meta["name"] = name
 
             return func
 
@@ -356,9 +352,6 @@ class ClickHouse(Dialect):
             "FUNCTION",
             "NAMED COLLECTION",
         }
-
-        def function_name(self, expression: exp.Func) -> str:
-            return (expression._meta and expression.meta.get("name")) or expression.sql_name()
 
         def safeconcat_sql(self, expression: exp.SafeConcat) -> str:
             # Clickhouse errors out if we try to cast a NULL value to TEXT

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -225,6 +225,7 @@ class ClickHouse(Dialect):
             anonymous: bool = False,
             optional_parens: bool = True,
         ) -> t.Optional[exp.Expression]:
+            name = self._curr and self._curr.text
             func = super()._parse_function(
                 functions=functions, anonymous=anonymous, optional_parens=optional_parens
             )
@@ -239,6 +240,9 @@ class ClickHouse(Dialect):
                         expressions=func.expressions,
                         params=params,
                     )
+
+            if func and name:
+                func.meta["name"] = name
 
             return func
 
@@ -352,6 +356,9 @@ class ClickHouse(Dialect):
             "FUNCTION",
             "NAMED COLLECTION",
         }
+
+        def function_name(self, expression: exp.Func) -> str:
+            return (expression._meta and expression.meta.get("name")) or expression.sql_name()
 
         def safeconcat_sql(self, expression: exp.SafeConcat) -> str:
             # Clickhouse errors out if we try to cast a NULL value to TEXT

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2379,10 +2379,10 @@ class Generator:
             elif arg_value is not None:
                 args.append(arg_value)
 
-        if not self.normalize_functions:
-            name = (expression._meta and expression.meta.get("name")) or expression.sql_name()
-        else:
+        if self.normalize_functions:
             name = expression.sql_name()
+        else:
+            name = (expression._meta and expression.meta.get("name")) or expression.sql_name()
 
         return self.func(name, *args)
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2379,7 +2379,7 @@ class Generator:
             elif arg_value is not None:
                 args.append(arg_value)
 
-        if not self.NORMALIZE_FUNCTIONS:
+        if not self.normalize_functions:
             name = (expression._meta and expression.meta.get("name")) or expression.sql_name()
         else:
             name = expression.sql_name()

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2367,9 +2367,6 @@ class Generator:
         op = self.maybe_comment(op, comments=expression.comments)
         return f"{self.sql(expression, 'this')} {op} {self.sql(expression, 'expression')}"
 
-    def function_name(self, expression: exp.Func) -> str:
-        return expression.sql_name()
-
     def function_fallback_sql(self, expression: exp.Func) -> str:
         args = []
 
@@ -2382,7 +2379,11 @@ class Generator:
             elif arg_value is not None:
                 args.append(arg_value)
 
-        return self.func(self.function_name(expression), *args)
+        name = expression.sql_name()
+        if not self.NORMALIZE_FUNCTIONS:
+            name = (expression._meta and expression.meta.get("name")) or name
+
+        return self.func(name, *args)
 
     def func(
         self,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2367,6 +2367,9 @@ class Generator:
         op = self.maybe_comment(op, comments=expression.comments)
         return f"{self.sql(expression, 'this')} {op} {self.sql(expression, 'expression')}"
 
+    def function_name(self, expression: exp.Func) -> str:
+        return expression.sql_name()
+
     def function_fallback_sql(self, expression: exp.Func) -> str:
         args = []
 
@@ -2379,7 +2382,7 @@ class Generator:
             elif arg_value is not None:
                 args.append(arg_value)
 
-        return self.func(expression.sql_name(), *args)
+        return self.func(self.function_name(expression), *args)
 
     def func(
         self,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2379,9 +2379,10 @@ class Generator:
             elif arg_value is not None:
                 args.append(arg_value)
 
-        name = expression.sql_name()
         if not self.NORMALIZE_FUNCTIONS:
-            name = (expression._meta and expression.meta.get("name")) or name
+            name = (expression._meta and expression.meta.get("name")) or expression.sql_name()
+        else:
+            name = expression.sql_name()
 
         return self.func(name, *args)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -835,6 +835,7 @@ class Parser(metaclass=_Parser):
     UNNEST_COLUMN_ONLY: bool = False
     ALIAS_POST_TABLESAMPLE: bool = False
     STRICT_STRING_CONCAT = False
+    NORMALIZE_FUNCTIONS = "upper"
     NULL_ORDERING: str = "nulls_are_small"
     SHOW_TRIE: t.Dict = {}
     SET_TRIE: t.Dict = {}
@@ -3360,7 +3361,10 @@ class Parser(metaclass=_Parser):
             args = self._parse_csv(lambda: self._parse_lambda(alias=alias))
 
             if function and not anonymous:
-                this = self.validate_expression(function(args), args)
+                func = self.validate_expression(function(args), args)
+                if not self.NORMALIZE_FUNCTIONS:
+                    func.meta["name"] = this
+                this = func
             else:
                 this = self.expression(exp.Anonymous, this=this, expressions=args)
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -390,7 +390,7 @@ class TestBigQuery(Validator):
             },
         )
         self.validate_all(
-            "current_timestamp",
+            "CURRENT_TIMESTAMP",
             write={
                 "bigquery": "CURRENT_TIMESTAMP()",
                 "duckdb": "CURRENT_TIMESTAMP",
@@ -401,7 +401,7 @@ class TestBigQuery(Validator):
             },
         )
         self.validate_all(
-            "current_timestamp()",
+            "CURRENT_TIMESTAMP()",
             write={
                 "bigquery": "CURRENT_TIMESTAMP()",
                 "duckdb": "CURRENT_TIMESTAMP",

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -6,6 +6,12 @@ class TestClickhouse(Validator):
     dialect = "clickhouse"
 
     def test_clickhouse(self):
+        expr = parse_one("count(x)")
+        self.assertEqual(expr.sql(dialect="clickhouse"), "COUNT(x)")
+        self.assertIsNone(expr._meta)
+
+        self.validate_identity("SELECT isNaN(1.0)")
+        self.validate_identity("SELECT startsWith('Spider-Man', 'Spi')")
         self.validate_identity("SELECT xor(TRUE, FALSE)")
         self.validate_identity("ATTACH DATABASE DEFAULT ENGINE = ORDINARY")
         self.validate_identity("CAST(['hello'], 'Array(Enum8(''hello'' = 1))')")
@@ -162,7 +168,7 @@ class TestClickhouse(Validator):
             ORDER BY loyalty ASC
             """,
             write={
-                "clickhouse": "SELECT loyalty, COUNT() FROM hits LEFT SEMI JOIN users USING (UserID)"
+                "clickhouse": "SELECT loyalty, count() FROM hits LEFT SEMI JOIN users USING (UserID)"
                 + " GROUP BY loyalty ORDER BY loyalty"
             },
         )
@@ -247,7 +253,7 @@ class TestClickhouse(Validator):
         for data_type in data_types:
             self.validate_all(
                 f"pow(2, 32)::{data_type}",
-                write={"clickhouse": f"CAST(POWER(2, 32) AS {data_type})"},
+                write={"clickhouse": f"CAST(pow(2, 32) AS {data_type})"},
             )
 
     def test_ddl(self):
@@ -304,8 +310,8 @@ GROUP BY
   id,
   toStartOfDay(timestamp)
 SET
-  max_hits = MAX(max_hits),
-  sum_hits = SUM(sum_hits)""",
+  max_hits = max(max_hits),
+  sum_hits = sum(sum_hits)""",
             },
             pretty=True,
         )
@@ -447,8 +453,8 @@ GROUP BY
   k1,
   k2
 SET
-  x = MAX(x),
-  y = MIN(y)""",
+  x = max(x),
+  y = min(y)""",
             },
             pretty=True,
         )

--- a/tests/dialects/test_drill.py
+++ b/tests/dialects/test_drill.py
@@ -66,7 +66,7 @@ class TestDrill(Validator):
             write={
                 "drill": "SELECT * FROM (SELECT education_level, salary, marital_status, "
                 "EXTRACT(year FROM age(birth_date)) AS age FROM cp.`employee.json`) "
-                "PIVOT(AVG(salary) AS avg_salary, AVG(age) AS avg_age FOR marital_status "
+                "PIVOT(avg(salary) AS avg_salary, avg(age) AS avg_age FOR marital_status "
                 "IN ('M' AS married, 'S' AS single))"
             },
         )


### PR DESCRIPTION
Fixes #1982

Some case-sensitive clickhouse functions have a corresponding `Expression` class and so when we parse them, their original name is discarded and we use whatever we have in `_sql_names` at generation time, which is not valid.

Changing all `Func`s to store their name in `this` like we do for `Anonymous` is cumbersome, because we have many `Func`s that reserve `this` to represent an argument. Instead, in this approach I used the `Expression._meta` attribute to preserve the original name, because it felt like the least intrusive way to fix this issue.

cc: @cpcloud