### PR TITLE
Fix(bigquery): parse JSON_OBJECT properly for key-value pairs

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -385,25 +385,6 @@ class BigQuery(Dialect):
 
             return table
 
-        def _parse_json_object(self) -> exp.JSONObject:
-            expressions: t.List[exp.Expression] = []
-            while True:
-                key = self._parse_field()
-                if key is None:
-                    if not expressions:
-                        break
-                    self.raise_error("Expecting key argument")
-                if not self._match(TokenType.COMMA):
-                    self.raise_error("Expecting a matching value argument")
-                value = self._parse_expression()
-                if value is None:
-                    self.raise_error("Expecting value argument")
-                expressions.append(self.expression(exp.JSONKeyValue, this=key, expression=value))
-                if not self._match(TokenType.COMMA):
-                    break
-
-            return self.expression(exp.JSONObject, expressions=expressions)
-
     class Generator(generator.Generator):
         EXPLICIT_UNION = True
         INTERVAL_ALLOWS_PLURAL_FORM = False

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -385,6 +385,25 @@ class BigQuery(Dialect):
 
             return table
 
+        def _parse_json_object(self) -> exp.JSONObject:
+            expressions: t.List[exp.Expression] = []
+            while True:
+                key = self._parse_field()
+                if key is None:
+                    if not expressions:
+                        break
+                    self.raise_error("Expecting key argument")
+                if not self._match(TokenType.COMMA):
+                    self.raise_error("Expecting a matching value argument")
+                value = self._parse_expression()
+                if value is None:
+                    self.raise_error("Expecting value argument")
+                expressions.append(self.expression(exp.JSONKeyValue, this=key, expression=value))
+                if not self._match(TokenType.COMMA):
+                    break
+
+            return self.expression(exp.JSONObject, expressions=expressions)
+
     class Generator(generator.Generator):
         EXPLICIT_UNION = True
         INTERVAL_ALLOWS_PLURAL_FORM = False
@@ -651,3 +670,6 @@ class BigQuery(Dialect):
                 expression = expression.copy()
                 expression.set("this", "SYSTEM_TIME")
             return super().version_sql(expression)
+
+        def jsonkeyvalue_sql(self, expression: exp.JSONKeyValue) -> str:
+            return f"{self.sql(expression, 'this')}, {self.sql(expression, 'expression')}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4139,9 +4139,9 @@ class Parser(metaclass=_Parser):
     def _parse_json_key_value(self) -> t.Optional[exp.JSONKeyValue]:
         self._match_text_seq("KEY")
         key = self._parse_field()
-        self._match(TokenType.COLON)
+        self._match_set((TokenType.COLON, TokenType.COMMA))
         self._match_text_seq("VALUE")
-        value = self._parse_field()
+        value = self._parse_column()
 
         if not key and not value:
             return None

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -759,7 +759,3 @@ WHERE
         self.validate_identity("SELECT JSON_OBJECT('a', 10, 'a', 'foo') AS json_data")
         with self.assertRaises(ParseError):
             transpile("SELECT JSON_OBJECT('a', 1, 'b') AS json_data", read="bigquery")
-        with self.assertRaises(ParseError):
-            transpile("SELECT JSON_OBJECT('a', 1, 'b',) AS json_data", read="bigquery")
-        with self.assertRaises(ParseError):
-            transpile("SELECT JSON_OBJECT('a', 1,) AS json_data", read="bigquery")

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -751,3 +751,15 @@ WHERE
             "WITH cte AS (SELECT 1 AS foo UNION ALL SELECT 2) SELECT foo FROM cte",
             read={"postgres": "WITH cte(foo) AS (SELECT 1 UNION ALL SELECT 2) SELECT foo FROM cte"},
         )
+
+    def test_json_object(self):
+        self.validate_identity("SELECT JSON_OBJECT() AS json_data")
+        self.validate_identity("SELECT JSON_OBJECT('foo', 10, 'bar', TRUE) AS json_data")
+        self.validate_identity("SELECT JSON_OBJECT('foo', 10, 'bar', ['a', 'b']) AS json_data")
+        self.validate_identity("SELECT JSON_OBJECT('a', 10, 'a', 'foo') AS json_data")
+        with self.assertRaises(ParseError):
+            transpile("SELECT JSON_OBJECT('a', 1, 'b') AS json_data", read="bigquery")
+        with self.assertRaises(ParseError):
+            transpile("SELECT JSON_OBJECT('a', 1, 'b',) AS json_data", read="bigquery")
+        with self.assertRaises(ParseError):
+            transpile("SELECT JSON_OBJECT('a', 1,) AS json_data", read="bigquery")


### PR DESCRIPTION
This PR fixes the different JSON_OBJECT function in BigQuery. See https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_object

I only fixed it for Signature 1 as it is relatively easy. For Signature 2 I think there needs be some changes to incorporate this syntax in the parser.