### PR TITLE
Fix: always expand sentinel line break in pretty mode

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -515,7 +515,7 @@ class Snowflake(Dialect):
             exp.Select: transforms.preprocess(
                 [
                     transforms.eliminate_distinct_on,
-                    transforms.explode_to_unnest(0),
+                    transforms.explode_to_unnest(),
                     transforms.eliminate_semi_and_anti_joins,
                 ]
             ),

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -706,6 +706,10 @@ FROM dw_1_dw_1_1.exactonline_2.transactionlines""",
 
     def test_pretty_line_breaks(self):
         self.assertEqual(transpile("SELECT '1\n2'", pretty=True)[0], "SELECT\n  '1\n2'")
+        self.assertEqual(
+            transpile("SELECT '1\n2'", pretty=True, unsupported_level=ErrorLevel.IGNORE)[0],
+            "SELECT\n  '1\n2'",
+        )
 
     @mock.patch("sqlglot.parser.logger")
     def test_error_level(self, logger):


### PR DESCRIPTION
This fixes the following bug:

```python
>>> import sqlglot
>>> print(sqlglot.transpile("SELECT 'foo\nbar'", unsupported_level=sqlglot.errors.ErrorLevel.IGNORE, pretty=True)[0])
SELECT
  'foo__SQLGLOT__LB__bar'
```

Bonus: cleaned up the `generate` command a bit because the preprocessing steps were noisy..