### PR TITLE
feat(databricks): transpile UPDATE FROM to MERGE INTO

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -49,6 +49,7 @@ class Databricks(Spark):
                 ]
             ),
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
+            exp.Update: transforms.preprocess([transforms.update_from]),
         }
 
         def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -9,6 +9,43 @@ if t.TYPE_CHECKING:
     from sqlglot.generator import Generator
 
 
+def update_from(expression: exp.Expression) -> exp.Expression:
+    """Transform UPDATE FROM to MERGE INTO"""
+    from_expression = expression.find(exp.From)
+    if isinstance(expression, exp.Update) and from_expression:
+        # perform MERGE INTO
+        """
+        class Update(Expression):
+            arg_types = {
+                    "with": False,
+                    "this": False,
+                    "expressions": True,
+                    "from": False,
+                    "where": False,
+                    "returning": False,
+                    "order": False,
+                    "limit": False,
+                }
+        class Merge(Expression):
+            arg_types = {"this": True, "using": True, "on": True, "expressions": True}
+        """
+        join = from_expression.find(exp.Join)
+        if join:
+            on = join.args.get("on")
+            table = join.find(exp.Table)
+            this = expression.this
+            expression.find(exp.Comment)
+
+            # {"matched": True, "source": False, "condition": False, "then": True}
+            # WHEN MATCHED THEN UPDATE SET state = z.state
+            then = exp.Update(expressions=expression)
+            when = exp.When(matched=True, then=then)
+
+            expression = exp.Merge(this=this, using=table, on=on, expressions=[when])
+
+    return expression
+
+
 def unalias_group(expression: exp.Expression) -> exp.Expression:
     """
     Replace references to select aliases in GROUP BY clauses.

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -190,3 +190,12 @@ class TestDatabricks(Validator):
                 "databricks": "WITH x AS (SELECT 1) SELECT * FROM x",
             },
         )
+
+    def test_update_from(self):
+        self.validate_all(
+            "MERGE INTO mynewtable USING zipcodes AS z ON LEFT(mynewtable.zip, 5) = z.zipcode WHEN MATCHED THEN UPDATE SET state = z.state",
+            read={
+                "tsql": "UPDATE mynewtable SET state = z.state FROM t_merge mynewtable JOIN zipcodes z ON LEFT(mynewtable.zip,5) = z.zipcode",
+                "databricks": "MERGE INTO mynewtable USING zipcodes z ON LEFT(mynewtable.zip, 5) = z.zipcode WHEN MATCHED THEN UPDATE SET state = z.state",
+            },
+        )

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -199,3 +199,10 @@ class TestDatabricks(Validator):
                 "databricks": "MERGE INTO mynewtable USING zipcodes z ON LEFT(mynewtable.zip, 5) = z.zipcode WHEN MATCHED THEN UPDATE SET state = z.state",
             },
         )
+        # tsql update from w/o join
+        self.validate_all(
+            "UPDATE statezips AS r_new SET r_new.geo = CASE WHEN r_new.geo LIKE '%west%' OR r_new.zip = '0' THEN 'West' ELSE 'Midwest' END WHERE r_new.geo IS NULL",
+            read={
+                "tsql": "UPDATE r_new SET r_new.geo = CASE WHEN r_new.geo LIKE '%west%' or r_new.zip = '0' THEN 'West' ELSE 'Midwest' END FROM statezips r_new WHERE r_new.geo IS NULL"
+            },
+        )


### PR DESCRIPTION
`UPDATE .. FROM` sql semantics is used to make a corelated update to a target table, where new values in the target are a function of values in a second table. TSQL

TSQL, PostgreSQL, Redshift, Snowflake do support `UPDATE .. FROM` sql syntax.
Databricks, DuckDB, Oracle don't support `UPDATE .. FROM` sql syntax but do support `MERGE INTO`.

This PR builds a `transforms.py:update_from` (`exp.Update`) transformer, and tests for and implements for the Databricks SQL dialect.

[Slack discussion:](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1695848302882859)

**Official Documentation References**
Additional References:
[Databricks MERGE INTO](https://docs.databricks.com/en/sql/language-manual/delta-merge-into.html)
[Databricks Update:](https://docs.databricks.com/en/sql/language-manual/delta-update.html)
[Oracle Update:](https://docs.oracle.com/javadb/10.8.3.0/ref/rrefsqlj26498.html)
[Oracle Merge:](https://docs.oracle.com/en/database/oracle/oracle-database/12.2/sqlrf/MERGE.html)
[Redshift UPDATE:](https://docs.aws.amazon.com/redshift/latest/dg/r_UPDATE.html)
[DuckDB UPDATE:](https://duckdb.org/docs/sql/statements/update.html)


TSQL syntax checking example:
<img width="1247" alt="image" src="https://github.com/tobymao/sqlglot/assets/1122251/b6daebd3-e078-4e17-ab3d-f4fbd2570ac4">

Databricks syntax checking example:
<img width="946" alt="image" src="https://github.com/tobymao/sqlglot/assets/1122251/ee5e2faa-2d9f-4681-a706-17f21c06cb1e">

