### PR TITLE
Feat[oracle,doris]:add oracle parsing and doris generation of trunc,to_date,sysdate

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -10,11 +10,62 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.mysql import MySQL
 
+DATE_DELTA_INTERVAL = {
+    "year": "year",
+    "yyyy": "year",
+    "yy": "year",
+    "quarter": "quarter",
+    "qq": "quarter",
+    "q": "quarter",
+    "month": "month",
+    "mm": "month",
+    "m": "month",
+    "week": "week",
+    "ww": "week",
+    "wk": "week",
+    "day": "day",
+    "dd": "day",
+    "d": "day",
+}
+
+
+def handle_date_trunc(self, expression: exp.DateTrunc) -> str:
+    unit = self.sql(expression, "unit").strip("\"'").lower()
+    this = self.sql(expression, "this")
+    if unit.isalpha():
+        mapped_unit = (
+            DATE_DELTA_INTERVAL.get(unit) if DATE_DELTA_INTERVAL.get(unit) != None else unit
+        )
+        return f"DATE_TRUNC({this}, '{mapped_unit}')"
+    elif unit.isdigit():
+        return f"TRUNCATE({this}, {unit})"
+    return f"DATE({this})"
+
+
+def handle_to_date(self: Doris.Generator, expression: exp.TsOrDsToDate) -> str:
+    this = self.sql(expression, "this")
+    time_format = self.format_time(expression)
+    if time_format and time_format not in (Doris.TIME_FORMAT, Doris.DATE_FORMAT):
+        return f"DATE_FORMAT({this}, {time_format})"
+    if isinstance(expression.this, exp.TsOrDsToDate):
+        return this
+    return f"TO_DATE({this})"
+
 
 class Doris(MySQL):
     DATE_FORMAT = "'yyyy-MM-dd'"
     DATEINT_FORMAT = "'yyyyMMdd'"
     TIME_FORMAT = "'yyyy-MM-dd HH:mm:ss'"
+
+    TIME_MAPPING = {
+        **MySQL.TIME_MAPPING,
+        "%Y": "yyyy",
+        "%m": "MM",
+        "%d": "dd",
+        "%s": "ss",
+        "%H": "HH24",
+        "%i": "mi",
+    }
 
     class Parser(MySQL.Parser):
         FUNCTIONS = {
@@ -22,6 +73,7 @@ class Doris(MySQL):
             "COLLECT_SET": exp.ArrayUniqueAgg.from_arg_list,
             "DATE_TRUNC": parse_timestamp_trunc,
             "REGEXP": exp.RegexpLike.from_arg_list,
+            "TO_DATE": exp.TsOrDsToDate.from_arg_list,
         }
 
     class Generator(MySQL.Generator):
@@ -40,21 +92,20 @@ class Doris(MySQL):
             **MySQL.Generator.TRANSFORMS,
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.ArrayAgg: rename_func("COLLECT_LIST"),
+            exp.ArrayUniqueAgg: rename_func("COLLECT_SET"),
             exp.CurrentTimestamp: lambda *_: "NOW()",
-            exp.DateTrunc: lambda self, e: self.func(
-                "DATE_TRUNC", e.this, "'" + e.text("unit") + "'"
-            ),
+            exp.DateTrunc: handle_date_trunc,
             exp.JSONExtractScalar: arrow_json_extract_sql,
             exp.JSONExtract: arrow_json_extract_sql,
+            exp.Map: rename_func("ARRAY_MAP"),
             exp.RegexpLike: rename_func("REGEXP"),
             exp.RegexpSplit: rename_func("SPLIT_BY_STRING"),
-            exp.ArrayUniqueAgg: rename_func("COLLECT_SET"),
             exp.StrToUnix: lambda self, e: f"UNIX_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.Split: rename_func("SPLIT_BY_STRING"),
             exp.TimeStrToDate: rename_func("TO_DATE"),
             exp.ToChar: lambda self, e: f"DATE_FORMAT({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.TsOrDsAdd: lambda self, e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",  # Only for day level
