### PR TITLE
Fix: don't bubble up CTEs for the CREATE DDL statement

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -417,7 +417,13 @@ class Hive(Dialect):
         INDEX_ON = "ON TABLE"
         EXTRACT_ALLOWS_QUOTES = False
         NVL2_SUPPORTED = False
-        SUPPORTS_NESTED_CTES = False
+
+        EXPRESSIONS_WITHOUT_NESTED_CTES = {
+            exp.Insert,
+            exp.Select,
+            exp.Subquery,
+            exp.Union,
+        }
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -611,9 +611,18 @@ class TSQL(Dialect):
         ALTER_TABLE_ADD_COLUMN_KEYWORD = False
         LIMIT_FETCH = "FETCH"
         COMPUTED_COLUMN_WITH_TYPE = False
-        SUPPORTS_NESTED_CTES = False
         CTE_RECURSIVE_KEYWORD_REQUIRED = False
         ENSURE_BOOLS = True
+
+        EXPRESSIONS_WITHOUT_NESTED_CTES = {
+            exp.Delete,
+            exp.Insert,
+            exp.Merge,
+            exp.Select,
+            exp.Subquery,
+            exp.Union,
+            exp.Update,
+        }
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -490,6 +490,7 @@ class Generator:
         if (
             not self.SUPPORTS_NESTED_CTES
             and isinstance(expression, exp.Expression)
+            and not isinstance(expression, exp.Create)  # CTAS needs the CTEs to come after CREATE
             and not expression.parent
             and "with" in expression.arg_types
             and any(node.parent is not expression for node in expression.find_all(exp.With))

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -230,9 +230,6 @@ class Generator:
     # Whether or not data types support additional specifiers like e.g. CHAR or BYTE (oracle)
     DATA_TYPE_SPECIFIERS_ALLOWED = False
 
-    # Whether or not nested CTEs (e.g. defined inside of subqueries) are allowed
-    SUPPORTS_NESTED_CTES = True
-
     # Whether or not conditions require booleans WHERE x = 0 vs WHERE x
     ENSURE_BOOLS = False
 
@@ -381,6 +378,9 @@ class Generator:
         exp.Paren,
     )
 
+    # Expressions that need to have all CTEs under them bubbled up to them
+    EXPRESSIONS_WITHOUT_NESTED_CTES: t.Set[t.Type[exp.Expression]] = set()
+
     KEY_VALUE_DEFINITONS = (exp.Bracket, exp.EQ, exp.PropertyEQ, exp.Slice)
 
     SENTINEL_LINE_BREAK = "__SQLGLOT__LB__"
@@ -484,15 +484,13 @@ class Generator:
         if copy:
             expression = expression.copy()
 
-        # Some dialects only support CTEs at the top level expression, so we need to bubble up nested
-        # CTEs to that level in order to produce a syntactically valid expression. This transformation
-        # happens here to minimize code duplication, since many expressions support CTEs.
+        # Some dialects only support CTEs at the top level expression for certain expression
+        # types, so we need to bubble up nested CTEs to that level in order to produce a
+        # syntactically valid expression. This transformation happens here to minimize code
+        # duplication, since many expressions support CTEs.
         if (
-            not self.SUPPORTS_NESTED_CTES
-            and isinstance(expression, exp.Expression)
-            and not isinstance(expression, exp.Create)  # CTAS needs the CTEs to come after CREATE
-            and not expression.parent
-            and "with" in expression.arg_types
+            not expression.parent
+            and type(expression) in self.EXPRESSIONS_WITHOUT_NESTED_CTES
             and any(node.parent is not expression for node in expression.find_all(exp.With))
         ):
             from sqlglot.transforms import move_ctes_to_top_level

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -8,6 +8,7 @@ class TestSpark(Validator):
     dialect = "spark"
 
     def test_ddl(self):
+        self.validate_identity("CREATE TABLE foo AS WITH t AS (SELECT 1 AS col) SELECT col FROM t")
         self.validate_identity("CREATE TEMPORARY VIEW test AS SELECT 1")
         self.validate_identity("CREATE TABLE foo (col VARCHAR(50))")
         self.validate_identity("CREATE TABLE foo (col STRUCT<struct_col_a: VARCHAR((50))>)")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -12,7 +12,7 @@ class TestTSQL(Validator):
         self.validate_identity("CAST(x AS int) OR y", "CAST(x AS INTEGER) <> 0 OR y <> 0")
 
         self.validate_all(
-            "WITH t(c) AS (SELECT 1) SELECT * INTO foo FROM (SELECT c FROM t) AS temp",
+            "WITH t(c) AS (SELECT 1) SELECT * INTO foo FROM (SELECT c AS c FROM t) AS temp",
             read={
                 "duckdb": "CREATE TABLE foo AS WITH t(c) AS (SELECT 1) SELECT c FROM t",
             },


### PR DESCRIPTION
References:
- https://learn.microsoft.com/en-us/sql/t-sql/queries/update-transact-sql?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/t-sql/statements/delete-transact-sql?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/t-sql/statements/insert-transact-sql?view=sql-server-ver16
- https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-cte.html