### PR TITLE
fix(mysql): transpile ISNULL to IS NULL

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -760,3 +760,7 @@ def is_parse_json(expression: exp.Expression) -> bool:
     return isinstance(expression, exp.ParseJSON) or (
         isinstance(expression, exp.Cast) and expression.is_type("json")
     )
+
+
+def isnull_to_is_null(args: t.List) -> exp.Expression:
+    return exp.Paren(this=exp.Paren(this=args[0]).is_(exp.null()))

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -763,4 +763,4 @@ def is_parse_json(expression: exp.Expression) -> bool:
 
 
 def isnull_to_is_null(args: t.List) -> exp.Expression:
-    return exp.Paren(this=exp.Paren(this=args[0]).is_(exp.null()))
+    return exp.Paren(this=exp.Is(this=seq_get(args, 0), expression=exp.null()))

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -9,6 +9,7 @@ from sqlglot.dialects.dialect import (
     date_add_interval_sql,
     datestrtodate_sql,
     format_time_lambda,
+    isnull_to_is_null,
     json_keyvalue_comma_sql,
     locate_to_strposition,
     max_or_greatest,
@@ -237,6 +238,7 @@ class MySQL(Dialect):
             "INSTR": lambda args: exp.StrPosition(substr=seq_get(args, 1), this=seq_get(args, 0)),
             "LOCATE": locate_to_strposition,
             "STR_TO_DATE": _str_to_date,
+            "ISNULL": isnull_to_is_null,
         }
 
         FUNCTION_PARSERS = {

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -871,3 +871,6 @@ COMMENT='客户账户表'"""
 
     def test_json_object(self):
         self.validate_identity("SELECT JSON_OBJECT('id', 87, 'name', 'carrot')")
+
+    def test_is_null(self):
+        self.validate_all("SELECT ((x) IS NULL)", read={"mysql": "SELECT ISNULL(x)"})

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -873,4 +873,6 @@ COMMENT='客户账户表'"""
         self.validate_identity("SELECT JSON_OBJECT('id', 87, 'name', 'carrot')")
 
     def test_is_null(self):
-        self.validate_all("SELECT ((x) IS NULL)", read={"mysql": "SELECT ISNULL(x)"})
+        self.validate_all(
+            "SELECT ISNULL(x)", read={"": "SELECT (x IS NULL)", "mysql": "SELECT (x IS NULL)"}
+        )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -874,5 +874,5 @@ COMMENT='客户账户表'"""
 
     def test_is_null(self):
         self.validate_all(
-            "SELECT ISNULL(x)", read={"": "SELECT (x IS NULL)", "mysql": "SELECT (x IS NULL)"}
+            "SELECT ISNULL(x)", write={"": "SELECT (x IS NULL)", "mysql": "SELECT (x IS NULL)"}
         )


### PR DESCRIPTION
IS NULL seems more standard than the ISNULL function.

I've wrapped it in parenthesis because I'm scared of operator precedence issues.