### PR TITLE
Fix(lineage): handle unions with SELECT STAR

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2450,7 +2450,7 @@ QUERY_MODIFIERS = {
     "windows": False,
     "distribute": False,
     "sort": False,
-    "cluster": False,
+    "clustass": False,
     "order": False,
     "limit": False,
     "offset": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2450,7 +2450,7 @@ QUERY_MODIFIERS = {
     "windows": False,
     "distribute": False,
     "sort": False,
-    "clustass": False,
+    "cluster": False,
     "order": False,
     "limit": False,
     "offset": False,

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -117,11 +117,11 @@ def lineage(
                         for i, select in enumerate(scope.expression.selects)
                         if select.alias_or_name == column or select.is_star
                     ),
-                    None,
+                    -1,  # mypy will not allow a None here, but a negative index should never be returned
                 )
             )
 
-            if index is None:
+            if index == -1:
                 raise ValueError(f"Could not find {column} in {scope.expression}")
 
             for s in scope.union_scopes:

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -93,7 +93,6 @@ def lineage(
 
         # Find the specific select clause that is the source of the column we want.
         # This can either be a specific, named select or a generic `*` clause.
-
         select = (
             scope.expression.selects[column]
             if isinstance(column, int)

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -112,9 +112,12 @@ def lineage(
                 column
                 if isinstance(column, int)
                 else next(
-                    i
-                    for i, select in enumerate(scope.expression.selects)
-                    if select.alias_or_name == column
+                    (
+                        i
+                        for i, select in enumerate(scope.expression.selects)
+                        if select.alias_or_name == column
+                    ),
+                    exp.Star() if scope.expression.is_star else None,
                 )
             )
 

--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -108,8 +108,24 @@ def lineage(
         if isinstance(scope.expression, exp.Union):
             upstream = upstream or Node(name="UNION", source=scope.expression, expression=select)
 
+            index = (
+                column
+                if isinstance(column, int)
+                else next(
+                    (
+                        i
+                        for i, select in enumerate(scope.expression.selects)
+                        if select.alias_or_name == column or select.is_star
+                    ),
+                    None,
+                )
+            )
+
+            if index is None:
+                raise ValueError(f"Could not find {column} in {scope.expression}")
+
             for s in scope.union_scopes:
-                to_node(select.name, scope=s, upstream=upstream)
+                to_node(index, scope=s, upstream=upstream)
 
             return upstream
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -253,4 +253,13 @@ class TestLineage(unittest.TestCase):
         node = lineage("x", query)
 
         self.assertEqual(node.name, "x")
-        self.assertEqual(len(node.downstream), 2)
+
+        downstream_a = node.downstream[0]
+        self.assertEqual(downstream_a.name, "*")
+        self.assertEqual(downstream_a.source.sql(), "SELECT * FROM catalog.db.table_a AS table_a")
+        downstream_b = node.downstream[1]
+        self.assertEqual(downstream_b.name, "*")
+        self.assertEqual(downstream_b.source.sql(), "SELECT * FROM catalog.db.table_b AS table_b")
+
+        # downstream_a = downstream_a.downstream[0]
+        # self.assertEqual(downstream_a.source.sql(), "catalog.db.table_a AS table_a")

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -260,6 +260,3 @@ class TestLineage(unittest.TestCase):
         downstream_b = node.downstream[1]
         self.assertEqual(downstream_b.name, "*")
         self.assertEqual(downstream_b.source.sql(), "SELECT * FROM catalog.db.table_b AS table_b")
-
-        # downstream_a = downstream_a.downstream[0]
-        # self.assertEqual(downstream_a.source.sql(), "catalog.db.table_a AS table_a")

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -255,8 +255,8 @@ class TestLineage(unittest.TestCase):
         self.assertEqual(node.name, "x")
 
         downstream_a = node.downstream[0]
-        self.assertEqual(downstream_a.name, "*")
+        self.assertEqual(downstream_a.name, "0")
         self.assertEqual(downstream_a.source.sql(), "SELECT * FROM catalog.db.table_a AS table_a")
         downstream_b = node.downstream[1]
-        self.assertEqual(downstream_b.name, "*")
+        self.assertEqual(downstream_b.name, "0")
         self.assertEqual(downstream_b.source.sql(), "SELECT * FROM catalog.db.table_b AS table_b")

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -235,3 +235,22 @@ class TestLineage(unittest.TestCase):
         node = node.downstream[0]
         self.assertEqual(node.name, "t3.my_column")
         self.assertEqual(node.source.sql(), "foo AS t3")
+
+    def test_lineage_cte_union(self) -> None:
+        query = """
+        WITH dataset AS (
+            SELECT *
+            FROM catalog.db.table_a
+
+            UNION
+
+            SELECT *
+            FROM catalog.db.table_b
+        )
+
+        SELECT x, created_at FROM dataset;
+        """
+        node = lineage("x", query)
+
+        self.assertEqual(node.name, "x")
+        self.assertEqual(len(node.downstream), 2)


### PR DESCRIPTION
Building lineage when unions have a `SELECT *` statement fails with a StopIteration error because there is no fallback case if the exact column is not found in the Union's select expressions. This adds a fallback case to handle these selects when building the lineage from the union.