### PR TITLE
Feat(tsql): transpile CREATE SCHEMA IF NOT EXISTS to dynamic SQL

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -666,6 +666,16 @@ class TSQL(Dialect):
 
             return sql
 
+        def create_sql(self, expression: exp.Create) -> str:
+            kind = self.sql(expression, "kind").upper()
+            exists = expression.args.get("exists")
+
+            if exists and kind == "SCHEMA":
+                schema_name = self.sql(expression, "this")
+                return f"IF NOT EXISTS (SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME = {schema_name}) EXEC('CREATE SCHEMA {schema_name}')"
+
+            return super().create_sql(expression)
+
         def offset_sql(self, expression: exp.Offset) -> str:
             return f"{super().offset_sql(expression)} ROWS"
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -411,6 +411,12 @@ class TestTSQL(Validator):
 
     def test_ddl(self):
         self.validate_all(
+            "IF NOT EXISTS (SELECT * FROM information_schema.schemata WHERE SCHEMA_NAME = foo) EXEC('CREATE SCHEMA foo')",
+            read={
+                "": "CREATE SCHEMA IF NOT EXISTS foo",
+            },
+        )
+        self.validate_all(
             "CREATE TABLE #mytemp (a INTEGER, b CHAR(2), c TIME(4), d FLOAT(24))",
             write={
                 "spark": "CREATE TEMPORARY TABLE mytemp (a INT, b CHAR(2), c TIMESTAMP, d FLOAT)",


### PR DESCRIPTION
Fixes #2065

Right now, transpiling `CREATE SCHEMA IF NOT EXISTS <name>` to T-SQL produces invalid code. This PR aims to address simple cases like this by transpiling them into dynamic SQL that checks whether the schema exists with an `IF` statement and if it doesn't it creates it with an `EXEC` call.

This seems to be a needed workaround because of T-SQL's [constraints](https://stackoverflow.com/a/5748107) around schema creation (see the corresponding issue for more context).

cc: @deschman