### PR TITLE
Fix(parser): ensure identifiers aren't treated as NO_PAREN_FUNCTIONS

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -728,6 +728,11 @@ class Parser(metaclass=_Parser):
         "NEXT": lambda self: self._parse_next_value_for(),
     }
 
+    INVALID_FUNC_NAME_TOKENS = {
+        TokenType.IDENTIFIER,
+        TokenType.STRING,
+    }
+
     FUNCTIONS_WITH_ALIASED_ARGS = {"STRUCT"}
 
     FUNCTION_PARSERS = {
@@ -3356,7 +3361,7 @@ class Parser(metaclass=_Parser):
         upper = this.upper()
 
         parser = self.NO_PAREN_FUNCTION_PARSERS.get(upper)
-        if optional_parens and parser and token_type != TokenType.IDENTIFIER:
+        if optional_parens and parser and token_type not in self.INVALID_FUNC_NAME_TOKENS:
             self._advance()
             return parser(self)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3356,7 +3356,7 @@ class Parser(metaclass=_Parser):
         upper = this.upper()
 
         parser = self.NO_PAREN_FUNCTION_PARSERS.get(upper)
-        if optional_parens and parser:
+        if optional_parens and parser and token_type != TokenType.IDENTIFIER:
             self._advance()
             return parser(self)
 

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -855,3 +855,4 @@ SELECT * FROM (tbl1 CROSS JOIN (SELECT * FROM tbl2) AS t1)
 /* comment1 */ DELETE FROM x /* comment2 */ WHERE y > 1
 /* comment */ CREATE TABLE foo AS SELECT 1
 SELECT next, transform, if
+SELECT "any", "case", "if", "next"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -217,6 +217,9 @@ class TestParser(unittest.TestCase):
             parse_one("IF(a > 0)")
 
         with self.assertRaises(ParseError):
+            parse_one("SELECT CASE FROM x")
+
+        with self.assertRaises(ParseError):
             parse_one("WITH cte AS (SELECT * FROM x)")
 
         with self.assertRaises(ParseError):


### PR DESCRIPTION
There was a regression due to https://github.com/tobymao/sqlglot/commit/0b4c6c859339d012f8302ff7fcb21195587ac428:

```python
>>> import sqlglot
>>> sqlglot.parse_one('SELECT "case"')
sqlglot.errors.ParseError: Expected END after CASE. Line 1, Col: 13.
  SELECT "case"
          ~~~~
```

This is because we use the text of `"CASE"` to do a dict lookup in `NO_PAREN_FUNCTION_PARSERS` and so instead of parsing an identifier we hit the above error in `_parse_case`.