### PR TITLE
fix(planner): missing step of subquery

### DIFF
--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -107,7 +107,15 @@ class Step:
         from_ = expression.args.get("from")
 
         if isinstance(expression, exp.Select) and from_:
-            step = Scan.from_expression(from_.this, ctes)
+            step_from = Scan.from_expression(from_.this, ctes)
+
+            if isinstance(from_.this, exp.Subquery):
+                step = Scan()
+                step.name = from_.alias_or_name
+                step.source = exp.to_identifier(from_.alias_or_name)
+                step.add_dependency(step_from)
+            else:
+                step = step_from
         elif isinstance(expression, exp.Union):
             step = SetOperation.from_expression(expression, ctes)
         else:


### PR DESCRIPTION
Change-Id: I72e57b11dc6d214a8cd13f18eb602b31ec5a6155

The plan of `select ... from (<subquery>) as t` is missing the step of `<subquery>`.

# Reproduce

```python
import sqlglot
from sqlglot.planner import Plan

print(Plan(sqlglot.parse_one('select tmp.a from (select t1.a from t1 join t2) tmp')))
```

Before, no subquery projection `t1.a` and the root step is a `Join`(fusion with the inner subquery):
```yaml
- Join: tmp (4392910480)
    Context:
      t2: INNER
      On: TRUE AND TRUE
    Projections:
      - tmp.a
    Dependencies:
    - Scan: t1 (4392621456)
      Context:
        Source: t1
      Projections:
    - Scan: t2 (4393026960)
      Context:
        Source: t2
      Projections:
```

After this PR:

```yaml
- Scan: tmp (4354970896)
    Context:
      Source: tmp
    Projections:
      - tmp.a
    Dependencies:
    - Join: tmp (4355246608)
      Context:
        t2: INNER
        On: TRUE AND TRUE
      Projections:
        - t1.a
      Dependencies:
      - Scan: t2 (4354682128)
        Context:
          Source: t2
        Projections:
      - Scan: t1 (4355180368)
        Context:
          Source: t1
        Projections:
```