### PR TITLE
Fix(parser): don't consume identifier in unnamed constraint parser

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3892,7 +3892,9 @@ class Parser(metaclass=_Parser):
     def _parse_unnamed_constraint(
         self, constraints: t.Optional[t.Collection[str]] = None
     ) -> t.Optional[exp.Expression]:
-        if not self._match_texts(constraints or self.CONSTRAINT_PARSERS):
+        if self._match(TokenType.IDENTIFIER, advance=False) or not self._match_texts(
+            constraints or self.CONSTRAINT_PARSERS
+        ):
             return None
 
         constraint = self._prev.text.upper()

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -30,6 +30,9 @@ class TestMySQL(Validator):
         self.validate_identity("CREATE TABLE foo (a BIGINT, FULLTEXT INDEX (b))")
         self.validate_identity("CREATE TABLE foo (a BIGINT, SPATIAL INDEX (b))")
         self.validate_identity(
+            "CREATE TABLE `oauth_consumer` (`key` VARCHAR(32) NOT NULL, UNIQUE `OAUTH_CONSUMER_KEY` (`key`))"
+        )
+        self.validate_identity(
             "CREATE TABLE `x` (`username` VARCHAR(200), PRIMARY KEY (`username`(16)))"
         )
         self.validate_identity(


### PR DESCRIPTION
Fixes #2376

TL;DR the issue is that MySQL overrides the `SCHEMA_UNNAMED_CONSTRAINTS` and adds `KEY` to it, so the ``` `key` ``` identifier's text unfortunately matches that and we eagerly consume it as an unnamed constraint even though we shouldn't.

Not sure if this is the correct approach.. I also thought about not matching identifiers in `_match_texts` but that's a change with a bigger impact and I wanted to discuss about it first.

cc @tobymao what do you think?