### PR TITLE
Fix: qualify alter table table refs in optimizer qualify

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -46,6 +46,15 @@ def qualify_tables(
     db = exp.parse_identifier(db, dialect=dialect) if db else None
     catalog = exp.parse_identifier(catalog, dialect=dialect) if catalog else None
 
+    if isinstance(expression, exp.AlterTable):
+        for reference in expression.find_all(exp.Table):
+            if isinstance(reference.this, exp.Identifier):
+                if not reference.args.get("db"):
+                    reference.set("db", db)
+                if not reference.args.get("catalog") and reference.args.get("db"):
+                    reference.set("catalog", catalog)
+        return expression
+
     for scope in traverse_scope(expression):
         for derived_table in itertools.chain(scope.ctes, scope.derived_tables):
             if isinstance(derived_table, exp.Subquery):

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -46,13 +46,12 @@ def qualify_tables(
     db = exp.parse_identifier(db, dialect=dialect) if db else None
     catalog = exp.parse_identifier(catalog, dialect=dialect) if catalog else None
 
-    def _qualify(*tables: exp.Table) -> None:
-        for table in tables:
-            if isinstance(table.this, exp.Identifier):
-                if not table.args.get("db"):
-                    table.set("db", db)
-                if not table.args.get("catalog") and table.args.get("db"):
-                    table.set("catalog", catalog)
+    def _qualify(table: exp.Table) -> None:
+        if isinstance(table.this, exp.Identifier):
+            if not table.args.get("db"):
+                table.set("db", db)
+            if not table.args.get("catalog") and table.args.get("db"):
+                table.set("catalog", catalog)
 
     if isinstance(expression, exp.AlterTable):
         _qualify(expression.this)

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -53,7 +53,7 @@ def qualify_tables(
                     reference.set("db", db)
                 if not reference.args.get("catalog") and reference.args.get("db"):
                     reference.set("catalog", catalog)
-        return expression
+        return t.cast(E, expression)
 
     for scope in traverse_scope(expression):
         for derived_table in itertools.chain(scope.ctes, scope.derived_tables):

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -53,9 +53,9 @@ def qualify_tables(
             if not table.args.get("catalog") and table.args.get("db"):
                 table.set("catalog", catalog)
 
-    if isinstance(expression, exp.AlterTable):
-        _qualify(expression.this)
-        return t.cast(E, expression)
+    if not isinstance(expression, exp.Subqueryable):
+        for table in expression.find_all(exp.Table):
+            _qualify(table)
 
     for scope in traverse_scope(expression):
         for derived_table in itertools.chain(scope.ctes, scope.derived_tables):

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -46,13 +46,17 @@ def qualify_tables(
     db = exp.parse_identifier(db, dialect=dialect) if db else None
     catalog = exp.parse_identifier(catalog, dialect=dialect) if catalog else None
 
-    if isinstance(expression, exp.AlterTable):
-        for reference in expression.find_all(exp.Table):
+    def _qualify(tree: E) -> E:
+        for reference in tree.find_all(exp.Table):
             if isinstance(reference.this, exp.Identifier):
                 if not reference.args.get("db"):
                     reference.set("db", db)
                 if not reference.args.get("catalog") and reference.args.get("db"):
                     reference.set("catalog", catalog)
+        return tree
+
+    if isinstance(expression, exp.AlterTable):
+        _qualify(expression)
         return t.cast(E, expression)
 
     for scope in traverse_scope(expression):
@@ -74,13 +78,7 @@ def qualify_tables(
                 pivots[0].set("alias", exp.TableAlias(this=exp.to_identifier(next_alias_name())))
 
         for name, source in scope.sources.items():
-            if isinstance(source, exp.Table):
-                if isinstance(source.this, exp.Identifier):
-                    if not source.args.get("db"):
-                        source.set("db", db)
-                    if not source.args.get("catalog") and source.args.get("db"):
-                        source.set("catalog", catalog)
-
+                _qualify(source)
                 pivots = pivots = source.args.get("pivots")
                 if not source.alias:
                     # Don't add the pivot's alias to the pivoted table, use the table's name instead

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -55,7 +55,7 @@ def qualify_tables(
                     table.set("catalog", catalog)
 
     if isinstance(expression, exp.AlterTable):
-        _qualify(*expression.find_all(exp.Table))
+        _qualify(expression.this)
         return t.cast(E, expression)
 
     for scope in traverse_scope(expression):

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -130,3 +130,7 @@ SELECT x FROM c.db.t AS t, LATERAL UNNEST(t.xs) AS _q_0;
 # title: table with ordinality
 SELECT * FROM t CROSS JOIN JSON_ARRAY_ELEMENTS(t.response) WITH ORDINALITY AS kv_json;
 SELECT * FROM c.db.t AS t CROSS JOIN JSON_ARRAY_ELEMENTS(t.response) WITH ORDINALITY AS kv_json;
+
+# title: alter table
+ALTER TABLE t ADD PRIMARY KEY (id) NOT ENFORCED;
+ALTER TABLE c.db.t ADD PRIMARY KEY (id) NOT ENFORCED;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -207,6 +207,13 @@ class TestOptimizer(unittest.TestCase):
             catalog="c",
         )
 
+        self.assertEqual(
+            optimizer.qualify_tables.qualify_tables(
+                parse_one("alter table b.c add primary key (id) not enforced"), catalog="a"
+            ).sql(),
+            "ALTER TABLE a.b.c ADD PRIMARY KEY (id) NOT ENFORCED",
+        )
+
     def test_normalize(self):
         self.assertEqual(
             optimizer.normalize.normalize(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -207,13 +207,6 @@ class TestOptimizer(unittest.TestCase):
             catalog="c",
         )
 
-        self.assertEqual(
-            optimizer.qualify_tables.qualify_tables(
-                parse_one("alter table b.c add primary key (id) not enforced"), catalog="a"
-            ).sql(),
-            "ALTER TABLE a.b.c ADD PRIMARY KEY (id) NOT ENFORCED",
-        )
-
     def test_normalize(self):
         self.assertEqual(
             optimizer.normalize.normalize(


### PR DESCRIPTION
As per discussion. We should qualify these table references if passed that particular expression type.