### PR TITLE
Feat(tsql): add support for OPTION clause, select only

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -894,7 +894,7 @@ class TSQL(Dialect):
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
-        def queryoption_sql(self, expression: exp.QueryOption):
+        def queryoption_sql(self, expression: exp.QueryOption) -> str:
             option_type = self.sql(expression, "this")
             option_value = self.sql(expression, "expression")
             if option_value:

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -63,6 +63,78 @@ DEFAULT_START_DATE = datetime.date(1900, 1, 1)
 
 BIT_TYPES = {exp.EQ, exp.NEQ, exp.Is, exp.In, exp.Select, exp.Alias}
 
+OPTION_PREFIX_TO_PARSE_FUNCTION = {
+    "LABEL": lambda self: self._generic_parse_option(
+        [
+            lambda: self._match(TokenType.EQ)
+            and self._return_option_with_value("LABEL", self._parse_primary())
+        ],
+    ),
+    "HASH": lambda self: self._generic_parse_option(["GROUP", "UNION", "JOIN"]),
+    "ORDER": lambda self: self._generic_parse_option(["GROUP"]),
+    "CONCAT": lambda self: self._generic_parse_option(["UNION"]),
+    "MERGE": lambda self: self._generic_parse_option(["UNION", "JOIN"]),
+    "LOOP": lambda self: self._generic_parse_option(["JOIN"]),
+    "DISABLE_OPTIMIZED_PLAN_FORCING": lambda self: self._generic_parse_option([]),
+    "EXPAND": lambda self: self._generic_parse_option(["VIEWS"]),
+    "FAST": lambda self: self._generic_parse_option(
+        [lambda: self._return_option_with_value("FAST", self._parse_number())]
+    ),
+    "FORCE": lambda self: self._generic_parse_option(
+        ["ORDER", "EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"]
+    ),
+    "DISABLE": lambda self: self._generic_parse_option(["EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"]),
+    "IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX": lambda self: self._generic_parse_option([]),
+    "KEEP": lambda self: self._generic_parse_option(["PLAN"]),
+    "KEEPFIXED": lambda self: self._generic_parse_option(["PLAN"]),
+    "MAX_GRANT_PERCENT": lambda self: self._generic_parse_option(
+        [
+            lambda: self._match(TokenType.EQ)
+            and self._generic_parse_option(
+                [lambda: self._return_option_with_value("MAX_GRANT_PERCENT", self._parse_number())],
+            )
+        ],
+    ),
+    "MIN_GRANT_PERCENT": lambda self: self._generic_parse_option(
+        [
+            lambda: self._match(TokenType.EQ)
+            and self._generic_parse_option(
+                [lambda: self._return_option_with_value("MIN_GRANT_PERCENT", self._parse_number())],
+            )
+        ],
+    ),
+    "MAXDOP": lambda self: self._generic_parse_option(
+        [lambda: self._return_option_with_value("MAXDOP", self._parse_number())]
+    ),
+    "MAXRECURSION": lambda self: self._generic_parse_option(
+        [lambda: self._return_option_with_value("MAXRECURSION", self._parse_number())],
+    ),
+    "NO_PERFORMANCE_SPOOL": lambda self: self._generic_parse_option([]),
+    "OPTIMIZE": lambda self: self._generic_parse_option(
+        [
+            # There is still no support for the following syntax:
+            # OPTIMIZE FOR ( @variable_name { UNKNOWN | = <literal_constant> } [ , ...n ] )
+            lambda: self._match_text_seq("FOR")
+            and self._generic_parse_option(["UNKNOWN"], "OPTIMIZE FOR")
+        ],
+    ),
+    "PARAMETERIZATION": lambda self: self._generic_parse_option(["SIMPLE", "FORCED"]),
+    "QUERYTRACEON": lambda self: self._generic_parse_option(
+        [lambda: self._return_option_with_value("QUERYTRACEON", self._parse_number())],
+    ),
+    "RECOMPILE": lambda self: self._generic_parse_option([]),
+    "ROBUST": lambda self: self._generic_parse_option(["PLAN"]),
+    "USE": lambda self: self._generic_parse_option(
+        [
+            lambda: self._match_text_seq("PLAN")
+            and self._return_option_with_value("USE PLAN", self._parse_primary())
+        ],
+    ),
+    # No support yet for TABLE HINT
+}
+
+OPTIONS_THAT_REQUIRE_EQUAL = ("MAX_GRANT_PERCENT", "MIN_GRANT_PERCENT", "LABEL")
+
 
 def _build_formatted_time(
     exp_class: t.Type[E], full_format_mapping: t.Optional[bool] = None
@@ -444,7 +516,7 @@ class TSQL(Dialect):
 
         QUERY_MODIFIER_PARSERS = {
             **parser.Parser.QUERY_MODIFIER_PARSERS,
-            TokenType.OPTION: lambda self: ("option", self._parse_option()),
+            TokenType.OPTION: lambda self: ("options", self._parse_option()),
         }
 
         FUNCTIONS = {
@@ -508,12 +580,42 @@ class TSQL(Dialect):
         STRING_ALIASES = True
         NO_PAREN_IF_COMMANDS = False
 
-        def _parse_string(self) -> t.Optional[exp.Expression]:
-            if self._curr is not None and self._curr.token_type == TokenType.NATIONAL_STRING:
-                result = self.PRIMARY_PARSERS[TokenType.NATIONAL_STRING](self, self._curr)
-                self._match(TokenType.NATIONAL_STRING)
-                return result
-            return super()._parse_string()
+        def _generic_parse_option(
+            self,
+            valid_continuations: t.List[t.Union[str, t.Callable]],
+            option_type: t.Optional[str] = None,
+        ) -> t.Optional[exp.QueryOption]:
+            # Handle the special case of options with no continuations.
+            option_type = self._prev.text.upper() if option_type is None else option_type
+            if not valid_continuations:
+                return self._return_option_with_value(
+                    self.expression(exp.Var, this=option_type), None
+                )
+
+            for valid_continuation in valid_continuations:
+                if callable(valid_continuation):
+                    res = valid_continuation()
+                    if res is not None:
+                        return res
+                elif isinstance(valid_continuation, str):
+                    if self._match_text_seq(valid_continuation):
+                        return self._return_option_with_value(
+                            self.expression(exp.Var, this=option_type), valid_continuation
+                        )
+            self.raise_error(f"Invalid {option_type} option")
+            return None
+
+        def _parse_option(self):
+            self._match(TokenType.OPTION)
+            return self._parse_wrapped_csv(self._parse_single_option)
+
+        def _parse_single_option(self) -> t.Optional[exp.Expression]:
+            cur_prefix = self._curr.text.upper()
+            if cur_prefix in OPTION_PREFIX_TO_PARSE_FUNCTION:
+                self._match_text_seq(cur_prefix.upper())
+                return OPTION_PREFIX_TO_PARSE_FUNCTION[cur_prefix](self)
+            self.raise_error("Invalid option type.")
+            return None
 
         def _parse_projections(self) -> t.List[exp.Expression]:
             """
@@ -791,6 +893,14 @@ class TSQL(Dialect):
             **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
+
+        def queryoption_sql(self, expression: exp.QueryOption):
+            option_type = self.sql(expression, "this")
+            option_value = self.sql(expression, "expression")
+            if option_value:
+                optional_equal_sign = "= " if option_type in OPTIONS_THAT_REQUIRE_EQUAL else ""
+                return f"{option_type} {optional_equal_sign}{option_value}"
+            return option_type
 
         def lateral_op(self, expression: exp.Lateral) -> str:
             cross_apply = expression.args.get("cross_apply")

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -436,6 +436,7 @@ class TSQL(Dialect):
             "OUTPUT": TokenType.RETURNING,
             "SYSTEM_USER": TokenType.CURRENT_USER,
             "FOR SYSTEM_TIME": TokenType.TIMESTAMP_SNAPSHOT,
+            "OPTION": TokenType.OPTION,
         }
 
     class Parser(parser.Parser):
@@ -496,11 +497,115 @@ class TSQL(Dialect):
             TokenType.END: lambda self: self._parse_command(),
         }
 
+        OPTION_PREFIX_TO_PARSE_FUNCTION = {
+            "LABEL": lambda self: self._generic_parse_option(
+                "LABEL",
+                [
+                    lambda: self._match(TokenType.EQ)
+                    and self._return_option_with_value("LABEL", self._parse_string())
+                ],
+            ),
+            "HASH": lambda self: self._generic_parse_option("HASH", ["GROUP", "UNION", "JOIN"]),
+            "ORDER": lambda self: self._generic_parse_option("ORDER", ["GROUP"]),
+            "CONCAT": lambda self: self._generic_parse_option("CONCAT", ["UNION"]),
+            "MERGE": lambda self: self._generic_parse_option("MERGE", ["UNION", "JOIN"]),
+            "LOOP": lambda self: self._generic_parse_option("LOOP", ["JOIN"]),
+            "DISABLE_OPTIMIZED_PLAN_FORCING": lambda self: self._generic_parse_option(
+                "DISABLE_OPTIMIZED_PLAN_FORCING", []
+            ),
+            "EXPAND": lambda self: self._generic_parse_option("EXPAND", ["VIEWS"]),
+            "FAST": lambda self: self._generic_parse_option(
+                "FAST", [lambda: self._return_option_with_value("FAST", self._parse_number())]
+            ),
+            "FORCE": lambda self: self._generic_parse_option(
+                "FORCE", ["ORDER", "EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"]
+            ),
+            "DISABLE": lambda self: self._generic_parse_option(
+                "DISABLE", ["EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"]
+            ),
+            "IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX": lambda self: self._generic_parse_option(
+                "IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX", []
+            ),
+            "KEEP": lambda self: self._generic_parse_option("KEEP", ["PLAN"]),
+            "KEEPFIXED": lambda self: self._generic_parse_option("KEEPFIXED", ["PLAN"]),
+            "MAX_GRANT_PERCENT": lambda self: self._generic_parse_option(
+                "MAX_GRANT_PERCENT",
+                [
+                    lambda: self._match(TokenType.EQ)
+                    and self._generic_parse_option(
+                        "MAX_GRANT_PERCENT",
+                        [
+                            lambda: self._return_option_with_value(
+                                "MAX_GRANT_PERCENT", self._parse_number(), requires_equals=True
+                            )
+                        ],
+                    )
+                ],
+            ),
+            "MIN_GRANT_PERCENT": lambda self: self._generic_parse_option(
+                "MIN_GRANT_PERCENT",
+                [
+                    lambda: self._match(TokenType.EQ)
+                    and self._generic_parse_option(
+                        "MIN_GRANT_PERCENT",
+                        [
+                            lambda: self._return_option_with_value(
+                                "MIN_GRANT_PERCENT", self._parse_number(), requires_equals=True
+                            )
+                        ],
+                    )
+                ],
+            ),
+            "MAXDOP": lambda self: self._generic_parse_option(
+                "MAXDOP", [lambda: self._return_option_with_value("MAXDOP", self._parse_number())]
+            ),
+            "MAXRECURSION": lambda self: self._generic_parse_option(
+                "MAXRECURSION",
+                [lambda: self._return_option_with_value("MAXRECURSION", self._parse_number())],
+            ),
+            "NO_PERFORMANCE_SPOOL": lambda self: self._generic_parse_option(
+                "NO_PERFORMANCE_SPOOL", []
+            ),
+            "OPTIMIZE": lambda self: self._generic_parse_option(
+                "OPTIMIZE",
+                [
+                    # There is still no support for the following syntax:
+                    # OPTIMIZE FOR ( @variable_name { UNKNOWN | = <literal_constant> } [ , ...n ] )
+                    lambda: self._match_text_seq("FOR")
+                    and self._generic_parse_option("OPTIMIZE FOR", ["UNKNOWN"])
+                ],
+            ),
+            "PARAMETERIZATION": lambda self: self._generic_parse_option(
+                "PARAMETERIZATION", ["SIMPLE", "FORCED"]
+            ),
+            "QUERYTRACEON": lambda self: self._generic_parse_option(
+                "QUERYTRACEON",
+                [lambda: self._return_option_with_value("QUERYTRACEON", self._parse_number())],
+            ),
+            "RECOMPILE": lambda self: self._generic_parse_option("RECOMPILE", []),
+            "ROBUST": lambda self: self._generic_parse_option("ROBUST", ["PLAN"]),
+            "USE": lambda self: self._generic_parse_option(
+                "USE",
+                [
+                    lambda: self._match_text_seq("PLAN")
+                    and self._return_option_with_value("USE PLAN", self._parse_string())
+                ],
+            ),
+            # No support yet for TABLE HINT
+        }
+
         LOG_DEFAULTS_TO_LN = True
 
         ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN = False
         STRING_ALIASES = True
         NO_PAREN_IF_COMMANDS = False
+
+        def _parse_string(self) -> t.Optional[exp.Expression]:
+            if self._curr is not None and self._curr.token_type == TokenType.NATIONAL_STRING:
+                result = self.PRIMARY_PARSERS[TokenType.NATIONAL_STRING](self, self._curr)
+                self._match(TokenType.NATIONAL_STRING)
+                return result
+            return super()._parse_string()
 
         def _parse_projections(self) -> t.List[exp.Expression]:
             """
@@ -572,6 +677,116 @@ class TSQL(Dialect):
             returns = super()._parse_returns()
             returns.set("table", table)
             return returns
+
+        def _parse_table_alias(
+            self, alias_tokens: t.Optional[t.Collection[TokenType]] = None
+        ) -> t.Optional[exp.TableAlias]:
+            index = self._index
+            has_options_clause = False
+            if self._match(TokenType.OPTION):
+                has_options_clause = True
+            self._retreat(index)
+            # Current tokens are not an alias, but an option. This will be handled in the _parse_option function.
+            if has_options_clause:
+                return None
+            return super()._parse_table_alias(alias_tokens=alias_tokens)
+
+        def _return_option_with_value(
+            self,
+            option_type: t.Optional[exp.Expression],
+            option_value: t.Optional[t.Union[str, exp.Expression]],
+            requires_equals=False,
+        ) -> t.Optional[exp.Option]:
+            if isinstance(option_value, str):
+                option_value = self.expression(exp.Identifier, this=option_value)
+            return self.expression(
+                exp.Option,
+                option_type=option_type,
+                option_value=option_value if option_value is not None else None,
+                requires_equals=requires_equals,
+            )
+
+        def _generic_parse_option(
+            self, option_name: str, valid_continuations: t.List[t.Union[str, t.Callable]]
+        ) -> t.Optional[exp.Option]:
+            # Handle the special case of options with no continuations.
+            if not valid_continuations:
+                return self._return_option_with_value(
+                    self.expression(exp.Identifier, this=option_name), None
+                )
+
+            for valid_continuation in valid_continuations:
+                if callable(valid_continuation):
+                    res = valid_continuation()
+                    if res is not None:
+                        return res
+                elif isinstance(valid_continuation, str):
+                    if self._match_text_seq(valid_continuation):
+                        return self._return_option_with_value(
+                            self.expression(exp.Identifier, this=option_name), valid_continuation
+                        )
+                else:
+                    # Shouldn't happen.
+                    raise AssertionError(
+                        f"_generic_parse_option only accepts strings and callables as valid continuations, not '{valid_continuation}'"
+                    )
+            self.raise_error(f"Invalid {option_name} option")
+            return None
+
+        def _parse_single_option(self) -> t.Optional[exp.Expression]:
+            cur_prefix = self._curr.text.upper()
+            if cur_prefix in self.OPTION_PREFIX_TO_PARSE_FUNCTION:
+                self._match_text_seq(cur_prefix.upper())
+                return self.OPTION_PREFIX_TO_PARSE_FUNCTION[cur_prefix](self)
+            else:
+                self.raise_error("Invalid option type.")
+                return None
+
+        def _parse_option(self):
+            self._match_l_paren()
+            options = self._parse_csv(self._parse_single_option)
+            options = [opt for opt in options if opt is not None]
+            self._match_r_paren()
+            return self.expression(exp.Options, options=options)
+
+        def _parse_select(
+            self,
+            nested: bool = False,
+            table: bool = False,
+            parse_subquery_alias: bool = True,
+            parse_set_operation: bool = True,
+        ) -> t.Optional[exp.Expression]:
+            result = super()._parse_select(
+                nested=nested,
+                table=table,
+                parse_subquery_alias=parse_subquery_alias,
+                parse_set_operation=parse_set_operation,
+            )
+            if result is not None and self._match(TokenType.OPTION):
+                option = self._parse_option()
+                result.set("option", option)
+            return result
+
+        def _parse_merge(self) -> exp.Merge:
+            result = super()._parse_merge()
+            if result is not None and self._match(TokenType.OPTION):
+                option = self._parse_option()
+                result.set("option", option)
+            return result
+
+        def _parse_update(self) -> exp.Update:
+            result = super()._parse_update()
+            if result is not None and self._match(TokenType.OPTION):
+                option = self._parse_option()
+                result.set("option", option)
+            return result
+
+        def _parse_delete(self) -> exp.Delete:
+            result = super()._parse_delete()
+            if result is not None and self._match(TokenType.OPTION):
+                option = self._parse_option()
+                result.set("option", option)
+            return result
 
         def _parse_convert(
             self, strict: bool, safe: t.Optional[bool] = None
@@ -970,6 +1185,36 @@ class TSQL(Dialect):
                 identifier = f"#{identifier}"
 
             return identifier
+
+        def option_sql(self, expression: exp.Option):
+            option_type = self.sql(expression, "option_type")
+            option_value = self.sql(expression, "option_value")
+            if option_value:
+                optional_equal_sign = "= " if expression.args.get("requires_equals") else ""
+                return f"{option_type} {optional_equal_sign}{option_value}"
+            return option_type
+
+        def _add_option_sql(self, expression: exp.Expression):
+            option = expression.args.get("option", None)
+            if option is not None:
+                return f" OPTION({','.join([self.sql(opt) for opt in option.args['options']])})"
+            return ""
+
+        def delete_sql(self, expression: exp.Delete):
+            result = super().delete_sql(expression)
+            return f"{result}{self._add_option_sql(expression)}"
+
+        def select_sql(self, expression: exp.Select):
+            result = super().select_sql(expression)
+            return f"{result}{self._add_option_sql(expression)}"
+
+        def merge_sql(self, expression: exp.Merge):
+            result = super().merge_sql(expression)
+            return f"{result}{self._add_option_sql(expression)}"
+
+        def update_sql(self, expression: exp.Update):
+            result = super().update_sql(expression)
+            return f"{result}{self._add_option_sql(expression)}"
 
         def constraint_sql(self, expression: exp.Constraint) -> str:
             this = self.sql(expression, "this")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1492,7 +1492,6 @@ class Delete(DML):
         "returning": False,
         "limit": False,
         "tables": False,  # Multiple-Table Syntax (MySQL)
-        "option": False,
     }
 
     def delete(
@@ -2777,7 +2776,6 @@ class Update(Expression):
         "returning": False,
         "order": False,
         "limit": False,
-        "option": False,
     }
 
 
@@ -5573,7 +5571,6 @@ class Merge(Expression):
         "on": True,
         "expressions": True,
         "with": False,
-        "option": False,
     }
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2556,18 +2556,14 @@ QUERY_MODIFIERS = {
     "sample": False,
     "settings": False,
     "format": False,
-    "option": False,
+    "options": False,
 }
 
 
 # https://learn.microsoft.com/en-us/sql/t-sql/queries/option-clause-transact-sql?view=sql-server-ver16
 # https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver16
-class Option(Expression):
-    arg_types = {"option_type": True, "option_value": False, "requires_equals": False}
-
-
-class Options(Expression):
-    arg_types = {"options": False}
+class QueryOption(Expression):
+    arg_types = {"this": True, "expression": False}
 
 
 # https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-ver16

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1492,6 +1492,7 @@ class Delete(DML):
         "returning": False,
         "limit": False,
         "tables": False,  # Multiple-Table Syntax (MySQL)
+        "option": False,
     }
 
     def delete(
@@ -2556,7 +2557,18 @@ QUERY_MODIFIERS = {
     "sample": False,
     "settings": False,
     "format": False,
+    "option": False,
 }
+
+
+# https://learn.microsoft.com/en-us/sql/t-sql/queries/option-clause-transact-sql?view=sql-server-ver16
+# https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-query?view=sql-server-ver16
+class Option(Expression):
+    arg_types = {"option_type": True, "option_value": False, "requires_equals": False}
+
+
+class Options(Expression):
+    arg_types = {"options": False}
 
 
 # https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-ver16
@@ -2765,6 +2777,7 @@ class Update(Expression):
         "returning": False,
         "order": False,
         "limit": False,
+        "option": False,
     }
 
 
