### PR TITLE
fix(bigquery): reverse log argument order

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -265,7 +265,7 @@ class BigQuery(Dialect):
     class Parser(parser.Parser):
         PREFIXED_PIVOT_COLUMNS = True
 
-        LOG_BASE_FIRST = False
+        LOG_BASE_FIRST = True
         LOG_DEFAULTS_TO_LN = True
 
         FUNCTIONS = {

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1728,7 +1728,7 @@ SELECT
         self.validate_all(
             "LOG(b, n)",
             read={
-                "bigquery": "LOG(n, b)",
+                "bigquery": "LOG(b, n)",
                 "databricks": "LOG(b, n)",
                 "drill": "LOG(b, n)",
                 "hive": "LOG(b, n)",


### PR DESCRIPTION
Reverse logarithm argument order according to https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#log.