### PR TITLE
Fix!(tsql): get rid of locking reads

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -580,7 +580,6 @@ class TSQL(Dialect):
             )
 
     class Generator(generator.Generator):
-        LOCKING_READS_SUPPORTED = True
         LIMIT_IS_TOP = True
         QUERY_HINTS = False
         RETURNING_END = False

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -546,7 +546,6 @@ class TestMySQL(Validator):
                 "oracle": "SELECT a FROM tbl FOR UPDATE",
                 "postgres": "SELECT a FROM tbl FOR UPDATE",
                 "redshift": "SELECT a FROM tbl",
-                "tsql": "SELECT a FROM tbl FOR UPDATE",
             },
         )
         self.validate_all(
@@ -556,7 +555,6 @@ class TestMySQL(Validator):
                 "mysql": "SELECT a FROM tbl FOR SHARE",
                 "oracle": "SELECT a FROM tbl FOR SHARE",
                 "postgres": "SELECT a FROM tbl FOR SHARE",
-                "tsql": "SELECT a FROM tbl FOR SHARE",
             },
         )
         self.validate_all(


### PR DESCRIPTION
it seems like T-SQL doesn't support locking reads, at least by default.