### PR TITLE
Add failing test for dateadd on redshift

### DIFF
--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -77,6 +77,18 @@ class TestRedshift(Validator):
             },
         )
         self.validate_all(
+            "SELECT DATEADD('hour',0,CAST('2020-02-02 01:03:05.124' AS TIMESTAMP))",
+            write={
+                "redshift": "SELECT DATEADD(hour, 0, CAST('2020-02-02 01:03:05.124' AS TIMESTAMP))",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEDIFF('second', '2020-02-02 01:03:05.124','2020-02-02 00:00:00.000')",
+            write={
+                "redshift": "SELECT DATEDIFF(second, CAST('2020-02-02 01:03:05.124' AS TIMESTAMP), CAST('2020-02-02 00:00:00.000' AS TIMESTAMP))",
+            },
+        )
+        self.validate_all(
             "SELECT STRTOL('abc', 16)",
             read={
                 "trino": "SELECT FROM_BASE('abc', 16)",


### PR DESCRIPTION
On Redshift, DATEADD can be used to modify timestamps, yielding timestamps. However, when sqlglot normalises such cases, the timestamps are forcibly cast to dates, which is a very different result.

This PR includes failing test cases, but I'm not sure how best to construct a fix. Failure messages follow:

```
======================================================================
FAIL: test_redshift (tests.dialects.test_redshift.TestRedshift.test_redshift) [SELECT DATEADD('hour',0,CAST('2020-02-02 01:03:05.124' AS TIMESTAMP)) -> redshift]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/steve/Projects/External/sqlglot/tests/dialects/test_dialect.py", line 60, in validate_all
    self.assertEqual(
AssertionError: "SELE[17 chars]0, CAST(CAST('2020-02-02 01:03:05.124' AS TIMESTAMP) AS DATE))" != "SELE[17 chars]0, CAST('2020-02-02 01:03:05.124' AS TIMESTAMP))"
- SELECT DATEADD(hour, 0, CAST(CAST('2020-02-02 01:03:05.124' AS TIMESTAMP) AS DATE))
?                         -----                                            ---------
+ SELECT DATEADD(hour, 0, CAST('2020-02-02 01:03:05.124' AS TIMESTAMP))


======================================================================
FAIL: test_redshift (tests.dialects.test_redshift.TestRedshift.test_redshift) [SELECT DATEDIFF('second', '2020-02-02 01:03:05.124','2020-02-02 00:00:00.000') -> redshift]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/steve/Projects/External/sqlglot/tests/dialects/test_dialect.py", line 60, in validate_all
    self.assertEqual(
AssertionError: "SELE[49 chars]' AS DATE), CAST('2020-02-02 00:00:00.000' AS DATE))" != "SELE[49 chars]' AS TIMESTAMP), CAST('2020-02-02 00:00:00.000' AS TIMESTAMP))"
- SELECT DATEDIFF(second, CAST('2020-02-02 01:03:05.124' AS DATE), CAST('2020-02-02 00:00:00.000' AS DATE))
?                                                           ^ ^^                                     ^ ^^
+ SELECT DATEDIFF(second, CAST('2020-02-02 01:03:05.124' AS TIMESTAMP), CAST('2020-02-02 00:00:00.000' AS TIMESTAMP))
?                                                           ^^^^^^ ^^                                     ^^^^^^ ^^
```