### PR TITLE
Feat(clickhouse): add support for JSONExtractString, clean up some helpers

### DIFF
--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -13,4 +13,5 @@ if t.TYPE_CHECKING:
 A = t.TypeVar("A", bound=t.Any)
 B = t.TypeVar("B", bound="sqlglot.exp.Binary")
 E = t.TypeVar("E", bound="sqlglot.exp.Expression")
+F = t.TypeVar("F", bound="sqlglot.exp.Func")
 T = t.TypeVar("T")

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -21,6 +21,9 @@ DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TsOrDsAdd, exp.DateSub]
 if t.TYPE_CHECKING:
     from sqlglot._typing import B, E
 
+    F = t.TypeVar("F", bound="exp.Func")
+    JSON_EXTRACT_TYPE = t.Union[exp.JSONExtract, exp.JSONExtractScalar]
+
 logger = logging.getLogger("sqlglot")
 
 
@@ -517,9 +520,7 @@ def if_sql(
     return _if_sql
 
 
-def arrow_json_extract_sql(
-    self: Generator, expression: exp.JSONExtract | exp.JSONExtractScalar
-) -> str:
+def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
     this = expression.this
     if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
         this.replace(exp.cast(this, "json"))
@@ -1011,42 +1012,57 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
 
 
 def parse_json_extract_path(
-    expr_type: t.Type[E],
-    supports_null_if_invalid: bool = False,
-) -> t.Callable[[t.List], E]:
-    def _parse_json_extract_path(args: t.List) -> E:
-        null_if_invalid = None
-
+    expr_type: t.Type[F], zero_based_indexing: bool = True
+) -> t.Callable[[t.List], F]:
+    def _parse_json_extract_path(args: t.List) -> F:
         segments: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
         for arg in args[1:]:
-            if isinstance(arg, exp.Literal):
-                text = arg.name
-                if is_int(text):
-                    segments.append(exp.JSONPathSubscript(this=int(text)))
-                else:
-                    segments.append(exp.JSONPathKey(this=text))
-            elif supports_null_if_invalid:
-                null_if_invalid = arg
+            if not isinstance(arg, exp.Literal):
+                # We use the fallback parser because we can't really transpile non-literals safely
+                return expr_type.from_arg_list(args)
 
-        this = seq_get(args, 0)
-        jsonpath = exp.JSONPath(expressions=segments)
+            text = arg.name
+            if is_int(text):
+                index = int(text)
+                segments.append(
+                    exp.JSONPathSubscript(this=index if zero_based_indexing else index - 1)
+                )
+            else:
+                segments.append(exp.JSONPathKey(this=text))
 
         # This is done to avoid failing in the expression validator due to the arg count
         del args[2:]
-
-        if expr_type is exp.JSONExtractScalar:
-            return expr_type(this=this, expression=jsonpath, null_if_invalid=null_if_invalid)
-
-        return expr_type(this=this, expression=jsonpath)
+        return expr_type(this=seq_get(args, 0), expression=exp.JSONPath(expressions=segments))
 
     return _parse_json_extract_path
 
 
