### PR TITLE
Fix(redshift): generate correct SQL VALUES clause alias

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1422,7 +1422,7 @@ class Generator:
         alias_node = expression.args.get("alias")
         column_names = alias_node and alias_node.columns
 
-        selects = []
+        selects: t.List[exp.Subqueryable] = []
 
         for i, tup in enumerate(expression.expressions):
             row = tup.expressions

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1445,7 +1445,7 @@ class Generator:
 
             return self.subquery_sql(subquery_expression.subquery(expression.alias, copy=False))
 
-        alias = f" AS {expression.alias}" if expression.alias else ""
+        alias = f" AS {self.sql(expression.args['alias'].this)}" if expression.alias else ""
         unions = " UNION ALL ".join(self.sql(select) for select in selects)
         return f"({unions}){alias}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1418,7 +1418,8 @@ class Generator:
 
         # Converts `VALUES...` expression into a series of select unions.
         expression = expression.copy()
-        column_names = expression.alias and expression.args["alias"].columns
+        alias_node = expression.args.get("alias")
+        column_names = alias_node and alias_node.columns
 
         selects = []
 
@@ -1436,16 +1437,16 @@ class Generator:
             # This may result in poor performance for large-cardinality `VALUES` tables, due to
             # the deep nesting of the resulting exp.Unions. If this is a problem, either increase
             # `sys.setrecursionlimit` to avoid RecursionErrors, or don't set `pretty`.
-            subquery_expression: exp.Select | exp.Union = selects[0]
+            subqueryable: exp.Subqueryable = selects[0]
             if len(selects) > 1:
                 for select in selects[1:]:
-                    subquery_expression = exp.union(
-                        subquery_expression, select, distinct=False, copy=False
-                    )
+                    subqueryable = exp.union(subqueryable, select, distinct=False, copy=False)
 
-            return self.subquery_sql(subquery_expression.subquery(expression.alias, copy=False))
+            return self.subquery_sql(
+                subqueryable.subquery(alias_node and alias_node.this, copy=False)
+            )
 
-        alias = f" AS {self.sql(expression.args['alias'].this)}" if expression.alias else ""
+        alias = f" AS {self.sql(alias_node, 'this')}" if alias_node else ""
         unions = " UNION ALL ".join(self.sql(select) for select in selects)
         return f"({unions}){alias}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import typing as t
 from collections import defaultdict
+from functools import reduce
 
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel, UnsupportedError, concat_messages
@@ -1437,11 +1438,7 @@ class Generator:
             # This may result in poor performance for large-cardinality `VALUES` tables, due to
             # the deep nesting of the resulting exp.Unions. If this is a problem, either increase
             # `sys.setrecursionlimit` to avoid RecursionErrors, or don't set `pretty`.
-            subqueryable: exp.Subqueryable = selects[0]
-            if len(selects) > 1:
-                for select in selects[1:]:
-                    subqueryable = exp.union(subqueryable, select, distinct=False, copy=False)
-
+            subqueryable = reduce(lambda x, y: exp.union(x, y, distinct=False, copy=False), selects)
             return self.subquery_sql(
                 subqueryable.subquery(alias_node and alias_node.this, copy=False)
             )

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -312,9 +312,9 @@ FROM (
             },
         )
         self.validate_all(
-            "SELECT a, b FROM (VALUES (1, 2), (3, 4)) AS t (a, b)",
+            'SELECT a, b FROM (VALUES (1, 2), (3, 4)) AS "t" (a, b)',
             write={
-                "redshift": "SELECT a, b FROM (SELECT 1 AS a, 2 AS b UNION ALL SELECT 3, 4) AS t",
+                "redshift": 'SELECT a, b FROM (SELECT 1 AS a, 2 AS b UNION ALL SELECT 3, 4) AS "t"',
             },
         )
         self.validate_all(

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -341,6 +341,16 @@ FROM (
                 "redshift": "INSERT INTO t (a, b) VALUES (1, 2), (3, 4)",
             },
         )
+        self.validate_identity(
+            'SELECT * FROM (VALUES (1)) AS "t"(a)',
+            '''SELECT
+  *
+FROM (
+  SELECT
+    1 AS a
+) AS "t"''',
+            pretty=True,
+        )
 
     def test_create_table_like(self):
         self.validate_all(


### PR DESCRIPTION
We're currently using the raw alias name when converting `VALUES` to `UNION ALL`, so we drop any quotes:

```python
>>> import sqlglot
>>> sqlglot.transpile('select * from (values (1)) as `t`(a)', 'spark', 'redshift')
['SELECT * FROM (SELECT 1 AS a) AS t']
```