### PR TITLE
Fix: tokenize CRLF sequence correctly

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -791,7 +791,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "\t": TokenType.SPACE,
         "\n": TokenType.BREAK,
         "\r": TokenType.BREAK,
-        "\r\n": TokenType.BREAK,
     }
 
     COMMANDS = {
@@ -904,6 +903,10 @@ class Tokenizer(metaclass=_Tokenizer):
 
     def _advance(self, i: int = 1, alnum: bool = False) -> None:
         if self.WHITE_SPACE.get(self._char) is TokenType.BREAK:
+            # Ensures we don't count an extra line if we get a \r\n line break sequence
+            if self._char == "\r" and self._peek == "\n":
+                i = 2
+
             self._col = 1
             self._line += 1
         else:

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -64,6 +64,13 @@ x"""
         self.assertEqual(Tokenizer().tokenize("'''abc'")[0].end, 6)
         self.assertEqual(Tokenizer().tokenize("'abc'")[0].start, 0)
 
+        tokens = Tokenizer().tokenize("SELECT\r\n  1,\r\n  2")
+
+        self.assertEqual(tokens[0].line, 1)
+        self.assertEqual(tokens[1].line, 2)
+        self.assertEqual(tokens[2].line, 2)
+        self.assertEqual(tokens[3].line, 3)
+
     def test_command(self):
         tokens = Tokenizer().tokenize("SHOW;")
         self.assertEqual(tokens[0].token_type, TokenType.SHOW)


### PR DESCRIPTION
We always check against a single character (`self._char`), so we'll never have a lookup hit for `"\r\n"` in `WHITE_SPACE`.

This means that that in systems that encode line breaks a `\r\n`, the lines stored in the tokens will be incorrect and so the errors will display misleading line numbers as well. This is showcased in the example below:

```python
>>> from sqlglot.tokens import Tokenizer
>>> for tok in Tokenizer().tokenize("select\r\n  1,\r\n  2"):
...     print(tok)
...
<Token token_type: TokenType.SELECT, text: select, line: 1, col: 6, start: 0, end: 5, comments: []>
<Token token_type: TokenType.NUMBER, text: 1, line: 3, col: 2, start: 10, end: 10, comments: []>
<Token token_type: TokenType.COMMA, text: ,, line: 3, col: 3, start: 11, end: 11, comments: []>
<Token token_type: TokenType.NUMBER, text: 2, line: 5, col: 2, start: 16, end: 16, comments: []>
```