### PR TITLE
Feat: improve transpilation of CREATE TABLE LIKE statement

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -614,6 +614,9 @@ class ClickHouse(Dialect):
             "NAMED COLLECTION",
         }
 
+        def likeproperty_sql(self, expression: exp.LikeProperty) -> str:
+            return f"AS {self.sql(expression, 'this')}"
+
         def _any_to_has(
             self,
             expression: exp.EQ | exp.NEQ,

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -569,11 +569,6 @@ def no_trycast_sql(self: Generator, expression: exp.TryCast) -> str:
     return self.cast_sql(expression)
 
 
-def no_properties_sql(self: Generator, expression: exp.Properties) -> str:
-    self.unsupported("Properties unsupported")
-    return ""
-
-
 def no_comment_column_constraint_sql(
     self: Generator, expression: exp.CommentColumnConstraint
 ) -> str:

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -99,6 +99,7 @@ class Drill(Dialect):
         QUERY_HINTS = False
         NVL2_SUPPORTED = False
         LAST_DAY_SUPPORTS_DATE_PART = False
+        SUPPORTS_CREATE_TABLE_LIKE = False
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -332,6 +332,7 @@ class DuckDB(Dialect):
         JSON_KEY_VALUE_PAIR_SEP = ","
         IGNORE_NULLS_IN_FUNC = True
         JSON_PATH_BRACKETED_KEY_SUPPORTED = False
+        SUPPORTS_CREATE_TABLE_LIKE = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
@@ -476,12 +477,6 @@ class DuckDB(Dialect):
         # can be transpiled to DuckDB, so we explicitly override them accordingly
         PROPERTIES_LOCATION[exp.LikeProperty] = exp.Properties.Location.POST_SCHEMA
         PROPERTIES_LOCATION[exp.TemporaryProperty] = exp.Properties.Location.POST_CREATE
-
-        def likeproperty_sql(self, expression: exp.LikeProperty) -> str:
-            if expression.expressions:
-                self.unsupported("Transpilation of LIKE property options is unsupported")
-
-            return f"AS SELECT * FROM {self.sql(expression, 'this')} LIMIT 0"
 
         def timefromparts_sql(self, expression: exp.TimeFromParts) -> str:
             nano = expression.args.get("nano")

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -393,6 +393,7 @@ class Postgres(Dialect):
         SUPPORTS_SELECT_INTO = True
         JSON_TYPE_REQUIRED_FOR_EXTRACTION = True
         SUPPORTS_UNLOGGED_TABLES = True
+        LIKE_PROPERTY_INSIDE_SCHEMA = True
 
         JSON_PATH_MAPPING = {
             exp.JSONPathKey: lambda n, **kwargs: n.name,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -291,6 +291,7 @@ class Presto(Dialect):
         STRUCT_DELIMITER = ("(", ")")
         LIMIT_ONLY_LITERALS = True
         SUPPORTS_SINGLE_ARG_CONCAT = False
+        LIKE_PROPERTY_INSIDE_SCHEMA = True
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -195,11 +195,6 @@ class Redshift(Postgres):
             exp.DataType.Type.VARBINARY: "VARBYTE",
         }
 
-        PROPERTIES_LOCATION = {
-            **Postgres.Generator.PROPERTIES_LOCATION,
-            exp.LikeProperty: exp.Properties.Location.POST_WITH,
-        }
-
         TRANSFORMS = {
             **Postgres.Generator.TRANSFORMS,
             exp.Concat: concat_to_dpipe_sql,

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -91,6 +91,7 @@ class SQLite(Dialect):
         QUERY_HINTS = False
         NVL2_SUPPORTED = False
         JSON_PATH_BRACKETED_KEY_SUPPORTED = False
+        SUPPORTS_CREATE_TABLE_LIKE = False
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,
@@ -151,10 +152,17 @@ class SQLite(Dialect):
             exp.TryCast: no_trycast_sql,
         }
 
+        # SQLite doesn't generally support CREATE TABLE .. properties
+        # https://www.sqlite.org/lang_createtable.html
         PROPERTIES_LOCATION = {
-            k: exp.Properties.Location.UNSUPPORTED
-            for k, v in generator.Generator.PROPERTIES_LOCATION.items()
+            prop: exp.Properties.Location.UNSUPPORTED
+            for prop in generator.Generator.PROPERTIES_LOCATION
         }
+
+        # There are a few exceptions (e.g. temporary tables) which are supported or
+        # can be transpiled to SQLite, so we explicitly override them accordingly
+        PROPERTIES_LOCATION[exp.LikeProperty] = exp.Properties.Location.POST_SCHEMA
+        PROPERTIES_LOCATION[exp.TemporaryProperty] = exp.Properties.Location.POST_CREATE
 
         LIMIT_FETCH = "LIMIT"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1293,7 +1293,7 @@ class Generator(metaclass=_Generator):
         if expression.expressions:
             self.unsupported("Transpilation of LIKE property options is unsupported")
 
-        select = exp.select("*").from_(self.sql(expression, "this")).limit(0)
+        select = exp.select("*").from_(expression.this).limit(0)
         return f"AS {self.sql(select)}"
 
     def fallbackproperty_sql(self, expression: exp.FallbackProperty) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -303,6 +303,12 @@ class Generator(metaclass=_Generator):
     # Whether or not UNLOGGED tables can be created
     SUPPORTS_UNLOGGED_TABLES = False
 
+    # Whether or not the CREATE TABLE LIKE statement is supported
+    SUPPORTS_CREATE_TABLE_LIKE = True
+
+    # Whether or not the LikeProperty needs to be specified inside of the schema clause
+    LIKE_PROPERTY_INSIDE_SCHEMA = False
+
     # Whether or not the JSON extraction operators expect a value of type JSON
     JSON_TYPE_REQUIRED_FOR_EXTRACTION = False
 
@@ -1274,9 +1280,21 @@ class Generator(metaclass=_Generator):
         return f"{property_name}={self.sql(expression, 'this')}"
 
     def likeproperty_sql(self, expression: exp.LikeProperty) -> str:
-        options = " ".join(f"{e.name} {self.sql(e, 'value')}" for e in expression.expressions)
-        options = f" {options}" if options else ""
-        return f"LIKE {self.sql(expression, 'this')}{options}"
+        if self.SUPPORTS_CREATE_TABLE_LIKE:
+            options = " ".join(f"{e.name} {self.sql(e, 'value')}" for e in expression.expressions)
+            options = f" {options}" if options else ""
+
+            like = f"LIKE {self.sql(expression, 'this')}{options}"
+            if self.LIKE_PROPERTY_INSIDE_SCHEMA and not isinstance(expression.parent, exp.Schema):
+                like = f"({like})"
+
+            return like
+
+        if expression.expressions:
+            self.unsupported("Transpilation of LIKE property options is unsupported")
+
+        select = exp.select("*").from_(self.sql(expression, "this")).limit(0)
+        return f"AS {self.sql(select)}"
 
     def fallbackproperty_sql(self, expression: exp.FallbackProperty) -> str:
         no = "NO " if expression.args.get("no") else ""

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -378,6 +378,31 @@ class TestDialect(Validator):
             read={"postgres": "INET '127.0.0.1/32'"},
         )
 
