### PR TITLE
Fix(duckdb): fix JSON pointer path parsing, reduce warning noise

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -444,7 +444,7 @@ class Dialect(metaclass=_Dialect):
 
         return expression
 
-    def parse_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+    def to_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
         if isinstance(path, exp.Literal):
             path_text = path.name
             if path.is_number:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import typing as t
 from enum import Enum, auto
 from functools import reduce
@@ -8,7 +9,7 @@ from sqlglot import exp
 from sqlglot.errors import ParseError
 from sqlglot.generator import Generator
 from sqlglot.helper import AutoName, flatten, is_int, seq_get
-from sqlglot.jsonpath import generate as generate_json_path
+from sqlglot.jsonpath import generate as generate_json_path, parse as parse_json_path
 from sqlglot.parser import Parser
 from sqlglot.time import TIMEZONES, format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
@@ -19,6 +20,8 @@ DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TsOrDsAdd, exp.DateSub]
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import B, E
+
+logger = logging.getLogger("sqlglot")
 
 
 class Dialects(str, Enum):
@@ -440,6 +443,19 @@ class Dialect(metaclass=_Dialect):
             )
 
         return expression
+
+    def parse_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+        if isinstance(path, exp.Literal):
+            path_text = path.name
+            if path.is_number:
+                path_text = f"[{path_text}]"
+
+            try:
+                return exp.JSONPath(expressions=parse_json_path(path_text))
+            except ParseError:
+                logger.warning(f"Invalid JSON path syntax: {path_text}")
+
+        return path
 
     def parse(self, sql: str, **opts) -> t.List[t.Optional[exp.Expression]]:
         return self.parser(**opts).parse(self.tokenize(sql), sql)

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -171,7 +171,7 @@ class DuckDB(Dialect):
     # https://duckdb.org/docs/sql/introduction.html#creating-a-new-table
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
 
-    def parse_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+    def to_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
         if isinstance(path, exp.Literal):
             # DuckDB also supports the JSON pointer syntax, where every path starts with a `/`.
             # Additionally, it allows accessing the back of lists using the `[#-i]` syntax.
@@ -181,7 +181,7 @@ class DuckDB(Dialect):
             if path_text.startswith("/") or "[#" in path_text:
                 return path
 
-        return super().parse_json_path(path)
+        return super().to_json_path(path)
 
     class Tokenizer(tokens.Tokenizer):
         KEYWORDS = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -63,7 +63,7 @@ def parse_logarithm(args: t.List, dialect: Dialect) -> exp.Func:
 def parse_extract_json_with_path(expr_type: t.Type[E]) -> t.Callable[[t.List, Dialect], E]:
     def _parser(args: t.List, dialect: Dialect) -> E:
         expression = expr_type(
-            this=seq_get(args, 0), expression=dialect.parse_json_path(seq_get(args, 1))
+            this=seq_get(args, 0), expression=dialect.to_json_path(seq_get(args, 1))
         )
         if len(args) > 2 and expr_type is exp.JSONExtract:
             expression.set("expressions", args[2:])
@@ -546,12 +546,12 @@ class Parser(metaclass=_Parser):
         TokenType.ARROW: lambda self, this, path: self.expression(
             exp.JSONExtract,
             this=this,
-            expression=self.dialect.parse_json_path(path),
+            expression=self.dialect.to_json_path(path),
         ),
         TokenType.DARROW: lambda self, this, path: self.expression(
             exp.JSONExtractScalar,
             this=this,
-            expression=self.dialect.parse_json_path(path),
+            expression=self.dialect.to_json_path(path),
         ),
         TokenType.HASH_ARROW: lambda self, this, path: self.expression(
             exp.JSONBExtract,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -89,6 +89,14 @@ class TestDuckDB(Validator):
                 },
             )
 
+        self.validate_identity("""SELECT '{"duck": [1, 2, 3]}' -> '$.duck[#-1]'""")
+        self.validate_all(
+            """SELECT JSON_EXTRACT('{"duck": [1, 2, 3]}', '/duck/0')""",
+            write={
+                "": """SELECT JSON_EXTRACT('{"duck": [1, 2, 3]}', '/duck/0')""",
+                "duckdb": """SELECT '{"duck": [1, 2, 3]}' -> '/duck/0'""",
+            },
+        )
         self.validate_all(
             """SELECT JSON('{"fruit":"banana"}') -> 'fruit'""",
             write={


### PR DESCRIPTION
This addresses two issues:

1. Right now, we parse DuckDB's JSON pointer paths incorrectly, and as a result we also clutter them at generation time:

```python
>>> import sqlglot
>>> print(sqlglot.transpile("""SELECT json_extract('{"duck": [1, 2, 3]}', '/duck/0');""", "duckdb")[0])
SELECT '{"duck": [1, 2, 3]}' -> '$["/duck/0"]'
```

2. DuckDB supports a variant of the [JSONPath](https://support.smartbear.com/alertsite/docs/monitors/api/endpoint/jsonpath.html) syntax spec, where one can access elements from the back of an array using the following syntax:

```sql
SELECT json_extract('{"duck": [1, 2, 3]}', '$.duck[#-1]');
-- 3
```

We currently emit a warning when encountering paths like this which can be noisy, since DuckDB users will probably expect this to _parse normally_.