### PR TITLE
Fix!: revert escape sequence changes introduced in #2230

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -417,6 +417,7 @@ class BigQuery(Dialect):
         TABLE_HINTS = False
         LIMIT_FETCH = "LIMIT"
         RENAME_TABLE_WITH_DB = False
+        ESCAPE_LINE_BREAK = True
         NVL2_SUPPORTED = False
         UNNEST_WITH_ORDINALITY = False
 
@@ -519,18 +520,6 @@ class BigQuery(Dialect):
             exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
-
-        UNESCAPED_SEQUENCE_TABLE = str.maketrans(  # type: ignore
-            {
-                "\a": "\\a",
-                "\b": "\\b",
-                "\f": "\\f",
-                "\n": "\\n",
-                "\r": "\\r",
-                "\t": "\\t",
-                "\v": "\\v",
-            }
-        )
 
         # from: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords
         RESERVED_KEYWORDS = {

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -333,8 +333,6 @@ class Generator:
         exp.Paren,
     )
 
-    UNESCAPED_SEQUENCE_TABLE = None  # type: ignore
-
     SENTINEL_LINE_BREAK = "__SQLGLOT__LB__"
 
     # Autofilled
@@ -347,6 +345,7 @@ class Generator:
     STRICT_STRING_CONCAT = False
     NORMALIZE_FUNCTIONS: bool | str = "upper"
     NULL_ORDERING = "nulls_are_small"
+    ESCAPE_LINE_BREAK = False
 
     can_identify: t.Callable[[str, str | bool], bool]
 
@@ -1659,8 +1658,8 @@ class Generator:
 
     def escape_str(self, text: str) -> str:
         text = text.replace(self.QUOTE_END, self._escaped_quote_end)
-        if self.UNESCAPED_SEQUENCE_TABLE:
-            text = text.translate(self.UNESCAPED_SEQUENCE_TABLE)
+        if self.ESCAPE_LINE_BREAK:
+            text = text.replace("\n", "\\n")
         elif self.pretty:
             text = text.replace("\n", self.SENTINEL_LINE_BREAK)
         return text


### PR DESCRIPTION
This PR reverts https://github.com/tobymao/sqlglot/commit/66aadfc60b9bffe914b89043b293a3e7357d5dde#, because my understanding of the intended "escaping" semantics at the time was incorrect.

Phillip's original BQ query in #2225 was `SELECT '\a\b\f\n\r\t\v'`, i.e. this is what one would type verbatim in BQ's editor to run it against the engine. However, the python string `"SELECT '\a\b\f\n\r\t\v'"` that was fed into `transpile` is not the "correct" representation of the above query, because it's not what one would get if they were to read that query from a file, i.e. the source of truth for what the SQL means, in python:

```
➜ cat test.sql
SELECT '\a\b\f\n\r\t\v'
➜ python
Python 3.10.13 (main, Aug 24 2023, 22:36:46) [Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> open('test.sql', 'r').read()
"SELECT '\\a\\b\\f\\n\\r\\t\\v'\n"
```

Feeding that last python string to `transpile`, we get back the original BQ query, so the roundtrip of 1) storing the query in a file 2) reading that query from the file into its python string representation and 3) generating SQL back for that same dialect yields the exact same query, which is the intended behavior of SQLGlot:

```
>>> import sqlglot
>>> sqlglot.transpile("SELECT '\\a\\b\\f\\n\\r\\t\\v'\n", "bigquery")
["SELECT '\\a\\b\\f\\n\\r\\t\\v'"]
>>> print(sqlglot.transpile("SELECT '\\a\\b\\f\\n\\r\\t\\v'\n", "bigquery")[0])
SELECT '\a\b\f\n\r\t\v'
```

See the discussion in https://github.com/tobymao/sqlglot/issues/2325 for more context. 

cc: @cpcloud 