### PR TITLE
Fix!(generator): don't join comments with newline in pretty mode

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -496,8 +496,7 @@ class Generator:
         if not comments or isinstance(expression, exp.Binary):
             return sql
 
-        sep = "\n" if self.pretty else " "
-        comments_sql = sep.join(
+        comments_sql = " ".join(
             f"/*{self.pad_comment(comment)}*/" for comment in comments if comment
         )
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -156,9 +156,7 @@ SELECT * FROM foo
 -- comment 2
 -- comment 3
 SELECT * FROM foo""",
-            """/* comment 1 */
-/* comment 2 */
-/* comment 3 */
+            """/* comment 1 */ /* comment 2 */ /* comment 3 */
 SELECT
   *
 FROM foo""",
@@ -182,8 +180,7 @@ line3*/ /*another comment*/ where 1=1 -- comment at the end""",
   *
 FROM tbl /* line1
 line2
-line3 */
-/* another comment */
+line3 */ /* another comment */
 WHERE
   1 = 1 /* comment at the end */""",
             pretty=True,
@@ -310,9 +307,7 @@ FROM v""",
             -- comment3
             DROP TABLE IF EXISTS db.tba
             """,
-            """/* comment1 */
-/* comment2 */
-/* comment3 */
+            """/* comment1 */ /* comment2 */ /* comment3 */
 DROP TABLE IF EXISTS db.tba""",
             pretty=True,
         )
@@ -337,9 +332,7 @@ SELECT
   c
 FROM tb_01
 WHERE
-  a /* comment5 */ = 1 AND b = 2 /* comment6 */
-  /* and c = 1 */
-  /* comment7 */""",
+  a /* comment5 */ = 1 AND b = 2 /* comment6 */ /* and c = 1 */ /* comment7 */""",
             pretty=True,
         )
         self.validate(
@@ -375,9 +368,15 @@ INNER JOIN b""",
             """SELECT
   *
 FROM a
-/* comment 1 */
-/* comment 2 */
+/* comment 1 */ /* comment 2 */
 LEFT OUTER JOIN b""",
+            pretty=True,
+        )
+        self.validate(
+            "SELECT\n  a /* sqlglot.meta case_sensitive */ -- noqa\nFROM tbl",
+            """SELECT
+  a /* sqlglot.meta case_sensitive */ /* noqa */
+FROM tbl""",
             pretty=True,
         )
 


### PR DESCRIPTION
Current behavior:

```python
>>> import sqlglot
>>> print(sqlglot.transpile("select a /* comment */ -- noqa", pretty=True)[0])
SELECT
  a /* comment */
  /* noqa */
```

This breaks the `noqa` linter hint because it moves it to a different line. I don't really like how descriptive comments such as those used above `SELECT` or `DROP` are now moved into a single line, but at least there's a path to fix this by using a _single_ comment instead of >1 consecutive ones, as in:

```sql
/*
 * this is a multi
 * line comment
 */
SELECT ....
```
```

An alternative could be to store additional information per each comment, such as if it's located on the same line as the token it's attached to or not so we can try to be a bit smarter about the separator we use when `pretty=True`.