### PR TITLE
Refactor: clean up tech debt in dialect implementations

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -148,59 +148,65 @@ class _Dialect(type):
 
 class Dialect(metaclass=_Dialect):
     INDEX_OFFSET = 0
-    """Determines the base index offset for arrays."""
+    """The base index offset for arrays."""
 
     WEEK_OFFSET = 0
-    """Determines the day of week of DATE_TRUNC(week). Defaults to 0 (Monday). -1 would be Sunday."""
+    """First day of the week in DATE_TRUNC(week). Defaults to 0 (Monday). -1 would be Sunday."""
 
     UNNEST_COLUMN_ONLY = False
-    """Determines whether or not `UNNEST` table aliases are treated as column aliases."""
+    """Whether `UNNEST` table aliases are treated as column aliases."""
 
     ALIAS_POST_TABLESAMPLE = False
-    """Determines whether or not the table alias comes after tablesample."""
+    """Whether the table alias comes after tablesample."""
 
     TABLESAMPLE_SIZE_IS_PERCENT = False
-    """Determines whether or not a size in the table sample clause represents percentage."""
+    """Whether a size in the table sample clause represents percentage."""
 
     NORMALIZATION_STRATEGY = NormalizationStrategy.LOWERCASE
     """Specifies the strategy according to which identifiers should be normalized."""
 
     IDENTIFIERS_CAN_START_WITH_DIGIT = False
-    """Determines whether or not an unquoted identifier can start with a digit."""
+    """Whether an unquoted identifier can start with a digit."""
 
     DPIPE_IS_STRING_CONCAT = True
-    """Determines whether or not the DPIPE token (`||`) is a string concatenation operator."""
+    """Whether the DPIPE token (`||`) is a string concatenation operator."""
 
     STRICT_STRING_CONCAT = False
-    """Determines whether or not `CONCAT`'s arguments must be strings."""
+    """Whether `CONCAT`'s arguments must be strings."""
 
     SUPPORTS_USER_DEFINED_TYPES = True
-    """Determines whether or not user-defined data types are supported."""
+    """Whether user-defined data types are supported."""
 
     SUPPORTS_SEMI_ANTI_JOIN = True
-    """Determines whether or not `SEMI` or `ANTI` joins are supported."""
+    """Whether `SEMI` or `ANTI` joins are supported."""
 
     NORMALIZE_FUNCTIONS: bool | str = "upper"
-    """Determines how function names are going to be normalized."""
+    """
+    Determines how function names are going to be normalized.
+    Possible values:
+        "upper" or True: Convert names to uppercase.
+        "lower": Convert names to lowercase.
+        False: Disables function name normalization.
+    """
 
     LOG_BASE_FIRST = True
-    """Determines whether or not the base comes first in the `LOG` function."""
+    """Whether the base comes first in the `LOG` function."""
 
     NULL_ORDERING = "nulls_are_small"
     """
-    Determines the default `NULL` ordering method to use if not explicitly set.
+    Default `NULL` ordering method to use if not explicitly set.
     Possible values: `"nulls_are_small"`, `"nulls_are_large"`, `"nulls_are_last"`
     """
 
     TYPED_DIVISION = False
     """
-    Determines whether or not the behavior of `a / b` depends on the types of `a` and `b`.
+    Whether the behavior of `a / b` depends on the types of `a` and `b`.
     False means `a / b` is always float division.
     True means `a / b` is integer division if both `a` and `b` are integers.
     """
 
     SAFE_DIVISION = False
-    """Determines whether division by zero throws an error (`False`) or returns NULL (`True`)."""
+    """Whether division by zero throws an error (`False`) or returns NULL (`True`)."""
 
     CONCAT_COALESCE = False
     """A `NULL` arg in `CONCAT` yields `NULL` by default, but in some dialects it yields an empty string."""
@@ -418,7 +424,7 @@ class Dialect(metaclass=_Dialect):
                 `"safe"`: Only returns `True` if the identifier is case-insensitive.
 
         Returns:
