### PR TITLE
Fix: time format chunk misses from mapping, but its constituent parts are not

### DIFF
--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -42,6 +42,10 @@ def format_time(
                 end -= 1
                 chars = sym
                 sym = None
+            else:
+                chars = chars[0]
+                end = start + 1
+
             start += len(chars)
             chunks.append(chars)
             current = trie
@@ -53,13 +57,7 @@ def format_time(
         if result != TrieResult.FAILED and end > size:
             chunks.append(chars)
 
-    return "".join(
-        mapping.get(
-            chars,
-            ":".join(mapping.get(subchunk, subchunk) for subchunk in chars.split(":")),
-        )
-        for chars in chunks
-    )
+    return "".join(mapping.get(chars, chars) for chars in chunks)
 
 
 TIMEZONES = {

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -53,7 +53,13 @@ def format_time(
         if result != TrieResult.FAILED and end > size:
             chunks.append(chars)
 
-    return "".join(mapping.get(chars, chars) for chars in chunks)
+    return "".join(
+        mapping.get(
+            chars,
+            ":".join(mapping.get(subchunk, subchunk) for subchunk in chars.split(":")),
+        )
+        for chars in chunks
+    )
 
 
 TIMEZONES = {

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -123,6 +123,7 @@ class TestMySQL(Validator):
         self.validate_identity("ALTER TABLE test_table ALTER COLUMN test_column SET DEFAULT 1")
 
     def test_identity(self):
+        self.validate_identity("SELECT DATE_FORMAT(NOW(), '%Y-%m-%d %H:%i:00.0000')")
         self.validate_identity("SELECT @var1 := 1, @var2")
         self.validate_identity("UNLOCK TABLES")
         self.validate_identity("LOCK TABLES `app_fields` WRITE")


### PR DESCRIPTION
Fixes #2597

This one is tricky, not 100% sure this is the correct approach. We map `%H:%i:00.0000` to `%H:%M:00.0000` and `%H:%M:` is recognized as a valid prefix because `%H:%M:%S` is in the inverse time trie due to the`"%T": "%H:%M:%S"` entry, but when we hit `0` we get a trie lookup failure and so we make a “chunk” out of `%H:%M:` . This leads to us mapping it back to itself later instead of mapping its `%M` back to `%i`.





