### PR TITLE
Fix: ensure eliminate_qualify won't introduce duplicate projections

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -100,7 +100,8 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
         outer_selects = exp.select(*[select.alias_or_name for select in expression.selects])
         qualify_filters = expression.args["qualify"].pop().this
 
-        for expr in qualify_filters.find_all((exp.Window, exp.Column)):
+        select_candidates = exp.Window if expression.is_star else (exp.Window, exp.Column)
+        for expr in qualify_filters.find_all(select_candidates):
             if isinstance(expr, exp.Window):
                 alias = find_new_name(expression.named_selects, "_w")
                 expression.select(exp.alias_(expr, alias), copy=False)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -99,7 +99,7 @@ class TestTransforms(unittest.TestCase):
         self.validate(
             eliminate_qualify,
             "SELECT * FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
-            "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS _w, p, o FROM qt) AS _t WHERE _w = 1",
+            "SELECT * FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) AS _w FROM qt) AS _t WHERE _w = 1",
         )
         self.validate(
             eliminate_qualify,


### PR DESCRIPTION
Introducing duplicate projections could lead to problems, e.g. if the query is used in a CTAS statement.