### PR TITLE
add some more types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
         files: ^(sqlglot/|tests/|setup.py)
       - id: mypy
         name: mypy
-        entry: mypy
+        entry: mypy sqlglot tests
         language: system
         types: [ python ]
         files: ^(sqlglot/|tests/)
-        require_serial: true
+        pass_filenames: false

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -120,14 +120,14 @@ class Expression(metaclass=_Expression):
         return hash((self.__class__, self.hashable_args))
 
     @property
-    def this(self):
+    def this(self) -> t.Any:
         """
         Retrieves the argument with key "this".
         """
         return self.args.get("this")
 
     @property
-    def expression(self):
+    def expression(self) -> t.Any:
         """
         Retrieves the argument with key "expression".
         """
@@ -2607,11 +2607,11 @@ class Union(Subqueryable):
         return self.this.unnest().selects
 
     @property
-    def left(self):
+    def left(self) -> t.Optional[Expression]:
         return self.this
 
     @property
-    def right(self):
+    def right(self) -> t.Optional[Expression]:
         return self.expression
 
 
@@ -3804,12 +3804,12 @@ class Binary(Condition):
     arg_types = {"this": True, "expression": True}
 
     @property
-    def left(self):
-        return self.this
+    def left(self) -> Expression:
+        return t.cast(Expression, self.this)
 
     @property
-    def right(self):
-        return self.expression
+    def right(self) -> Expression:
+        return t.cast(Expression, self.expression)
 
 
 class Add(Binary):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2607,11 +2607,11 @@ class Union(Subqueryable):
         return self.this.unnest().selects
 
     @property
-    def left(self) -> t.Optional[Expression]:
+    def left(self) -> Expression:
         return self.this
 
     @property
-    def right(self) -> t.Optional[Expression]:
+    def right(self) -> Expression:
         return self.expression
 
 
@@ -3805,11 +3805,11 @@ class Binary(Condition):
 
     @property
     def left(self) -> Expression:
-        return t.cast(Expression, self.this)
+        return self.this
 
     @property
     def right(self) -> Expression:
-        return t.cast(Expression, self.expression)
+        return self.expression
 
 
 class Add(Binary):

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -478,9 +478,12 @@ def simplify_equality(expression: exp.Expression) -> exp.Expression:
             return expression
 
         if l.__class__ in INVERSE_DATE_OPS:
+            # could be any of the INVERSE_DATE_OPS keys
+            l = t.cast(exp.IntervalOp, l.expression)
             a = l.this
             b = l.interval()
         else:
+            l = t.cast(exp.Binary, l)
             a, b = l.left, l.right
 
         if not a_predicate(a) and b_predicate(b):
@@ -813,6 +816,7 @@ def simplify_datetrunc_predicate(expression: exp.Expression) -> exp.Expression:
         else:
             return expression
 
+        l = t.cast(exp.DateTrunc, l)
         unit = l.unit.name.lower()
         date = extract_date(r)
 
@@ -825,6 +829,7 @@ def simplify_datetrunc_predicate(expression: exp.Expression) -> exp.Expression:
         rs = expression.expressions
 
         if rs and all(_is_datetrunc_predicate(l, r) for r in rs):
+            l = t.cast(exp.DateTrunc, l)
             unit = l.unit.name.lower()
 
             ranges = []

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -425,8 +425,8 @@ class SetOperation(Step):
         cls, expression: exp.Expression, ctes: t.Optional[t.Dict[str, Step]] = None
     ) -> Step:
         assert isinstance(expression, exp.Union)
-        left = Step.from_expression(expression.left, ctes)
-        right = Step.from_expression(expression.right, ctes)
+        left = Step.from_expression(expression.left, ctes)  # type: ignore[arg-type]
+        right = Step.from_expression(expression.right, ctes)  # type: ignore[arg-type]
         step = cls(
             op=expression.__class__,
             left=left.name,

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -425,8 +425,8 @@ class SetOperation(Step):
         cls, expression: exp.Expression, ctes: t.Optional[t.Dict[str, Step]] = None
     ) -> Step:
         assert isinstance(expression, exp.Union)
-        left = Step.from_expression(expression.left, ctes)  # type: ignore[arg-type]
-        right = Step.from_expression(expression.right, ctes)  # type: ignore[arg-type]
+        left = Step.from_expression(expression.left, ctes)
+        right = Step.from_expression(expression.right, ctes)
         step = cls(
             op=expression.__class__,
             left=left.name,


### PR DESCRIPTION
I had quite a lot of `cast`s in my code, this should remove most of them.

It's a shame we can't mark `expression.this` as a `Expression` which is always seems to be for me, but in you code you have some places where you're assuming it's a `str`, so I assume it's not always an `Expression`.