### PR TITLE
Fix!(starrocks): parse regexp, datediff correctly, fix datediff generation

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -17,6 +17,7 @@ class StarRocks(MySQL):
             "DATE_TRUNC": lambda args: exp.TimestampTrunc(
                 this=seq_get(args, 1), unit=seq_get(args, 0)
             ),
+            "REGEXP": exp.RegexpLike.from_arg_list,
         }
 
     class Generator(MySQL.Generator):
@@ -34,7 +35,6 @@ class StarRocks(MySQL):
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.JSONExtractScalar: arrow_json_extract_sql,
             exp.JSONExtract: arrow_json_extract_sql,
-            exp.DateDiff: rename_func("DATEDIFF"),
             exp.RegexpLike: rename_func("REGEXP"),
             exp.StrToUnix: lambda self, e: f"UNIX_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TimestampTrunc: lambda self, e: self.func(

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -17,6 +17,12 @@ class StarRocks(MySQL):
             "DATE_TRUNC": lambda args: exp.TimestampTrunc(
                 this=seq_get(args, 1), unit=seq_get(args, 0)
             ),
+            "DATEDIFF": lambda args: exp.DateDiff(
+                this=seq_get(args, 0), expression=seq_get(args, 1), unit=exp.Literal.string("DAY")
+            ),
+            "DATE_DIFF": lambda args: exp.DateDiff(
+                this=seq_get(args, 1), expression=seq_get(args, 2), unit=seq_get(args, 0)
+            ),
             "REGEXP": exp.RegexpLike.from_arg_list,
         }
 
@@ -33,6 +39,9 @@ class StarRocks(MySQL):
         TRANSFORMS = {
             **MySQL.Generator.TRANSFORMS,
             exp.ApproxDistinct: approx_count_distinct_sql,
+            exp.DateDiff: lambda self, e: self.func(
+                "DATE_DIFF", exp.Literal.string(e.text("unit") or "DAY"), e.this, e.expression
+            ),
             exp.JSONExtractScalar: arrow_json_extract_sql,
             exp.JSONExtract: arrow_json_extract_sql,
             exp.RegexpLike: rename_func("REGEXP"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -200,8 +200,13 @@ class TestBigQuery(Validator):
         )
         self.validate_all(
             "REGEXP_CONTAINS('foo', '.*')",
-            read={"bigquery": "REGEXP_CONTAINS('foo', '.*')"},
-            write={"mysql": "REGEXP_LIKE('foo', '.*')"},
+            read={
+                "bigquery": "REGEXP_CONTAINS('foo', '.*')",
+            },
+            write={
+                "mysql": "REGEXP_LIKE('foo', '.*')",
+                "starrocks": "REGEXP('foo', '.*')",
+            },
         ),
         self.validate_all(
             '"""x"""',
@@ -481,6 +486,14 @@ class TestBigQuery(Validator):
             write={
                 "bigquery": "DATE_DIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE), DAY)",
                 "mysql": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+                "starrocks": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+            },
+        )
+        self.validate_all(
+            "DATE_DIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE), DAY)",
+            read={
+                "mysql": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+                "starrocks": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -486,7 +486,7 @@ class TestBigQuery(Validator):
             write={
                 "bigquery": "DATE_DIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE), DAY)",
                 "mysql": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
-                "starrocks": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+                "starrocks": "DATE_DIFF('DAY', CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
             },
         )
         self.validate_all(
@@ -500,7 +500,7 @@ class TestBigQuery(Validator):
             "DATE_DIFF(DATE '2010-07-07', DATE '2008-12-25', MINUTE)",
             write={
                 "bigquery": "DATE_DIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE), MINUTE)",
-                "mysql": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+                "starrocks": "DATE_DIFF('MINUTE', CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -202,6 +202,8 @@ class TestBigQuery(Validator):
             "REGEXP_CONTAINS('foo', '.*')",
             read={
                 "bigquery": "REGEXP_CONTAINS('foo', '.*')",
+                "mysql": "REGEXP_LIKE('foo', '.*')",
+                "starrocks": "REGEXP('foo', '.*')",
             },
             write={
                 "mysql": "REGEXP_LIKE('foo', '.*')",

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -1,7 +1,7 @@
 from tests.dialects.test_dialect import Validator
 
 
-class TestMySQL(Validator):
+class TestStarrocks(Validator):
     dialect = "starrocks"
 
     def test_identity(self):
@@ -10,6 +10,12 @@ class TestMySQL(Validator):
 
     def test_time(self):
         self.validate_identity("TIMESTAMP('2022-01-01')")
+        self.validate_identity(
+            "SELECT DATE_DIFF('second', '2010-11-30 23:59:59', '2010-11-30 20:58:59')"
+        )
+        self.validate_identity(
+            "SELECT DATE_DIFF('minute', '2010-11-30 23:59:59', '2010-11-30 20:58:59')"
+        )
 
     def test_regex(self):
         self.validate_all(
@@ -17,5 +23,8 @@ class TestMySQL(Validator):
             read={
                 "mysql": "SELECT REGEXP_LIKE(abc, '%foo%')",
                 "starrocks": "SELECT REGEXP(abc, '%foo%')",
+            },
+            write={
+                "mysql": "SELECT REGEXP_LIKE(abc, '%foo%')",
             },
         )

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -13,8 +13,9 @@ class TestMySQL(Validator):
 
     def test_regex(self):
         self.validate_all(
-            "SELECT REGEXP_LIKE(abc, '%foo%')",
-            write={
+            "SELECT REGEXP(abc, '%foo%')",
+            read={
+                "mysql": "SELECT REGEXP_LIKE(abc, '%foo%')",
                 "starrocks": "SELECT REGEXP(abc, '%foo%')",
             },
         )


### PR DESCRIPTION
See:
- https://github.com/tobymao/sqlglot/pull/2006#discussion_r1287176192
- https://github.com/tobymao/sqlglot/pull/2006#discussion_r1287181377

References:
- https://docs.starrocks.io/en-us/3.0/sql-reference/sql-functions/like_predicate-functions/regexp
- https://docs.starrocks.io/en-us/3.0/sql-reference/sql-functions/date-time-functions/datediff
- https://docs.starrocks.io/en-us/3.0/sql-reference/sql-functions/date-time-functions/date_diff