-            Whether or not the given text can be identified.
+            Whether the given text can be identified.
         """
         if identify is True or identify == "always":
             return True

--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -4,7 +4,7 @@ from sqlglot import exp
 from sqlglot.dialects.dialect import (
     approx_count_distinct_sql,
     arrow_json_extract_sql,
-    parse_timestamp_trunc,
+    build_timestamp_trunc,
     rename_func,
     time_format,
 )
@@ -20,7 +20,7 @@ class Doris(MySQL):
         FUNCTIONS = {
             **MySQL.Parser.FUNCTIONS,
             "COLLECT_SET": exp.ArrayUniqueAgg.from_arg_list,
-            "DATE_TRUNC": parse_timestamp_trunc,
+            "DATE_TRUNC": build_timestamp_trunc,
             "REGEXP": exp.RegexpLike.from_arg_list,
             "TO_DATE": exp.TsOrDsToDate.from_arg_list,
         }
@@ -46,7 +46,7 @@ class Doris(MySQL):
             exp.ArgMin: rename_func("MIN_BY"),
             exp.ArrayAgg: rename_func("COLLECT_LIST"),
             exp.ArrayUniqueAgg: rename_func("COLLECT_SET"),
-            exp.CurrentTimestamp: lambda *_: "NOW()",
+            exp.CurrentTimestamp: lambda self, _: self.func("NOW"),
             exp.DateTrunc: lambda self, e: self.func(
                 "DATE_TRUNC", e.this, "'" + e.text("unit") + "'"
             ),
@@ -55,14 +55,13 @@ class Doris(MySQL):
             exp.Map: rename_func("ARRAY_MAP"),
             exp.RegexpLike: rename_func("REGEXP"),
             exp.RegexpSplit: rename_func("SPLIT_BY_STRING"),
-            exp.StrToUnix: lambda self,
-            e: f"UNIX_TIMESTAMP({self.sql(e, 'this')}, {self.format_time(e)})",
+            exp.StrToUnix: lambda self, e: self.func("UNIX_TIMESTAMP", e.this, self.format_time(e)),
             exp.Split: rename_func("SPLIT_BY_STRING"),
             exp.TimeStrToDate: rename_func("TO_DATE"),
-            exp.ToChar: lambda self,
-            e: f"DATE_FORMAT({self.sql(e, 'this')}, {self.format_time(e)})",
-            exp.TsOrDsAdd: lambda self,
-            e: f"DATE_ADD({self.sql(e, 'this')}, {self.sql(e, 'expression')})",  # Only for day level
+            exp.ToChar: lambda self, e: self.func("DATE_FORMAT", e.this, self.format_time(e)),
+            exp.TsOrDsAdd: lambda self, e: self.func(
+                "DATE_ADD", e.this, e.expression
+            ),  # Only for day level
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this),
             exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
             exp.TimestampTrunc: lambda self, e: self.func(

--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -59,9 +59,7 @@ class Doris(MySQL):
             exp.Split: rename_func("SPLIT_BY_STRING"),
             exp.TimeStrToDate: rename_func("TO_DATE"),
             exp.ToChar: lambda self, e: self.func("DATE_FORMAT", e.this, self.format_time(e)),
-            exp.TsOrDsAdd: lambda self, e: self.func(
-                "DATE_ADD", e.this, e.expression
-            ),  # Only for day level
+            exp.TsOrDsAdd: lambda self, e: self.func("DATE_ADD", e.this, e.expression),
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this),
             exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
             exp.TimestampTrunc: lambda self, e: self.func(

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -130,6 +130,7 @@ def _json_format_sql(self: DuckDB.Generator, expression: exp.JSONFormat) -> str:
 def _unix_to_time_sql(self: DuckDB.Generator, expression: exp.UnixToTime) -> str:
     scale = expression.args.get("scale")
     timestamp = expression.this
+
     if scale in (None, exp.UnixToTime.SECONDS):
         return self.func("TO_TIMESTAMP", timestamp)
     if scale == exp.UnixToTime.MILLIS:

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -4,7 +4,7 @@ import typing as t
 
 from sqlglot import exp
 from sqlglot.dialects.dialect import rename_func
-from sqlglot.dialects.hive import _parse_ignore_nulls
+from sqlglot.dialects.hive import _build_with_ignore_nulls
 from sqlglot.dialects.spark2 import Spark2, temporary_storage_provider
 from sqlglot.helper import seq_get
 from sqlglot.transforms import (
@@ -15,7 +15,7 @@ from sqlglot.transforms import (
 )
 
 
-def _parse_datediff(args: t.List) -> exp.Expression:
+def _build_datediff(args: t.List) -> exp.Expression:
     """
     Although Spark docs don't mention the "unit" argument, Spark3 added support for
     it at some point. Databricks also supports this variant (see below).
