### PR TITLE
Fix!(tsql): ensure derived table projections are named / have aliases

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -203,7 +203,7 @@ def _parse_date_delta(
 
 
 def qualify_derived_table_outputs(expression: exp.Expression) -> exp.Expression:
-    """Ensures all output columns are aliased for CTEs and Subqueries."""
+    """Ensures all (unnamed) output columns are aliased for CTEs and Subqueries."""
     alias = expression.args.get("alias")
 
     if (

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -432,6 +432,7 @@ def move_ctes_to_top_level(expression: exp.Expression) -> exp.Expression:
 
 
 def ensure_bools(expression: exp.Expression) -> exp.Expression:
+    """Converts numeric values used in conditions into explicit boolean expressions."""
     from sqlglot.optimizer.canonicalize import ensure_bools
 
     def _ensure_bool(node: exp.Expression) -> None:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1947,7 +1947,7 @@ SELECT
                 "spark2": "WITH t AS (SELECT 1 AS c) SELECT * FROM (SELECT c FROM t) AS subq",
                 "sqlite": "SELECT * FROM (WITH t AS (SELECT 1 AS c) SELECT c FROM t) AS subq",
                 "trino": "SELECT * FROM (WITH t AS (SELECT 1 AS c) SELECT c FROM t) AS subq",
-                "tsql": "WITH t AS (SELECT 1 AS c) SELECT * FROM (SELECT c FROM t) AS subq",
+                "tsql": "WITH t AS (SELECT 1 AS c) SELECT * FROM (SELECT c AS c FROM t) AS subq",
             },
         )
         self.validate_all(
@@ -1956,13 +1956,13 @@ SELECT
                 "bigquery": "SELECT * FROM (SELECT * FROM (WITH t AS (SELECT 1 AS c) SELECT c FROM t) AS subq1) AS subq2",
                 "duckdb": "SELECT * FROM (SELECT * FROM (WITH t AS (SELECT 1 AS c) SELECT c FROM t) AS subq1) AS subq2",
                 "hive": "WITH t AS (SELECT 1 AS c) SELECT * FROM (SELECT * FROM (SELECT c FROM t) AS subq1) AS subq2",
-                "tsql": "WITH t AS (SELECT 1 AS c) SELECT * FROM (SELECT * FROM (SELECT c FROM t) AS subq1) AS subq2",
+                "tsql": "WITH t AS (SELECT 1 AS c) SELECT * FROM (SELECT * FROM (SELECT c AS c FROM t) AS subq1) AS subq2",
             },
         )
         self.validate_all(
             "WITH t1(x) AS (SELECT 1) SELECT * FROM (WITH t2(y) AS (SELECT 2) SELECT y FROM t2) AS subq",
             write={
                 "duckdb": "WITH t1(x) AS (SELECT 1) SELECT * FROM (WITH t2(y) AS (SELECT 2) SELECT y FROM t2) AS subq",
-                "tsql": "WITH t1(x) AS (SELECT 1), t2(y) AS (SELECT 2) SELECT * FROM (SELECT y FROM t2) AS subq",
+                "tsql": "WITH t1(x) AS (SELECT 1), t2(y) AS (SELECT 2) SELECT * FROM (SELECT y AS y FROM t2) AS subq",
             },
         )

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -216,7 +216,7 @@ class TestRedshift(Validator):
                 "tableau": "SELECT a, b FROM (SELECT a, b, ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC NULLS FIRST) AS _row_number FROM x) AS _t WHERE _row_number = 1",
                 "teradata": "SELECT a, b FROM (SELECT a, b, ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC NULLS FIRST) AS _row_number FROM x) AS _t WHERE _row_number = 1",
                 "trino": "SELECT a, b FROM (SELECT a, b, ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC NULLS FIRST) AS _row_number FROM x) AS _t WHERE _row_number = 1",
-                "tsql": "SELECT a, b FROM (SELECT a, b, ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC NULLS FIRST) AS _row_number FROM x) AS _t WHERE _row_number = 1",
+                "tsql": "SELECT a, b FROM (SELECT a AS a, b AS b, ROW_NUMBER() OVER (PARTITION BY a ORDER BY c DESC NULLS FIRST) AS _row_number FROM x) AS _t WHERE _row_number = 1",
             },
         )
         self.validate_all(


### PR DESCRIPTION
This aims to fix a bug where T-SQL projections are left unnamed for derived tables, which MSSQL doesn't like:

```
1> with t as (select 1) select * from t
2> go
...
No column name was specified for column 1 of 't'.
1> with t as (select 1 as c) select * from t
2> go
c
-----------
          1

(1 rows affected)
1> select * from (select 1) subq
2> go
...
No column name was specified for column 1 of 'subq'.
1> select * from (select 1 as c) subq
2> go
c
-----------
          1

(1 rows affected)
```