### PR TITLE
Refactor!: deprecate case where transforms can be plain strs

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -699,8 +699,6 @@ class Generator(metaclass=_Generator):
 
         if callable(transform):
             sql = transform(self, expression)
-        elif transform:
-            sql = transform
         elif isinstance(expression, exp.Expression):
             exp_handler_name = f"{expression.key}_sql"
 


### PR DESCRIPTION
This path isn't ever reached and to my understanding it's very old code; I believe the intention was to allow strings too, but we never really did that, it seems. Thought I'd clean it up so it's clear we can only have callables in `TRANSFORMS`.