### PR TITLE
Fix!(spark): parse computed column constraints appropriately

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -591,6 +591,7 @@ class TSQL(Dialect):
         NVL2_SUPPORTED = False
         ALTER_TABLE_ADD_COLUMN_KEYWORD = False
         LIMIT_FETCH = "FETCH"
+        COMPUTED_COLUMN_WITH_TYPE = False
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -14,6 +14,7 @@ from sqlglot.dialects.dialect import (
     parse_date_delta,
     rename_func,
     timestrtotime_sql,
+    ts_or_ds_to_date_sql,
 )
 from sqlglot.expressions import DataType
 from sqlglot.helper import seq_get
@@ -630,6 +631,7 @@ class TSQL(Dialect):
             exp.TemporaryProperty: lambda self, e: "",
             exp.TimeStrToTime: timestrtotime_sql,
             exp.TimeToStr: _format_sql,
+            exp.TsOrDsToDate: ts_or_ds_to_date_sql("tsql"),
         }
 
         TRANSFORMS.pop(exp.ReturnsProperty)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -207,7 +207,7 @@ class Generator:
     # The keyword used to clone a table in a DDL statement
     CLONE_KEYWORD = "CLONE"
 
-    # Whether or not to incldue the type of a computed column in the CREATE DDL
+    # Whether or not to include the type of a computed column in the CREATE DDL
     COMPUTED_COLUMN_WITH_TYPE = True
 
     TYPE_MAPPING = {

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -207,6 +207,9 @@ class Generator:
     # The keyword used to clone a table in a DDL statement
     CLONE_KEYWORD = "CLONE"
 
+    # Whether or not to incldue the type of a computed column in the CREATE DDL
+    COMPUTED_COLUMN_WITH_TYPE = True
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -651,6 +654,9 @@ class Generator:
         constraints = f" {constraints}" if constraints else ""
         position = self.sql(expression, "position")
         position = f" {position}" if position else ""
+
+        if expression.find(exp.ComputedColumnConstraint) and not self.COMPUTED_COLUMN_WITH_TYPE:
+            kind = ""
 
         return f"{exists}{column}{kind}{constraints}{position}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3761,7 +3761,9 @@ class Parser(metaclass=_Parser):
 
         return self.expression(exp.CompressColumnConstraint, this=self._parse_bitwise())
 
-    def _parse_generated_as_identity(self) -> exp.GeneratedAsIdentityColumnConstraint:
+    def _parse_generated_as_identity(
+        self,
+    ) -> exp.GeneratedAsIdentityColumnConstraint | exp.ComputedColumnConstraint:
         if self._match_text_seq("BY", "DEFAULT"):
             on_null = self._match_pair(TokenType.ON, TokenType.NULL)
             this = self.expression(

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -32,6 +32,7 @@ class TestDatabricks(Validator):
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",
             write={
                 "databricks": "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(TO_DATE(y))))",
+                "tsql": "CREATE TABLE foo (x INTEGER AS YEAR(CAST(y AS DATE)))",
             },
         )
 

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -32,7 +32,7 @@ class TestDatabricks(Validator):
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",
             write={
                 "databricks": "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(TO_DATE(y))))",
-                "tsql": "CREATE TABLE foo (x INTEGER AS YEAR(CAST(y AS DATE)))",
+                "tsql": "CREATE TABLE foo (x AS YEAR(CAST(y AS DATE)))",
             },
         )
 


### PR DESCRIPTION
Fixes #2301

References:
- https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-using.html
- https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/relational-databases/tables/specify-computed-columns-in-a-table?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16
- https://github.com/apache/spark/pull/38823