@@ -61,8 +61,8 @@ class Spark(Spark2):
     class Parser(Spark2.Parser):
         FUNCTIONS = {
             **Spark2.Parser.FUNCTIONS,
-            "ANY_VALUE": _parse_ignore_nulls(exp.AnyValue),
-            "DATEDIFF": _parse_datediff,
+            "ANY_VALUE": _build_with_ignore_nulls(exp.AnyValue),
+            "DATEDIFF": _build_datediff,
         }
 
         def _parse_generated_as_identity(

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -45,6 +45,7 @@ def _str_to_date(self: Spark2.Generator, expression: exp.StrToDate) -> str:
 def _unix_to_time_sql(self: Spark2.Generator, expression: exp.UnixToTime) -> str:
     scale = expression.args.get("scale")
     timestamp = expression.this
+
     if scale is None:
         return self.sql(exp.cast(exp.func("from_unixtime", timestamp), "timestamp"))
     if scale == exp.UnixToTime.SECONDS:

--- a/sqlglot/dialects/tableau.py
+++ b/sqlglot/dialects/tableau.py
@@ -34,8 +34,8 @@ class Tableau(Dialect):
         def count_sql(self, expression: exp.Count) -> str:
             this = expression.this
             if isinstance(this, exp.Distinct):
-                return f"COUNTD({self.expressions(this, flat=True)})"
-            return f"COUNT({self.sql(expression, 'this')})"
+                return self.func("COUNTD", *this.expressions)
+            return self.func("COUNT", this)
 
     class Parser(parser.Parser):
         FUNCTIONS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -67,8 +67,8 @@ class Expression(metaclass=_Expression):
     Attributes:
         key: a unique key for each class in the Expression hierarchy. This is useful for hashing
             and representing expressions as strings.
-        arg_types: determines what arguments (child nodes) are supported by an expression. It
-            maps arg keys to booleans that indicate whether the corresponding args are optional.
+        arg_types: determines the arguments (child nodes) supported by an expression. It maps
+            arg keys to booleans that indicate whether the corresponding args are optional.
         parent: a reference to the parent expression (or None, in case of root expressions).
         arg_key: the arg key an expression is associated with, i.e. the name its parent expression
             uses to refer to it.
@@ -680,7 +680,7 @@ class Expression(metaclass=_Expression):
             *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
             dialect: the dialect used to parse the input expression.
-            copy: whether or not to copy the involved expressions (only applies to Expressions).
+            copy: whether to copy the involved expressions (only applies to Expressions).
             opts: other options to use to parse the input expressions.
 
         Returns:
@@ -706,7 +706,7 @@ class Expression(metaclass=_Expression):
             *expressions: the SQL code strings to parse.
                 If an `Expression` instance is passed, it will be used as-is.
             dialect: the dialect used to parse the input expression.
-            copy: whether or not to copy the involved expressions (only applies to Expressions).
+            copy: whether to copy the involved expressions (only applies to Expressions).
             opts: other options to use to parse the input expressions.
 
         Returns:
@@ -723,7 +723,7 @@ class Expression(metaclass=_Expression):
             'NOT x = 1'
 
         Args:
-            copy: whether or not to copy this object.
+            copy: whether to copy this object.
 
         Returns:
             The new Not instance.
@@ -3820,7 +3820,7 @@ class DataType(Expression):
             dialect: the dialect to use for parsing `dtype`, in case it's a string.
             udt: when set to True, `dtype` will be used as-is if it can't be parsed into a
                 DataType, thus creating a user-defined type.
-            copy: whether or not to copy the data type.
+            copy: whether to copy the data type.
             kwargs: additional arguments to pass in the constructor of DataType.
 
         Returns:
@@ -4309,9 +4309,9 @@ class Func(Condition):
     Attributes:
         is_var_len_args (bool): if set to True the last argument defined in arg_types will be
             treated as a variable length argument and the argument's value will be stored as a list.
-        _sql_names (list): determines the SQL name (1st item in the list) and aliases (subsequent items)
-            for this function expression. These values are used to map this node to a name during parsing
-            as well as to provide the function's name during SQL string generation. By default the SQL
+        _sql_names (list): the SQL name (1st item in the list) and aliases (subsequent items) for this
+            function expression. These values are used to map this node to a name during parsing as
+            well as to provide the function's name during SQL string generation. By default the SQL
             name is set to the expression's class name transformed to snake case.
     """
 
@@ -5626,7 +5626,7 @@ def maybe_parse(
             input expression is a SQL string).
         prefix: a string to prefix the sql with before it gets parsed
             (automatically includes a space)
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
         **opts: other options to use to parse the input expressions (again, in the case
             that an input expression is a SQL string).
 
@@ -5897,7 +5897,7 @@ def union(
             If an `Expression` instance is passed, it will be used as-is.
         distinct: set the DISTINCT flag if and only if this is true.
         dialect: the dialect used to parse the input expression.
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
         opts: other options to use to parse the input expressions.
 
     Returns:
@@ -5931,7 +5931,7 @@ def intersect(
             If an `Expression` instance is passed, it will be used as-is.
         distinct: set the DISTINCT flag if and only if this is true.
         dialect: the dialect used to parse the input expression.
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
         opts: other options to use to parse the input expressions.
 
     Returns:
@@ -5965,7 +5965,7 @@ def except_(
             If an `Expression` instance is passed, it will be used as-is.
         distinct: set the DISTINCT flag if and only if this is true.
         dialect: the dialect used to parse the input expression.
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
         opts: other options to use to parse the input expressions.
 
     Returns:
@@ -6127,7 +6127,7 @@ def insert(
         overwrite: whether to INSERT OVERWRITE or not.
         returning: sql conditional parsed into a RETURNING statement
         dialect: the dialect used to parse the input expressions.
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -6168,7 +6168,7 @@ def condition(
             If an Expression instance is passed, this is used as-is.
         dialect: the dialect used to parse the input expression (in the case that the
             input expression is a SQL string).
-        copy: Whether or not to copy `expression` (only applies to expressions).
+        copy: Whether to copy `expression` (only applies to expressions).
         **opts: other options to use to parse the input expressions (again, in the case
             that the input expression is a SQL string).
 
@@ -6198,7 +6198,7 @@ def and_(
         *expressions: the SQL code strings to parse.
             If an Expression instance is passed, this is used as-is.
         dialect: the dialect used to parse the input expression.
-        copy: whether or not to copy `expressions` (only applies to Expressions).
+        copy: whether to copy `expressions` (only applies to Expressions).
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -6221,7 +6221,7 @@ def or_(
         *expressions: the SQL code strings to parse.
             If an Expression instance is passed, this is used as-is.
         dialect: the dialect used to parse the input expression.
-        copy: whether or not to copy `expressions` (only applies to Expressions).
+        copy: whether to copy `expressions` (only applies to Expressions).
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -6296,8 +6296,8 @@ def to_identifier(name, quoted=None, copy=True):
 
     Args:
         name: The name to turn into an identifier.
-        quoted: Whether or not force quote the identifier.
-        copy: Whether or not to copy name if it's an Identifier.
+        quoted: Whether to force quote the identifier.
+        copy: Whether to copy name if it's an Identifier.
 
     Returns:
         The identifier ast node.
@@ -6379,7 +6379,7 @@ def to_table(
     Args:
         sql_path: a `[catalog].[schema].[table]` string.
         dialect: the source dialect according to which the table name will be parsed.
-        copy: Whether or not to copy a table if it is passed in.
+        copy: Whether to copy a table if it is passed in.
         kwargs: the kwargs to instantiate the resulting `Table` expression with.
 
     Returns:
@@ -6439,10 +6439,10 @@ def alias_(
             If an Expression instance is passed, this is used as-is.
         alias: the alias name to use. If the name has
             special characters it is quoted.
-        table: Whether or not to create a table alias, can also be a list of columns.
-        quoted: whether or not to quote the alias
+        table: Whether to create a table alias, can also be a list of columns.
+        quoted: whether to quote the alias
         dialect: the dialect used to parse the input expression.
-        copy: Whether or not to copy the expression.
+        copy: Whether to copy the expression.
         **opts: other options to use to parse the input expressions.
 
     Returns:
@@ -6549,7 +6549,7 @@ def column(
         catalog: Catalog name.
         fields: Additional fields using dots.
         quoted: Whether to force quotes on the column's identifiers.
-        copy: Whether or not to copy identifiers if passed in.
+        copy: Whether to copy identifiers if passed in.
 
     Returns:
         The new Column instance.
@@ -6576,7 +6576,7 @@ def cast(expression: ExpOrStr, to: DATA_TYPE, copy: bool = True, **opts) -> Cast
     Args:
         expression: The expression to cast.
         to: The datatype to cast to.
-        copy: Whether or not to copy the supplied expressions.
+        copy: Whether to copy the supplied expressions.
 
     Returns:
         The new Cast instance.
@@ -6704,7 +6704,7 @@ def rename_column(
         table_name: Name of the table
         old_column: The old name of the column
         new_column: The new name of the column
-        exists: Whether or not to add the `IF EXISTS` clause
+        exists: Whether to add the `IF EXISTS` clause
 
     Returns:
         Alter table expression
@@ -6727,7 +6727,7 @@ def convert(value: t.Any, copy: bool = False) -> Expression:
 
     Args:
         value: A python object.
-        copy: Whether or not to copy `value` (only applies to Expressions and collections).
+        copy: Whether to copy `value` (only applies to Expressions and collections).
 
     Returns:
         Expression: the equivalent expression object.
@@ -6847,7 +6847,7 @@ def normalize_table_name(table: str | Table, dialect: DialectType = None, copy: 
     Args:
         table: the table to normalize
         dialect: the dialect to use for normalization rules
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
 
     Examples:
         >>> normalize_table_name("`A-B`.c", dialect="bigquery")
@@ -6872,7 +6872,7 @@ def replace_tables(
         expression: expression node to be transformed and replaced.
         mapping: mapping of table names.
         dialect: the dialect of the mapping table
-        copy: whether or not to copy the expression.
+        copy: whether to copy the expression.
 
     Examples:
         >>> from sqlglot import exp, parse_one
@@ -6959,7 +6959,7 @@ def expand(
         expression: The expression to expand.
         sources: A dictionary of name to Subqueryables.
         dialect: The dialect of the sources dict.
-        copy: Whether or not to copy the expression during transformation. Defaults to True.
+        copy: Whether to copy the expression during transformation. Defaults to True.
 
     Returns:
         The transformed expression.
@@ -6993,7 +6993,7 @@ def func(name: str, *args, copy: bool = True, dialect: DialectType = None, **kwa
     Args:
         name: the name of the function to build.
         args: the args used to instantiate the function of interest.
-        copy: whether or not to copy the argument expressions.
+        copy: whether to copy the argument expressions.
         dialect: the source dialect.
         kwargs: the kwargs used to instantiate the function of interest.
 
@@ -7096,7 +7096,7 @@ def array(
 
     Args:
         expressions: the expressions to add to the array.
-        copy: whether or not to copy the argument expressions.
+        copy: whether to copy the argument expressions.
         dialect: the source dialect.
         kwargs: the kwargs used to instantiate the function of interest.
 
@@ -7123,7 +7123,7 @@ def tuple_(
 
     Args:
         expressions: the expressions to add to the tuple.
-        copy: whether or not to copy the argument expressions.
+        copy: whether to copy the argument expressions.
         dialect: the source dialect.
         kwargs: the kwargs used to instantiate the function of interest.
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -38,19 +38,19 @@ class Generator(metaclass=_Generator):
     Generator converts a given syntax tree to the corresponding SQL string.
 
     Args:
-        pretty: Whether or not to format the produced SQL string.
+        pretty: Whether to format the produced SQL string.
             Default: False.
         identify: Determines when an identifier should be quoted. Possible values are:
             False (default): Never quote, except in cases where it's mandatory by the dialect.
             True or 'always': Always quote.
             'safe': Only quote identifiers that are case insensitive.
-        normalize: Whether or not to normalize identifiers to lowercase.
+        normalize: Whether to normalize identifiers to lowercase.
             Default: False.
-        pad: Determines the pad size in a formatted string.
+        pad: The pad size in a formatted string.
             Default: 2.
-        indent: Determines the indentation size in a formatted string.
+        indent: The indentation size in a formatted string.
             Default: 2.
-        normalize_functions: Whether or not to normalize all function names. Possible values are:
+        normalize_functions: How to normalize function names. Possible values are:
             "upper" or True (default): Convert names to uppercase.
             "lower": Convert names to lowercase.
             False: Disables function name normalization.
@@ -59,14 +59,14 @@ class Generator(metaclass=_Generator):
         max_unsupported: Maximum number of unsupported messages to include in a raised UnsupportedError.
             This is only relevant if unsupported_level is ErrorLevel.RAISE.
             Default: 3
-        leading_comma: Determines whether or not the comma is leading or trailing in select expressions.
+        leading_comma: Whether the comma is leading or trailing in select expressions.
             This is only relevant when generating in pretty mode.
             Default: False
         max_text_width: The max number of characters in a segment before creating new lines in pretty mode.
             The default is on the smaller end because the length only represents a segment and not the true
             line length.
             Default: 80
-        comments: Whether or not to preserve comments in the output SQL code.
+        comments: Whether to preserve comments in the output SQL code.
             Default: True
     """
 
@@ -140,15 +140,15 @@ class Generator(metaclass=_Generator):
         exp.WithJournalTableProperty: lambda self, e: f"WITH JOURNAL TABLE={self.sql(e, 'this')}",
     }
 
