### PR TITLE
Fix(postgres): ensure json extraction can roundtrip unaltered

### DIFF
--- a/sqlglot/dataframe/sql/functions.py
+++ b/sqlglot/dataframe/sql/functions.py
@@ -1030,7 +1030,7 @@ def posexplode_outer(col: ColumnOrName) -> Column:
 
 
 def get_json_object(col: ColumnOrName, path: str) -> Column:
-    return Column.invoke_expression_over_column(col, expression.JSONExtract, path=lit(path))
+    return Column.invoke_expression_over_column(col, expression.JSONExtract, expression=lit(path))
 
 
 def json_tuple(col: ColumnOrName, *fields: str) -> Column:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -17,11 +17,11 @@ from sqlglot.trie import new_trie
 
 DATE_ADD_OR_DIFF = t.Union[exp.DateAdd, exp.TsOrDsAdd, exp.DateDiff, exp.TsOrDsDiff]
 DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TsOrDsAdd, exp.DateSub]
+JSON_EXTRACT_TYPE = t.Union[exp.JSONExtract, exp.JSONExtractScalar]
+
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import B, E, F
-
-    JSON_EXTRACT_TYPE = t.Union[exp.JSONExtract, exp.JSONExtractScalar]
 
 logger = logging.getLogger("sqlglot")
 
