### PR TITLE
fix(optimizer): dont cast right side of IS

### DIFF
--- a/sqlglot/optimizer/canonicalize.py
+++ b/sqlglot/optimizer/canonicalize.py
@@ -42,8 +42,22 @@ def replace_date_funcs(node: exp.Expression) -> exp.Expression:
     return node
 
 
+COERCED_DATE_OPS = (
+    exp.Add,
+    exp.Sub,
+    exp.EQ,
+    exp.NEQ,
+    exp.GT,
+    exp.GTE,
+    exp.LT,
+    exp.LTE,
+    exp.NullSafeEQ,
+    exp.NullSafeNEQ,
+)
+
+
 def coerce_type(node: exp.Expression) -> exp.Expression:
-    if isinstance(node, exp.Binary):
+    if isinstance(node, COERCED_DATE_OPS):
         _coerce_date(node.left, node.right)
     elif isinstance(node, exp.Between):
         _coerce_date(node.this, node.args["low"])

--- a/tests/fixtures/optimizer/canonicalize.sql
+++ b/tests/fixtures/optimizer/canonicalize.sql
@@ -13,6 +13,9 @@ SELECT 1 + 3.2 AS "a" FROM "w" AS "w";
 SELECT CAST('2022-01-01' AS DATE) + INTERVAL '1' day;
 SELECT CAST('2022-01-01' AS DATE) + INTERVAL '1' day AS "_col_0";
 
+SELECT CAST('2022-01-01' AS DATE) IS NULL AS "a";
+SELECT CAST('2022-01-01' AS DATE) IS NULL AS "a";
+
 --------------------------------------
 -- Ensure boolean predicates
 --------------------------------------


### PR DESCRIPTION
Code is currently casting
```sql
CAST('2022-01-01' AS DATE) IS NULL
```
to
```sql
CAST('2022-01-01' AS DATE) IS CAST(NULL AS DATE)
```
which isn't valid SQL. No bueno.