### PR TITLE
Feat: support parameters in BigQuery / DuckDB

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -858,3 +858,6 @@ class BigQuery(Dialect):
             if expression.name == "TIMESTAMP":
                 expression.set("this", "SYSTEM_TIME")
             return super().version_sql(expression)
+
+        def placeholder_sql(self, expression: exp.Placeholder) -> str:
+            return f"@{expression.name}" if expression.name else "?"

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -313,6 +313,7 @@ class DuckDB(Dialect):
             return pivot_column_names(aggregations, dialect="duckdb")
 
     class Generator(generator.Generator):
+        PARAMETER_TOKEN = "$"
         JOIN_HINTS = False
         TABLE_HINTS = False
         QUERY_HINTS = False

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -994,3 +994,10 @@ class TestDuckDB(Validator):
             read={"bigquery": "IS_INF(x)"},
             write={"bigquery": "IS_INF(x)", "duckdb": "ISINF(x)"},
         )
+
+    def test_parameter_token(self):
+        self.validate_all(
+            "SELECT $foo",
+            read={"bigquery": "SELECT @foo"},
+            write={"bigquery": "SELECT @foo", "duckdb": "SELECT $foo"},
+        )


### PR DESCRIPTION
- Add `PARAMETER_TOKEN` to duckdb dialect
- Add `placeholder_sql` to bigquery dialect

Ref: https://cloud.google.com/bigquery/docs/parameterized-queries
Ref: https://duckdb.org/docs/sql/query_syntax/prepared_statements.html#syntax