### PR TITLE
feat!: Change Expression.__repr__ format

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ print(repr(parse_one("SELECT a + 1 AS z")))
 ```
 
 ```python
-(SELECT expressions:
-  (ALIAS this:
-    (ADD this:
-      (COLUMN this:
-        (IDENTIFIER this: a, quoted: False)), expression:
-      (LITERAL this: 1, is_string: False)), alias:
-    (IDENTIFIER this: z, quoted: False)))
+Select(
+  expressions=[
+    Alias(
+      this=Add(
+        this=Column(
+          this=Identifier(this=a, quoted=False)),
+        expression=Literal(this=1, is_string=False)),
+      alias=Identifier(this=z, quoted=False))])
 ```
 
 ### AST Diff
@@ -353,19 +354,17 @@ diff(parse_one("SELECT a + b, c, d"), parse_one("SELECT c, a - b, d"))
 
 ```python
 [
-  Remove(expression=(ADD this:
-    (COLUMN this:
-      (IDENTIFIER this: a, quoted: False)), expression:
-    (COLUMN this:
-      (IDENTIFIER this: b, quoted: False)))),
-  Insert(expression=(SUB this:
-    (COLUMN this:
-      (IDENTIFIER this: a, quoted: False)), expression:
-    (COLUMN this:
-      (IDENTIFIER this: b, quoted: False)))),
-  Move(expression=(COLUMN this:
-    (IDENTIFIER this: c, quoted: False))),
-  Keep(source=(IDENTIFIER this: b, quoted: False), target=(IDENTIFIER this: b, quoted: False)),
+  Remove(expression=Add(
+    this=Column(
+      this=Identifier(this=a, quoted=False)),
+    expression=Column(
+      this=Identifier(this=b, quoted=False)))),
+  Insert(expression=Sub(
+    this=Column(
+      this=Identifier(this=a, quoted=False)),
+    expression=Column(
+      this=Identifier(this=b, quoted=False)))),
+  Keep(source=Identifier(this=d, quoted=False), target=Identifier(this=d, quoted=False)),
   ...
 ]
 ```

--- a/posts/ast_primer.md
+++ b/posts/ast_primer.md
@@ -17,29 +17,32 @@ An AST is a data structure that represents a SQL statement. The best way to glea
 ```python
 repr(ast)
 
-# (SELECT expressions: 
-#   (COLUMN this: 
-#     (IDENTIFIER this: a, quoted: False)), from: 
-#   (FROM this: 
-#     (SUBQUERY this: 
-#       (SELECT expressions: 
-#         (COLUMN this: 
-#           (IDENTIFIER this: a, quoted: False)), from: 
-#         (FROM this: 
-#           (TABLE this: 
-#             (IDENTIFIER this: x, quoted: False)))), alias: 
-#       (TABLEALIAS this: 
-#         (IDENTIFIER this: x, quoted: False)))))
+# Select(
+#   expressions=[
+#     Column(
+#       this=Identifier(this=a, quoted=False))],
+#   from=From(
+#     this=Subquery(
+#       this=Select(
+#         expressions=[
+#           Column(
+#             this=Identifier(this=a, quoted=False))],
+#         from=From(
+#           this=Table(
+#             this=Identifier(this=x, quoted=False)))),
+#       alias=TableAlias(
+#         this=Identifier(this=x, quoted=False)))))
 ```
 
 This is a textual representation of the internal data structure. Here's a breakdown of some of its components:
 ```
