### PR TITLE
Fix!(databricks): parse GENERATED ALWAYS AS into ComputedColumnConstraint

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -72,22 +72,6 @@ class Databricks(Spark):
             this = self.sql(expression, "this")
             return f"GENERATED ALWAYS AS {this}"
 
-        def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
-            c = expression.find(exp.GeneratedAsIdentityColumnConstraint)
-            kind = self.sql(expression, "kind")
-            if c and isinstance(expression.this, exp.Identifier) and kind == "INT":
-                # only BIGINT GENERATED ALWAYS AS IDENTITY constraints are supported, upcast to BIGINT
-                expression = expression.copy()
-                expression.set("kind", "BIGINT")
-            return super().columndef_sql(expression, sep)
-
-        def generatedasidentitycolumnconstraint_sql(
-            self, expression: exp.GeneratedAsIdentityColumnConstraint
-        ) -> str:
-            expression = expression.copy()
-            expression.set("this", True)  # trigger ALWAYS in super class
-            return super().generatedasidentitycolumnconstraint_sql(expression)
-
     class Tokenizer(Spark.Tokenizer):
         HEX_STRINGS = []
 

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from sqlglot import exp, transforms
+import typing as t
+
+from sqlglot import exp, parser, transforms
 from sqlglot.dialects.dialect import parse_date_delta, timestamptrunc_sql
 from sqlglot.dialects.spark import Spark
 from sqlglot.dialects.tsql import generate_date_delta_with_unit_sql
@@ -21,6 +23,21 @@ class Databricks(Spark):
         FACTOR = {
             **Spark.Parser.FACTOR,
             TokenType.COLON: exp.JSONExtract,
+        }
+
+        def _parse_generated(self, kind: t.Optional[str] = None) -> exp.ComputedColumnConstraint:
+            self._match_text_seq("ALWAYS")
+            self._match(TokenType.ALIAS)
+            this = self._parse_expression()
+
+            return self.expression(
+                exp.ComputedColumnConstraint,
+                this=this,
+            )
+
+        CONSTRAINT_PARSERS = {
+            **parser.Parser.CONSTRAINT_PARSERS,
+            "GENERATED": lambda self: self._parse_generated(),
         }
 
     class Generator(Spark.Generator):
@@ -50,6 +67,26 @@ class Databricks(Spark):
             ),
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
         }
+
+        def computedcolumnconstraint_sql(self, expression: exp.ComputedColumnConstraint) -> str:
+            this = self.sql(expression, "this")
+            return f"GENERATED ALWAYS AS {this}"
+
+        def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
+            c = expression.find(exp.GeneratedAsIdentityColumnConstraint)
+            kind = self.sql(expression, "kind")
+            if c and isinstance(expression.this, exp.Identifier) and kind == "INT":
+                # only BIGINT GENERATED ALWAYS AS IDENTITY constraints are supported, upcast to BIGINT
+                expression = expression.copy()
+                expression.set("kind", "BIGINT")
+            return super().columndef_sql(expression, sep)
+
+        def generatedasidentitycolumnconstraint_sql(
+            self, expression: exp.GeneratedAsIdentityColumnConstraint
+        ) -> str:
+            expression = expression.copy()
+            expression.set("this", True)  # trigger ALWAYS in super class
+            return super().generatedasidentitycolumnconstraint_sql(expression)
 
     class Tokenizer(Spark.Tokenizer):
         HEX_STRINGS = []

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -32,6 +32,7 @@ class TestDatabricks(Validator):
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",
             write={
                 "databricks": "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(TO_DATE(y))))",
+                "tsql": "CREATE TABLE foo (x INTEGER AS (YEAR(TS_OR_DS_TO_DATE(y))))",
             },
         )
 


### PR DESCRIPTION
fixes https://github.com/tobymao/sqlglot/issues/2301 the parsing of `GENERATED ALWAYS AS` is now into a ComputedColumnConstraint