### PR TITLE
Feat(executor): add support for array_unique_agg

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -258,6 +258,7 @@ class Snowflake(Dialect):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "ARRAYAGG": exp.ArrayAgg.from_arg_list,
+            "ARRAY_UNIQUE_AGG": exp.ArrayUniqueAgg.from_arg_list,
             "ARRAY_CONSTRUCT": exp.Array.from_arg_list,
             "ARRAY_GENERATE_RANGE": lambda args: exp.GenerateSeries(
                 # ARRAY_GENERATE_RANGE has an exlusive end; we normalize it to be inclusive

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -258,7 +258,6 @@ class Snowflake(Dialect):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "ARRAYAGG": exp.ArrayAgg.from_arg_list,
-            "ARRAY_UNIQUE_AGG": exp.ArrayUniqueAgg.from_arg_list,
             "ARRAY_CONSTRUCT": exp.Array.from_arg_list,
             "ARRAY_GENERATE_RANGE": lambda args: exp.GenerateSeries(
                 # ARRAY_GENERATE_RANGE has an exlusive end; we normalize it to be inclusive

--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -143,6 +143,7 @@ ENV = {
     "exp": exp,
     # aggs
     "ARRAYAGG": list,
+    "ARRAYUNIQUEAGG": filter_nulls(lambda acc: list(set(acc))),
     "AVG": filter_nulls(statistics.fmean if PYTHON_VERSION >= (3, 8) else statistics.mean),  # type: ignore
     "COUNT": filter_nulls(lambda acc: sum(1 for _ in acc), False),
     "MAX": filter_nulls(max),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4345,6 +4345,10 @@ class ArrayUnionAgg(AggFunc):
     pass
 
 
+class ArrayUniqueAgg(AggFunc):
+    pass
+
+
 class Avg(AggFunc):
     pass
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -777,7 +777,7 @@ class TestExecutor(unittest.TestCase):
                 {"a": 2, "b": 10},
                 {"a": 2, "b": 20},
                 {"a": 3, "b": 10},
-                {"a": 3, "b": None}
+                {"a": 3, "b": None},
             ],
         }
 
@@ -792,7 +792,6 @@ class TestExecutor(unittest.TestCase):
                 result = execute(sql, tables=tables)
                 self.assertEqual(result.columns, columns)
                 self.assertEqual(result.rows, expected)
-
 
     def test_dict_values(self):
         tables = {

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -768,6 +768,32 @@ class TestExecutor(unittest.TestCase):
                 self.assertEqual(result.columns, columns)
                 self.assertEqual(result.rows, expected)
 
+    def test_array_unique_agg(self):
+        tables = {
+            "x": [
+                {"a": 1, "b": 10},
+                {"a": 1, "b": 20},
+                {"a": 1, "b": 10},
+                {"a": 2, "b": 10},
+                {"a": 2, "b": 20},
+                {"a": 3, "b": 10},
+                {"a": 3, "b": None}
+            ],
+        }
+
+        for sql, expected, columns in (
+            (
+                "SELECT a, ARRAY_UNIQUE_AGG(b) FROM x GROUP BY a",
+                [(1, [10, 20]), (2, [10, 20]), (3, [10])],
+                ("a", "_col_1"),
+            ),
+        ):
+            with self.subTest(sql):
+                result = execute(sql, tables=tables)
+                self.assertEqual(result.columns, columns)
+                self.assertEqual(result.rows, expected)
+
+
     def test_dict_values(self):
         tables = {
             "foo": [{"raw": {"name": "Hello, World"}}],


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/functions/array_unique_agg 

> The function ignores NULL values in column. If column contains only NULL values or the table containing column is empty, the function returns an empty ARRAY.

