### PR TITLE
Convert SIGNUM function to SIGN

### DIFF
--- a/sqlglot/dataframe/sql/functions.py
+++ b/sqlglot/dataframe/sql/functions.py
@@ -210,7 +210,7 @@ def sec(col: ColumnOrName) -> Column:
 
 
 def signum(col: ColumnOrName) -> Column:
-    return Column.invoke_anonymous_function(col, "SIGNUM")
+    return Column.invoke_expression_over_column(col, expression.Sign)
 
 
 def sin(col: ColumnOrName) -> Column:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5313,6 +5313,10 @@ class SHA2(Func):
     arg_types = {"this": True, "length": False}
 
 
+class Sign(Func):
+    _sql_names = ["SIGN", "SIGNUM"]
+
+
 class SortArray(Func):
     arg_types = {"this": True, "asc": False}
 

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -191,6 +191,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             exp.DateToDi,
             exp.Floor,
             exp.Levenshtein,
+            exp.Sign,
             exp.StrPosition,
             exp.TsOrDiToDi,
         },

--- a/tests/dataframe/unit/test_functions.py
+++ b/tests/dataframe/unit/test_functions.py
@@ -280,9 +280,9 @@ class TestFunctions(unittest.TestCase):
 
     def test_signum(self):
         col_str = SF.signum("cola")
-        self.assertEqual("SIGNUM(cola)", col_str.sql())
+        self.assertEqual("SIGN(cola)", col_str.sql())
         col = SF.signum(SF.col("cola"))
-        self.assertEqual("SIGNUM(cola)", col.sql())
+        self.assertEqual("SIGN(cola)", col.sql())
 
     def test_sin(self):
         col_str = SF.sin("cola")

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1142,3 +1142,18 @@ MATCH_RECOGNIZE (
                 "presto": "DATE_FORMAT(ts, '%y')",
             },
         )
+
+    def test_signum(self):
+        self.validate_all(
+            "SIGN(x)",
+            read={
+                "presto": "SIGN(x)",
+                "spark": "SIGNUM(x)",
+                "starrocks": "SIGN(x)",
+            },
+            write={
+                "presto": "SIGN(x)",
+                "spark": "SIGN(x)",
+                "starrocks": "SIGN(x)",
+            },
+        )


### PR DESCRIPTION
Spark has [`SIGNUM`](https://spark.apache.org/docs/latest/api/sql/#signum) and `SIGN`](https://spark.apache.org/docs/latest/api/sql/#sign) functions

 but `SIGNUM` does not exist in [Presto](https://trino.io/docs/current/functions/math.html#mathematical-functions), [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#sign), [Starrocks](https://docs.starrocks.io/docs/2.3/sql-reference/sql-functions/math-functions/sign/)

So it seems simpler to always transpile to `SIGN` for all dialects (and to incorrectly parse `SIGNUM` even if the query engines don't support it)