### PR TITLE
Revert <number> <date_part> changes

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -47,29 +47,7 @@ TIME_DIFF_FACTOR = {
     "HOUR": " / 3600",
 }
 
-INTERVAL_VARS = {
-    "SECOND",
-    "SECONDS",
-    "MINUTE",
-    "MINUTES",
-    "DAY",
-    "DAYS",
-    "MONTH",
-    "MONTHS",
-    "YEAR",
-    "YEARS",
-}
-
-
 DIFF_MONTH_SWITCH = ("YEAR", "QUARTER", "MONTH")
-
-
-def _parse_number(self: Hive.Parser, token: TokenType) -> t.Optional[exp.Expression]:
-    number = super(type(self), self).PRIMARY_PARSERS[TokenType.NUMBER](self, token)
-    if self._match(TokenType.VAR, advance=False) and self._curr.text.upper() in INTERVAL_VARS:
-        return exp.Interval(this=number, unit=self._parse_var())
-
-    return number
 
 
 def _add_date_sql(self: Hive.Generator, expression: exp.DateAdd | exp.DateSub) -> str:
@@ -304,11 +282,6 @@ class Hive(Dialect):
             "WITH SERDEPROPERTIES": lambda self: exp.SerdeProperties(
                 expressions=self._parse_wrapped_csv(self._parse_property)
             ),
-        }
-
-        PRIMARY_PARSERS = {
-            **parser.Parser.PRIMARY_PARSERS,
-            TokenType.NUMBER: _parse_number,
         }
 
         def _parse_transform(self) -> t.Optional[exp.Transform | exp.QueryTransform]:

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp, parser, transforms
+from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
     binary_from_function,
     create_with_partitions_sql,
@@ -164,9 +164,6 @@ class Spark2(Hive):
             "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
             "SHUFFLE_REPLICATE_NL": lambda self: self._parse_join_hint("SHUFFLE_REPLICATE_NL"),
         }
-
-        # We dont' want to inherit Hive's TokenType.NUMBER override
-        PRIMARY_PARSERS = parser.Parser.PRIMARY_PARSERS.copy()
 
         def _parse_add_column(self) -> t.Optional[exp.Expression]:
             return self._match_text_seq("ADD", "COLUMNS") and self._parse_schema()

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -394,14 +394,6 @@ class TestHive(Validator):
         self.validate_identity("SELECT * FROM my_table VERSION AS OF DATE_ADD(CURRENT_DATE, -1)")
 
         self.validate_identity(
-            "SELECT CAST('1998-01-01' AS DATE) + 30 years",
-            "SELECT CAST('1998-01-01' AS DATE) + INTERVAL 30 years",
-        )
-        self.validate_identity(
-            "SELECT 30 + 50 bla",
-            "SELECT 30 + 50 AS bla",
-        )
-        self.validate_identity(
             "SELECT ROW() OVER (DISTRIBUTE BY x SORT BY y)",
             "SELECT ROW() OVER (PARTITION BY x ORDER BY y)",
         )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -243,10 +243,6 @@ TBLPROPERTIES (
             "SELECT STR_TO_MAP('a:1,b:2,c:3')",
             "SELECT STR_TO_MAP('a:1,b:2,c:3', ',', ':')",
         )
-        self.validate_identity(
-            "SELECT CAST('1998-01-01' AS DATE) + 30 years",
-            "SELECT CAST('1998-01-01' AS DATE) + 30 AS years",
-        )
 
         self.validate_all(
             "foo.bar",


### PR DESCRIPTION
Turns out these changes were incorrect because we don't examine the surrounding context of the number being parsed, and so something like:

```python
INTERVAL 1 DAY
```

is currently converted into

```python
INTERVAL (INTERVAL 1 DAY)
```

I think that fixing this case would require us to look back 2 tokens (because `self._prev` is the number token itself), which means we'd need to pollute the number parsing logic even more. I don't think the ROI is worth it anymore, so I decided to simply revert, at least for now.
