### PR TITLE
Feat!(snowflake): deactivate collation in REGEXP_LIKE

### DIFF
--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -40,7 +40,7 @@ class TestRedshift(Validator):
             "x ~* 'pat'",
             write={
                 "redshift": "x ~* 'pat'",
-                "snowflake": "REGEXP_LIKE(x, 'pat', 'i')",
+                "snowflake": "REGEXP_LIKE(COLLATE(x, ''), COLLATE('pat', ''), 'i')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -33,7 +33,6 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT HLL(DISTINCT a, b, c)")
         self.validate_identity("$x")  # parameter
         self.validate_identity("a$b")  # valid snowflake identifier
-        self.validate_identity("SELECT REGEXP_LIKE(a, b, c)")
         self.validate_identity("CREATE TABLE foo (bar FLOAT AUTOINCREMENT START 0 INCREMENT 1)")
         self.validate_identity("ALTER TABLE IF EXISTS foo SET TAG a = 'a', b = 'b', c = 'c'")
         self.validate_identity("ALTER TABLE foo UNSET TAG a, b, c")
@@ -48,6 +47,10 @@ class TestSnowflake(Validator):
             'DESCRIBE TABLE "SNOWFLAKE_SAMPLE_DATA"."TPCDS_SF100TCL"."WEB_SITE" type=stage'
         )
         self.validate_identity(
+            "SELECT REGEXP_LIKE(a, b, c)",
+            "SELECT REGEXP_LIKE(COLLATE(a, ''), COLLATE(b, ''), c)",
+        )
+        self.validate_identity(
             "CREATE TABLE foo (ID INT COMMENT $$some comment$$)",
             "CREATE TABLE foo (ID INT COMMENT 'some comment')",
         )
@@ -60,7 +63,7 @@ class TestSnowflake(Validator):
         )
         self.validate_identity(
             r"SELECT RLIKE(a, $$regular expression with \ characters: \d{2}-\d{3}-\d{4}$$, 'i') FROM log_source",
-            r"SELECT REGEXP_LIKE(a, 'regular expression with \\ characters: \\d{2}-\\d{3}-\\d{4}', 'i') FROM log_source",
+            r"SELECT REGEXP_LIKE(COLLATE(a, ''), COLLATE('regular expression with \\ characters: \\d{2}-\\d{3}-\\d{4}', ''), 'i') FROM log_source",
         )
         self.validate_identity(
             r"SELECT $$a ' \ \t \x21 z $ $$",
@@ -485,7 +488,7 @@ class TestSnowflake(Validator):
             "SELECT RLIKE(a, b)",
             write={
                 "hive": "SELECT a RLIKE b",
-                "snowflake": "SELECT REGEXP_LIKE(a, b)",
+                "snowflake": "SELECT REGEXP_LIKE(COLLATE(a, ''), COLLATE(b, ''))",
                 "spark": "SELECT a RLIKE b",
             },
         )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -348,7 +348,7 @@ TBLPROPERTIES (
                 "bigquery": "SELECT REGEXP_CONTAINS('John Doe', 'John.*')",
                 "hive": "SELECT 'John Doe' RLIKE 'John.*'",
                 "postgres": "SELECT 'John Doe' ~ 'John.*'",
-                "snowflake": "SELECT REGEXP_LIKE('John Doe', 'John.*')",
+                "snowflake": "SELECT REGEXP_LIKE(COLLATE('John Doe', ''), COLLATE('John.*', ''))",
                 "spark": "SELECT 'John Doe' RLIKE 'John.*'",
             },
         )


### PR DESCRIPTION
From Snowflake's docs: "Arguments with collation specifications are currently not supported."

For example, both of the following queries fail in Snowflake:

```
-- Function REGEXP_LIKE does not support collation.
SELECT REGEXP_LIKE(COLLATE('foo', 'en-ci'), 'pattern');
SELECT REGEXP_LIKE('foo', COLLATE('pattern', 'en-ci'));
```

This PR ensures that there's no collation in either argument to avoid such errors.

References:
- https://docs.snowflake.com/en/sql-reference/functions/regexp_like#collation-details
- https://docs.snowflake.com/en/sql-reference/collation#specification-examples