### PR TITLE
Fix(schema): don't specialize type variable in MappingSchema

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -192,7 +192,7 @@ class AbstractMappingSchema(t.Generic[T]):
         )
 
 
-class MappingSchema(AbstractMappingSchema[t.Dict[str, str]], Schema):
+class MappingSchema(AbstractMappingSchema[t.Dict[str, str | exp.DataType]], Schema):
     """
     Schema based on a nested mapping.
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -192,7 +192,7 @@ class AbstractMappingSchema(t.Generic[T]):
         )
 
 
-class MappingSchema(AbstractMappingSchema[t.Dict[str, str | exp.DataType]], Schema):
+class MappingSchema(AbstractMappingSchema[t.Dict[str, t.Union[str, exp.DataType]]], Schema):
     """
     Schema based on a nested mapping.
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -192,7 +192,7 @@ class AbstractMappingSchema(t.Generic[T]):
         )
 
 
-class MappingSchema(AbstractMappingSchema[t.Dict[str, t.Union[str, exp.DataType]]], Schema):
+class MappingSchema(AbstractMappingSchema, Schema):
     """
     Schema based on a nested mapping.
 


### PR DESCRIPTION
In SQLMesh we use the `MappingSchema` to store `DataType`s and it works just fine. Not sure why we restricted the type hint to just `str` for the types to begin with.