### PR TITLE
Fix(clickhouse): don't generate parentheses, match R_PAREN conditionally

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -318,6 +318,7 @@ class ClickHouse(Dialect):
         QUERY_HINTS = False
         STRUCT_DELIMITER = ("(", ")")
         NVL2_SUPPORTED = False
+        TABLESAMPLE_REQUIRES_PARENS = False
 
         STRING_TYPE_MAPPING = {
             exp.DataType.Type.CHAR: "String",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2734,14 +2734,14 @@ class Parser(metaclass=_Parser):
         )
         method = self._parse_var(tokens=(TokenType.ROW,))
 
-        self._match(TokenType.L_PAREN)
+        matched_l_paren = self._match(TokenType.L_PAREN)
 
         if self.TABLESAMPLE_CSV:
             num = None
             expressions = self._parse_csv(self._parse_primary)
         else:
             expressions = None
-            num = self._parse_primary()
+            num = self._parse_term()
 
         if self._match_text_seq("BUCKET"):
             bucket_numerator = self._parse_number()
@@ -2756,7 +2756,8 @@ class Parser(metaclass=_Parser):
         elif num:
             size = num
 
-        self._match(TokenType.R_PAREN)
+        if matched_l_paren:
+            self._match_r_paren()
 
         if self._match(TokenType.L_PAREN):
             method = self._parse_var()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2741,7 +2741,11 @@ class Parser(metaclass=_Parser):
             expressions = self._parse_csv(self._parse_primary)
         else:
             expressions = None
-            num = self._parse_term()
+            num = (
+                self._parse_factor()
+                if self._match(TokenType.NUMBER, advance=False)
+                else self._parse_primary()
+            )
 
         if self._match_text_seq("BUCKET"):
             bucket_numerator = self._parse_number()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -24,7 +24,9 @@ class TestClickhouse(Validator):
         self.assertEqual(expr.sql(dialect="clickhouse"), "COUNT(x)")
         self.assertIsNone(expr._meta)
 
-        self.validate_identity("SELECT sum(foo * bar) FROM bla SAMPLE (10000000)")
+        self.validate_identity("SELECT * FROM (SELECT a FROM b SAMPLE 0.01)")
+        self.validate_identity("SELECT * FROM (SELECT a FROM b SAMPLE 1 / 10 OFFSET 1 / 2)")
+        self.validate_identity("SELECT sum(foo * bar) FROM bla SAMPLE 10000000")
         self.validate_identity("CAST(x AS Nested(ID UInt32, Serial UInt32, EventTime DATETIME))")
         self.validate_identity("CAST(x AS Enum('hello' = 1, 'world' = 2))")
         self.validate_identity("CAST(x AS Enum('hello', 'world'))")


### PR DESCRIPTION
Addresses https://github.com/tobymao/sqlglot/issues/2323#issuecomment-1736991605 and fixes another generation bug.

References:
- https://clickhouse.com/docs/en/sql-reference/statements/select/sample
- https://play.clickhouse.com/play?user=play#U0VMRUNUIHN1bShmb28gKiBiYXIpIEZST00gYmxhIFNBTVBMRSAoMTAwMDAwMDAp