### PR TITLE
Fix(redshift): don't rewrite JSON_PARSE to PARSE_JSON

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -175,6 +175,7 @@ class Redshift(Postgres):
             exp.GeneratedAsIdentityColumnConstraint: generatedasidentitycolumnconstraint_sql,
             exp.JSONExtract: _json_sql,
             exp.JSONExtractScalar: _json_sql,
+            exp.ParseJSON: rename_func("JSON_PARSE"),
             exp.SafeConcat: concat_to_dpipe_sql,
             exp.Select: transforms.preprocess(
                 [transforms.eliminate_distinct_on, transforms.eliminate_semi_and_anti_joins]

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -310,6 +310,7 @@ ORDER BY
         self.validate_identity(
             "SELECT attr AS attr, JSON_TYPEOF(val) AS value_type FROM customer_orders_lineitem AS c, UNPIVOT c.c_orders AS val AT attr WHERE c_custkey = 9451"
         )
+        self.validate_identity("SELECT JSON_PARSE('[]')")
 
     def test_values(self):
         # Test crazy-sized VALUES clause to UNION ALL conversion to ensure we don't get RecursionError


### PR DESCRIPTION
Fixes #2442, following the example of how the Trino dialect overrides the naming for this function.