### PR TITLE
feat(sql): propagate constants to projections

### DIFF
--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -934,13 +934,13 @@ x = 5 AND (y = x OR z = 1);
 x = 5 AND x + 3 = 8;
 x = 5;
 
-x = 5 AND (SELECT x FROM t WHERE y = 1);
+(SELECT x FROM t WHERE y = 1) AND x = 5;
 (SELECT x FROM t WHERE y = 1) AND x = 5;
 
-x = 1 AND y > 0 AND (SELECT z = 5 FROM t WHERE y = 1);
+(SELECT z = 5 FROM t WHERE y = 1) AND x = 1 AND y > 0;
 (SELECT z = 5 FROM t WHERE y = 1) AND x = 1 AND y > 0;
 
-x = 1 AND x = y AND (SELECT z FROM t WHERE a AND (b OR c));
+(SELECT z FROM t WHERE a AND (b OR c)) AND x = 1 AND x = y;
 (SELECT z FROM t WHERE a AND (b OR c)) AND 1 = y AND x = 1;
 
 t1.a = 39 AND t2.b = t1.a AND t3.c = t2.b;
@@ -955,11 +955,20 @@ x = 1;
 x = 1 AND CASE x WHEN 5 THEN FALSE ELSE TRUE END;
 x = 1;
 
-x = y AND CASE WHEN x = 5 THEN FALSE ELSE TRUE END;
+CASE WHEN x = 5 THEN FALSE ELSE TRUE END AND x = y;
 CASE WHEN x = 5 THEN FALSE ELSE TRUE END AND x = y;
 
-x = 1 AND CASE WHEN y = 5 THEN x = z END;
+CASE WHEN y = 5 THEN x = z END AND x = 1;
 CASE WHEN y = 5 THEN 1 = z END AND x = 1;
+
+SELECT a FROM x WHERE a = 1;
+SELECT 1 FROM x WHERE a = 1;
+
+SELECT SUM(a), MIN(b) FROM x WHERE b = 1 AND c > 3;
+SELECT SUM(a), MIN(1) FROM x WHERE b = 1 AND c > 3;
+
+SELECT (SELECT MIN(a) FROM x) FROM x WHERE a = 1;
+SELECT (SELECT MIN(a) FROM x) FROM x WHERE a = 1;
 
 --------------------------------------
 -- Simplify Conditionals


### PR DESCRIPTION
Tableau sends our application queries like this:

```sql
SELECT
  SUM(a) AS a,
  MIN(b) AS b
FROM x
WHERE b = '123'
```

This is a reasonable query for Tableau to generate, but these are problematic for our application, which has a complex query rewriter.

This rule rewrites this as:
```sql
SELECT
  SUM(a) AS a,
  MIN('123') AS b
FROM x
WHERE b = '123'
```

Which is slightly simpler.

I chose to add this to constant propagation, since its kinda similar. Happy to move it somewhere else.

@georgesittas I think this simplifies the constant propagation code a little bit. Let me know what you think.