### PR TITLE
Fix(snowflake): use ToArray expression to preserve TO_ARRAY in snowflake

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4318,6 +4318,11 @@ class Array(Func):
     is_var_len_args = True
 
 
+# https://docs.snowflake.com/en/sql-reference/functions/to_array
+class ToArray(Func):
+    pass
+
+
 # https://docs.snowflake.com/en/sql-reference/functions/to_char
 # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/TO_CHAR-number.html
 class ToChar(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3078,6 +3078,16 @@ class Generator:
     def operator_sql(self, expression: exp.Operator) -> str:
         return self.binary(expression, f"OPERATOR({self.sql(expression, 'operator')})")
 
+    def toarray_sql(self, expression: exp.ToArray) -> str:
+        from sqlglot.optimizer.annotate_types import annotate_types
+
+        arg = annotate_types(expression.this)
+        if arg.is_type(exp.DataType.Type.ARRAY):
+            return self.sql(arg)
+
+        cond_for_null = arg.is_(exp.null())
+        return self.sql(exp.func("IF", cond_for_null, exp.null(), exp.Array(expressions=[arg])))
+
     def _simplify_unless_literal(self, expression: E) -> E:
         if not isinstance(expression, exp.Literal):
             from sqlglot.optimizer.simplify import simplify

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -36,6 +36,8 @@ WHERE
   )""",
         )
 
+        self.validate_identity("SELECT TO_ARRAY(CAST(x AS ARRAY))")
+        self.validate_identity("SELECT TO_ARRAY(CAST(['test'] AS VARIANT))")
         self.validate_identity("SELECT user_id, value FROM table_name sample ($s) SEED (0)")
         self.validate_identity("SELECT ARRAY_UNIQUE_AGG(x)")
         self.validate_identity("SELECT OBJECT_CONSTRUCT()")
@@ -143,26 +145,18 @@ WHERE
             "CAST(x AS NCHAR VARYING)",
             "CAST(x AS VARCHAR)",
         )
-        self.validate_identity(
-            "SELECT TO_ARRAY(x::ARRAY)",
-            "SELECT CAST(x AS ARRAY)",
-        )
-        self.validate_identity(
-            "SELECT TO_ARRAY(['test']::VARIANT)",
-            "SELECT TO_ARRAY(CAST(['test'] AS VARIANT))",
-        )
 
         self.validate_all(
             "SELECT TO_ARRAY(['test'])",
             write={
-                "snowflake": "SELECT ['test']",
+                "snowflake": "SELECT TO_ARRAY(['test'])",
                 "spark": "SELECT ARRAY('test')",
             },
         )
         self.validate_all(
             "SELECT TO_ARRAY(['test'])",
             write={
-                "snowflake": "SELECT ['test']",
+                "snowflake": "SELECT TO_ARRAY(['test'])",
                 "spark": "SELECT ARRAY('test')",
             },
         )
@@ -535,8 +529,8 @@ WHERE
         self.validate_all(
             "TO_ARRAY(x)",
             write={
-                "spark": "ARRAY(x)",
-                "snowflake": "[x]",
+                "spark": "IF(x IS NULL, NULL, ARRAY(x))",
+                "snowflake": "TO_ARRAY(x)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
I realized that Snowflake's [TO_ARRAY](https://docs.snowflake.com/en/sql-reference/functions/to_array) function has a few edge cases that don't make it easy to parse it into `exp.Array`, so this PR introduces a new expression type to represent it in a way as to make it easy to preserve it on identity transpilation and follow a best-effort approach when transpiling to other dialects. I think the only cases that we'll fail to transpile are when we have a JSON null argument and a `VARIANT` that wraps around an array.