+    def test_ddl(self):
+        self.validate_all(
+            "CREATE TABLE a LIKE b",
+            write={
+                "": "CREATE TABLE a LIKE b",
+                "bigquery": "CREATE TABLE a LIKE b",
+                "clickhouse": "CREATE TABLE a AS b",
+                "databricks": "CREATE TABLE a LIKE b",
+                "doris": "CREATE TABLE a LIKE b",
+                "drill": "CREATE TABLE a AS SELECT * FROM b LIMIT 0",
+                "duckdb": "CREATE TABLE a AS SELECT * FROM b LIMIT 0",
+                "hive": "CREATE TABLE a LIKE b",
+                "mysql": "CREATE TABLE a LIKE b",
+                "oracle": "CREATE TABLE a LIKE b",
+                "postgres": "CREATE TABLE a (LIKE b)",
+                "presto": "CREATE TABLE a (LIKE b)",
+                "redshift": "CREATE TABLE a (LIKE b)",
+                "snowflake": "CREATE TABLE a LIKE b",
+                "spark": "CREATE TABLE a LIKE b",
+                "sqlite": "CREATE TABLE a AS SELECT * FROM b LIMIT 0",
+                "trino": "CREATE TABLE a (LIKE b)",
+                "tsql": "SELECT TOP 0 * INTO a FROM b AS temp",
+            },
+        )
+
     def test_heredoc_strings(self):
         for dialect in ("clickhouse", "postgres", "redshift"):
             # Invalid matching tag

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -481,16 +481,26 @@ FROM (
         )
 
     def test_create_table_like(self):
