### PR TITLE
Fix!: unnabreviate units, e.g. ms to millisecond

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4082,14 +4082,14 @@ class TimeUnit(Expression):
         "y": "year",
     }
 
+    VAR_LIKE = (Column, Literal, Var)
+
     def __init__(self, **args):
         unit = args.get("unit")
-        if isinstance(unit, (Column, Literal)):
+        if isinstance(unit, self.VAR_LIKE):
             args["unit"] = Var(this=self.UNABBREVIATED_UNIT_NAME.get(unit.name) or unit.name)
         elif isinstance(unit, Week):
             unit.set("this", Var(this=unit.this.name))
-        elif isinstance(unit, Var):
-            unit.set("this", self.UNABBREVIATED_UNIT_NAME.get(unit.this) or unit.this)
 
         super().__init__(**args)
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4069,12 +4069,27 @@ class TimeUnit(Expression):
 
     arg_types = {"unit": False}
 
+    UNABBREVIATED_UNIT_NAME = {
+        "d": "day",
+        "h": "hour",
+        "m": "minute",
+        "ms": "millisecond",
+        "ns": "nanosecond",
+        "q": "quarter",
+        "s": "second",
+        "us": "microsecond",
+        "w": "week",
+        "y": "year",
+    }
+
     def __init__(self, **args):
         unit = args.get("unit")
         if isinstance(unit, (Column, Literal)):
-            args["unit"] = Var(this=unit.name)
+            args["unit"] = Var(this=self.UNABBREVIATED_UNIT_NAME.get(unit.name) or unit.name)
         elif isinstance(unit, Week):
             unit.set("this", Var(this=unit.this.name))
+        elif isinstance(unit, Var):
+            unit.set("this", self.UNABBREVIATED_UNIT_NAME.get(unit.this) or unit.this)
 
         super().__init__(**args)
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -102,6 +102,13 @@ class TestClickhouse(Validator):
         )
 
         self.validate_all(
+            "SELECT CAST('2020-01-01' AS TIMESTAMP) + INTERVAL '500' microsecond",
+            read={
+                "duckdb": "SELECT TIMESTAMP '2020-01-01' + INTERVAL '500 us'",
+                "postgres": "SELECT TIMESTAMP '2020-01-01' + INTERVAL '500 us'",
+            },
+        )
+        self.validate_all(
             "SELECT CURRENT_DATE()",
             read={
                 "clickhouse": "SELECT CURRENT_DATE()",

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -632,6 +632,11 @@ class TestExpressions(unittest.TestCase):
         week = unit.find(exp.Week)
         self.assertEqual(week.this, exp.var("thursday"))
 
+        for abbreviated_unit, unnabreviated_unit in exp.TimeUnit.UNABBREVIATED_UNIT_NAME.items():
+            interval = parse_one(f"interval '500 {abbreviated_unit}'")
+            self.assertIsInstance(interval.unit, exp.Var)
+            self.assertEqual(interval.unit.name, unnabreviated_unit)
+
     def test_identifier(self):
         self.assertTrue(exp.to_identifier('"x"').quoted)
         self.assertFalse(exp.to_identifier("x").quoted)


### PR DESCRIPTION
Fixes #2448