### PR TITLE
fix(snowflake): Support more scale values for Snowflake's to_timestamp function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -40,18 +40,23 @@ def _parse_to_timestamp(args: t.List) -> t.Union[exp.StrToTime, exp.UnixToTime, 
             # case: <string_expr> [ , <format> ]
             return format_time_lambda(exp.StrToTime, "snowflake")(args)
 
-        # case: <numeric_expr> [ , <scale> ]
-        if second_arg.name not in ["0", "3", "9"]:
-            raise ValueError(
-                f"Scale for snowflake numeric timestamp is {second_arg}, but should be 0, 3, or 9"
-            )
-
-        if second_arg.name == "0":
-            timescale = exp.UnixToTime.SECONDS
-        elif second_arg.name == "3":
-            timescale = exp.UnixToTime.MILLIS
-        elif second_arg.name == "9":
-            timescale = exp.UnixToTime.NANOS
+        timescale = None
+        try:
+            timescale_idx = int(second_arg.name)
+            timescale = [
+                exp.UnixToTime.SECONDS,
+                exp.UnixToTime.DECIS,
+                exp.UnixToTime.CENTIS,
+                exp.UnixToTime.MILLIS,
+                exp.UnixToTime.DECIMILLIS,
+                exp.UnixToTime.CENTIMILLIS,
+                exp.UnixToTime.MICROS,
+                exp.UnixToTime.DECIMICROS,
+                exp.UnixToTime.CENTIMICROS,
+                exp.UnixToTime.NANOS,
+            ][timescale_idx]
+        except (ValueError, IndexError):
+            pass
 
         return exp.UnixToTime(this=first_arg, scale=timescale)
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5365,10 +5365,16 @@ class UnixToStr(Func):
 class UnixToTime(Func):
     arg_types = {"this": True, "scale": False, "zone": False, "hours": False, "minutes": False}
 
-    SECONDS = Literal.string("seconds")
-    MILLIS = Literal.string("millis")
-    MICROS = Literal.string("micros")
-    NANOS = Literal.string("nanos")
+    SECONDS = Literal.string("seconds")  # ^0
+    DECIS = Literal.string("decis")  # ^1
+    CENTIS = Literal.string("centis")  # ^2
+    MILLIS = Literal.string("millis")  # ^3
+    DECIMILLIS = Literal.string("decimillis")  # ^4
+    CENTIMILLIS = Literal.string("centimillis")  # ^5
+    MICROS = Literal.string("micros")  # ^6
+    DECIMICROS = Literal.string("decimicros")  # ^7
+    CENTIMICROS = Literal.string("centimicros")  # ^8
+    NANOS = Literal.string("nanos")  # ^9
 
 
 class UnixToTimeStr(Func):


### PR DESCRIPTION
The docs have 0, 3, and 9 as examples but it works for all values between 0 and 9, inclusive. This removes the check and instead tries to choose the right scale and defaults to None if it fails.

![image](https://github.com/tobymao/sqlglot/assets/1406/a65dc827-e969-44d9-ad44-c8488c00a634)
