### PR TITLE
Fix(parser): enable parsing of values into Identifier for some dialects

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -266,6 +266,7 @@ class Hive(Dialect):
     class Parser(parser.Parser):
         LOG_DEFAULTS_TO_LN = True
         STRICT_CAST = False
+        VALUES_FOLLOWED_BY_PAREN = False
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -445,6 +445,7 @@ class MySQL(Dialect):
 
         LOG_DEFAULTS_TO_LN = True
         STRING_ALIASES = True
+        VALUES_FOLLOWED_BY_PAREN = False
 
         def _parse_primary_key_part(self) -> t.Optional[exp.Expression]:
             this = self._parse_id_var()

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -88,6 +88,7 @@ class Oracle(Dialect):
     class Parser(parser.Parser):
         ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN = False
         WINDOW_BEFORE_PAREN_TOKENS = {TokenType.OVER, TokenType.KEEP}
+        VALUES_FOLLOWED_BY_PAREN = False
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -225,6 +225,8 @@ class Presto(Dialect):
         }
 
     class Parser(parser.Parser):
+        VALUES_FOLLOWED_BY_PAREN = False
+
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "ARBITRARY": exp.AnyValue.from_arg_list,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -47,6 +47,11 @@ class Redshift(Postgres):
     }
 
     class Parser(Postgres.Parser):
