### PR TITLE
Fix(hive): parse <number> <date_part> as an interval instead of an alias

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -47,7 +47,29 @@ TIME_DIFF_FACTOR = {
     "HOUR": " / 3600",
 }
 
+INTERVAL_VARS = {
+    "SECOND",
+    "SECONDS",
+    "MINUTE",
+    "MINUTES",
+    "DAY",
+    "DAYS",
+    "MONTH",
+    "MONTHS",
+    "YEAR",
+    "YEARS",
+}
+
+
 DIFF_MONTH_SWITCH = ("YEAR", "QUARTER", "MONTH")
+
+
+def _parse_number(self: Hive.Parser, token: TokenType) -> t.Optional[exp.Expression]:
+    number = parser.Parser.PRIMARY_PARSERS[TokenType.NUMBER](self, token)
+    if self._match(TokenType.VAR, advance=False) and self._curr.text.upper() in INTERVAL_VARS:
+        return exp.Interval(this=number, unit=self._parse_var())
+
+    return number
 
 
 def _add_date_sql(self: generator.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
@@ -282,6 +304,11 @@ class Hive(Dialect):
             "WITH SERDEPROPERTIES": lambda self: exp.SerdeProperties(
                 expressions=self._parse_wrapped_csv(self._parse_property)
             ),
+        }
+
+        PRIMARY_PARSERS = {
+            **parser.Parser.PRIMARY_PARSERS,
+            TokenType.NUMBER: _parse_number,
         }
 
         def _parse_transform(self) -> t.Optional[exp.Transform | exp.QueryTransform]:

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -65,7 +65,7 @@ DIFF_MONTH_SWITCH = ("YEAR", "QUARTER", "MONTH")
 
 
 def _parse_number(self: Hive.Parser, token: TokenType) -> t.Optional[exp.Expression]:
-    number = parser.Parser.PRIMARY_PARSERS[TokenType.NUMBER](self, token)
+    number = super(type(self), self).PRIMARY_PARSERS[TokenType.NUMBER](self, token)
     if self._match(TokenType.VAR, advance=False) and self._curr.text.upper() in INTERVAL_VARS:
         return exp.Interval(this=number, unit=self._parse_var())
 

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp, transforms
+from sqlglot import exp, parser, transforms
 from sqlglot.dialects.dialect import (
     binary_from_function,
     create_with_partitions_sql,
@@ -164,6 +164,9 @@ class Spark2(Hive):
             "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
             "SHUFFLE_REPLICATE_NL": lambda self: self._parse_join_hint("SHUFFLE_REPLICATE_NL"),
         }
+
+        # We dont' want to inherit Hive's TokenType.NUMBER override
+        PRIMARY_PARSERS = parser.Parser.PRIMARY_PARSERS.copy()
 
         def _parse_add_column(self) -> t.Optional[exp.Expression]:
             return self._match_text_seq("ADD", "COLUMNS") and self._parse_schema()

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -394,6 +394,14 @@ class TestHive(Validator):
         self.validate_identity("SELECT * FROM my_table VERSION AS OF DATE_ADD(CURRENT_DATE, -1)")
 
         self.validate_identity(
+            "SELECT CAST('1998-01-01' AS DATE) + 30 years",
+            "SELECT CAST('1998-01-01' AS DATE) + INTERVAL 30 years",
+        )
+        self.validate_identity(
+            "SELECT 30 + 50 bla",
+            "SELECT 30 + 50 AS bla",
+        )
+        self.validate_identity(
             "SELECT ROW() OVER (DISTRIBUTE BY x SORT BY y)",
             "SELECT ROW() OVER (PARTITION BY x ORDER BY y)",
         )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -243,6 +243,10 @@ TBLPROPERTIES (
             "SELECT STR_TO_MAP('a:1,b:2,c:3')",
             "SELECT STR_TO_MAP('a:1,b:2,c:3', ',', ':')",
         )
+        self.validate_identity(
+            "SELECT CAST('1998-01-01' AS DATE) + 30 years",
+            "SELECT CAST('1998-01-01' AS DATE) + 30 AS years",
+        )
 
         self.validate_all(
             "foo.bar",


### PR DESCRIPTION
Fixes #2123

Tested in https://demo.gethue.com/hue/editor/?type=hiv (enter `demo` for both the username and the password):

<img width="1165" alt="Screenshot 2023-09-04 at 7 15 59 PM" src="https://github.com/tobymao/sqlglot/assets/46752250/b1095ff1-2882-44d1-9b0b-141884d09742">

The date parts were chosen based on Hive's [docs](https://cwiki.apache.org/confluence/display/hive/languagemanual+types#LanguageManualTypes-Intervals) for the interval type:

![image](https://github.com/tobymao/sqlglot/assets/46752250/2aeb23ea-e4f9-40da-abcd-ea1b60567577)

