### PR TITLE
Fix(teradata): add UPD and DEL abbreviations

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -38,6 +38,7 @@ class Teradata(Dialect):
             "^=": TokenType.NEQ,
             "BYTEINT": TokenType.SMALLINT,
             "COLLECT": TokenType.COMMAND,
+            "DEL": TokenType.DELETE,
             "EQ": TokenType.EQ,
             "GE": TokenType.GTE,
             "GT": TokenType.GT,
@@ -53,6 +54,7 @@ class Teradata(Dialect):
             "SEL": TokenType.SELECT,
             "ST_GEOMETRY": TokenType.GEOMETRY,
             "TOP": TokenType.TOP,
+            "UPD": TokenType.UPDATE,
         }
 
         # Teradata does not support % as a modulo operator

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -161,6 +161,8 @@ class TestTeradata(Validator):
             "SELECT col1, col2 FROM dbc.table1 WHERE col1 EQ 'value1' MINUS SELECT col1, col2 FROM dbc.table2",
             "SELECT col1, col2 FROM dbc.table1 WHERE col1 = 'value1' EXCEPT SELECT col1, col2 FROM dbc.table2",
         )
+        self.validate_identity("UPD a SET b = 1", "UPDATE a SET b = 1")
+        self.validate_identity("DEL FROM a", "DELETE FROM a")
 
     def test_datatype(self):
         self.validate_all(


### PR DESCRIPTION
See
https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Manipulation-Language/Statement-Syntax/UPDATE/UPDATE-Syntax-Joined-Tables-Form and https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Manipulation-Language/Statement-Syntax/DELETE/DELETE-Syntax