### PR TITLE
Feat: add STR_TO_TIME parsing and generation for teradata and sqlite

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -27,6 +27,16 @@ def _date_add_sql(self: SQLite.Generator, expression: exp.DateAdd) -> str:
     modifier = f"'{modifier} {unit.name}'" if unit else f"'{modifier}'"
     return self.func("DATE", expression.this, modifier)
 
+def str_to_date_sql(self: SQLite.Generator, expression: exp.StrToDate) -> str:
+    date_string = self.sql(expression, "this")
+    format_specifier = self.format_time(expression)
+    return f"STRFTIME({format_specifier}, {date_string})"
+
+
+def str_to_time_sql(self: SQLite.Generator, expression: exp.StrToTime) -> str:
+    time_string = self.sql(expression, "this")
+    format_specifier = self.format_time(expression)
+    return f"STRFTIME({format_specifier}, {time_string})"
 
 def _transform_create(expression: exp.Expression) -> exp.Expression:
     """Move primary key to a column and enforce auto_increment on primary keys."""
@@ -138,6 +148,8 @@ class SQLite(Dialect):
             exp.TableSample: no_tablesample_sql,
             exp.TimeStrToTime: lambda self, e: self.sql(e, "this"),
             exp.TryCast: no_trycast_sql,
+            exp.StrToDate: str_to_date_sql,
+            exp.StrToTime: str_to_time_sql
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -27,6 +27,7 @@ def _date_add_sql(self: SQLite.Generator, expression: exp.DateAdd) -> str:
     modifier = f"'{modifier} {unit.name}'" if unit else f"'{modifier}'"
     return self.func("DATE", expression.this, modifier)
 
+
 def str_to_date_sql(self: SQLite.Generator, expression: exp.StrToDate) -> str:
     date_string = self.sql(expression, "this")
     format_specifier = self.format_time(expression)
@@ -37,6 +38,7 @@ def str_to_time_sql(self: SQLite.Generator, expression: exp.StrToTime) -> str:
     time_string = self.sql(expression, "this")
     format_specifier = self.format_time(expression)
     return f"STRFTIME({format_specifier}, {time_string})"
+
 
 def _transform_create(expression: exp.Expression) -> exp.Expression:
     """Move primary key to a column and enforce auto_increment on primary keys."""
@@ -149,7 +151,7 @@ class SQLite(Dialect):
             exp.TimeStrToTime: lambda self, e: self.sql(e, "this"),
             exp.TryCast: no_trycast_sql,
             exp.StrToDate: str_to_date_sql,
-            exp.StrToTime: str_to_time_sql
+            exp.StrToTime: str_to_time_sql,
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -28,16 +28,10 @@ def _date_add_sql(self: SQLite.Generator, expression: exp.DateAdd) -> str:
     return self.func("DATE", expression.this, modifier)
 
 
-def str_to_date_sql(self: SQLite.Generator, expression: exp.StrToDate) -> str:
-    date_string = self.sql(expression, "this")
+def str_to_datetime_sql(self: SQLite.Generator, expression) -> str:
+    datetime_string = self.sql(expression, "this")
     format_specifier = self.format_time(expression)
-    return f"STRFTIME({format_specifier}, {date_string})"
-
-
-def str_to_time_sql(self: SQLite.Generator, expression: exp.StrToTime) -> str:
-    time_string = self.sql(expression, "this")
-    format_specifier = self.format_time(expression)
-    return f"STRFTIME({format_specifier}, {time_string})"
+    return f"STRFTIME({format_specifier}, {datetime_string})"
 
 
 def _transform_create(expression: exp.Expression) -> exp.Expression:
@@ -150,8 +144,8 @@ class SQLite(Dialect):
             exp.TableSample: no_tablesample_sql,
             exp.TimeStrToTime: lambda self, e: self.sql(e, "this"),
             exp.TryCast: no_trycast_sql,
-            exp.StrToDate: str_to_date_sql,
-            exp.StrToTime: str_to_time_sql,
+            exp.StrToDate: str_to_datetime_sql,
+            exp.StrToTime: str_to_datetime_sql,
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -7,12 +7,6 @@ from sqlglot.dialects.dialect import Dialect, max_or_greatest, min_or_least, ren
 from sqlglot.tokens import TokenType
 
 
-def str_to_date_sql(self: Teradata.Generator, expression: exp.StrToDate) -> str:
-    date_string = self.sql(expression, "this")
-    format_specifier = self.format_time(expression)
-    return f"TO_DATE({date_string}, {format_specifier})"
-
-
 def str_to_time_sql(self: Teradata.Generator, expression: exp.StrToTime) -> str:
     time_string = self.sql(expression, "this")
     format_specifier = self.format_time(expression)

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -7,6 +7,18 @@ from sqlglot.dialects.dialect import Dialect, max_or_greatest, min_or_least, ren
 from sqlglot.tokens import TokenType
 
 
