### PR TITLE
Feat(clickhouse): add support for LIMIT BY clause

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1796,7 +1796,7 @@ class Lambda(Expression):
 
 
 class Limit(Expression):
-    arg_types = {"this": False, "expression": True, "offset": False}
+    arg_types = {"this": False, "expression": True, "offset": False, "expressions": False}
 
 
 class Literal(Condition):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1841,7 +1841,10 @@ class Generator(metaclass=_Generator):
 
         args_sql = ", ".join(self.sql(e) for e in args)
         args_sql = f"({args_sql})" if any(top and not e.is_number for e in args) else args_sql
-        return f"{this}{self.seg('TOP' if top else 'LIMIT')} {args_sql}"
+        expressions = self.expressions(expression, flat=True)
+        expressions = f" BY {expressions}" if expressions else ""
+
+        return f"{this}{self.seg('TOP' if top else 'LIMIT')} {args_sql}{expressions}"
 
     def offset_sql(self, expression: exp.Offset) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3340,8 +3340,18 @@ class Parser(metaclass=_Parser):
             else:
                 offset = None
 
+            if self._match_text_seq("BY"):
+                expressions = self._parse_csv(self._parse_bitwise)
+            else:
+                expressions = None
+
             limit_exp = self.expression(
-                exp.Limit, this=this, expression=expression, offset=offset, comments=comments
+                exp.Limit,
+                this=this,
+                expression=expression,
+                offset=offset,
+                comments=comments,
+                expressions=expressions,
             )
 
             return limit_exp

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -76,6 +76,9 @@ class TestClickhouse(Validator):
         self.validate_identity("SELECT arrayJoin([1, 2, 3] AS src) AS dst, 'Hello', src")
         self.validate_identity("""SELECT JSONExtractString('{"x": {"y": 1}}', 'x', 'y')""")
         self.validate_identity(
+            "SELECT * FROM table LIMIT 1 BY CONCAT(datalayerVariantNo, datalayerProductId, warehouse)"
+        )
+        self.validate_identity(
             """SELECT JSONExtractString('{"a": "hello", "b": [-100, 200.0, 300]}', 'a')"""
         )
         self.validate_identity(


### PR DESCRIPTION
Addresses https://tobiko-data.slack.com/archives/C0448SFS3PF/p1707220020280219.

Based on https://clickhouse.com/docs/en/sql-reference/statements/select/limit-by, it seems like we can also have

```sql
LIMIT n OFFSET offset_value BY expressions
```

This PR doesn't handle this version properly, at least not yet. I wasn't sure how we wanna do this, provided that `OFFSET` is treated as a separate modifier. Should we just add an `expressions` arg to `exp.Offset` and do something similar in its parser / generator?