### PR TITLE
Fix(optimizer): don't propagate equality constraints from IF/CASE outwards

### DIFF
--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -907,5 +907,17 @@ x = 1 AND y > 0 AND (SELECT z = 5 FROM t WHERE y = 1);
 x = 1 AND x = y AND (SELECT z FROM t WHERE a AND (b OR c));
 x = 1 AND (SELECT z FROM t WHERE a AND (b OR c)) AND 1 = y;
 
-SELECT * FROM t1, t2, t3 WHERE t1.a = 39 AND t2.b = t1.a AND t3.c = t2.b;
-SELECT * FROM t1, t2, t3 WHERE t1.a = 39 AND t2.b = 39 AND t3.c = 39;
+t1.a = 39 AND t2.b = t1.a AND t3.c = t2.b;
+t1.a = 39 AND t2.b = 39 AND t3.c = 39;
+
+x = 1 AND CASE WHEN x = 5 THEN FALSE ELSE TRUE END;
+x = 1 AND CASE WHEN FALSE THEN FALSE ELSE TRUE END;
+
+x = 1 AND IF(x = 5, FALSE, TRUE);
+x = 1 AND CASE WHEN FALSE THEN FALSE ELSE TRUE END;
+
+x = y AND CASE WHEN x = 5 THEN FALSE ELSE TRUE END;
+x = y AND CASE WHEN x = 5 THEN FALSE ELSE TRUE END;
+
+x = 1 AND CASE WHEN y = 5 THEN x = z END;
+x = 1 AND CASE WHEN y = 5 THEN 1 = z END;


### PR DESCRIPTION
This PR adds support for a `prune` callback argument in `walk_in_scope`, similar to how `walk` works. It then leverages it to fix the bug demonstrated below:

Before:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.simplify import simplify
>>>
>>> simplify(parse_one("x = 1 and case when x = 5 then false else true end"), constant_propagation=True).sql()
'FALSE'
```

After:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.simplify import simplify
>>>
>>> simplify(parse_one("x = 1 and case when x = 5 then false else true end"), constant_propagation=True).sql()
'x = 1 AND CASE WHEN FALSE THEN FALSE ELSE TRUE END'
```

One obvious improvement that can be made in a followup PR (I plan to do this soon) is to reduce conditional expressions such as `IF` and `CASE` when the conditions are statically known to be `TRUE` or `FALSE`.