### PR TITLE
Fix: make `RegexpILike` a subclass of `Binary` as well as `Func`

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4877,7 +4877,7 @@ class RegexpLike(Binary, Func):
     arg_types = {"this": True, "expression": True, "flag": False}
 
 
-class RegexpILike(Func):
+class RegexpILike(Binary, Func):
     arg_types = {"this": True, "expression": True, "flag": False}
 
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -732,3 +732,8 @@ class TestPostgres(Validator):
         self.validate_all(
             "VAR_POP(x)", read={"": "VARIANCE_POP(x)"}, write={"postgres": "VAR_POP(x)"}
         )
+
+    def test_regexp_binary(self):
+        """See https://github.com/tobymao/sqlglot/pull/2404 for details."""
+        self.assertIsInstance(parse_one("'thomas' ~ '.*thomas.*'", read="postgres"), exp.Binary)
+        self.assertIsInstance(parse_one("'thomas' ~* '.*thomas.*'", read="postgres"), exp.Binary)


### PR DESCRIPTION
Maybe I'm missing something, but this looks like a simple omission to me - `RegexpLike` is a subclass of `Binary`, so I guess `RegexpILike` should be too.

Thanks so much for sqlglot by the way, it's awesome. Let me know if I can sponsor you.