### PR TITLE
fix: add parentheses to no_safe_divide args

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -533,7 +533,7 @@ def no_recursive_cte_sql(self: Generator, expression: exp.With) -> str:
 def no_safe_divide_sql(self: Generator, expression: exp.SafeDivide) -> str:
     n = self.sql(expression, "this")
     d = self.sql(expression, "expression")
-    return f"IF({d} <> 0, {n} / {d}, NULL)"
+    return f"IF(({d}) <> 0, ({n}) / ({d}), NULL)"
 
 
 def no_tablesample_sql(self: Generator, expression: exp.TableSample) -> str:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -432,7 +432,7 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
-            "IF(y <> 0, x / y, NULL)",
+            "IF((y) <> 0, (x) / (y), NULL)",
             read={
                 "bigquery": "SAFE_DIVIDE(x, y)",
             },


### PR DESCRIPTION
When transpiling from a language that supports `SAFE_DIVIDE` to one that does not where the arguments are nested, it is possible to cause incorrect behaviour. For instance, the following yields an incorrect query result, going from BigQuery (`SAFE_DIVIDE` supported) to DuckDB (unsupported). Observe that the `IF` condition has an ambiguous argument, and that the same is true after a round trip through the transpiler:
```py
In [15]: print(bq)                                                                                                                                                                                                                       

(
              SAFE_DIVIDE(
                commanded_curvature - LAG(commanded_curvature) OVER (ORDER BY header_timestamp ASC), 
                header_timestamp -  LAG(header_timestamp) OVER (ORDER BY header_timestamp ASC)
              )
            ) AS steer_jerk

In [16]: print(transpile(bq, read="bigquery", write="duckdb", identify=True, pretty=True)[0])                                                                                                                                            
(
  IF("header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST) <> 0, "commanded_curvature" - LAG("commanded_curvature") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST) / "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST), NULL)
) AS "steer_jerk"

In [17]: print(transpile(transpile(bq, read="bigquery", write="duckdb", identify=True, pretty=True)[0], read="duckdb", write="duckdb", identify=True, pretty=True)[0])                                                                   
(
  CASE
    WHEN "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST) <> 0
    THEN "commanded_curvature" - LAG("commanded_curvature") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST) / "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
    ELSE NULL
  END
) AS "steer_jerk"
```
Conversely, when manually adding parentheses around the arguments to `SAFE_DIVIDE`, the query results are correct:
```py
In [19]: bq = """ 
    ...: SELECT 
    ...:             header_timestamp as _time, 
    ...:             CAST(FLOOR(header_timestamp*1e3) AS INT64) as unix_millis, 
    ...:             commanded_curvature, 
    ...:            ( 
    ...:               SAFE_DIVIDE( 
    ...:                 (commanded_curvature - LAG(commanded_curvature) OVER (ORDER BY header_timestamp ASC)),  
    ...:                 (header_timestamp -  LAG(header_timestamp) OVER (ORDER BY header_timestamp ASC)) 
    ...:               ) 
    ...:             ) AS steer_jerk, 
    ...:             velocity 
    ...:         FROM 
    ...:             attributes_mpc_planned_av_state 
    ...:         ORDER BY _time"""                                                                                                                                                                                                       

In [20]: print(transpile(bq, read="bigquery", write="duckdb", identify=True, pretty=True)[0])                                                                                                                                            
SELECT
  "header_timestamp" AS "_time",
  CAST(FLOOR("header_timestamp" * 1e3) AS BIGINT) AS "unix_millis",
  "commanded_curvature",
  (
    IF((
      "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
    ) <> 0, (
      "commanded_curvature" - LAG("commanded_curvature") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
    ) / (
      "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
    ), NULL)
  ) AS "steer_jerk",
  "velocity"
FROM "attributes_mpc_planned_av_state"
ORDER BY
  "_time" NULLS FIRST

In [21]: print(transpile(transpile(bq, read="bigquery", write="duckdb", identify=True, pretty=True)[0], read="duckdb", write="duckdb", identify=True, pretty=True)[0])                                                                   
SELECT
  "header_timestamp" AS "_time",
  CAST(FLOOR("header_timestamp" * 1e3) AS BIGINT) AS "unix_millis",
  "commanded_curvature",
  (
    CASE
      WHEN (
        "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
      ) <> 0
      THEN (
        "commanded_curvature" - LAG("commanded_curvature") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
      ) / (
        "header_timestamp" - LAG("header_timestamp") OVER (ORDER BY "header_timestamp" ASC NULLS FIRST)
      )
      ELSE NULL
    END
  ) AS "steer_jerk",
  "velocity"
FROM "attributes_mpc_planned_av_state"
ORDER BY
  "_time" NULLS FIRST
  ```