### PR TITLE
Fix: don't treat VALUES as a keyword in BigQuery, Redshift

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -330,7 +330,6 @@ class BigQuery(Dialect):
             "RECORD": TokenType.STRUCT,
             "TIMESTAMP": TokenType.TIMESTAMPTZ,
         }
-
         KEYWORDS.pop("DIV", None)
         KEYWORDS.pop("VALUES", None)
 

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -330,7 +330,9 @@ class BigQuery(Dialect):
             "RECORD": TokenType.STRUCT,
             "TIMESTAMP": TokenType.TIMESTAMPTZ,
         }
-        KEYWORDS.pop("DIV")
+
+        KEYWORDS.pop("DIV", None)
+        KEYWORDS.pop("VALUES", None)
 
     class Parser(parser.Parser):
         PREFIXED_PIVOT_COLUMNS = True
@@ -407,11 +409,6 @@ class BigQuery(Dialect):
         NESTED_TYPE_TOKENS = {
             *parser.Parser.NESTED_TYPE_TOKENS,
             TokenType.TABLE,
-        }
-
-        ID_VAR_TOKENS = {
-            *parser.Parser.ID_VAR_TOKENS,
-            TokenType.VALUES,
         }
 
         PROPERTY_PARSERS = {

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -330,8 +330,8 @@ class BigQuery(Dialect):
             "RECORD": TokenType.STRUCT,
             "TIMESTAMP": TokenType.TIMESTAMPTZ,
         }
-        KEYWORDS.pop("DIV", None)
-        KEYWORDS.pop("VALUES", None)
+        KEYWORDS.pop("DIV")
+        KEYWORDS.pop("VALUES")
 
     class Parser(parser.Parser):
         PREFIXED_PIVOT_COLUMNS = True

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -158,7 +158,7 @@ class Redshift(Postgres):
             "UNLOAD": TokenType.COMMAND,
             "VARBYTE": TokenType.VARBINARY,
         }
-        KEYWORDS.pop("VALUES", None)
+        KEYWORDS.pop("VALUES")
 
         # Redshift allows # to appear as a table identifier prefix
         SINGLE_TOKENS = Postgres.Tokenizer.SINGLE_TOKENS.copy()

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -47,11 +47,6 @@ class Redshift(Postgres):
     }
 
     class Parser(Postgres.Parser):
-        ID_VAR_TOKENS = {
-            *Postgres.Parser.ID_VAR_TOKENS,
-            TokenType.VALUES,
-        }
-
         FUNCTIONS = {
             **Postgres.Parser.FUNCTIONS,
             "ADD_MONTHS": lambda args: exp.TsOrDsAdd(
@@ -163,6 +158,7 @@ class Redshift(Postgres):
             "UNLOAD": TokenType.COMMAND,
             "VARBYTE": TokenType.VARBINARY,
         }
+        KEYWORDS.pop("VALUES", None)
 
         # Redshift allows # to appear as a table identifier prefix
         SINGLE_TOKENS = Postgres.Tokenizer.SINGLE_TOKENS.copy()


### PR DESCRIPTION
Fixes #2963

Many of the lines changed are just reordered tests - did that to group `validate_identity` and `validate_all` together but can revert if it's too noisy. Will comment inline to point out the changed / added ones.