+        ID_VAR_TOKENS = {
+            *Postgres.Parser.ID_VAR_TOKENS,
+            TokenType.VALUES,
+        }
+
         FUNCTIONS = {
             **Postgres.Parser.FUNCTIONS,
             "ADD_MONTHS": lambda args: exp.TsOrDsAdd(

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -74,6 +74,7 @@ class Teradata(Dialect):
 
     class Parser(parser.Parser):
         TABLESAMPLE_CSV = True
+        VALUES_FOLLOWED_BY_PAREN = False
 
         CHARSET_TRANSLATORS = {
             "GRAPHIC_TO_KANJISJIS",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -85,6 +85,10 @@ WHERE
             "SELECT a FROM test PIVOT(SUM(x) FOR y IN ('z', 'q')) AS x TABLESAMPLE (0.1)"
         )
         self.validate_identity(
+            "value:values::string",
+            "CAST(GET_PATH(value, 'values') AS TEXT)",
+        )
+        self.validate_identity(
             """SELECT GET_PATH(PARSE_JSON('{"y": [{"z": 1}]}'), 'y[0]:z')""",
             """SELECT GET_PATH(PARSE_JSON('{"y": [{"z": 1}]}'), 'y[0].z')""",
         )

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -847,3 +847,5 @@ WITH use(use) AS (SELECT 1) SELECT use FROM use
 SELECT recursive FROM t
 SELECT (ROW_NUMBER() OVER (PARTITION BY user ORDER BY date ASC) - ROW_NUMBER() OVER (PARTITION BY user, segment ORDER BY date ASC)) AS group_id FROM example_table
 CAST(foo AS BPCHAR)
+values
+SELECT values

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -849,3 +849,4 @@ SELECT (ROW_NUMBER() OVER (PARTITION BY user ORDER BY date ASC) - ROW_NUMBER() O
 CAST(foo AS BPCHAR)
 values
 SELECT values
+SELECT values AS values FROM t WHERE values + 1 > 3

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -218,6 +218,7 @@ with t1 as (
     ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) as row_num
   FROM
     x
+  ORDER BY x.a, x.b, row_num
 )
 SELECT
   t1.a,
@@ -226,7 +227,7 @@ FROM
   t1
 WHERE
   row_num = 1;
-WITH t1 AS (SELECT x.a AS a, x.b AS b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x AS x) SELECT t1.a AS a, t1.b AS b FROM t1 AS t1 WHERE t1.row_num = 1;
+WITH t1 AS (SELECT x.a AS a, x.b AS b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x AS x ORDER BY x.a, x.b, row_num) SELECT t1.a AS a, t1.b AS b FROM t1 AS t1 WHERE t1.row_num = 1;
 
 # title: Test preventing merge of window expressions join clause
 with t1 as (
@@ -301,6 +302,7 @@ with t1 as (
     ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) as row_num
   FROM
     x
+  ORDER BY x.a, x.b, row_num
 )
 SELECT
   t1.a,
@@ -308,7 +310,7 @@ SELECT
   t1.row_num
 FROM
   t1;
-SELECT x.a AS a, x.b AS b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x AS x;
+SELECT x.a AS a, x.b AS b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x AS x ORDER BY x.a, x.b, row_num;
 
 # title: Don't merge window functions, inner table is aliased in outer query
 with t1 as (

--- a/tests/fixtures/optimizer/tpc-h/tpc-h.sql
+++ b/tests/fixtures/optimizer/tpc-h/tpc-h.sql
@@ -15,7 +15,7 @@ select
 from
         lineitem
 where
-        l_shipdate <= date '1998-12-01' - interval '90' day
+        CAST(l_shipdate AS DATE) <= date '1998-12-01' - interval '90' day
 group by
         l_returnflag,
         l_linestatus
@@ -218,8 +218,8 @@ select
 from
         orders
 where
-        o_orderdate >= date '1993-07-01'
-        and o_orderdate < date '1993-07-01' + interval '3' month
+        CAST(o_orderdate AS DATE) >= date '1993-07-01'
+        and CAST(o_orderdate AS DATE) < date '1993-07-01' + interval '3' month
         and exists (
                 select
                         *
@@ -278,8 +278,8 @@ where
         and s_nationkey = n_nationkey
         and n_regionkey = r_regionkey
         and r_name = 'ASIA'
-        and o_orderdate >= date '1994-01-01'
-        and o_orderdate < date '1994-01-01' + interval '1' year
+        and CAST(o_orderdate AS DATE) >= date '1994-01-01'
+        and CAST(o_orderdate AS DATE) < date '1994-01-01' + interval '1' year
 group by
         n_name
 order by
@@ -316,8 +316,8 @@ select
 from
         lineitem
 where
-        l_shipdate >= date '1994-01-01'
-        and l_shipdate < date '1994-01-01' + interval '1' year
+        CAST(l_shipdate AS DATE) >= date '1994-01-01'
+        and CAST(l_shipdate AS DATE) < date '1994-01-01' + interval '1' year
         and l_discount between 0.06 - 0.01 and 0.06 + 0.01
         and l_quantity < 24;
 SELECT
@@ -362,7 +362,7 @@ from
                                 (n1.n_name = 'FRANCE' and n2.n_name = 'GERMANY')
                                 or (n1.n_name = 'GERMANY' and n2.n_name = 'FRANCE')
                         )
-                        and l_shipdate between date '1995-01-01' and date '1996-12-31'
+                        and CAST(l_shipdate AS DATE) between date '1995-01-01' and date '1996-12-31'
         ) as shipping
 group by
         supp_nation,
@@ -446,7 +446,7 @@ from
                         and n1.n_regionkey = r_regionkey
                         and r_name = 'AMERICA'
                         and s_nationkey = n2.n_nationkey
-                        and o_orderdate between date '1995-01-01' and date '1996-12-31'
+                        and CAST(o_orderdate AS DATE) between date '1995-01-01' and date '1996-12-31'
                         and p_type = 'ECONOMY ANODIZED STEEL'
         ) as all_nations
 group by
@@ -574,8 +574,8 @@ from
 where
         c_custkey = o_custkey
         and l_orderkey = o_orderkey
-        and o_orderdate >= date '1993-10-01'
-        and o_orderdate < date '1993-10-01' + interval '3' month
+        and CAST(o_orderdate AS DATE) >= date '1993-10-01'
+        and CAST(o_orderdate AS DATE) < date '1993-10-01' + interval '3' month
         and l_returnflag = 'R'
         and c_nationkey = n_nationkey
 group by
@@ -714,8 +714,8 @@ where
         and l_shipmode in ('MAIL', 'SHIP')
         and l_commitdate < l_receiptdate
         and l_shipdate < l_commitdate
-        and l_receiptdate >= date '1994-01-01'
-        and l_receiptdate < date '1994-01-01' + interval '1' year
+        and CAST(l_receiptdate AS DATE) >= date '1994-01-01'
+        and CAST(l_receiptdate AS DATE) < date '1994-01-01' + interval '1' year
 group by
         l_shipmode
 order by
@@ -813,8 +813,8 @@ from
         part
 where
         l_partkey = p_partkey
-        and l_shipdate >= date '1995-09-01'
-        and l_shipdate < date '1995-09-01' + interval '1' month;
+        and CAST(l_shipdate AS DATE) >= date '1995-09-01'
+        and CAST(l_shipdate AS DATE) < date '1995-09-01' + interval '1' month;
 SELECT
   100.00 * SUM(
     CASE
@@ -844,8 +844,8 @@ with revenue (supplier_no, total_revenue) as (
         from
                 lineitem
         where
-                l_shipdate >= date '1996-01-01'
-                and l_shipdate < date '1996-01-01' + interval '3' month
+                CAST(l_shipdate AS DATE) >= date '1996-01-01'
+                and CAST(l_shipdate AS DATE) < date '1996-01-01' + interval '3' month
         group by
                 l_suppkey)
 select
@@ -1223,8 +1223,8 @@ where
                                 where
                                         l_partkey = ps_partkey
                                         and l_suppkey = ps_suppkey
-                                        and l_shipdate >= date '1994-01-01'
-                                        and l_shipdate < date '1994-01-01' + interval '1' year
+                                        and CAST(l_shipdate AS DATE) >= date '1994-01-01'
+                                        and CAST(l_shipdate AS DATE) < date '1994-01-01' + interval '1' year
                         )
         )
         and s_nationkey = n_nationkey

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -839,3 +839,17 @@ class TestParser(unittest.TestCase):
                     ),
                 )
                 self.assertEqual(ast.sql(dialect=dialect), "CREATE SCHEMA catalog.schema")
