### PR TITLE
feat(optimizer): ensure boolean predicates on CASE statement

### DIFF
--- a/sqlglot/optimizer/canonicalize.py
+++ b/sqlglot/optimizer/canonicalize.py
@@ -84,7 +84,7 @@ def ensure_bool_predicates(expression: exp.Expression) -> exp.Expression:
         _replace_int_predicate(expression.left)
         _replace_int_predicate(expression.right)
 
-    elif isinstance(expression, (exp.Where, exp.Having)):
+    elif isinstance(expression, (exp.Where, exp.Having, exp.If)):
         _replace_int_predicate(expression.this)
 
     return expression
@@ -114,5 +114,8 @@ def _replace_cast(node: exp.Expression, to: exp.DataType.Type) -> None:
 
 
 def _replace_int_predicate(expression: exp.Expression) -> None:
-    if expression.type and expression.type.this in exp.DataType.INTEGER_TYPES:
+    if isinstance(expression, exp.Coalesce):
+        for _, child in expression.iter_expressions():
+            _replace_int_predicate(child)
+    elif expression.type and expression.type.this in exp.DataType.INTEGER_TYPES:
         expression.replace(exp.NEQ(this=expression.copy(), expression=exp.Literal.number(0)))

--- a/tests/fixtures/optimizer/canonicalize.sql
+++ b/tests/fixtures/optimizer/canonicalize.sql
@@ -29,6 +29,12 @@ SELECT "x"."a" AS "a" FROM "x" AS "x" GROUP BY "x"."a" HAVING SUM("x"."b") <> 0 
 SELECT a FROM x WHERE 1;
 SELECT "x"."a" AS "a" FROM "x" AS "x" WHERE 1 <> 0;
 
+SELECT a FROM x WHERE COALESCE(0, 1);
+SELECT "x"."a" AS "a" FROM "x" AS "x" WHERE COALESCE(0 <> 0, 1 <> 0);
+
+SELECT a FROM x WHERE CASE WHEN COALESCE(b, 1) THEN 1 ELSE 0 END;
+SELECT "x"."a" AS "a" FROM "x" AS "x" WHERE CASE WHEN COALESCE("x"."b" <> 0, 1 <> 0) THEN 1 ELSE 0 END <> 0;
+
 --------------------------------------
 -- Replace date functions
 --------------------------------------

--- a/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
+++ b/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
@@ -4793,10 +4793,10 @@ WITH "foo" AS (
     "foo"."i_item_sk" AS "i_item_sk",
     "foo"."d_moy" AS "d_moy",
     "foo"."mean" AS "mean",
-    CASE "foo"."mean" WHEN 0 THEN NULL ELSE "foo"."stdev" / "foo"."mean" END AS "cov"
+    CASE "foo"."mean" WHEN FALSE THEN NULL ELSE "foo"."stdev" / "foo"."mean" END AS "cov"
   FROM "foo" AS "foo"
   WHERE
-    CASE "foo"."mean" WHEN 0 THEN 0 ELSE "foo"."stdev" / "foo"."mean" END > 1
+    CASE "foo"."mean" WHEN FALSE THEN 0 ELSE "foo"."stdev" / "foo"."mean" END > 1
 )
 SELECT
   "inv1"."w_warehouse_sk" AS "w_warehouse_sk",


### PR DESCRIPTION
`SELECT COALESCE(TRUE, 0)` breaks trino:

```
trino error: line 1:23: All COALESCE operands must be the same type or coercible to a common type. Cannot find common type between boolean and integer, all types (without duplicates): [boolean, integer]
```

Conversely, mysql doesn't have a boolean type, so we see predicates like `SELECT ... WHERE COALESCE(..., 0)`
