### PR TITLE
Feat(optimizer): allow star expansion to be turned off

### DIFF
--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -23,6 +23,7 @@ def qualify(
     catalog: t.Optional[str] = None,
     schema: t.Optional[dict | Schema] = None,
     expand_alias_refs: bool = True,
+    expand_stars: bool = True,
     infer_schema: t.Optional[bool] = None,
     isolate_tables: bool = False,
     qualify_columns: bool = True,
@@ -48,6 +49,9 @@ def qualify(
         catalog: Default catalog name for tables.
         schema: Schema to infer column names and types.
         expand_alias_refs: Whether or not to expand references to aliases.
+        expand_stars: Whether or not to expand star queries. This is a necessary step
+            for most of the optimizer's rules to work; do not set to False unless you
+            know what you're doing!
         infer_schema: Whether or not to infer the schema if missing.
         isolate_tables: Whether or not to isolate table selects.
         qualify_columns: Whether or not to qualify columns.
@@ -72,7 +76,11 @@ def qualify(
 
     if qualify_columns:
         expression = qualify_columns_func(
-            expression, schema, expand_alias_refs=expand_alias_refs, infer_schema=infer_schema
+            expression,
+            schema,
+            expand_alias_refs=expand_alias_refs,
+            expand_stars=expand_stars,
+            infer_schema=infer_schema,
         )
 
     if quote_identifiers:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -17,6 +17,7 @@ def qualify_columns(
     expression: exp.Expression,
     schema: t.Dict | Schema,
     expand_alias_refs: bool = True,
+    expand_stars: bool = True,
     infer_schema: t.Optional[bool] = None,
 ) -> exp.Expression:
     """
@@ -33,6 +34,9 @@ def qualify_columns(
         expression: Expression to qualify.
         schema: Database schema.
         expand_alias_refs: Whether or not to expand references to aliases.
+        expand_stars: Whether or not to expand star queries. This is a necessary step
+            for most of the optimizer's rules to work; do not set to False unless you
+            know what you're doing!
         infer_schema: Whether or not to infer the schema if missing.
 
     Returns:
@@ -57,7 +61,8 @@ def qualify_columns(
             _expand_alias_refs(scope, resolver)
 
         if not isinstance(scope.expression, exp.UDTF):
-            _expand_stars(scope, resolver, using_column_tables, pseudocolumns)
+            if expand_stars:
+                _expand_stars(scope, resolver, using_column_tables, pseudocolumns)
             qualify_outputs(scope)
 
         _expand_group_by(scope)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -229,6 +229,15 @@ class TestOptimizer(unittest.TestCase):
     def test_qualify_columns(self, logger):
         self.assertEqual(
             optimizer.qualify_columns.qualify_columns(
+                parse_one("WITH x AS (SELECT a FROM db.y) SELECT * FROM db.x"),
+                schema={"db": {"x": {"z": "int"}, "y": {"a": "int"}}},
+                expand_stars=False,
+            ).sql(),
+            "WITH x AS (SELECT y.a AS a FROM db.y) SELECT * FROM db.x",
+        )
+
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
                 parse_one("WITH x AS (SELECT a FROM db.y) SELECT z FROM db.x"),
                 schema={"db": {"x": {"z": "int"}, "y": {"a": "int"}}},
                 infer_schema=False,


### PR DESCRIPTION
People have [asked](https://github.com/tobymao/sqlglot/issues/2760#issuecomment-1875664452) for the star expansion to be optionally turned off a few times already, so I thought it wouldn't hurt if we exposed an option for that.