### PR TITLE
Feat: make the CREATE parser more lenient

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -286,6 +286,7 @@ class Postgres(Dialect):
             **parser.Parser.PROPERTY_PARSERS,
             "SET": lambda self: self.expression(exp.SetConfigProperty, this=self._parse_set()),
         }
+        PROPERTY_PARSERS.pop("INPUT", None)
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1449,6 +1449,9 @@ class Parser(metaclass=_Parser):
                     exp.Clone, this=self._parse_table(schema=True), shallow=shallow, copy=copy
                 )
 
+        if self._curr:
+            return self._parse_as_command(start)
+
         return self.expression(
             exp.Create,
             comments=comments,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -600,6 +600,13 @@ class TestPostgres(Validator):
         self.validate_identity("CREATE FUNCTION x(INT) RETURNS INT SET search_path = 'public'")
         self.validate_identity("CREATE FUNCTION x(INT) RETURNS INT SET foo FROM CURRENT")
         self.validate_identity(
+            "CREATE FUNCTION add(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT"
+        )
+        self.validate_identity(
+            "CREATE FUNCTION add(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE STRICT"
+        )
+
+        self.validate_identity(
             "CREATE CONSTRAINT TRIGGER my_trigger AFTER INSERT OR DELETE OR UPDATE OF col_a, col_b ON public.my_table DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION do_sth()"
         )
         self.validate_identity(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -603,9 +603,11 @@ class TestPostgres(Validator):
             "CREATE FUNCTION add(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE RETURNS NULL ON NULL INPUT"
         )
         self.validate_identity(
+            "CREATE FUNCTION add(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE CALLED ON NULL INPUT"
+        )
+        self.validate_identity(
             "CREATE FUNCTION add(integer, integer) RETURNS integer AS 'select $1 + $2;' LANGUAGE SQL IMMUTABLE STRICT"
         )
-
         self.validate_identity(
             "CREATE CONSTRAINT TRIGGER my_trigger AFTER INSERT OR DELETE OR UPDATE OF col_a, col_b ON public.my_table DEFERRABLE INITIALLY DEFERRED FOR EACH ROW EXECUTE FUNCTION do_sth()"
         )


### PR DESCRIPTION
This basically allows the create parser to produce a `Command` when it hasn't consumed the whole token stream, meaning that we'll avoid raising `ParseError`s when e.g. unknown table properties are encountered. Instead, we'll simply accept whatever the user supplies, store it as a string and when https://github.com/tobymao/sqlglot/pull/2874 is in, emit a warning to let them know.

The motivation is to avoid having to add first-class support for DDL clauses that may be too engine-specific and not transpilable. Of course, if we ever need to transpile or switch off specific props or analyze the AST, we'll still have to implement parsing and generation logic for the corresponding properties, but hopefully we should not need that often.