### PR TITLE
Fix(executor): add table normalization, fix python type mapping

### DIFF
--- a/sqlglot/executor/__init__.py
+++ b/sqlglot/executor/__init__.py
@@ -28,6 +28,11 @@ if t.TYPE_CHECKING:
     from sqlglot.schema import Schema
 
 
+PYTHON_TYPE_TO_SQLGLOT = {
+    "dict": "MAP",
+}
+
+
 def execute(
     sql: str | Expression,
     schema: t.Optional[t.Dict | Schema] = None,
@@ -50,7 +55,7 @@ def execute(
     Returns:
         Simple columnar data structure.
     """
-    tables_ = ensure_tables(tables)
+    tables_ = ensure_tables(tables, dialect=read)
 
     if not schema:
         schema = {}
@@ -61,7 +66,8 @@ def execute(
             assert table is not None
 
             for column in table.columns:
-                nested_set(schema, [*keys, column], type(table[0][column]).__name__)
+                py_type = type(table[0][column]).__name__
+                nested_set(schema, [*keys, column], PYTHON_TYPE_TO_SQLGLOT.get(py_type) or py_type)
 
     schema = ensure_schema(schema, dialect=read)
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -723,3 +723,24 @@ class TestExecutor(unittest.TestCase):
                 result = execute(sql, tables=tables)
                 self.assertEqual(result.columns, columns)
                 self.assertEqual(result.rows, expected)
+
+    def test_dict_values(self):
+        tables = {
+            "foo": [{"raw": {"name": "Hello, World"}}],
+        }
+        result = execute("SELECT raw:name AS name FROM foo", read="snowflake", tables=tables)
+
+        self.assertEqual(result.columns, ("NAME",))
+        self.assertEqual(result.rows, [("Hello, World",)])
+
+        tables = {
+            '"ITEM"': [
+                {"id": 1, "attributes": {"flavor": "cherry", "taste": "sweet"}},
+                {"id": 2, "attributes": {"flavor": "lime", "taste": "sour"}},
+                {"id": 3, "attributes": {"flavor": "apple", "taste": None}},
+            ]
+        }
+        result = execute("SELECT i.attributes.flavor FROM `ITEM` i", read="bigquery", tables=tables)
+
+        self.assertEqual(result.columns, ("flavor",))
+        self.assertEqual(result.rows, [("cherry",), ("lime",), ("apple",)])


### PR DESCRIPTION
FYI there was probably a change related to the normalization logic, which broke the case mentioned in https://github.com/tobymao/sqlglot/issues/1676 (for which we didn't have a unit test, it seems). We were never hitting the section where we try to parse `DICT` as a `DataType`, so this bug was hidden at the time the issue was marked as resolved.