### PR TITLE
Fix!(databricks): upgrade IDENTITY column type to BIGINT if INT 

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -52,12 +52,12 @@ class Databricks(Spark):
         }
 
         def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
-            c = expression.find(exp.GeneratedAsIdentityColumnConstraint)
+            constraint = expression.find(exp.GeneratedAsIdentityColumnConstraint)
             kind = self.sql(expression, "kind")
-            if c and isinstance(expression.this, exp.Identifier) and kind == "INT":
+            if constraint and isinstance(expression.this, exp.Identifier) and kind == "INT":
                 # only BIGINT generated identity constraints are supported
                 expression = expression.copy()
-                expression.set("kind", "BIGINT")
+                expression.set("kind", exp.DataType.build("bigint"))
             return super().columndef_sql(expression, sep)
 
         def generatedasidentitycolumnconstraint_sql(

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -51,6 +51,15 @@ class Databricks(Spark):
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
         }
 
+        def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
+            c = expression.find(exp.GeneratedAsIdentityColumnConstraint)
+            kind = self.sql(expression, "kind")
+            if c and isinstance(expression.this, exp.Identifier) and kind == "INT":
+                # only BIGINT generated identity constraints are supported
+                expression = expression.copy()
+                expression.set("kind", "BIGINT")
+            return super().columndef_sql(expression, sep)
+
         def generatedasidentitycolumnconstraint_sql(
             self, expression: exp.GeneratedAsIdentityColumnConstraint
         ) -> str:

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -53,8 +53,12 @@ class Databricks(Spark):
 
         def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
             constraint = expression.find(exp.GeneratedAsIdentityColumnConstraint)
-            kind = self.sql(expression, "kind")
-            if constraint and isinstance(expression.this, exp.Identifier) and kind == "INT":
+            kind = expression.args.get("kind")
+            if (
+                constraint
+                and isinstance(kind, exp.DataType)
+                and kind.this in exp.DataType.INTEGER_TYPES
+            ):
                 # only BIGINT generated identity constraints are supported
                 expression = expression.copy()
                 expression.set("kind", exp.DataType.build("bigint"))

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -506,7 +506,7 @@ class TestTSQL(Validator):
                 "tsql": "CREATE TABLE tbl (id INTEGER NOT NULL IDENTITY(10, 1) PRIMARY KEY)",
             },
             write={
-                "databricks": "CREATE TABLE tbl (id INT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 10 INCREMENT BY 1) PRIMARY KEY)",
+                "databricks": "CREATE TABLE tbl (id BIGINT NOT NULL GENERATED ALWAYS AS IDENTITY (START WITH 10 INCREMENT BY 1) PRIMARY KEY)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Only BIGINT column type is supported on Databricks as IDENTITY column.
It's harmless to upgrade INT to BIGINT for identity columns and is what a human transpiler would do.
a INT column type will generate a parse exception in spark/databricks.


**Official Documentation**
https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-table-using.html#parameters

GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( [ START WITH start ] [ INCREMENT BY step ] ) ]

Applies to: check marked yes Databricks SQL check marked yes Databricks Runtime 10.3 and above

Defines an identity column. When you write to the table, and do not provide values for the identity column, it will be automatically assigned a unique and statistically increasing (or decreasing if step is negative) value. This clause is only supported for Delta Lake tables. This clause can only be used for columns with **BIGINT** data type.