### PR TITLE
fix!: expand positional args in order by as aliases

### DIFF
--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -65,10 +65,10 @@ SELECT a AS j, b FROM x ORDER BY j;
 SELECT x.a AS j, x.b AS b FROM x AS x ORDER BY j;
 
 SELECT a AS j, b AS a FROM x ORDER BY 1;
-SELECT x.a AS j, x.b AS a FROM x AS x ORDER BY x.a;
+SELECT x.a AS j, x.b AS a FROM x AS x ORDER BY j;
 
 SELECT SUM(a) AS c, SUM(b) AS d FROM x ORDER BY 1, 2;
-SELECT SUM(x.a) AS c, SUM(x.b) AS d FROM x AS x ORDER BY SUM(x.a), SUM(x.b);
+SELECT SUM(x.a) AS c, SUM(x.b) AS d FROM x AS x ORDER BY c, d;
 
 # execute: false
 SELECT CAST(a AS INT) FROM x ORDER BY a;
@@ -76,7 +76,7 @@ SELECT CAST(x.a AS INT) AS a FROM x AS x ORDER BY a;
 
 # execute: false
 SELECT SUM(a), SUM(b) AS c FROM x ORDER BY 1, 2;
-SELECT SUM(x.a) AS _col_0, SUM(x.b) AS c FROM x AS x ORDER BY SUM(x.a), SUM(x.b);
+SELECT SUM(x.a) AS _col_0, SUM(x.b) AS c FROM x AS x ORDER BY _col_0, c;
 
 SELECT a AS j, b FROM x GROUP BY j, b;
 SELECT x.a AS j, x.b AS b FROM x AS x GROUP BY x.a, x.b;
@@ -85,7 +85,10 @@ SELECT a, b FROM x GROUP BY 1, 2;
 SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY x.a, x.b;
 
 SELECT a, b FROM x ORDER BY 1, 2;
-SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY x.a, x.b;
+SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a, b;
+
+SELECT DISTINCT a AS c, b AS d FROM x ORDER BY 1;
+SELECT DISTINCT x.a AS c, x.b AS d FROM x AS x ORDER BY c;
 
 SELECT 2 FROM x GROUP BY 1;
 SELECT 2 AS "2" FROM x AS x GROUP BY 1;

--- a/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
+++ b/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
@@ -5699,7 +5699,7 @@ WHERE
   END > 0.1
 ORDER BY
   "v1"."sum_sales" - "v1"."avg_monthly_sales",
-  "v1"."d_moy"
+  "d_moy"
 LIMIT 100;
 
 --------------------------------------
@@ -6020,9 +6020,9 @@ WITH "date_dim_2" AS (
   WHERE
     "store"."currency_rank" <= 10 OR "store"."return_rank" <= 10
   ORDER BY
-    1,
-    "store"."return_rank",
-    "store"."currency_rank"
+    "channel",
+    "return_rank",
+    "currency_rank"
   LIMIT 100
 ), "cte_4" AS (
   SELECT
@@ -6997,7 +6997,7 @@ WHERE
   END > 0.1
 ORDER BY
   "v1"."sum_sales" - "v1"."avg_monthly_sales",
-  "v1"."avg_monthly_sales"
+  "avg_monthly_sales"
 LIMIT 100;
 
 --------------------------------------
@@ -10061,9 +10061,9 @@ WHERE
   AND "t_s_firstyear"."year1" = 1999
   AND "t_s_firstyear"."year_total" > 0
 ORDER BY
-  "t_s_secyear"."customer_id",
-  "t_s_secyear"."customer_first_name",
-  "t_s_secyear"."customer_last_name"
+  "customer_id",
+  "customer_first_name",
+  "customer_last_name"
 LIMIT 100;
 
 --------------------------------------


### PR DESCRIPTION
projections may not exist in dialects like spark making optimizations like this illegal

```sql
with x AS (select 1 a, 2 b)
SELECT DISTINCT x.a AS c, x.b AS d
FROM x
ORDER by x.a
```