-    # Whether or not null ordering is supported in order by
+    # Whether null ordering is supported in order by
     # True: Full Support, None: No support, False: No support in window specifications
     NULL_ORDERING_SUPPORTED: t.Optional[bool] = True
 
-    # Whether or not ignore nulls is inside the agg or outside.
+    # Whether ignore nulls is inside the agg or outside.
     # FIRST(x IGNORE NULLS) OVER vs FIRST (x) IGNORE NULLS OVER
     IGNORE_NULLS_IN_FUNC = False
 
-    # Whether or not locking reads (i.e. SELECT ... FOR UPDATE/SHARE) are supported
+    # Whether locking reads (i.e. SELECT ... FOR UPDATE/SHARE) are supported
     LOCKING_READS_SUPPORTED = False
 
     # Always do union distinct or union all
@@ -157,25 +157,25 @@ class Generator(metaclass=_Generator):
     # Wrap derived values in parens, usually standard but spark doesn't support it
     WRAP_DERIVED_VALUES = True
 
-    # Whether or not create function uses an AS before the RETURN
+    # Whether create function uses an AS before the RETURN
     CREATE_FUNCTION_RETURN_AS = True
 
-    # Whether or not MERGE ... WHEN MATCHED BY SOURCE is allowed
+    # Whether MERGE ... WHEN MATCHED BY SOURCE is allowed
     MATCHED_BY_SOURCE = True
 
