### PR TITLE
Fix(teradata): support `TRYCAST`

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -112,9 +112,13 @@ class Teradata(Dialect):
 
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
+            # TRY_CAST is called TRYCAST in Teradata.
+            # https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Data-Type-Conversions/TRYCAST
+            "TRYCAST": parser.Parser.FUNCTION_PARSERS["TRY_CAST"],
             "RANGE_N": lambda self: self._parse_rangen(),
             "TRANSLATE": lambda self: self._parse_translate(self.STRICT_CAST),
         }
+        FUNCTION_PARSERS.pop("TRY_CAST")
 
         def _parse_translate(self, strict: bool) -> exp.Expression:
             this = self._parse_conjunction()
@@ -191,6 +195,9 @@ class Teradata(Dialect):
                 expression.to.pop()
 
             return super().cast_sql(expression, safe_prefix=safe_prefix)
+
+        def trycast_sql(self, expression: exp.TryCast) -> str:
+            return self.cast_sql(expression, safe_prefix="TRY")
 
         def tablesample_sql(
             self, expression: exp.TableSample, seed_prefix: str = "SEED", sep=" AS "

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -112,7 +112,6 @@ class Teradata(Dialect):
 
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
-            # TRY_CAST is called TRYCAST in Teradata.
             # https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Data-Type-Conversions/TRYCAST
             "TRYCAST": parser.Parser.FUNCTION_PARSERS["TRY_CAST"],
             "RANGE_N": lambda self: self._parse_rangen(),

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -118,7 +118,6 @@ class Teradata(Dialect):
             "RANGE_N": lambda self: self._parse_rangen(),
             "TRANSLATE": lambda self: self._parse_translate(self.STRICT_CAST),
         }
-        FUNCTION_PARSERS.pop("TRY_CAST")
 
         def _parse_translate(self, strict: bool) -> exp.Expression:
             this = self._parse_conjunction()

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -191,3 +191,14 @@ class TestTeradata(Validator):
             },
         )
         self.validate_identity("CAST('1992-01' AS FORMAT 'YYYY-DD')")
+
+        self.validate_all(
+            "TRYCAST('-2.5' AS DECIMAL(5, 2))",
+            read={
+                "snowflake": "TRY_CAST('-2.5' AS DECIMAL(5, 2))",
+            },
+            write={
+                "snowflake": "TRY_CAST('-2.5' AS DECIMAL(5, 2))",
+                "teradata": "TRYCAST('-2.5' AS DECIMAL(5, 2))",
+            },
+        )


### PR DESCRIPTION
See https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Data-Type-Conversions/TRYCAST