### PR TITLE
feat(clickhouse): add basic support for system statement

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -93,6 +93,7 @@ class ClickHouse(Dialect):
             "IPV6": TokenType.IPV6,
             "AGGREGATEFUNCTION": TokenType.AGGREGATEFUNCTION,
             "SIMPLEAGGREGATEFUNCTION": TokenType.SIMPLEAGGREGATEFUNCTION,
+            "SYSTEM": TokenType.COMMAND,
         }
 
         SINGLE_TOKENS = {

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -369,6 +369,7 @@ class TestClickhouse(Validator):
             "SELECT STARTS_WITH('a', 'b'), STARTSWITH('a', 'b')",
             write={"clickhouse": "SELECT startsWith('a', 'b'), startsWith('a', 'b')"},
         )
+        self.validate_identity("SYSTEM STOP MERGES foo.bar")
 
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")


### PR DESCRIPTION
First of all, thanks a lot for your project. It really helps me during at my job. But I still have a few problems with the ClickHouse support, one problem being the lack of [SYSTEM statement](https://clickhouse.com/docs/en/sql-reference/statements/system) support. We use this statement to stop merges on temporary tables in ETL processes, so ETL code parsing fails without that one. If you think the support for SYSTEM statement should be more than just having command (which is honestly perfectly fine for me, as it could be easily parsed manually, if needed at all), please let me know and I'll modify the PR