### PR TITLE
Fix!: raise ParseError on duplicate query modifiers

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2223,6 +2223,8 @@ class Parser(metaclass=_Parser):
                     key, expression = parser(self)
 
                     if expression:
+                        if this.args.get(key):
+                            raise ParseError(f"{key} is already set")
                         this.set(key, expression)
                         if key == "limit":
                             offset = expression.args.pop("offset", None)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -225,6 +225,12 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(ParseError):
             parse_one("SELECT foo( FROM bar")
 
+        with self.assertRaises(ParseError):
+            parse_one("SELECT * FROM foo WHERE true WHERE false")
+
+        with self.assertRaises(ParseError):
+            parse_one("SELECT * FROM foo LIMIT 10 LIMIT 100")
+
         self.assertEqual(
             parse_one(
                 "CREATE TABLE t (i UInt8) ENGINE = AggregatingMergeTree() ORDER BY tuple()",


### PR DESCRIPTION
Currently, when sqlglot parses SQL queries with duplicate query modifiers, it silently discards everything except the last one.

For example:
```sql
SELECT * FROM foo WHERE bar1 WHERE bar2 WHERE bar3
```
is parsed as if it were `SELECT * FROM foo WHERE bar3`.

This PR throws an error on such cases instead.

### Impact

I'm not sure how big the impact of this change will be, but I'm not surprised if it is quite big. I have added some tests and all the current tests pass but I am cautious that this might silently break other things.