### PR TITLE
fix: add TIMESTAMP_scale parsers, generators, tests to BQ closes 2611

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -109,6 +109,9 @@ class TestBigQuery(Validator):
         self.validate_identity("ROLLBACK TRANSACTION")
         self.validate_identity("CAST(x AS BIGNUMERIC)")
         self.validate_identity("SELECT y + 1 FROM x GROUP BY y + 1 ORDER BY 1")
+        self.validate_identity("SELECT TIMESTAMP_SECONDS(2) AS t")
+        self.validate_identity("SELECT TIMESTAMP_MICROS(2) AS t")
+        self.validate_identity("SELECT TIMESTAMP_MILLIS(2) AS t")
         self.validate_identity(
             "FOR record IN (SELECT word, word_count FROM bigquery-public-data.samples.shakespeare LIMIT 5) DO SELECT record.word, record.word_count"
         )


### PR DESCRIPTION
Previously, Unix-to-timestamp conversions were improperly converted in BigQuery, namely
- TIMESTAMP_MICROS,
- TIMESTAMP_MILLIS, and
- TIMESTAMP_SECONDS
[per the docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions). 

Here the parser and generator for BigQuery is updated to convert these functions to `exp.UnixToTime` with the appropriate scales, and a `validate_identity` is added to check for correctness in a roundtrip conversion.