-    # Whether or not the INTERVAL expression works only with values like '1 day'
+    # Whether the INTERVAL expression works only with values like '1 day'
     SINGLE_STRING_INTERVAL = False
 
-    # Whether or not the plural form of date parts like day (i.e. "days") is supported in INTERVALs
+    # Whether the plural form of date parts like day (i.e. "days") is supported in INTERVALs
     INTERVAL_ALLOWS_PLURAL_FORM = True
 
-    # Whether or not limit and fetch are supported (possible values: "ALL", "LIMIT", "FETCH")
+    # Whether limit and fetch are supported (possible values: "ALL", "LIMIT", "FETCH")
     LIMIT_FETCH = "ALL"
 
-    # Whether or not limit and fetch allows expresions or just limits
+    # Whether limit and fetch allows expresions or just limits
     LIMIT_ONLY_LITERALS = False
 
-    # Whether or not a table is allowed to be renamed with a db
+    # Whether a table is allowed to be renamed with a db
     RENAME_TABLE_WITH_DB = True
 
     # The separator for grouping sets and rollups
@@ -184,105 +184,105 @@ class Generator(metaclass=_Generator):
     # The string used for creating an index on a table
     INDEX_ON = "ON"
 
-    # Whether or not join hints should be generated
+    # Whether join hints should be generated
     JOIN_HINTS = True
 
-    # Whether or not table hints should be generated
+    # Whether table hints should be generated
     TABLE_HINTS = True
 
-    # Whether or not query hints should be generated
+    # Whether query hints should be generated
     QUERY_HINTS = True
 
     # What kind of separator to use for query hints
     QUERY_HINT_SEP = ", "
 
-    # Whether or not comparing against booleans (e.g. x IS TRUE) is supported
+    # Whether comparing against booleans (e.g. x IS TRUE) is supported
     IS_BOOL_ALLOWED = True
 
-    # Whether or not to include the "SET" keyword in the "INSERT ... ON DUPLICATE KEY UPDATE" statement
+    # Whether to include the "SET" keyword in the "INSERT ... ON DUPLICATE KEY UPDATE" statement
     DUPLICATE_KEY_UPDATE_WITH_SET = True
 
-    # Whether or not to generate the limit as TOP <value> instead of LIMIT <value>
+    # Whether to generate the limit as TOP <value> instead of LIMIT <value>
     LIMIT_IS_TOP = False
 
-    # Whether or not to generate INSERT INTO ... RETURNING or INSERT INTO RETURNING ...
+    # Whether to generate INSERT INTO ... RETURNING or INSERT INTO RETURNING ...
     RETURNING_END = True
 
-    # Whether or not to generate the (+) suffix for columns used in old-style join conditions
+    # Whether to generate the (+) suffix for columns used in old-style join conditions
     COLUMN_JOIN_MARKS_SUPPORTED = False
 
-    # Whether or not to generate an unquoted value for EXTRACT's date part argument
+    # Whether to generate an unquoted value for EXTRACT's date part argument
     EXTRACT_ALLOWS_QUOTES = True
 
-    # Whether or not TIMETZ / TIMESTAMPTZ will be generated using the "WITH TIME ZONE" syntax
+    # Whether TIMETZ / TIMESTAMPTZ will be generated using the "WITH TIME ZONE" syntax
     TZ_TO_WITH_TIME_ZONE = False
 
-    # Whether or not the NVL2 function is supported
+    # Whether the NVL2 function is supported
     NVL2_SUPPORTED = True
 
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
     SELECT_KINDS: t.Tuple[str, ...] = ("STRUCT", "VALUE")
 
-    # Whether or not VALUES statements can be used as derived tables.
+    # Whether VALUES statements can be used as derived tables.
     # MySQL 5 and Redshift do not allow this, so when False, it will convert
     # SELECT * VALUES into SELECT UNION
     VALUES_AS_TABLE = True
 
-    # Whether or not the word COLUMN is included when adding a column with ALTER TABLE
+    # Whether the word COLUMN is included when adding a column with ALTER TABLE
     ALTER_TABLE_INCLUDE_COLUMN_KEYWORD = True
 
     # UNNEST WITH ORDINALITY (presto) instead of UNNEST WITH OFFSET (bigquery)
     UNNEST_WITH_ORDINALITY = True
 
-    # Whether or not FILTER (WHERE cond) can be used for conditional aggregation
+    # Whether FILTER (WHERE cond) can be used for conditional aggregation
     AGGREGATE_FILTER_SUPPORTED = True
 
