### PR TITLE
fix(mysql): str_to_date for datetime

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -67,10 +67,12 @@ TIME_SPECIFIERS = {"f", "H", "h", "I", "i", "k", "l", "p", "r", "S", "s", "T"}
 
 def _has_time_specifier(date_format: str) -> bool:
     i = 0
-    while i < len(date_format):
+    length = len(date_format)
+
+    while i < length:
         if date_format[i] == "%":
             i += 1
-            if i < len(date_format) and date_format[i] in TIME_SPECIFIERS:
+            if i < length and date_format[i] in TIME_SPECIFIERS:
                 return True
         i += 1
     return False

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -839,10 +839,6 @@ class TestDialect(Validator):
         )
         self.validate_all(
             "STR_TO_DATE(x, '%Y-%m-%dT%H:%M:%S')",
-            read={
-                "mysql": "STR_TO_DATE(x, '%Y-%m-%dT%H:%i:%S')",
-                "starrocks": "STR_TO_DATE(x, '%Y-%m-%dT%H:%i:%S')",
-            },
             write={
                 "drill": "TO_DATE(x, 'yyyy-MM-dd''T''HH:mm:ss')",
                 "mysql": "STR_TO_DATE(x, '%Y-%m-%dT%T')",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -564,6 +564,13 @@ class TestMySQL(Validator):
             "STR_TO_DATE(x, '%M')",
             read={"": "TS_OR_DS_TO_DATE(x, '%B')"},
         )
+        self.validate_all(
+            "STR_TO_DATE(x, '%Y-%m-%d')",
+            write={"presto": "CAST(DATE_PARSE(x, '%Y-%m-%d') AS DATE)"},
+        )
+        self.validate_all(
+            "STR_TO_DATE(x, '%Y-%m-%dT%T')", write={"presto": "DATE_PARSE(x, '%Y-%m-%dT%T')"}
+        )
 
     def test_mysql(self):
         self.validate_all(


### PR DESCRIPTION
Transpiling `STR_TO_DATE(x, '%Y-%m-%dT%T')` to `CAST(DATE_PARSE(x, '%Y-%m-%dT%T') AS DATE)` is wrong.

From [MySQL docs](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_str-to-date):
> STR_TO_DATE() returns a [DATETIME](https://dev.mysql.com/doc/refman/8.0/en/datetime.html) value if the format string contains both date and time parts, or a [DATE](https://dev.mysql.com/doc/refman/8.0/en/datetime.html) or [TIME](https://dev.mysql.com/doc/refman/8.0/en/time.html) value if the string contains only date or time parts

I don't love doing this with a regex at parse time... open to other ideas.