### PR TITLE
Fix(tsql): generate IDENTITY instead of AUTO_INCREMENT

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -631,6 +631,7 @@ class TSQL(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: any_value_to_max_sql,
+            exp.AutoIncrementColumnConstraint: lambda *_: "IDENTITY(1, 1)",
             exp.DateAdd: generate_date_delta_with_unit_sql,
             exp.DateDiff: generate_date_delta_with_unit_sql,
             exp.CurrentDate: rename_func("GETDATE"),
@@ -763,3 +764,11 @@ class TSQL(Dialect):
             this = self.sql(expression, "this")
             expressions = self.expressions(expression, flat=True, sep=" ")
             return f"CONSTRAINT {this} {expressions}"
+
+        # https://learn.microsoft.com/en-us/answers/questions/448821/create-table-in-sql-server
+        def generatedasidentitycolumnconstraint_sql(
+            self, expression: exp.GeneratedAsIdentityColumnConstraint
+        ) -> str:
+            start = self.sql(expression, "start") or "1"
+            increment = self.sql(expression, "increment") or "1"
+            return f"IDENTITY({start}, {increment})"

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -631,7 +631,7 @@ class TSQL(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: any_value_to_max_sql,
-            exp.AutoIncrementColumnConstraint: lambda *_: "IDENTITY(1, 1)",
+            exp.AutoIncrementColumnConstraint: lambda *_: "IDENTITY",
             exp.DateAdd: generate_date_delta_with_unit_sql,
             exp.DateDiff: generate_date_delta_with_unit_sql,
             exp.CurrentDate: rename_func("GETDATE"),

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -444,6 +444,13 @@ class TestTSQL(Validator):
 
     def test_ddl(self):
         self.validate_all(
+            "CREATE TABLE tbl (id INTEGER IDENTITY(1, 1) PRIMARY KEY)",
+            read={
+                "mysql": "CREATE TABLE tbl (id INT AUTO_INCREMENT PRIMARY KEY)",
+                "tsql": "CREATE TABLE tbl (id INTEGER IDENTITY(1, 1) PRIMARY KEY)",
+            },
+        )
+        self.validate_all(
             "IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = object_id('db.tbl') AND name = 'idx') EXEC('CREATE INDEX idx ON db.tbl')",
             read={
                 "": "CREATE INDEX IF NOT EXISTS idx ON db.tbl",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -451,6 +451,13 @@ class TestTSQL(Validator):
             },
         )
         self.validate_all(
+            "CREATE TABLE tbl (id INTEGER NOT NULL IDENTITY(10, 1) PRIMARY KEY)",
+            read={
+                "postgres": "CREATE TABLE tbl (id INT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 10) PRIMARY KEY)",
+                "tsql": "CREATE TABLE tbl (id INTEGER NOT NULL IDENTITY(10, 1) PRIMARY KEY)",
+            },
+        )
+        self.validate_all(
             "IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = object_id('db.tbl') AND name = 'idx') EXEC('CREATE INDEX idx ON db.tbl')",
             read={
                 "": "CREATE INDEX IF NOT EXISTS idx ON db.tbl",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -444,10 +444,10 @@ class TestTSQL(Validator):
 
     def test_ddl(self):
         self.validate_all(
-            "CREATE TABLE tbl (id INTEGER IDENTITY(1, 1) PRIMARY KEY)",
+            "CREATE TABLE tbl (id INTEGER IDENTITY PRIMARY KEY)",
             read={
                 "mysql": "CREATE TABLE tbl (id INT AUTO_INCREMENT PRIMARY KEY)",
-                "tsql": "CREATE TABLE tbl (id INTEGER IDENTITY(1, 1) PRIMARY KEY)",
+                "tsql": "CREATE TABLE tbl (id INTEGER IDENTITY PRIMARY KEY)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #2126

References:
- https://learn.microsoft.com/en-us/answers/questions/448821/create-table-in-sql-server
- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql-identity-property?view=sql-server-ver15
- https://www.postgresqltutorial.com/postgresql-tutorial/postgresql-identity-column/