### PR TITLE
Feat(clickhouse): support Date32 type

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -63,6 +63,7 @@ class ClickHouse(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "ATTACH": TokenType.COMMAND,
+            "DATE32": TokenType.DATE32,
             "DATETIME64": TokenType.DATETIME64,
             "DICTIONARY": TokenType.DICTIONARY,
             "ENUM": TokenType.ENUM,
@@ -519,6 +520,7 @@ class ClickHouse(Dialect):
             **STRING_TYPE_MAPPING,
             exp.DataType.Type.ARRAY: "Array",
             exp.DataType.Type.BIGINT: "Int64",
+            exp.DataType.Type.DATE32: "Date32",
             exp.DataType.Type.DATETIME64: "DateTime64",
             exp.DataType.Type.DOUBLE: "Float64",
             exp.DataType.Type.ENUM: "Enum",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3635,6 +3635,7 @@ class DataType(Expression):
         BOOLEAN = auto()
         CHAR = auto()
         DATE = auto()
+        DATE32 = auto()
         DATEMULTIRANGE = auto()
         DATERANGE = auto()
         DATETIME = auto()
@@ -3762,6 +3763,7 @@ class DataType(Expression):
         Type.TIMESTAMP_MS,
         Type.TIMESTAMP_NS,
         Type.DATE,
+        Type.DATE32,
         Type.DATETIME,
         Type.DATETIME64,
     }

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -195,6 +195,7 @@ class Parser(metaclass=_Parser):
         TokenType.DATETIME,
         TokenType.DATETIME64,
         TokenType.DATE,
+        TokenType.DATE32,
         TokenType.INT4RANGE,
         TokenType.INT4MULTIRANGE,
         TokenType.INT8RANGE,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -147,6 +147,7 @@ class TokenType(AutoName):
     DATETIME = auto()
     DATETIME64 = auto()
     DATE = auto()
+    DATE32 = auto()
     INT4RANGE = auto()
     INT4MULTIRANGE = auto()
     INT8RANGE = auto()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -727,3 +727,4 @@ LIFETIME(MIN 0 MAX 0)""",
             pretty=True,
         )
         self.validate_identity("""CREATE TABLE ip_data (ip4 IPv4, ip6 IPv6) ENGINE=TinyLog()""")
+        self.validate_identity("""CREATE TABLE dates (dt1 Date32) ENGINE=TinyLog()""")


### PR DESCRIPTION
Another one of these strange types. See here: https://clickhouse.com/docs/en/sql-reference/data-types/date32

Semantically and physically it's totally different from `DATE` thus cannot be directly cast...