### PR TITLE
allow JSON_EXTRACT_SCALAR in BQ to pass a single argument

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -331,8 +331,7 @@ class BigQuery(Dialect):
             "DIV": binary_from_function(exp.IntDiv),
             "GENERATE_ARRAY": exp.GenerateSeries.from_arg_list,
             "JSON_EXTRACT_SCALAR": lambda args: exp.JSONExtractScalar(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1) or exp.Literal.string('$')
+                this=seq_get(args, 0), expression=seq_get(args, 1) or exp.Literal.string("$")
             ),
             "MD5": exp.MD5Digest.from_arg_list,
             "TO_HEX": _parse_to_hex,

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -330,6 +330,10 @@ class BigQuery(Dialect):
             "DATETIME_SUB": parse_date_delta_with_interval(exp.DatetimeSub),
             "DIV": binary_from_function(exp.IntDiv),
             "GENERATE_ARRAY": exp.GenerateSeries.from_arg_list,
+            "JSON_EXTRACT_SCALAR": lambda args: exp.JSONExtractScalar(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1) or exp.Literal.string('$')
+            ),
             "MD5": exp.MD5Digest.from_arg_list,
             "TO_HEX": _parse_to_hex,
             "PARSE_DATE": lambda args: format_time_lambda(exp.StrToDate, "bigquery")(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -180,8 +180,7 @@ class TestBigQuery(Validator):
         )
         self.validate_identity("""SELECT JSON_EXTRACT_SCALAR('{"a": 5}', '$.a')""")
         self.validate_identity(
-            """SELECT JSON_EXTRACT_SCALAR('5')""",
-            """SELECT JSON_EXTRACT_SCALAR('5', '$')"""
+            """SELECT JSON_EXTRACT_SCALAR('5')""", """SELECT JSON_EXTRACT_SCALAR('5', '$')"""
         )
 
         self.validate_all("SELECT SPLIT(foo)", write={"bigquery": "SELECT SPLIT(foo, ',')"})

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -178,6 +178,11 @@ class TestBigQuery(Validator):
             "SELECT * FROM UNNEST(x) WITH OFFSET EXCEPT DISTINCT SELECT * FROM UNNEST(y) WITH OFFSET",
             "SELECT * FROM UNNEST(x) WITH OFFSET AS offset EXCEPT DISTINCT SELECT * FROM UNNEST(y) WITH OFFSET AS offset",
         )
+        self.validate_identity("""SELECT JSON_EXTRACT_SCALAR('{"a": 5}', '$.a')""")
+        self.validate_identity(
+            """SELECT JSON_EXTRACT_SCALAR('5')""",
+            """SELECT JSON_EXTRACT_SCALAR('5', '$')"""
+        )
 
         self.validate_all("SELECT SPLIT(foo)", write={"bigquery": "SELECT SPLIT(foo, ',')"})
         self.validate_all("SELECT 1 AS hash", write={"bigquery": "SELECT 1 AS `hash`"})


### PR DESCRIPTION
BigQuery allows `JSON_EXTRACT_SCALAR` to get only a single argument, where the expression defaults to '$', as can be seen [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_extract_scalar).

So I added a change that will automatically add this default.
In my change after converting back to SQL the '$' parameter will be explicitly added - I thought it makes sense but please let me know if not.