### PR TITLE
Refactor!: set sample clause keyword(s) as class constant to enable transpilation

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -484,6 +484,7 @@ class ClickHouse(Dialect):
         STRUCT_DELIMITER = ("(", ")")
         NVL2_SUPPORTED = False
         TABLESAMPLE_REQUIRES_PARENS = False
+        SAMPLE_CLAUSE = "SAMPLE"
 
         STRING_TYPE_MAPPING = {
             exp.DataType.Type.CHAR: "String",

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -153,8 +153,8 @@ class Oracle(Dialect):
         COLUMN_JOIN_MARKS_SUPPORTED = True
         DATA_TYPE_SPECIFIERS_ALLOWED = True
         ALTER_TABLE_INCLUDE_COLUMN_KEYWORD = False
-
         LIMIT_FETCH = "FETCH"
+        SAMPLE_CLAUSE = "SAMPLE"
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -175,6 +175,7 @@ class Teradata(Dialect):
         JOIN_HINTS = False
         TABLE_HINTS = False
         QUERY_HINTS = False
+        SAMPLE_CLAUSE = "SAMPLE"
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
@@ -214,7 +215,11 @@ class Teradata(Dialect):
             return self.cast_sql(expression, safe_prefix="TRY")
 
         def tablesample_sql(
-            self, expression: exp.TableSample, seed_prefix: str = "SEED", sep=" AS "
+            self,
+            expression: exp.TableSample,
+            seed_prefix: str = "SEED",
+            sep: str = " AS ",
+            sample_clause: t.Optional[str] = None,
         ) -> str:
             return f"{self.sql(expression, 'this')} SAMPLE {self.expressions(expression)}"
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3481,7 +3481,6 @@ class TableSample(Expression):
         "rows": False,
         "size": False,
         "seed": False,
-        "kind": False,
     }
 
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2874,9 +2874,6 @@ class Parser(metaclass=_Parser):
         size = None
         seed = None
 
-        kind = (
-            self._prev.text if self._prev.token_type == TokenType.TABLE_SAMPLE else "USING SAMPLE"
-        )
         method = self._parse_var(tokens=(TokenType.ROW,), upper=True)
 
         matched_l_paren = self._match(TokenType.L_PAREN)
@@ -2926,7 +2923,6 @@ class Parser(metaclass=_Parser):
             rows=rows,
             size=size,
             seed=seed,
-            kind=kind,
         )
 
     def _parse_pivots(self) -> t.Optional[t.List[exp.Pivot]]:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -712,6 +712,16 @@ class TestDuckDB(Validator):
                 "duckdb": "SELECT * FROM tbl, tbl2 WHERE tbl.i = tbl2.i USING SAMPLE RESERVOIR (20 PERCENT)"
             },
         )
+        self.validate_all(
+            "SELECT * FROM example TABLESAMPLE (3) REPEATABLE (82)",
+            read={
+                "snowflake": "SELECT * FROM example SAMPLE (3) SEED (82)",
+            },
+            write={
+                "duckdb": "SELECT * FROM example TABLESAMPLE (3) REPEATABLE (82)",
+                "snowflake": "SELECT * FROM example TABLESAMPLE (3) SEED (82)",
+            },
+        )
 
     def test_array(self):
         self.validate_identity("ARRAY(SELECT id FROM t)")


### PR DESCRIPTION
Fixes #2747


- DuckDB uses `USING SAMPLE` to sample the whole resulting relation in a query, and `TABLESAMPLE` for sampling just a simple intermediate result. See https://duckdb.org/docs/sql/samples.html
- Snowflake treats `SAMPLE` and `TABLESAMPLE` as synonyms, see https://docs.snowflake.com/en/sql-reference/constructs/sample