+
+    def test_values_as_identifier(self):
+        sql = "SELECT values FROM t WHERE values + 1 > x"
+        for dialect in (
+            None,
+            "bigquery",
+            "clickhouse",
+            "duckdb",
+            "postgres",
+            "redshift",
+            "snowflake",
+        ):
+            with self.subTest(dialect):
+                self.assertEqual(parse_one(sql, dialect=dialect).sql(dialect=dialect), sql)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -843,7 +843,6 @@ class TestParser(unittest.TestCase):
     def test_values_as_identifier(self):
         sql = "SELECT values FROM t WHERE values + 1 > x"
         for dialect in (
-            None,
             "bigquery",
             "clickhouse",
             "duckdb",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -554,11 +554,12 @@ FROM base""",
         self.validate(
             "WITH A(filter) AS (VALUES 1, 2, 3) SELECT * FROM A WHERE filter >= 2",
             "WITH A(filter) AS (VALUES (1), (2), (3)) SELECT * FROM A WHERE filter >= 2",
+            read="presto",
         )
         self.validate(
             "SELECT BOOL_OR(a > 10) FROM (VALUES 1, 2, 15) AS T(a)",
             "SELECT BOOL_OR(a > 10) FROM (VALUES (1), (2), (15)) AS T(a)",
-            write="presto",
+            read="presto",
         )
 
     def test_alter(self):


### PR DESCRIPTION
Fixes #2957

I investigated a bit and this is what I found for the dialects currently supported by SQLGlot w.r.t. the `VALUES` clause syntax:

- Doesn't have a `VALUES` clause: BQ, Redshift

- '(' needs to follow `VALUES`: ClickHouse, DuckDB, Postgres, Snowflake, SQLite, T-SQL

- 'ROW' needs to follow `VALUES`: MySQL, probably Doris and Starrocks too due to lineage (haven't tested)

- "Anything" can follow `VALUES` (side effect of allowing stuff like `VALUES 1, 2, 3`): DataBricks, Hive, Oracle, Presto, Spark, Teradata, Trino

This PR allows `values` to be parsed into an `Identifier` for the first three categories. For the last one, fixing the parser is a bit more tricky (due to ambiguity) and so we decided to tackle it in a future PR. FWIW Presto and Trino don't seem to allow an unquoted `values` to be used as an identifier:

```
trino> select 1 as values;
Query 20240213_162108_00003_sw76y failed: line 1:13: mismatched input 'values'. Expecting: <identifier>
select 1 as values
```

However, Spark for example allows it:

```
spark-sql (default)> with t as (select 1 as values) select values from t;
1
```

References:
- https://duckdb.org/docs/sql/query_syntax/values.html
- https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-values.html
- https://dev.mysql.com/doc/refman/8.0/en/values.html
- https://docs.oracle.com/javadb/10.6.2.1/ref/rrefsqlj11277.html
- https://www.postgresql.org/docs/current/sql-values.html
- https://prestodb.io/docs/current/sql/values.html
- https://docs.snowflake.com/en/sql-reference/constructs/values
- https://www.sqlite.org/lang_select.html
- https://teradata.github.io/presto/docs/0.167-t/sql/values.html
- https://learn.microsoft.com/en-us/sql/t-sql/queries/table-value-constructor-transact-sql?view=sql-server-ver16