### PR TITLE
Fix!(hive): truncate division result in _date_diff_sql

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -116,11 +116,12 @@ def _date_diff_sql(self: Hive.Generator, expression: exp.DateDiff | exp.TsOrDsDi
     multiplier_sql = f" / {multiplier}" if multiplier > 1 else ""
     diff_sql = f"{sql_func}({self.format_args(expression.this, expression.expression)})"
 
-    if months_between:
-        # MONTHS_BETWEEN returns a float, so we need to truncate the fractional part
-        diff_sql = f"CAST({diff_sql} AS INT)"
+    if months_between or multiplier_sql:
+        # MONTHS_BETWEEN returns a float, so we need to truncate the fractional part.
+        # For the same reason, we want to truncate if there's a divisor present.
+        diff_sql = f"CAST({diff_sql}{multiplier_sql} AS INT)"
 
-    return f"{diff_sql}{multiplier_sql}"
+    return diff_sql
 
 
 def _json_format_sql(self: Hive.Generator, expression: exp.JSONFormat) -> str:

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -260,7 +260,7 @@ class TestRedshift(Validator):
             write={
                 "bigquery": "SELECT DATE_DIFF(CAST('2009-12-31' AS DATETIME), CAST('2009-01-01' AS DATETIME), week)",
                 "duckdb": "SELECT DATE_DIFF('week', CAST('2009-01-01' AS TIMESTAMP), CAST('2009-12-31' AS TIMESTAMP))",
-                "hive": "SELECT DATEDIFF('2009-12-31', '2009-01-01') / 7",
+                "hive": "SELECT CAST(DATEDIFF('2009-12-31', '2009-01-01') / 7 AS INT)",
                 "postgres": "SELECT CAST(EXTRACT(days FROM (CAST('2009-12-31' AS TIMESTAMP) - CAST('2009-01-01' AS TIMESTAMP))) / 7 AS BIGINT)",
                 "presto": "SELECT DATE_DIFF('week', CAST('2009-01-01' AS TIMESTAMP), CAST('2009-12-31' AS TIMESTAMP))",
                 "redshift": "SELECT DATEDIFF(week, '2009-01-01', '2009-12-31')",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -312,7 +312,7 @@ TBLPROPERTIES (
             write={
                 "bigquery": "SELECT DATE_DIFF(CAST('2020-12-31' AS DATE), CAST('2020-01-01' AS DATE), week)",
                 "duckdb": "SELECT DATE_DIFF('week', CAST('2020-01-01' AS DATE), CAST('2020-12-31' AS DATE))",
-                "hive": "SELECT DATEDIFF(TO_DATE('2020-12-31'), TO_DATE('2020-01-01')) / 7",
+                "hive": "SELECT CAST(DATEDIFF(TO_DATE('2020-12-31'), TO_DATE('2020-01-01')) / 7 AS INT)",
                 "postgres": "SELECT CAST(EXTRACT(days FROM (CAST(CAST('2020-12-31' AS DATE) AS TIMESTAMP) - CAST(CAST('2020-01-01' AS DATE) AS TIMESTAMP))) / 7 AS BIGINT)",
                 "redshift": "SELECT DATEDIFF(week, CAST('2020-01-01' AS DATE), CAST('2020-12-31' AS DATE))",
                 "snowflake": "SELECT DATEDIFF(week, CAST('2020-01-01' AS DATE), CAST('2020-12-31' AS DATE))",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1133,10 +1133,7 @@ WHERE
 
     def test_date_diff(self):
         self.validate_identity("SELECT DATEDIFF(hour, 1.5, '2021-01-01')")
-        self.validate_identity(
-            "SELECT DATEDIFF(year, '2020-01-01', '2021-01-01')",
-            "SELECT DATEDIFF(year, CAST('2020-01-01' AS DATETIME2), CAST('2021-01-01' AS DATETIME2))",
-        )
+
         self.validate_all(
             "SELECT DATEDIFF(quarter, 0, '2021-01-01')",
             write={
@@ -1158,7 +1155,7 @@ WHERE
             write={
                 "tsql": "SELECT DATEDIFF(year, CAST('2020-01-01' AS DATETIME2), CAST('2021-01-01' AS DATETIME2))",
                 "spark": "SELECT DATEDIFF(year, CAST('2020-01-01' AS TIMESTAMP), CAST('2021-01-01' AS TIMESTAMP))",
-                "spark2": "SELECT CAST(MONTHS_BETWEEN(CAST('2021-01-01' AS TIMESTAMP), CAST('2020-01-01' AS TIMESTAMP)) AS INT) / 12",
+                "spark2": "SELECT CAST(MONTHS_BETWEEN(CAST('2021-01-01' AS TIMESTAMP), CAST('2020-01-01' AS TIMESTAMP)) / 12 AS INT)",
             },
         )
         self.validate_all(
@@ -1174,7 +1171,7 @@ WHERE
             write={
                 "databricks": "SELECT DATEDIFF(quarter, CAST('start' AS TIMESTAMP), CAST('end' AS TIMESTAMP))",
                 "spark": "SELECT DATEDIFF(quarter, CAST('start' AS TIMESTAMP), CAST('end' AS TIMESTAMP))",
-                "spark2": "SELECT CAST(MONTHS_BETWEEN(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP)) AS INT) / 3",
+                "spark2": "SELECT CAST(MONTHS_BETWEEN(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP)) / 3 AS INT)",
                 "tsql": "SELECT DATEDIFF(quarter, CAST('start' AS DATETIME2), CAST('end' AS DATETIME2))",
             },
         )


### PR DESCRIPTION
Before:

```python
>>> import sqlglot
>>> sqlglot.transpile("SELECT DATEDIFF(week, '2020-01-01', '2020-12-31')", "spark", "hive")
["SELECT DATEDIFF(TO_DATE('2020-12-31'), TO_DATE('2020-01-01')) / 7"]
```

Spark yields:

```
spark-sql (default)> SELECT DATEDIFF(week, '2020-01-01', '2020-12-31');
52
Time taken: 4.038 seconds, Fetched 1 row(s)
```

But the transpiled Hive query yields:

<img width="503" alt="Screenshot 2023-11-25 at 2 48 40 AM" src="https://github.com/tobymao/sqlglot/assets/46752250/c1b83daf-7e17-43ac-b6a3-7f56b2d325f4">

After:

```python
>>> import sqlglot
>>> sqlglot.transpile("SELECT DATEDIFF(week, '2020-01-01', '2020-12-31')", "spark", "hive")
["SELECT CAST(DATEDIFF(TO_DATE('2020-12-31'), TO_DATE('2020-01-01')) / 7 AS INT)"]
```

<img width="598" alt="Screenshot 2023-11-25 at 2 50 53 AM" src="https://github.com/tobymao/sqlglot/assets/46752250/1489e77d-c50d-4d23-af08-f124d86a6bc2">