### PR TITLE
Fix(snowflake): allow window to be used as a table alias

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -239,6 +239,8 @@ class Snowflake(Dialect):
     class Parser(parser.Parser):
         IDENTIFY_PIVOT_STRINGS = True
 
+        TABLE_ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS | {TokenType.WINDOW}
+
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "ARRAYAGG": exp.ArrayAgg.from_arg_list,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -51,6 +51,10 @@ class TestSnowflake(Validator):
             "SELECT state, city, SUM(retail_price * quantity) AS gross_revenue FROM sales GROUP BY ALL"
         )
         self.validate_identity(
+            "SELECT * FROM foo window",
+            "SELECT * FROM foo AS window",
+        )
+        self.validate_identity(
             r"SELECT RLIKE(a, $$regular expression with \ characters: \d{2}-\d{3}-\d{4}$$, 'i') FROM log_source",
             r"SELECT REGEXP_LIKE(a, 'regular expression with \\ characters: \\d{2}-\\d{3}-\\d{4}', 'i') FROM log_source",
         )


### PR DESCRIPTION
Fixes #2335

It doesn't seem like Snowflake supports Postgres' `FROM x WINDOW y AS (...)` syntax, e.g. this is invalid in Snowflake:

```sql
SELECT SUM(x) OVER a, SUM(y) OVER b FROM c WINDOW a AS (PARTITION BY d), b AS (PARTITION BY e)
```

I also checked their docs and didn't find an example with `WINDOW` having special meaning after a table reference in the `FROM` or `JOIN` clause.

References:
- https://docs.snowflake.com/en/sql-reference/functions-analytic#window-syntax-and-usage
- https://community.snowflake.com/s/question/0D50Z00008fZVLZSA4/is-there-a-way-to-reuse-a-partition-by-clause-