### PR TITLE
Feat(snowflake): support for ALTER TABLE SWAP WITH

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -309,6 +309,7 @@ class Snowflake(Dialect):
                 expressions=self._parse_csv(self._parse_id_var),
                 unset=True,
             ),
+            "SWAP": lambda self: self._parse_alter_table_swap(),
         }
 
         STATEMENT_PARSERS = {
@@ -405,6 +406,10 @@ class Snowflake(Dialect):
                     scope = self._parse_table()
 
             return self.expression(exp.Show, this=this, scope=scope, scope_kind=scope_kind)
+
+        def _parse_alter_table_swap(self) -> exp.SwapTable:
+            self._match_text_seq("WITH")
+            return self.expression(exp.SwapTable, this=self._parse_table(schema=True))
 
     class Tokenizer(tokens.Tokenizer):
         STRING_ESCAPES = ["\\", "'"]
@@ -614,3 +619,7 @@ class Snowflake(Dialect):
             increment = expression.args.get("increment")
             increment = f" INCREMENT {increment}" if increment else ""
             return f"AUTOINCREMENT{start}{increment}"
+
+        def swaptable_sql(self, expression: exp.RenameTable) -> str:
+            this = self.sql(expression, "this")
+            return f"SWAP WITH {this}"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1235,6 +1235,10 @@ class RenameTable(Expression):
     pass
 
 
+class SwapTable(Expression):
+    pass
+
+
 class Comment(Expression):
     arg_types = {"this": True, "kind": True, "expression": True, "exists": False}
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -36,6 +36,7 @@ class TestSnowflake(Validator):
         self.validate_identity("COMMENT IF EXISTS ON TABLE foo IS 'bar'")
         self.validate_identity("SELECT CONVERT_TIMEZONE('UTC', 'America/Los_Angeles', col)")
         self.validate_identity("REGEXP_REPLACE('target', 'pattern', '\n')")
+        self.validate_identity("ALTER TABLE a SWAP WITH b")
         self.validate_identity(
             'DESCRIBE TABLE "SNOWFLAKE_SAMPLE_DATA"."TPCDS_SF100TCL"."WEB_SITE" type=stage'
         )
@@ -1150,3 +1151,8 @@ MATCH_RECOGNIZE (
 
         self.assertIsNotNone(table)
         self.assertEqual(table.sql(dialect="snowflake"), '"TEST"."PUBLIC"."customers"')
+
+    def test_swap(self):
+        ast = parse_one("ALTER TABLE a SWAP WITH b", read="snowflake")
+        assert isinstance(ast, exp.AlterTable)
+        assert isinstance(ast.args["actions"][0], exp.SwapTable)


### PR DESCRIPTION
Snowflake has a unique "ALTER TABLE a SWAP WITH b" syntax, this adds supports analogous to "ALTER TABLE a RENAME TO b".