@@ -5554,7 +5567,14 @@ class Use(Expression):
 
 
 class Merge(Expression):
-    arg_types = {"this": True, "using": True, "on": True, "expressions": True, "with": False}
+    arg_types = {
+        "this": True,
+        "using": True,
+        "on": True,
+        "expressions": True,
+        "with": False,
+        "option": False,
+    }
 
 
 class When(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2070,6 +2070,10 @@ class Generator(metaclass=_Generator):
             else []
         )
 
+        options = self.expressions(expression, key="options")
+        if options:
+            options = f" OPTION{self.wrap(options)}"
+
         return csv(
             *sqls,
             *[self.sql(join) for join in expression.args.get("joins") or []],
@@ -2083,21 +2087,12 @@ class Generator(metaclass=_Generator):
             self.sql(expression, "order"),
             *offset_limit_modifiers,
             *self.after_limit_modifiers(expression),
-            *self.sql(expression, "option"),
+            options,
             sep="",
         )
 
-    def option_sql(self, expression: exp.Option):
-        option_type = self.sql(expression, "option_type")
-        option_value = self.sql(expression, "option_value")
-        if option_value:
-            optional_equal_sign = "= " if expression.args.get("requires_equals") else ""
-            return f"{option_type} {optional_equal_sign}{option_value}"
-        return option_type
-
-    def options_sql(self, expression: exp.Options):
-        options_sql = csv(*[self.sql(opt) for opt in expression.args.get("options", [])])
-        return f" OPTION({options_sql})"
+    def queryoption_sql(self, expression: exp.QueryOption):
+        return ""
 
     def offset_limit_modifiers(
         self, expression: exp.Expression, fetch: bool, limit: t.Optional[exp.Fetch | exp.Limit]

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2091,7 +2091,7 @@ class Generator(metaclass=_Generator):
             sep="",
         )
 
