### PR TITLE
fix(presto): coerce DATEADD expression to BIGINT

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -187,6 +187,10 @@ def _unix_to_time_sql(self: Presto.Generator, expression: exp.UnixToTime) -> str
 
 
 def _to_int(expression: exp.Expression) -> exp.Expression:
+    if not expression.type:
+        from sqlglot.optimizer.annotate_types import annotate_types
+
+        annotate_types(expression)
     if expression.type and expression.type.this not in exp.DataType.INTEGER_TYPES:
         return exp.cast(expression, to=exp.DataType.Type.BIGINT)
     return expression

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -188,7 +188,7 @@ def _unix_to_time_sql(self: Presto.Generator, expression: exp.UnixToTime) -> str
 
 def _to_int(expression: exp.Expression) -> exp.Expression:
     if expression.type and expression.type.this not in exp.DataType.INTEGER_TYPES:
-        return exp.cast(expression.copy(), to=exp.DataType.Type.BIGINT)
+        return exp.cast(expression, to=exp.DataType.Type.BIGINT)
     return expression
 
 

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -186,6 +186,12 @@ def _unix_to_time_sql(self: Presto.Generator, expression: exp.UnixToTime) -> str
     return ""
 
 
+def _to_int(expression: exp.Expression) -> exp.Expression:
+    if expression.type and expression.type.this not in exp.DataType.INTEGER_TYPES:
+        return exp.cast(expression.copy(), to=exp.DataType.Type.BIGINT)
+    return expression
+
+
 class Presto(Dialect):
     INDEX_OFFSET = 1
     NULL_ORDERING = "nulls_are_last"
@@ -315,7 +321,12 @@ class Presto(Dialect):
             exp.Cast: transforms.preprocess([transforms.epoch_cast_to_ts]),
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.DateAdd: lambda self, e: self.func(
-                "DATE_ADD", exp.Literal.string(e.text("unit") or "day"), e.expression, e.this
+                "DATE_ADD",
+                exp.Literal.string(e.text("unit") or "day"),
+                _to_int(
+                    e.expression,
+                ),
+                e.this,
             ),
             exp.DateDiff: lambda self, e: self.func(
                 "DATE_DIFF", exp.Literal.string(e.text("unit") or "day"), e.expression, e.this
@@ -325,7 +336,7 @@ class Presto(Dialect):
             exp.DateSub: lambda self, e: self.func(
                 "DATE_ADD",
                 exp.Literal.string(e.text("unit") or "day"),
-                e.expression * -1,
+                _to_int(e.expression * -1),
                 e.this,
             ),
             exp.Decode: lambda self, e: encode_decode_sql(self, e, "FROM_UTF8"),

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1044,3 +1044,11 @@ MATCH_RECOGNIZE (
 )""",
             pretty=True,
         )
+
+    def test_date_add(self):
+        expression = parse_one("DATE_ADD(x, y, DAY)")
+        self.assertEqual("DATE_ADD('DAY', y, x)", expression.sql(dialect="presto"))
+        expression.expression.type = exp.DataType.Type.DECIMAL
+        self.assertEqual("DATE_ADD('DAY', CAST(y AS BIGINT), x)", expression.sql(dialect="presto"))
+        expression.expression.type = exp.DataType.Type.BIGINT
+        self.assertEqual("DATE_ADD('DAY', y, x)", expression.sql(dialect="presto"))

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -379,6 +379,16 @@ class TestPresto(Validator):
                 "presto": "TIMESTAMP(x, '12:00:00')",
             },
         )
+        self.validate_all(
+            "DATE_ADD('DAY', CAST(x AS BIGINT), y)",
+            write={
+                "presto": "DATE_ADD('DAY', CAST(x AS BIGINT), y)",
+            },
+            read={
+                "presto": "DATE_ADD('DAY', x, y)",
+            },
+        )
+        self.validate_identity("DATE_ADD('DAY', 1, y)")
 
     def test_ddl(self):
         self.validate_all(
@@ -1044,11 +1054,3 @@ MATCH_RECOGNIZE (
 )""",
             pretty=True,
         )
-
-    def test_date_add(self):
-        expression = parse_one("DATE_ADD(x, y, DAY)")
-        self.assertEqual("DATE_ADD('DAY', y, x)", expression.sql(dialect="presto"))
-        expression.expression.type = exp.DataType.Type.DECIMAL
-        self.assertEqual("DATE_ADD('DAY', CAST(y AS BIGINT), x)", expression.sql(dialect="presto"))
-        expression.expression.type = exp.DataType.Type.BIGINT
-        self.assertEqual("DATE_ADD('DAY', y, x)", expression.sql(dialect="presto"))


### PR DESCRIPTION
Take 2.

I'm scared to put this in the optimizer, since we don't handle intervals very well, and there seems to be quite a bit of differences between dialects. I don't love putting it in the generator, but it seems safe:

```
SELECT DATE_ADD('DAY', 1.0, CAST('2023-01-01' AS DATE))
...
trino error: line 1:8: Unexpected parameters (varchar(3), double, date) for function date_add. Expected: date_add(varchar(x), bigint, date), date_add(varchar(x), bigint, time(p) with time zone), date_add(varchar(x), bigint, time(p)), date_add(varchar(x), bigint, timestamp(p) with time zone), date_add(varchar(x), bigint, timestamp(p))
```