### PR TITLE
Fix(oracle): TO_TIMESTAMP not parsed as StrToTime

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -94,6 +94,7 @@ class Oracle(Dialect):
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "TO_CHAR": to_char,
             "TO_TIMESTAMP": format_time_lambda(exp.StrToTime, "oracle"),
+            "TO_DATE": format_time_lambda(exp.StrToDate, "oracle"),
         }
 
         FUNCTION_PARSERS: t.Dict[str, t.Callable] = {
@@ -195,6 +196,7 @@ class Oracle(Dialect):
                 ]
             ),
             exp.StrToTime: lambda self, e: f"TO_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
+            exp.StrToDate: lambda self, e: f"TO_DATE({self.sql(e, 'this')}, {self.format_time(e)})",
             exp.Subquery: lambda self, e: self.subquery_sql(e, sep=" "),
             exp.Substring: rename_func("SUBSTR"),
             exp.Table: lambda self, e: self.table_sql(e, sep=" "),

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -82,6 +82,7 @@ class Oracle(Dialect):
         "WW": "%W",  # Week of year (1-53)
         "YY": "%y",  # 15
         "YYYY": "%Y",  # 2015
+        "FF6": "%f",  # only 6 digits are supported in python formats
     }
 
     class Parser(parser.Parser):
@@ -92,6 +93,7 @@ class Oracle(Dialect):
             **parser.Parser.FUNCTIONS,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "TO_CHAR": to_char,
+            "TO_TIMESTAMP": format_time_lambda(exp.StrToTime, "oracle"),
         }
 
         FUNCTION_PARSERS: t.Dict[str, t.Callable] = {

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -156,6 +156,13 @@ class TestOracle(Validator):
                 "duckdb": "SELECT STRPTIME('2024-12-12 12:12:12.000000', '%Y-%m-%d %H:%M:%S.%f')",
             },
         )
+        self.validate_all(
+            "SELECT TO_DATE('2024-12-12', 'YYYY-MM-DD')",
+            write={
+                "oracle": "SELECT TO_DATE('2024-12-12', 'YYYY-MM-DD')",
+                "duckdb": "SELECT CAST(STRPTIME('2024-12-12', '%Y-%m-%d') AS DATE)",
+            },
+        )
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -149,6 +149,13 @@ class TestOracle(Validator):
                 "postgres": "CAST(x AS sch.udt)",
             },
         )
+        self.validate_all(
+            "SELECT TO_TIMESTAMP('2024-12-12 12:12:12.000000', 'YYYY-MM-DD HH24:MI:SS.FF6')",
+            write={
+                "oracle": "SELECT TO_TIMESTAMP('2024-12-12 12:12:12.000000', 'YYYY-MM-DD HH24:MI:SS.FF6')",
+                "duckdb": "SELECT STRPTIME('2024-12-12 12:12:12.000000', '%Y-%m-%d %H:%M:%S.%f')",
+            }
+        )
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -154,7 +154,7 @@ class TestOracle(Validator):
             write={
                 "oracle": "SELECT TO_TIMESTAMP('2024-12-12 12:12:12.000000', 'YYYY-MM-DD HH24:MI:SS.FF6')",
                 "duckdb": "SELECT STRPTIME('2024-12-12 12:12:12.000000', '%Y-%m-%d %H:%M:%S.%f')",
-            }
+            },
         )
 
     def test_join_marker(self):


### PR DESCRIPTION
Fixes: #2831

Supporting only `.FF6` is probably too strict. Open to suggestions (python uses 6 digits with padding for `.%f` so...).
