### PR TITLE
Feat(sqlite): add support for IIF

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -134,7 +134,6 @@ class Spark2(Hive):
                 ),
                 zone=seq_get(args, 1),
             ),
-            "IIF": exp.If.from_arg_list,
             "INT": _parse_as_cast("int"),
             "MAP_FROM_ARRAYS": exp.Map.from_arg_list,
             "RLIKE": exp.RegexpLike.from_arg_list,

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -132,6 +132,7 @@ class SQLite(Dialect):
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.DateAdd: _date_add_sql,
             exp.DateStrToDate: lambda self, e: self.sql(e, "this"),
+            exp.If: rename_func("IIF"),
             exp.ILike: no_ilike_sql,
             exp.JSONExtract: _json_extract_sql,
             exp.JSONExtractScalar: arrow_json_extract_sql,

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -457,7 +457,6 @@ class TSQL(Dialect):
             "FORMAT": _parse_format,
             "GETDATE": exp.CurrentTimestamp.from_arg_list,
             "HASHBYTES": _parse_hashbytes,
-            "IIF": exp.If.from_arg_list,
             "ISNULL": exp.Coalesce.from_arg_list,
             "JSON_QUERY": parser.parse_extract_json_with_path(exp.JSONExtract),
             "JSON_VALUE": parser.parse_extract_json_with_path(exp.JSONExtractScalar),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4878,6 +4878,7 @@ class Xor(Connector, Func):
 
 class If(Func):
     arg_types = {"this": True, "true": True, "false": False}
+    _sql_names = ["IF", "IIF"]
 
 
 class Nullif(Func):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2101,7 +2101,7 @@ SELECT
                 "databricks": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
                 "presto": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
                 "snowflake": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
-                "sqlite": "SELECT SUM(CASE WHEN col % 2 = 0 THEN 1 ELSE 0 END) FROM foo",
+                "sqlite": "SELECT SUM(IIF(col % 2 = 0, 1, 0)) FROM foo",
                 "tsql": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
             },
         )
@@ -2116,7 +2116,7 @@ SELECT
                 "": "SELECT COUNT_IF(col % 2 = 0) FILTER(WHERE col < 1000) FROM foo",
                 "databricks": "SELECT COUNT_IF(col % 2 = 0) FILTER(WHERE col < 1000) FROM foo",
                 "presto": "SELECT COUNT_IF(col % 2 = 0) FILTER(WHERE col < 1000) FROM foo",
-                "sqlite": "SELECT SUM(CASE WHEN col % 2 = 0 THEN 1 ELSE 0 END) FILTER(WHERE col < 1000) FROM foo",
+                "sqlite": "SELECT SUM(IIF(col % 2 = 0, 1, 0)) FILTER(WHERE col < 1000) FROM foo",
                 "tsql": "SELECT COUNT_IF(col % 2 = 0) FILTER(WHERE col < 1000) FROM foo",
             },
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -462,7 +462,7 @@ WHERE
             "DIV0(foo, bar)",
             write={
                 "snowflake": "IFF(bar = 0, 0, foo / bar)",
-                "sqlite": "CASE WHEN bar = 0 THEN 0 ELSE CAST(foo AS REAL) / bar END",
+                "sqlite": "IIF(bar = 0, 0, CAST(foo AS REAL) / bar)",
                 "presto": "IF(bar = 0, 0, CAST(foo AS DOUBLE) / bar)",
                 "spark": "IF(bar = 0, 0, foo / bar)",
                 "hive": "IF(bar = 0, 0, foo / bar)",
@@ -473,7 +473,7 @@ WHERE
             "ZEROIFNULL(foo)",
             write={
                 "snowflake": "IFF(foo IS NULL, 0, foo)",
-                "sqlite": "CASE WHEN foo IS NULL THEN 0 ELSE foo END",
+                "sqlite": "IIF(foo IS NULL, 0, foo)",
                 "presto": "IF(foo IS NULL, 0, foo)",
                 "spark": "IF(foo IS NULL, 0, foo)",
                 "hive": "IF(foo IS NULL, 0, foo)",
@@ -484,7 +484,7 @@ WHERE
             "NULLIFZERO(foo)",
             write={
                 "snowflake": "IFF(foo = 0, NULL, foo)",
-                "sqlite": "CASE WHEN foo = 0 THEN NULL ELSE foo END",
+                "sqlite": "IIF(foo = 0, NULL, foo)",
                 "presto": "IF(foo = 0, NULL, foo)",
                 "spark": "IF(foo = 0, NULL, foo)",
                 "hive": "IF(foo = 0, NULL, foo)",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -610,12 +610,6 @@ TBLPROPERTIES (
             },
         )
 
-    def test_iif(self):
-        self.validate_all(
-            "SELECT IIF(cond, 'True', 'False')",
-            write={"spark": "SELECT IF(cond, 'True', 'False')"},
-        )
-
     def test_bool_or(self):
         self.validate_all(
             "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -29,6 +29,14 @@ class TestTSQL(Validator):
         self.validate_identity("CAST(x AS int) OR y", "CAST(x AS INTEGER) <> 0 OR y <> 0")
 
         self.validate_all(
+            "SELECT IIF(cond <> 0, 'True', 'False')",
+            read={
+                "spark": "SELECT IF(cond, 'True', 'False')",
+                "sqlite": "SELECT IIF(cond, 'True', 'False')",
+                "tsql": "SELECT IIF(cond <> 0, 'True', 'False')",
+            },
+        )
+        self.validate_all(
             "SELECT TRIM(BOTH 'a' FROM a)",
             read={
                 "mysql": "SELECT TRIM(BOTH 'a' FROM a)",
@@ -1299,20 +1307,6 @@ WHERE
                 "spark": "SELECT DATEDIFF(QUARTER, CAST('start' AS TIMESTAMP), CAST('end' AS TIMESTAMP))",
                 "spark2": "SELECT CAST(MONTHS_BETWEEN(CAST('end' AS TIMESTAMP), CAST('start' AS TIMESTAMP)) / 3 AS INT)",
                 "tsql": "SELECT DATEDIFF(QUARTER, CAST('start' AS DATETIME2), CAST('end' AS DATETIME2))",
-            },
-        )
-
-    def test_iif(self):
-        self.validate_identity(
-            "SELECT IF(cond, 'True', 'False')", "SELECT IIF(cond <> 0, 'True', 'False')"
-        )
-        self.validate_identity(
-            "SELECT IIF(cond, 'True', 'False')", "SELECT IIF(cond <> 0, 'True', 'False')"
-        )
-        self.validate_all(
-            "SELECT IIF(cond, 'True', 'False');",
-            write={
-                "spark": "SELECT IF(cond, 'True', 'False')",
             },
         )
 


### PR DESCRIPTION
Got rid of the Spark test for `IIF` because it doesn't support it (tried both v2 and v3). The addition to `FUNCTIONS` must have been an oversight, relevant commit is https://github.com/tobymao/sqlglot/commit/e2cdde57b.

Reference: https://www.sqlite.org/lang_corefunc.html#iif