### PR TITLE
Feat!(oracle): refactor parsing of 'FORMAT JSON', add support for JSON_ARRAY

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -69,6 +69,10 @@ class Oracle(Dialect):
 
         FUNCTION_PARSERS: t.Dict[str, t.Callable] = {
             **parser.Parser.FUNCTION_PARSERS,
+            "JSON_ARRAY": lambda self: self._parse_json_array(
+                exp.JSONArray,
+                expressions=self._parse_csv(lambda: self._parse_format_json(self._parse_bitwise())),
+            ),
             "XMLTABLE": _parse_xml_table,
         }
 

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -7,6 +7,9 @@ from sqlglot.dialects.dialect import Dialect, no_ilike_sql, rename_func, trim_sq
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
+if t.TYPE_CHECKING:
+    from sqlglot._typing import E
+
 
 def _parse_xml_table(self: Oracle.Parser) -> exp.XMLTable:
     this = self._parse_string()
@@ -73,6 +76,11 @@ class Oracle(Dialect):
                 exp.JSONArray,
                 expressions=self._parse_csv(lambda: self._parse_format_json(self._parse_bitwise())),
             ),
+            "JSON_ARRAYAGG": lambda self: self._parse_json_array(
+                exp.JSONArrayAgg,
+                this=self._parse_format_json(self._parse_bitwise()),
+                order=self._parse_order(),
+            ),
             "XMLTABLE": _parse_xml_table,
         }
 
@@ -85,6 +93,15 @@ class Oracle(Dialect):
         # SELECT UNIQUE .. is old-style Oracle syntax for SELECT DISTINCT ..
         # Reference: https://stackoverflow.com/a/336455
         DISTINCT_TOKENS = {TokenType.DISTINCT, TokenType.UNIQUE}
+
+        def _parse_json_array(self, expr_type: t.Type[E], **kwargs) -> E:
+            return self.expression(
+                expr_type,
+                null_handling=self._parse_null_handling(),
+                return_type=self._match_text_seq("RETURNING") and self._parse_type(),
+                strict=self._match_text_seq("STRICT"),
+                **kwargs,
+            )
 
         def _parse_column(self) -> t.Optional[exp.Expression]:
             column = super()._parse_column()

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4479,6 +4479,10 @@ class IsNan(Func):
     _sql_names = ["IS_NAN", "ISNAN"]
 
 
+class FormatJson(Expression):
+    pass
+
+
 class JSONKeyValue(Expression):
     arg_types = {"this": True, "expression": True}
 
@@ -4489,8 +4493,17 @@ class JSONObject(Func):
         "null_handling": False,
         "unique_keys": False,
         "return_type": False,
-        "format_json": False,
         "encoding": False,
+    }
+
+
+# https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_ARRAY.html
+class JSONArray(Func):
+    arg_types = {
+        "expressions": True,
+        "null_handling": False,
+        "return_type": False,
+        "strict": False,
     }
 
 
