### PR TITLE
Feat!: add support for heredoc strings (Postgres, ClickHouse)

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -43,6 +43,7 @@ class ClickHouse(Dialect):
         STRING_ESCAPES = ["'", "\\"]
         BIT_STRINGS = [("0b", "")]
         HEX_STRINGS = [("0x", ""), ("0X", "")]
+        HEREDOC_STRINGS = ["$"]
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
@@ -73,6 +74,11 @@ class ClickHouse(Dialect):
             "UINT32": TokenType.UINT,
             "UINT64": TokenType.UBIGINT,
             "UINT8": TokenType.UTINYINT,
+        }
+
+        SINGLE_TOKENS = {
+            **tokens.Tokenizer.SINGLE_TOKENS,
+            "$": TokenType.HEREDOC_STRING,
         }
 
     class Parser(parser.Parser):

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -248,11 +248,10 @@ class Postgres(Dialect):
     }
 
     class Tokenizer(tokens.Tokenizer):
-        QUOTES = ["'", "$$"]
-
         BIT_STRINGS = [("b'", "'"), ("B'", "'")]
         HEX_STRINGS = [("x'", "'"), ("X'", "'")]
         BYTE_STRINGS = [("e'", "'"), ("E'", "'")]
+        HEREDOC_STRINGS = ["$"]
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
@@ -296,7 +295,7 @@ class Postgres(Dialect):
 
         SINGLE_TOKENS = {
             **tokens.Tokenizer.SINGLE_TOKENS,
-            "$": TokenType.PARAMETER,
+            "$": TokenType.HEREDOC_STRING,
         }
 
         VAR_SINGLE_TOKENS = {"$"}

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -590,6 +590,9 @@ class Parser(metaclass=_Parser):
             exp.National, this=token.text
         ),
         TokenType.RAW_STRING: lambda self, token: self.expression(exp.RawString, this=token.text),
+        TokenType.HEREDOC_STRING: lambda self, token: self.expression(
+            exp.RawString, this=token.text
+        ),
         TokenType.SESSION_PARAMETER: lambda self, _: self._parse_session_parameter(),
     }
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -310,7 +310,7 @@ class TestDialect(Validator):
         )
 
     def test_heredoc_strings(self):
-        for dialect in ("clickhouse", "postgres"):
+        for dialect in ("clickhouse", "postgres", "redshift"):
             # Invalid matching tag
             with self.assertRaises(TokenError):
                 parse_one("SELECT $tag1$invalid heredoc string$tag2$", dialect=dialect)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -5,6 +5,7 @@ from sqlglot import (
     Dialects,
     ErrorLevel,
     ParseError,
+    TokenError,
     UnsupportedError,
     parse_one,
 )
@@ -307,6 +308,32 @@ class TestDialect(Validator):
             "CAST('127.0.0.1/32' AS INET)",
             read={"postgres": "INET '127.0.0.1/32'"},
         )
+
+    def test_heredoc_strings(self):
+        for dialect in ("clickhouse", "postgres"):
+            # Invalid matching tag
+            with self.assertRaises(TokenError):
+                parse_one("SELECT $tag1$invalid heredoc string$tag2$", dialect=dialect)
+
+            # Unmatched tag
+            with self.assertRaises(TokenError):
+                parse_one("SELECT $tag1$invalid heredoc string", dialect=dialect)
+
+            # Without tag
+            self.validate_all(
+                "SELECT 'this is a heredoc string'",
+                read={
+                    dialect: "SELECT $$this is a heredoc string$$",
+                },
+            )
+
+            # With tag
+            self.validate_all(
+                "SELECT 'this is also a heredoc string'",
+                read={
+                    dialect: "SELECT $foo$this is also a heredoc string$foo$",
+                },
+            )
 
     def test_decode(self):
         self.validate_identity("DECODE(bin, charset)")

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -326,12 +326,24 @@ class TestDialect(Validator):
                     dialect: "SELECT $$this is a heredoc string$$",
                 },
             )
+            self.validate_all(
+                "SELECT ''",
+                read={
+                    dialect: "SELECT $$$$",
+                },
+            )
 
             # With tag
             self.validate_all(
                 "SELECT 'this is also a heredoc string'",
                 read={
                     dialect: "SELECT $foo$this is also a heredoc string$foo$",
+                },
+            )
+            self.validate_all(
+                "SELECT ''",
+                read={
+                    dialect: "SELECT $foo$$foo$",
                 },
             )
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -207,7 +207,6 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT ARRAY[1, 2, 3] @> ARRAY[1, 2]")
         self.validate_identity("SELECT ARRAY[1, 2, 3] <@ ARRAY[1, 2]")
         self.validate_identity("SELECT ARRAY[1, 2, 3] && ARRAY[1, 2]")
-        self.validate_identity("$x")
         self.validate_identity("x$")
         self.validate_identity("SELECT ARRAY[1, 2, 3]")
         self.validate_identity("SELECT ARRAY(SELECT 1)")

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -226,7 +226,6 @@ class TestRedshift(Validator):
         self.validate_identity("SELECT * FROM #x")
         self.validate_identity("SELECT INTERVAL '5 day'")
         self.validate_identity("foo$")
-        self.validate_identity("$foo")
         self.validate_identity("CAST('bla' AS SUPER)")
         self.validate_identity("CREATE TABLE real1 (realcol REAL)")
         self.validate_identity("CAST('foo' AS HLLSKETCH)")


### PR DESCRIPTION
Fixes #2316 - planning to do another pass on this and double-check some changed tests etc.

cc: @pkit

References:
- https://clickhouse.com/docs/en/sql-reference/syntax#heredoc
- https://www.postgresql.org/docs/8.1/sql-syntax.html (see «Dollar-Quoted String Constants» section)