### PR TITLE
Fix(clickhouse): map RegexpILike to match

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -388,6 +388,7 @@ class ClickHouse(Dialect):
             exp.Pivot: no_pivot_sql,
             exp.Quantile: _quantile_sql,
             exp.RegexpLike: lambda self, e: f"match({self.format_args(e.this, e.expression)})",
+            exp.RegexpILike: lambda self, e: f"match({self.format_args(e.this, e.expression)})",
             exp.StartsWith: rename_func("startsWith"),
             exp.StrPosition: lambda self, e: f"position({self.format_args(e.this, e.args.get('substr'), e.args.get('position'))})",
             exp.VarMap: lambda self, e: _lower_func(var_map_sql(self, e)),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -86,9 +86,15 @@ class TestClickhouse(Validator):
         )
 
         self.validate_all(
-            "match('thomas', '.*thomas.*')",
+            "SELECT match('ThOmAs', CONCAT('(?i)', 'thomas'))",
             read={
-                "postgres": "'thomas' ~* '.*thomas.*'",
+                "postgres": "SELECT 'ThOmAs' ~* 'thomas'",
+            },
+        )
+        self.validate_all(
+            "SELECT match('ThOmAs', CONCAT('(?i)', x)) FROM t",
+            read={
+                "postgres": "SELECT 'ThOmAs' ~* x FROM t",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -86,6 +86,12 @@ class TestClickhouse(Validator):
         )
 
         self.validate_all(
+            "match('thomas', '.*thomas.*')",
+            read={
+                "postgres": "'thomas' ~* '.*thomas.*'",
+            },
+        )
+        self.validate_all(
             "SELECT '\\0'",
             read={
                 "mysql": "SELECT '\0'",


### PR DESCRIPTION
Fixes #2406

Couldn't find another variant for case-insensitive matching. There's `ILIKE` but I don't think it works with regex patterns?

Reference: https://clickhouse.com/docs/en/sql-reference/functions/string-search-functions