### PR TITLE
Fix(snowflake): don't add time format in TO_TIMESTAMP if not supplied

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -32,7 +32,7 @@ def _check_int(s: str) -> bool:
 
 
 # from https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html
-def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime, exp.Cast]:
+def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime, exp.TimeStrToTime]:
     if len(args) == 2:
         first_arg, second_arg = args
         if second_arg.is_string:

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -32,7 +32,7 @@ def _check_int(s: str) -> bool:
 
 
 # from https://docs.snowflake.com/en/sql-reference/functions/to_timestamp.html
-def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime]:
+def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime, exp.Cast]:
     if len(args) == 2:
         first_arg, second_arg = args
         if second_arg.is_string:
@@ -60,8 +60,8 @@ def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime]:
     # reduce it using `simplify_literals` first and then check if it's a Literal.
     first_arg = seq_get(args, 0)
     if not isinstance(simplify_literals(first_arg, root=True), Literal):
-        # case: <variant_expr>
-        return format_time_lambda(exp.StrToTime, "snowflake", default=True)(args)
+        # case: <variant_expr> or other expressions such as columns
+        return exp.cast(first_arg, "timestamp")
 
     if first_arg.is_string:
         if _check_int(first_arg.this):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -61,7 +61,7 @@ def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime, 
     first_arg = seq_get(args, 0)
     if not isinstance(simplify_literals(first_arg, root=True), Literal):
         # case: <variant_expr> or other expressions such as columns
-        return exp.cast(first_arg, "timestamp")
+        return exp.TimeStrToTime.from_arg_list(args)
 
     if first_arg.is_string:
         if _check_int(first_arg.this):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -77,6 +77,10 @@ class TestSnowflake(Validator):
             "SELECT {fn CEILING(5.3)}",
             "SELECT CEIL(5.3)",
         )
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP(x) FROM t",
+            "SELECT CAST(x AS TIMESTAMPNTZ) FROM t",
+        )
 
         self.validate_all("CAST(x AS BYTEINT)", write={"snowflake": "CAST(x AS INT)"})
         self.validate_all("CAST(x AS CHAR VARYING)", write={"snowflake": "CAST(x AS VARCHAR)"})


### PR DESCRIPTION
Addresses https://github.com/tobymao/sqlglot/issues/2069#issuecomment-1783424741

For more context, this was first added in: https://github.com/tobymao/sqlglot/commit/8532f465b