### PR TITLE
Suppress generation of 'NULL' constraint during create table

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -109,6 +109,10 @@ def _array_sort_sql(self: generator.Generator, expression: exp.ArraySort) -> str
     return f"SORT_ARRAY({self.sql(expression, 'this')})"
 
 
+def notnullcolumnconstraint_sql(self, expression: exp.NotNullColumnConstraint) -> str:
+    return f"{'' if expression.args.get('allow_null') else 'NOT NULL'}"
+
+
 def _property_sql(self: generator.Generator, expression: exp.Property) -> str:
     return f"'{expression.name}'={self.sql(expression, 'value')}"
 
@@ -422,6 +426,7 @@ class Hive(Dialect):
             exp.MD5Digest: lambda self, e: self.func("UNHEX", self.func("MD5", e.this)),
             exp.Min: min_or_least,
             exp.MonthsBetween: lambda self, e: self.func("MONTHS_BETWEEN", e.this, e.expression),
+            exp.NotNullColumnConstraint: notnullcolumnconstraint_sql,
             exp.VarMap: var_map_sql,
             exp.Create: create_with_partitions_sql,
             exp.Quantile: rename_func("PERCENTILE"),

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -5,6 +5,15 @@ from tests.dialects.test_dialect import Validator
 class TestTSQL(Validator):
     dialect = "tsql"
 
+    def test_create_table(self):
+        self.validate_identity("CREATE TABLE x (A INTEGER NOT NULL, B INTEGER NULL)")
+        self.validate_all(
+            "CREATE TABLE x ( A INTEGER NOT NULL, B INTEGER NULL )",
+            write={
+                "hive": "CREATE TABLE x (A INT NOT NULL, B INT)",
+            },
+        )
+
     def test_tsql(self):
         self.validate_identity(
             'CREATE TABLE x (CONSTRAINT "pk_mytable" UNIQUE NONCLUSTERED (a DESC)) ON b (c)'


### PR DESCRIPTION
Hive, Spark, Databricks support the `NOT NULL` constraint but do not support the `NULL` constraint.

This PR suppresses 'NULL' column constraint generation in the Hive dialect and by extension Spark2, Spark(3), Databricks.


** NOT NULL constraint documentation **
https://issues.apache.org/jira/browse/HIVE-16575