### PR TITLE
Fix: include empty lists in the hide_missing repr check

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5426,7 +5426,9 @@ def _to_s(node: t.Any, hide_missing: bool = True, level: int = 0) -> str:
     delim = f",{indent}"
 
     if isinstance(node, Expression):
-        args = {k: v for k, v in node.args.items() if v is not None or not hide_missing}
+        args = {
+            k: v for k, v in node.args.items() if (v is not None and v != []) or not hide_missing
+        }
 
         if (node.type or not hide_missing) and not isinstance(node, DataType):
             args["_type"] = node.type


### PR DESCRIPTION
We currently show empty lists when `repr`ing an AST. This can become noisy because we construct empty lists all over the place due to the `_parse_csv` methods, so this PR hides them (the commented args below won't show up at all).

```python
>>> import sqlglot
>>> sqlglot.parse_one("CREATE TABLE z (a INT, b VARCHAR COMMENT 'z')")
Create(
  this=Schema(
    this=Table(
      this=Identifier(this=z, quoted=False)),
    expressions=[
      ColumnDef(
        this=Identifier(this=a, quoted=False),
        kind=DataType(this=Type.INT, nested=False, prefix=False),
        constraints=[  # <----- case no. 1
          ]),
      ColumnDef(
        this=Identifier(this=b, quoted=False),
        kind=DataType(this=Type.VARCHAR, nested=False, prefix=False),
        constraints=[
          ColumnConstraint(
            kind=CommentColumnConstraint(
              this=Literal(this=z, is_string=True)))])]),
  kind=TABLE,
  exists=False,
  indexes=[  # <------ case no. 2
    ])
```