### PR TITLE
Fix!(snowflake): don't quote DUAL table because it has special meaning

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -248,7 +248,7 @@ class Snowflake(Dialect):
         ):
             return t.cast(E, expression)
 
-        return Dialect.quote_identifier(expression, identify=identify)
+        return super().quote_identifier(expression, identify=identify)
 
     class Parser(parser.Parser):
         IDENTIFY_PIVOT_STRINGS = True

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -241,7 +241,7 @@ class Snowflake(Dialect):
     def quote_identifier(cls, expression: E, identify: bool = True) -> E:
         if isinstance(expression, exp.Identifier) and not (
             # This disables quoting DUAL in SELECT ... FROM DUAL, because Snowflake treats an
-            # unquoted DUAL keyword in a special way and does not map it to an existing table
+            # unquoted DUAL keyword in a special way and does not map it to a user-defined table
             expression.name.lower() == "dual"
             and isinstance(expression.parent, exp.Table)
         ):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp, generator, parser, tokens, transforms
+from sqlglot._typing import E
 from sqlglot.dialects.dialect import (
     Dialect,
     binary_from_function,
@@ -235,6 +236,18 @@ class Snowflake(Dialect):
         "FF6": "%f",
         "ff6": "%f",
     }
+
+    @classmethod
+    def quote_identifier(cls, expression: E, identify: bool = True) -> E:
+        if isinstance(expression, exp.Identifier) and not (
+            # This disables quoting DUAL in SELECT ... FROM DUAL, because Snowflake treats an
+            # unquoted DUAL keyword in a special way and does not map it to an existing table
+            expression.name.lower() == "dual"
+            and isinstance(expression.parent, exp.Table)
+        ):
+            return t.cast(E, Dialect.quote_identifier(expression, identify=identify))
+
+        return expression
 
     class Parser(parser.Parser):
         IDENTIFY_PIVOT_STRINGS = True

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -239,15 +239,16 @@ class Snowflake(Dialect):
 
     @classmethod
     def quote_identifier(cls, expression: E, identify: bool = True) -> E:
-        if isinstance(expression, exp.Identifier) and not (
-            # This disables quoting DUAL in SELECT ... FROM DUAL, because Snowflake treats an
-            # unquoted DUAL keyword in a special way and does not map it to a user-defined table
-            expression.name.lower() == "dual"
+        # This disables quoting DUAL in SELECT ... FROM DUAL, because Snowflake treats an
+        # unquoted DUAL keyword in a special way and does not map it to a user-defined table
+        if (
+            isinstance(expression, exp.Identifier)
             and isinstance(expression.parent, exp.Table)
+            and expression.name.lower() == "dual"
         ):
-            return t.cast(E, Dialect.quote_identifier(expression, identify=identify))
+            return t.cast(E, expression)
 
-        return expression
+        return Dialect.quote_identifier(expression, identify=identify)
 
     class Parser(parser.Parser):
         IDENTIFY_PIVOT_STRINGS = True

--- a/tests/fixtures/optimizer/quote_identifiers.sql
+++ b/tests/fixtures/optimizer/quote_identifiers.sql
@@ -9,3 +9,11 @@ SELECT "x"."a" AS "a" FROM "db"."x";
 
 SELECT @x;
 SELECT @x;
+
+# dialect: snowflake
+SELECT * FROM DUAL;
+SELECT * FROM DUAL;
+
+# dialect: snowflake
+SELECT dual FROM t;
+SELECT "dual" FROM "t";

--- a/tests/fixtures/optimizer/quote_identifiers.sql
+++ b/tests/fixtures/optimizer/quote_identifiers.sql
@@ -15,6 +15,14 @@ SELECT * FROM DUAL;
 SELECT * FROM DUAL;
 
 # dialect: snowflake
+SELECT * FROM "DUAL";
+SELECT * FROM "DUAL";
+
+# dialect: snowflake
+SELECT * FROM "dual";
+SELECT * FROM "dual";
+
+# dialect: snowflake
 SELECT dual FROM t;
 SELECT "dual" FROM "t";
 

--- a/tests/fixtures/optimizer/quote_identifiers.sql
+++ b/tests/fixtures/optimizer/quote_identifiers.sql
@@ -17,3 +17,7 @@ SELECT * FROM DUAL;
 # dialect: snowflake
 SELECT dual FROM t;
 SELECT "dual" FROM "t";
+
+# dialect: snowflake
+SELECT * FROM t AS dual;
+SELECT * FROM "t" AS "dual";

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -298,6 +298,13 @@ class TestOptimizer(unittest.TestCase):
 
         self.assertEqual(optimizer.normalize_identifiers.normalize_identifiers("a%").sql(), '"a%"')
 
+    def test_quote_identifiers(self):
+        self.check_file(
+            "quote_identifiers",
+            optimizer.qualify_columns.quote_identifiers,
+            set_dialect=True,
+        )
+
     def test_pushdown_projection(self):
         self.check_file("pushdown_projections", pushdown_projections, schema=self.schema)
 


### PR DESCRIPTION
Snowflake treats `DUAL` in a special way when it's used in a `FROM` clause, and quoting it breaks queries.

For example:

```
CREATE TABLE "DUAL" (a DOUBLE);
SELECT * FROM "DUAL";
```

<img width="1200" alt="Screenshot 2023-11-09 at 11 13 50 PM" src="https://github.com/tobymao/sqlglot/assets/46752250/87089112-2d15-4ef1-8634-852647bdb002">

```
SELECT * FROM DUAL;
```

<img width="1222" alt="Screenshot 2023-11-09 at 11 14 22 PM" src="https://github.com/tobymao/sqlglot/assets/46752250/91320a9e-d795-45d8-8360-7e06db7bc896">

