### PR TITLE
Fix: remove find method from Schema

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -106,19 +106,6 @@ class Schema(abc.ABC):
         name = column if isinstance(column, str) else column.name
         return name in self.column_names(table, dialect=dialect, normalize=normalize)
 
-    @abc.abstractmethod
-    def find(self, table: exp.Table, raise_on_missing: bool = True) -> t.Optional[t.Any]:
-        """
-        Returns the schema of a given table.
-
-        Args:
-            table: the target table.
-            raise_on_missing: whether or not to raise in case the schema is not found.
-
-        Returns:
-            The schema of the target table.
-        """
-
     @property
     @abc.abstractmethod
     def supported_table_args(self) -> t.Tuple[str, ...]:
@@ -170,6 +157,16 @@ class AbstractMappingSchema:
         return [table.text(part) for part in exp.TABLE_PARTS if table.text(part)]
 
     def find(self, table: exp.Table, raise_on_missing: bool = True) -> t.Optional[t.Any]:
+        """
+        Returns the schema of a given table.
+
+        Args:
+            table: the target table.
+            raise_on_missing: whether or not to raise in case the schema is not found.
+
+        Returns:
+            The schema of the target table.
+        """
         parts = self.table_parts(table)[0 : len(self.supported_table_args)]
         value, trie = in_trie(self.mapping_trie, parts)
 


### PR DESCRIPTION
Chatted with Barak and realized this method imposes an additional constraint on Schema implementors which is probably unnecessary, so I decided to revert the change and only keep it under `AbstractMappingSchema`.

Context behind the addition of this method: https://github.com/tobymao/sqlglot/pull/2869