### PR TITLE
feat(postgres): add support OID postgres type

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3534,6 +3534,7 @@ class DataType(Expression):
         NUMRANGE = auto()
         NVARCHAR = auto()
         OBJECT = auto()
+        OID = auto()
         ROWVERSION = auto()
         SERIAL = auto()
         SET = auto()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -200,6 +200,7 @@ class Parser(metaclass=_Parser):
         TokenType.VARIANT,
         TokenType.OBJECT,
         TokenType.OBJECT_IDENTIFIER,
+        TokenType.OID,
         TokenType.INET,
         TokenType.IPADDRESS,
         TokenType.IPPREFIX,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -154,6 +154,7 @@ class TokenType(AutoName):
     IMAGE = auto()
     VARIANT = auto()
     OBJECT = auto()
+    OID = auto()
     INET = auto()
     IPADDRESS = auto()
     IPPREFIX = auto()
@@ -608,6 +609,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "NOTNULL": TokenType.NOTNULL,
         "NULL": TokenType.NULL,
         "OBJECT": TokenType.OBJECT,
+        "OID": TokenType.OID,
         "OFFSET": TokenType.OFFSET,
         "ON": TokenType.ON,
         "OR": TokenType.OR,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -159,6 +159,11 @@ class TestPostgres(Validator):
         self.assertIsInstance(expr, exp.AlterTable)
         self.assertEqual(expr.sql(dialect="postgres"), alter_table_only)
 
+        oid_table = "CREATE TABLE public.propertydata (propertyvalue oid)"
+        expr = parse_one(oid_table)
+        oid_type = expr.find(exp.ColumnDef).find(exp.DataType).this
+        self.assertEqual(oid_type, exp.DataType.Type.OID)
+
         self.validate_identity(
             """ALTER TABLE ONLY "Album" ADD CONSTRAINT "FK_AlbumArtistId" FOREIGN KEY ("ArtistId") REFERENCES "Artist" ("ArtistId") ON DELETE CASCADE"""
         )


### PR DESCRIPTION
Postgres supports data type OID and it is possible to explicitly create a column with this type. 
This PR adds support for OID data type

**Docs**
[Object Identifier Types](https://www.postgresql.org/docs/16/datatype-oid.html)
The list of all data types can be viewed with the command `\dT *`