### PR TITLE
Feat: add support for transpiling some datetime functions from bq to databricks

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sqlglot import exp, transforms
-from sqlglot.dialects.dialect import parse_date_delta
+from sqlglot.dialects.dialect import parse_date_delta, timestamptrunc_sql
 from sqlglot.dialects.spark import Spark
 from sqlglot.dialects.tsql import generate_date_delta_with_unit_sql
 from sqlglot.tokens import TokenType
@@ -28,6 +28,19 @@ class Databricks(Spark):
             **Spark.Generator.TRANSFORMS,
             exp.DateAdd: generate_date_delta_with_unit_sql,
             exp.DateDiff: generate_date_delta_with_unit_sql,
+            exp.DatetimeAdd: lambda self, e: self.func(
+                "TIMESTAMPADD", e.text("unit"), e.text("expression"), e.this
+            ),
+            exp.DatetimeSub: lambda self, e: self.func(
+                "TIMESTAMPADD",
+                e.text("unit"),
+                exp.Mul(this=e.text("expression"), expression=exp.Literal.number(-1)),
+                e.this,
+            ),
+            exp.DatetimeDiff: lambda self, e: self.func(
+                "TIMESTAMPDIFF", e.text("unit"), exp.Literal.string(e.text("expression")), e.this
+            ),
+            exp.DatetimeTrunc: timestamptrunc_sql,
             exp.JSONExtract: lambda self, e: self.binary(e, ":"),
             exp.Select: transforms.preprocess(
                 [

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -38,7 +38,7 @@ class Databricks(Spark):
                 e.this,
             ),
             exp.DatetimeDiff: lambda self, e: self.func(
-                "TIMESTAMPDIFF", e.text("unit"), exp.Literal.string(e.text("expression")), e.this
+                "TIMESTAMPDIFF", e.text("unit"), e.expression, e.this
             ),
             exp.DatetimeTrunc: timestamptrunc_sql,
             exp.JSONExtract: lambda self, e: self.binary(e, ":"),

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -29,7 +29,7 @@ class Databricks(Spark):
             exp.DateAdd: generate_date_delta_with_unit_sql,
             exp.DateDiff: generate_date_delta_with_unit_sql,
             exp.DatetimeAdd: lambda self, e: self.func(
-                "TIMESTAMPADD", e.text("unit"), e.text("expression"), e.this
+                "TIMESTAMPADD", e.text("unit"), e.expression, e.this
             ),
             exp.DatetimeSub: lambda self, e: self.func(
                 "TIMESTAMPADD",

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -34,7 +34,7 @@ class Databricks(Spark):
             exp.DatetimeSub: lambda self, e: self.func(
                 "TIMESTAMPADD",
                 e.text("unit"),
-                exp.Mul(this=e.text("expression"), expression=exp.Literal.number(-1)),
+                exp.Mul(this=e.expression.copy(), expression=exp.Literal.number(-1)),
                 e.this,
             ),
             exp.DatetimeDiff: lambda self, e: self.func(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -105,6 +105,34 @@ class TestBigQuery(Validator):
         self.validate_all('x <> """"""', write={"bigquery": "x <> ''"})
         self.validate_all("x <> ''''''", write={"bigquery": "x <> ''"})
         self.validate_all("CAST(x AS DATETIME)", read={"": "x::timestamp"})
+        self.validate_all(
+            "SELECT DATETIME_DIFF('2023-01-01T00:00:00', '2023-01-01T05:00:00', MILLISECOND)",
+            write={
+                "bigquery": "SELECT DATETIME_DIFF('2023-01-01T00:00:00', '2023-01-01T05:00:00', MILLISECOND)",
+                "databricks": "SELECT TIMESTAMPDIFF(MILLISECOND, '2023-01-01T05:00:00', '2023-01-01T00:00:00')",
+            },
+        ),
+        self.validate_all(
+            "SELECT DATETIME_ADD('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",
+            write={
+                "bigquery": "SELECT DATETIME_ADD('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",
+                "databricks": "SELECT TIMESTAMPADD(MILLISECOND, 1, '2023-01-01T00:00:00')",
+            },
+        ),
+        self.validate_all(
+            "SELECT DATETIME_SUB('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",
+            write={
+                "bigquery": "SELECT DATETIME_SUB('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",
+                "databricks": "SELECT TIMESTAMPADD(MILLISECOND, 1 * -1, '2023-01-01T00:00:00')",
+            },
+        ),
+        self.validate_all(
+            "SELECT DATETIME_TRUNC('2023-01-01T01:01:01', HOUR)",
+            write={
+                "bigquery": "SELECT DATETIME_TRUNC('2023-01-01T01:01:01', HOUR)",
+                "databricks": "SELECT DATE_TRUNC('HOUR', '2023-01-01T01:01:01')",
+            },
+        ),
         self.validate_all("LEAST(x, y)", read={"sqlite": "MIN(x, y)"})
         self.validate_all("CAST(x AS CHAR)", write={"bigquery": "CAST(x AS STRING)"})
         self.validate_all("CAST(x AS NCHAR)", write={"bigquery": "CAST(x AS STRING)"})


### PR DESCRIPTION
This PR aims to improve compatibility on datetime functions when transpiling from BigQuery to Databricks SQL. 

I've tested the results on both engines and noticed the difference that the datetime results on BQ are in  ISO 8601 (with the T between date and time), while the proposed changes are not. This behavior should be acceptable for my current flows, but if you think there is a better way to do this (or any other part), I'll be happy to adjust!

BigQuery:
![image](https://github.com/tobymao/sqlglot/assets/20783380/d372d3ee-8b15-4c3f-8599-3adb69efcf3e)


Databricks:
![image](https://github.com/tobymao/sqlglot/assets/20783380/cb6a17be-9e37-4390-9735-f1d2dcab55bd)
