### PR TITLE
Fix: alter table rename should not qualify with db in postgres

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -387,6 +387,7 @@ class Postgres(Dialect):
 
     class Generator(generator.Generator):
         SINGLE_STRING_INTERVAL = True
+        RENAME_TABLE_WITH_DB = False
         LOCKING_READS_SUPPORTED = True
         JOIN_HINTS = False
         TABLE_HINTS = False

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -165,7 +165,6 @@ class Redshift(Postgres):
 
     class Generator(Postgres.Generator):
         LOCKING_READS_SUPPORTED = False
-        RENAME_TABLE_WITH_DB = False
         QUERY_HINTS = False
         VALUES_AS_TABLE = False
         TZ_TO_WITH_TIME_ZONE = True


### PR DESCRIPTION
<img width="898" alt="image" src="https://github.com/tobymao/sqlglot/assets/41213451/5a7c2a79-bc02-4903-b86c-6ea5179de5a1">

The correct SQL to emit is as follows:

ALTER TABLE <[name](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-PARMS-NAME)> RENAME TO <[new_name](https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-PARMS-NEW-NAME)>`

Note the subtle difference in terminology. Its not explicitly called out as a gotcha which would be nice in the postgres docs. 