+        self.validate_identity(
+            "CREATE TABLE SOUP (LIKE other_table) DISTKEY(soup1) SORTKEY(soup2) DISTSTYLE ALL"
+        )
+
         self.validate_all(
-            "CREATE TABLE t1 LIKE t2",
+            "CREATE TABLE t1 (LIKE t2)",
             write={
+                "postgres": "CREATE TABLE t1 (LIKE t2)",
+                "presto": "CREATE TABLE t1 (LIKE t2)",
                 "redshift": "CREATE TABLE t1 (LIKE t2)",
+                "trino": "CREATE TABLE t1 (LIKE t2)",
             },
         )
         self.validate_all(
-            "CREATE TABLE SOUP (LIKE other_table) DISTKEY(soup1) SORTKEY(soup2) DISTSTYLE ALL",
+            "CREATE TABLE t1 (col VARCHAR, LIKE t2)",
             write={
-                "redshift": "CREATE TABLE SOUP (LIKE other_table) DISTKEY(soup1) SORTKEY(soup2) DISTSTYLE ALL",
+                "postgres": "CREATE TABLE t1 (col VARCHAR, LIKE t2)",
+                "presto": "CREATE TABLE t1 (col VARCHAR, LIKE t2)",
+                "redshift": "CREATE TABLE t1 (col VARCHAR, LIKE t2)",
+                "trino": "CREATE TABLE t1 (col VARCHAR, LIKE t2)",
             },
         )
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1055,13 +1055,6 @@ WHERE
         )
 
         self.validate_all(
-            "CREATE TABLE t2 LIKE t1",
-            write={
-                "duckdb": "CREATE TABLE t2 AS SELECT * FROM t1 LIMIT 0",
-                "snowflake": "CREATE TABLE t2 LIKE t1",
-            },
-        )
-        self.validate_all(
             "CREATE TABLE orders_clone CLONE orders",
             read={
                 "bigquery": "CREATE TABLE orders_clone CLONE orders",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1055,6 +1055,13 @@ WHERE
         )
 
         self.validate_all(
+            "CREATE TABLE t2 LIKE t1",
+            write={
+                "duckdb": "CREATE TABLE t2 AS SELECT * FROM t1 LIMIT 0",
+                "snowflake": "CREATE TABLE t2 LIKE t1",
+            },
+        )
+        self.validate_all(
             "CREATE TABLE orders_clone CLONE orders",
             read={
                 "bigquery": "CREATE TABLE orders_clone CLONE orders",

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -10,11 +10,9 @@ class TestSQLite(Validator):
         self.validate_identity("INSERT OR IGNORE INTO foo (x, y) VALUES (1, 2)")
         self.validate_identity("INSERT OR REPLACE INTO foo (x, y) VALUES (1, 2)")
         self.validate_identity("INSERT OR ROLLBACK INTO foo (x, y) VALUES (1, 2)")
+        self.validate_identity("CREATE TABLE foo (id INTEGER PRIMARY KEY ASC)")
+        self.validate_identity("CREATE TEMPORARY TABLE foo (id INTEGER)")
 
-        self.validate_all(
-            "CREATE TABLE foo (id INTEGER PRIMARY  KEY ASC)",
-            write={"sqlite": "CREATE TABLE foo (id INTEGER PRIMARY KEY ASC)"},
-        )
         self.validate_all(
             """
             CREATE TABLE "Track"


### PR DESCRIPTION
Fixes #2922

We can probably transfer this logic to the base generator and control it with a flag, so other dialects besides duckdb can leverage it. Can open a separate PR for it later or do it here, just need a bit more time to investigate.