### PR TITLE
Feat(duckdb): improve support for INT128, HUGEINT, NUMERIC

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -41,7 +41,6 @@ class ClickHouse(Dialect):
             "FLOAT32": TokenType.FLOAT,
             "FLOAT64": TokenType.DOUBLE,
             "GLOBAL": TokenType.GLOBAL,
-            "INT128": TokenType.INT128,
             "INT16": TokenType.SMALLINT,
             "INT256": TokenType.INT256,
             "INT32": TokenType.INT,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -659,6 +659,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "TINYINT": TokenType.TINYINT,
         "SHORT": TokenType.SMALLINT,
         "SMALLINT": TokenType.SMALLINT,
+        "INT128": TokenType.INT128,
         "INT2": TokenType.SMALLINT,
         "INTEGER": TokenType.INT,
         "INT": TokenType.INT,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -497,8 +497,12 @@ class TestDuckDB(Validator):
         self.validate_identity("CAST(x AS USMALLINT)")
         self.validate_identity("CAST(x AS UTINYINT)")
         self.validate_identity("CAST(x AS TEXT)")
+        self.validate_identity("CAST(x AS INT128)")
+        self.validate_identity("CAST(x AS DOUBLE)")
+        self.validate_identity("CAST(x AS DECIMAL(15, 4))")
 
-        self.validate_all("CAST(x AS NUMERIC)", write={"duckdb": "CAST(x AS DOUBLE)"})
+        self.validate_all("CAST(x AS NUMERIC(1, 2))", write={"duckdb": "CAST(x AS DECIMAL(1, 2))"})
+        self.validate_all("CAST(x AS HUGEINT)", write={"duckdb": "CAST(x AS INT128)"})
         self.validate_all("CAST(x AS CHAR)", write={"duckdb": "CAST(x AS TEXT)"})
         self.validate_all("CAST(x AS BPCHAR)", write={"duckdb": "CAST(x AS TEXT)"})
         self.validate_all("CAST(x AS STRING)", write={"duckdb": "CAST(x AS TEXT)"})
@@ -513,6 +517,20 @@ class TestDuckDB(Validator):
         self.validate_all("CAST(x AS BINARY)", write={"duckdb": "CAST(x AS BLOB)"})
         self.validate_all("CAST(x AS VARBINARY)", write={"duckdb": "CAST(x AS BLOB)"})
         self.validate_all("CAST(x AS LOGICAL)", write={"duckdb": "CAST(x AS BOOLEAN)"})
+        self.validate_all(
+            "CAST(x AS NUMERIC)",
+            write={
+                "duckdb": "CAST(x AS DECIMAL(18, 3))",
+                "postgres": "CAST(x AS DECIMAL(18, 3))",
+            },
+        )
+        self.validate_all(
+            "CAST(x AS DECIMAL)",
+            write={
+                "duckdb": "CAST(x AS DECIMAL(18, 3))",
+                "postgres": "CAST(x AS DECIMAL(18, 3))",
+            },
+        )
         self.validate_all(
             "CAST(x AS BIT)",
             read={


### PR DESCRIPTION
Fixes #2022

Still investigating about the `TIMESTAMP_*` types.