### PR TITLE
Fix: ensure Expression is not an iterable to avoid inf. loops

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -757,6 +757,12 @@ class Expression(metaclass=_Expression):
             this=self.copy(), expressions=[convert(e, copy=True) for e in ensure_list(other)]
         )
 
+    def __iter__(self):
+        # We define this because __getitem__ converts Expression into an iterable, which is
+        # problematic because one can hit infinite loops if they do "for x in some_expr: ..."
+        # See: https://peps.python.org/pep-0234/
+        raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
+
     def isin(
         self,
         *expressions: t.Any,

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -380,7 +380,9 @@ def is_iterable(value: t.Any) -> bool:
     Returns:
         A `bool` value indicating if it is an iterable.
     """
-    return hasattr(value, "__iter__") and not isinstance(value, (str, bytes))
+    from sqlglot import Expression
+
+    return hasattr(value, "__iter__") and not isinstance(value, (str, bytes, Expression))
 
 
 def flatten(values: t.Iterable[t.Iterable[t.Any] | t.Any]) -> t.Iterator[t.Any]:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -14,6 +14,11 @@ class TestExpressions(unittest.TestCase):
     def test_depth(self):
         self.assertEqual(parse_one("x(1)").find(exp.Literal).depth, 1)
 
+    def test_iter(self):
+        with self.assertRaises(TypeError):
+            for x in parse_one("SELECT 1"):
+                pass
+
     def test_eq(self):
         self.assertNotEqual(exp.to_identifier("a"), exp.to_identifier("A"))
 


### PR DESCRIPTION
Before:

```python
>>> import sqlglot
>>> for x in sqlglot.parse_one("select 1"):
...     pass
...
<infinite loop - hangs>
```

After:
```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sqlglot/expressions.py", line 764, in __iter__
    raise TypeError(f"'{self.__class__.__name__}' object is not iterable")
TypeError: 'Select' object is not iterable
```