### PR TITLE
Feat: add terse coalesce operator

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -369,7 +369,6 @@ class Parser(metaclass=_Parser):
         TokenType.CARET: exp.BitwiseXor,
         TokenType.PIPE: exp.BitwiseOr,
         TokenType.DPIPE: exp.DPipe,
-        TokenType.DQMARK: exp.Coalesce,
     }
 
     TERM = {
@@ -3021,14 +3020,13 @@ class Parser(metaclass=_Parser):
 
         while True:
             if self._match_set(self.BITWISE):
-                if self._prev.token_type == TokenType.DQMARK:
-                    this = self.expression(exp.Coalesce, this=this, expressions=self._parse_term())
-                else:
-                    this = self.expression(
-                        self.BITWISE[self._prev.token_type],
-                        this=this,
-                        expression=self._parse_term(),
-                    )
+                this = self.expression(
+                    self.BITWISE[self._prev.token_type],
+                    this=this,
+                    expression=self._parse_term(),
+                )
+            elif self._match(TokenType.DQMARK):
+                this = self.expression(exp.Coalesce, this=this, expressions=self._parse_term())
             elif self._match_pair(TokenType.LT, TokenType.LT):
                 this = self.expression(
                     exp.BitwiseLeftShift, this=this, expression=self._parse_term()
@@ -3228,10 +3226,6 @@ class Parser(metaclass=_Parser):
                 field = self._parse_types()
                 if not field:
                     self.raise_error("Expected type")
-            elif op_token == TokenType.DQMARK:
-                field = self._parse_column()
-                if not field:
-                    self.raise_error("Expected column")
             elif op and self._curr:
                 self._advance()
                 value = self._prev.text

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -442,6 +442,11 @@ class Parser(metaclass=_Parser):
             this=this,
             to=to,
         ),
+        TokenType.DQMARK: lambda self, this, expressions: self.expression(
+            exp.Coalesce,
+            this=this,
+            expressions=expressions,
+        ),
         TokenType.ARROW: lambda self, this, path: self.expression(
             exp.JSONExtract,
             this=this,
@@ -3222,6 +3227,10 @@ class Parser(metaclass=_Parser):
                 field = self._parse_types()
                 if not field:
                     self.raise_error("Expected type")
+            elif op_token == TokenType.DQMARK:
+                field = self._parse_column()
+                if not field:
+                    self.raise_error("Expected column")
             elif op and self._curr:
                 self._advance()
                 value = self._prev.text

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3037,10 +3037,6 @@ class Parser(metaclass=_Parser):
                 this = self.expression(
                     exp.BitwiseRightShift, this=this, expression=self._parse_term()
                 )
-            elif self._match_pair(TokenType.GT, TokenType.GT):
-                this = self.expression(
-                    exp.BitwiseRightShift, this=this, expression=self._parse_term()
-                )
             else:
                 break
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -21,6 +21,7 @@ class TokenType(AutoName):
     PLUS = auto()
     COLON = auto()
     DCOLON = auto()
+    DQMARK = auto()
     SEMICOLON = auto()
     STAR = auto()
     BACKSLASH = auto()
@@ -504,6 +505,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "#>>": TokenType.DHASH_ARROW,
         "<->": TokenType.LR_ARROW,
         "&&": TokenType.DAMP,
+        "??": TokenType.DQMARK,
         "ALL": TokenType.ALL,
         "ALWAYS": TokenType.ALWAYS,
         "AND": TokenType.AND,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -694,3 +694,14 @@ class TestParser(unittest.TestCase):
 
     def test_parse_floats(self):
         self.assertTrue(parse_one("1. ").is_number)
+
+    def test_parse_terse_coalesce(self):
+        self.assertIsNotNone(parse_one("SELECT x ?? y FROM z").find(exp.Coalesce))
+        self.assertEqual(
+            parse_one("SELECT a, b ?? 'No Data' FROM z").sql(),
+            "SELECT a, COALESCE(b, 'No Data') FROM z",
+        )
+        self.assertEqual(
+            parse_one("SELECT a, b ?? c ?? 'No Data' FROM z").sql(),
+            "SELECT a, COALESCE(b, COALESCE(c, 'No Data')) FROM z",
+        )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -703,5 +703,5 @@ class TestParser(unittest.TestCase):
         )
         self.assertEqual(
             parse_one("SELECT a, b ?? c ?? 'No Data' FROM z").sql(),
-            "SELECT a, COALESCE(b, COALESCE(c, 'No Data')) FROM z",
+            "SELECT a, COALESCE(COALESCE(b, c), 'No Data') FROM z",
         )


### PR DESCRIPTION
One of the most common operations we perform in queries other than casting is coalescing. Offering a terse syntax available to all dialects just as you do with the `::` casting is hugely beneficial. This feature is also immediately attractive within a SQLMesh project and is just generally a pretty neat showcase of the power of sqlglot.

`SELECT x ?? y FROM z` -> `SELECT COALESCE(x, y) FROM z`
`"SELECT a, b ?? 'No Data' FROM z"` -> `SELECT a, COALESCE(b, 'No Data') FROM z`

cc: @tobymao 