-            exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this),
+            exp.TsOrDsToDate: handle_to_date,
             exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
             exp.TimestampTrunc: lambda self, e: self.func(
                 "DATE_TRUNC", e.this, "'" + e.text("unit") + "'"
@@ -63,5 +114,4 @@ class Doris(MySQL):
                 "FROM_UNIXTIME", e.this, time_format("doris")(self, e)
             ),
             exp.UnixToTime: rename_func("FROM_UNIXTIME"),
-            exp.Map: rename_func("ARRAY_MAP"),
         }

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -92,6 +92,11 @@ class Oracle(Dialect):
             **parser.Parser.FUNCTIONS,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "TO_CHAR": to_char,
+            "TRUNC": lambda args: exp.DateTrunc(
+                unit=seq_get(args, 1),
+                this=seq_get(args, 0),
+            ),
+            "TO_DATE": exp.TsOrDsToDate.from_arg_list,
         }
 
         FUNCTION_PARSERS: t.Dict[str, t.Callable] = {
@@ -239,4 +244,5 @@ class Oracle(Dialect):
             "START": TokenType.BEGIN,
             "TOP": TokenType.TOP,
             "VARCHAR2": TokenType.VARCHAR,
+            "SYSDATE": TokenType.CURRENT_TIMESTAMP,
         }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4555,7 +4555,7 @@ class DateDiff(Func, TimeUnit):
 
 
 class DateTrunc(Func):
-    arg_types = {"unit": True, "this": True, "zone": False}
+    arg_types = {"unit": True, "this": False, "zone": False}
 
     def __init__(self, **args):
         unit = args.get("unit")

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -798,7 +798,7 @@ class TestDialect(Validator):
                 "snowflake": "DATE_TRUNC('DAY', x)",
                 "starrocks": "DATE_TRUNC('DAY', x)",
                 "spark": "TRUNC(x, 'DAY')",
-                "doris": "DATE_TRUNC(x, 'DAY')",
+                "doris": "DATE_TRUNC(x, 'day')",
             },
         )
         self.validate_all(
@@ -872,7 +872,7 @@ class TestDialect(Validator):
                 "snowflake": "DATE_TRUNC('YEAR', x)",
                 "starrocks": "DATE_TRUNC('YEAR', x)",
                 "spark": "TRUNC(x, 'YEAR')",
-                "doris": "DATE_TRUNC(x, 'YEAR')",
+                "doris": "DATE_TRUNC(x, 'year')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -133,6 +133,20 @@ class TestOracle(Validator):
             },
         )
 
+        self.validate_all(
+            "DATE_TRUNC('DAY', x)",
+            read={
+                "oracle": "TRUNC(x, 'DAY')",
+            },
+        )
+
+        self.validate_all(
+            "CAST(x AS DATE)",
+            read={
+                "oracle": "TO_DATE(x)",
+            },
+        )
+
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")
 


### PR DESCRIPTION
Trunc function:
In Oracle, the trunc function is divided into two types: date and value, and unit is in the second position, contrary to other dialects
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/TRUNC-date.html#GUID-BC82227A-2698-4EC8-8C1A-ABECC64B0E79
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/TRUNC-number.html#GUID-911AE7FE-E04A-471D-8B0E-9C50EBEFE07D
Doris:
- https://doris.apache.org/docs/dev/sql-manual/sql-functions/date-time-functions/date-trunc
- https://doris.apache.org/docs/dev/sql-manual/sql-functions/numeric-functions/truncate

TO_DATE function:
  oracle：
  tips：
  HH hours ->calculated as 12 hours
  HH24 hours -> calculated in 24 hours
  MI -> points
  SS -> seconds
  MM -> month
- https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/TO_DATE.html#GUID-D226FA7C-F7AD-41A0-BB1D-BD8EF9440118
doris：
- https://doris.apache.org/docs/dev/sql-manual/sql-functions/date-time-functions/to-date/
- https://doris.apache.org/docs/dev/sql-manual/sql-functions/date-time-functions/date-format/