### PR TITLE
Fix!(bigquery): preserve the correct exp.Clone keyword

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -419,7 +419,6 @@ class BigQuery(Dialect):
         RENAME_TABLE_WITH_DB = False
         NVL2_SUPPORTED = False
         UNNEST_WITH_ORDINALITY = False
-        CLONE_KEYWORD = "COPY"
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -394,6 +394,7 @@ class Snowflake(Dialect):
         TABLE_HINTS = False
         QUERY_HINTS = False
         AGGREGATE_FILTER_SUPPORTED = False
+        SUPPORTS_TABLE_COPY = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1048,6 +1048,7 @@ class Clone(Expression):
         "kind": False,
         "shallow": False,
         "expression": False,
+        "keyword": False,
     }
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1041,6 +1041,8 @@ class Create(DDL):
 
 
 # https://docs.snowflake.com/en/sql-reference/sql/create-clone
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_clone_statement
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_copy
 class Clone(Expression):
     arg_types = {
         "this": True,
@@ -1048,7 +1050,7 @@ class Clone(Expression):
         "kind": False,
         "shallow": False,
         "expression": False,
-        "keyword": False,
+        "copy": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -826,7 +826,7 @@ class Generator:
     def clone_sql(self, expression: exp.Clone) -> str:
         this = self.sql(expression, "this")
         shallow = "SHALLOW " if expression.args.get("shallow") else ""
-        this = f"{shallow}{self.CLONE_KEYWORD} {this}"
+        this = f"{shallow}{expression.args.get('keyword') or self.CLONE_KEYWORD} {this}"
         when = self.sql(expression, "when")
 
         if when:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -204,11 +204,11 @@ class Generator:
     # Whether or not session variables / parameters are supported, e.g. @x in T-SQL
     SUPPORTS_PARAMETERS = True
 
-    # The keyword used to clone a table in a DDL statement
-    CLONE_KEYWORD = "CLONE"
-
     # Whether or not to include the type of a computed column in the CREATE DDL
     COMPUTED_COLUMN_WITH_TYPE = True
+
+    # Whether or not CREATE TABLE .. COPY .. is supported. False means we'll generate CLONE instead of COPY
+    SUPPORTS_TABLE_COPY = True
 
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
@@ -826,7 +826,8 @@ class Generator:
     def clone_sql(self, expression: exp.Clone) -> str:
         this = self.sql(expression, "this")
         shallow = "SHALLOW " if expression.args.get("shallow") else ""
-        this = f"{shallow}{expression.args.get('keyword') or self.CLONE_KEYWORD} {this}"
+        keyword = "COPY" if expression.args.get("copy") and self.SUPPORTS_TABLE_COPY else "CLONE"
+        this = f"{shallow}{keyword} {this}"
         when = self.sql(expression, "when")
 
         if when:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1346,7 +1346,7 @@ class Parser(metaclass=_Parser):
             shallow = self._match_text_seq("SHALLOW")
 
             if self._match_texts(self.CLONE_KEYWORDS):
-                keyword = self._prev.text
+                copy = self._prev.text.lower() == "copy"
                 clone = self._parse_table(schema=True)
                 when = self._match_texts({"AT", "BEFORE"}) and self._prev.text.upper()
                 clone_kind = (
@@ -1363,7 +1363,7 @@ class Parser(metaclass=_Parser):
                     kind=clone_kind,
                     shallow=shallow,
                     expression=clone_expression,
-                    keyword=keyword,
+                    copy=copy,
                 )
 
         return self.expression(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1346,6 +1346,7 @@ class Parser(metaclass=_Parser):
             shallow = self._match_text_seq("SHALLOW")
 
             if self._match_texts(self.CLONE_KEYWORDS):
+                keyword = self._prev.text
                 clone = self._parse_table(schema=True)
                 when = self._match_texts({"AT", "BEFORE"}) and self._prev.text.upper()
                 clone_kind = (
@@ -1362,6 +1363,7 @@ class Parser(metaclass=_Parser):
                     kind=clone_kind,
                     shallow=shallow,
                     expression=clone_expression,
+                    keyword=keyword,
                 )
 
         return self.expression(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -123,10 +123,6 @@ class TestBigQuery(Validator):
             """SELECT PARSE_JSON('"foo"') AS json_data""",
         )
         self.validate_identity(
-            "CREATE OR REPLACE TABLE `a.b.c` COPY `a.b.d`",
-            "CREATE OR REPLACE TABLE a.b.c COPY a.b.d",
-        )
-        self.validate_identity(
             "CREATE OR REPLACE TABLE `a.b.c` CLONE `a.b.d`",
             "CREATE OR REPLACE TABLE a.b.c CLONE a.b.d",
         )
@@ -138,6 +134,13 @@ class TestBigQuery(Validator):
         self.validate_all('x <> """"""', write={"bigquery": "x <> ''"})
         self.validate_all("x <> ''''''", write={"bigquery": "x <> ''"})
         self.validate_all("CAST(x AS DATETIME)", read={"": "x::timestamp"})
+        self.validate_all(
+            "CREATE OR REPLACE TABLE `a.b.c` COPY `a.b.d`",
+            write={
+                "bigquery": "CREATE OR REPLACE TABLE a.b.c COPY a.b.d",
+                "snowflake": "CREATE OR REPLACE TABLE a.b.c CLONE a.b.d",
+            },
+        )
         self.validate_all(
             "SELECT DATETIME_DIFF('2023-01-01T00:00:00', '2023-01-01T05:00:00', MILLISECOND)",
             write={

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -123,8 +123,12 @@ class TestBigQuery(Validator):
             """SELECT PARSE_JSON('"foo"') AS json_data""",
         )
         self.validate_identity(
-            "CREATE OR REPLACE TABLE `a.b.c` copy `a.b.d`",
+            "CREATE OR REPLACE TABLE `a.b.c` COPY `a.b.d`",
             "CREATE OR REPLACE TABLE a.b.c COPY a.b.d",
+        )
+        self.validate_identity(
+            "CREATE OR REPLACE TABLE `a.b.c` CLONE `a.b.d`",
+            "CREATE OR REPLACE TABLE a.b.c CLONE a.b.d",
         )
 
         self.validate_all("SELECT SPLIT(foo)", write={"bigquery": "SELECT SPLIT(foo, ',')"})

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -660,7 +660,6 @@ class TestSnowflake(Validator):
         self.validate_identity("CREATE MATERIALIZED VIEW a COMMENT='...' AS SELECT 1 FROM x")
         self.validate_identity("CREATE DATABASE mytestdb_clone CLONE mytestdb")
         self.validate_identity("CREATE SCHEMA mytestschema_clone CLONE testschema")
-        self.validate_identity("CREATE TABLE orders_clone CLONE orders")
         self.validate_identity("CREATE TABLE IDENTIFIER('foo') (COLUMN1 VARCHAR, COLUMN2 VARCHAR)")
         self.validate_identity("CREATE TABLE IDENTIFIER($foo) (col1 VARCHAR, col2 VARCHAR)")
         self.validate_identity(
@@ -679,6 +678,16 @@ class TestSnowflake(Validator):
             "CREATE OR REPLACE TABLE EXAMPLE_DB.DEMO.USERS (ID DECIMAL(38, 0) NOT NULL, PRIMARY KEY (ID), FOREIGN KEY (CITY_CODE) REFERENCES EXAMPLE_DB.DEMO.CITIES (CITY_CODE))"
         )
 
+        self.validate_all(
+            "CREATE TABLE orders_clone CLONE orders",
+            read={
+                "bigquery": "CREATE TABLE orders_clone CLONE orders",
+            },
+            write={
+                "bigquery": "CREATE TABLE orders_clone CLONE orders",
+                "snowflake": "CREATE TABLE orders_clone CLONE orders",
+            },
+        )
         self.validate_all(
             "CREATE OR REPLACE TRANSIENT TABLE a (id INT)",
             read={


### PR DESCRIPTION
BigQuery supports both `CREATE ... COPY ...` and `CREATE ... CLONE ...` and they have different semantics. I was unaware of this when I merged https://github.com/tobymao/sqlglot/commit/8ed0a810ef4ec36ca648ad55b7a873ce04b8da30 and accidentally broke a SQLMesh test.

References:
- https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_clone_statement
- https://tsaiprabhanj.medium.com/bigquery-copy-vs-clone-table-d4a57c6de422
- https://docs.snowflake.com/en/sql-reference/sql/create-clone