### PR TITLE
fix: don't unnest subqueries when the parent select doesn't have a fr…

### DIFF
--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -43,7 +43,11 @@ def unnest(select, parent_select, next_alias_name):
     predicate = select.find_ancestor(exp.Condition)
     alias = next_alias_name()
 
-    if not predicate or parent_select is not predicate.parent_select:
+    if (
+        not predicate
+        or parent_select is not predicate.parent_select
+        or not parent_select.args.get("from")
+    ):
         return
 
     # This subquery returns a scalar and can just be converted to a cross join

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -209,3 +209,15 @@ WHERE
   )
   AND ARRAY_ALL(_u_19."", _x -> _x = x.a)
   AND x.a > COALESCE(_u_21.d, 0);
+SELECT
+  CAST((
+    SELECT
+      x.a AS a
+    FROM x
+  ) AS TEXT) AS a;
+SELECT
+  CAST((
+    SELECT
+      x.a AS a
+    FROM x
+  ) AS TEXT) AS a;


### PR DESCRIPTION
…om since the subquery can't be joined

I think there's probably still a way to optimize by lifting the subquery but doesn't seem worth it for these types of queries