### PR TITLE
Feat(doris):Add conversion from oracle add_months to Doris months_add

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -58,6 +58,7 @@ class Doris(MySQL):
             exp.StrToUnix: lambda self, e: self.func("UNIX_TIMESTAMP", e.this, self.format_time(e)),
             exp.Split: rename_func("SPLIT_BY_STRING"),
             exp.TimeStrToDate: rename_func("TO_DATE"),
+            exp.AddMonths: rename_func("MONTHS_ADD"),
             exp.TsOrDsAdd: lambda self, e: self.func("DATE_ADD", e.this, e.expression),
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this),
             exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -30,6 +30,11 @@ def _build_timetostr_or_tochar(args: t.List) -> exp.TimeToStr | exp.ToChar:
 
     return exp.ToChar.from_arg_list(args)
 
+def _build_addmonths(args: t.List) -> exp.AddMonths:
+    return exp.AddMonths(
+        this=seq_get(args, 0),
+        integer=seq_get(args, 1)
+    )
 
 class Oracle(Dialect):
     ALIAS_POST_TABLESAMPLE = True
@@ -77,6 +82,7 @@ class Oracle(Dialect):
             "TO_CHAR": _build_timetostr_or_tochar,
             "TO_TIMESTAMP": build_formatted_time(exp.StrToTime, "oracle"),
             "TO_DATE": build_formatted_time(exp.StrToDate, "oracle"),
+            "ADD_MONTHS": _build_addmonths
         }
 
         FUNCTION_PARSERS: t.Dict[str, t.Callable] = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5434,6 +5434,10 @@ class TimeStrToDate(Func):
     pass
 
 
+class AddMonths(Func):
+    arg_types = {"this": True, "integer": True}
+
+
 class TimeStrToTime(Func):
     pass
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -625,6 +625,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("TIME_TO_TIME_STR(a)"), exp.Cast)
         self.assertIsInstance(parse_one("TIME_TO_UNIX(a)"), exp.TimeToUnix)
         self.assertIsInstance(parse_one("TIME_STR_TO_DATE(a)"), exp.TimeStrToDate)
+        self.assertIsInstance(parse_one("ADD_MONTHS(a, 1)"), exp.AddMonths)
         self.assertIsInstance(parse_one("TIME_STR_TO_TIME(a)"), exp.TimeStrToTime)
         self.assertIsInstance(parse_one("TIME_STR_TO_UNIX(a)"), exp.TimeStrToUnix)
         self.assertIsInstance(parse_one("TRIM(LEADING 'b' FROM 'bla')"), exp.Trim)


### PR DESCRIPTION
When `add_months` is converted from oracle to doris, `add_months` should be converted to `months_add`
[docs](https://doris.apache.org/zh-CN/docs/dev/sql-manual/sql-functions/date-time-functions/months-add?)