### PR TITLE
Fix(presto): remove equals sign from CREATE TABLE comment

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -387,6 +387,7 @@ class Presto(Dialect):
             exp.Right: right_to_substring_sql,
             exp.SafeDivide: no_safe_divide_sql,
             exp.Schema: _schema_sql,
+            exp.SchemaCommentProperty: lambda self, e: f"COMMENT {e.this}",
             exp.Select: transforms.preprocess(
                 [
                     transforms.eliminate_qualify,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -387,7 +387,7 @@ class Presto(Dialect):
             exp.Right: right_to_substring_sql,
             exp.SafeDivide: no_safe_divide_sql,
             exp.Schema: _schema_sql,
-            exp.SchemaCommentProperty: lambda self, e: f"COMMENT {e.this}",
+            exp.SchemaCommentProperty: lambda self, e: self.naked_property(e),
             exp.Select: transforms.preprocess(
                 [
                     transforms.eliminate_qualify,

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -472,10 +472,10 @@ class TestPresto(Validator):
         )
 
         self.validate_all(
-            'CREATE TABLE IF NOT EXISTS x ("cola" INTEGER, "ds" TEXT) WITH (PARTITIONED BY=("ds"))',
+            """CREATE TABLE IF NOT EXISTS x ("cola" INTEGER, "ds" TEXT) COMMENT 'comment' WITH (PARTITIONED BY=("ds"))""",
             write={
-                "spark": "CREATE TABLE IF NOT EXISTS x (`cola` INT, `ds` STRING) PARTITIONED BY (`ds`)",
-                "presto": """CREATE TABLE IF NOT EXISTS x ("cola" INTEGER, "ds" VARCHAR) WITH (PARTITIONED_BY=ARRAY['ds'])""",
+                "spark": "CREATE TABLE IF NOT EXISTS x (`cola` INT, `ds` STRING) COMMENT 'comment' PARTITIONED BY (`ds`)",
+                "presto": """CREATE TABLE IF NOT EXISTS x ("cola" INTEGER, "ds" VARCHAR) COMMENT 'comment' WITH (PARTITIONED_BY=ARRAY['ds'])""",
             },
         )
 

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -75,7 +75,7 @@ class TestSpark(Validator):
   col_a INTEGER,
   date VARCHAR
 )
-COMMENT='Test comment: blah'
+COMMENT 'Test comment: blah'
 WITH (
   PARTITIONED_BY=ARRAY['date'],
   FORMAT='ICEBERG',


### PR DESCRIPTION
https://prestodb.io/docs/current/sql/create-table.html
https://trino.io/docs/current/sql/create-table.html