### PR TITLE
Fix(clickhouse): add ipv4/6 data type parser

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -85,6 +85,8 @@ class ClickHouse(Dialect):
             "UINT32": TokenType.UINT,
             "UINT64": TokenType.UBIGINT,
             "UINT8": TokenType.UTINYINT,
+            "IPV4": TokenType.IPV4,
+            "IPV6": TokenType.IPV6,
         }
 
         SINGLE_TOKENS = {
@@ -541,6 +543,8 @@ class ClickHouse(Dialect):
             exp.DataType.Type.UINT256: "UInt256",
             exp.DataType.Type.USMALLINT: "UInt16",
             exp.DataType.Type.UTINYINT: "UInt8",
+            exp.DataType.Type.IPV4: "IPv4",
+            exp.DataType.Type.IPV6: "IPv6",
         }
 
         TRANSFORMS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3662,6 +3662,8 @@ class DataType(Expression):
         INTERVAL = auto()
         IPADDRESS = auto()
         IPPREFIX = auto()
+        IPV4 = auto()
+        IPV6 = auto()
         JSON = auto()
         JSONB = auto()
         LONGBLOB = auto()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -234,6 +234,8 @@ class Parser(metaclass=_Parser):
         TokenType.INET,
         TokenType.IPADDRESS,
         TokenType.IPPREFIX,
+        TokenType.IPV4,
+        TokenType.IPV6,
         TokenType.UNKNOWN,
         TokenType.NULL,
         *ENUM_TYPE_TOKENS,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -182,6 +182,8 @@ class TokenType(AutoName):
     INET = auto()
     IPADDRESS = auto()
     IPPREFIX = auto()
+    IPV4 = auto()
+    IPV6 = auto()
     ENUM = auto()
     ENUM8 = auto()
     ENUM16 = auto()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -726,3 +726,4 @@ LIFETIME(MIN 0 MAX 0)""",
             },
             pretty=True,
         )
+        self.validate_identity("""CREATE TABLE ip_data (ip4 IPv4, ip6 IPv6) ENGINE=TinyLog()""")


### PR DESCRIPTION
See https://clickhouse.com/docs/en/sql-reference/data-types/ipv4 and https://clickhouse.com/docs/en/sql-reference/data-types/ipv6
It's pretty similar to Presto `IPADDRESS` type, but sematically different as Presto type is IPV6 with IPV4 convertion.