### PR TITLE
Enable tests for the Rust tokenizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,15 +18,21 @@ install-pre-commit:
 	pre-commit install
 
 test:
+	SQLGLOT_NATIVE_TOKENIZER=0 python -m unittest
+
+test-rs:
 	python -m unittest
 
 unit:
+	SKIP_INTEGRATION=1 SQLGLOT_NATIVE_TOKENIZER=0 python -m unittest
+
+unit-rs:
 	SKIP_INTEGRATION=1 python -m unittest
 
 style:
 	pre-commit run --all-files
 
-check: style test
+check: style test test-rs
 
 docs:
 	python pdoc/cli.py -o docs

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import typing as t
 from enum import auto
 
@@ -9,6 +10,14 @@ from sqlglot.trie import TrieResult, in_trie, new_trie
 
 if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import DialectType
+
+
+try:
+    import sqlglotrs  # noqa
+
+    USE_NATIVE_TOKENIZER = os.environ.get("SQLGLOT_NATIVE_TOKENIZER", "1") == "1"
+except ImportError:
+    USE_NATIVE_TOKENIZER = False
 
 
 class TokenType(AutoName):
@@ -848,6 +857,9 @@ class Tokenizer(metaclass=_Tokenizer):
 
     def tokenize(self, sql: str) -> t.List[Token]:
         """Returns a list of tokens corresponding to the SQL string `sql`."""
+        if USE_NATIVE_TOKENIZER:
+            return self.tokenize_native(sql)
+
         self.reset()
         self.sql = sql
         self.size = len(sql)

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -13,7 +13,7 @@ if t.TYPE_CHECKING:
 
 
 try:
-    import sqlglotrs  # noqa
+    import sqlglotrs  # type: ignore
 
     USE_NATIVE_TOKENIZER = os.environ.get("SQLGLOT_NATIVE_TOKENIZER", "1") == "1"
 except ImportError:


### PR DESCRIPTION
This PR adds a flag which controls whether to use the native tokenizer or the Python one. It also enables the continuous testing of the native implementation using the existing test suite.