### PR TITLE
Feat!(bigquery): improve handling of array JSON_OBJECT syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4144,7 +4144,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_json_key_value(self) -> t.Optional[exp.JSONKeyValue]:
         self._match_text_seq("KEY")
-        key = self._parse_field()
+        key = self._parse_column()
         self._match_set((TokenType.COLON, TokenType.COMMA))
         self._match_text_seq("VALUE")
         value = self._parse_column()

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -824,7 +824,7 @@ class TestPresto(Validator):
         self.validate_all(
             """JSON_FORMAT(JSON '"x"')""",
             write={
-                "bigquery": """TO_JSON_STRING(CAST('"x"' AS JSON))""",
+                "bigquery": """TO_JSON_STRING(JSON '"x"')""",
                 "duckdb": """CAST(TO_JSON(CAST('"x"' AS JSON)) AS TEXT)""",
                 "presto": """JSON_FORMAT(CAST('"x"' AS JSON))""",
                 "spark": """REGEXP_EXTRACT(TO_JSON(FROM_JSON('["x"]', SCHEMA_OF_JSON('["x"]'))), '^.(.*).$', 1)""",


### PR DESCRIPTION
This PR was motivated by https://github.com/tobymao/sqlglot/pull/2136. It seems like `CAST(... AS JSON)` is not valid in BQ, at least for the examples I tried:

```sql
SELECT CAST(1 AS JSON) AS foo  -- Invalid cast from INT64 to JSON at [1:13]
SELECT CAST('"foo"' AS JSON) AS foo  -- Invalid cast from STRING to JSON at [1:13]
SELECT CAST('foo' AS JSON) AS foo  -- Invalid cast from STRING to JSON at [1:13]
```

Reference: https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_object

cc: @middagj