-    # Whether or not JOIN sides (LEFT, RIGHT) are supported in conjunction with SEMI/ANTI join kinds
+    # Whether JOIN sides (LEFT, RIGHT) are supported in conjunction with SEMI/ANTI join kinds
     SEMI_ANTI_JOIN_WITH_SIDE = True
 
-    # Whether or not to include the type of a computed column in the CREATE DDL
+    # Whether to include the type of a computed column in the CREATE DDL
     COMPUTED_COLUMN_WITH_TYPE = True
 
-    # Whether or not CREATE TABLE .. COPY .. is supported. False means we'll generate CLONE instead of COPY
+    # Whether CREATE TABLE .. COPY .. is supported. False means we'll generate CLONE instead of COPY
     SUPPORTS_TABLE_COPY = True
 
-    # Whether or not parentheses are required around the table sample's expression
+    # Whether parentheses are required around the table sample's expression
     TABLESAMPLE_REQUIRES_PARENS = True
 
-    # Whether or not a table sample clause's size needs to be followed by the ROWS keyword
+    # Whether a table sample clause's size needs to be followed by the ROWS keyword
     TABLESAMPLE_SIZE_IS_ROWS = True
 
     # The keyword(s) to use when generating a sample clause
     TABLESAMPLE_KEYWORDS = "TABLESAMPLE"
 
-    # Whether or not the TABLESAMPLE clause supports a method name, like BERNOULLI
+    # Whether the TABLESAMPLE clause supports a method name, like BERNOULLI
     TABLESAMPLE_WITH_METHOD = True
 
     # The keyword to use when specifying the seed of a sample clause
     TABLESAMPLE_SEED_KEYWORD = "SEED"
 
-    # Whether or not COLLATE is a function instead of a binary operator
+    # Whether COLLATE is a function instead of a binary operator
     COLLATE_IS_FUNC = False
 
-    # Whether or not data types support additional specifiers like e.g. CHAR or BYTE (oracle)
+    # Whether data types support additional specifiers like e.g. CHAR or BYTE (oracle)
     DATA_TYPE_SPECIFIERS_ALLOWED = False
 
-    # Whether or not conditions require booleans WHERE x = 0 vs WHERE x
+    # Whether conditions require booleans WHERE x = 0 vs WHERE x
     ENSURE_BOOLS = False
 
-    # Whether or not the "RECURSIVE" keyword is required when defining recursive CTEs
+    # Whether the "RECURSIVE" keyword is required when defining recursive CTEs
     CTE_RECURSIVE_KEYWORD_REQUIRED = True
 
-    # Whether or not CONCAT requires >1 arguments
+    # Whether CONCAT requires >1 arguments
     SUPPORTS_SINGLE_ARG_CONCAT = True
 
-    # Whether or not LAST_DAY function supports a date part argument
+    # Whether LAST_DAY function supports a date part argument
     LAST_DAY_SUPPORTS_DATE_PART = True
 
-    # Whether or not named columns are allowed in table aliases
+    # Whether named columns are allowed in table aliases
     SUPPORTS_TABLE_ALIAS_COLUMNS = True
 
-    # Whether or not UNPIVOT aliases are Identifiers (False means they're Literals)
+    # Whether UNPIVOT aliases are Identifiers (False means they're Literals)
     UNPIVOT_ALIASES_ARE_IDENTIFIERS = True
 
     # What delimiter to use for separating JSON key/value pairs
@@ -291,29 +291,29 @@ class Generator(metaclass=_Generator):
     # INSERT OVERWRITE TABLE x override
     INSERT_OVERWRITE = " OVERWRITE TABLE"
 
-    # Whether or not the SELECT .. INTO syntax is used instead of CTAS
+    # Whether the SELECT .. INTO syntax is used instead of CTAS
     SUPPORTS_SELECT_INTO = False
 
-    # Whether or not UNLOGGED tables can be created
+    # Whether UNLOGGED tables can be created
     SUPPORTS_UNLOGGED_TABLES = False
 
-    # Whether or not the CREATE TABLE LIKE statement is supported
+    # Whether the CREATE TABLE LIKE statement is supported
     SUPPORTS_CREATE_TABLE_LIKE = True
 
-    # Whether or not the LikeProperty needs to be specified inside of the schema clause
+    # Whether the LikeProperty needs to be specified inside of the schema clause
     LIKE_PROPERTY_INSIDE_SCHEMA = False
 
-    # Whether or not DISTINCT can be followed by multiple args in an AggFunc. If not, it will be
+    # Whether DISTINCT can be followed by multiple args in an AggFunc. If not, it will be
     # transpiled into a series of CASE-WHEN-ELSE, ultimately using a tuple conseisting of the args
     MULTI_ARG_DISTINCT = True
 
-    # Whether or not the JSON extraction operators expect a value of type JSON
+    # Whether the JSON extraction operators expect a value of type JSON
     JSON_TYPE_REQUIRED_FOR_EXTRACTION = False
 
-    # Whether or not bracketed keys like ["foo"] are supported in JSON paths
+    # Whether bracketed keys like ["foo"] are supported in JSON paths
     JSON_PATH_BRACKETED_KEY_SUPPORTED = True
 
-    # Whether or not to escape keys using single quotes in JSON paths
+    # Whether to escape keys using single quotes in JSON paths
     JSON_PATH_SINGLE_QUOTE_ESCAPE = False
 
     # The JSONPathPart expressions supported by this dialect
@@ -530,7 +530,7 @@ class Generator(metaclass=_Generator):
 
         Args:
             expression: The syntax tree.
-            copy: Whether or not to copy the expression. The generator performs mutations so
+            copy: Whether to copy the expression. The generator performs mutations so
                 it is safer to copy.
 
         Returns:

