### PR TITLE
Chore: add minimum python version required to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "local_scheme": "no-local-version",
     },
     setup_requires=["setuptools_scm"],
-    python_requires='>=3.7',
+    python_requires=">=3.7",
     extras_require={
         "dev": [
             "autoflake",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
         "local_scheme": "no-local-version",
     },
     setup_requires=["setuptools_scm"],
+    python_requires='>=3.7',
     extras_require={
         "dev": [
             "autoflake",


### PR DESCRIPTION
Fixes #2168

Reference: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires