### PR TITLE
Fix(snowflake): only generate TRY_CAST if cast value is of text type

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -562,6 +562,14 @@ class Snowflake(Dialect):
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
+        def trycast_sql(self, expression: exp.TryCast) -> str:
+            value = expression.this
+            if value.is_string or value.is_type(*exp.DataType.TEXT_TYPES):
+                return super().trycast_sql(expression)
+
+            # TRY_CAST only works for string values in Snowflake
+            return self.cast_sql(expression)
+
         def log_sql(self, expression: exp.Log) -> str:
             if not expression.expression:
                 return self.func("LN", expression.this)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -564,7 +564,7 @@ class Snowflake(Dialect):
 
         def trycast_sql(self, expression: exp.TryCast) -> str:
             value = expression.this
-            if value.is_string or value.is_type(*exp.DataType.TEXT_TYPES):
+            if value.type is None or value.is_type(*exp.DataType.TEXT_TYPES):
                 return super().trycast_sql(expression)
 
             # TRY_CAST only works for string values in Snowflake

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -564,7 +564,9 @@ class Snowflake(Dialect):
 
         def trycast_sql(self, expression: exp.TryCast) -> str:
             value = expression.this
-            if value.type is None or value.is_type(*exp.DataType.TEXT_TYPES):
+            if value.type is None or value.is_type(
+                *exp.DataType.TEXT_TYPES, exp.DataType.Type.UNKNOWN
+            ):
                 return super().trycast_sql(expression)
 
             # TRY_CAST only works for string values in Snowflake

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1202,11 +1202,13 @@ MATCH_RECOGNIZE (
         assert isinstance(ast.args["actions"][0], exp.SwapTable)
 
     def test_try_cast(self):
+        self.validate_identity("SELECT TRY_CAST(x AS DOUBLE)")
+
         self.validate_all(
-            "CAST(x AS TEXT)",
+            "TRY_CAST(x AS TEXT)",
             read={
                 "hive": "CAST(x AS STRING)",
-                "snowflake": "CAST(x AS TEXT)",
+                "snowflake": "TRY_CAST(x AS TEXT)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1200,3 +1200,25 @@ MATCH_RECOGNIZE (
         ast = parse_one("ALTER TABLE a SWAP WITH b", read="snowflake")
         assert isinstance(ast, exp.AlterTable)
         assert isinstance(ast.args["actions"][0], exp.SwapTable)
+
+    def test_try_cast(self):
+        self.validate_all(
+            "CAST(x AS TEXT)",
+            read={
+                "hive": "CAST(x AS STRING)",
+                "snowflake": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "TRY_CAST('foo' AS TEXT)",
+            read={
+                "hive": "CAST('foo' AS STRING)",
+            },
+        )
+
+        from sqlglot.optimizer.annotate_types import annotate_types
+
+        expression = parse_one("SELECT CAST(t.x AS STRING) FROM t", read="hive")
+        expression = annotate_types(expression, schema={"t": {"x": "string"}})
+
+        self.assertEqual(expression.sql(dialect="snowflake"), "SELECT TRY_CAST(t.x AS TEXT) FROM t")


### PR DESCRIPTION
From Snowflake's [docs](https://docs.snowflake.com/en/sql-reference/functions/try_cast):

![image](https://github.com/tobymao/sqlglot/assets/46752250/977cb819-3b0d-4498-a2a5-c94d155a1f7e)