--- a/sqlglot/optimizer/normalize.py
+++ b/sqlglot/optimizer/normalize.py
@@ -76,7 +76,7 @@ def normalized(expression: exp.Expression, dnf: bool = False) -> bool:
 
     Args:
         expression: The expression to check if it's normalized.
-        dnf: Whether or not to check if the expression is in Disjunctive Normal Form (DNF).
+        dnf: Whether to check if the expression is in Disjunctive Normal Form (DNF).
             Default: False, i.e. we check if it's in Conjunctive Normal Form (CNF).
     """
     ancestor, root = (exp.And, exp.Or) if dnf else (exp.Or, exp.And)
@@ -99,7 +99,7 @@ def normalization_distance(expression: exp.Expression, dnf: bool = False) -> int
 
     Args:
         expression: The expression to compute the normalization distance for.
-        dnf: Whether or not to check if the expression is in Disjunctive Normal Form (DNF).
+        dnf: Whether to check if the expression is in Disjunctive Normal Form (DNF).
             Default: False, i.e. we check if it's in Conjunctive Normal Form (CNF).
 
     Returns:

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -48,15 +48,15 @@ def qualify(
         db: Default database name for tables.
         catalog: Default catalog name for tables.
         schema: Schema to infer column names and types.
-        expand_alias_refs: Whether or not to expand references to aliases.
-        expand_stars: Whether or not to expand star queries. This is a necessary step
+        expand_alias_refs: Whether to expand references to aliases.
+        expand_stars: Whether to expand star queries. This is a necessary step
             for most of the optimizer's rules to work; do not set to False unless you
             know what you're doing!
-        infer_schema: Whether or not to infer the schema if missing.
-        isolate_tables: Whether or not to isolate table selects.
-        qualify_columns: Whether or not to qualify columns.
-        validate_qualify_columns: Whether or not to validate columns.
-        quote_identifiers: Whether or not to run the quote_identifiers step.
+        infer_schema: Whether to infer the schema if missing.
+        isolate_tables: Whether to isolate table selects.
+        qualify_columns: Whether to qualify columns.
+        validate_qualify_columns: Whether to validate columns.
+        quote_identifiers: Whether to run the quote_identifiers step.
             This step is necessary to ensure correctness for case sensitive queries.
             But this flag is provided in case this step is performed at a later time.
         identify: If True, quote all identifiers, else only necessary ones.

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -35,11 +35,11 @@ def qualify_columns(
     Args:
         expression: Expression to qualify.
         schema: Database schema.
-        expand_alias_refs: Whether or not to expand references to aliases.
-        expand_stars: Whether or not to expand star queries. This is a necessary step
+        expand_alias_refs: Whether to expand references to aliases.
+        expand_stars: Whether to expand star queries. This is a necessary step
             for most of the optimizer's rules to work; do not set to False unless you
             know what you're doing!
-        infer_schema: Whether or not to infer the schema if missing.
+        infer_schema: Whether to infer the schema if missing.
 
     Returns:
         The qualified expression.

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -41,7 +41,7 @@ def simplify(
 
     Args:
         expression (sqlglot.Expression): expression to simplify
-        constant_propagation: whether or not the constant propagation rule should be used
+        constant_propagation: whether the constant propagation rule should be used
 
     Returns:
         sqlglot.Expression: simplified expression

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -87,8 +87,8 @@ class Parser(metaclass=_Parser):
     Args:
         error_level: The desired error level.
             Default: ErrorLevel.IMMEDIATE
-        error_message_context: Determines the amount of context to capture from a
-            query string when displaying the error message (in number of characters).
+        error_message_context: The amount of context to capture from a query string when displaying
+            the error message (in number of characters).
             Default: 100
         max_errors: Maximum number of error messages to include in a raised ParseError.
             This is only relevant if error_level is ErrorLevel.RAISE.
@@ -982,32 +982,31 @@ class Parser(metaclass=_Parser):
 
     LOG_DEFAULTS_TO_LN = False
 
-    # Whether or not ADD is present for each column added by ALTER TABLE
+    # Whether ADD is present for each column added by ALTER TABLE
     ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN = True
 
-    # Whether or not the table sample clause expects CSV syntax
+    # Whether the table sample clause expects CSV syntax
     TABLESAMPLE_CSV = False
 
-    # Whether or not the SET command needs a delimiter (e.g. "=") for assignments
+    # Whether the SET command needs a delimiter (e.g. "=") for assignments
     SET_REQUIRES_ASSIGNMENT_DELIMITER = True
 
     # Whether the TRIM function expects the characters to trim as its first argument
     TRIM_PATTERN_FIRST = False
 
-    # Whether or not string aliases are supported `SELECT COUNT(*) 'count'`
+    # Whether string aliases are supported `SELECT COUNT(*) 'count'`
     STRING_ALIASES = False
 
     # Whether query modifiers such as LIMIT are attached to the UNION node (vs its right operand)
     MODIFIERS_ATTACHED_TO_UNION = True
     UNION_MODIFIERS = {"order", "limit", "offset"}
 
-    # Parses no parenthesis if statements as commands
+    # Whether to parse IF statements that aren't followed by a left parenthesis as commands
     NO_PAREN_IF_COMMANDS = True
 
-    # Whether or not the -> and ->> operators expect documents of type JSON (e.g. Postgres)
+    # Whether the -> and ->> operators expect documents of type JSON (e.g. Postgres)
     JSON_ARROWS_REQUIRE_JSON_TYPE = False
 
-    # Whether or not a VALUES keyword needs to be followed by '(' to form a VALUES clause.
     # If this is True and '(' is not found, the keyword will be treated as an identifier
     VALUES_FOLLOWED_BY_PAREN = True
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1007,6 +1007,7 @@ class Parser(metaclass=_Parser):
     # Whether the -> and ->> operators expect documents of type JSON (e.g. Postgres)
     JSON_ARROWS_REQUIRE_JSON_TYPE = False
 
+    # Whether or not a VALUES keyword needs to be followed by '(' to form a VALUES clause.
     # If this is True and '(' is not found, the keyword will be treated as an identifier
     VALUES_FOLLOWED_BY_PAREN = True
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -92,7 +92,7 @@ class Schema(abc.ABC):
         normalize: t.Optional[bool] = None,
     ) -> bool:
         """
