### PR TITLE
Refactor!(parser): make text matching return None for consistency

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1402,7 +1402,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
 
 
 class GeneratedAsRowColumnConstraint(ColumnConstraintKind):
-    arg_types = {"start": True, "hidden": False}
+    arg_types = {"start": False, "hidden": False}
 
 
 # https://dev.mysql.com/doc/refman/8.0/en/create-table.html
@@ -2017,7 +2017,13 @@ class AutoRefreshProperty(Property):
 
 
 class BlockCompressionProperty(Property):
-    arg_types = {"autotemp": False, "always": False, "default": True, "manual": True, "never": True}
+    arg_types = {
+        "autotemp": False,
+        "always": False,
+        "default": False,
+        "manual": False,
+        "never": False,
+    }
 
 
 class CharacterSetProperty(Property):
@@ -2100,11 +2106,11 @@ class OutputModelProperty(Property):
 
 class IsolatedLoadingProperty(Property):
     arg_types = {
-        "no": True,
-        "concurrent": True,
-        "for_all": True,
-        "for_insert": True,
-        "for_none": True,
+        "no": False,
+        "concurrent": False,
+        "for_all": False,
+        "for_insert": False,
+        "for_none": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -775,7 +775,7 @@ class Generator:
     def generatedasrowcolumnconstraint_sql(
         self, expression: exp.GeneratedAsRowColumnConstraint
     ) -> str:
-        start = "START" if expression.args["start"] else "END"
+        start = "START" if expression.args.get("start") else "END"
         hidden = " HIDDEN" if expression.args.get("hidden") else ""
         return f"GENERATED ALWAYS AS ROW {start}{hidden}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5247,7 +5247,7 @@ class Parser(metaclass=_Parser):
 
             if self._match_text_seq("CHECK"):
                 expression = self._parse_wrapped(self._parse_conjunction)
-                enforced = self._match_text_seq("ENFORCED")
+                enforced = self._match_text_seq("ENFORCED") or False
 
                 return self.expression(
                     exp.AddConstraint, this=this, expression=expression, enforced=enforced
@@ -5637,7 +5637,7 @@ class Parser(metaclass=_Parser):
             if advance:
                 self._advance()
             return True
-        return False
+        return None
 
     def _match_text_seq(self, *texts, advance=True):
         index = self._index
@@ -5646,7 +5646,7 @@ class Parser(metaclass=_Parser):
                 self._advance()
             else:
                 self._retreat(index)
-                return False
+                return None
 
         if not advance:
             self._retreat(index)


### PR DESCRIPTION
We currently return `False` in some `match` methods, and `None` in some others. This PR changes the former category to also return `None` for consistency. The motivation for this is to allow e.g. `_match_text_seq` to be used inline when instantiating an expression without having to worry about `False` having special semantics. So, something like:

```python
self.expression(exp.Foo, this=self._match_text_seq(...) and ...)
```