### PR TITLE
Feat: Keep track of which source table a lineage node came from

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -209,7 +209,11 @@ def lineage(
             if isinstance(source, Scope):
                 # The table itself came from a more specific scope. Recurse into that one using the unaliased column name.
                 to_node(
-                    c.name, scope=source, scope_name=table, upstream=node, alias=aliases.get(table)
+                    c.name,
+                    scope=source,
+                    scope_name=table,
+                    upstream=node,
+                    alias=aliases.get(table) or alias,
                 )
             else:
                 # The source is not a scope - we've reached the end of the line. At this point, if a source is not found

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -95,7 +95,7 @@ class TestLineage(unittest.TestCase):
             downstream.source.sql(),
             "SELECT x.a AS a FROM x AS x",
         )
-        self.assertEqual(downstream.alias, "")
+        self.assertEqual(downstream.alias, "z")
 
     def test_lineage_source_with_star(self) -> None:
         node = lineage(
@@ -153,7 +153,7 @@ class TestLineage(unittest.TestCase):
         downstream = downstream.downstream[0]
         self.assertEqual(downstream.source.sql(), "(VALUES (1), (2)) AS t(a)")
         self.assertEqual(downstream.expression.sql(), "a")
-        self.assertEqual(downstream.alias, "")
+        self.assertEqual(downstream.alias, "y")
 
     def test_lineage_cte_name_appears_in_schema(self) -> None:
         schema = {"a": {"b": {"t1": {"c1": "int"}, "t2": {"c2": "int"}}}}


### PR DESCRIPTION
Before, we were only tracking source table for the outermost query of sources, but losing that information in any of their CTEs, subqueries, values, etc.