### PR TITLE
Feat(clickhouse): add support for WITH FILL, INTERPOLATED clauses

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1960,7 +1960,12 @@ class Offset(Expression):
 
 
 class Order(Expression):
-    arg_types = {"this": False, "expressions": True}
+    arg_types = {"this": False, "expressions": True, "interpolate": False}
+
+
+# https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier
+class WithFill(Expression):
+    arg_types = {"from": False, "to": False, "step": False}
 
 
 # hive specific sorts
@@ -1978,7 +1983,7 @@ class Sort(Order):
 
 
 class Ordered(Expression):
-    arg_types = {"this": True, "desc": False, "nulls_first": True}
+    arg_types = {"this": True, "desc": False, "nulls_first": True, "with_fill": False}
 
 
 class Property(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1786,7 +1786,24 @@ class Generator:
     def order_sql(self, expression: exp.Order, flat: bool = False) -> str:
         this = self.sql(expression, "this")
         this = f"{this} " if this else this
-        return self.op_expressions(f"{this}ORDER BY", expression, flat=this or flat)  # type: ignore
+        order = self.op_expressions(f"{this}ORDER BY", expression, flat=this or flat)  # type: ignore
+        interpolated_values = [
+            f"{self.sql(named_expression, 'alias')} AS {self.sql(named_expression, 'this')}"
+            for named_expression in expression.args.get("interpolate") or []
+        ]
+        interpolate = (
+            f" INTERPOLATE ({', '.join(interpolated_values)})" if interpolated_values else ""
+        )
+        return f"{order}{interpolate}"
+
+    def withfill_sql(self, expression: exp.WithFill) -> str:
+        from_sql = self.sql(expression, "from")
+        from_sql = f" FROM {from_sql}" if from_sql else ""
+        to_sql = self.sql(expression, "to")
+        to_sql = f" TO {to_sql}" if to_sql else ""
+        step_sql = self.sql(expression, "step")
+        step_sql = f" STEP {step_sql}" if step_sql else ""
+        return f"WITH FILL{from_sql}{to_sql}{step_sql}"
 
     def cluster_sql(self, expression: exp.Cluster) -> str:
         return self.op_expressions("CLUSTER BY", expression)
@@ -1828,7 +1845,10 @@ class Generator:
             this = f"CASE WHEN {this} IS NULL THEN 1 ELSE 0 END{null_sort_order}, {this}"
             nulls_sort_change = ""
 
-        return f"{this}{sort_order}{nulls_sort_change}"
+        with_fill = self.sql(expression, "with_fill")
+        with_fill = f" {with_fill}" if with_fill else ""
+
+        return f"{this}{sort_order}{nulls_sort_change}{with_fill}"
 
     def matchrecognize_sql(self, expression: exp.MatchRecognize) -> str:
         partition = self.partition_by_sql(expression)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3163,20 +3163,13 @@ class Parser(metaclass=_Parser):
             nulls_first = True
 
         if self._match_text_seq("WITH", "FILL"):
-            from_ = None
-            to = None
-            step = None
-
-            if self._match(TokenType.FROM):
-                from_ = self._parse_bitwise()
-            if self._match_text_seq("TO"):
-                to = self._parse_bitwise()
-            if self._match_text_seq("STEP"):
-                step = self._parse_bitwise()
-
             with_fill = self.expression(
                 exp.WithFill,
-                **{"from": from_, "to": to, "step": step},  # type: ignore
+                **{  # type: ignore
+                    "from": self._match(TokenType.FROM) and self._parse_bitwise(),
+                    "to": self._match_text_seq("TO") and self._parse_bitwise(),
+                    "step": self._match_text_seq("STEP") and self._parse_bitwise(),
+                },
             )
         else:
             with_fill = None

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3163,14 +3163,21 @@ class Parser(metaclass=_Parser):
             nulls_first = True
 
         if self._match_text_seq("WITH", "FILL"):
-            with_fill = self.expression(exp.WithFill)
+            from_ = None
+            to = None
+            step = None
 
             if self._match(TokenType.FROM):
-                with_fill.set("from", self._parse_bitwise())
+                from_ = self._parse_bitwise()
             if self._match_text_seq("TO"):
-                with_fill.set("to", self._parse_bitwise())
+                to = self._parse_bitwise()
             if self._match_text_seq("STEP"):
-                with_fill.set("step", self._parse_bitwise())
+                step = self._parse_bitwise()
+
+            with_fill = self.expression(
+                exp.WithFill,
+                **{"from": from_, "to": to, "step": step},  # type: ignore
+            )
         else:
             with_fill = None
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3162,7 +3162,6 @@ class Parser(metaclass=_Parser):
         ):
             nulls_first = True
 
-        with_fill = None
         if self._match_text_seq("WITH", "FILL"):
             with_fill = self.expression(exp.WithFill)
 
@@ -3172,6 +3171,8 @@ class Parser(metaclass=_Parser):
                 with_fill.set("to", self._parse_bitwise())
             if self._match_text_seq("STEP"):
                 with_fill.set("step", self._parse_bitwise())
+        else:
+            with_fill = None
 
         return self.expression(
             exp.Ordered, this=this, desc=desc, nulls_first=nulls_first, with_fill=with_fill

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -71,6 +71,9 @@ class TestClickhouse(Validator):
         self.validate_identity("CAST(x as MEDIUMINT)", "CAST(x AS Int32)")
         self.validate_identity("SELECT arrayJoin([1, 2, 3] AS src) AS dst, 'Hello', src")
         self.validate_identity(
+            "SELECT n, source FROM (SELECT toFloat32(number % 10) AS n, 'original' AS source FROM numbers(10) WHERE number % 3 = 1) ORDER BY n WITH FILL"
+        )
+        self.validate_identity(
             "SELECT n, source FROM (SELECT toFloat32(number % 10) AS n, 'original' AS source FROM numbers(10) WHERE number % 3 = 1) ORDER BY n WITH FILL FROM 0 TO 5.51 STEP 0.5"
         )
         self.validate_identity(

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -71,6 +71,15 @@ class TestClickhouse(Validator):
         self.validate_identity("CAST(x as MEDIUMINT)", "CAST(x AS Int32)")
         self.validate_identity("SELECT arrayJoin([1, 2, 3] AS src) AS dst, 'Hello', src")
         self.validate_identity(
+            "SELECT n, source FROM (SELECT toFloat32(number % 10) AS n, 'original' AS source FROM numbers(10) WHERE number % 3 = 1) ORDER BY n WITH FILL FROM 0 TO 5.51 STEP 0.5"
+        )
+        self.validate_identity(
+            "SELECT toDate((number * 10) * 86400) AS d1, toDate(number * 86400) AS d2, 'original' AS source FROM numbers(10) WHERE (number % 3) = 1 ORDER BY d2 WITH FILL, d1 WITH FILL STEP 5"
+        )
+        self.validate_identity(
+            "SELECT n, source, inter FROM (SELECT toFloat32(number % 10) AS n, 'original' AS source, number AS inter FROM numbers(10) WHERE number % 3 = 1) ORDER BY n WITH FILL FROM 0 TO 5.51 STEP 0.5 INTERPOLATE (inter AS inter + 1)"
+        )
+        self.validate_identity(
             "SELECT SUM(1) AS impressions, arrayJoin(cities) AS city, arrayJoin(browsers) AS browser FROM (SELECT ['Istanbul', 'Berlin', 'Bobruisk'] AS cities, ['Firefox', 'Chrome', 'Chrome'] AS browsers) GROUP BY 2, 3"
         )
         self.validate_identity(


### PR DESCRIPTION
Fixes #2699

Reference: https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier