### PR TITLE
fix(optimizer): more support for date literals in simplify

### DIFF
--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -43,6 +43,9 @@ TRUE;
 1.0 = 1;
 TRUE;
 
+CAST('2023-01-01' AS DATE) = CAST('2023-01-01' AS DATE);
+TRUE;
+
 'x' = 'y';
 FALSE;
 
@@ -663,6 +666,15 @@ ROW() OVER () = 1 OR ROW() OVER () IS NULL;
 a AND b AND COALESCE(ROW() OVER (), 1) = 1;
 a AND b AND (ROW() OVER () = 1 OR ROW() OVER () IS NULL);
 
+COALESCE(1, 2);
+1;
+
+COALESCE(CAST(CAST('2023-01-01' AS TIMESTAMP) AS DATE), x);
+CAST(CAST('2023-01-01' AS TIMESTAMP) AS DATE);
+
+COALESCE(CAST(NULL AS DATE), x);
+COALESCE(CAST(NULL AS DATE), x);
+
 --------------------------------------
 -- CONCAT
 --------------------------------------
@@ -775,6 +787,9 @@ x >= CAST('2022-01-01' AS DATE);
 
 DATE_TRUNC('year', x) > TS_OR_DS_TO_DATE(TS_OR_DS_TO_DATE('2021-01-02'));
 x >= CAST('2022-01-01' AS DATE);
+
+DATE_TRUNC('year', x) > TS_OR_DS_TO_DATE(TS_OR_DS_TO_DATE('2021-01-02', '%Y'));
+DATE_TRUNC('year', x) > TS_OR_DS_TO_DATE(TS_OR_DS_TO_DATE('2021-01-02', '%Y'));
 
 -- right is not a date
 DATE_TRUNC('year', x) <> '2021-01-02';


### PR DESCRIPTION
Here's an actual predicate from Tableau we're dealing with:
```sql
(
  CASE 
  WHEN (
    IFNULL(
      DATE('2050-01-01'),
      STR_TO_DATE('2050-01-01','%b %e %Y')
    ) = DATE('2023-10-01')) 
  THEN DATE(DATE_ADD(date_trunc('month', CURDATE()), INTERVAL -1 MONTH)) 
  ELSE DATE(DATE('2023-10-01')) END
) = date_trunc('month', `Custom SQL Query`.`Date`)
```

This breaks partition pruning.

With this change, we get
```sql
`Custom SQL Query`.`Date` < CAST('2023-11-01' AS DATE) 
AND `Custom SQL Query`.`Date` >= CAST('2023-10-01' AS DATE)
```