### PR TITLE
Fix(snowflake): canonicalize stage tables by converting them to strings

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -339,7 +339,7 @@ class Snowflake(Dialect):
                     while self._match_set(self.STAGED_FILE_SINGLE_TOKENS):
                         table_name += self._prev.text
 
-                table = exp.var(table_name)
+                table = exp.Literal.string(table_name)
             elif self._match(TokenType.STRING, advance=False):
                 table = self._parse_string()
 


### PR DESCRIPTION
According to Snowflake's docs, both internal and external location URIs can be strings. This PR converts non-string URIs into string URIs as a canonicalization step.

<img width="799" alt="Screenshot 2023-09-29 at 9 23 51 PM" src="https://github.com/tobymao/sqlglot/assets/46752250/78e71234-7e89-4c48-a59e-2f08efc0ff81">

Reference: https://docs.snowflake.com/en/user-guide/querying-stage