### PR TITLE
feat(optimizer): simplify date_trunc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
             "python-dateutil",
             "pdoc",
             "pre-commit",
+            "types-python-dateutil",
         ],
     },
     classifiers=[

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -4,7 +4,9 @@ import typing as t
 
 import sqlglot
 
-# A little hack for backwards compatibility with Python 3.7, which doesn't have Protocols.
+# A little hack for backwards compatibility with Python 3.7.
+# For example, we might want a TypeVar for objects that support comparison e.g. SupportsRichComparisonT from typeshed.
+# But Python 3.7 doesn't support Protocols, so we'd also need typing_extensions, which we don't want as a dependency.
 A = t.TypeVar("A", bound=t.Any)
 
 E = t.TypeVar("E", bound="sqlglot.exp.Expression")

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -4,21 +4,8 @@ import typing as t
 
 import sqlglot
 
+# A little hack for backwards compatibility with Python 3.7, which doesn't have Protocols.
+A = t.TypeVar("A", bound=t.Any)
 
-class Comparable(t.Protocol):
-    def __lt__(self, __other: t.Any) -> bool:
-        ...
-
-    def __le__(self, __other: t.Any) -> bool:
-        ...
-
-    def __gt__(self, __other: t.Any) -> bool:
-        ...
-
-    def __ge__(self, __other: t.Any) -> bool:
-        ...
-
-
-C = t.TypeVar("C", bound=Comparable)
 E = t.TypeVar("E", bound="sqlglot.exp.Expression")
 T = t.TypeVar("T")

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -4,5 +4,21 @@ import typing as t
 
 import sqlglot
 
+
+class Comparable(t.Protocol):
+    def __lt__(self, __other: t.Any) -> bool:
+        ...
+
+    def __le__(self, __other: t.Any) -> bool:
+        ...
+
+    def __gt__(self, __other: t.Any) -> bool:
+        ...
+
+    def __ge__(self, __other: t.Any) -> bool:
+        ...
+
+
+C = t.TypeVar("C", bound=Comparable)
 E = t.TypeVar("E", bound="sqlglot.exp.Expression")
 T = t.TypeVar("T")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4329,8 +4329,8 @@ class DateTrunc(Func):
     arg_types = {"unit": True, "this": True, "zone": False}
 
     @property
-    def unit(self) -> t.Optional[Expression]:
-        return self.args.get("unit")
+    def unit(self) -> Expression:
+        return self.args["unit"]
 
 
 class DatetimeAdd(Func, TimeUnit):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4328,6 +4328,10 @@ class DateDiff(Func, TimeUnit):
 class DateTrunc(Func):
     arg_types = {"unit": True, "this": True, "zone": False}
 
+    @property
+    def unit(self) -> t.Optional[Expression]:
+        return self.args.get("unit")
+
 
 class DatetimeAdd(Func, TimeUnit):
     arg_types = {"this": True, "expression": True, "unit": False}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4396,6 +4396,10 @@ class TimestampDiff(Func, TimeUnit):
 class TimestampTrunc(Func, TimeUnit):
     arg_types = {"this": True, "unit": True, "zone": False}
 
+    @property
+    def unit(self) -> Expression:
+        return self.args["unit"]
+
 
 class TimeAdd(Func, TimeUnit):
     arg_types = {"this": True, "expression": True, "unit": False}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -664,16 +664,6 @@ class Expression(metaclass=_Expression):
 
         return load(obj)
 
-
-IntoType = t.Union[
-    str,
-    t.Type[Expression],
-    t.Collection[t.Union[str, t.Type[Expression]]],
-]
-ExpOrStr = t.Union[str, Expression]
-
-
-class Condition(Expression):
     def and_(
         self,
         *expressions: t.Optional[ExpOrStr],
@@ -884,6 +874,18 @@ class Condition(Expression):
 
     def __invert__(self) -> Not:
         return not_(self.copy())
+
+
+IntoType = t.Union[
+    str,
+    t.Type[Expression],
+    t.Collection[t.Union[str, t.Type[Expression]]],
+]
+ExpOrStr = t.Union[str, Expression]
+
+
+class Condition(Expression):
+    """Logical conditions like x AND y, or simply x"""
 
 
 class Predicate(Condition):

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -439,23 +439,19 @@ def first(it: t.Iterable[T]) -> T:
 
 
 def merge_ranges(ranges: t.List[t.Tuple[A, A]]) -> t.List[t.Tuple[A, A]]:
-    # type: ignore
     if not ranges:
         return []
 
-    # First, sort the ranges by starts
-    sorted_ranges = sorted(ranges, key=lambda x: x[0])  # type: ignore
+    ranges = sorted(ranges)
 
-    merged_ranges = [sorted_ranges[0]]
+    merged = [ranges[0]]
 
-    for start, end in sorted_ranges[1:]:
-        last_start, last_end = merged_ranges[-1]
+    for start, end in ranges[1:]:
+        last_start, last_end = merged[-1]
 
-        # If the current range overlaps with the last merged range, merge them
-        if start <= last_end:  # type: ignore
-            new_end = max(last_end, end)
-            merged_ranges[-1] = (last_start, new_end)
+        if start <= last_end:
+            merged[-1] = (last_start, max(last_end, end))
         else:
-            merged_ranges.append((start, end))
+            merged.append((start, end))
 
-    return merged_ranges
+    return merged

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -13,7 +13,7 @@ from itertools import count
 
 if t.TYPE_CHECKING:
     from sqlglot import exp
-    from sqlglot._typing import C, E, T
+    from sqlglot._typing import A, E, T
     from sqlglot.expressions import Expression
 
 
@@ -438,12 +438,13 @@ def first(it: t.Iterable[T]) -> T:
     return next(i for i in it)
 
 
-def merge_ranges(ranges: t.List[t.Tuple[C, C]]) -> t.List[t.Tuple[C, C]]:
+def merge_ranges(ranges: t.List[t.Tuple[A, A]]) -> t.List[t.Tuple[A, A]]:
+    # type: ignore
     if not ranges:
         return []
 
     # First, sort the ranges by starts
-    sorted_ranges = sorted(ranges, key=lambda x: x[0])
+    sorted_ranges = sorted(ranges, key=lambda x: x[0])  # type: ignore
 
     merged_ranges = [sorted_ranges[0]]
 
@@ -451,7 +452,7 @@ def merge_ranges(ranges: t.List[t.Tuple[C, C]]) -> t.List[t.Tuple[C, C]]:
         last_start, last_end = merged_ranges[-1]
 
         # If the current range overlaps with the last merged range, merge them
-        if start <= last_end:
+        if start <= last_end:  # type: ignore
             new_end = max(last_end, end)
             merged_ranges[-1] = (last_start, new_end)
         else:

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -13,8 +13,9 @@ from itertools import count
 
 if t.TYPE_CHECKING:
     from sqlglot import exp
-    from sqlglot._typing import E, T
+    from sqlglot._typing import C, E, T
     from sqlglot.expressions import Expression
+
 
 CAMEL_CASE_PATTERN = re.compile("(?<!^)(?=[A-Z])")
 PYTHON_VERSION = sys.version_info[:2]
@@ -435,3 +436,25 @@ def dict_depth(d: t.Dict) -> int:
 def first(it: t.Iterable[T]) -> T:
     """Returns the first element from an iterable (useful for sets)."""
     return next(i for i in it)
+
+
+def merge_ranges(ranges: t.List[t.Tuple[C, C]]) -> t.List[t.Tuple[C, C]]:
+    if not ranges:
+        return []
+
+    # First, sort the ranges by starts
+    sorted_ranges = sorted(ranges, key=lambda x: x[0])
+
+    merged_ranges = [sorted_ranges[0]]
+
+    for start, end in sorted_ranges[1:]:
+        last_start, last_end = merged_ranges[-1]
+
+        # If the current range overlaps with the last merged range, merge them
+        if start <= last_end:
+            new_end = max(last_end, end)
+            merged_ranges[-1] = (last_start, new_end)
+        else:
+            merged_ranges.append((start, end))
+
+    return merged_ranges

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -575,8 +575,8 @@ def _datetrunc_range(date: datetime.date, unit: str) -> t.Optional[DateRange]:
 def _datetrunc_eq_expression(left: exp.Expression, drange: DateRange) -> exp.Expression:
     """Get the logical expression for a date range"""
     return exp.and_(
-        exp.GTE(this=left.copy(), expression=date_literal(drange[0])),
-        exp.LT(this=left.copy(), expression=date_literal(drange[1])),
+        left >= date_literal(drange[0]),
+        left < date_literal(drange[1]),
         copy=False,
     )
 
@@ -599,8 +599,8 @@ def _datetrunc_neq(
         return None
 
     return exp.and_(
-        exp.LT(this=left.copy(), expression=date_literal(drange[0])),
-        exp.GTE(this=left.copy(), expression=date_literal(drange[1])),
+        left < date_literal(drange[0]),
+        left >= date_literal(drange[1]),
         copy=False,
     )
 
@@ -609,14 +609,10 @@ DateTruncBinaryTransform = t.Callable[
     [exp.Expression, datetime.date, str], t.Optional[exp.Expression]
 ]
 DATETRUNC_BINARY_COMPARISONS: t.Dict[t.Type[exp.Expression], DateTruncBinaryTransform] = {
-    exp.LT: lambda l, d, u: exp.LT(this=l.copy(), expression=date_literal(date_floor(d, u))),
-    exp.GT: lambda l, d, u: exp.GTE(
-        this=l.copy(), expression=date_literal(date_floor(d, u) + interval(u))
-    ),
-    exp.LTE: lambda l, d, u: exp.LT(
-        this=l.copy(), expression=date_literal(date_floor(d, u) + interval(u))
-    ),
-    exp.GTE: lambda l, d, u: exp.GTE(this=l.copy(), expression=date_literal(date_ceil(d, u))),
+    exp.LT: lambda l, d, u: l < date_literal(date_floor(d, u)),
+    exp.GT: lambda l, d, u: l >= date_literal(date_floor(d, u) + interval(u)),
+    exp.LTE: lambda l, d, u: l < date_literal(date_floor(d, u) + interval(u)),
+    exp.GTE: lambda l, d, u: l >= date_literal(date_ceil(d, u)),
     exp.EQ: _datetrunc_eq,
     exp.NEQ: _datetrunc_neq,
 }

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -775,22 +775,22 @@ def interval(unit: str, n: int = 1):
 
     if unit == "year":
         return relativedelta(years=1 * n)
-    elif unit == "quarter":
+    if unit == "quarter":
         return relativedelta(months=3 * n)
-    elif unit == "month":
+    if unit == "month":
         return relativedelta(months=1 * n)
-    elif unit == "week":
+    if unit == "week":
         return relativedelta(weeks=1 * n)
-    elif unit == "day":
+    if unit == "day":
         return relativedelta(days=1 * n)
-    else:
-        raise UnsupportedUnit(f"Unsupported unit: {unit}")
+
+    raise UnsupportedUnit(f"Unsupported unit: {unit}")
 
 
 def date_floor(d: datetime.date, unit: str) -> datetime.date:
     if unit == "year":
         return datetime.date(year=d.year, month=1, day=1)
-    elif unit == "quarter":
+    if unit == "quarter":
         if d.month <= 3:
             return datetime.date(year=d.year, month=1, day=1)
         elif d.month <= 6:
@@ -799,13 +799,13 @@ def date_floor(d: datetime.date, unit: str) -> datetime.date:
             return datetime.date(year=d.year, month=7, day=1)
         else:
             return datetime.date(year=d.year, month=10, day=1)
-    elif unit == "month":
+    if unit == "month":
         return datetime.date(year=d.year, month=d.month, day=1)
-    elif unit == "week":
+    if unit == "week":
         # Assuming week starts on Monday (0) and ends on Sunday (6)
         d = d - datetime.timedelta(days=d.weekday())
         return datetime.date(year=d.year, month=d.month, day=d.day)
-    elif unit == "day":
+    if unit == "day":
         return datetime.date(year=d.year, month=d.month, day=d.day)
 
     raise UnsupportedUnit(f"Unsupported unit: {unit}")

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -680,3 +680,77 @@ CONCAT('a', x, y, 'bc');
 
 'a' || 'b' || x;
 CONCAT('ab', x);
+
+--------------------------------------
+-- DATE_TRUNC
+--------------------------------------
+DATE_TRUNC('day', CAST(x AS DATE));
+CAST(x AS DATE);
+
+DATE_TRUNC('year', x) = CAST('2021-01-01' AS DATE);
+x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
+
+DATE_TRUNC('quarter', x) = CAST('2021-01-01' AS DATE);
+x < CAST('2021-04-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
+
+DATE_TRUNC('month', x) = CAST('2021-01-01' AS DATE);
+x < CAST('2021-02-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
+
+DATE_TRUNC('week', x) = CAST('2021-01-04' AS DATE);
+x < CAST('2021-01-11' AS DATE) AND x >= CAST('2021-01-04' AS DATE);
+
+CAST('2021-01-01' AS DATE) = DATE_TRUNC('year', x);
+x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
+
+-- Always false, except for nulls
+DATE_TRUNC('quarter', x) = CAST('2021-01-02' AS DATE);
+DATE_TRUNC('quarter', x) = CAST('2021-01-02' AS DATE);
+
+DATE_TRUNC('year', x) <> CAST('2021-01-01' AS DATE);
+x < CAST('2021-01-01' AS DATE) AND x >= CAST('2022-01-01' AS DATE);
+
+-- Always true, except for nulls
+DATE_TRUNC('year', x) <> CAST('2021-01-02' AS DATE);
+DATE_TRUNC('year', x) <> CAST('2021-01-02' AS DATE);
+
+DATE_TRUNC('year', x) <= CAST('2021-01-01' AS DATE);
+x < CAST('2022-01-01' AS DATE);
+
+DATE_TRUNC('year', x) <= CAST('2021-01-02' AS DATE);
+x < CAST('2022-01-01' AS DATE);
+
+CAST('2021-01-01' AS DATE) >= DATE_TRUNC('year', x);
+x < CAST('2022-01-01' AS DATE);
+
+DATE_TRUNC('year', x) < CAST('2021-01-01' AS DATE);
+x < CAST('2021-01-01' AS DATE);
+
+DATE_TRUNC('year', x) < CAST('2021-01-02' AS DATE);
+x < CAST('2021-01-01' AS DATE);
+
+DATE_TRUNC('year', x) >= CAST('2021-01-01' AS DATE);
+x >= CAST('2021-01-01' AS DATE);
+
+DATE_TRUNC('year', x) >= CAST('2021-01-02' AS DATE);
+x >= CAST('2022-01-01' AS DATE);
+
+DATE_TRUNC('year', x) > CAST('2021-01-01' AS DATE);
+x >= CAST('2022-01-01' AS DATE);
+
+DATE_TRUNC('year', x) > CAST('2021-01-02' AS DATE);
+x >= CAST('2022-01-01' AS DATE);
+
+-- right is not a date
+DATE_TRUNC('year', x) <> '2021-01-02';
+DATE_TRUNC('year', x) <> '2021-01-02';
+
+DATE_TRUNC('year', x) IN (CAST('2021-01-01' AS DATE), CAST('2023-01-01' AS DATE));
+(x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE)) OR (x < CAST('2024-01-01' AS DATE) AND x >= CAST('2023-01-01' AS DATE));
+
+-- merge ranges
+DATE_TRUNC('year', x) IN (CAST('2021-01-01' AS DATE), CAST('2022-01-01' AS DATE));
+x < CAST('2023-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
+
+-- one of the values will always be false
+DATE_TRUNC('year', x) IN (CAST('2021-01-01' AS DATE), CAST('2022-01-02' AS DATE));
+x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -684,9 +684,6 @@ CONCAT('ab', x);
 --------------------------------------
 -- DATE_TRUNC
 --------------------------------------
-DATE_TRUNC('day', CAST(x AS DATE));
-CAST(x AS DATE);
-
 DATE_TRUNC('year', x) = CAST('2021-01-01' AS DATE);
 x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
 
@@ -698,6 +695,9 @@ x < CAST('2021-02-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
 
 DATE_TRUNC('week', x) = CAST('2021-01-04' AS DATE);
 x < CAST('2021-01-11' AS DATE) AND x >= CAST('2021-01-04' AS DATE);
+
+DATE_TRUNC('day', x) = CAST('2021-01-01' AS DATE);
+x < CAST('2021-01-02' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
 
 CAST('2021-01-01' AS DATE) = DATE_TRUNC('year', x);
 x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
@@ -754,3 +754,6 @@ x < CAST('2023-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
 -- one of the values will always be false
 DATE_TRUNC('year', x) IN (CAST('2021-01-01' AS DATE), CAST('2022-01-02' AS DATE));
 x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);
+
+TIMESTAMP_TRUNC(x, YEAR) = CAST('2021-01-01' AS DATETIME);
+x < CAST('2022-01-01 00:00:00' AS DATETIME) AND x >= CAST('2021-01-01 00:00:00' AS DATETIME);

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,7 +1,7 @@
 import unittest
 
 from sqlglot.dialects import BigQuery, Dialect, Snowflake
-from sqlglot.helper import name_sequence, tsort
+from sqlglot.helper import merge_ranges, name_sequence, tsort
 
 
 class TestHelper(unittest.TestCase):
@@ -66,3 +66,10 @@ class TestHelper(unittest.TestCase):
         self.assertEqual(s1(), "a2")
         self.assertEqual(s2(), "b1")
         self.assertEqual(s2(), "b2")
+
+    def test_merge_ranges(self):
+        self.assertEqual([], merge_ranges([]))
+        self.assertEqual([(0, 1)], merge_ranges([(0, 1)]))
+        self.assertEqual([(0, 1), (2, 3)], merge_ranges([(0, 1), (2, 3)]))
+        self.assertEqual([(0, 3)], merge_ranges([(0, 1), (1, 3)]))
+        self.assertEqual([(0, 1), (2, 4)], merge_ranges([(2, 3), (0, 1), (3, 4)]))


### PR DESCRIPTION
Simplify DATE_TRUNC functions.

This is particularly useful because of date partitioned tables.

```sql
SELECT
  DATE_TRUNC('week', CAST(ts AS DATE)) AS week,
  SUM(measure) AS metric
FROM fact
WHERE DATE_TRUNC('week', CAST(ts AS DATE)) >= CAST('2023-01-01' AS DATE)
GROUP BY 1
```

The WHERE predicate is kind of silly, but it happens. Especially by programmatically generated queries.

Some engines don't have this optimization, in which case partition pruning will fail.