### PR TITLE
Fix(duckdb): unqualify columns under Pivot

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -294,9 +294,8 @@ class DuckDB(Dialect):
             exp.ParseJSON: rename_func("JSON"),
             exp.PercentileCont: rename_func("QUANTILE_CONT"),
             exp.PercentileDisc: rename_func("QUANTILE_DISC"),
-            # DuckDB doesn't allow qualified columns inside of PIVOT expressions, see:
-            # - https://github.com/duckdb/duckdb/blob/671faf92411182f81dce42ac43de8bfb05d9909e/src/planner/binder/tableref/bind_pivot.cpp#L61
-            # - https://github.com/duckdb/duckdb/commit/16ffa4f90188696c5317cc1b21f0171efe0a2a4f#diff-578581d2f8f501c39d5157c6e97dd79b6ddf18a9528c8841fb776eb1063c15a6R14
+            # DuckDB doesn't allow qualified columns inside of PIVOT expressions.
+            # See: https://github.com/duckdb/duckdb/blob/671faf92411182f81dce42ac43de8bfb05d9909e/src/planner/binder/tableref/bind_pivot.cpp#L61-L62
             exp.Pivot: transforms.preprocess([transforms.unqualify_columns]),
             exp.Properties: no_properties_sql,
             exp.RegexpExtract: regexp_extract_sql,

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -451,10 +451,8 @@ def ensure_bools(expression: exp.Expression) -> exp.Expression:
 
 def unqualify_columns(expression: exp.Expression) -> exp.Expression:
     for column in expression.find_all(exp.Column):
-        for part in ("table", "db", "catalog"):
-            arg = column.args.get(part)
-            if arg:
-                arg.pop()
+        for part in column.parts[:-1]:
+            part.pop()
 
     return expression
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -449,6 +449,18 @@ def ensure_bools(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
+def unqualify_columns(expression: exp.Expression) -> exp.Expression:
+    for column in expression.find_all(exp.Column):
+        if column.table:
+            column.args["table"].pop()
+        if column.db:
+            column.args["db"].pop()
+        if column.catalog:
+            column.args["catalog"].pop()
+
+    return expression
+
+
 def preprocess(
     transforms: t.List[t.Callable[[exp.Expression], exp.Expression]],
 ) -> t.Callable[[Generator, exp.Expression], str]:

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -451,6 +451,7 @@ def ensure_bools(expression: exp.Expression) -> exp.Expression:
 
 def unqualify_columns(expression: exp.Expression) -> exp.Expression:
     for column in expression.find_all(exp.Column):
+        # We only wanna pop off the table, db, catalog args
         for part in column.parts[:-1]:
             part.pop()
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -451,12 +451,10 @@ def ensure_bools(expression: exp.Expression) -> exp.Expression:
 
 def unqualify_columns(expression: exp.Expression) -> exp.Expression:
     for column in expression.find_all(exp.Column):
-        if column.table:
-            column.args["table"].pop()
-        if column.db:
-            column.args["db"].pop()
-        if column.catalog:
-            column.args["catalog"].pop()
+        for part in ("table", "db", "catalog"):
+            arg = column.args.get(part)
+            if arg:
+                arg.pop()
 
     return expression
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -155,6 +155,7 @@ class TestDuckDB(Validator):
         self.validate_all(
             "SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))",
             read={
+                "duckdb": "SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))",
                 "snowflake": "SELECT * FROM produce PIVOT(SUM(produce.sales) FOR produce.quarter IN ('Q1', 'Q2'))",
             },
         )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -153,6 +153,12 @@ class TestDuckDB(Validator):
         self.validate_all("x ~ y", write={"duckdb": "REGEXP_MATCHES(x, y)"})
         self.validate_all("SELECT * FROM 'x.y'", write={"duckdb": 'SELECT * FROM "x.y"'})
         self.validate_all(
+            "SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))",
+            read={
+                "snowflake": "SELECT * FROM produce PIVOT(SUM(produce.sales) FOR produce.quarter IN ('Q1', 'Q2'))",
+            },
+        )
+        self.validate_all(
             "SELECT UNNEST([1, 2, 3])",
             write={
                 "duckdb": "SELECT UNNEST([1, 2, 3])",


### PR DESCRIPTION
DuckDB doesn't allow qualified columns inside of PIVOT expressions, for example:

```
D WITH Produce AS (
>   SELECT 'Kale' as product, 51 as sales, 'Q1' as quarter, 2020 as year
> )
> SELECT * FROM Produce PIVOT(SUM(Produce.sales) FOR Produce.quarter IN ('Q1', 'Q2', 'Q3', 'Q4'));
Error: Binder Error: PIVOT expression cannot contain qualified columns
D WITH Produce AS (
>   SELECT 'Kale' as product, 51 as sales, 'Q1' as quarter, 2020 as year
> )
> SELECT * FROM Produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4'));
┌─────────┬───────┬────────┬────────┬────────┬────────┐
│ product │ year  │   Q1   │   Q2   │   Q3   │   Q4   │
│ varchar │ int32 │ int128 │ int128 │ int128 │ int128 │
├─────────┼───────┼────────┼────────┼────────┼────────┤
│ Kale    │  2020 │     51 │        │        │        │
└─────────┴───────┴────────┴────────┴────────┴────────┘
D
```

This is a problem both when we're transpiling a `PIVOT` that contains qualified columns to DuckDB and when we're running the optimizer and all columns get qualified as a result.

References:
- https://github.com/duckdb/duckdb/blob/671faf92411182f81dce42ac43de8bfb05d9909e/src/planner/binder/tableref/bind_pivot.cpp#L61
- https://github.com/duckdb/duckdb/commit/16ffa4f90188696c5317cc1b21f0171efe0a2a4f#diff-578581d2f8f501c39d5157c6e97dd79b6ddf18a9528c8841fb776eb1063c15a6R14