### PR TITLE
Fix(dataframe): ensure Column.alias preserves quotes

### DIFF
--- a/sqlglot/dataframe/sql/column.py
+++ b/sqlglot/dataframe/sql/column.py
@@ -214,9 +214,12 @@ class Column:
     def alias(self, name: str) -> Column:
         from sqlglot.dataframe.sql.session import SparkSession
 
-        alias: exp.Expression = sqlglot.maybe_parse(name, dialect=SparkSession().dialect)
+        dialect = SparkSession().dialect
+        alias: exp.Expression = sqlglot.maybe_parse(name, dialect=dialect)
         new_expression = exp.alias_(
-            self.column_expression, alias.this if isinstance(alias, exp.Column) else name
+            self.column_expression,
+            alias.this if isinstance(alias, exp.Column) else name,
+            dialect=dialect,
         )
         return Column(new_expression)
 

--- a/sqlglot/dataframe/sql/column.py
+++ b/sqlglot/dataframe/sql/column.py
@@ -212,7 +212,12 @@ class Column:
         return self.expression.sql(**{"dialect": SparkSession().dialect, **kwargs})
 
     def alias(self, name: str) -> Column:
-        new_expression = exp.alias_(self.column_expression, name)
+        from sqlglot.dataframe.sql.session import SparkSession
+
+        alias: exp.Expression = sqlglot.maybe_parse(name, dialect=SparkSession().dialect)
+        new_expression = exp.alias_(
+            self.column_expression, alias.this if isinstance(alias, exp.Column) else name
+        )
         return Column(new_expression)
 
     def asc(self) -> Column:

--- a/tests/dataframe/unit/test_session_case_sensitivity.py
+++ b/tests/dataframe/unit/test_session_case_sensitivity.py
@@ -79,3 +79,9 @@ class TestSessionCaseSensitivity(DataFrameTestBase):
                         df.sql()
                 else:
                     self.compare_sql(df, expected)
+
+    def test_alias(self):
+        col = F.col('"Name"')
+        self.assertEqual(col.sql(dialect=self.spark.dialect), '"Name"')
+        self.assertEqual(col.alias("nAME").sql(dialect=self.spark.dialect), '"Name" AS NAME')
+        self.assertEqual(col.alias('"nAME"').sql(dialect=self.spark.dialect), '"Name" AS "nAME"')


### PR DESCRIPTION
The issue here was that 1) `name` was parsed according to Spark, instead of using the session's dialect 2) if quotes were present in `name`, the whole alias name would be treated as an "unsafe identifier" in `to_identifier`, which resulted in adding more quotes and thus generating incorrect SQL.