### PR TITLE
Fix(tsql): double datatype to float

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -598,6 +598,7 @@ class TSQL(Dialect):
             exp.DataType.Type.BOOLEAN: "BIT",
             exp.DataType.Type.DECIMAL: "NUMERIC",
             exp.DataType.Type.DATETIME: "DATETIME2",
+            exp.DataType.Type.DOUBLE: "FLOAT",
             exp.DataType.Type.INT: "INTEGER",
             exp.DataType.Type.TIMESTAMP: "DATETIME2",
             exp.DataType.Type.TIMESTAMPTZ: "DATETIMEOFFSET",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -32,7 +32,7 @@ class TestTSQL(Validator):
         self.validate_all(
             """CREATE TABLE [dbo].[mytable](
                 [email] [varchar](255) NOT NULL,
-                CONSTRAINT [UN_t_mytable] UNIQUE NONCLUSTERED 
+                CONSTRAINT [UN_t_mytable] UNIQUE NONCLUSTERED
                 (
                     [email] ASC
                 )
@@ -343,7 +343,7 @@ class TestTSQL(Validator):
             "CAST(x as DOUBLE)",
             write={
                 "spark": "CAST(x AS DOUBLE)",
-                "tsql": "CAST(x AS DOUBLE)",
+                "tsql": "CAST(x AS FLOAT)",
             },
         )
 


### PR DESCRIPTION
tsql does not have a DOUBLE data type, MS maps to FLOAT in .NET

https://learn.microsoft.com/en-us/dotnet/api/system.data.sqldbtype?view=net-7.0&redirectedfrom=MSDN

