### PR TITLE
Fix: add table alias in unnest with columns only

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -891,6 +891,10 @@ class Generator:
         alias = self.sql(expression, "this")
         columns = self.expressions(expression, key="columns", flat=True)
         columns = f"({columns})" if columns else ""
+
+        if not alias and not self.UNNEST_COLUMN_ONLY:
+            alias = "_t"
+
         return f"{alias}{columns}"
 
     def bitstring_sql(self, expression: exp.BitString) -> str:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -143,6 +143,13 @@ class TestBigQuery(Validator):
         self.validate_all("x <> ''''''", write={"bigquery": "x <> ''"})
         self.validate_all("CAST(x AS DATETIME)", read={"": "x::timestamp"})
         self.validate_all(
+            "SELECT * FROM t WHERE EXISTS(SELECT * FROM unnest(nums) AS x WHERE x > 1)",
+            write={
+                "bigquery": "SELECT * FROM t WHERE EXISTS(SELECT * FROM UNNEST(nums) AS x WHERE x > 1)",
+                "duckdb": "SELECT * FROM t WHERE EXISTS(SELECT * FROM UNNEST(nums) AS _t(x) WHERE x > 1)",
+            },
+        )
+        self.validate_all(
             "NULL",
             read={
                 "duckdb": "NULL = a",
@@ -476,9 +483,8 @@ class TestBigQuery(Validator):
             },
             write={
                 "bigquery": "SELECT * FROM UNNEST(['7', '14']) AS x",
-                "presto": "SELECT * FROM UNNEST(ARRAY['7', '14']) AS (x)",
-                "hive": "SELECT * FROM UNNEST(ARRAY('7', '14')) AS (x)",
-                "spark": "SELECT * FROM UNNEST(ARRAY('7', '14')) AS (x)",
+                "presto": "SELECT * FROM UNNEST(ARRAY['7', '14']) AS _t(x)",
+                "spark": "SELECT * FROM UNNEST(ARRAY('7', '14')) AS _t(x)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #2455

This is probably not the most robust way to solve the issue, but not sure. What do you think @tobymao?

```
D WITH Sequences AS (
>     SELECT 1 AS id, [0, 1, 1, 2, 3, 5] AS some_numbers UNION ALL
>     SELECT 2 AS id, [2, 4, 8, 16, 32] AS some_numbers UNION ALL
>     SELECT 3 AS id, [5, 10] AS some_numbers
> )
> SELECT
>   id AS matching_rows
> FROM Sequences
> WHERE EXISTS(
>   SELECT * FROM UNNEST(some_numbers) AS _t(x) WHERE x > 5
> );
┌───────────────┐
│ matching_rows │
│     int32     │
├───────────────┤
│             2 │
│             3 │
└───────────────┘
```

<img width="549" alt="Screenshot 2023-10-24 at 8 38 06 PM" src="https://github.com/tobymao/sqlglot/assets/46752250/d06e08ef-d461-4a68-b499-1bf360b152ab">
