### PR TITLE
fix: have table exclude this if schema target

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -457,8 +457,10 @@ class BigQuery(Dialect):
 
             return this
 
-        def _parse_table_parts(self, schema: bool = False) -> exp.Table:
-            table = super()._parse_table_parts(schema=schema)
+        def _parse_table_parts(
+            self, schema: bool = False, is_db_reference: bool = False
+        ) -> exp.Table:
+            table = super()._parse_table_parts(schema=schema, is_db_reference=is_db_reference)
             if isinstance(table.this, exp.Identifier) and "." in table.name:
                 catalog, db, this, *rest = (
                     t.cast(t.Optional[exp.Expression], exp.to_identifier(x))

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -354,9 +354,14 @@ class ClickHouse(Dialect):
             joins: bool = False,
             alias_tokens: t.Optional[t.Collection[TokenType]] = None,
             parse_bracket: bool = False,
+            is_db_reference: bool = False,
         ) -> t.Optional[exp.Expression]:
             this = super()._parse_table(
-                schema=schema, joins=joins, alias_tokens=alias_tokens, parse_bracket=parse_bracket
+                schema=schema,
+                joins=joins,
+                alias_tokens=alias_tokens,
+                parse_bracket=parse_bracket,
+                is_db_reference=is_db_reference,
             )
 
             if self._match(TokenType.FINAL):

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -91,6 +91,7 @@ class Redshift(Postgres):
             joins: bool = False,
             alias_tokens: t.Optional[t.Collection[TokenType]] = None,
             parse_bracket: bool = False,
+            is_db_reference: bool = False,
         ) -> t.Optional[exp.Expression]:
             # Redshift supports UNPIVOTing SUPER objects, e.g. `UNPIVOT foo.obj[0] AS val AT attr`
             unpivot = self._match(TokenType.UNPIVOT)
@@ -99,6 +100,7 @@ class Redshift(Postgres):
                 joins=joins,
                 alias_tokens=alias_tokens,
                 parse_bracket=parse_bracket,
+                is_db_reference=is_db_reference,
             )
 
             return self.expression(exp.Pivot, this=table, unpivot=True) if unpivot else table

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -534,7 +534,9 @@ class Snowflake(Dialect):
 
             return table
 
-        def _parse_table_parts(self, schema: bool = False) -> exp.Table:
+        def _parse_table_parts(
+            self, schema: bool = False, is_db_reference: bool = False
+        ) -> exp.Table:
             # https://docs.snowflake.com/en/user-guide/querying-stage
             if self._match(TokenType.STRING, advance=False):
                 table = self._parse_string()
@@ -550,7 +552,9 @@ class Snowflake(Dialect):
                 self._match(TokenType.L_PAREN)
                 while self._curr and not self._match(TokenType.R_PAREN):
                     if self._match_text_seq("FILE_FORMAT", "=>"):
-                        file_format = self._parse_string() or super()._parse_table_parts()
+                        file_format = self._parse_string() or super()._parse_table_parts(
+                            is_db_reference=is_db_reference
+                        )
                     elif self._match_text_seq("PATTERN", "=>"):
                         pattern = self._parse_string()
                     else:
@@ -560,7 +564,7 @@ class Snowflake(Dialect):
 
                 table = self.expression(exp.Table, this=table, format=file_format, pattern=pattern)
             else:
-                table = super()._parse_table_parts(schema=schema)
+                table = super()._parse_table_parts(schema=schema, is_db_reference=is_db_reference)
 
             return self._parse_at_before(table)
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2571,7 +2571,7 @@ class HistoricalData(Expression):
 
 class Table(Expression):
     arg_types = {
-        "this": True,
+        "this": False,
         "alias": False,
         "db": False,
         "catalog": False,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -805,3 +805,37 @@ class TestParser(unittest.TestCase):
             error_level=ErrorLevel.IGNORE,
         )
         self.assertEqual(ast[0].sql(), "CONCAT_WS()")
+
+    def test_parse_drop_schema(self):
+        for dialect in [None, "bigquery", "snowflake"]:
+            with self.subTest(dialect):
+                ast = parse_one("DROP SCHEMA catalog.schema", dialect=dialect)
+                self.assertEqual(
+                    ast,
+                    exp.Drop(
+                        this=exp.Table(
+                            this=None,
+                            db=exp.Identifier(this="schema", quoted=False),
+                            catalog=exp.Identifier(this="catalog", quoted=False),
+                        ),
+                        kind="SCHEMA",
+                    ),
+                )
+                self.assertEqual(ast.sql(dialect=dialect), "DROP SCHEMA catalog.schema")
+
+    def test_parse_create_schema(self):
+        for dialect in [None, "bigquery", "snowflake"]:
+            with self.subTest(dialect):
+                ast = parse_one("CREATE SCHEMA catalog.schema", dialect=dialect)
+                self.assertEqual(
+                    ast,
+                    exp.Create(
+                        this=exp.Table(
+                            this=None,
+                            db=exp.Identifier(this="schema", quoted=False),
+                            catalog=exp.Identifier(this="catalog", quoted=False),
+                        ),
+                        kind="SCHEMA",
+                    ),
+                )
+                self.assertEqual(ast.sql(dialect=dialect), "CREATE SCHEMA catalog.schema")


### PR DESCRIPTION
Prior to this change table objects which were the target of `CREATE SCHEMA` or `DROP SCHEMA` would set this as the db name and then db as the catalog name (if provided). The rendered SQL is fine but if we call something like `qualify_table` on the expression and try to set a catalog if one does not exist then it will add the catalog when it is not needed since it will see the catalog filed as None when really catalog is set but it is just set in the `db` field. 