### PR TITLE
Feat(clickhouse): AggregateFunction data type

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -88,6 +88,8 @@ class ClickHouse(Dialect):
             "UINT8": TokenType.UTINYINT,
             "IPV4": TokenType.IPV4,
             "IPV6": TokenType.IPV6,
+            "AGGREGATEFUNCTION": TokenType.AGGREGATEFUNCTION,
+            "SIMPLEAGGREGATEFUNCTION": TokenType.SIMPLEAGGREGATEFUNCTION,
         }
 
         SINGLE_TOKENS = {
@@ -547,6 +549,8 @@ class ClickHouse(Dialect):
             exp.DataType.Type.UTINYINT: "UInt8",
             exp.DataType.Type.IPV4: "IPv4",
             exp.DataType.Type.IPV6: "IPv6",
+            exp.DataType.Type.AGGREGATEFUNCTION: "AggregateFunction",
+            exp.DataType.Type.SIMPLEAGGREGATEFUNCTION: "SimpleAggregateFunction",
         }
 
         TRANSFORMS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3627,6 +3627,8 @@ class DataType(Expression):
 
     class Type(AutoName):
         ARRAY = auto()
+        AGGREGATEFUNCTION = auto()
+        SIMPLEAGGREGATEFUNCTION = auto()
         BIGDECIMAL = auto()
         BIGINT = auto()
         BIGSERIAL = auto()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -148,6 +148,11 @@ class Parser(metaclass=_Parser):
         TokenType.ENUM16,
     }
 
+    AGGREGATE_TYPE_TOKENS = {
+        TokenType.AGGREGATEFUNCTION,
+        TokenType.SIMPLEAGGREGATEFUNCTION,
+    }
+
     TYPE_TOKENS = {
         TokenType.BIT,
         TokenType.BOOLEAN,
@@ -241,6 +246,7 @@ class Parser(metaclass=_Parser):
         TokenType.NULL,
         *ENUM_TYPE_TOKENS,
         *NESTED_TYPE_TOKENS,
+        *AGGREGATE_TYPE_TOKENS,
     }
 
     SIGNED_TO_UNSIGNED_TYPE_TOKEN = {
@@ -3627,6 +3633,7 @@ class Parser(metaclass=_Parser):
 
         nested = type_token in self.NESTED_TYPE_TOKENS
         is_struct = type_token in self.STRUCT_TYPE_TOKENS
+        is_aggregate = type_token in self.AGGREGATE_TYPE_TOKENS
         expressions = None
         maybe_func = False
 
@@ -3641,6 +3648,18 @@ class Parser(metaclass=_Parser):
                 )
             elif type_token in self.ENUM_TYPE_TOKENS:
                 expressions = self._parse_csv(self._parse_equality)
+            elif is_aggregate:
+                func_or_ident = self._parse_function(anonymous=True) or self._parse_id_var(
+                    any_token=False, tokens=(TokenType.VAR,)
+                )
+                if not func_or_ident or not self._match(TokenType.COMMA):
+                    return None
+                expressions = self._parse_csv(
+                    lambda: self._parse_types(
+                        check_func=check_func, schema=schema, allow_identifiers=allow_identifiers
+                    )
+                )
+                expressions.insert(0, func_or_ident)
             else:
                 expressions = self._parse_csv(self._parse_type_size)
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -191,6 +191,8 @@ class TokenType(AutoName):
     FIXEDSTRING = auto()
     LOWCARDINALITY = auto()
     NESTED = auto()
+    AGGREGATEFUNCTION = auto()
+    SIMPLEAGGREGATEFUNCTION = auto()
     UNKNOWN = auto()
 
     # keywords

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -728,3 +728,19 @@ LIFETIME(MIN 0 MAX 0)""",
         )
         self.validate_identity("""CREATE TABLE ip_data (ip4 IPv4, ip6 IPv6) ENGINE=TinyLog()""")
         self.validate_identity("""CREATE TABLE dates (dt1 Date32) ENGINE=TinyLog()""")
+        self.validate_all(
+            """
+            CREATE TABLE t (
+                a AggregateFunction(quantiles(0.5, 0.9), UInt64),
+                b AggregateFunction(quantiles, UInt64),
+                c SimpleAggregateFunction(sum, Float64)
+            )""",
+            write={
+                "clickhouse": """CREATE TABLE t (
+  a AggregateFunction(quantiles(0.5, 0.9), UInt64),
+  b AggregateFunction(quantiles, UInt64),
+  c SimpleAggregateFunction(sum, Float64)
+)"""
+            },
+            pretty=True,
+        )


### PR DESCRIPTION
these can be used in column definitions:
- AggregateFunction
- SimpleAggregateFunction

See https://clickhouse.com/docs/en/sql-reference/data-types/aggregatefunction and https://clickhouse.com/docs/en/sql-reference/data-types/simpleaggregatefunction

These are pretty peculiar, 'cos the first argument is either a "function identifier" or a "parameterized function identifier".
`sqlglot` has no notion of both, so I've just opted out for usual identifiers/functions, works in my case.
From ClickHouse docs it's not clear where else it can be used except column definitions, probably nowhere.
For expressions they use special functions like `initializeAggregation()` or `finalizeAggregation()`