### PR TITLE
fix(spark): CREATE TABLE ... PARTITIONED BY fixes

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -654,28 +654,6 @@ def time_format(
     return _time_format
 
 
-def create_with_partitions_sql(self: Generator, expression: exp.Create) -> str:
-    """
-    In Hive and Spark, the PARTITIONED BY property acts as an extension of a table's schema. When the
-    PARTITIONED BY value is an array of column names, they are transformed into a schema. The corresponding
-    columns are removed from the create statement.
-    """
-    has_schema = isinstance(expression.this, exp.Schema)
-    is_partitionable = expression.args.get("kind") in ("TABLE", "VIEW")
-
-    if has_schema and is_partitionable:
-        prop = expression.find(exp.PartitionedByProperty)
-        if prop and prop.this and not isinstance(prop.this, exp.Schema):
-            schema = expression.this
-            columns = {v.name.upper() for v in prop.this.expressions}
-            partitions = [col for col in schema.expressions if col.name.upper() in columns]
-            schema.set("expressions", [e for e in schema.expressions if e not in partitions])
-            prop.replace(exp.PartitionedByProperty(this=exp.Schema(expressions=partitions)))
-            expression.set("this", schema)
-
-    return self.create_sql(expression)
-
-
 def parse_date_delta(
     exp_class: t.Type[E], unit_mapping: t.Optional[t.Dict[str, str]] = None
 ) -> t.Callable[[t.List], E]:

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -5,7 +5,6 @@ import typing as t
 from sqlglot import exp, generator, parser, tokens, transforms
 from sqlglot.dialects.dialect import (
     Dialect,
-    create_with_partitions_sql,
     datestrtodate_sql,
     format_time_lambda,
     no_trycast_sql,
@@ -13,6 +12,7 @@ from sqlglot.dialects.dialect import (
     str_position_sql,
     timestrtotime_sql,
 )
+from sqlglot.transforms import preprocess, move_schema_columns_to_partitioned_by
 
 
 def _date_add_sql(kind: str) -> t.Callable[[Drill.Generator, exp.DateAdd | exp.DateSub], str]:
@@ -125,7 +125,7 @@ class Drill(Dialect):
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.ArrayContains: rename_func("REPEATED_CONTAINS"),
             exp.ArraySize: rename_func("REPEATED_COUNT"),
-            exp.Create: create_with_partitions_sql,
+            exp.Create: preprocess([move_schema_columns_to_partitioned_by]),
             exp.DateAdd: _date_add_sql("ADD"),
             exp.DateStrToDate: datestrtodate_sql,
             exp.DateSub: _date_add_sql("SUB"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1090,6 +1090,11 @@ class Create(DDL):
         "clone": False,
     }
 
+    @property
+    def kind(self) -> t.Optional[str]:
+        kind = self.args.get("kind")
+        return kind and kind.upper()
+
 
 # https://docs.snowflake.com/en/sql-reference/sql/create-clone
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_clone_statement

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -510,7 +510,8 @@ def move_schema_columns_to_partitioned_by(expression: exp.Expression) -> exp.Exp
     """
     assert isinstance(expression, exp.Create)
     has_schema = isinstance(expression.this, exp.Schema)
-    is_partitionable = expression.args.get("kind").upper() in {"TABLE", "VIEW"}
+    kind = expression.args.get("kind")
+    is_partitionable = kind and kind.upper() in {"TABLE", "VIEW"}
 
     if has_schema and is_partitionable:
         prop = expression.find(exp.PartitionedByProperty)

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -487,17 +487,14 @@ def ctas_with_tmp_tables_to_create_tmp_view(
     )
 
     # CTAS with temp tables map to CREATE TEMPORARY VIEW
-    kind = expression.args["kind"]
-    if kind.upper() == "TABLE" and temporary:
+    if expression.kind == "TABLE" and temporary:
         if expression.expression:
             return exp.Create(
                 kind="TEMPORARY VIEW",
                 this=expression.this,
                 expression=expression.expression,
             )
-        else:
-            # CREATE TEMPORARY TABLE may require storage provider
-            return tmp_storage_provider(expression)
+        return tmp_storage_provider(expression)
 
     return expression
 
@@ -510,8 +507,7 @@ def move_schema_columns_to_partitioned_by(expression: exp.Expression) -> exp.Exp
     """
     assert isinstance(expression, exp.Create)
     has_schema = isinstance(expression.this, exp.Schema)
-    kind = expression.args.get("kind")
-    is_partitionable = kind and kind.upper() in {"TABLE", "VIEW"}
+    is_partitionable = expression.kind in {"TABLE", "VIEW"}
 
     if has_schema and is_partitionable:
         prop = expression.find(exp.PartitionedByProperty)

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -152,7 +152,7 @@ class TestHive(Validator):
                 "duckdb": "CREATE TABLE x (w TEXT)",  # Partition columns should exist in table
                 "presto": "CREATE TABLE x (w VARCHAR, y INTEGER, z INTEGER) WITH (PARTITIONED_BY=ARRAY['y', 'z'])",
                 "hive": "CREATE TABLE x (w STRING) PARTITIONED BY (y INT, z INT)",
-                "spark": "CREATE TABLE x (w STRING) PARTITIONED BY (y INT, z INT)",
+                "spark": "CREATE TABLE x (w STRING, y INT, z INT) PARTITIONED BY (y, z)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -424,7 +424,7 @@ class TestPresto(Validator):
                 "duckdb": "CREATE TABLE x (w TEXT, y INT, z INT)",
                 "presto": "CREATE TABLE x (w VARCHAR, y INTEGER, z INTEGER) WITH (PARTITIONED_BY=ARRAY['y', 'z'])",
                 "hive": "CREATE TABLE x (w STRING) PARTITIONED BY (y INT, z INT)",
-                "spark": "CREATE TABLE x (w STRING) PARTITIONED BY (y INT, z INT)",
+                "spark": "CREATE TABLE x (w STRING, y INT, z INT) PARTITIONED BY (y, z)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -93,11 +93,12 @@ TBLPROPERTIES (
   'x'='1'
 )""",
                 "spark": """CREATE TABLE blah (
-  col_a INT
+  col_a INT,
+  date STRING
 )
 COMMENT 'Test comment: blah'
 PARTITIONED BY (
-  date STRING
+  date
 )
 USING ICEBERG
 TBLPROPERTIES (
@@ -123,13 +124,6 @@ TBLPROPERTIES (
             "ALTER TABLE StudentInfo DROP COLUMNS (LastName, DOB)",
             write={
                 "spark": "ALTER TABLE StudentInfo DROP COLUMNS (LastName, DOB)",
-            },
-        )
-        self.validate_all(
-            "CREATE TABLE x USING ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
-            identify=True,
-            write={
-                "spark": "CREATE TABLE `x` USING ICEBERG PARTITIONED BY (MONTHS(`y`)) LOCATION 's3://z'",
             },
         )
 


### PR DESCRIPTION
Spark 3 supports two CREATE TABLE formats:
https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-hiveformat.html
https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-create-table-datasource.html

Some of the spark dialect assumes the former, some assumes the latter, and you can easily end up with an invalid statement.

All this DDL transpilation feels very messy to me... I hated this change.
