### PR TITLE
fix(optimizer): CTE aliases overridden in FROM

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -102,11 +102,11 @@ class Scope:
         """Branch from the current scope to a new, inner scope"""
         return Scope(
             expression=expression.unnest(),
-            sources=sources.copy() if sources else {},
+            sources=sources.copy() if sources else None,
             parent=self,
             scope_type=scope_type,
             cte_sources={**self.cte_sources, **(cte_sources or {})},
-            lateral_sources=lateral_sources.copy() if lateral_sources else {},
+            lateral_sources=lateral_sources.copy() if lateral_sources else None,
             **kwargs,
         )
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -37,6 +37,7 @@ class Scope:
             For example:
                 SELECT c FROM x LATERAL VIEW EXPLODE (a) AS c;
             The LATERAL VIEW EXPLODE gets x as a source.
+        cte_sources (dict[str, Scope]): Sources from CTES
         outer_column_list (list[str]): If this is a derived table or CTE, and the outer query
             defines a column list of it's alias of this scope, this is that list of columns.
             For example:
@@ -61,11 +62,14 @@ class Scope:
         parent=None,
         scope_type=ScopeType.ROOT,
         lateral_sources=None,
+        cte_sources=None,
     ):
         self.expression = expression
         self.sources = sources or {}
-        self.lateral_sources = lateral_sources.copy() if lateral_sources else {}
+        self.lateral_sources = lateral_sources or {}
+        self.cte_sources = cte_sources or {}
         self.sources.update(self.lateral_sources)
+        self.sources.update(self.cte_sources)
         self.outer_column_list = outer_column_list or []
         self.parent = parent
         self.scope_type = scope_type
@@ -92,13 +96,17 @@ class Scope:
         self._pivots = None
         self._references = None
 
-    def branch(self, expression, scope_type, chain_sources=None, **kwargs):
+    def branch(
+        self, expression, scope_type, sources=None, cte_sources=None, lateral_sources=None, **kwargs
+    ):
         """Branch from the current scope to a new, inner scope"""
         return Scope(
             expression=expression.unnest(),
-            sources={**self.cte_sources, **(chain_sources or {})},
+            sources=sources.copy() if sources else {},
             parent=self,
             scope_type=scope_type,
+            cte_sources={**self.cte_sources, **(cte_sources or {})},
+            lateral_sources=lateral_sources.copy() if lateral_sources else {},
             **kwargs,
         )
 
@@ -304,20 +312,6 @@ class Scope:
                 )
 
         return self._references
-
-    @property
-    def cte_sources(self):
-        """
-        Sources that are CTEs.
-
-        Returns:
-            dict[str, Scope]: Mapping of source alias to Scope
-        """
-        return {
-            alias: scope
-            for alias, scope in self.sources.items()
-            if isinstance(scope, Scope) and scope.is_cte
-        }
 
     @property
     def external_columns(self):
@@ -575,7 +569,7 @@ def _traverse_ctes(scope):
         for child_scope in _traverse_scope(
             scope.branch(
                 cte.this,
-                chain_sources=sources,
+                cte_sources=sources,
                 outer_column_list=cte.alias_column_names,
                 scope_type=ScopeType.CTE,
             )
@@ -587,12 +581,14 @@ def _traverse_ctes(scope):
 
             if recursive_scope:
                 child_scope.add_source(alias, recursive_scope)
+                child_scope.cte_sources[alias] = recursive_scope
 
         # append the final child_scope yielded
         if child_scope:
             scope.cte_scopes.append(child_scope)
 
     scope.sources.update(sources)
+    scope.cte_sources.update(sources)
 
 
 def _is_derived_table(expression: exp.Subquery) -> bool:
@@ -728,7 +724,7 @@ def _traverse_ddl(scope):
     yield from _traverse_ctes(scope)
 
     query_scope = scope.branch(
-        scope.expression.expression, scope_type=ScopeType.DERIVED_TABLE, chain_sources=scope.sources
+        scope.expression.expression, scope_type=ScopeType.DERIVED_TABLE, sources=scope.sources
     )
     query_scope._collect()
     query_scope._ctes = scope.ctes + query_scope._ctes

--- a/tests/fixtures/optimizer/eliminate_ctes.sql
+++ b/tests/fixtures/optimizer/eliminate_ctes.sql
@@ -46,3 +46,71 @@ FROM x;
 SELECT
   a
 FROM x;
+
+# title: CTE reference in subquery where alias matches outer table name
+WITH q AS (
+  SELECT
+    a
+  FROM y
+)
+SELECT
+  a
+FROM x AS q
+WHERE
+  a IN (
+    SELECT
+      a
+    FROM q
+  );
+WITH q AS (
+  SELECT
+    a
+  FROM y
+)
+SELECT
+  a
+FROM x AS q
+WHERE
+  a IN (
+    SELECT
+      a
+    FROM q
+  );
+
+# title: CTE reference in subquery where alias matches outer table name and outer alias is also CTE
+WITH q AS (
+  SELECT
+    a
+  FROM y
+), q2 AS (
+  SELECT
+    a
+  FROM y
+)
+SELECT
+  a
+FROM q2 AS q
+WHERE
+  a IN (
+    SELECT
+      a
+    FROM q
+  );
+WITH q AS (
+  SELECT
+    a
+  FROM y
+), q2 AS (
+  SELECT
+    a
+  FROM y
+)
+SELECT
+  a
+FROM q2 AS q
+WHERE
+  a IN (
+    SELECT
+      a
+    FROM q
+  );

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -411,3 +411,20 @@ FROM (
       ON _q_0.a = y.b
 );
 SELECT y.b AS b FROM (x AS x JOIN y AS y ON x.a = y.b);
+
+# title: merge cte into subquery with overlapping alias
+WITH q AS (
+  SELECT
+    y.b AS a
+  FROM y AS y
+)
+SELECT
+  q.a AS a
+FROM x AS q
+WHERE
+  q.a IN (
+    SELECT
+      q.a AS a
+    FROM q AS q
+  );
+SELECT q.a AS a FROM x AS q WHERE q.a IN (SELECT y.b AS a FROM y AS y);

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -145,9 +145,10 @@ class TestOptimizer(unittest.TestCase):
 
             with self.subTest(title):
                 optimized = future.result()
+                actual = optimized.sql(pretty=pretty, dialect=dialect)
                 self.assertEqual(
                     expected,
-                    optimized.sql(pretty=pretty, dialect=dialect),
+                    actual,
                 )
 
             if string_to_bool(execute):


### PR DESCRIPTION
We need to maintain references to CTE scopes. 


```sql
WITH q AS (
  SELECT
    a
  FROM y
)
SELECT
  a
FROM x AS q  -- q is overridden in this scope
WHERE
  a IN (
    SELECT
      a
    FROM q  -- this is a new subquery scope, but q should still be the CTE
  );
```