### PR TITLE
Fix(optimizer): don't merge CTEs with EXPLODE projections into outer scopes

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -181,7 +181,7 @@ def _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join):
         and not any(inner_select.args.get(arg) for arg in UNMERGABLE_ARGS)
         and inner_select.args.get("from")
         and not outer_scope.pivots
-        and not any(e.find(exp.AggFunc, exp.Select) for e in inner_select.expressions)
+        and not any(e.find(exp.AggFunc, exp.Select, exp.Explode) for e in inner_select.expressions)
         and not (leave_tables_isolated and len(outer_scope.selected_sources) > 1)
         and not (
             isinstance(from_or_join, exp.Join)

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -1023,3 +1023,25 @@ SELECT
 FROM "table1" AS "table1"
 LEFT JOIN "alias3"
   ON "table1"."cid" = "alias3"."cid";
+
+# title: CTE with EXPLODE cannot be merged
+# dialect: spark
+# execute: false
+SELECT Name,
+       FruitStruct.`$id`,
+       FruitStruct.value
+  FROM
+       (SELECT Name,
+               explode(Fruits) as FruitStruct
+          FROM fruits_table);
+WITH `_q_0` AS (
+  SELECT
+    `fruits_table`.`name` AS `name`,
+    EXPLODE(`fruits_table`.`fruits`) AS `fruitstruct`
+  FROM `fruits_table` AS `fruits_table`
+)
+SELECT
+  `_q_0`.`name` AS `name`,
+  `_q_0`.`fruitstruct`.`$id` AS `$id`,
+  `_q_0`.`fruitstruct`.`value` AS `value`
+FROM `_q_0` AS `_q_0`;


### PR DESCRIPTION
Before:

```python
>>> query = """
... SELECT Name,
...        FruitStruct.`$id`,
...        FruitStruct.value
...   FROM
...        (SELECT Name,
...                explode(Fruits) as FruitStruct
...           FROM fruits_table)
... """
>>> from sqlglot.optimizer import optimize
>>> print(optimize(query, dialect="spark").sql(dialect="spark", pretty=True))
SELECT
  `fruits_table`.`name` AS `name`,
  EXPLODE(`fruits_table`.`fruits`).`$id` AS `$id`,
  EXPLODE(`fruits_table`.`fruits`).`value` AS `value`
FROM `fruits_table` AS `fruits_table`
```

Spark doesn't like ``` EXPLODE(...).`$id` ``` apparently, so this PR aims to fix this issue:

```
spark-sql (default)> SELECT EXPLODE(ARRAY(CAST(STRUCT('fooo') AS STRUCT<a: STRING>))).a;
[FIELD_NOT_FOUND] No such struct field `a` in `col`.
spark-sql (default)> WITH cte(col) AS (SELECT EXPLODE(ARRAY(CAST(STRUCT('fooo') AS STRUCT<a: STRING>)))) SELECT col.a FROM cte;
a
fooo
Time taken: 3.967 seconds, Fetched 1 row(s)
```