-Expression type    child key
-  |               /
-(SELECT expressions:
-  (COLUMN this:  ---------------------------------- COLUMN is a child node of SELECT
-    (IDENTIFIER this: a, quoted: False)), from:  -- "from:" is another child key of SELECT
-  (FROM this: ------------------------------------- FROM is also a child node of SELECT
+`Select` is the expression type
+  |
+Select(
+  expressions=[  ------------------------------- `expressions` is a child key of `Select`
+    Column(  ----------------------------------- `Column` is the expression type of the child
+      this=Identifier(this=a, quoted=False))],
+  from=From(  ---------------------------------- `from` is another child key of `Select`
   ...
 ```
 
@@ -49,19 +52,19 @@ The nodes in this tree are instances of `sqlglot.Expression`. Nodes reference th
 ```python
 ast.args
 # {
-#    "expressions": [(COLUMN this: ...)],
-#    "from": (FROM this: ...),
+#    "expressions": [Column(this=...)],
+#    "from": From(this=...),
 #    ...
 # }
 
 ast.args["expressions"][0]
-# (COLUMN this: ...)
+# Column(this=...)
 
 ast.args["expressions"][0].args["this"]
-# (IDENTIFIER this: ...)
+# Identifier(this=...)
 
 ast.args["from"]
-# (FROM this: ...)
+# From(this=...)
 
 assert ast.args["expressions"][0].args["this"].parent.parent is ast
 ```
@@ -109,8 +112,9 @@ You can traverse an AST using just args, but there are some higher-order functio
 > ast = parse_one("SELECT NOW()", dialect="postgres")
 > 
 > repr(ast)
-> # (SELECT expressions: 
-> #   (CURRENTTIMESTAMP ))  -- CURRENTTIMESTAMP, not NOW()
+> # Select(
+> #   expressions=[
+> #     CurrentTimestamp()])
 > ```
 > 
 > This is because SQLGlot tries to converge dialects on a standard AST. This means you can often write one piece of code that handles multiple dialects.
@@ -132,15 +136,17 @@ The walk methods of `Expression` (`find`, `find_all`, and `walk`) are the simple
 from sqlglot import exp
 
 ast.find(exp.Select)
-# (SELECT expressions: 
-#   (COLUMN this: 
-#     (IDENTIFIER this: a, quoted: False)), from:
+# Select(
+#   expressions=[
+#     Column(
+#       this=Identifier(this=a, quoted=False))],
 # ...
 
 list(ast.find_all(exp.Select))
-# [(SELECT expressions: 
-#   (COLUMN this: 
-#     (IDENTIFIER this: a, quoted: False)), from:
+# [Select(
+#   expressions=[
+#     Column(
+#       this=Identifier(this=a, quoted=False))],
 # ...
 ```
 

--- a/posts/ast_primer.md
+++ b/posts/ast_primer.md
@@ -1,4 +1,4 @@
-# A Primer on SQLGlot's Abstract Syntax Tree
+# Primer on SQLGlot's Abstract Syntax Tree
 
 SQLGlot is a powerful tool for analyzing and transforming SQL, but the learning curve can be intimidating.
  

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -497,7 +497,7 @@ class Expression(metaclass=_Expression):
         return self.sql()
 
     def __repr__(self) -> str:
-        return self._to_s()
+        return _to_s(self)
 
     def sql(self, dialect: DialectType = None, **opts) -> str:
         """
@@ -513,30 +513,6 @@ class Expression(metaclass=_Expression):
         from sqlglot.dialects import Dialect
 
         return Dialect.get_or_raise(dialect).generate(self, **opts)
-
-    def _to_s(self, hide_missing: bool = True, level: int = 0) -> str:
-        indent = "" if not level else "\n"
-        indent += "".join(["  "] * level)
-        left = f"({self.key.upper()} "
-
-        args: t.Dict[str, t.Any] = {
-            k: ", ".join(
-                v._to_s(hide_missing=hide_missing, level=level + 1)
-                if hasattr(v, "_to_s")
-                else str(v)
-                for v in ensure_list(vs)
-                if v is not None
-            )
-            for k, vs in self.args.items()
-        }
-        args["comments"] = self.comments
-        args["type"] = self.type
-        args = {k: v for k, v in args.items() if v or not hide_missing}
-
-        right = ", ".join(f"{k}: {v}" for k, v in args.items())
-        right += ")"
-
-        return indent + left + right
 
     def transform(self, fun, *args, copy=True, **kwargs):
         """
@@ -580,8 +556,9 @@ class Expression(metaclass=_Expression):
         For example::
 
             >>> tree = Select().select("x").from_("tbl")
-            >>> tree.find(Column).replace(Column(this="y"))
-            (COLUMN this: y)
+            >>> tree.find(Column).replace(column("y"))
+            Column(
+              this=Identifier(this=y, quoted=False))
             >>> tree.sql()
             'SELECT y FROM tbl'
 
@@ -5390,9 +5367,9 @@ def maybe_parse(
 
     Example:
         >>> maybe_parse("1")
-        (LITERAL this: 1, is_string: False)
+        Literal(this=1, is_string=False)
         >>> maybe_parse(to_identifier("x"))
-        (IDENTIFIER this: x, quoted: False)
+        Identifier(this=x, quoted=False)
 
     Args:
         sql_or_expression: the SQL code string or an expression
@@ -5437,6 +5414,34 @@ def maybe_copy(instance: E, copy: bool = True) -> E:
 
 def maybe_copy(instance, copy=True):
     return instance.copy() if copy and instance else instance
+
+
+def _to_s(node: t.Any, hide_missing: bool = True, level: int = 0) -> str:
+    """Generate a textual representation of an Expression tree"""
+    if isinstance(node, Expression):
+        args = {k: v for k, v in node.args.items() if v is not None or not hide_missing}
+        if node.comments or not hide_missing:
+            args["comments"] = node.comments
+        if node.type or not hide_missing:
+            args["type"] = node.type
+
+        # Inline Expressions that don't have any child Expressions.
+        # This helps make expressions like Identifier more compact.
+        if any(isinstance(v, (Expression, list, tuple)) for v in args.values()):
+            indent = "\n" + ("  " * (level + 1))
+            delim = f",{indent}"
+        else:
+            indent = ""
+            delim = ", "
+
+        items = delim.join([f"{k}={_to_s(v, hide_missing, level + 1)}" for k, v in args.items()])
+        return f"{node.__class__.__name__}({indent}{items})"
+    if isinstance(node, (list, tuple)):
+        indent = "\n" + ("  " * (level + 1))
+        delim = f",{indent}"
+        items = delim.join(_to_s(i, hide_missing, level + 1) for i in node)
+        return f"[{indent}{items}]"
+    return str(node)
 
 
 def _is_wrong_expression(expression, into):
@@ -6373,10 +6378,10 @@ def var(name: t.Optional[ExpOrStr]) -> Var:
 
     Example:
         >>> repr(var('x'))
-        '(VAR this: x)'
+        'Var(this=x)'
 
         >>> repr(var(column('x', table='y')))
-        '(VAR this: x)'
+        'Var(this=x)'
 
     Args:
         name: The name of the var or an expression who's name will become the var.


### PR DESCRIPTION
As [discussed on slack](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1703632977455049):

The current format can be really hard to read.
```python
from sqlglot import parse_one

ast = parse_one("SELECT a, b FROM (SELECT a, b FROM x) AS x")

print(repr(ast))
```

```
(SELECT expressions: **[1]** **[3]**
  (COLUMN this: 
    (IDENTIFIER this: a, quoted: False)),
  (COLUMN this:
    (IDENTIFIER this: b, quoted: False)), from: **[2]**
  (FROM this:
    (SUBQUERY this:
      (SELECT expressions:
        (COLUMN this:
          (IDENTIFIER this: a, quoted: False)),
        (COLUMN this:
          (IDENTIFIER this: b, quoted: False)), from:
        (FROM this: 
          (TABLE this: 
            (IDENTIFIER this: x, quoted: False)))), alias: 
      (TABLEALIAS this: 
        (IDENTIFIER this: x, quoted: False)))))
```

Some problems of this format:
[1] No delineator for lists make it unclear when an arg has a list value and unclear where the list begins and ends.
[2] Arg keys at the end of lines make it hard to tell which expression the arg applies to.
[3] All-caps expression types don't match class names exactly

Inspired by Python's [ast](https://docs.python.org/3/library/ast.html) module, I propose we switch to this:

```
Select(
  expressions=[
    Column(
      this=Identifier(this=a, quoted=False)),
    Column(
      this=Identifier(this=b, quoted=False))],
  from=From(
    this=Subquery(
      this=Select(
        expressions=[
          Column(
            this=Identifier(this=a, quoted=False)),
          Column(
            this=Identifier(this=b, quoted=False))],
        from=Table(
          this=Identifier(this=x, quoted=False)),
      alias=TableAlias(
        this=Identifier(this=a, quoted=False))))))
```
This is similarly compact and, IMO, solves problems 1-3.