### PR TITLE
Feat(executor): add support for TRIM, fix TRIM CSV-style parsing order

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -101,6 +101,8 @@ def _unqualify_pivot_columns(expression: exp.Expression) -> exp.Expression:
 
 class Spark2(Hive):
     class Parser(Hive.Parser):
+        TRIM_PATTERN_FIRST = True
+
         FUNCTIONS = {
             **Hive.Parser.FUNCTIONS,
             "AGGREGATE": exp.Reduce.from_arg_list,

--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -97,11 +97,6 @@ def substring(this, start=None, length=None):
     return this[start:end]
 
 
-@null_if_any("this")
-def trim(this, expression=None):
-    return this.strip(expression)
-
-
 @null_if_any
 def cast(this, to):
     if to == exp.DataType.Type.DATE:
@@ -207,5 +202,5 @@ ENV = {
     "CURRENTTIME": datetime.datetime.now,
     "CURRENTDATE": datetime.date.today,
     "STRFTIME": null_if_any(lambda fmt, arg: datetime.datetime.fromisoformat(arg).strftime(fmt)),
-    "TRIM": trim,
+    "TRIM": null_if_any(lambda this, e=None: this.strip(e)),
 }

--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -97,6 +97,11 @@ def substring(this, start=None, length=None):
     return this[start:end]
 
 
+@null_if_any("this")
+def trim(this, expression=None):
+    return this.strip(expression)
+
+
 @null_if_any
 def cast(this, to):
     if to == exp.DataType.Type.DATE:
@@ -202,4 +207,5 @@ ENV = {
     "CURRENTTIME": datetime.datetime.now,
     "CURRENTDATE": datetime.date.today,
     "STRFTIME": null_if_any(lambda fmt, arg: datetime.datetime.fromisoformat(arg).strftime(fmt)),
+    "TRIM": trim,
 }

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -891,6 +891,9 @@ class Parser(metaclass=_Parser):
     # Whether or not the SET command needs a delimiter (e.g. "=") for assignments.
     SET_REQUIRES_ASSIGNMENT_DELIMITER = True
 
+    # Whether the TRIM function expects the trim characters to be the first argument
+    TRIM_PATTERN_FIRST = False
+
     __slots__ = (
         "error_level",
         "error_message_context",
@@ -4410,16 +4413,18 @@ class Parser(metaclass=_Parser):
 
         position = None
         collation = None
+        expression = None
 
         if self._match_texts(self.TRIM_TYPES):
             position = self._prev.text.upper()
 
-        expression = self._parse_bitwise()
+        this = self._parse_bitwise()
         if self._match_set((TokenType.FROM, TokenType.COMMA)):
-            this = self._parse_bitwise()
-        else:
-            this = expression
-            expression = None
+            invert_order = self._prev.token_type == TokenType.FROM or self.TRIM_PATTERN_FIRST
+            expression = self._parse_bitwise()
+
+            if invert_order:
+                this, expression = expression, this
 
         if self._match(TokenType.COLLATE):
             collation = self._parse_bitwise()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -888,10 +888,10 @@ class Parser(metaclass=_Parser):
     # Whether or not the table sample clause expects CSV syntax
     TABLESAMPLE_CSV = False
 
-    # Whether or not the SET command needs a delimiter (e.g. "=") for assignments.
+    # Whether or not the SET command needs a delimiter (e.g. "=") for assignments
     SET_REQUIRES_ASSIGNMENT_DELIMITER = True
 
-    # Whether the TRIM function expects the trim characters to be the first argument
+    # Whether the TRIM function expects the characters to trim as its first argument
     TRIM_PATTERN_FIRST = False
 
     __slots__ = (

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -135,6 +135,18 @@ class TestBigQuery(Validator):
         self.validate_all("x <> ''''''", write={"bigquery": "x <> ''"})
         self.validate_all("CAST(x AS DATETIME)", read={"": "x::timestamp"})
         self.validate_all(
+            "TRIM(item, '*')",
+            read={
+                "snowflake": "TRIM(item, '*')",
+                "spark": "TRIM('*', item)",
+            },
+            write={
+                "bigquery": "TRIM(item, '*')",
+                "snowflake": "TRIM(item, '*')",
+                "spark": "TRIM('*' FROM item)",
+            },
+        )
+        self.validate_all(
             "CREATE OR REPLACE TABLE `a.b.c` COPY `a.b.d`",
             write={
                 "bigquery": "CREATE OR REPLACE TABLE a.b.c COPY a.b.d",

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -624,6 +624,8 @@ class TestExecutor(unittest.TestCase):
             ("LEFT('12345', 3)", "123"),
             ("RIGHT('12345', 3)", "345"),
             ("DATEDIFF('2022-01-03'::date, '2022-01-01'::TIMESTAMP::DATE)", 2),
+            ("TRIM(' foo ')", "foo"),
+            ("TRIM('afoob', 'ab')", "foo"),
         ]:
             with self.subTest(sql):
                 result = execute(f"SELECT {sql}")


### PR DESCRIPTION
Closes #2341

It seems like we weren't parsing the arguments in the correct order for Snowflake and BigQuery, because the CSV parsing was taking into account only Spark's syntax which expects the trim pattern first and then the actual value.

References:
- https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#trim
- https://docs.snowflake.com/en/sql-reference/functions/trim
- https://spark.apache.org/docs/2.4.4/api/sql/#trim