### PR TITLE
Fix!: MySQL Timestamp Data Types

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -33,6 +33,8 @@ class Doris(MySQL):
             exp.DataType.Type.TIMESTAMPTZ: "DATETIME",
         }
 
+        TIMESTAMP_FUNC_TYPES = set()
+
         TRANSFORMS = {
             **MySQL.Generator.TRANSFORMS,
             exp.ApproxDistinct: approx_count_distinct_sql,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -563,9 +563,16 @@ class MySQL(Dialect):
             exp.DataType.Type.UTINYINT: "TINYINT",
         }
 
+        TIMESTAMP_TYPE_MAPPING = {
+            exp.DataType.Type.TIMESTAMP: "DATETIME",
+            exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
+            exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP",
+        }
+
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             **UNSIGNED_TYPE_MAPPING,
+            **TIMESTAMP_TYPE_MAPPING,
         }
 
         TYPE_MAPPING.pop(exp.DataType.Type.MEDIUMTEXT)
@@ -618,6 +625,13 @@ class MySQL(Dialect):
             return f"{self.sql(expression, 'this')} MEMBER OF({self.sql(expression, 'expression')})"
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
+            if expression.to.this in {
+                exp.DataType.Type.TIMESTAMP,
+                exp.DataType.Type.TIMESTAMPTZ,
+                exp.DataType.Type.TIMESTAMPLTZ,
+            }:
+                return super().func("TIMESTAMP", expression.this)
+
             to = self.CAST_MAPPING.get(expression.to.this)
 
             if to:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -631,7 +631,7 @@ class MySQL(Dialect):
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
             if expression.to.this in self.TIMESTAMP_FUNC_TYPES:
-                return super().func("TIMESTAMP", expression.this)
+                return self.func("TIMESTAMP", expression.this)
 
             to = self.CAST_MAPPING.get(expression.to.this)
 

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -599,6 +599,11 @@ class MySQL(Dialect):
             exp.DataType.Type.VARCHAR: "CHAR",
         }
 
+        TIMESTAMP_FUNC_TYPES = {
+            exp.DataType.Type.TIMESTAMPTZ,
+            exp.DataType.Type.TIMESTAMPLTZ,
+        }
+
         def datatype_sql(self, expression: exp.DataType) -> str:
             # https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html
             result = super().datatype_sql(expression)
@@ -625,11 +630,7 @@ class MySQL(Dialect):
             return f"{self.sql(expression, 'this')} MEMBER OF({self.sql(expression, 'expression')})"
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
-            if expression.to.this in {
-                exp.DataType.Type.TIMESTAMP,
-                exp.DataType.Type.TIMESTAMPTZ,
-                exp.DataType.Type.TIMESTAMPLTZ,
-            }:
+            if expression.to.this in self.TIMESTAMP_FUNC_TYPES:
                 return super().func("TIMESTAMP", expression.this)
 
             to = self.CAST_MAPPING.get(expression.to.this)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -282,14 +282,16 @@ class TestDialect(Validator):
                 "starrocks": "CAST(a AS DATETIME)",
                 "redshift": "CAST(a AS TIMESTAMP)",
                 "doris": "CAST(a AS DATETIME)",
+                "mysql": "CAST(a AS DATETIME)",
             },
         )
         self.validate_all(
             "CAST(a AS TIMESTAMPTZ)",
             write={
-                "starrocks": "CAST(a AS DATETIME)",
+                "starrocks": "TIMESTAMP(a)",
                 "redshift": "CAST(a AS TIMESTAMP WITH TIME ZONE)",
                 "doris": "CAST(a AS DATETIME)",
+                "mysql": "TIMESTAMP(a)",
             },
         )
         self.validate_all("CAST(a AS TINYINT)", write={"oracle": "CAST(a AS NUMBER)"})

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -870,7 +870,7 @@ class TestDialect(Validator):
             "TIMESTAMP '2022-01-01'",
             write={
                 "drill": "CAST('2022-01-01' AS TIMESTAMP)",
-                "mysql": "CAST('2022-01-01' AS TIMESTAMP)",
+                "mysql": "CAST('2022-01-01' AS DATETIME)",
                 "starrocks": "CAST('2022-01-01' AS DATETIME)",
                 "hive": "CAST('2022-01-01' AS TIMESTAMP)",
                 "doris": "CAST('2022-01-01' AS DATETIME)",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -221,7 +221,7 @@ class TestMySQL(Validator):
                 "spark": "CAST(x AS BLOB) + CAST(y AS BLOB)",
             },
         )
-        self.validate_all("CAST(x AS TIMESTAMP)", write={"mysql": "TIMESTAMP(x)"})
+        self.validate_all("CAST(x AS TIMESTAMP)", write={"mysql": "CAST(x AS DATETIME)"})
         self.validate_all("CAST(x AS TIMESTAMPTZ)", write={"mysql": "TIMESTAMP(x)"})
         self.validate_all("CAST(x AS TIMESTAMPLTZ)", write={"mysql": "TIMESTAMP(x)"})
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -215,6 +215,9 @@ class TestMySQL(Validator):
                 "spark": "CAST(x AS BLOB) + CAST(y AS BLOB)",
             },
         )
+        self.validate_all("CAST(x AS TIMESTAMP)", write={"mysql": "TIMESTAMP(x)"})
+        self.validate_all("CAST(x AS TIMESTAMPTZ)", write={"mysql": "TIMESTAMP(x)"})
+        self.validate_all("CAST(x AS TIMESTAMPLTZ)", write={"mysql": "TIMESTAMP(x)"})
 
     def test_canonical_functions(self):
         self.validate_identity("SELECT LEFT('str', 2)", "SELECT LEFT('str', 2)")

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -96,6 +96,12 @@ class TestMySQL(Validator):
                 "mysql": "CREATE TABLE IF NOT EXISTS industry_info (a BIGINT(20) NOT NULL AUTO_INCREMENT, b BIGINT(20) NOT NULL, c VARCHAR(1000), PRIMARY KEY (a), UNIQUE d (b), INDEX e (b))",
             },
         )
+        self.validate_all(
+            "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMPTZ, ts_ltz TIMESTAMPLTZ)",
+            write={
+                "mysql": "CREATE TABLE test (ts DATETIME, ts_tz TIMESTAMP, ts_ltz TIMESTAMP)",
+            },
+        )
 
     def test_identity(self):
         self.validate_identity(


### PR DESCRIPTION
Correctly maps `TIMESTAMP` -> `DATETIME` and uses `TIMESTAMP` function when creating the timestamp types. 