-    def queryoption_sql(self, expression: exp.QueryOption):
+    def queryoption_sql(self, expression: exp.QueryOption) -> str:
         return ""
 
     def offset_limit_modifiers(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2083,8 +2083,21 @@ class Generator(metaclass=_Generator):
             self.sql(expression, "order"),
             *offset_limit_modifiers,
             *self.after_limit_modifiers(expression),
+            *self.sql(expression, "option"),
             sep="",
         )
+
+    def option_sql(self, expression: exp.Option):
+        option_type = self.sql(expression, "option_type")
+        option_value = self.sql(expression, "option_value")
+        if option_value:
+            optional_equal_sign = "= " if expression.args.get("requires_equals") else ""
+            return f"{option_type} {optional_equal_sign}{option_value}"
+        return option_type
+
+    def options_sql(self, expression: exp.Options):
+        options_sql = csv(*[self.sql(opt) for opt in expression.args.get("options", [])])
+        return f" OPTION({options_sql})"
 
     def offset_limit_modifiers(
         self, expression: exp.Expression, fetch: bool, limit: t.Optional[exp.Fetch | exp.Limit]

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -923,6 +923,101 @@ class Parser(metaclass=_Parser):
         TokenType.START_WITH: lambda self: ("connect", self._parse_connect()),
     }
 
