### PR TITLE
fix(parser, redshift): parse dateadd alias date_add

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -37,6 +37,11 @@ class Redshift(Postgres):
                 expression=seq_get(args, 1),
                 unit=seq_get(args, 0),
             ),
+            "DATE_ADD": lambda args: exp.DateAdd(
+                this=exp.TsOrDsToDate(this=seq_get(args, 2)),
+                expression=seq_get(args, 1),
+                unit=seq_get(args, 0),
+            ),
             "DATEDIFF": lambda args: exp.DateDiff(
                 this=exp.TsOrDsToDate(this=seq_get(args, 2)),
                 expression=exp.TsOrDsToDate(this=seq_get(args, 1)),

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -18,6 +18,12 @@ class TestRedshift(Validator):
             },
         )
         self.validate_all(
+            "SELECT DATE_ADD('day', 1, DATE('2023-01-01'))",
+            write={
+                "redshift": "SELECT DATEADD(day, 1, DATE('2023-01-01'))",
+            },
+        )
+        self.validate_all(
             "SELECT STRTOL('abc', 16)",
             read={
                 "trino": "SELECT FROM_BASE('abc', 16)",


### PR DESCRIPTION
Redshift also supports using `DATE_ADD` as an alias of `DATEADD`. Right now, they both functions are parsed differently:

```
sql = "SELECT DATE_ADD('day', 1, date('2023-01-01'))"
sqlglot.transpile(sql, read='redshift', write='redshift')
> ["SELECT DATEADD(day, 1, 'day')"]

sql = "SELECT DATEADD('day', 1, date('2023-01-01'))"
sqlglot.transpile(sql, read='redshift', write='redshift')
> ["SELECT DATEADD(day, 1, DATE('2023-01-01'))
```

Added the same parser used on DATEADD to fix this difference.