### PR TITLE
Fix(mysql): generate JSON_OBJECT properly

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -593,6 +593,9 @@ class MySQL(Dialect):
         def jsonarraycontains_sql(self, expression: exp.JSONArrayContains) -> str:
             return f"{self.sql(expression, 'this')} MEMBER OF({self.sql(expression, 'expression')})"
 
+        def jsonkeyvalue_sql(self, expression: exp.JSONKeyValue) -> str:
+            return f"{self.sql(expression, 'this')}, {self.sql(expression, 'expression')}"
+
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
             to = self.CAST_MAPPING.get(expression.to.this)
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -829,3 +829,6 @@ COMMENT='客户账户表'"""
 
         cmd = self.parse_one("SET x = 1, y = 2")
         self.assertEqual(len(cmd.expressions), 2)
+
+    def test_json_object(self):
+        self.validate_identity("SELECT JSON_OBJECT('id', 87, 'name', 'carrot')")


### PR DESCRIPTION
Similar to #2136, MySQL also uses a comma to separate key and value.

https://dev.mysql.com/doc/refman/8.0/en/json-creation-functions.html#function_json-object