+    OPTION_PREFIX_TO_PARSE_FUNCTION = {
+        "LABEL": lambda self: self._generic_parse_option(
+            "LABEL",
+            [
+                lambda: self._match(TokenType.EQ)
+                and self._return_option_with_value("LABEL", self._parse_string())
+            ],
+        ),
+        "HASH": lambda self: self._generic_parse_option("HASH", ["GROUP", "UNION", "JOIN"]),
+        "ORDER": lambda self: self._generic_parse_option("ORDER", ["GROUP"]),
+        "CONCAT": lambda self: self._generic_parse_option("CONCAT", ["UNION"]),
+        "MERGE": lambda self: self._generic_parse_option("MERGE", ["UNION", "JOIN"]),
+        "LOOP": lambda self: self._generic_parse_option("LOOP", ["JOIN"]),
+        "DISABLE_OPTIMIZED_PLAN_FORCING": lambda self: self._generic_parse_option(
+            "DISABLE_OPTIMIZED_PLAN_FORCING", []
+        ),
+        "EXPAND": lambda self: self._generic_parse_option("EXPAND", ["VIEWS"]),
+        "FAST": lambda self: self._generic_parse_option(
+            "FAST", [lambda: self._return_option_with_value("FAST", self._parse_number())]
+        ),
+        "FORCE": lambda self: self._generic_parse_option(
+            "FORCE", ["ORDER", "EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"]
+        ),
+        "DISABLE": lambda self: self._generic_parse_option(
+            "DISABLE", ["EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"]
+        ),
+        "IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX": lambda self: self._generic_parse_option(
+            "IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX", []
+        ),
+        "KEEP": lambda self: self._generic_parse_option("KEEP", ["PLAN"]),
+        "KEEPFIXED": lambda self: self._generic_parse_option("KEEPFIXED", ["PLAN"]),
+        "MAX_GRANT_PERCENT": lambda self: self._generic_parse_option(
+            "MAX_GRANT_PERCENT",
+            [
+                lambda: self._match(TokenType.EQ)
+                and self._generic_parse_option(
+                    "MAX_GRANT_PERCENT",
+                    [
+                        lambda: self._return_option_with_value(
+                            "MAX_GRANT_PERCENT", self._parse_number(), requires_equals=True
+                        )
+                    ],
+                )
+            ],
+        ),
+        "MIN_GRANT_PERCENT": lambda self: self._generic_parse_option(
+            "MIN_GRANT_PERCENT",
+            [
+                lambda: self._match(TokenType.EQ)
+                and self._generic_parse_option(
+                    "MIN_GRANT_PERCENT",
+                    [
+                        lambda: self._return_option_with_value(
+                            "MIN_GRANT_PERCENT", self._parse_number(), requires_equals=True
+                        )
+                    ],
+                )
+            ],
+        ),
+        "MAXDOP": lambda self: self._generic_parse_option(
+            "MAXDOP", [lambda: self._return_option_with_value("MAXDOP", self._parse_number())]
+        ),
+        "MAXRECURSION": lambda self: self._generic_parse_option(
+            "MAXRECURSION",
+            [lambda: self._return_option_with_value("MAXRECURSION", self._parse_number())],
+        ),
+        "NO_PERFORMANCE_SPOOL": lambda self: self._generic_parse_option("NO_PERFORMANCE_SPOOL", []),
+        "OPTIMIZE": lambda self: self._generic_parse_option(
+            "OPTIMIZE",
+            [
+                # There is still no support for the following syntax:
+                # OPTIMIZE FOR ( @variable_name { UNKNOWN | = <literal_constant> } [ , ...n ] )
+                lambda: self._match_text_seq("FOR")
+                and self._generic_parse_option("OPTIMIZE FOR", ["UNKNOWN"])
+            ],
+        ),
+        "PARAMETERIZATION": lambda self: self._generic_parse_option(
+            "PARAMETERIZATION", ["SIMPLE", "FORCED"]
+        ),
+        "QUERYTRACEON": lambda self: self._generic_parse_option(
+            "QUERYTRACEON",
+            [lambda: self._return_option_with_value("QUERYTRACEON", self._parse_number())],
+        ),
+        "RECOMPILE": lambda self: self._generic_parse_option("RECOMPILE", []),
+        "ROBUST": lambda self: self._generic_parse_option("ROBUST", ["PLAN"]),
+        "USE": lambda self: self._generic_parse_option(
+            "USE",
+            [
+                lambda: self._match_text_seq("PLAN")
+                and self._return_option_with_value("USE PLAN", self._parse_string())
+            ],
+        ),
+        # No support yet for TABLE HINT
+    }
+
     SET_PARSERS = {
         "GLOBAL": lambda self: self._parse_set_item_assignment("GLOBAL"),
         "LOCAL": lambda self: self._parse_set_item_assignment("LOCAL"),
@@ -2481,6 +2576,65 @@ class Parser(metaclass=_Parser):
                         continue
                 break
         return this
+
+    def _generic_parse_option(
+        self, option_name: str, valid_continuations: t.List[t.Union[str, t.Callable]]
+    ) -> t.Optional[exp.Option]:
+        # Handle the special case of options with no continuations.
+        if not valid_continuations:
+            return self._return_option_with_value(
+                self.expression(exp.Identifier, this=option_name), None
+            )
+
+        for valid_continuation in valid_continuations:
+            if callable(valid_continuation):
+                res = valid_continuation()
+                if res is not None:
+                    return res
+            elif isinstance(valid_continuation, str):
+                if self._match_text_seq(valid_continuation):
+                    return self._return_option_with_value(
+                        self.expression(exp.Identifier, this=option_name), valid_continuation
+                    )
+            else:
+                # Shouldn't happen.
+                self.raise_error(
+                    f"_generic_parse_option only accepts strings and callables as valid continuations, not '{valid_continuation}'"
+                )
+        self.raise_error(f"Invalid {option_name} option")
+        return None
+
+    def _return_option_with_value(
+        self,
+        option_type: t.Optional[exp.Expression],
+        option_value: t.Optional[t.Union[str, exp.Expression]],
+        requires_equals=False,
+    ) -> t.Optional[exp.Option]:
+        if isinstance(option_value, str):
+            option_value = self.expression(exp.Identifier, this=option_value)
+        return self.expression(
+            exp.Option,
+            option_type=option_type,
+            option_value=option_value if option_value is not None else None,
+            requires_equals=requires_equals,
+        )
+
+    def _parse_single_option(self) -> t.Optional[exp.Expression]:
+        cur_prefix = self._curr.text.upper()
+        if cur_prefix in self.OPTION_PREFIX_TO_PARSE_FUNCTION:
+            self._match_text_seq(cur_prefix.upper())
+            return self.OPTION_PREFIX_TO_PARSE_FUNCTION[cur_prefix](self)
+        else:
+            self.raise_error("Invalid option type.")
+            return None
+
+    def _parse_option(self):
+        self._match(TokenType.OPTION)
+        self._match_l_paren()
+        options = self._parse_csv(self._parse_single_option)
+        options = [opt for opt in options if opt is not None]
+        self._match_r_paren()
+        return self.expression(exp.Options, options=options)
 
     def _parse_hint(self) -> t.Optional[exp.Hint]:
         if self._match(TokenType.HINT):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -370,6 +370,7 @@ class TokenType(AutoName):
     UNIQUE = auto()
     VERSION_SNAPSHOT = auto()
     TIMESTAMP_SNAPSHOT = auto()
+    OPTION = auto()
 
 
 _ALL_TOKEN_TYPES = list(TokenType)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -87,7 +87,7 @@ class TestTSQL(Validator):
         ]
         for query in raising_queries:
             with self.assertRaises(ParseError, msg=f"When running '{query}'"):
