### PR TITLE
Fix: create the struct key properly in struct_extract_sql

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -414,9 +414,9 @@ def str_position_sql(self: Generator, expression: exp.StrPosition) -> str:
 
 
 def struct_extract_sql(self: Generator, expression: exp.StructExtract) -> str:
-    this = self.sql(expression, "this")
-    struct_key = self.sql(exp.Identifier(this=expression.expression.copy(), quoted=True))
-    return f"{this}.{struct_key}"
+    return (
+        f"{self.sql(expression, 'this')}.{self.sql(exp.to_identifier(expression.expression.name))}"
+    )
 
 
 def var_map_sql(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -182,18 +182,18 @@ class TestDuckDB(Validator):
             "STRUCT_EXTRACT(x, 'abc')",
             write={
                 "duckdb": "STRUCT_EXTRACT(x, 'abc')",
-                "presto": 'x."abc"',
-                "hive": "x.`abc`",
-                "spark": "x.`abc`",
+                "presto": "x.abc",
+                "hive": "x.abc",
+                "spark": "x.abc",
             },
         )
         self.validate_all(
             "STRUCT_EXTRACT(STRUCT_EXTRACT(x, 'y'), 'abc')",
             write={
                 "duckdb": "STRUCT_EXTRACT(STRUCT_EXTRACT(x, 'y'), 'abc')",
-                "presto": 'x."y"."abc"',
-                "hive": "x.`y`.`abc`",
-                "spark": "x.`y`.`abc`",
+                "presto": "x.y.abc",
+                "hive": "x.y.abc",
+                "spark": "x.y.abc",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -245,6 +245,12 @@ TBLPROPERTIES (
         )
 
         self.validate_all(
+            "foo.bar",
+            read={
+                "": "STRUCT_EXTRACT(foo, bar)",
+            },
+        )
+        self.validate_all(
             "MAP(1, 2, 3, 4)",
             write={
                 "spark": "MAP(1, 2, 3, 4)",


### PR DESCRIPTION
The issue here was:

```python
>>> sqlglot.parse_one("STRUCT_EXTRACT(foo, bar)").sql(dialect="spark")
'foo.``'
```

Notice how `bar` is dropped. The reason is that the identifier created in the following lines has an incorrect AST: there's a `Column` under the `Indentifier` node:

https://github.com/tobymao/sqlglot/blob/cc0a6e2f362af447db990825357f00d4f512e805/sqlglot/dialects/dialect.py#L416-L419