### PR TITLE
Fix!(tsql): parse alias = expression into an Alias

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -395,6 +395,25 @@ class TSQL(Dialect):
 
         CONCAT_NULL_OUTPUTS_STRING = True
 
+        def _parse_set_operations(
+            self, this: t.Optional[exp.Expression]
+        ) -> t.Optional[exp.Expression]:
+            """
+            T-SQL supports the syntax alias = expression in the SELECT's projection list,
+            so we transform all parsed Select expressions to convert their EQ projections
+            into Alias expressions. This transformation is implemented here because all
+            Selects flow into this method at the end of _parse_select.
+
+            See: https://learn.microsoft.com/en-us/sql/t-sql/queries/select-clause-transact-sql?view=sql-server-ver16#syntax
+            """
+            if isinstance(this, exp.Select):
+                for select in this.selects:
+                    if isinstance(select, exp.EQ) and isinstance(select.this, exp.Column):
+                        select.replace(
+                            exp.alias_(select.expression.pop(), select.this.pop().this, copy=False)
+                        )
+            return super()._parse_set_operations(this)
+
         def _parse_commit_or_rollback(self) -> exp.Commit | exp.Rollback:
             """Applies to SQL Server and Azure SQL Database
             COMMIT [ { TRAN | TRANSACTION }

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1935,6 +1935,9 @@ class Parser(metaclass=_Parser):
         # https://prestodb.io/docs/current/sql/values.html
         return self.expression(exp.Tuple, expressions=[self._parse_conjunction()])
 
+    def _parse_projections(self) -> t.List[t.Optional[exp.Expression]]:
+        return self._parse_expressions()
+
     def _parse_select(
         self, nested: bool = False, table: bool = False, parse_subquery_alias: bool = True
     ) -> t.Optional[exp.Expression]:
@@ -1974,14 +1977,14 @@ class Parser(metaclass=_Parser):
                 self.raise_error("Cannot specify both ALL and DISTINCT after SELECT")
 
             limit = self._parse_limit(top=True)
-            expressions = self._parse_expressions()
+            projections = self._parse_projections()
 
             this = self.expression(
                 exp.Select,
                 kind=kind,
                 hint=hint,
                 distinct=distinct,
-                expressions=expressions,
+                expressions=projections,
                 limit=limit,
             )
             this.comments = comments

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -6,6 +6,10 @@ class TestTSQL(Validator):
     dialect = "tsql"
 
     def test_tsql(self):
+        projection = parse_one("SELECT a = 1", read="tsql").selects[0]
+        projection.assert_is(exp.Alias)
+        projection.args["alias"].assert_is(exp.Identifier)
+
         self.validate_identity("UPDATE x SET y = 1 OUTPUT x.a, x.b INTO @y FROM y")
         self.validate_identity("UPDATE x SET y = 1 OUTPUT x.a, x.b FROM y")
         self.validate_identity("INSERT INTO x (y) OUTPUT x.a, x.b INTO l SELECT * FROM z")
@@ -25,6 +29,10 @@ class TestTSQL(Validator):
         self.validate_identity('SELECT "x"."y" FROM foo')
         self.validate_identity("SELECT * FROM #foo")
         self.validate_identity("SELECT * FROM ##foo")
+        self.validate_identity("SELECT a = 1", "SELECT 1 AS a")
+        self.validate_identity(
+            "SELECT a = 1 UNION ALL SELECT a = b", "SELECT 1 AS a UNION ALL SELECT b AS a"
+        )
         self.validate_identity(
             "SELECT x FROM @MyTableVar AS m JOIN Employee ON m.EmployeeID = Employee.EmployeeID"
         )


### PR DESCRIPTION
I wanted to avoid changing the base parser for this as it seems very non-standard (?). I also considered overriding `_parse_select` which made the most sense at first, but it always calls `_parse_set_operations` at the end, which means we'd need to actually run a transform and search for `exp.Select`, which could be costly for deeply nested UNIONs, for example.