### PR TITLE
Fix: unify named and unnamed constraint parsing

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1421,6 +1421,10 @@ class Constraint(Expression):
     arg_types = {"this": True, "expressions": True}
 
 
+class UnnamedConstraint(Expression):
+    arg_types = {"this": False, "expressions": True}
+
+
 class Delete(Expression):
     arg_types = {
         "with": False,

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1453,3 +1453,11 @@ FROM OPENJSON(@json) WITH (
                 "spark": "SET count = (SELECT COUNT(1) FROM x)",
             },
         )
+
+    def test_multiple_unnamed_constraints(self):
+        self.validate_identity(
+            'CREATE TABLE "dbo"."benchmark" ('
+            '"name" CHAR(7) NOT NULL, '
+            '"internal_id" VARCHAR(10) NOT NULL, '
+            'UNIQUE NONCLUSTERED ("internal_id" ASC))'
+        )


### PR DESCRIPTION
`CREATE TABLE "test" ("name" CHAR (7) NOT NULL, "internal_id" VARCHAR(10) NOT NULL, UNIQUE NONCLUSTERED ("internal_id" ASC))` fails to parse whereas `CREATE TABLE "test" ("name" CHAR (7) NOT NULL, "internal_id" VARCHAR(10) NOT NULL, Constraint CTest UNIQUE NONCLUSTERED ("internal_id" ASC))` does not due to the former not parsing multiple constraints like the latter.