### PR TITLE
feat(lineage): terminal table node for select star

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -159,6 +159,11 @@ def lineage(
         if upstream:
             upstream.downstream.append(node)
 
+        # if the select is a star add all scope sources as downstreams
+        if select.is_star:
+            for source in scope.sources.values():
+                node.downstream.append(Node(name=select.sql(), source=source, expression=source))
+
         # Find all columns that went into creating this one to list their lineage nodes.
         source_columns = set(select.find_all(exp.Column))
 

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -260,3 +260,16 @@ class TestLineage(unittest.TestCase):
         downstream_b = node.downstream[1]
         self.assertEqual(downstream_b.name, "0")
         self.assertEqual(downstream_b.source.sql(), "SELECT * FROM catalog.db.table_b AS table_b")
+
+    def test_select_star(self) -> None:
+        node = lineage("x", "SELECT x from (SELECT * from table_a)")
+
+        self.assertEqual(node.name, "x")
+
+        downstream = node.downstream[0]
+        self.assertEqual(downstream.name, "_q_0.x")
+        self.assertEqual(downstream.source.sql(), "SELECT * FROM table_a AS table_a")
+
+        downstream = downstream.downstream[0]
+        self.assertEqual(downstream.name, "*")
+        self.assertEqual(downstream.source.sql(), "table_a AS table_a")


### PR DESCRIPTION
adds final nodes to lineage trees when a `select *` expression is found named "*" with the source set to each table in the select * scope. 