### PR TITLE
fix!: refactor structs to always be property eqs

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -129,6 +129,7 @@ class ClickHouse(Dialect):
             "MAP": parser.build_var_map,
             "MATCH": exp.RegexpLike.from_arg_list,
             "RANDCANONICAL": exp.Rand.from_arg_list,
+            "TUPLE": exp.Struct.from_arg_list,
             "UNIQ": exp.ApproxDistinct.from_arg_list,
             "XOR": lambda args: exp.Xor(expressions=args),
         }

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -631,3 +631,15 @@ class Hive(Dialect):
         def version_sql(self, expression: exp.Version) -> str:
             sql = super().version_sql(expression)
             return sql.replace("FOR ", "", 1)
+
+        def struct_sql(self, expression: exp.Struct) -> str:
+            values = []
+
+            for i, e in enumerate(expression.expressions):
+                if isinstance(e, exp.PropertyEQ):
+                    self.unsupported("Hive does not support named structs.")
+                    values.append(e.expression)
+                else:
+                    values.append(e)
+
+            return self.func("STRUCT", *values)

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -453,11 +453,32 @@ class Presto(Dialect):
             return super().bracket_sql(expression)
 
         def struct_sql(self, expression: exp.Struct) -> str:
-            if any(isinstance(arg, self.KEY_VALUE_DEFINITIONS) for arg in expression.expressions):
-                self.unsupported("Struct with key-value definitions is unsupported.")
-                return self.function_fallback_sql(expression)
+            from sqlglot.optimizer.annotate_types import annotate_types
 
-            return rename_func("ROW")(self, expression)
+            expression = annotate_types(expression)
+            values: t.List[str] = []
+            schema: t.List[str] = []
+            unknown_type = False
+
+            for e in expression.expressions:
+                if isinstance(e, exp.PropertyEQ):
+                    if e.type and e.type.is_type(exp.DataType.Type.UNKNOWN):
+                        unknown_type = True
+                    else:
+                        schema.append(f"{self.sql(e, 'this')} {self.sql(e.type)}")
+                    values.append(self.sql(e, "expression"))
+                else:
+                    values.append(self.sql(e))
+
+            size = len(expression.expressions)
+
+            if not size or len(schema) != size:
+                if unknown_type:
+                    self.unsupported(
+                        "Cannot convert untyped key-value definitions (try annotate_types)."
+                    )
+                return self.func("ROW", *values)
+            return f"CAST(ROW({', '.join(values)}) AS ROW({', '.join(schema)}))"
 
         def interval_sql(self, expression: exp.Interval) -> str:
             unit = self.sql(expression, "unit")

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -21,7 +21,7 @@ from sqlglot.dialects.dialect import (
     var_map_sql,
 )
 from sqlglot.expressions import Literal
-from sqlglot.helper import is_int, seq_get
+from sqlglot.helper import flatten, is_int, seq_get
 from sqlglot.tokens import TokenType
 
 if t.TYPE_CHECKING:
@@ -66,7 +66,7 @@ def _build_object_construct(args: t.List) -> t.Union[exp.StarMap, exp.Struct]:
 
     return exp.Struct(
         expressions=[
-            t.cast(exp.Condition, k).eq(v) for k, v in zip(expression.keys, expression.values)
+            exp.PropertyEQ(this=k, expression=v) for k, v in zip(expression.keys, expression.values)
         ]
     )
 
