### PR TITLE
Fix: silence Pandas warning by replacing executor None values with np.NaN

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -4,6 +4,7 @@ from datetime import date
 from multiprocessing import Pool
 
 import duckdb
+import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -94,6 +95,11 @@ class TestExecutor(unittest.TestCase):
                     sql, _ = self.sqls[i]
                     a = self.cached_execute(sql)
                     b = pd.DataFrame(table.rows, columns=table.columns)
+
+                    # The executor represents NULL values as None, whereas DuckDB represents them as NaN,
+                    # and so the following is done to silence Pandas' "Mismatched null-like values" warnings
+                    b = b.fillna(value=np.nan)
+
                     assert_frame_equal(a, b, check_dtype=False, check_index_type=False)
 
     def test_execute_callable(self):


### PR DESCRIPTION
This can also be fixed at the executor level, but that would be a breaking change and I wasn't sure if we even want to change the representation of `NULL` values. See also: https://github.com/pandas-dev/pandas/pull/52081.

The warning can be seen [here](https://github.com/tobymao/sqlglot/actions/runs/6439453133/job/17487149707) (corresponding to the latest commit in main):

<img width="1043" alt="Screenshot 2023-10-07 at 8 04 33 PM" src="https://github.com/tobymao/sqlglot/assets/46752250/b9b2cfa9-10ed-48a8-92b8-e04c2e086508">