### PR TITLE
Feat: Supporting RANGE <-> GENERATE_SERIES between DuckDB & SQLite

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -87,7 +87,7 @@ def _build_generate_series(end_exclusive: bool = False) -> t.Callable[[t.List], 
             args.insert(0, exp.Literal.number("0"))
 
         gen_series = exp.GenerateSeries.from_arg_list(args)
-        gen_series.args["is_end_exclusive"] = end_exclusive
+        gen_series.set("is_end_exclusive", end_exclusive)
 
         return gen_series
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4434,7 +4434,7 @@ class ToChar(Func):
 
 
 class GenerateSeries(Func):
-    arg_types = {"start": True, "end": True, "step": False}
+    arg_types = {"start": True, "end": True, "step": False, "is_end_exclusive": False}
 
 
 class ArrayAgg(AggFunc):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3456,8 +3456,5 @@ class Generator(metaclass=_Generator):
         ]
 
     def generateseries_sql(self, expression: exp.GenerateSeries) -> str:
-        start = expression.args.get("start")
-        end = expression.args.get("end")
-        step = expression.args.get("step")
-
-        return self.func("GENERATE_SERIES", start, end, step)
+        expression.set("is_end_exclusive", None)
+        return self.function_fallback_sql(expression)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3454,3 +3454,10 @@ class Generator(metaclass=_Generator):
             for value in values
             if value
         ]
+
+    def generateseries_sql(self, expression: exp.GenerateSeries) -> str:
+        start = expression.args.get("start")
+        end = expression.args.get("end")
+        step = expression.args.get("step")
+
+        return self.func("GENERATE_SERIES", start, end, step)

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -174,7 +174,6 @@ class TestDuckDB(Validator):
             },
         )
 
-        self.validate_identity("SELECT i FROM RANGE(5) AS _(i) ORDER BY i ASC")
         self.validate_identity("INSERT INTO x BY NAME SELECT 1 AS y")
         self.validate_identity("SELECT 1 AS x UNION ALL BY NAME SELECT 2 AS x")
         self.validate_identity("SELECT SUM(x) FILTER (x = 1)", "SELECT SUM(x) FILTER(WHERE x = 1)")
@@ -624,6 +623,26 @@ class TestDuckDB(Validator):
                 "duckdb": "SELECT COUNT_IF(x)",
                 "bigquery": "SELECT COUNTIF(x)",
             },
+        )
+
+        self.validate_identity("SELECT * FROM RANGE(1, 5, 10)")
+        self.validate_identity("SELECT * FROM GENERATE_SERIES(2, 13, 4)")
+
+        self.validate_all(
+            "WITH t AS (SELECT i, i*i*i*i*i AS i5 FROM RANGE(1,5) t(i)) SELECT * FROM t",
+            write={
+                "sqlite": "WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM (SELECT value AS i FROM GENERATE_SERIES(1, 5)) AS t) SELECT * FROM t",
+            },
+        )
+
+        self.validate_identity(
+            """SELECT i FROM RANGE(5) AS _(i) ORDER BY i ASC""",
+            """SELECT i FROM RANGE(0, 5) AS _(i) ORDER BY i ASC""",
+        )
+
+        self.validate_identity(
+            """SELECT i FROM GENERATE_SERIES(12) AS _(i) ORDER BY i ASC""",
+            """SELECT i FROM GENERATE_SERIES(0, 12) AS _(i) ORDER BY i ASC""",
         )
 
     def test_array_index(self):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -631,13 +631,9 @@ class TestDuckDB(Validator):
         self.validate_all(
             "WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) t(i)) SELECT * FROM t",
             write={
+                "duckdb": "WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) AS t(i)) SELECT * FROM t",
                 "sqlite": "WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM (SELECT value AS i FROM GENERATE_SERIES(1, 5)) AS t) SELECT * FROM t",
             },
-        )
-
-        self.validate_identity(
-            """WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) t(i)) SELECT * FROM t""",
-            """WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) AS t(i)) SELECT * FROM t""",
         )
 
         self.validate_identity(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -629,10 +629,15 @@ class TestDuckDB(Validator):
         self.validate_identity("SELECT * FROM GENERATE_SERIES(2, 13, 4)")
 
         self.validate_all(
-            "WITH t AS (SELECT i, i*i*i*i*i AS i5 FROM RANGE(1,5) t(i)) SELECT * FROM t",
+            "WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) t(i)) SELECT * FROM t",
             write={
                 "sqlite": "WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM (SELECT value AS i FROM GENERATE_SERIES(1, 5)) AS t) SELECT * FROM t",
             },
+        )
+
+        self.validate_identity(
+            """WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) t(i)) SELECT * FROM t""",
+            """WITH t AS (SELECT i, i * i * i * i * i AS i5 FROM RANGE(1, 5) AS t(i)) SELECT * FROM t""",
         )
 
         self.validate_identity(


### PR DESCRIPTION
Hi,

The following PR aims to address [discussion#2995 ](https://github.com/tobymao/sqlglot/discussions/2995)

Key changes:

- SQLite now explicitly rejects table alias columns. In order to implement the sample query from the discussion which uses this DuckDB feature, SQLite now wraps the output of `exp.GenerateSeries` in a subquery with the proper (i.e first) column reference if a TableAlias is binding to the function call. 

- The AST node `exp.GenerateSeries` now carries one more argument (state) to mark whether the end is inclusive/exclusive, as the same function appears on other dialects and/or in other flavors e.g. DuckDB supports `RANGE` (exclusive end) _and_ `GENERATE_SERIES` (inclusive end). 

Future PRs should hopefully: 
- Aim to support the flavors of `GENERATE_SERIES / RANGE` across all dialects through the `exp.GenerateSeries`
- Transform the range appropriately (wherever possible) e.g in DuckDB the proper transpilation should be `RANGE(1, 5) -> GENERATE_SERIES(1, 4)` to match the data output

Docs
---------
- [DuckDB Range Functions](https://duckdb.org/docs/sql/functions/nested.html#range-functions)
- [SQLite GENERATE_SERIES Function](https://www.sqlite.org/series.html)