### PR TITLE
Feat(lineage): lineage from UDTFs that use columns

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -143,7 +143,13 @@ def lineage(
             upstream.downstream.append(node)
 
         # Find all columns that went into creating this one to list their lineage nodes.
-        for c in set(select.find_all(exp.Column)):
+        source_columns = set(select.find_all(exp.Column))
+
+        # If the source is a UDTF find columns used in the UTDF to generate the table
+        if isinstance(source, exp.UDTF):
+            source_columns |= set(source.find_all(exp.Column))
+
+        for c in set(source_columns):
             table = c.table
             source = scope.sources.get(table)
 

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -149,7 +149,7 @@ def lineage(
         if isinstance(source, exp.UDTF):
             source_columns |= set(source.find_all(exp.Column))
 
-        for c in set(source_columns):
+        for c in source_columns:
             table = c.table
             source = scope.sources.get(table)
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -218,3 +218,8 @@ class TestLineage(unittest.TestCase):
             downstream.expression.sql(dialect="snowflake"),
             "VALUE",
         )
+        self.assertEqual(len(downstream.downstream), 1)
+
+        downstream = downstream.downstream[0]
+        self.assertEqual(downstream.name, "TEST_TABLE.RESULT")
+        self.assertEqual(downstream.source.sql(dialect="snowflake"), "TEST_TABLE AS TEST_TABLE")


### PR DESCRIPTION
This is the second part to solve extracting a full lineage from a `LATERAL FLATTEN(...` statement in Snowflake #2413, and adds support for getting all columns used in a UDTF to then build downstream nodes for those columns. 

This extends the set of columns generated by doing a `select.find_all(exp.Column)` with any columns found by searching `source.find_all(exp.Column)`, when the source is an instance of `exp.UDTF`. I'm not 100% that's the best way to implement it -- will select.find_all(...) ever return other columns when reading from a UDTF? -- if not this should probably be an `if isinstance(source, exp.UDTF)...else...` instead. 