### PR TITLE
Fix!(duckdb): parse STRUCT_PACK names to identifiers instead of columns

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -159,6 +159,13 @@ def _rename_unless_within_group(
     )
 
 
+def _parse_struct_pack(args: t.List) -> exp.Struct:
+    args_with_columns_as_identifiers = [
+        exp.PropertyEQ(this=arg.this.this, expression=arg.expression) for arg in args
+    ]
+    return exp.Struct.from_arg_list(args_with_columns_as_identifiers)
+
+
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = False
@@ -252,7 +259,7 @@ class DuckDB(Dialect):
             "STRING_SPLIT_REGEX": exp.RegexpSplit.from_arg_list,
             "STRING_TO_ARRAY": exp.Split.from_arg_list,
             "STRPTIME": format_time_lambda(exp.StrToTime, "duckdb"),
-            "STRUCT_PACK": exp.Struct.from_arg_list,
+            "STRUCT_PACK": _parse_struct_pack,
             "STR_SPLIT": exp.Split.from_arg_list,
             "STR_SPLIT_REGEX": exp.RegexpSplit.from_arg_list,
             "TO_TIMESTAMP": exp.UnixToTime.from_arg_list,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -7,6 +7,10 @@ class TestDuckDB(Validator):
     dialect = "duckdb"
 
     def test_duckdb(self):
+        struct_pack = parse_one('STRUCT_PACK("a b" := 1)', read="duckdb")
+        self.assertIsInstance(struct_pack.expressions[0].this, exp.Identifier)
+        self.assertEqual(struct_pack.sql(dialect="duckdb"), "{'a b': 1}")
+
         self.validate_all(
             "SELECT SUM(X) OVER (ORDER BY x RANGE BETWEEN 1 PRECEDING AND CURRENT ROW)",
             write={


### PR DESCRIPTION
Motivation behind this PR is this optimizer error:

```python
>>> from sqlglot.optimizer import optimize
>>> optimize("select struct_pack(a := 1)", dialect="duckdb")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "sqlglot/optimizer/optimizer.py", line 92, in optimize
    expression = rule(expression, **rule_kwargs)
  File "sqlglot/optimizer/qualify.py", line 90, in qualify
    validate_qualify_columns_func(expression)
  File "sqlglot/optimizer/qualify_columns.py", line 87, in validate_qualify_columns
    raise OptimizeError(f"Column '{column}' could not be resolved{for_table}")
sqlglot.errors.OptimizeError: Column 'a' could not be resolved
```