### PR TITLE
Fix(bigquery): allow overlaps to be used as an identifier

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -343,6 +343,9 @@ class BigQuery(Dialect):
             "OPTIONS": lambda self: exp.Properties(expressions=self._parse_with_property()),
         }
 
+        RANGE_PARSERS = parser.Parser.RANGE_PARSERS.copy()
+        RANGE_PARSERS.pop(TokenType.OVERLAPS, None)
+
         NULL_TOKENS = {TokenType.NULL, TokenType.UNKNOWN}
 
         def _parse_table_part(self, schema: bool = False) -> t.Optional[exp.Expression]:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -285,6 +285,7 @@ class Parser(metaclass=_Parser):
         TokenType.NEXT,
         TokenType.OFFSET,
         TokenType.ORDINALITY,
+        TokenType.OVERLAPS,
         TokenType.OVERWRITE,
         TokenType.PARTITION,
         TokenType.PERCENT,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -107,6 +107,10 @@ class TestBigQuery(Validator):
             "SELECT LAST_VALUE(a IGNORE NULLS) OVER y FROM x WINDOW y AS (PARTITION BY CATEGORY)",
         )
         self.validate_identity(
+            "SELECT a overlaps",
+            "SELECT a AS overlaps",
+        )
+        self.validate_identity(
             "SELECT y + 1 z FROM x GROUP BY y + 1 ORDER BY z",
             "SELECT y + 1 AS z FROM x GROUP BY z ORDER BY z",
         )


### PR DESCRIPTION
Fixes #2272