### PR TITLE
feat: kill

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1053,6 +1053,10 @@ class Describe(Expression):
     arg_types = {"this": True, "kind": False, "expressions": False}
 
 
+class Kill(Expression):
+    arg_types = {"this": True, "kind": False}
+
+
 class Pragma(Expression):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1245,6 +1245,13 @@ class Generator:
     def introducer_sql(self, expression: exp.Introducer) -> str:
         return f"{self.sql(expression, 'this')} {self.sql(expression, 'expression')}"
 
+    def kill_sql(self, expression: exp.Kill) -> str:
+        kind = self.sql(expression, "kind")
+        kind = f" {kind}" if kind else ""
+        this = self.sql(expression, "this")
+        this = f" {this}" if this else ""
+        return f"KILL{kind}{this}"
+
     def pseudotype_sql(self, expression: exp.PseudoType) -> str:
         return expression.name.upper()
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -278,6 +278,7 @@ class Parser(metaclass=_Parser):
         TokenType.ISNULL,
         TokenType.INTERVAL,
         TokenType.KEEP,
+        TokenType.KILL,
         TokenType.LEFT,
         TokenType.LOAD,
         TokenType.MERGE,
@@ -544,6 +545,7 @@ class Parser(metaclass=_Parser):
         TokenType.DESCRIBE: lambda self: self._parse_describe(),
         TokenType.DROP: lambda self: self._parse_drop(),
         TokenType.INSERT: lambda self: self._parse_insert(),
+        TokenType.KILL: lambda self: self._parse_kill(),
         TokenType.LOAD: lambda self: self._parse_load(),
         TokenType.MERGE: lambda self: self._parse_merge(),
         TokenType.PIVOT: lambda self: self._parse_simplified_pivot(),
@@ -1824,6 +1826,15 @@ class Parser(metaclass=_Parser):
             overwrite=overwrite,
             alternative=alternative,
             ignore=ignore,
+        )
+
+    def _parse_kill(self) -> exp.Kill:
+        kind = exp.var(self._prev.text) if self._match_texts(("CONNECTION", "QUERY")) else None
+
+        return self.expression(
+            exp.Kill,
+            this=self._parse_primary(),
+            kind=kind,
         )
 
     def _parse_on_conflict(self) -> t.Optional[exp.OnConflict]:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -247,6 +247,7 @@ class TokenType(AutoName):
     JOIN = auto()
     JOIN_MARKER = auto()
     KEEP = auto()
+    KILL = auto()
     LANGUAGE = auto()
     LATERAL = auto()
     LEFT = auto()
@@ -595,6 +596,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "ISNULL": TokenType.ISNULL,
         "JOIN": TokenType.JOIN,
         "KEEP": TokenType.KEEP,
+        "KILL": TokenType.KILL,
         "LATERAL": TokenType.LATERAL,
         "LEFT": TokenType.LEFT,
         "LIKE": TokenType.LIKE,

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -861,3 +861,6 @@ SELECT * FROM (tbl1 CROSS JOIN (SELECT * FROM tbl2) AS t1)
 SELECT next, transform, if
 SELECT "any", "case", "if", "next"
 SELECT x FROM y ORDER BY x ASC
+KILL '123'
+KILL CONNECTION 123
+KILL QUERY '123'


### PR DESCRIPTION
KILL statement.

This is based on MySQL's.

There are versions of TSQL's KILL statement for which this won't work: https://learn.microsoft.com/en-us/sql/t-sql/language-elements/kill-transact-sql?view=sql-server-ver16

But those should be failing today anyways.