-        Returns whether or not `column` appears in `table`'s schema.
+        Returns whether `column` appears in `table`'s schema.
 
         Args:
             table: the source table.
@@ -115,7 +115,7 @@ class Schema(abc.ABC):
 
     @property
     def empty(self) -> bool:
-        """Returns whether or not the schema is empty."""
+        """Returns whether the schema is empty."""
         return True
 
 
@@ -162,7 +162,7 @@ class AbstractMappingSchema:
 
         Args:
             table: the target table.
-            raise_on_missing: whether or not to raise in case the schema is not found.
+            raise_on_missing: whether to raise in case the schema is not found.
 
         Returns:
             The schema of the target table.

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -577,7 +577,7 @@ class Tokenizer(metaclass=_Tokenizer):
     STRING_ESCAPES = ["'"]
     VAR_SINGLE_TOKENS: t.Set[str] = set()
 
-    # Whether or not the heredoc tags follow the same lexical rules as unquoted identifiers
+    # Whether the heredoc tags follow the same lexical rules as unquoted identifiers
     HEREDOC_TAG_IS_IDENTIFIER = False
 
     # Token that we'll generate as a fallback if the heredoc prefix doesn't correspond to a heredoc

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -729,7 +729,7 @@ class TestDialect(Validator):
             write={
                 "duckdb": "TO_TIMESTAMP(x)",
                 "hive": "FROM_UNIXTIME(x)",
-                "oracle": "TO_DATE('1970-01-01','YYYY-MM-DD') + (x / 86400)",
+                "oracle": "TO_DATE('1970-01-01', 'YYYY-MM-DD') + (x / 86400)",
                 "postgres": "TO_TIMESTAMP(x)",
                 "presto": "FROM_UNIXTIME(x)",
                 "starrocks": "FROM_UNIXTIME(x)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -594,9 +594,9 @@ WHERE
         self.validate_all(
             "SELECT TO_TIMESTAMP(16599817290000, 4)",
             write={
-                "bigquery": "SELECT TIMESTAMP_SECONDS(CAST(16599817290000 / POW(10, 4) AS INT64))",
+                "bigquery": "SELECT TIMESTAMP_SECONDS(CAST(16599817290000 / POWER(10, 4) AS INT64))",
                 "snowflake": "SELECT TO_TIMESTAMP(16599817290000, 4)",
-                "spark": "SELECT TIMESTAMP_SECONDS(16599817290000 / POW(10, 4))",
+                "spark": "SELECT TIMESTAMP_SECONDS(16599817290000 / POWER(10, 4))",
             },
         )
         self.validate_all(
@@ -609,11 +609,11 @@ WHERE
         self.validate_all(
             "SELECT TO_TIMESTAMP(1659981729000000000, 9)",
             write={
-                "bigquery": "SELECT TIMESTAMP_SECONDS(CAST(1659981729000000000 / POW(10, 9) AS INT64))",
-                "duckdb": "SELECT TO_TIMESTAMP(1659981729000000000 / POW(10, 9))",
+                "bigquery": "SELECT TIMESTAMP_SECONDS(CAST(1659981729000000000 / POWER(10, 9) AS INT64))",
+                "duckdb": "SELECT TO_TIMESTAMP(1659981729000000000 / POWER(10, 9))",
                 "presto": "SELECT FROM_UNIXTIME(CAST(1659981729000000000 AS DOUBLE) / POW(10, 9))",
                 "snowflake": "SELECT TO_TIMESTAMP(1659981729000000000, 9)",
-                "spark": "SELECT TIMESTAMP_SECONDS(1659981729000000000 / POW(10, 9))",
+                "spark": "SELECT TIMESTAMP_SECONDS(1659981729000000000 / POWER(10, 9))",
             },
         )
         self.validate_all(


### PR DESCRIPTION
I've been meaning to do this sweep for quite some time. The changes at a high level are:

- Several misc. refactors, like the `_derived_table_values_to_unnest` one
- Use `build` instead of `parse` when defining helper callbacks that are used as values in `FUNCTIONS` entries - the latter term [wasn't quite correct](https://github.com/tobymao/sqlglot/pull/2946#discussion_r1484646526), as there's no _parsing_ involved but rather only constructing expressions
- Use `self.func` in most places over manually constructing strings like `f"FOO({...})`. This ensures we'll use the pretty-printing logic for these functions when needed. There are some exceptions that I didn't change because they were more complex, e.g. they had additional casts and nested function calls and I wanted to avoid the parsing overhead
- Rename a few things here and there to better capture the intent of the corresponding functions / variables / methods
- Try to enforce some level of consistency w.r.t. naming schemes, formatting, code structure etc

These changes are somewhat opinionated, happy to chat more and revert those that others don't agree with. The motivation was to gradually try and make the codebase a bit cleaner so that newcomers can navigate it more easily and avoid replicating smelly patterns. A nice side effect was that in the process I found some things that could be cleaned up.

Need to do another pass on this to make sure I didn't miss something & double-check that the changes are good.