### PR TITLE
test: allow running the test suite without having pyspark installed

### DIFF
--- a/tests/dataframe/integration/test_dataframe.py
+++ b/tests/dataframe/integration/test_dataframe.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # type: ignore[import]
 
 pytest.importorskip("pyspark")
 

--- a/tests/dataframe/integration/test_dataframe.py
+++ b/tests/dataframe/integration/test_dataframe.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("pyspark")
+
 from pyspark.sql import functions as F
 
 from sqlglot.dataframe.sql import functions as SF

--- a/tests/dataframe/integration/test_grouped_data.py
+++ b/tests/dataframe/integration/test_grouped_data.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # type: ignore[import]
 
 pytest.importorskip("pyspark")
 

--- a/tests/dataframe/integration/test_grouped_data.py
+++ b/tests/dataframe/integration/test_grouped_data.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("pyspark")
+
 from pyspark.sql import functions as F
 
 from sqlglot.dataframe.sql import functions as SF

--- a/tests/dataframe/integration/test_session.py
+++ b/tests/dataframe/integration/test_session.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # type: ignore[import]
 
 pytest.importorskip("pyspark")
 

--- a/tests/dataframe/integration/test_session.py
+++ b/tests/dataframe/integration/test_session.py
@@ -1,3 +1,7 @@
+import pytest
+
+pytest.importorskip("pyspark")
+
 from pyspark.sql import functions as F
 
 from sqlglot.dataframe.sql import functions as SF


### PR DESCRIPTION
Would love to be able to run `pytest` full stop without having to install `pyspark`. This PR skips test files that require pyspark for test collection.