@@ -768,10 +768,6 @@ class Snowflake(Dialect):
                 "POSITION", e.args.get("substr"), e.this, e.args.get("position")
             ),
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
-            exp.Struct: lambda self, e: self.func(
-                "OBJECT_CONSTRUCT",
-                *(arg for expression in e.expressions for arg in expression.flatten()),
-            ),
             exp.Stuff: rename_func("INSERT"),
             exp.TimestampDiff: lambda self, e: self.func(
                 "TIMESTAMPDIFF", e.unit, e.expression, e.this
@@ -947,3 +943,19 @@ class Snowflake(Dialect):
 
         def cluster_sql(self, expression: exp.Cluster) -> str:
             return f"CLUSTER BY ({self.expressions(expression, flat=True)})"
+
+        def struct_sql(self, expression: exp.Struct) -> str:
+            keys = []
+            values = []
+
+            for i, e in enumerate(expression.expressions):
+                if isinstance(e, exp.PropertyEQ):
+                    keys.append(
+                        exp.Literal.string(e.name) if isinstance(e.this, exp.Identifier) else e.this
+                    )
+                    values.append(e.expression)
+                else:
+                    keys.append(exp.Literal.string(f"_{i}"))
+                    values.append(e)
+
+            return self.func("OBJECT_CONSTRUCT", *flatten(zip(keys, values)))

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -263,14 +263,9 @@ class Spark2(Hive):
         CREATE_FUNCTION_RETURN_AS = False
 
         def struct_sql(self, expression: exp.Struct) -> str:
-            args = []
-            for arg in expression.expressions:
-                if isinstance(arg, self.KEY_VALUE_DEFINITIONS):
-                    args.append(exp.alias_(arg.expression, arg.this.name))
-                else:
-                    args.append(arg)
+            from sqlglot.generator import Generator
 
-            return self.func("STRUCT", *args)
+            return Generator.struct_sql(self, expression)
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
             if is_parse_json(expression.this):

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -275,6 +275,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         exp.Min: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Null: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.NULL),
         exp.Nullif: lambda self, e: self._annotate_by_args(e, "this", "expression"),
+        exp.PropertyEQ: lambda self, e: self._annotate_by_args(e, "expression"),
         exp.Slice: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.UNKNOWN),
         exp.Struct: lambda self, e: self._annotate_by_args(e, "expressions", struct=True),
         exp.Sum: lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True),

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -560,6 +560,22 @@ def move_partitioned_by_to_schema_columns(expression: exp.Expression) -> exp.Exp
     return expression
 
 
+def struct_kv_to_alias(expression: exp.Expression) -> exp.Expression:
+    """
+    Convert struct arguments to aliases: STRUCT(1 AS y) .
+    """
+    if isinstance(expression, exp.Struct):
+        expression.set(
+            "expressions",
+            [
+                exp.alias_(e.expression, e.this) if isinstance(e, exp.PropertyEQ) else e
+                for e in expression.expressions
+            ],
+        )
+
+    return expression
+
+
 def preprocess(
     transforms: t.List[t.Callable[[exp.Expression], exp.Expression]],
 ) -> t.Callable[[Generator, exp.Expression], str]:

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -612,12 +612,6 @@ class TestHive(Validator):
             },
         )
         self.validate_all(
-            "STRUCT(a = b, c = d)",
-            read={
-                "snowflake": "OBJECT_CONSTRUCT(a, b, c, d)",
-            },
-        )
-        self.validate_all(
             "MAP(a, b, c, d)",
             read={
                 "": "VAR_MAP(a, b, c, d)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -372,15 +372,17 @@ WHERE
             write={"snowflake": "SELECT * FROM (VALUES (0)) AS foo(bar)"},
         )
         self.validate_all(
-            "OBJECT_CONSTRUCT(a, b, c, d)",
+            "OBJECT_CONSTRUCT('a', b, 'c', d)",
             read={
-                "": "STRUCT(a as b, c as d)",
+                "": "STRUCT(b as a, d as c)",
             },
             write={
                 "duckdb": "{'a': b, 'c': d}",
-                "snowflake": "OBJECT_CONSTRUCT(a, b, c, d)",
+                "snowflake": "OBJECT_CONSTRUCT('a', b, 'c', d)",
             },
         )
+        self.validate_identity("OBJECT_CONSTRUCT(a, b, c, d)")
+
         self.validate_all(
             "SELECT i, p, o FROM qt QUALIFY ROW_NUMBER() OVER (PARTITION BY p ORDER BY o) = 1",
             write={


### PR DESCRIPTION
closes #3015, allowing presto to have named structs if types are known