### PR TITLE
Feat(optimizer): add support for the UNPIVOT operator

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -529,6 +529,7 @@ class BigQuery(Dialect):
         UNNEST_WITH_ORDINALITY = False
         COLLATE_IS_FUNC = True
         LIMIT_ONLY_LITERALS = True
+        SUPPORTS_TABLE_ALIAS_COLUMNS = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -530,6 +530,7 @@ class BigQuery(Dialect):
         COLLATE_IS_FUNC = True
         LIMIT_ONLY_LITERALS = True
         SUPPORTS_TABLE_ALIAS_COLUMNS = False
+        UNPIVOT_ALIASES_ARE_IDENTIFIERS = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -351,7 +351,7 @@ def _unqualify_unpivot_columns(expression: exp.Expression) -> exp.Expression:
         >>> print(_unqualify_unpivot_columns(expr).sql(dialect="snowflake"))
         SELECT * FROM m_sales UNPIVOT(sales FOR month IN (jan, feb, mar, april))
     """
-    if isinstance(expression, exp.Pivot) and expression.is_unpivot:
+    if isinstance(expression, exp.Pivot) and expression.unpivot:
         expression = transforms.unqualify_columns(expression)
 
     return expression

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -93,12 +93,7 @@ def _unqualify_pivot_columns(expression: exp.Expression) -> exp.Expression:
         SELECT * FROM tbl PIVOT(SUM(tbl.sales) FOR quarter IN ('Q1', 'Q1'))
     """
     if isinstance(expression, exp.Pivot):
-        expression.args["field"].transform(
-            lambda node: exp.column(node.output_name, quoted=node.this.quoted)
-            if isinstance(node, exp.Column)
-            else node,
-            copy=False,
-        )
+        expression.set("field", transforms.unqualify_columns(expression.args["field"]))
 
     return expression
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4118,6 +4118,15 @@ class Alias(Expression):
         return self.alias
 
 
+# BigQuery requires the UNPIVOT column list aliases to be either strings or ints, but
+# Spark requires identifiers. This enables us to transpile between the two easily.
+#
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unpivot_operator
+# https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-unpivot.html
+class PivotAlias(Alias):
+    pass
+
+
 class Aliases(Expression):
     arg_types = {"this": True, "expressions": True}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3532,8 +3532,8 @@ class Pivot(Expression):
     }
 
     @property
-    def is_unpivot(self) -> t.Optional[bool]:
-        return self.args.get("unpivot")
+    def unpivot(self) -> bool:
+        return bool(self.args.get("unpivot"))
 
 
 class Window(Condition):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4119,10 +4119,7 @@ class Alias(Expression):
 
 
 # BigQuery requires the UNPIVOT column list aliases to be either strings or ints, but
-# Spark requires identifiers. This enables us to transpile between the two easily.
-#
-# https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unpivot_operator
-# https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-unpivot.html
+# other dialects require identifiers. This enables us to transpile between them easily.
 class PivotAlias(Alias):
     pass
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3531,6 +3531,10 @@ class Pivot(Expression):
         "include_nulls": False,
     }
 
