### PR TITLE
Fix: treat parameters as primary expressions

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -605,6 +605,7 @@ class Parser(metaclass=_Parser):
         TokenType.NATIONAL_STRING: lambda self, token: self.expression(
             exp.National, this=token.text
         ),
+        TokenType.PARAMETER: lambda self, _: self._parse_parameter(),
         TokenType.RAW_STRING: lambda self, token: self.expression(exp.RawString, this=token.text),
         TokenType.HEREDOC_STRING: lambda self, token: self.expression(
             exp.RawString, this=token.text

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -13,6 +13,7 @@ class TestSnowflake(Validator):
         expr.selects[0].assert_is(exp.AggFunc)
         self.assertEqual(expr.sql(dialect="snowflake"), "SELECT APPROX_TOP_K(C4, 3, 5) FROM t")
 
+        self.validate_identity("SELECT user_id, value FROM table_name sample ($s) SEED (0)")
         self.validate_identity("SELECT ARRAY_UNIQUE_AGG(x)")
         self.validate_identity("SELECT OBJECT_CONSTRUCT()")
         self.validate_identity("SELECT DAYOFMONTH(CURRENT_TIMESTAMP())")


### PR DESCRIPTION
Fix #2604