### PR TITLE
Feat: transpile Trino unicode to \u... strings (Spark, Snowflake)

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -18,7 +18,7 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger("sqlglot")
 
-UNICODE_CODE_POINT_RE = re.compile(r"\\(\d+)")
+ESCAPED_UNICODE_RE = re.compile(r"\\(\d+)")
 
 
 class Generator:
@@ -927,11 +927,11 @@ class Generator:
             return f"{self.dialect.UNICODE_START}{this}{self.dialect.UNICODE_END}{escape}"
 
         if escape:
-            pattern = re.compile(fr"{escape.name}(\d+)")
+            pattern = re.compile(rf"{escape.name}(\d+)")
         else:
-            pattern = UNICODE_CODE_POINT_RE
+            pattern = ESCAPED_UNICODE_RE
 
-        this = pattern.sub(r'\\u\1', this)
+        this = pattern.sub(r"\\u\1", this)
         return f"{self.dialect.QUOTE_START}{this}{self.dialect.QUOTE_END}"
 
     def rawstring_sql(self, expression: exp.RawString) -> str:

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -546,13 +546,21 @@ class TestPresto(Validator):
 
     def test_unicode_string(self):
         for prefix in ("u&", "U&"):
-            self.validate_identity(
+            self.validate_all(
                 f"{prefix}'Hello winter \\2603 !'",
-                "U&'Hello winter \\2603 !'",
+                write={
+                    "presto": "U&'Hello winter \\2603 !'",
+                    "snowflake": "'Hello winter \\u2603 !'",
+                    "spark": "'Hello winter \\u2603 !'",
+                },
             )
-            self.validate_identity(
+            self.validate_all(
                 f"{prefix}'Hello winter #2603 !' UESCAPE '#'",
-                "U&'Hello winter #2603 !' UESCAPE '#'",
+                write={
+                    "presto": "U&'Hello winter #2603 !' UESCAPE '#'",
+                    "snowflake": "'Hello winter \\u2603 !'",
+                    "spark": "'Hello winter \\u2603 !'",
+                },
             )
 
     def test_presto(self):


### PR DESCRIPTION
Fixes #2702

References:
- https://trino.io/docs/current/language/types.html#varchar
- https://spark.apache.org/docs/latest/sql-ref-literals.html#parameters
- https://docs.snowflake.com/en/sql-reference/data-types-text#escape-sequences-in-single-quoted-string-constants