### PR TITLE
Fix(teradata): support `**` for exponent

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -339,12 +339,6 @@ class Postgres(Dialect):
             TokenType.END: lambda self: self._parse_commit_or_rollback(),
         }
 
-        def _parse_factor(self) -> t.Optional[exp.Expression]:
-            return self._parse_tokens(self._parse_exponent, self.FACTOR)
-
-        def _parse_exponent(self) -> t.Optional[exp.Expression]:
-            return self._parse_tokens(self._parse_unary, self.EXPONENT)
-
         def _parse_date_part(self) -> exp.Expression:
             part = self._parse_type()
             self._match(TokenType.COMMA)

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -36,7 +36,7 @@ class Teradata(Dialect):
         # https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Arithmetic-Trigonometric-Hyperbolic-Operators/Functions
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
-            "**": TokenType.DOUBLE_STAR,
+            "**": TokenType.DSTAR,
             "^=": TokenType.NEQ,
             "BYTEINT": TokenType.SMALLINT,
             "COLLECT": TokenType.COMMAND,
@@ -119,14 +119,8 @@ class Teradata(Dialect):
         }
 
         EXPONENT = {
-            TokenType.DOUBLE_STAR: exp.Pow,
+            TokenType.DSTAR: exp.Pow,
         }
-
-        def _parse_factor(self) -> t.Optional[exp.Expression]:
-            return self._parse_tokens(self._parse_exponent, self.FACTOR)
-
-        def _parse_exponent(self) -> t.Optional[exp.Expression]:
-            return self._parse_tokens(self._parse_unary, self.EXPONENT)
 
         def _parse_translate(self, strict: bool) -> exp.Expression:
             this = self._parse_conjunction()

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -33,6 +33,7 @@ class Teradata(Dialect):
 
     class Tokenizer(tokens.Tokenizer):
         # https://docs.teradata.com/r/Teradata-Database-SQL-Functions-Operators-Expressions-and-Predicates/March-2017/Comparison-Operators-and-Functions/Comparison-Operators/ANSI-Compliance
+        # https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Arithmetic-Trigonometric-Hyperbolic-Operators/Functions
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "**": TokenType.DOUBLE_STAR,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -423,6 +423,8 @@ class Parser(metaclass=_Parser):
         TokenType.STAR: exp.Mul,
     }
 
+    EXPONENT = set()
+
     TIMES = {
         TokenType.TIME,
         TokenType.TIMETZ,
@@ -3376,7 +3378,10 @@ class Parser(metaclass=_Parser):
         return self._parse_tokens(self._parse_factor, self.TERM)
 
     def _parse_factor(self) -> t.Optional[exp.Expression]:
-        return self._parse_tokens(self._parse_unary, self.FACTOR)
+        return self._parse_tokens(self._parse_exponent, self.FACTOR)
+
+    def _parse_exponent(self) -> t.Optional[exp.Expression]:
+        return self._parse_tokens(self._parse_unary, self.EXPONENT)
 
     def _parse_unary(self) -> t.Optional[exp.Expression]:
         if self._match_set(self.UNARY_PARSERS):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -423,7 +423,7 @@ class Parser(metaclass=_Parser):
         TokenType.STAR: exp.Mul,
     }
 
-    EXPONENT = set()
+    EXPONENT: t.Dict[TokenType, t.Type[exp.Expression]] = {}
 
     TIMES = {
         TokenType.TIME,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -56,6 +56,7 @@ class TokenType(AutoName):
     SESSION_PARAMETER = auto()
     DAMP = auto()
     XOR = auto()
+    DOUBLE_STAR = auto()
 
     BLOCK_START = auto()
     BLOCK_END = auto()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -56,7 +56,7 @@ class TokenType(AutoName):
     SESSION_PARAMETER = auto()
     DAMP = auto()
     XOR = auto()
-    DOUBLE_STAR = auto()
+    DSTAR = auto()
 
     BLOCK_START = auto()
     BLOCK_END = auto()

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -225,6 +225,7 @@ class TestSnowflake(Validator):
                 "spark": "POWER(x, 2)",
                 "sqlite": "POWER(x, 2)",
                 "starrocks": "POWER(x, 2)",
+                "teradata": "x ** 2",
                 "trino": "POWER(x, 2)",
                 "tsql": "POWER(x, 2)",
             },

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -147,6 +147,9 @@ class TestTeradata(Validator):
     def test_mod(self):
         self.validate_all("a MOD b", write={"teradata": "a MOD b", "mysql": "a % b"})
 
+    def test_power(self):
+        self.validate_all("a ** b", write={"teradata": "a ** b", "mysql": "POWER(a, b)"})
+
     def test_abbrev(self):
         self.validate_identity("a LT b", "a < b")
         self.validate_identity("a LE b", "a <= b")


### PR DESCRIPTION
See https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Arithmetic-Trigonometric-Hyperbolic-Operators/Functions