-                self.parse_one(query, read="tsql")
+                self.parse_one(query)
 
         logger = logging.getLogger("sqlglot")
         with self.assertLogs(logger) as cm:

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -91,7 +91,7 @@ class TestTSQL(Validator):
 
         logger = logging.getLogger("sqlglot")
         with self.assertLogs(logger) as cm:
-            parse_one("ALTER TABLE table2 OPTION(HASH GROUP)")
+            parse_one("ALTER TABLE table2 OPTION(HASH GROUP)", read="tsql")
             self.assertEqual(len(cm.output), 1)
             msg = cm.output[0]
             self.assertIn("Falling back to parsing as a 'Command'", msg)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -43,6 +43,7 @@ class TestTSQL(Validator):
             "RECOMPILE",
             "ROBUST PLAN",
             "USE PLAN N'<xml_plan>'",
+            "LABEL = 'MyLabel'",
         ]
 
         possible_statements = [
@@ -59,20 +60,20 @@ class TestTSQL(Validator):
         for statement, option in itertools.product(possible_statements, possible_options):
             query = f"{statement} OPTION({option})"
             result = self.validate_identity(query)
-            options = result.args.get("option")
-            self.assertIsInstance(options, exp.Options)
-            for actual_opt in options.args.get("options"):
-                self.assertIsInstance(actual_opt, exp.Option)
+            options = result.args.get("options")
+            self.assertIsInstance(options, list, f"When parsing query {query}")
+            is_query_options = map(lambda o: isinstance(o, exp.QueryOption), options)
+            self.assertTrue(all(is_query_options), f"When parsing query {query}")
 
         for statement, option1, option2 in itertools.product(
             possible_statements, possible_options, possible_options
         ):
             query = f"{statement} OPTION({', '.join([option1,option2])})"
             result = self.validate_identity(query)
-            options = result.args.get("option")
-            self.assertIsInstance(options, exp.Options)
-            for actual_opt in options.args.get("options"):
-                self.assertIsInstance(actual_opt, exp.Option)
+            options = result.args.get("options")
+            self.assertIsInstance(options, list, f"When parsing query {query}")
+            is_query_options = map(lambda o: isinstance(o, exp.QueryOption), options)
+            self.assertTrue(all(is_query_options), f"When parsing query {query}")
 
         raising_queries = [
             # Missing parentheses

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -87,7 +87,7 @@ class TestTSQL(Validator):
         ]
         for query in raising_queries:
             with self.assertRaises(ParseError, msg=f"When running '{query}'"):
-                self.parse_one(query)
+                self.parse_one(query, read="tsql")
 
         logger = logging.getLogger("sqlglot")
         with self.assertLogs(logger) as cm:

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -91,7 +91,7 @@ class TestTSQL(Validator):
 
         logger = logging.getLogger("sqlglot")
         with self.assertLogs(logger) as cm:
-            parse_one("ALTER TABLE table2 OPTION(HASH GROUP)", read="tsql")
+            self.parse_one("ALTER TABLE table2 OPTION(HASH GROUP)")
             self.assertEqual(len(cm.output), 1)
             msg = cm.output[0]
             self.assertIn("Falling back to parsing as a 'Command'", msg)


### PR DESCRIPTION
This is a new implementation of  the OPTION clause parsing, using query modifiers.
Note that in order to use query modifiers, a lot of the tsql specific logic had to be hoisted up to the generic parser.
