### PR TITLE
Feat(postgres): add support for operators with schema path

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -362,7 +362,7 @@ class Postgres(Dialect):
                     exp.Operator,
                     comments=self._prev_comments,
                     this=this,
-                    operator=exp.Anonymous(this="OPERATOR", expressions=[op]),
+                    operator=op,
                     expression=self._parse_bitwise(),
                 )
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -349,21 +349,27 @@ class Postgres(Dialect):
         }
 
         def _parse_operator(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
-            if not self._match(TokenType.L_PAREN):
-                return this
+            while True:
+                if not self._match(TokenType.L_PAREN):
+                    break
 
-            op = ""
-            while self._curr and not self._match(TokenType.R_PAREN):
-                op += self._curr.text
-                self._advance()
+                op = ""
+                while self._curr and not self._match(TokenType.R_PAREN):
+                    op += self._curr.text
+                    self._advance()
 
-            return self.expression(
-                exp.Operator,
-                comments=self._prev_comments,
-                this=this,
-                operator=exp.Anonymous(this="OPERATOR", expressions=[op]),
-                expression=self._parse_bitwise(),
-            )
+                this = self.expression(
+                    exp.Operator,
+                    comments=self._prev_comments,
+                    this=this,
+                    operator=exp.Anonymous(this="OPERATOR", expressions=[op]),
+                    expression=self._parse_bitwise(),
+                )
+
+                if not self._match(TokenType.OPERATOR):
+                    break
+
+            return this
 
         def _parse_date_part(self) -> exp.Expression:
             part = self._parse_type()

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4036,6 +4036,11 @@ class NEQ(Binary, Predicate):
     pass
 
 
+# https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATH
+class Operator(Binary):
+    arg_types = {"this": True, "operator": True, "expression": True}
+
+
 class SimilarTo(Binary, Predicate):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3051,10 +3051,7 @@ class Generator:
         return f"REFRESH {table}{this}"
 
     def operator_sql(self, expression: exp.Operator) -> str:
-        this = self.sql(expression, "this")
-        operator = self.sql(expression, "operator")
-        expr = self.sql(expression, "expression")
-        return f"{this} {operator} {expr}"
+        return self.binary(expression, self.sql(expression, "operator"))
 
     def _simplify_unless_literal(self, expression: E) -> E:
         if not isinstance(expression, exp.Literal):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3050,6 +3050,12 @@ class Generator:
         table = "" if isinstance(expression.this, exp.Literal) else "TABLE "
         return f"REFRESH {table}{this}"
 
+    def operator_sql(self, expression: exp.Operator) -> str:
+        this = self.sql(expression, "this")
+        operator = self.sql(expression, "operator")
+        expr = self.sql(expression, "expression")
+        return f"{this} {operator} {expr}"
+
     def _simplify_unless_literal(self, expression: E) -> E:
         if not isinstance(expression, exp.Literal):
             from sqlglot.optimizer.simplify import simplify

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3051,7 +3051,7 @@ class Generator:
         return f"REFRESH {table}{this}"
 
     def operator_sql(self, expression: exp.Operator) -> str:
-        return self.binary(expression, self.sql(expression, "operator"))
+        return self.binary(expression, f"OPERATOR({self.sql(expression, 'operator')})")
 
     def _simplify_unless_literal(self, expression: E) -> E:
         if not isinstance(expression, exp.Literal):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -293,6 +293,7 @@ class Parser(metaclass=_Parser):
         TokenType.NATURAL,
         TokenType.NEXT,
         TokenType.OFFSET,
+        TokenType.OPERATOR,
         TokenType.ORDINALITY,
         TokenType.OVERLAPS,
         TokenType.OVERWRITE,
@@ -3336,7 +3337,7 @@ class Parser(metaclass=_Parser):
 
         return this
 
-    def _parse_between(self, this: exp.Expression) -> exp.Between:
+    def _parse_between(self, this: t.Optional[exp.Expression]) -> exp.Between:
         low = self._parse_bitwise()
         self._match(TokenType.AND)
         high = self._parse_bitwise()
@@ -5362,7 +5363,9 @@ class Parser(metaclass=_Parser):
         self._match_r_paren()
         return self.expression(exp.DictRange, this=this, min=min, max=max)
 
-    def _parse_comprehension(self, this: exp.Expression) -> t.Optional[exp.Comprehension]:
+    def _parse_comprehension(
+        self, this: t.Optional[exp.Expression]
+    ) -> t.Optional[exp.Comprehension]:
         index = self._index
         expression = self._parse_column()
         if not self._match(TokenType.IN):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -276,6 +276,7 @@ class TokenType(AutoName):
     OBJECT_IDENTIFIER = auto()
     OFFSET = auto()
     ON = auto()
+    OPERATOR = auto()
     ORDER_BY = auto()
     ORDERED = auto()
     ORDINALITY = auto()

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -186,6 +186,7 @@ class TestPostgres(Validator):
         expr.right.assert_is(exp.Literal)
         self.assertEqual(expr.sql(dialect="postgres"), "1 OPERATOR(+) 2 OPERATOR(*) 3")
 
+        self.validate_identity("SELECT operator FROM t")
         self.validate_identity("SELECT 1 OPERATOR(+) 2")
         self.validate_identity("SELECT 1 OPERATOR(pg_catalog.+) 2")
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -203,6 +203,16 @@ class TestPostgres(Validator):
         self.assertIsInstance(expr, exp.AlterTable)
         self.assertEqual(expr.sql(dialect="postgres"), alter_table_only)
 
+        self.validate_identity("SELECT 1 OPERATOR(+) 2")
+        self.validate_identity("SELECT 1 OPERATOR(pg_catalog.+) 2")
+        self.validate_identity(
+            "SELECT c.oid, n.nspname, c.relname "
+            "FROM pg_catalog.pg_class AS c "
+            "LEFT JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace "
+            "WHERE c.relname OPERATOR(pg_catalog.~) '^(courses)$' COLLATE pg_catalog.default AND "
+            "pg_catalog.PG_TABLE_IS_VISIBLE(c.oid) "
+            "ORDER BY 2, 3"
+        )
         self.validate_identity(
             "SELECT ARRAY[]::INT[] AS foo",
             "SELECT CAST(ARRAY[] AS INT[]) AS foo",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -188,6 +188,7 @@ class TestPostgres(Validator):
 
         self.validate_identity("SELECT operator FROM t")
         self.validate_identity("SELECT 1 OPERATOR(+) 2")
+        self.validate_identity("SELECT 1 OPERATOR(+) /* foo */ 2")
         self.validate_identity("SELECT 1 OPERATOR(pg_catalog.+) 2")
 
     def test_postgres(self):


### PR DESCRIPTION
Fixes #2609

Note that the associativity is as follows:

```
georgesittas=# select 1 operator(+) 2 operator(*) 3;
 ?column?
----------
        9
(1 row)
```