@@ -1018,7 +1018,7 @@ def parse_json_extract_path(
 
 
 def json_extract_segments(
-    name: str, quoted_index: bool = True
+    name: str, quoted_index: bool = True, op: t.Optional[str] = None
 ) -> t.Callable[[Generator, JSON_EXTRACT_TYPE], str]:
     def _json_extract_segments(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
         path = expression.expression
@@ -1036,6 +1036,8 @@ def json_extract_segments(
 
                 segments.append(path)
 
+        if op:
+            return f" {op} ".join([self.sql(expression.this), *segments])
         return self.func(name, expression.this, *segments)
 
     return _json_extract_segments

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -487,8 +487,10 @@ class Hive(Dialect):
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.IsNan: rename_func("ISNAN"),
-            exp.JSONExtract: rename_func("GET_JSON_OBJECT"),
-            exp.JSONExtractScalar: rename_func("GET_JSON_OBJECT"),
+            exp.JSONExtract: lambda self, e: self.func("GET_JSON_OBJECT", e.this, e.expression),
+            exp.JSONExtractScalar: lambda self, e: self.func(
+                "GET_JSON_OBJECT", e.this, e.expression
+            ),
             exp.JSONFormat: _json_format_sql,
             exp.Left: left_to_substring_sql,
             exp.Map: var_map_sql,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -197,6 +197,7 @@ class Redshift(Postgres):
             exp.FromBase: rename_func("STRTOL"),
             exp.GeneratedAsIdentityColumnConstraint: generatedasidentitycolumnconstraint_sql,
             exp.JSONExtract: json_extract_segments("JSON_EXTRACT_PATH_TEXT"),
+            exp.JSONExtractScalar: json_extract_segments("JSON_EXTRACT_PATH_TEXT"),
             exp.GroupConcat: rename_func("LISTAGG"),
             exp.ParseJSON: rename_func("JSON_PARSE"),
             exp.Select: transforms.preprocess(

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -724,8 +724,10 @@ class Snowflake(Dialect):
             ),
             exp.GroupConcat: rename_func("LISTAGG"),
             exp.If: if_sql(name="IFF", false_value="NULL"),
-            exp.JSONExtract: rename_func("GET_PATH"),
-            exp.JSONExtractScalar: rename_func("JSON_EXTRACT_PATH_TEXT"),
+            exp.JSONExtract: lambda self, e: self.func("GET_PATH", e.this, e.expression),
+            exp.JSONExtractScalar: lambda self, e: self.func(
+                "JSON_EXTRACT_PATH_TEXT", e.this, e.expression
+            ),
             exp.JSONObject: lambda self, e: self.func("OBJECT_CONSTRUCT_KEEP_NULL", *e.expressions),
             exp.JSONPathRoot: lambda *_: "",
             exp.LogicalAnd: rename_func("BOOLAND_AGG"),

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -288,8 +288,8 @@ def _parse_as_text(
 def _json_extract_sql(
     self: TSQL.Generator, expression: exp.JSONExtract | exp.JSONExtractScalar
 ) -> str:
-    json_query = rename_func("JSON_QUERY")(self, expression)
-    json_value = rename_func("JSON_VALUE")(self, expression)
+    json_query = self.func("JSON_QUERY", expression.this, expression.expression)
+    json_value = self.func("JSON_VALUE", expression.this, expression.expression)
     return self.func("ISNULL", json_query, json_value)
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5033,7 +5033,7 @@ class JSONBContains(Binary):
 
 
 class JSONExtract(Binary, Func):
-    arg_types = {"this": True, "expression": True, "expressions": False}
+    arg_types = {"this": True, "expression": True, "only_json_types": False, "expressions": False}
     _sql_names = ["JSON_EXTRACT"]
     is_var_len_args = True
 
@@ -5043,7 +5043,7 @@ class JSONExtract(Binary, Func):
 
 
 class JSONExtractScalar(Binary, Func):
-    arg_types = {"this": True, "expression": True, "expressions": False}
+    arg_types = {"this": True, "expression": True, "only_json_types": False, "expressions": False}
     _sql_names = ["JSON_EXTRACT_SCALAR"]
     is_var_len_args = True
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -97,6 +97,12 @@ class Generator(metaclass=_Generator):
         exp.InlineLengthColumnConstraint: lambda self, e: f"INLINE LENGTH {self.sql(e, 'this')}",
         exp.InputModelProperty: lambda self, e: f"INPUT{self.sql(e, 'this')}",
         exp.IntervalSpan: lambda self, e: f"{self.sql(e, 'this')} TO {self.sql(e, 'expression')}",
+        exp.JSONExtract: lambda self, e: self.func(
+            "JSON_EXTRACT", e.this, e.expression, *e.expressions
+        ),
+        exp.JSONExtractScalar: lambda self, e: self.func(
+            "JSON_EXTRACT_SCALAR", e.this, e.expression, *e.expressions
+        ),
         exp.LanguageProperty: lambda self, e: self.naked_property(e),
         exp.LocationProperty: lambda self, e: self.naked_property(e),
         exp.LogProperty: lambda self, e: f"{'NO ' if e.args.get('no') else ''}LOG",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -550,11 +550,13 @@ class Parser(metaclass=_Parser):
             exp.JSONExtract,
             this=this,
             expression=self.dialect.to_json_path(path),
+            only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
         ),
         TokenType.DARROW: lambda self, this, path: self.expression(
             exp.JSONExtractScalar,
             this=this,
             expression=self.dialect.to_json_path(path),
+            only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
         ),
         TokenType.HASH_ARROW: lambda self, this, path: self.expression(
             exp.JSONBExtract,
@@ -1004,6 +1006,9 @@ class Parser(metaclass=_Parser):
 
     # Parses no parenthesis if statements as commands
     NO_PAREN_IF_COMMANDS = True
+
+    # Whether or not the -> and ->> operators expect documents of type JSON (e.g. Postgres)
+    JSON_ARROWS_REQUIRE_JSON_TYPE = False
 
     # Whether or not a VALUES keyword needs to be followed by '(' to form a VALUES clause.
     # If this is True and '(' is not found, the keyword will be treated as an identifier


### PR DESCRIPTION
Fixes #2971

Based on Postgres' [docs](https://www.postgresql.org/docs/9.3/functions-json.html), the various arrow json operators expect their document operand to be a JSON[B] value.

> [Table 9-40](https://www.postgresql.org/docs/9.3/functions-json.html#FUNCTIONS-JSON-OP-TABLE) shows the operators that are available for use with JSON (see [Section 8.14](https://www.postgresql.org/docs/9.3/datatype-json.html)) data.

Additionally, their function counterparts also work with raw text JSON documents:

```sql
json_extract_path('{"f2":{"f3":1},"f4":{"f5":99,"f6":"foo"}}', 'f4')
```

This means that we can't _always_ produce just _one_ of these two syntax forms: if we produce an arrow then we'll break queries where JSON documents are strings (like above), whereas if we produce a function we'll break queries where the document's type is incompatible (like in the linked issue, where we need a `JSONB*` alternative).

This PR is an attempt to preserve this information at the AST level so we can satisfy the type constraints at generation time by producing a suitable operator / function.