### PR TITLE
Feat: guess the correct dialect in case we get an unknown one

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -307,7 +307,7 @@ class Dialect(metaclass=_Dialect):
             if not result:
                 from difflib import get_close_matches
 
-                similar = seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0)
+                similar = seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0) or ""
                 if similar:
                     similar = f" Did you mean {similar}?"
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -305,7 +305,13 @@ class Dialect(metaclass=_Dialect):
 
             result = cls.get(dialect_name.strip())
             if not result:
-                raise ValueError(f"Unknown dialect '{dialect_name}'.")
+                from difflib import get_close_matches
+
+                similar = seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0)
+                if similar:
+                    similar = f" Did you mean {similar}?"
+
+                raise ValueError(f"Unknown dialect '{dialect_name}'.{similar}")
 
             return result(**kwargs)
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -109,6 +109,11 @@ class TestDialect(Validator):
 
         self.assertEqual(str(cm.exception), "Unknown dialect 'myqsl'. Did you mean mysql?")
 
+        with self.assertRaises(ValueError) as cm:
+            Dialect.get_or_raise("asdfjasodiufjsd")
+
+        self.assertEqual(str(cm.exception), "Unknown dialect 'asdfjasodiufjsd'.")
+
     def test_compare_dialects(self):
         bigquery_class = Dialect["bigquery"]
         bigquery_object = BigQuery()

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -104,6 +104,11 @@ class TestDialect(Validator):
             "Please use the correct format: 'dialect [, k1 = v2 [, ...]]'.",
         )
 
+        with self.assertRaises(ValueError) as cm:
+            Dialect.get_or_raise("myqsl")
+
+        self.assertEqual(str(cm.exception), "Unknown dialect 'myqsl'. Did you mean mysql?")
+
     def test_compare_dialects(self):
         bigquery_class = Dialect["bigquery"]
         bigquery_object = BigQuery()


### PR DESCRIPTION
I've typed `duckbd` instead of `duckdb` so many times and it's finally occurred to me that the UX can be improved a bit :D

Reference: https://docs.python.org/3/library/difflib.html#difflib.get_close_matches