### PR TITLE
Fix(snowflake, duckdb): generate TimestampDiff correctly

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -362,6 +362,9 @@ class DuckDB(Dialect):
             exp.StrToUnix: lambda self, e: f"EPOCH(STRPTIME({self.sql(e, 'this')}, {self.format_time(e)}))",
             exp.Struct: _struct_sql,
             exp.Timestamp: no_timestamp_sql,
+            exp.TimestampDiff: lambda self, e: self.func(
+                "DATE_DIFF", exp.Literal.string(e.unit), e.expression, e.this
+            ),
             exp.TimestampFromParts: rename_func("MAKE_TIMESTAMP"),
             exp.TimestampTrunc: timestamptrunc_sql,
             exp.TimeStrToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE)",

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -578,6 +578,9 @@ class Snowflake(Dialect):
                 *(arg for expression in e.expressions for arg in expression.flatten()),
             ),
             exp.Stuff: rename_func("INSERT"),
+            exp.TimestampDiff: lambda self, e: self.func(
+                "TIMESTAMPDIFF", e.unit, e.expression, e.this
+            ),
             exp.TimestampTrunc: timestamptrunc_sql,
             exp.TimeStrToTime: timestrtotime_sql,
             exp.TimeToStr: lambda self, e: self.func(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -191,6 +191,14 @@ class TestBigQuery(Validator):
         self.validate_all("x <> ''''''", write={"bigquery": "x <> ''"})
         self.validate_all("CAST(x AS DATETIME)", read={"": "x::timestamp"})
         self.validate_all(
+            "SELECT TIMESTAMP_DIFF(TIMESTAMP_SECONDS(60), TIMESTAMP_SECONDS(0), minute)",
+            write={
+                "bigquery": "SELECT TIMESTAMP_DIFF(TIMESTAMP_SECONDS(60), TIMESTAMP_SECONDS(0), MINUTE)",
+                "duckdb": "SELECT DATE_DIFF('MINUTE', TO_TIMESTAMP(0), TO_TIMESTAMP(60))",
+                "snowflake": "SELECT TIMESTAMPDIFF(MINUTE, TO_TIMESTAMP(0), TO_TIMESTAMP(60))",
+            },
+        )
+        self.validate_all(
             "SELECT TIMESTAMP_MICROS(x)",
             read={
                 "duckdb": "SELECT MAKE_TIMESTAMP(x)",


### PR DESCRIPTION
References:
- https://duckdb.org/docs/sql/functions/timestamp.html
- https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp_diff
- https://docs.snowflake.com/en/sql-reference/functions/timestampdiff