### PR TITLE
Feat(mysql): add unsigned decimal type

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -598,6 +598,7 @@ class MySQL(Dialect):
             exp.DataType.Type.UMEDIUMINT: "MEDIUMINT",
             exp.DataType.Type.USMALLINT: "SMALLINT",
             exp.DataType.Type.UTINYINT: "TINYINT",
+            exp.DataType.Type.UDECIMAL: "DECIMAL",
         }
 
         TIMESTAMP_TYPE_MAPPING = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3581,6 +3581,7 @@ class DataType(Expression):
         UINT128 = auto()
         UINT256 = auto()
         UMEDIUMINT = auto()
+        UDECIMAL = auto()
         UNIQUEIDENTIFIER = auto()
         UNKNOWN = auto()  # Sentinel value, useful for type annotation
         USERDEFINED = "USER-DEFINED"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -178,6 +178,7 @@ class Parser(metaclass=_Parser):
         TokenType.DATERANGE,
         TokenType.DATEMULTIRANGE,
         TokenType.DECIMAL,
+        TokenType.UDECIMAL,
         TokenType.BIGDECIMAL,
         TokenType.UUID,
         TokenType.GEOGRAPHY,
@@ -215,6 +216,7 @@ class Parser(metaclass=_Parser):
         TokenType.MEDIUMINT: TokenType.UMEDIUMINT,
         TokenType.SMALLINT: TokenType.USMALLINT,
         TokenType.TINYINT: TokenType.UTINYINT,
+        TokenType.DECIMAL: TokenType.UDECIMAL,
     }
 
     SUBQUERY_PREDICATES = {

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -99,6 +99,7 @@ class TokenType(AutoName):
     FLOAT = auto()
     DOUBLE = auto()
     DECIMAL = auto()
+    UDECIMAL = auto()
     BIGDECIMAL = auto()
     CHAR = auto()
     NCHAR = auto()

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -12,6 +12,8 @@ class TestMySQL(Validator):
             self.validate_identity(f"CREATE TABLE t (id {t} UNSIGNED)")
             self.validate_identity(f"CREATE TABLE t (id {t}(10) UNSIGNED)")
 
+        self.validate_identity("CREATE TABLE t (id DECIMAL(20, 4) UNSIGNED)")
+
         self.validate_all(
             "CREATE TABLE t (id INT UNSIGNED)",
             write={


### PR DESCRIPTION
In MySQL, the `DECIMAL` type can also be unsigned. 
```
[DECIMAL[(M[,D])] [UNSIGNED] [ZEROFILL]]
```
This PR adds a `UDECIMAL` type.

docs: https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html