### PR TITLE
Fix(hive): don't generate BYTE when transpiling Oracle's VARCHAR(5 BYTE)

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -562,18 +562,13 @@ class Hive(Dialect):
                 expression = exp.DataType.build("text")
             elif expression.this in exp.DataType.TEMPORAL_TYPES:
                 expression = exp.DataType.build(expression.this)
-
-            size_expression = expression.find(exp.DataTypeParam)
-            if size_expression:
-                if expression.is_type("float"):
+            elif expression.is_type("float"):
+                size_expression = expression.find(exp.DataTypeParam)
+                if size_expression:
                     size = int(size_expression.name)
                     expression = (
                         exp.DataType.build("float") if size <= 32 else exp.DataType.build("double")
                     )
-                elif size_expression.expression:
-                    # This removes keywords like `BYTE` (Oracle) in `CAST(x AS VARCHAR(5 BYTE))`
-                    expression = expression.copy()
-                    t.cast(exp.DataTypeParam, expression.find(exp.DataTypeParam)).expression.pop()
 
             return super().datatype_sql(expression)
 

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -562,13 +562,18 @@ class Hive(Dialect):
                 expression = exp.DataType.build("text")
             elif expression.this in exp.DataType.TEMPORAL_TYPES:
                 expression = exp.DataType.build(expression.this)
-            elif expression.is_type("float"):
-                size_expression = expression.find(exp.DataTypeParam)
-                if size_expression:
+
+            size_expression = expression.find(exp.DataTypeParam)
+            if size_expression:
+                if expression.is_type("float"):
                     size = int(size_expression.name)
                     expression = (
                         exp.DataType.build("float") if size <= 32 else exp.DataType.build("double")
                     )
+                elif size_expression.expression:
+                    # This removes keywords like `BYTE` (Oracle) in `CAST(x AS VARCHAR(5 BYTE))`
+                    expression = expression.copy()
+                    t.cast(exp.DataTypeParam, expression.find(exp.DataTypeParam)).expression.pop()
 
             return super().datatype_sql(expression)
 

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -153,6 +153,7 @@ class Oracle(Dialect):
         JOIN_HINTS = False
         TABLE_HINTS = False
         COLUMN_JOIN_MARKS_SUPPORTED = True
+        DATA_TYPE_SPECIFIERS_ALLOWED = True
 
         LIMIT_FETCH = "FETCH"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -216,6 +216,9 @@ class Generator:
     # Whether or not COLLATE is a function instead of a binary operator
     COLLATE_IS_FUNC = False
 
+    # Whether or not data types support additional specifiers like e.g. CHAR or BYTE (oracle)
+    DATA_TYPE_SPECIFIERS_ALLOWED = False
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -892,7 +895,7 @@ class Generator:
     def datatypeparam_sql(self, expression: exp.DataTypeParam) -> str:
         this = self.sql(expression, "this")
         specifier = self.sql(expression, "expression")
-        specifier = f" {specifier}" if specifier else ""
+        specifier = f" {specifier}" if specifier and self.DATA_TYPE_SPECIFIERS_ALLOWED else ""
         return f"{this}{specifier}"
 
     def datatype_sql(self, expression: exp.DataType) -> str:

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -22,8 +22,6 @@ class TestOracle(Validator):
         self.validate_identity("SELECT * FROM t FOR UPDATE OF s.t.c, s.t.v SKIP LOCKED")
         self.validate_identity("SELECT STANDARD_HASH('hello')")
         self.validate_identity("SELECT STANDARD_HASH('hello', 'MD5')")
-        self.validate_identity("SELECT CAST(NULL AS VARCHAR2(2328 CHAR)) AS COL1")
-        self.validate_identity("SELECT CAST(NULL AS VARCHAR2(2328 BYTE)) AS COL1")
         self.validate_identity("SELECT * FROM table_name@dblink_name.database_link_domain")
         self.validate_identity("SELECT * FROM table_name SAMPLE (25) s")
         self.validate_identity("SELECT * FROM V$SESSION")
@@ -60,6 +58,20 @@ class TestOracle(Validator):
             "SELECT * FROM t SAMPLE (0.25)",
         )
 
+        self.validate_all(
+            "SELECT CAST(NULL AS VARCHAR2(2328 CHAR)) AS COL1",
+            write={
+                "oracle": "SELECT CAST(NULL AS VARCHAR2(2328 CHAR)) AS COL1",
+                "spark": "SELECT CAST(NULL AS VARCHAR(2328)) AS COL1",
+            },
+        )
+        self.validate_all(
+            "SELECT CAST(NULL AS VARCHAR2(2328 BYTE)) AS COL1",
+            write={
+                "oracle": "SELECT CAST(NULL AS VARCHAR2(2328 BYTE)) AS COL1",
+                "spark": "SELECT CAST(NULL AS VARCHAR(2328)) AS COL1",
+            },
+        )
         self.validate_all(
             "NVL(NULL, 1)",
             write={


### PR DESCRIPTION
Fixes #2356

This shouldn't be breaking, I remember adding support for the `expression` argument only to handle Oracle's `BYTE`, `CHAR` type specifiers, see https://github.com/tobymao/sqlglot/commit/3ee16c5e8