@@ -4498,7 +4511,6 @@ class JSONObject(Func):
 class JSONArrayAgg(Func):
     arg_types = {
         "this": True,
-        "format_json": False,
         "order": False,
         "null_handling": False,
         "return_type": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2023,6 +2023,9 @@ class Generator:
     def jsonkeyvalue_sql(self, expression: exp.JSONKeyValue) -> str:
         return f"{self.sql(expression, 'this')}: {self.sql(expression, 'expression')}"
 
+    def formatjson_sql(self, expression: exp.FormatJson) -> str:
+        return f"{self.sql(expression, 'this')} FORMAT JSON"
+
     def jsonobject_sql(self, expression: exp.JSONObject) -> str:
         null_handling = expression.args.get("null_handling")
         null_handling = f" {null_handling}" if null_handling else ""
@@ -2033,18 +2036,26 @@ class Generator:
             unique_keys = ""
         return_type = self.sql(expression, "return_type")
         return_type = f" RETURNING {return_type}" if return_type else ""
-        format_json = " FORMAT JSON" if expression.args.get("format_json") else ""
         encoding = self.sql(expression, "encoding")
         encoding = f" ENCODING {encoding}" if encoding else ""
         return self.func(
             "JSON_OBJECT",
             *expression.expressions,
-            suffix=f"{null_handling}{unique_keys}{return_type}{format_json}{encoding})",
+            suffix=f"{null_handling}{unique_keys}{return_type}{encoding})",
+        )
+
+    def jsonarray_sql(self, expression: exp.JSONArray) -> str:
+        null_handling = expression.args.get("null_handling")
+        null_handling = f" {null_handling}" if null_handling else ""
+        return_type = self.sql(expression, "return_type")
+        return_type = f" RETURNING {return_type}" if return_type else ""
+        strict = " STRICT" if expression.args.get("strict") else ""
+        return self.func(
+            "JSON_ARRAY", *expression.expressions, suffix=f"{null_handling}{return_type}{strict})"
         )
 
     def jsonarrayagg_sql(self, expression: exp.JSONArrayAgg) -> str:
         this = self.sql(expression, "this")
-        format_json = " FORMAT JSON" if expression.args.get("format_json") else ""
         order = self.sql(expression, "order")
         null_handling = expression.args.get("null_handling")
         null_handling = f" {null_handling}" if null_handling else ""
@@ -2054,7 +2065,7 @@ class Generator:
         return self.func(
             "JSON_ARRAYAGG",
             this,
-            suffix=f"{format_json}{order}{null_handling}{return_type}{strict})",
+            suffix=f"{order}{null_handling}{return_type}{strict})",
         )
 
     def openjsoncolumndef_sql(self, expression: exp.OpenJSONColumnDef) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -769,10 +769,6 @@ class Parser(metaclass=_Parser):
         "CONVERT": lambda self: self._parse_convert(self.STRICT_CAST),
         "DECODE": lambda self: self._parse_decode(),
         "EXTRACT": lambda self: self._parse_extract(),
-        "JSON_ARRAY": lambda self: self._parse_json_array(
-            exp.JSONArray,
-            expressions=self._parse_csv(lambda: self._parse_format_json(self._parse_bitwise())),
-        ),
         "JSON_ARRAYAGG": lambda self: self._parse_json_array(
             exp.JSONArrayAgg,
             this=self._parse_format_json(self._parse_bitwise()),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -769,11 +769,6 @@ class Parser(metaclass=_Parser):
         "CONVERT": lambda self: self._parse_convert(self.STRICT_CAST),
         "DECODE": lambda self: self._parse_decode(),
         "EXTRACT": lambda self: self._parse_extract(),
-        "JSON_ARRAYAGG": lambda self: self._parse_json_array(
-            exp.JSONArrayAgg,
-            this=self._parse_format_json(self._parse_bitwise()),
-            order=self._parse_order(),
-        ),
         "JSON_OBJECT": lambda self: self._parse_json_object(),
         "LOG": lambda self: self._parse_logarithm(),
         "MATCH": lambda self: self._parse_match_against(),
@@ -4233,15 +4228,6 @@ class Parser(metaclass=_Parser):
             unique_keys=unique_keys,
             return_type=return_type,
             encoding=encoding,
-        )
-
-    def _parse_json_array(self, expr_type: t.Type[E], **kwargs) -> E:
-        return self.expression(
-            expr_type,
-            null_handling=self._parse_null_handling(),
-            return_type=self._match_text_seq("RETURNING") and self._parse_type(),
-            strict=self._match_text_seq("STRICT"),
-            **kwargs,
         )
 
     def _parse_logarithm(self) -> exp.Func:

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -6,6 +6,7 @@ class TestOracle(Validator):
     dialect = "oracle"
 
     def test_oracle(self):
+        self.validate_identity("SELECT JSON_OBJECT(k1: v1 FORMAT JSON, k2: v2 FORMAT JSON)")
         self.validate_identity("SELECT JSON_OBJECT('name': first_name || ' ' || last_name) FROM t")
         self.validate_identity("COALESCE(c1, c2, c3)")
         self.validate_identity("SELECT * FROM TABLE(foo)")
@@ -25,6 +26,9 @@ class TestOracle(Validator):
         self.validate_identity("SELECT * FROM table_name@dblink_name.database_link_domain")
         self.validate_identity("SELECT * FROM table_name SAMPLE (25) s")
         self.validate_identity("SELECT * FROM V$SESSION")
+        self.validate_identity(
+            "SELECT JSON_ARRAY(FOO() FORMAT JSON, BAR() NULL ON NULL RETURNING CLOB STRICT)"
+        )
         self.validate_identity(
             "SELECT JSON_ARRAYAGG(FOO() FORMAT JSON ORDER BY bar NULL ON NULL RETURNING CLOB STRICT)"
         )


### PR DESCRIPTION
Fixes item 3 of #2187

References:
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_ARRAY.html
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_OBJECT.html