### PR TITLE
Refactor: move limit method to Query, get rid of Subquery.subquery override

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -874,7 +874,7 @@ class TSQL(Dialect):
                 if ctas_with:
                     ctas_with = ctas_with.pop()
 
-                if isinstance(ctas_expression, exp.Query):
+                if isinstance(ctas_expression, exp.UNWRAPPED_QUERIES):
                     ctas_expression = ctas_expression.subquery()
 
                 select_into = exp.select("*").from_(exp.alias_(ctas_expression, "temp", table=True))

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3466,14 +3466,6 @@ class Subquery(DerivedTable, Query):
             expression = t.cast(Subquery, expression.parent)
         return expression
 
-    def subquery(self, alias: t.Optional[ExpOrStr] = None, copy: bool = True) -> Subquery:
-        instance = maybe_copy(self, copy)
-        if not isinstance(alias, Expression):
-            alias = TableAlias(this=to_identifier(alias)) if alias else None
-
-        instance.set("alias", alias)
-        return instance
-
     def select(
         self,
         *expressions: t.Optional[ExpOrStr],

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -942,7 +942,7 @@ class Query(Expression):
 
     def limit(
         self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
-    ) -> Query:
+    ) -> Select:
         """
         Adds a LIMIT clause to this query.
 
@@ -960,9 +960,13 @@ class Query(Expression):
             opts: other options to use to parse the input expressions.
 
         Returns:
-            The limited query.
+            A limit Select expression.
         """
-        raise NotImplementedError
+        return (
+            select("*")
+            .from_(self.subquery(alias="_l_0", copy=copy))
+            .limit(expression, dialect=dialect, copy=False, **opts)
+        )
 
     @property
     def ctes(self) -> t.List[CTE]:
@@ -2682,15 +2686,6 @@ class Union(Query):
         **QUERY_MODIFIERS,
     }
 
-    def limit(
-        self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
-    ) -> Select:
-        return (
-            select("*")
-            .from_(self.subquery(alias="_l_0", copy=copy))
-            .limit(expression, dialect=dialect, copy=False, **opts)
-        )
-
     def select(
         self,
         *expressions: t.Optional[ExpOrStr],
@@ -3489,13 +3484,6 @@ class Subquery(DerivedTable, Query):
     ) -> Subquery:
         this = maybe_copy(self, copy)
         this.unnest().select(*expressions, append=append, dialect=dialect, copy=False, **opts)
-        return this
-
-    def limit(
-        self, expression: ExpOrStr | int, dialect: DialectType = None, copy: bool = True, **opts
-    ) -> Subquery:
-        this = maybe_copy(self, copy)
-        this.unnest().limit(expression, dialect=dialect, copy=False, **opts)
         return this
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -960,7 +960,7 @@ class Query(Expression):
             opts: other options to use to parse the input expressions.
 
         Returns:
-            A limit Select expression.
+            A limited Select expression.
         """
         return (
             select("*")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -692,12 +692,7 @@ class TestTSQL(Validator):
             "SELECT * INTO foo.bar.baz FROM (SELECT * FROM a.b.c) AS temp",
             read={
                 "": "CREATE TABLE foo.bar.baz AS SELECT * FROM a.b.c",
-            },
-        )
-        self.validate_all(
-            "SELECT * INTO foo.bar.baz FROM (SELECT * FROM a.b.c) AS temp",
-            read={
-                "": "CREATE TABLE foo.bar.baz AS (SELECT * FROM a.b.c)",
+                "duckdb": "CREATE TABLE foo.bar.baz AS (SELECT * FROM a.b.c)",
             },
         )
         self.validate_all(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -502,13 +502,20 @@ class TestBuild(unittest.TestCase):
                 "SELECT x FROM (SELECT x FROM tbl UNION SELECT x FROM bar) AS unioned",
             ),
             (lambda: parse_one("(SELECT 1)").select("2"), "(SELECT 1, 2)"),
-            (lambda: parse_one("(SELECT 1)").limit(1), "SELECT * FROM (SELECT 1) AS _l_0 LIMIT 1"),
+            (
+                lambda: parse_one("(SELECT 1)").limit(1),
+                "SELECT * FROM ((SELECT 1)) AS _l_0 LIMIT 1",
+            ),
+            (
+                lambda: parse_one("WITH t AS (SELECT 1) (SELECT 1)").limit(1),
+                "SELECT * FROM (WITH t AS (SELECT 1) (SELECT 1)) AS _l_0 LIMIT 1",
+            ),
             (
                 lambda: parse_one("(SELECT 1 LIMIT 2)").limit(1),
-                "SELECT * FROM (SELECT 1 LIMIT 2) AS _l_0 LIMIT 1",
+                "SELECT * FROM ((SELECT 1 LIMIT 2)) AS _l_0 LIMIT 1",
             ),
-            (lambda: parse_one("(SELECT 1)").subquery(), "(SELECT 1)"),
-            (lambda: parse_one("(SELECT 1)").subquery("alias"), "(SELECT 1) AS alias"),
+            (lambda: parse_one("(SELECT 1)").subquery(), "((SELECT 1))"),
+            (lambda: parse_one("(SELECT 1)").subquery("alias"), "((SELECT 1)) AS alias"),
             (
                 lambda: parse_one("(select * from foo)").with_("foo", "select 1 as c"),
                 "WITH foo AS (SELECT 1 AS c) (SELECT * FROM foo)",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -502,8 +502,11 @@ class TestBuild(unittest.TestCase):
                 "SELECT x FROM (SELECT x FROM tbl UNION SELECT x FROM bar) AS unioned",
             ),
             (lambda: parse_one("(SELECT 1)").select("2"), "(SELECT 1, 2)"),
-            (lambda: parse_one("(SELECT 1)").limit(1), "(SELECT 1 LIMIT 1)"),
-            (lambda: parse_one("(SELECT 1 LIMIT 2)").limit(1), "(SELECT 1 LIMIT 1)"),
+            (lambda: parse_one("(SELECT 1)").limit(1), "SELECT * FROM (SELECT 1) AS _l_0 LIMIT 1"),
+            (
+                lambda: parse_one("(SELECT 1 LIMIT 2)").limit(1),
+                "SELECT * FROM (SELECT 1 LIMIT 2) AS _l_0 LIMIT 1",
+            ),
             (lambda: parse_one("(SELECT 1)").subquery(), "(SELECT 1)"),
             (lambda: parse_one("(SELECT 1)").subquery("alias"), "(SELECT 1) AS alias"),
             (


### PR DESCRIPTION
I decided to move the `SELECT * FROM (...) LIMIT ...` logic in the `Query` class so that all queries will return a `Select` when limited. This can be useful if you wanna create a `Select` expression in order to use the rest of its builders ([example](https://github.com/TobikoData/sqlmesh/blob/8258d0eb7419f8683cdffc2500a4234f36c6df05/sqlmesh/core/model/definition.py#L428)), not available in `Query`.

I also got rid of the `Subquery.subquery` override because with the `limit` change it'd prove problematic, see:

```python
                lambda: parse_one("WITH t AS (SELECT 1) (SELECT 1)").limit(1),
                "SELECT * FROM (WITH t AS (SELECT 1) (SELECT 1)) AS _l_0 LIMIT 1",
```

If we don't wrap `Subquery` when calling `subquery`, the above builder will produce:

```sql
SELECT * FROM WITH t AS (SELECT 1) (SELECT 1) AS _l_0 LIMIT 1
```

which is invalid syntax.