### PR TITLE
Feat(redshift): add support for DATE_DIFF

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -27,6 +27,14 @@ def _parse_date_add(args: t.List) -> exp.DateAdd:
     )
 
 
+def _parse_datediff(args: t.List) -> exp.DateDiff:
+    return exp.DateDiff(
+        this=exp.TsOrDsToDate(this=seq_get(args, 2)),
+        expression=exp.TsOrDsToDate(this=seq_get(args, 1)),
+        unit=seq_get(args, 0),
+    )
+
+
 class Redshift(Postgres):
     # https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
     RESOLVES_IDENTIFIERS_AS_UPPERCASE = None
@@ -51,11 +59,8 @@ class Redshift(Postgres):
             ),
             "DATEADD": _parse_date_add,
             "DATE_ADD": _parse_date_add,
-            "DATEDIFF": lambda args: exp.DateDiff(
-                this=exp.TsOrDsToDate(this=seq_get(args, 2)),
-                expression=exp.TsOrDsToDate(this=seq_get(args, 1)),
-                unit=seq_get(args, 0),
-            ),
+            "DATEDIFF": _parse_datediff,
+            "DATE_DIFF": _parse_datediff,
             "LISTAGG": exp.GroupConcat.from_arg_list,
             "STRTOL": exp.FromBase.from_arg_list,
         }

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -7,6 +7,10 @@ class TestRedshift(Validator):
 
     def test_redshift(self):
         self.validate_identity(
+            "SELECT DATE_DIFF('month', CAST('2020-02-29 00:00:00' AS TIMESTAMP), CAST('2020-03-02 00:00:00' AS TIMESTAMP))",
+            "SELECT DATEDIFF(month, CAST(CAST('2020-02-29 00:00:00' AS TIMESTAMP) AS DATE), CAST(CAST('2020-03-02 00:00:00' AS TIMESTAMP) AS DATE))",
+        )
+        self.validate_identity(
             "SELECT * FROM x WHERE y = DATEADD('month', -1, DATE_TRUNC('month', (SELECT y FROM #temp_table)))",
             "SELECT * FROM x WHERE y = DATEADD(month, -1, CAST(DATE_TRUNC('month', (SELECT y FROM #temp_table)) AS DATE))",
         )


### PR DESCRIPTION
Seems like Redshift also supports this variant but doesn't document it. The only source I found on it was a [SO thread](https://stackoverflow.com/questions/67197117/redshift-datediff-vs-date-diff). I managed to execute queries that contain it successfully on their engine - it seems that the unit must be a string.

<img width="678" alt="Screenshot 2023-10-31 at 11 12 56 AM" src="https://github.com/tobymao/sqlglot/assets/46752250/0b93b422-eb1b-47f9-ac27-301aa92aa2bb">
