### PR TITLE
Feat/tsql Add transpiling for `SET KEY VALUE`

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -49,6 +49,12 @@ TIME_DIFF_FACTOR = {
 
 DIFF_MONTH_SWITCH = ("YEAR", "QUARTER", "MONTH")
 
+def setitem_sql(self, expression: exp.SetItem) -> str:
+    left = self.sql(expression.this.left)   # IDENTIFIER, PARAMETER
+    right = self.sql(expression.this.right) # COLUMN, SUBQUERY
+    var = expression.args["var"]
+    eq = ' = '
+    return f"{left}{eq}{right}"
 
 def _add_date_sql(self: generator.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
     unit = expression.text("unit").upper()
@@ -460,6 +466,7 @@ class Hive(Dialect):
             exp.NumberToStr: rename_func("FORMAT_NUMBER"),
             exp.LastDateOfMonth: rename_func("LAST_DAY"),
             exp.National: lambda self, e: self.national_sql(e, prefix=""),
+            exp.SetItem: setitem_sql,
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -670,7 +670,6 @@ class TSQL(Dialect):
             exp.Min: min_or_least,
             exp.NumberToStr: _format_sql,
             exp.Select: transforms.preprocess([transforms.eliminate_distinct_on]),
-            # exp.Set: set_sql,
             exp.SetItem: setitem_sql,
             exp.SHA: lambda self, e: self.func("HASHBYTES", exp.Literal.string("SHA1"), e.this),
             exp.SHA2: lambda self, e: self.func(

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -200,17 +200,6 @@ def _parse_date_delta(
     return inner_func
 
 
-def setitem_sql(self, expression: exp.SetItem) -> str:
-    """tsql does not use '=' in SET command but does use '=' with Variables"""
-
-    left = self.sql(expression.this.left)
-    right = self.sql(expression.this.right)
-    if isinstance(expression.this.left, exp.Identifier):
-        return f"{left} {right}"
-    else:
-        return f"{left} = {right}"
-
-
 class TSQL(Dialect):
     RESOLVES_IDENTIFIERS_AS_UPPERCASE = None
     NULL_ORDERING = "nulls_are_small"
@@ -670,7 +659,7 @@ class TSQL(Dialect):
             exp.Min: min_or_least,
             exp.NumberToStr: _format_sql,
             exp.Select: transforms.preprocess([transforms.eliminate_distinct_on]),
-            exp.SetItem: setitem_sql,
+            exp.SetItem: lambda self, e: f"{self.sql(e.this.left)}{' ' if isinstance(e.this.left, exp.Identifier) else ' = '}{self.sql(e.this.right)}",
             exp.SHA: lambda self, e: self.func("HASHBYTES", exp.Literal.string("SHA1"), e.this),
             exp.SHA2: lambda self, e: self.func(
                 "HASHBYTES",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1058,6 +1058,7 @@ class SetItem(Expression):
         "kind": False,
         "collate": False,  # MySQL SET NAMES statement
         "global": False,
+        "var": False,
     }
 
 

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -45,7 +45,7 @@ class classproperty(property):
 def seq_get(seq: t.Sequence[T], index: int) -> t.Optional[T]:
     """Returns the value in `seq` at position `index`, or `None` if `index` is out of bounds."""
     try:
-        return seq[index]
+        return seq[index] if index < len(seq) else None
     except IndexError:
         return None
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4797,15 +4797,11 @@ class Parser(metaclass=_Parser):
             return self._parse_set_transaction(global_=kind == "GLOBAL")
 
         left = self._parse_primary() or self._parse_id_var()
-
-        if not self._match_texts(("=", "TO")):
-            self._retreat(index)
-            return None
-
+        eq = self._match_texts(("=", "TO"))
         right = self._parse_statement() or self._parse_id_var()
         this = self.expression(exp.EQ, this=left, expression=right)
 
-        return self.expression(exp.SetItem, this=this, kind=kind)
+        return self.expression(exp.SetItem, this=this, kind=kind, var=eq)
 
     def _parse_set_transaction(self, global_: bool = False) -> exp.Expression:
         self._match_text_seq("TRANSACTION")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -604,6 +604,23 @@ WHERE
                 "spark": "SET KEY = VALUE",
             },
         )
+        self.validate_all(
+            "SET @count = (select count(1) FROM x)",
+            write={
+                "tsql": "SET @count = (SELECT COUNT(1) FROM x)",
+                "duckdb": "SET count = (SELECT COUNT(1) FROM x)",
+                "spark": "SET count = (SELECT COUNT(1) FROM x)",
+            },
+        )
+        self.validate_all(
+            "SET @user OFF",
+            write={
+                "tsql": "SET @user OFF",
+                "duckdb": "SET user = OFF",
+                "spark": "SET user = OFF",
+            },
+        )
+
 
     def test_procedure_keywords(self):
         self.validate_identity("BEGIN")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -595,6 +595,16 @@ WHERE
             pretty=True,
         )
 
+    def test_set(self):
+        self.validate_all(
+            "SET KEY VALUE",
+            write={
+                "tsql": "SET KEY VALUE",
+                "duckdb": "SET KEY = VALUE",
+                "spark": "SET KEY = VALUE",
+            },
+        )
+
     def test_procedure_keywords(self):
         self.validate_identity("BEGIN")
         self.validate_identity("END")


### PR DESCRIPTION
Add transpiling for `SET KEY VALUE`.
These statements now run on Spark / Databricks.

** Documentation **
[Set Statements](https://learn.microsoft.com/en-us/sql/t-sql/statements/set-statements-transact-sql?view=sql-server-ver16)
[Set Variable](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/set-local-variable-transact-sql?view=sql-server-ver16)