+def str_to_date_sql(self: Teradata.Generator, expression: exp.StrToDate) -> str:
+    date_string = self.sql(expression, "this")
+    format_specifier = self.format_time(expression)
+    return f"TO_DATE({date_string}, {format_specifier})"
+
+
+def str_to_time_sql(self: Teradata.Generator, expression: exp.StrToTime) -> str:
+    time_string = self.sql(expression, "this")
+    format_specifier = self.format_time(expression)
+    return f"TO_TIMESTAMP({time_string}, {format_specifier})"
+
+
 class Teradata(Dialect):
     SUPPORTS_SEMI_ANTI_JOIN = False
     TYPED_DIVISION = True
@@ -202,6 +214,7 @@ class Teradata(Dialect):
             exp.StrToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE FORMAT {self.format_time(e)})",
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
             exp.Use: lambda self, e: f"DATABASE {self.sql(e, 'this')}",
+            exp.StrToTime: lambda self, e: str_to_time_sql(self, e)
         }
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -214,7 +214,7 @@ class Teradata(Dialect):
             exp.StrToDate: lambda self, e: f"CAST({self.sql(e, 'this')} AS DATE FORMAT {self.format_time(e)})",
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
             exp.Use: lambda self, e: f"DATABASE {self.sql(e, 'this')}",
-            exp.StrToTime: lambda self, e: str_to_time_sql(self, e)
+            exp.StrToTime: lambda self, e: str_to_time_sql(self, e),
         }
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -142,16 +142,14 @@ class TestSQLite(Validator):
         )
         self.validate_all(
             "SELECT STR_TO_DATE('2022-01-01', '%Y-%m-%d')",
-            write = {
-                        "mysql": "SELECT STR_TO_DATE('2022-01-01', '%Y-%m-%d')",
-                        "sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')"
-                    }
+            write={
+                "mysql": "SELECT STR_TO_DATE('2022-01-01', '%Y-%m-%d')",
+                "sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')",
+            },
         )
         self.validate_all(
             "SELECT CAST('2022-01-01' AS DATE FORMAT '%Y-%m-%d')",
-            write = {
-                "sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')"
-            }
+            write={"sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')"},
         )
 
     def test_datediff(self):

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -140,6 +140,19 @@ class TestSQLite(Validator):
             read={"snowflake": "LEAST(x, y, z)"},
             write={"snowflake": "LEAST(x, y, z)"},
         )
+        self.validate_all(
+            "SELECT STR_TO_DATE('2022-01-01', '%Y-%m-%d')",
+            write = {
+                        "mysql": "SELECT STR_TO_DATE('2022-01-01', '%Y-%m-%d')",
+                        "sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')"
+                    }
+        )
+        self.validate_all(
+            "SELECT CAST('2022-01-01' AS DATE FORMAT '%Y-%m-%d')",
+            write = {
+                "sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')"
+            }
+        )
 
     def test_datediff(self):
         self.validate_all(

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -147,10 +147,9 @@ class TestSQLite(Validator):
                 "sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')",
             },
         )
-        self.validate_all(
-            "SELECT CAST('2022-01-01' AS DATE FORMAT '%Y-%m-%d')",
-            write={"sqlite": "SELECT STRFTIME('%Y-%m-%d', '2022-01-01')"},
-        )
+        self.validate_identity("STRFTIME('%Y-%m-%d %H:%M:%f', '2024-01-01 13:14:15.123')")
+        self.validate_identity("STRFTIME('%Y-%m-%d %I:%M:%S %p', '2024-01-01 01:14:15 PM')")
+        self.validate_identity("STRFTIME('%d-%b-%Y', '01-Jan-2024')")
 
     def test_datediff(self):
         self.validate_all(

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -223,25 +223,10 @@ class TestTeradata(Validator):
                 "postgres": "TO_TIMESTAMP('2024-01-01 13:14:15', 'YYYY-MM-DD HH24:MI:SS')",
             },
         )
