### PR TITLE
feat: simplify COALESCE

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -486,13 +486,17 @@ def simplify_coalesce(expression):
     if isinstance(rightmost_arg, CONSTANTS) and isinstance(other, CONSTANTS):
         rightmost_arg.pop()
 
+        # Remove the COALESCE function. This is an optimization, skipping a simplify iteration,
+        # since we already remove COALESCE at the top of this function.
+        coalesce = coalesce if coalesce.expressions else coalesce.this
+
         return exp.or_(
             exp.and_(
-                coalesce.copy().is_(exp.null()).not_(),
-                expression.copy(),
+                coalesce.is_(exp.null()).not_(),
+                expression,
             ),
             exp.and_(
-                coalesce.copy().is_(exp.null()),
+                coalesce.is_(exp.null()),
                 type(expression)(this=rightmost_arg.copy(), expression=other.copy()),
             ),
         )

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -469,15 +469,16 @@ def simplify_coalesce(expression):
     else:
         return expression
 
-    # 'COALESCE(x, 1) = 2' ->
-    #     '(
-    #         NOT COALESCE(x) IS NULL
-    #         AND COALESCE(x) = 2
-    #      )
-    #      OR (
-    #          COALESCE(x) IS NULL
-    #          AND 1 = 2
-    #      )
+    # COALESCE(x, 1) = 2
+    # becomes
+    # (
+    #     NOT COALESCE(x) IS NULL
+    #     AND COALESCE(x) = 2
+    # )
+    # OR (
+    #     COALESCE(x) IS NULL
+    #     AND 1 = 2
+    # )
     # This may seem more complex, but subsequent simplify steps will further reduce this.
     #
     # This transformation is valid for non-constants,

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -436,7 +436,6 @@ CONSTANTS = (
     exp.Literal,
     exp.Boolean,
     exp.Null,
-    exp.Date,
 )
 
 

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -602,3 +602,33 @@ TRUE;
 
 x = 2018 OR x <> 2018;
 x <> 2018 OR x = 2018;
+
+--------------------------------------
+-- Coalesce
+--------------------------------------
+COALESCE(x);
+x;
+
+COALESCE(x, 1) = 2;
+x = 2 AND NOT x IS NULL;
+
+2 = COALESCE(x, 1);
+2 = x AND NOT x IS NULL;
+
+COALESCE(x, 1, 1) = 1 + 1;
+x = 2 AND NOT x IS NULL;
+
+COALESCE(x, 3) <= 2;
+x <= 2 AND NOT x IS NULL;
+
+COALESCE(x, 1) <> 2;
+x <> 2 OR x IS NULL;
+
+COALESCE(x, 1) <= 2;
+x <= 2 OR x IS NULL;
+
+COALESCE(x, 1) = 1;
+x = 1 OR x IS NULL;
+
+COALESCE(x, 1) IS NULL;
+FALSE;

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -618,6 +618,9 @@ x = 2 AND NOT x IS NULL;
 COALESCE(x, 1, 1) = 1 + 1;
 x = 2 AND NOT x IS NULL;
 
+COALESCE(x, 1, 2) = 2;
+x = 2 AND NOT x IS NULL;
+
 COALESCE(x, 3) <= 2;
 x <= 2 AND NOT x IS NULL;
 

--- a/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
+++ b/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
@@ -10833,9 +10833,11 @@ LEFT JOIN "ws"
   AND "ws"."ws_item_sk" = "ss"."ss_item_sk"
   AND "ws"."ws_sold_year" = "ss"."ss_sold_year"
 WHERE
-  "ss"."ss_sold_year" = 1999
-  AND COALESCE("cs"."cs_qty", 0) > 0
-  AND COALESCE("ws"."ws_qty", 0) > 0
+  "cs"."cs_qty" > 0
+  AND "ss"."ss_sold_year" = 1999
+  AND "ws"."ws_qty" > 0
+  AND NOT "cs"."cs_qty" IS NULL
+  AND NOT "ws"."ws_qty" IS NULL
 ORDER BY
   "ss_item_sk",
   "ss"."ss_qty" DESC,


### PR DESCRIPTION
This is a tricky one.

I don't think this is necessarily simpler _semantically_. But it does remove COALESCE functions, which is kind of a normalization.

And it _does_ optimize queries for StarRocks. Not sure about other engines.