### PR TITLE
Fix!(tsql): use square bracket quotes by default, not quotes

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -377,7 +377,7 @@ class TSQL(Dialect):
     }
 
     class Tokenizer(tokens.Tokenizer):
-        IDENTIFIERS = ['"', ("[", "]")]
+        IDENTIFIERS = [("[", "]"), '"']
         QUOTES = ["'", '"']
         HEX_STRINGS = [("0x", ""), ("0X", "")]
         VAR_SINGLE_TOKENS = {"@", "$", "#"}


### PR DESCRIPTION
The motivation behind this PR is that T-SQL requires the session parameter `QUOTED_IDENTIFIER` to be set to `ON` for double quotes to work when used around db objects. For example:

```
1> SET QUOTED_IDENTIFIER ON
2> WITH "t" AS (SELECT 1 AS c) SELECT * FROM "t"
3> GO
c          
-----------
          1

(1 rows affected)
1> WITH [t] AS (SELECT 1 AS c) SELECT * FROM [t]
2> GO
c          
-----------
          1

(1 rows affected)
1> SET QUOTED_IDENTIFIER OFF
2> WITH "t" AS (SELECT 1 AS c) SELECT * FROM "t"
3> GO
Msg 102, Level 15, State 1, Server 58a9c7ad0aac, Line 2
Incorrect syntax near 't'.
Msg 102, Level 15, State 1, Server 58a9c7ad0aac, Line 2
Incorrect syntax near 't'.
1> WITH [t] AS (SELECT 1 AS c) SELECT * FROM [t]
2> GO
c          
-----------
          1

(1 rows affected)
```

This showcases that depending on the engine's state, double quotes may be invalid syntax. However, their docs say:

> QUOTED_IDENTIFIER does not affect delimited identifiers enclosed in brackets ([ ]).

Meaning that square brackets should be always correct syntax (🤞).

Reference: https://learn.microsoft.com/en-us/sql/t-sql/statements/set-quoted-identifier-transact-sql?view=sql-server-ver16