-def json_path_segments(self: Generator, expression: exp.JSONPath) -> t.List[str]:
-    segments = []
-    for segment in expression.expressions:
-        path = self.sql(segment)
-        if path:
-            segments.append(f"{self.dialect.QUOTE_START}{path}{self.dialect.QUOTE_END}")
+def json_extract_segments(
+    name: str, quoted_index: bool = True
+) -> t.Callable[[Generator, JSON_EXTRACT_TYPE], str]:
+    def _json_extract_segments(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
+        path = expression.expression
+        if not isinstance(path, exp.JSONPath):
+            return rename_func(name)(self, expression)
 
-    return segments
+        segments = []
+        for segment in path.expressions:
+            path = self.sql(segment)
+            if path:
+                if isinstance(segment, exp.JSONPathPart) and (
+                    quoted_index or not isinstance(segment, exp.JSONPathSubscript)
+                ):
+                    path = f"{self.dialect.QUOTE_START}{path}{self.dialect.QUOTE_END}"
+
+                segments.append(path)
+
+        return self.func(name, expression.this, *segments)
+
+    return _json_extract_segments
+
+
+def json_path_key_only_name(self: Generator, expression: exp.JSONPathKey) -> str:
+    if isinstance(expression.this, exp.JSONPathWildcard):
+        self.unsupported("Unsupported wildcard in JSONPathKey expression")
+
+    return expression.name

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -19,9 +19,8 @@ DATE_ADD_OR_DIFF = t.Union[exp.DateAdd, exp.TsOrDsAdd, exp.DateDiff, exp.TsOrDsD
 DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TsOrDsAdd, exp.DateSub]
 
 if t.TYPE_CHECKING:
-    from sqlglot._typing import B, E
+    from sqlglot._typing import B, E, F
 
-    F = t.TypeVar("F", bound="exp.Func")
     JSON_EXTRACT_TYPE = t.Union[exp.JSONExtract, exp.JSONExtractScalar]
 
 logger = logging.getLogger("sqlglot")

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -9,7 +9,7 @@ from sqlglot.errors import ExecuteError
 from sqlglot.executor.context import Context
 from sqlglot.executor.env import ENV
 from sqlglot.executor.table import RowReader, Table
-from sqlglot.helper import csv_reader, subclasses
+from sqlglot.helper import csv_reader, ensure_list, subclasses
 
 
 class PythonExecutor:
@@ -368,7 +368,7 @@ def _rename(self, e):
 
         if isinstance(e, exp.Func) and e.is_var_len_args:
             *head, tail = values
-            return self.func(e.key, *head, *tail)
+            return self.func(e.key, *head, *ensure_list(tail))
 
         return self.func(e.key, *values)
     except Exception as ex:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5017,10 +5017,9 @@ class JSONBContains(Binary):
 
 
 class JSONExtract(Binary, Func):
-    # MySQL and SQLite support a variant of JSON_EXTRACT where you can have multiple JSON
-    # paths and you get back a list of values. These paths will be stored in `expressions`
     arg_types = {"this": True, "expression": True, "expressions": False}
     _sql_names = ["JSON_EXTRACT"]
+    is_var_len_args = True
 
     @property
     def output_name(self) -> str:
@@ -5028,8 +5027,9 @@ class JSONExtract(Binary, Func):
 
 
 class JSONExtractScalar(Binary, Func):
-    arg_types = {"this": True, "expression": True, "null_if_invalid": False}
+    arg_types = {"this": True, "expression": True, "expressions": False}
     _sql_names = ["JSON_EXTRACT_SCALAR"]
+    is_var_len_args = True
 
     @property
     def output_name(self) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3851,12 +3851,14 @@ class Parser(metaclass=_Parser):
         return self.expression(exp.AtTimeZone, this=this, zone=self._parse_unary())
 
     def _parse_column(self) -> t.Optional[exp.Expression]:
+        this = self._parse_column_reference()
+        return self._parse_column_ops(this) if this else self._parse_bracket(this)
+
+    def _parse_column_reference(self) -> t.Optional[exp.Expression]:
         this = self._parse_field()
         if isinstance(this, exp.Identifier):
             this = self.expression(exp.Column, this=this)
-        elif not this:
-            return self._parse_bracket(this)
-        return self._parse_column_ops(this)
+        return this
 
     def _parse_column_ops(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
         this = self._parse_bracket(this)
@@ -3870,13 +3872,11 @@ class Parser(metaclass=_Parser):
                 if not field:
                     self.raise_error("Expected type")
             elif op and self._curr:
-                self._advance()
-                value = self._prev.text
-                field = (
-                    exp.Literal.number(value)
-                    if self._prev.token_type == TokenType.NUMBER
-                    else exp.Literal.string(value)
-                )
+                if self._curr.token_type == TokenType.NUMBER:
+                    self._advance()
+                    field = exp.Literal.number(self._prev.text)
+                else:
+                    field = self._parse_column_reference()
             else:
                 field = self._parse_field(anonymous_func=True, any_token=True)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3872,11 +3872,7 @@ class Parser(metaclass=_Parser):
                 if not field:
                     self.raise_error("Expected type")
             elif op and self._curr:
-                if self._curr.token_type == TokenType.NUMBER:
-                    self._advance()
-                    field = exp.Literal.number(self._prev.text)
-                else:
-                    field = self._parse_column_reference()
+                field = self._parse_column_reference()
             else:
                 field = self._parse_field(anonymous_func=True, any_token=True)
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -74,6 +74,10 @@ class TestClickhouse(Validator):
         self.validate_identity("CAST(x AS DATETIME)")
         self.validate_identity("CAST(x as MEDIUMINT)", "CAST(x AS Int32)")
         self.validate_identity("SELECT arrayJoin([1, 2, 3] AS src) AS dst, 'Hello', src")
+        self.validate_identity("""SELECT JSONExtractString('{"x": {"y": 1}}', 'x', 'y')""")
+        self.validate_identity(
+            """SELECT JSONExtractString('{"a": "hello", "b": [-100, 200.0, 300]}', 'a')"""
+        )
         self.validate_identity(
             "ATTACH DATABASE DEFAULT ENGINE = ORDINARY", check_command_warning=True
         )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1126,6 +1126,7 @@ class TestDialect(Validator):
             write={
                 "": """JSON_EXTRACT(x, '$["a b"]')""",
                 "bigquery": """JSON_EXTRACT(x, '$[\\'a b\\']')""",
+                "clickhouse": "JSONExtractString(x, 'a b')",
                 "duckdb": """x -> '$."a b"'""",
                 "mysql": """JSON_EXTRACT(x, '$."a b"')""",
                 "postgres": "JSON_EXTRACT_PATH(x, 'a b')",
@@ -1153,6 +1154,7 @@ class TestDialect(Validator):
             },
             write={
                 "bigquery": "JSON_EXTRACT(x, '$.y')",
+                "clickhouse": "JSONExtractString(x, 'y')",
                 "doris": "x -> '$.y'",
                 "duckdb": "x -> '$.y'",
                 "mysql": "JSON_EXTRACT(x, '$.y')",
@@ -1170,6 +1172,7 @@ class TestDialect(Validator):
             "JSON_EXTRACT_SCALAR(x, '$.y')",
             read={
                 "bigquery": "JSON_EXTRACT_SCALAR(x, '$.y')",
+                "clickhouse": "JSONExtractString(x, 'y')",
                 "duckdb": "x ->> 'y'",
                 "postgres": "x ->> 'y'",
                 "presto": "JSON_EXTRACT_SCALAR(x, '$.y')",
@@ -1180,6 +1183,7 @@ class TestDialect(Validator):
             },
             write={
                 "bigquery": "JSON_EXTRACT_SCALAR(x, '$.y')",
+                "clickhouse": "JSONExtractString(x, 'y')",
                 "duckdb": "x ->> '$.y'",
                 "postgres": "JSON_EXTRACT_PATH_TEXT(x, 'y')",
                 "presto": "JSON_EXTRACT_SCALAR(x, '$.y')",
@@ -1204,6 +1208,7 @@ class TestDialect(Validator):
             },
             write={
                 "bigquery": "JSON_EXTRACT(x, '$.y[0].z')",
+                "clickhouse": "JSONExtractString(x, 'y', 1, 'z')",
                 "doris": "x -> '$.y[0].z'",
                 "duckdb": "x -> '$.y[0].z'",
                 "mysql": "JSON_EXTRACT(x, '$.y[0].z')",
@@ -1222,6 +1227,7 @@ class TestDialect(Validator):
             "JSON_EXTRACT_SCALAR(x, '$.y[0].z')",
             read={
                 "bigquery": "JSON_EXTRACT_SCALAR(x, '$.y[0].z')",
+                "clickhouse": "JSONExtractString(x, 'y', 1, 'z')",
                 "duckdb": "x ->> '$.y[0].z'",
                 "presto": "JSON_EXTRACT_SCALAR(x, '$.y[0].z')",
                 "snowflake": "JSON_EXTRACT_PATH_TEXT(x, 'y[0].z')",
@@ -1230,6 +1236,7 @@ class TestDialect(Validator):
             },
             write={
                 "bigquery": "JSON_EXTRACT_SCALAR(x, '$.y[0].z')",
+                "clickhouse": "JSONExtractString(x, 'y', 1, 'z')",
                 "duckdb": "x ->> '$.y[0].z'",
                 "postgres": "JSON_EXTRACT_PATH_TEXT(x, 'y', '0', 'z')",
                 "presto": "JSON_EXTRACT_SCALAR(x, '$.y[0].z')",
@@ -1244,6 +1251,7 @@ class TestDialect(Validator):
             "JSON_EXTRACT(x, '$.y[*]')",
             write={
                 "bigquery": UnsupportedError,
+                "clickhouse": UnsupportedError,
                 "duckdb": "x -> '$.y[*]'",
                 "mysql": "JSON_EXTRACT(x, '$.y[*]')",
                 "postgres": UnsupportedError,
@@ -1259,6 +1267,7 @@ class TestDialect(Validator):
             "JSON_EXTRACT(x, '$.y[*]')",
             write={
                 "bigquery": "JSON_EXTRACT(x, '$.y')",
+                "clickhouse": "JSONExtractString(x, 'y')",
                 "postgres": "JSON_EXTRACT_PATH(x, 'y')",
                 "redshift": "JSON_EXTRACT_PATH_TEXT(x, 'y')",
                 "snowflake": "GET_PATH(x, 'y')",
@@ -1270,6 +1279,7 @@ class TestDialect(Validator):
             "JSON_EXTRACT(x, '$.y.*')",
             write={
                 "bigquery": UnsupportedError,
+                "clickhouse": UnsupportedError,
                 "duckdb": "x -> '$.y.*'",
                 "mysql": "JSON_EXTRACT(x, '$.y.*')",
                 "postgres": UnsupportedError,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -41,6 +41,7 @@ class TestDuckDB(Validator):
         )
         self.validate_identity("SELECT 1 WHERE x > $1")
         self.validate_identity("SELECT 1 WHERE x > $name")
+        self.validate_identity("""SELECT '{"x": 1}' -> c FROM t""")
 
         self.assertEqual(
             parse_one("select * from t limit (select 5)").sql(dialect="duckdb"),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -319,6 +319,18 @@ class TestPostgres(Validator):
         )
 
         self.validate_all(
+            "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",
+            read={
+                "clickhouse": "SELECT JSONExtractString(x, k1, k2, k3) FROM t",
+                "redshift": "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",
+            },
+            write={
+                "clickhouse": "SELECT JSONExtractString(x, k1, k2, k3) FROM t",
+                "postgres": "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",
+                "redshift": "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",
+            },
+        )
+        self.validate_all(
             "x #> 'y'",
             read={
                 "": "JSONB_EXTRACT(x, 'y')",

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -306,6 +306,9 @@ class TestRedshift(Validator):
         self.validate_identity("SELECT APPROXIMATE AS y")
         self.validate_identity("CREATE TABLE t (c BIGINT IDENTITY(0, 1))")
         self.validate_identity(
+            """SELECT JSON_EXTRACT_PATH_TEXT('{"f2":{"f3":1},"f4":{"f5":99,"f6":"star"}', 'f4', 'f6', TRUE)"""
+        )
+        self.validate_identity(
             "SELECT CONCAT('abc', 'def')",
             "SELECT 'abc' || 'def'",
         )

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -71,7 +71,7 @@ class TestSQLite(Validator):
         self.validate_identity("SELECT UNIXEPOCH('now', 'subsec')")
         self.validate_identity("SELECT TIMEDIFF('now', '1809-02-12')")
         self.validate_identity(
-            "SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[2]', '$[0]')",
+            "SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[2]', '$[0]', '$[1]')",
         )
         self.validate_identity(
             """SELECT item AS "item", some AS "some" FROM data WHERE (item = 'value_1' COLLATE NOCASE) AND (some = 't' COLLATE NOCASE) ORDER BY item ASC LIMIT 1 OFFSET 0"""


### PR DESCRIPTION
Several changes here, not necessarily related to each other:

- Improve parsing / transpilation of clickhouse's `JSONExtractString`, fixes https://github.com/tobymao/sqlglot/issues/2051. Note that clickhouse uses 1-based indexing, so I had to slightly change the logic in some parts to take this into account. Perhaps and interesting observation here is that the dialect offset is not necessarily tied to the JSON path offset.
- Refactored some helpers that concern JSON path parsing and generation and are used by clickhouse, postgres, redshift.
- Fixed some issues related to columns being used in json paths (supported by clickhouse, duckdb, postgres). This involved a change that may need some attention in the parser (I split `_parse_column` into two methods, can elaborate if needed).
- Finally, fixed an issue with multi-arg `JSON_EXTRACT` calls. It turns out that I had a bug in my implementation and so previously we'd support up to 3 arguments because of the `null_if_invalid` flag, but 4 would fail. I extended both `JSONExtract` and `JSONExtractScalar` to accept arbitrarily many args to amend this.

References:
- https://clickhouse.com/docs/en/sql-reference/functions/json-functions
- https://docs.aws.amazon.com/redshift/latest/dg/JSON_EXTRACT_PATH_TEXT.html