### PR TITLE
Feat(optimizer): simplify CONCAT_WS

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -617,7 +617,6 @@ def simplify_concat(expression):
         return expression
 
     if isinstance(expression, exp.ConcatWs):
-        # Skip the separator value
         sep_expr, *expressions = expression.expressions
         sep = sep_expr.name
         concat_type = exp.ConcatWs

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -619,10 +619,8 @@ def simplify_concat(expression):
     if isinstance(expression, exp.ConcatWs):
         # Skip the separator value
         sep_expr, *expressions = expression.expressions
-
-        # CONCAT_WS is equivalent to CONCAT when the separator is the empty string
         sep = sep_expr.name
-        concat_type = exp.ConcatWs if sep else exp.Concat
+        concat_type = exp.ConcatWs
     else:
         expressions = expression.expressions
         sep = ""

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -638,7 +638,7 @@ def simplify_concat(expression):
         return new_args[0]
 
     if concat_type is exp.ConcatWs:
-        new_args = [exp.Literal.string(sep)] + new_args
+        new_args = [sep_expr] + new_args
 
     return concat_type(expressions=new_args)
 

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -73,7 +73,7 @@ def simplify(expression):
         node = simplify_not(node)
         node = flatten(node)
         node = simplify_connectors(node, root)
-        node = remove_compliments(node, root)
+        node = remove_complements(node, root)
         node = simplify_coalesce(node)
         node.parent = expression.parent
         node = simplify_literals(node, root)
@@ -287,19 +287,19 @@ def _simplify_comparison(expression, left, right, or_=False):
     return None
 
 
-def remove_compliments(expression, root=True):
+def remove_complements(expression, root=True):
     """
-    Removing compliments.
+    Removing complements.
 
     A AND NOT A -> FALSE
     A OR NOT A -> TRUE
     """
     if isinstance(expression, exp.Connector) and (root or not expression.same_parent):
-        compliment = exp.false() if isinstance(expression, exp.And) else exp.true()
+        complement = exp.false() if isinstance(expression, exp.And) else exp.true()
 
         for a, b in itertools.permutations(expression.flatten(), 2):
             if is_complement(a, b):
-                return compliment
+                return complement
     return expression
 
 
@@ -609,21 +609,41 @@ SAFE_CONCATS = (exp.SafeConcat, exp.SafeDPipe)
 
 def simplify_concat(expression):
     """Reduces all groups that contain string literals by concatenating them."""
-    if not isinstance(expression, CONCATS) or isinstance(expression, exp.ConcatWs):
+    if not isinstance(expression, CONCATS) or (
+        # We can't reduce a CONCAT_WS call if we don't statically know the separator
+        isinstance(expression, exp.ConcatWs)
+        and not expression.expressions[0].is_string
+    ):
         return expression
+
+    if isinstance(expression, exp.ConcatWs):
+        # Skip the separator value
+        sep_expr, *expressions = expression.expressions
+
+        # CONCAT_WS is equivalent to CONCAT when the separator is the empty string
+        sep = sep_expr.name
+        concat_type = exp.ConcatWs if sep else exp.Concat
+    else:
+        expressions = expression.expressions
+        sep = ""
+        concat_type = exp.SafeConcat if isinstance(expression, SAFE_CONCATS) else exp.Concat
 
     new_args = []
     for is_string_group, group in itertools.groupby(
-        expression.expressions or expression.flatten(), lambda e: e.is_string
+        expressions or expression.flatten(), lambda e: e.is_string
     ):
         if is_string_group:
-            new_args.append(exp.Literal.string("".join(string.name for string in group)))
+            new_args.append(exp.Literal.string(sep.join(string.name for string in group)))
         else:
             new_args.extend(group)
 
-    # Ensures we preserve the right concat type, i.e. whether it's "safe" or not
-    concat_type = exp.SafeConcat if isinstance(expression, SAFE_CONCATS) else exp.Concat
-    return new_args[0] if len(new_args) == 1 else concat_type(expressions=new_args)
+    if len(new_args) == 1 and new_args[0].is_string:
+        return new_args[0]
+
+    if concat_type is exp.ConcatWs:
+        new_args = [exp.Literal.string(sep)] + new_args
+
+    return concat_type(expressions=new_args)
 
 
 DateRange = t.Tuple[datetime.date, datetime.date]

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -700,7 +700,7 @@ CONCAT_WS('-', x, y);
 CONCAT_WS('-', x, y);
 
 CONCAT_WS('', x, y);
-CONCAT(x, y);
+CONCAT_WS('', x, y);
 
 CONCAT_WS('-', x);
 CONCAT_WS('-', x);

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -669,17 +669,41 @@ a AND b AND (ROW() OVER () = 1 OR ROW() OVER () IS NULL);
 CONCAT(x, y);
 CONCAT(x, y);
 
+CONCAT_WS(sep, x, y);
+CONCAT_WS(sep, x, y);
+
 CONCAT(x);
 x;
 
 CONCAT('a', 'b', 'c');
 'abc';
 
+CONCAT('a', NULL);
+CONCAT('a', NULL);
+
+CONCAT_WS('-', 'a', 'b', 'c');
+'a-b-c';
+
 CONCAT('a', x, y, 'b', 'c');
 CONCAT('a', x, y, 'bc');
 
+CONCAT_WS('-', 'a', x, y, 'b', 'c');
+CONCAT_WS('-', 'a', x, y, 'b-c');
+
 'a' || 'b';
 'ab';
+
+CONCAT_WS('-', 'a');
+'a';
+
+CONCAT_WS('-', x, y);
+CONCAT_WS('-', x, y);
+
+CONCAT_WS('-', x);
+CONCAT_WS('-', x);
+
+CONCAT_WS(sep, 'a', 'b');
+CONCAT_WS(sep, 'a', 'b');
 
 'a' || 'b' || x;
 CONCAT('ab', x);

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -699,6 +699,9 @@ CONCAT_WS('-', 'a');
 CONCAT_WS('-', x, y);
 CONCAT_WS('-', x, y);
 
+CONCAT_WS('', x, y);
+CONCAT(x, y);
+
 CONCAT_WS('-', x);
 CONCAT_WS('-', x);
 


### PR DESCRIPTION
This PR:

- Fixes a typo in the optimizer (~which is a breaking change, I guess~): compliments -> complements 😄 
- Improves `simplify_concat` by extending it to also handle `CONCAT_WS`

Regarding the second point, a core assumption here is that the separator always comes first in the argument list of `CONCAT_WS`. This is the case in several dialects I checked (*), and is also reinforced by the tests we have. In any case, I think the optimization is valid and if there's ever an exception to this then it should be probably handled at parse time in order to facilitate transpilation too.

(*): Postgres, MySQL, DuckDB, Spark, Presto, Trino, Snowflake, T-SQL