-        self.validate_all(
-            "CAST('2024-01-01' AS DATE FORMAT 'YYYY-MM-DD')",
-            write={"teradata": "CAST('2024-01-01' AS DATE FORMAT 'YYYY-MM-DD')"},
+        self.validate_identity("CAST('2024-01-01' AS DATE FORMAT 'YYYY-MM-DD')")
+        self.validate_identity("CAST('2024/01/01' AS DATE FORMAT 'YYYY/MM/DD')")
+        self.validate_identity(
+            "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')"
         )
-        self.validate_all(
-            "CAST('2024/01/01' AS DATE FORMAT 'YYYY/MM/DD')",
-            write={"teradata": "CAST('2024/01/01' AS DATE FORMAT 'YYYY/MM/DD')"},
-        )
-        self.validate_all(
-            "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')",
-            write={
-                "teradata": "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')"
-            },
-        )
-        self.validate_all(
-            "TO_TIMESTAMP('2024-01-01 01:14:15 PM', 'YYYY-MM-DDbHH:MI:SSBT')",
-            write={"teradata": "TO_TIMESTAMP('2024-01-01 01:14:15 PM', 'YYYY-MM-DDbHH:MI:SSBT')"},
-        )
-        self.validate_all(
-            "CAST('01-Jan-2024' AS DATE FORMAT 'DD-MMM-YYYY')",
-            write={"teradata": "CAST('01-Jan-2024' AS DATE FORMAT 'DD-MMM-YYYY')"},
-        )
+        self.validate_identity("TO_TIMESTAMP('2024-01-01 01:14:15 PM', 'YYYY-MM-DDbHH:MI:SSBT')")
+        self.validate_identity("CAST('01-Jan-2024' AS DATE FORMAT 'DD-MMM-YYYY')")

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -205,3 +205,41 @@ class TestTeradata(Validator):
                 "teradata": "TRYCAST('-2.5' AS DECIMAL(5, 2))",
             },
         )
+
+    def test_str_to_time(self):
+        self.validate_all(
+            "TO_DATE('2024-01-01', 'YYYY-MM-DD')",
+            write={
+                "teradata": "TO_DATE('2024-01-01', 'YYYY-MM-DD')",
+                "oracle": "TO_DATE('2024-01-01', 'YYYY-MM-DD')",
+                "postgres": "TO_DATE('2024-01-01', 'YYYY-MM-DD')",
+            },
+        )
+        self.validate_all(
+            "TO_TIMESTAMP('2024-01-01 13:14:15', 'YYYY-MM-DD HH24:MI:SS')",
+            write={
+                "teradata": "TO_TIMESTAMP('2024-01-01 13:14:15', 'YYYY-MM-DD HH24:MI:SS')",
+                "oracle": "TO_TIMESTAMP('2024-01-01 13:14:15', 'YYYY-MM-DD HH24:MI:SS')",
+                "postgres": "TO_TIMESTAMP('2024-01-01 13:14:15', 'YYYY-MM-DD HH24:MI:SS')",
+            },
+        )
+        self.validate_all(
+            "CAST('2024-01-01' AS DATE FORMAT 'YYYY-MM-DD')",
+            write={"teradata": "CAST('2024-01-01' AS DATE FORMAT 'YYYY-MM-DD')"},
+        )
+        self.validate_all(
+            "CAST('2024/01/01' AS DATE FORMAT 'YYYY/MM/DD')",
+            write={"teradata": "CAST('2024/01/01' AS DATE FORMAT 'YYYY/MM/DD')"},
+        )
+        self.validate_all(
+            "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')",
+            write={"teradata": "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')"},
+        )
+        self.validate_all(
+            "TO_TIMESTAMP('2024-01-01 01:14:15 PM', 'YYYY-MM-DDbHH:MI:SSBT')",
+            write={"teradata": "TO_TIMESTAMP('2024-01-01 01:14:15 PM', 'YYYY-MM-DDbHH:MI:SSBT')"},
+        )
+        self.validate_all(
+            "CAST('01-Jan-2024' AS DATE FORMAT 'DD-MMM-YYYY')",
+            write={"teradata": "CAST('01-Jan-2024' AS DATE FORMAT 'DD-MMM-YYYY')"},
+        )

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -233,7 +233,9 @@ class TestTeradata(Validator):
         )
         self.validate_all(
             "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')",
-            write={"teradata": "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')"},
+            write={
+                "teradata": "TO_TIMESTAMP('2024-01-01 13:14:15.123', 'YYYY-MM-DDBHH:MI:SS.S(3)')"
+            },
         )
         self.validate_all(
             "TO_TIMESTAMP('2024-01-01 01:14:15 PM', 'YYYY-MM-DDbHH:MI:SSBT')",


### PR DESCRIPTION
The PR introduces the functionality of converting strings to date-time or timestamp objects with custom formats in Teradata and SQLite. 

https://dbmstutorials.com/random_teradata/teradata-string-to-timestamp.html
https://www.sqlitetutorial.net/sqlite-date-functions/sqlite-strftime-function/