### PR TITLE
Fix(parser): solve interval parsing bug

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3154,12 +3154,12 @@ class Parser(metaclass=_Parser):
 
             if len(parts) == 2:
                 if unit:
-                    # this is not actually a unit, it's something else
+                    # This is not actually a unit, it's something else (e.g. a "window side")
                     unit = None
                     self._retreat(self._index - 1)
-                else:
-                    this = exp.Literal.string(parts[0])
-                    unit = self.expression(exp.Var, this=parts[1])
+
+                this = exp.Literal.string(parts[0])
+                unit = self.expression(exp.Var, this=parts[1])
 
         return self.expression(exp.Interval, this=this, unit=unit)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -711,3 +711,11 @@ class TestParser(unittest.TestCase):
             parse_one("SELECT a, b ?? c ?? 'No Data' FROM z").sql(),
             "SELECT a, COALESCE(COALESCE(b, c), 'No Data') FROM z",
         )
+
+    def test_parse_intervals(self):
+        ast = parse_one(
+            "SELECT a FROM tbl WHERE a <= DATE '1998-12-01' - INTERVAL '71 days' GROUP BY b"
+        )
+
+        self.assertEqual(ast.find(exp.Interval).this.sql(), "'71'")
+        self.assertEqual(ast.find(exp.Interval).unit.assert_is(exp.Var).sql(), "days")


### PR DESCRIPTION
Fixes #2154

Before:

```python
>>> import sqlglot
>>> expression1 = sqlglot.parse_one("select a from tbl where a <= date '1998-12-01' - interval '71 days' group by b")
>>> expression2 = sqlglot.parse_one("select a from tbl where a <= date '1998-12-01' - interval '71 days'")
>>> expression1
...
        (INTERVAL this:
          (LITERAL this: 71 days, is_string: True))))), group:
...
>>> expression2
...
        (INTERVAL this:
          (LITERAL this: 71, is_string: True), unit:
          (VAR this: days))))))
```

After:

```python
>>> import sqlglot
>>> expression1 = sqlglot.parse_one("select a from tbl where a <= date '1998-12-01' - interval '71 days' group by b")
>>> expression2 = sqlglot.parse_one("select a from tbl where a <= date '1998-12-01' - interval '71 days'")
>>> expression1
...
        (INTERVAL this:
          (LITERAL this: 71, is_string: True), unit:
          (VAR this: days))))), group:
...
>>> expression2
...
        (INTERVAL this:
          (LITERAL this: 71, is_string: True), unit:
          (VAR this: days))))))
```