### PR TITLE
Feat!(optimizer): simplify concat

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -122,7 +122,7 @@ class _Dialect(type):
                 if hasattr(subclass, name):
                     setattr(subclass, name, value)
 
-        if not klass.STRICT_STRING_CONCAT:
+        if not klass.STRICT_STRING_CONCAT and klass.DPIPE_IS_STRING_CONCAT:
             klass.parser_class.BITWISE[TokenType.DPIPE] = exp.SafeDPipe
 
         klass.generator_class.can_identify = klass.can_identify
@@ -146,6 +146,9 @@ class Dialect(metaclass=_Dialect):
 
     # Determines whether or not an unquoted identifier can start with a digit
     IDENTIFIERS_CAN_START_WITH_DIGIT = False
+
+    # Determines whether or not the DPIPE token ('||') is a string concatenation operator
+    DPIPE_IS_STRING_CONCAT = True
 
     # Determines whether or not CONCAT's arguments must be strings
     STRICT_STRING_CONCAT = False

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -94,6 +94,7 @@ def _date_add_sql(kind: str) -> t.Callable[[generator.Generator, exp.DateAdd | e
 
 class MySQL(Dialect):
     TIME_FORMAT = "'%Y-%m-%d %T'"
+    DPIPE_IS_STRING_CONCAT = False
 
     # https://prestodb.io/docs/current/functions/datetime.html#mysql-date-functions
     TIME_MAPPING = {
@@ -195,7 +196,13 @@ class MySQL(Dialect):
             **parser.Parser.CONJUNCTION,
             TokenType.DAMP: exp.And,
             TokenType.XOR: exp.Xor,
+            TokenType.DPIPE: exp.Or,
         }
+
+        # MySQL uses || as a synonym to the logical OR operator
+        # https://dev.mysql.com/doc/refman/8.0/en/logical-operators.html#operator_or
+        BITWISE = parser.Parser.BITWISE.copy()
+        BITWISE.pop(TokenType.DPIPE)
 
         TABLE_ALIAS_TOKENS = (
             parser.Parser.TABLE_ALIAS_TOKENS - parser.Parser.TABLE_INDEX_HINT_TOKENS

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -509,7 +509,7 @@ SAFE_CONCATS = (exp.SafeConcat, exp.SafeDPipe)
 
 def simplify_concat(expression):
     """Reduces all groups that contain string literals by concatenating them."""
-    if not isinstance(expression, CONCATS):
+    if not isinstance(expression, CONCATS) or isinstance(expression, exp.ConcatWs):
         return expression
 
     new_args = []

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -103,6 +103,7 @@ class TestMySQL(Validator):
         self.validate_identity("@@GLOBAL.max_connections")
         self.validate_identity("CREATE TABLE A LIKE B")
         self.validate_identity("SELECT * FROM t1, t2 FOR SHARE OF t1, t2 SKIP LOCKED")
+        self.validate_identity("SELECT a || b", "SELECT a OR b")
         self.validate_identity(
             """SELECT * FROM foo WHERE 3 MEMBER OF(JSON_EXTRACT(info, '$.value'))"""
         )

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -944,3 +944,9 @@ SELECT
 FROM "m"
 JOIN "n" AS "foo"("a")
   ON "m"."a" = "foo"."a";
+
+# title: reduction of string concatenation that uses CONCAT(..), || and +
+# execute: false
+SELECT CONCAT('a', 'b') || CONCAT(CONCAT('c', 'd'), CONCAT('e', 'f')) + ('g' || 'h' || 'i');
+SELECT
+  'abcdefghi' AS "_col_0";

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -657,8 +657,8 @@ x;
 CONCAT('a', 'b', 'c');
 'abc';
 
-CONCAT('a', x, 'b', 'c');
-CONCAT('a', x, 'bc');
+CONCAT('a', x, y, 'b', 'c');
+CONCAT('a', x, y, 'bc');
 
 'a' || 'b';
 'ab';

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -644,3 +644,24 @@ x = 1 OR x IS NULL;
 
 COALESCE(x, 1) IS NULL;
 FALSE;
+
+--------------------------------------
+-- CONCAT
+--------------------------------------
+CONCAT(x, y);
+CONCAT(x, y);
+
+CONCAT(x);
+x;
+
+CONCAT('a', 'b', 'c');
+'abc';
+
+CONCAT('a', x, 'b', 'c');
+CONCAT('a', x, 'bc');
+
+'a' || 'b';
+'ab';
+
+'a' || 'b' || x;
+CONCAT('ab', x);

--- a/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
+++ b/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
@@ -857,7 +857,7 @@ WITH "salesreturns" AS (
 ), "cte_10" AS (
   SELECT
     'catalog channel' AS "channel",
-    'catalog_page' || "csr"."cp_catalog_page_id" AS "id",
+    CONCAT('catalog_page', "csr"."cp_catalog_page_id") AS "id",
     "csr"."sales" AS "sales",
     "csr"."returns1" AS "returns1",
     "csr"."profit" - "csr"."profit_loss" AS "profit"
@@ -865,7 +865,7 @@ WITH "salesreturns" AS (
   UNION ALL
   SELECT
     'web channel' AS "channel",
-    'web_site' || "wsr"."web_site_id" AS "id",
+    CONCAT('web_site', "wsr"."web_site_id") AS "id",
     "wsr"."sales" AS "sales",
     "wsr"."returns1" AS "returns1",
     "wsr"."profit" - "wsr"."profit_loss" AS "profit"
@@ -873,7 +873,7 @@ WITH "salesreturns" AS (
 ), "x" AS (
   SELECT
     'store channel' AS "channel",
-    'store' || "ssr"."s_store_id" AS "id",
+    CONCAT('store', "ssr"."s_store_id") AS "id",
     "ssr"."sales" AS "sales",
     "ssr"."returns1" AS "returns1",
     "ssr"."profit" - "ssr"."profit_loss" AS "profit"
@@ -8611,7 +8611,7 @@ WITH "date_dim_2" AS (
     "warehouse"."w_county" AS "w_county",
     "warehouse"."w_state" AS "w_state",
     "warehouse"."w_country" AS "w_country",
-    'ZOUROS' || ',' || 'ZHOU' AS "ship_carriers",
+    'ZOUROS,ZHOU' AS "ship_carriers",
     "date_dim"."d_year" AS "year1",
     SUM(
       CASE
@@ -8806,7 +8806,7 @@ WITH "date_dim_2" AS (
     "warehouse"."w_county" AS "w_county",
     "warehouse"."w_state" AS "w_state",
     "warehouse"."w_country" AS "w_country",
-    'ZOUROS' || ',' || 'ZHOU' AS "ship_carriers",
+    'ZOUROS,ZHOU' AS "ship_carriers",
     "date_dim"."d_year" AS "year1",
     SUM(
       CASE
@@ -11123,7 +11123,7 @@ WITH "date_dim_2" AS (
 ), "cte_4" AS (
   SELECT
     'catalog channel' AS "channel",
-    'catalog_page' || "csr"."catalog_page_id" AS "id",
+    CONCAT('catalog_page', "csr"."catalog_page_id") AS "id",
     "csr"."sales" AS "sales",
     "csr"."returns1" AS "returns1",
     "csr"."profit" AS "profit"
@@ -11131,7 +11131,7 @@ WITH "date_dim_2" AS (
   UNION ALL
   SELECT
     'web channel' AS "channel",
-    'web_site' || "wsr"."web_site_id" AS "id",
+    CONCAT('web_site', "wsr"."web_site_id") AS "id",
     "wsr"."sales" AS "sales",
     "wsr"."returns1" AS "returns1",
     "wsr"."profit" AS "profit"
@@ -11139,7 +11139,7 @@ WITH "date_dim_2" AS (
 ), "x" AS (
   SELECT
     'store channel' AS "channel",
-    'store' || "ssr"."store_id" AS "id",
+    CONCAT('store', "ssr"."store_id") AS "id",
     "ssr"."sales" AS "sales",
     "ssr"."returns1" AS "returns1",
     "ssr"."profit" AS "profit"
@@ -11571,7 +11571,7 @@ ORDER  BY c_customer_id
 LIMIT 100;
 SELECT
   "customer"."c_customer_id" AS "customer_id",
-  "customer"."c_last_name" || ', ' || "customer"."c_first_name" AS "customername"
+  CONCAT("customer"."c_last_name", ', ', "customer"."c_first_name") AS "customername"
 FROM "customer" AS "customer"
 JOIN "customer_address" AS "customer_address"
   ON "customer"."c_current_addr_sk" = "customer_address"."ca_address_sk"


### PR DESCRIPTION
This PR implements a new transformation for simplifying `CONCAT(...)` calls by reducing _groups_ of consecutive string literal arguments into single string literals.

Before:
```python
CONCAT('a', 'b', 'c') --> CONCAT('a', 'b', 'c')
```

After:
```python
CONCAT('a', 'b', 'c') --> 'abc'
```

Additionally, I fixed a bug in the MySQL dialect, where `||` was wrongly interpreted as a string concatenation operator, when it's actually a synonym to the [logical OR operator](https://dev.mysql.com/doc/refman/8.0/en/logical-operators.html#operator_or).