+    @property
+    def is_unpivot(self) -> t.Optional[bool]:
+        return self.args.get("unpivot")
+
 
 class Window(Condition):
     arg_types = {

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1526,7 +1526,7 @@ class Generator:
 
         alias = self.sql(expression, "alias")
         alias = f" AS {alias}" if alias else ""
-        direction = "UNPIVOT" if expression.is_unpivot else "PIVOT"
+        direction = "UNPIVOT" if expression.unpivot else "PIVOT"
         field = self.sql(expression, "field")
         include_nulls = expression.args.get("include_nulls")
         if include_nulls is not None:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -245,6 +245,9 @@ class Generator:
     # Whether or not LAST_DAY function supports a date part argument
     LAST_DAY_SUPPORTS_DATE_PART = True
 
+    # Whether or not named columns are allowed in table aliases
+    SUPPORTS_TABLE_ALIAS_COLUMNS = True
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -907,6 +910,10 @@ class Generator:
         alias = self.sql(expression, "this")
         columns = self.expressions(expression, key="columns", flat=True)
         columns = f"({columns})" if columns else ""
+
+        if columns and not self.SUPPORTS_TABLE_ALIAS_COLUMNS:
+            columns = ""
+            self.unsupported("Named columns are not supported in table alias.")
 
         if not alias and not self.dialect.UNNEST_COLUMN_ONLY:
             alias = "_t"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1526,8 +1526,7 @@ class Generator:
 
         alias = self.sql(expression, "alias")
         alias = f" AS {alias}" if alias else ""
-        unpivot = expression.args.get("unpivot")
-        direction = "UNPIVOT" if unpivot else "PIVOT"
+        direction = "UNPIVOT" if expression.is_unpivot else "PIVOT"
         field = self.sql(expression, "field")
         include_nulls = expression.args.get("include_nulls")
         if include_nulls is not None:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -382,7 +382,6 @@ def _expand_stars(
     replace_columns: t.Dict[int, t.Dict[str, str]] = {}
     coalesced_columns = set()
 
-    pivot_columns = None
     pivot_output_columns = None
     pivot_exclude_columns = None
 
@@ -397,7 +396,7 @@ def _expand_stars(
                     c.output_name for e in field.expressions for c in e.find_all(exp.Column)
                 }
         else:
-            pivot_columns = set(c.output_name for c in pivot.find_all(exp.Column))
+            pivot_exclude_columns = set(c.output_name for c in pivot.find_all(exp.Column))
 
             pivot_output_columns = [c.output_name for c in pivot.args.get("columns", [])]
             if not pivot_output_columns:
@@ -432,15 +431,8 @@ def _expand_stars(
             table_id = id(table)
             columns_to_exclude = except_columns.get(table_id) or set()
 
-            if pivot and pivot_output_columns:
-                implicit_columns = None
-
-                if pivot.unpivot:
-                    if pivot_exclude_columns:
-                        implicit_columns = [c for c in columns if c not in pivot_exclude_columns]
-                elif pivot_columns:
-                    implicit_columns = [c for c in columns if c not in pivot_columns]
-
+            if pivot and pivot_output_columns and pivot_exclude_columns:
+                implicit_columns = [c for c in columns if c not in pivot_exclude_columns]
                 if implicit_columns:
                     new_selections.extend(
                         exp.alias_(exp.column(name, table=pivot.alias), name, copy=False)

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -86,7 +86,7 @@ def validate_qualify_columns(expression: E) -> E:
                 for_table = f" for table: '{column.table}'" if column.table else ""
                 raise OptimizeError(f"Column '{column}' could not be resolved{for_table}")
 
-            if unqualified_columns and scope.pivots and scope.pivots[0].is_unpivot:
+            if unqualified_columns and scope.pivots and scope.pivots[0].unpivot:
                 # New columns produced by the UNPIVOT can't be qualified, but there may be columns
                 # under the UNPIVOT's IN clause that can and should be qualified. We recompute
                 # this list here to ensure those in the former category will be excluded.
@@ -388,7 +388,7 @@ def _expand_stars(
 
     pivot = t.cast(t.Optional[exp.Pivot], seq_get(scope.pivots, 0))
     if isinstance(pivot, exp.Pivot):
-        if pivot.is_unpivot:
+        if pivot.unpivot:
             pivot_output_columns = [c.output_name for c in _unpivot_columns(pivot)]
 
             field = pivot.args.get("field")
@@ -435,7 +435,7 @@ def _expand_stars(
             if pivot and pivot_output_columns:
                 implicit_columns = None
 
-                if pivot.is_unpivot:
+                if pivot.unpivot:
                     if pivot_exclude_columns:
                         implicit_columns = [c for c in columns if c not in pivot_exclude_columns]
                 elif pivot_columns:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -41,6 +41,9 @@ def qualify_columns(
 
     Returns:
         The qualified expression.
+
+    Notes:
+        - Currently only handles a single PIVOT or UNPIVOT operator
     """
     schema = ensure_schema(schema)
     infer_schema = schema.empty if infer_schema is None else infer_schema
@@ -73,19 +76,39 @@ def qualify_columns(
 
 def validate_qualify_columns(expression: E) -> E:
     """Raise an `OptimizeError` if any columns aren't qualified"""
-    unqualified_columns = []
+    all_unqualified_columns = []
     for scope in traverse_scope(expression):
         if isinstance(scope.expression, exp.Select):
-            unqualified_columns.extend(scope.unqualified_columns)
+            unqualified_columns = scope.unqualified_columns
+
             if scope.external_columns and not scope.is_correlated_subquery and not scope.pivots:
                 column = scope.external_columns[0]
-                raise OptimizeError(
-                    f"""Column '{column}' could not be resolved{f" for table: '{column.table}'" if column.table else ''}"""
-                )
+                for_table = f" for table: '{column.table}'" if column.table else ""
+                raise OptimizeError(f"Column '{column}' could not be resolved{for_table}")
 
-    if unqualified_columns:
-        raise OptimizeError(f"Ambiguous columns: {unqualified_columns}")
+            if unqualified_columns and scope.pivots and scope.pivots[0].is_unpivot:
+                # New columns produced by the UNPIVOT can't be qualified, but there may be columns
+                # under the UNPIVOT's IN clause that can and should be qualified. We recompute
+                # this list here to ensure those in the former category will be excluded.
+                unpivot_columns = set(_unpivot_columns(scope.pivots[0]))
+                unqualified_columns = [c for c in unqualified_columns if c not in unpivot_columns]
+
+            all_unqualified_columns.extend(unqualified_columns)
+
+    if all_unqualified_columns:
+        raise OptimizeError(f"Ambiguous columns: {all_unqualified_columns}")
+
     return expression
+
+
+def _unpivot_columns(unpivot: exp.Pivot) -> t.Iterator[exp.Column]:
+    name_column = []
+    field = unpivot.args.get("field")
+    if isinstance(field, exp.In) and isinstance(field.this, exp.Column):
+        name_column.append(field.this)
+
+    value_columns = (c for e in unpivot.expressions for c in e.find_all(exp.Column))
+    return itertools.chain(name_column, value_columns)
 
 
 def _pop_table_column_aliases(derived_tables: t.List[exp.CTE | exp.Subquery]) -> None:
@@ -221,6 +244,7 @@ def _expand_alias_refs(scope: Scope, resolver: Resolver) -> None:
     replace_columns(expression.args.get("group"), literal_index=True)
     replace_columns(expression.args.get("having"), resolve_table=True)
     replace_columns(expression.args.get("qualify"), resolve_table=True)
+
     scope.clear_cache()
 
 
@@ -358,18 +382,26 @@ def _expand_stars(
     replace_columns: t.Dict[int, t.Dict[str, str]] = {}
     coalesced_columns = set()
 
-    # TODO: handle optimization of multiple PIVOTs (and possibly UNPIVOTs) in the future
     pivot_columns = None
     pivot_output_columns = None
+    pivot_exclude_columns = None
+
     pivot = t.cast(t.Optional[exp.Pivot], seq_get(scope.pivots, 0))
+    if isinstance(pivot, exp.Pivot):
+        if pivot.is_unpivot:
+            pivot_output_columns = [c.output_name for c in _unpivot_columns(pivot)]
 
-    has_pivoted_source = pivot and not pivot.args.get("unpivot")
-    if pivot and has_pivoted_source:
-        pivot_columns = set(col.output_name for col in pivot.find_all(exp.Column))
+            field = pivot.args.get("field")
+            if isinstance(field, exp.In):
+                pivot_exclude_columns = {
+                    c.output_name for e in field.expressions for c in e.find_all(exp.Column)
+                }
+        else:
+            pivot_columns = set(c.output_name for c in pivot.find_all(exp.Column))
 
-        pivot_output_columns = [col.output_name for col in pivot.args.get("columns", [])]
-        if not pivot_output_columns:
-            pivot_output_columns = [col.alias_or_name for col in pivot.expressions]
+            pivot_output_columns = [c.output_name for c in pivot.args.get("columns", [])]
+            if not pivot_output_columns:
+                pivot_output_columns = [c.alias_or_name for c in pivot.expressions]
 
     for expression in scope.expression.selects:
         if isinstance(expression, exp.Star):
@@ -394,12 +426,22 @@ def _expand_stars(
             if pseudocolumns:
                 columns = [name for name in columns if name.upper() not in pseudocolumns]
 
-            if columns and "*" not in columns:
-                table_id = id(table)
-                columns_to_exclude = except_columns.get(table_id) or set()
+            if not columns or "*" in columns:
+                return
 
-                if pivot and has_pivoted_source and pivot_columns and pivot_output_columns:
-                    implicit_columns = [col for col in columns if col not in pivot_columns]
+            table_id = id(table)
+            columns_to_exclude = except_columns.get(table_id) or set()
+
+            if pivot and pivot_output_columns:
+                implicit_columns = None
+
+                if pivot.is_unpivot:
+                    if pivot_exclude_columns:
+                        implicit_columns = [c for c in columns if c not in pivot_exclude_columns]
+                elif pivot_columns:
+                    implicit_columns = [c for c in columns if c not in pivot_columns]
+
+                if implicit_columns:
                     new_selections.extend(
                         exp.alias_(exp.column(name, table=pivot.alias), name, copy=False)
                         for name in implicit_columns + pivot_output_columns
@@ -407,30 +449,28 @@ def _expand_stars(
                     )
                     continue
 
-                for name in columns:
-                    if name in using_column_tables and table in using_column_tables[name]:
-                        if name in coalesced_columns:
-                            continue
+            for name in columns:
+                if name in using_column_tables and table in using_column_tables[name]:
+                    if name in coalesced_columns:
+                        continue
 
-                        coalesced_columns.add(name)
-                        tables = using_column_tables[name]
-                        coalesce = [exp.column(name, table=table) for table in tables]
+                    coalesced_columns.add(name)
+                    tables = using_column_tables[name]
+                    coalesce = [exp.column(name, table=table) for table in tables]
 
-                        new_selections.append(
-                            alias(
-                                exp.Coalesce(this=coalesce[0], expressions=coalesce[1:]),
-                                alias=name,
-                                copy=False,
-                            )
+                    new_selections.append(
+                        alias(
+                            exp.Coalesce(this=coalesce[0], expressions=coalesce[1:]),
+                            alias=name,
+                            copy=False,
                         )
-                    elif name not in columns_to_exclude:
-                        alias_ = replace_columns.get(table_id, {}).get(name, name)
-                        column = exp.column(name, table=table)
-                        new_selections.append(
-                            alias(column, alias_, copy=False) if alias_ != name else column
-                        )
-            else:
-                return
+                    )
+                elif name not in columns_to_exclude:
+                    alias_ = replace_columns.get(table_id, {}).get(name, name)
+                    column = exp.column(name, table=table)
+                    new_selections.append(
+                        alias(column, alias_, copy=False) if alias_ != name else column
+                    )
 
     # Ensures we don't overwrite the initial selections with an empty list
     if new_selections:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2971,9 +2971,14 @@ class Parser(metaclass=_Parser):
 
     def _parse_pivot_in(self) -> exp.In:
         def _parse_aliased_expression() -> t.Optional[exp.Expression]:
-            expr = self._parse_conjunction()
+            this = self._parse_conjunction()
+
             self._match(TokenType.ALIAS)
-            return self.expression(exp.Alias, this=expr, alias=self._parse_field())
+            alias = self._parse_field()
+            if alias:
+                return self.expression(exp.PivotAlias, this=this, alias=alias)
+
+            return this
 
         value = self._parse_column()
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -145,6 +145,12 @@ class TestBigQuery(Validator):
         self.validate_identity("SELECT TIMESTAMP_MILLIS(2) AS t")
         self.validate_identity("""SELECT JSON_EXTRACT_SCALAR('{"a": 5}', '$.a')""")
         self.validate_identity(
+            "SELECT * FROM Produce UNPIVOT((first_half_sales, second_half_sales) FOR semesters IN ((Q1, Q2) AS 'semester_1', (Q3, Q4) AS 'semester_2'))",
+        )
+        self.validate_identity(
+            "SELECT * FROM Produce UNPIVOT((first_half_sales, second_half_sales) FOR semesters IN ((Q1, Q2) AS 1, (Q3, Q4) AS 2))",
+        )
+        self.validate_identity(
             "FOR record IN (SELECT word, word_count FROM bigquery-public-data.samples.shakespeare LIMIT 5) DO SELECT record.word, record.word_count"
         )
         self.validate_identity(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -17,13 +17,15 @@ class TestBigQuery(Validator):
     maxDiff = None
 
     def test_bigquery(self):
-        self.validate_all(
-            "SELECT UNIX_DATE(DATE '2008-12-25')",
-            write={
-                "bigquery": "SELECT UNIX_DATE(CAST('2008-12-25' AS DATE))",
-                "duckdb": "SELECT DATE_DIFF('DAY', CAST('1970-01-01' AS DATE), CAST('2008-12-25' AS DATE))",
-            },
-        )
+        with self.assertLogs(helper_logger) as cm:
+            self.validate_identity(
+                "SELECT * FROM t AS t(c1, c2)",
+                "SELECT * FROM t AS t",
+            )
+
+            self.assertEqual(
+                cm.output, ["WARNING:sqlglot:Named columns are not supported in table alias."]
+            )
 
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(
@@ -218,6 +220,13 @@ class TestBigQuery(Validator):
             "SELECT * FROM UNNEST(x) WITH OFFSET AS offset EXCEPT DISTINCT SELECT * FROM UNNEST(y) WITH OFFSET AS offset",
         )
 
+        self.validate_all(
+            "SELECT UNIX_DATE(DATE '2008-12-25')",
+            write={
+                "bigquery": "SELECT UNIX_DATE(CAST('2008-12-25' AS DATE))",
+                "duckdb": "SELECT DATE_DIFF('DAY', CAST('1970-01-01' AS DATE), CAST('2008-12-25' AS DATE))",
+            },
+        )
         self.validate_all(
             "SELECT LAST_DAY(CAST('2008-11-25' AS DATE), MONTH)",
             read={

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -626,8 +626,7 @@ SELECT
   "_q_0"."G" AS "G",
   "_q_0"."'x'" AS "'x'",
   "_q_0"."'y'" AS "'y'"
-FROM "U" AS "U" PIVOT(SUM("U"."F") FOR "U"."H" IN ('x', 'y')) AS "_q_0"
-;
+FROM "U" AS "U" PIVOT(SUM("U"."F") FOR "U"."H" IN ('x', 'y')) AS "_q_0";
 
 # title: selecting all columns from a pivoted source and generating spark
 # note: spark doesn't allow pivot aliases or qualified columns for the pivot's "field" (`h`)
@@ -643,6 +642,19 @@ FROM (
     *
   FROM `u` AS `u` PIVOT(SUM(`u`.`f`) FOR `h` IN ('x', 'y'))
 ) AS `_q_0`;
+
+# title: unpivoted source with a single value column
+# execute: false
+# dialect: snowflake
+SELECT * FROM m_sales AS m_sales(empid, dept, jan, feb) UNPIVOT(sales FOR month IN (jan, feb)) ORDER BY empid;
+SELECT
+  "_q_0"."EMPID" AS "EMPID",
+  "_q_0"."DEPT" AS "DEPT",
+  "_q_0"."MONTH" AS "MONTH",
+  "_q_0"."SALES" AS "SALES"
+FROM "M_SALES" AS "M_SALES"("EMPID", "DEPT", "JAN", "FEB") UNPIVOT("SALES" FOR "MONTH" IN ("JAN", "FEB")) AS "_q_0"
+ORDER BY
+  "_q_0"."EMPID";
 
 # title: quoting is maintained
 # dialect: snowflake

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -656,17 +656,6 @@ FROM "M_SALES" AS "M_SALES"("EMPID", "DEPT", "JAN", "FEB") UNPIVOT("SALES" FOR "
 ORDER BY
   "_q_0"."EMPID";
 
-# title: unpivoted table source with a single value column, unpivot columns can be qualified
-# execute: false
-# dialect: bigquery
-# note: the named columns aren't supported by BQ but we add them here to avoid defining a schema
-SELECT * FROM produce AS produce(product, q1, q2, q3, q4) UNPIVOT(sales FOR quarter IN (q1, q2, q3, q4));
-SELECT
-  `_q_0`.`product` AS `product`,
-  `_q_0`.`quarter` AS `quarter`,
-  `_q_0`.`sales` AS `sales`
-FROM `produce` AS `produce` UNPIVOT(`sales` FOR `quarter` IN (`produce`.`q1`, `produce`.`q2`, `produce`.`q3`, `produce`.`q4`)) AS `_q_0`;
-
 # title: unpivoted derived table source with a single value column
 # execute: false
 # dialect: snowflake
@@ -686,6 +675,28 @@ FROM (
 ) AS "M_SALES" UNPIVOT("SALES" FOR "MONTH" IN ("JAN", "FEB")) AS "_q_0"
 ORDER BY
   "_q_0"."EMPID";
+
+# title: unpivoted table source with a single value column, unpivot columns can be qualified
+# execute: false
+# dialect: bigquery
+# note: the named columns aren't supported by BQ but we add them here to avoid defining a schema
+SELECT * FROM produce AS produce(product, q1, q2, q3, q4) UNPIVOT(sales FOR quarter IN (q1, q2, q3, q4));
+SELECT
+  `_q_0`.`product` AS `product`,
+  `_q_0`.`quarter` AS `quarter`,
+  `_q_0`.`sales` AS `sales`
+FROM `produce` AS `produce` UNPIVOT(`sales` FOR `quarter` IN (`produce`.`q1`, `produce`.`q2`, `produce`.`q3`, `produce`.`q4`)) AS `_q_0`;
+
+# title: unpivoted table source with multiple value columns
+# execute: false
+# dialect: bigquery
+SELECT * FROM produce AS produce(product, q1, q2, q3, q4) UNPIVOT((first_half_sales, second_half_sales) FOR semesters IN ((Q1, Q2) AS 'semester_1', (Q3, Q4) AS 'semester_2'));
+SELECT
+  `_q_0`.`product` AS `product`,
+  `_q_0`.`semesters` AS `semesters`,
+  `_q_0`.`first_half_sales` AS `first_half_sales`,
+  `_q_0`.`second_half_sales` AS `second_half_sales`
+FROM `produce` AS `produce` UNPIVOT((`first_half_sales`, `second_half_sales`) FOR `semesters` IN ((`produce`.`q1`, `produce`.`q2`) AS 'semester_1', (`produce`.`q3`, `produce`.`q4`) AS 'semester_2')) AS `_q_0`;
 
 # title: quoting is maintained
 # dialect: snowflake

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -643,7 +643,7 @@ FROM (
   FROM `u` AS `u` PIVOT(SUM(`u`.`f`) FOR `h` IN ('x', 'y'))
 ) AS `_q_0`;
 
-# title: unpivoted table source with a single value column
+# title: unpivoted table source with a single value column, unpivot columns can't be qualified
 # execute: false
 # dialect: snowflake
 SELECT * FROM m_sales AS m_sales(empid, dept, jan, feb) UNPIVOT(sales FOR month IN (jan, feb)) ORDER BY empid;
@@ -655,6 +655,17 @@ SELECT
 FROM "M_SALES" AS "M_SALES"("EMPID", "DEPT", "JAN", "FEB") UNPIVOT("SALES" FOR "MONTH" IN ("JAN", "FEB")) AS "_q_0"
 ORDER BY
   "_q_0"."EMPID";
+
+# title: unpivoted table source with a single value column, unpivot columns can be qualified
+# execute: false
+# dialect: bigquery
+# note: the named columns aren't supported by BQ but we add them here to avoid defining a schema
+SELECT * FROM produce AS produce(product, q1, q2, q3, q4) UNPIVOT(sales FOR quarter IN (q1, q2, q3, q4));
+SELECT
+  `_q_0`.`product` AS `product`,
+  `_q_0`.`quarter` AS `quarter`,
+  `_q_0`.`sales` AS `sales`
+FROM `produce` AS `produce` UNPIVOT(`sales` FOR `quarter` IN (`produce`.`q1`, `produce`.`q2`, `produce`.`q3`, `produce`.`q4`)) AS `_q_0`;
 
 # title: unpivoted derived table source with a single value column
 # execute: false

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -656,7 +656,7 @@ FROM "M_SALES" AS "M_SALES"("EMPID", "DEPT", "JAN", "FEB") UNPIVOT("SALES" FOR "
 ORDER BY
   "_q_0"."EMPID";
 
-# title: unpivoted subquery source with a single value column
+# title: unpivoted derived table source with a single value column
 # execute: false
 # dialect: snowflake
 SELECT * FROM (SELECT * FROM m_sales) AS m_sales(empid, dept, jan, feb) UNPIVOT(sales FOR month IN (jan, feb)) ORDER BY empid;

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -643,7 +643,7 @@ FROM (
   FROM `u` AS `u` PIVOT(SUM(`u`.`f`) FOR `h` IN ('x', 'y'))
 ) AS `_q_0`;
 
-# title: unpivoted source with a single value column
+# title: unpivoted table source with a single value column
 # execute: false
 # dialect: snowflake
 SELECT * FROM m_sales AS m_sales(empid, dept, jan, feb) UNPIVOT(sales FOR month IN (jan, feb)) ORDER BY empid;
@@ -653,6 +653,26 @@ SELECT
   "_q_0"."MONTH" AS "MONTH",
   "_q_0"."SALES" AS "SALES"
 FROM "M_SALES" AS "M_SALES"("EMPID", "DEPT", "JAN", "FEB") UNPIVOT("SALES" FOR "MONTH" IN ("JAN", "FEB")) AS "_q_0"
+ORDER BY
+  "_q_0"."EMPID";
+
+# title: unpivoted subquery source with a single value column
+# execute: false
+# dialect: snowflake
+SELECT * FROM (SELECT * FROM m_sales) AS m_sales(empid, dept, jan, feb) UNPIVOT(sales FOR month IN (jan, feb)) ORDER BY empid;
+SELECT
+  "_q_0"."EMPID" AS "EMPID",
+  "_q_0"."DEPT" AS "DEPT",
+  "_q_0"."MONTH" AS "MONTH",
+  "_q_0"."SALES" AS "SALES"
+FROM (
+  SELECT
+    "M_SALES"."EMPID" AS "EMPID",
+    "M_SALES"."DEPT" AS "DEPT",
+    "M_SALES"."JAN" AS "JAN",
+    "M_SALES"."FEB" AS "FEB"
+  FROM "M_SALES" AS "M_SALES"
+) AS "M_SALES" UNPIVOT("SALES" FOR "MONTH" IN ("JAN", "FEB")) AS "_q_0"
 ORDER BY
   "_q_0"."EMPID";
 


### PR DESCRIPTION
Still need to test a few more engines but this should be a good start (will iterate on this PR).

References:
- https://docs.snowflake.com/en/sql-reference/constructs/unpivot
- https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#unpivot_operator
- https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-unpivot.html
- https://docs.aws.amazon.com/redshift/latest/dg/r_FROM_clause-pivot-unpivot-examples.html#r_FROM_clause-unpivot-examples
- https://learn.microsoft.com/en-us/sql/t-sql/queries/from-using-pivot-and-unpivot?view=sql-server-ver16