### PR TITLE
Fix!(optimizer): annotate text + numeric using the numeric type

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -299,6 +299,16 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         ),
         **swap_all(
             {
+                # text + numeric will yield the numeric type to match most dialects' semantics
+                (text, numeric): lambda l, r: t.cast(
+                    exp.DataType.Type, l.type if l.type in exp.DataType.NUMERIC_TYPES else r.type
+                )
+                for text in exp.DataType.TEXT_TYPES
+                for numeric in exp.DataType.NUMERIC_TYPES
+            }
+        ),
+        **swap_all(
+            {
                 (exp.DataType.Type.DATE, exp.DataType.Type.INTERVAL): lambda l, r: _coerce_date(
                     l, r.args.get("unit")
                 ),

--- a/tests/fixtures/optimizer/canonicalize.sql
+++ b/tests/fixtures/optimizer/canonicalize.sql
@@ -10,6 +10,9 @@ SELECT CAST(1 AS VARCHAR) AS "a" FROM "w" AS "w";
 SELECT CAST(1 + 3.2 AS DOUBLE) AS a FROM w AS w;
 SELECT 1 + 3.2 AS "a" FROM "w" AS "w";
 
+SELECT '1' + 1 AS "col";
+SELECT '1' + 1 AS "col";
+
 SELECT CAST('2022-01-01' AS DATE) + INTERVAL '1' day;
 SELECT CAST('2022-01-01' AS DATE) + INTERVAL '1' day AS "_col_0";
 

--- a/tests/fixtures/optimizer/canonicalize.sql
+++ b/tests/fixtures/optimizer/canonicalize.sql
@@ -13,6 +13,9 @@ SELECT 1 + 3.2 AS "a" FROM "w" AS "w";
 SELECT '1' + 1 AS "col";
 SELECT '1' + 1 AS "col";
 
+SELECT '1' + '1' AS "col";
+SELECT CONCAT('1', '1') AS "col";
+
 SELECT CAST('2022-01-01' AS DATE) + INTERVAL '1' day;
 SELECT CAST('2022-01-01' AS DATE) + INTERVAL '1' day AS "_col_0";
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -584,6 +584,11 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         self.assertEqual(expression.right.this.left.type.this, exp.DataType.Type.INT)
         self.assertEqual(expression.right.this.right.type.this, exp.DataType.Type.INT)
 
+        for numeric_type in ("BIGINT", "DOUBLE", "INT"):
+            query = f"SELECT '1' + CAST(x AS {numeric_type})"
+            expression = annotate_types(parse_one(query)).expressions[0]
+            self.assertEqual(expression.type, exp.DataType.build(numeric_type))
+
     def test_typeddiv_annotation(self):
         expressions = annotate_types(
             parse_one("SELECT 2 / 3, 2 / 3.0", dialect="presto")


### PR DESCRIPTION
BigQuery, ClickHouse, DuckDB, Trino, Presto: int + str fails for both 1 + ‘1’ and 1 + ‘a’
Postgres, Redshift, Snowflake, T-SQL: int + str fails only for 1 + ‘a’, yields 2 for 1 + ‘1’
Hive (, Spark2?): 1 + ‘1’ yields 2, 1 + ‘a’ yields null
Spark (, Databricks?): 1 + '1' yields 2.0, 1 + 'a' yields null
MySQL, SQLite: 1 + ‘1’ yields 2, 1 + ‘a’ yields 1

Note that Spark (at least ≥v3.4.0, which I'm testing with) infers the type of `1 + '1'` to be `double` (see below). I haven't taken this into account in this PR since it seems to be the exception to the rule, but happy to discuss more about it.

```python
>>> spark.sql("select 1 + '1'")
DataFrame[(1 + 1): double]
```