### PR TITLE
Feat(oracle): add support for JSON_TABLE

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -81,6 +81,7 @@ class Oracle(Dialect):
                 this=self._parse_format_json(self._parse_bitwise()),
                 order=self._parse_order(),
             ),
+            "JSON_TABLE": lambda self: self._parse_json_table(),
             "XMLTABLE": _parse_xml_table,
         }
 
@@ -94,10 +95,33 @@ class Oracle(Dialect):
         # Reference: https://stackoverflow.com/a/336455
         DISTINCT_TOKENS = {TokenType.DISTINCT, TokenType.UNIQUE}
 
+        # Note: this is currently incomplete; it only implements the "JSON_value_column" part
+        def _parse_json_column_def(self) -> exp.JSONColumnDef:
+            this = self._parse_id_var()
+            kind = self._parse_types(allow_identifiers=False)
+            path = self._match_text_seq("PATH") and self._parse_string()
+            return self.expression(exp.JSONColumnDef, this=this, kind=kind, path=path)
+
+        def _parse_json_table(self) -> exp.JSONTable:
+            this = self._parse_format_json(self._parse_bitwise())
+            path = self._match(TokenType.COMMA) and self._parse_string()
+            error_handling = self._parse_on_handling("ERROR", "ERROR", "NULL")
+            empty_handling = self._parse_on_handling("EMPTY", "ERROR", "NULL")
+            self._match(TokenType.COLUMN)
+            expressions = self._parse_wrapped_csv(self._parse_json_column_def)
+
+            return exp.JSONTable(
+                this=this,
+                expressions=expressions,
+                path=path,
+                error_handling=error_handling,
+                empty_handling=empty_handling,
+            )
+
         def _parse_json_array(self, expr_type: t.Type[E], **kwargs) -> E:
             return self.expression(
                 expr_type,
-                null_handling=self._parse_null_handling(),
+                null_handling=self._parse_on_handling("NULL", "NULL", "ABSENT"),
                 return_type=self._match_text_seq("RETURNING") and self._parse_type(),
                 strict=self._match_text_seq("STRICT"),
                 **kwargs,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4525,6 +4525,23 @@ class JSONArrayAgg(Func):
     }
 
 
+# https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_TABLE.html
+# Note: parsing of JSON column definitions is currently incomplete.
+class JSONColumnDef(Expression):
+    arg_types = {"this": True, "kind": False, "path": False}
+
+
+# # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_TABLE.html
+class JSONTable(Func):
+    arg_types = {
+        "this": True,
+        "expressions": True,
+        "path": False,
+        "error_handling": False,
+        "empty_handling": False,
+    }
+
+
 class OpenJSONColumnDef(Expression):
     arg_types = {"this": True, "kind": True, "path": False, "as_json": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2068,6 +2068,27 @@ class Generator:
             suffix=f"{order}{null_handling}{return_type}{strict})",
         )
 
+    def jsoncolumndef_sql(self, expression: exp.JSONColumnDef) -> str:
+        this = self.sql(expression, "this")
+        kind = self.sql(expression, "kind")
+        kind = f" {kind}" if kind else ""
+        path = self.sql(expression, "path")
+        path = f" PATH {path}" if path else ""
+        return f"{this}{kind}{path}"
+
+    def jsontable_sql(self, expression: exp.JSONTable) -> str:
+        this = self.sql(expression, "this")
+        path = self.sql(expression, "path")
+        path = f", {path}" if path else ""
+        error_handling = expression.args.get("error_handling")
+        error_handling = f" {error_handling}" if error_handling else ""
+        empty_handling = expression.args.get("empty_handling")
+        empty_handling = f" {empty_handling}" if empty_handling else ""
+        columns = f" COLUMNS ({self.expressions(expression, skip_first=True)})"
+        return self.func(
+            "JSON_TABLE", this, suffix=f"{path}{error_handling}{empty_handling}{columns})"
+        )
+
     def openjsoncolumndef_sql(self, expression: exp.OpenJSONColumnDef) -> str:
         this = self.sql(expression, "this")
         kind = self.sql(expression, "kind")


### PR DESCRIPTION
Fixes #2187

Note that the `COLUMNS` clause requires parentheses according to Oracle's spec, so right now the form `COLUMNS ...` without parentheses fails, cc @sashindeitidata are you sure your queries are valid Oracle SQL w.r.t. this? If they are, then this should be an easy fix (i.e. not requiring parens).

The `JSON_TABLE` hasn't been fully implemented, and also `JSON_VALUE` is still parsed into an `Anonymous`. I believe the issue should be addressed with these PRs. We'll be happy to accept contributions related to improving support for these functions. I think adding full support is out of scope for the time being.

Reference: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_TABLE.html