### PR TITLE
Feat: Support dialect across all Dataframe Operations

### DIFF
--- a/sqlglot/dataframe/sql/normalize.py
+++ b/sqlglot/dataframe/sql/normalize.py
@@ -5,7 +5,6 @@ import typing as t
 from sqlglot import expressions as exp
 from sqlglot.dataframe.sql.column import Column
 from sqlglot.dataframe.sql.util import get_tables_from_expression_with_join
-from sqlglot.dialects import Spark
 from sqlglot.helper import ensure_list
 
 NORMALIZE_INPUT = t.TypeVar("NORMALIZE_INPUT", bound=t.Union[str, exp.Expression, Column])
@@ -20,7 +19,7 @@ def normalize(spark: SparkSession, expression_context: exp.Select, expr: t.List[
     for expression in expressions:
         identifiers = expression.find_all(exp.Identifier)
         for identifier in identifiers:
-            Spark.normalize_identifier(identifier)
+            identifier.transform(spark.dialect.normalize_identifier)
             replace_alias_name_with_cte_name(spark, expression_context, identifier)
             replace_branch_and_sequence_ids_with_cte_name(spark, expression_context, identifier)
 

--- a/sqlglot/dataframe/sql/window.py
+++ b/sqlglot/dataframe/sql/window.py
@@ -48,7 +48,9 @@ class WindowSpec:
         return WindowSpec(self.expression.copy())
 
     def sql(self, **kwargs) -> str:
-        return self.expression.sql(dialect="spark", **kwargs)
+        from sqlglot.dataframe.sql.session import SparkSession
+
+        return self.expression.sql(dialect=SparkSession().dialect, **kwargs)
 
     def partitionBy(self, *cols: t.Union[ColumnOrName, t.List[ColumnOrName]]) -> WindowSpec:
         from sqlglot.dataframe.sql.column import Column

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -33,6 +33,15 @@ class AutoName(Enum):
         return name
 
 
+class classproperty(property):
+    """
+    Similar to a normal property but works for class methods
+    """
+
+    def __get__(self, obj: t.Any, owner: t.Any = None) -> t.Any:
+        return classmethod(self.fget).__get__(None, owner)()  # type: ignore
+
+
 def seq_get(seq: t.Sequence[T], index: int) -> t.Optional[T]:
     """Returns the value in `seq` at position `index`, or `None` if `index` is out of bounds."""
     try:

--- a/tests/dataframe/unit/dataframe_sql_validator.py
+++ b/tests/dataframe/unit/dataframe_sql_validator.py
@@ -1,14 +1,11 @@
-import typing as t
-import unittest
-
 from sqlglot.dataframe.sql import types
-from sqlglot.dataframe.sql.dataframe import DataFrame
 from sqlglot.dataframe.sql.session import SparkSession
-from sqlglot.helper import ensure_list
+from tests.dataframe.unit.dataframe_test_base import DataFrameTestBase
 
 
-class DataFrameSQLValidator(unittest.TestCase):
+class DataFrameSQLValidator(DataFrameTestBase):
     def setUp(self) -> None:
+        super().setUp()
         self.spark = SparkSession()
         self.employee_schema = types.StructType(
             [
@@ -29,12 +26,3 @@ class DataFrameSQLValidator(unittest.TestCase):
         self.df_employee = self.spark.createDataFrame(
             data=employee_data, schema=self.employee_schema
         )
-
-    def compare_sql(
-        self, df: DataFrame, expected_statements: t.Union[str, t.List[str]], pretty=False
-    ):
-        actual_sqls = df.sql(pretty=pretty)
-        expected_statements = ensure_list(expected_statements)
-        self.assertEqual(len(expected_statements), len(actual_sqls))
-        for expected, actual in zip(expected_statements, actual_sqls):
-            self.assertEqual(expected, actual)

--- a/tests/dataframe/unit/dataframe_test_base.py
+++ b/tests/dataframe/unit/dataframe_test_base.py
@@ -1,0 +1,23 @@
+import typing as t
+import unittest
+
+import sqlglot
+from sqlglot import MappingSchema
+from sqlglot.dataframe.sql import SparkSession
+from sqlglot.dataframe.sql.dataframe import DataFrame
+from sqlglot.helper import ensure_list
+
+
+class DataFrameTestBase(unittest.TestCase):
+    def setUp(self) -> None:
+        sqlglot.schema = MappingSchema()
+        SparkSession._instance = None
+
+    def compare_sql(
+        self, df: DataFrame, expected_statements: t.Union[str, t.List[str]], pretty=False
+    ):
+        actual_sqls = df.sql(pretty=pretty)
+        expected_statements = ensure_list(expected_statements)
+        self.assertEqual(len(expected_statements), len(actual_sqls))
+        for expected, actual in zip(expected_statements, actual_sqls):
+            self.assertEqual(expected, actual)

--- a/tests/dataframe/unit/test_session.py
+++ b/tests/dataframe/unit/test_session.py
@@ -1,9 +1,6 @@
-from unittest import mock
-
 import sqlglot
 from sqlglot.dataframe.sql import functions as F, types
 from sqlglot.dataframe.sql.session import SparkSession
-from sqlglot.schema import MappingSchema
 from tests.dataframe.unit.dataframe_sql_validator import DataFrameSQLValidator
 
 
@@ -68,7 +65,6 @@ class TestDataframeSession(DataFrameSQLValidator):
 
         self.compare_sql(df, expected)
 
-    @mock.patch("sqlglot.schema", MappingSchema())
     def test_sql_select_only(self):
         query = "SELECT cola, colb FROM table"
         sqlglot.schema.add_table("table", {"cola": "string", "colb": "string"}, dialect="spark")
@@ -78,16 +74,6 @@ class TestDataframeSession(DataFrameSQLValidator):
             df.sql(pretty=False)[0],
         )
 
-    @mock.patch("sqlglot.schema", MappingSchema())
-    def test_select_quoted(self):
-        sqlglot.schema.add_table("`TEST`", {"name": "string"}, dialect="spark")
-
-        self.assertEqual(
-            SparkSession().table("`TEST`").select(F.col("name")).sql(dialect="snowflake")[0],
-            '''SELECT "test"."name" AS "name" FROM "test" AS "test"''',
-        )
-
-    @mock.patch("sqlglot.schema", MappingSchema())
     def test_sql_with_aggs(self):
         query = "SELECT cola, colb FROM table"
         sqlglot.schema.add_table("table", {"cola": "string", "colb": "string"}, dialect="spark")
@@ -97,7 +83,6 @@ class TestDataframeSession(DataFrameSQLValidator):
             df.sql(pretty=False, optimize=False)[0],
         )
 
-    @mock.patch("sqlglot.schema", MappingSchema())
     def test_sql_create(self):
         query = "CREATE TABLE new_table AS WITH t1 AS (SELECT cola, colb FROM table) SELECT cola, colb, FROM t1"
         sqlglot.schema.add_table("table", {"cola": "string", "colb": "string"}, dialect="spark")
@@ -105,7 +90,6 @@ class TestDataframeSession(DataFrameSQLValidator):
         expected = "CREATE TABLE new_table AS SELECT `table`.`cola` AS `cola`, `table`.`colb` AS `colb` FROM `table` AS `table`"
         self.compare_sql(df, expected)
 
-    @mock.patch("sqlglot.schema", MappingSchema())
     def test_sql_insert(self):
         query = "WITH t1 AS (SELECT cola, colb FROM table) INSERT INTO new_table SELECT cola, colb FROM t1"
         sqlglot.schema.add_table("table", {"cola": "string", "colb": "string"}, dialect="spark")
@@ -114,5 +98,4 @@ class TestDataframeSession(DataFrameSQLValidator):
         self.compare_sql(df, expected)
 
     def test_session_create_builder_patterns(self):
-        spark = SparkSession()
-        self.assertEqual(spark.builder.appName("abc").getOrCreate(), spark)
+        self.assertEqual(SparkSession.builder.appName("abc").getOrCreate(), SparkSession())

--- a/tests/dataframe/unit/test_session_case_sensitivity.py
+++ b/tests/dataframe/unit/test_session_case_sensitivity.py
@@ -1,0 +1,81 @@
+import sqlglot
+from sqlglot.dataframe.sql import functions as F
+from sqlglot.dataframe.sql.session import SparkSession
+from sqlglot.errors import OptimizeError
+from tests.dataframe.unit.dataframe_test_base import DataFrameTestBase
+
+
+class TestSessionCaseSensitivity(DataFrameTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.spark = SparkSession.builder.config("sqlframe.dialect", "snowflake").getOrCreate()
+
+    tests = [
+        (
+            "All lower no intention of CS",
+            "test",
+            "test",
+            {"name": "VARCHAR"},
+            "name",
+            '''SELECT "TEST"."NAME" AS "NAME" FROM "TEST" AS "TEST"''',
+        ),
+        (
+            "Table has CS while column does not",
+            '"Test"',
+            '"Test"',
+            {"name": "VARCHAR"},
+            "name",
+            '''SELECT "TEST"."NAME" AS "NAME" FROM "Test" AS "TEST"''',
+        ),
+        (
+            "Column has CS while table does not",
+            "test",
+            "test",
+            {'"Name"': "VARCHAR"},
+            '"Name"',
+            '''SELECT "TEST"."Name" AS "Name" FROM "TEST" AS "TEST"''',
+        ),
+        (
+            "Both Table and column have CS",
+            '"Test"',
+            '"Test"',
+            {'"Name"': "VARCHAR"},
+            '"Name"',
+            '''SELECT "TEST"."Name" AS "Name" FROM "Test" AS "TEST"''',
+        ),
+        (
+            "Lowercase CS table and column",
+            '"test"',
+            '"test"',
+            {'"name"': "VARCHAR"},
+            '"name"',
+            '''SELECT "TEST"."name" AS "name" FROM "test" AS "TEST"''',
+        ),
+        (
+            "CS table and column and query table but no CS in query column",
+            '"test"',
+            '"test"',
+            {'"name"': "VARCHAR"},
+            "name",
+            OptimizeError(),
+        ),
+        (
+            "CS table and column and query column but no CS in query table",
+            '"test"',
+            "test",
+            {'"name"': "VARCHAR"},
+            '"name"',
+            OptimizeError(),
+        ),
+    ]
+
+    def test_basic_case_sensitivity(self):
+        for test_name, table_name, spark_table, schema, spark_column, expected in self.tests:
+            with self.subTest(test_name):
+                sqlglot.schema.add_table(table_name, schema, dialect=self.spark.dialect)
+                df = self.spark.table(spark_table).select(F.col(spark_column))
+                if isinstance(expected, OptimizeError):
+                    with self.assertRaises(OptimizeError):
+                        df.sql()
+                else:
+                    self.compare_sql(df, expected)

--- a/tests/dataframe/unit/test_window.py
+++ b/tests/dataframe/unit/test_window.py
@@ -1,10 +1,9 @@
-import unittest
-
 from sqlglot.dataframe.sql import functions as F
 from sqlglot.dataframe.sql.window import Window, WindowSpec
+from tests.dataframe.unit.dataframe_test_base import DataFrameTestBase
 
 
-class TestDataframeWindow(unittest.TestCase):
+class TestDataframeWindow(DataFrameTestBase):
     def test_window_spec_partition_by(self):
         partition_by = WindowSpec().partitionBy(F.col("cola"), F.col("colb"))
         self.assertEqual("OVER (PARTITION BY cola, colb)", partition_by.sql())


### PR DESCRIPTION
Slack thread that prompted this change: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1692679901587439?thread_ts=1692679773.389409&cid=C0448SFS3PF

Prior to this change all input was assumed to be Spark and then you could transpile that final query to whatever dialect you wanted. One challenge with this approach is when the user wants to do something that isn't natively supported by Spark. This example was that the user wanted case-sensitive columns but all column input into the Dataframe was assumed to be Spark and therefore case-insensitive. 

This change makes it so that the SparkSession can be configured for a specific dialect and therefore that dialect would be used for parsing all user input. As shown by the tests, this then support case-sensitive input if the target engine is case-sensitive. 

The old behavior of allowing a dialect to be defined with the `sql` method is still supported for backwards compatibility. A warning is shown if their dialect doesn't match the configured dialect and shows them how to fix this going forward. The plan is to eventually drop `dialect` from `sql` in a future major release. 