### PR TITLE
fix(optimizer): more optimizations for qualifying wide tables

### DIFF
--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -6,7 +6,7 @@ import logging
 import re
 import sys
 import typing as t
-from collections.abc import Collection
+from collections.abc import Collection, Set
 from contextlib import contextmanager
 from copy import copy
 from enum import Enum
@@ -496,3 +496,31 @@ DATE_UNITS = {"day", "week", "month", "quarter", "year", "year_month"}
 
 def is_date_unit(expression: t.Optional[exp.Expression]) -> bool:
     return expression is not None and expression.name.lower() in DATE_UNITS
+
+
+K = t.TypeVar("K")
+V = t.TypeVar("V")
+
+
+class SingleValuedMapping(t.Mapping[K, V]):
+    """
+    Mapping where all keys return the same value.
+
+    This rigamarole is meant to avoid copying keys, which was originally intended
+    as an optimization while qualifying columns for tables with lots of columns.
+    """
+
+    def __init__(self, keys: t.Collection[K], value: V):
+        self._keys = keys if isinstance(keys, Set) else set(keys)
+        self._value = value
+
+    def __getitem__(self, key: K) -> V:
+        if key in self._keys:
+            return self._value
+        raise KeyError(key)
+
+    def __len__(self) -> int:
+        return len(self._keys)
+
+    def __iter__(self) -> t.Iterator[K]:
+        return iter(self._keys)

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -49,7 +49,7 @@ class Schema(abc.ABC):
         only_visible: bool = False,
         dialect: DialectType = None,
         normalize: t.Optional[bool] = None,
-    ) -> t.List[str]:
+    ) -> t.Sequence[str]:
         """
         Get the column names for a table.
 
@@ -60,7 +60,7 @@ class Schema(abc.ABC):
             normalize: whether to normalize identifiers according to the dialect of interest.
 
         Returns:
-            The list of column names.
+            The sequence of column names.
         """
 
     @abc.abstractmethod


### PR DESCRIPTION
We have a virtual table with 100s of thousands of columns.

This type of thing could also be a problem with sqlmesh metrics.

We're trying to avoid copying this massive list of columns, as it can be super slow.

Using `Sequence` for `Schema.column_names` lets us cache and return a sorted set.
