### PR TITLE
Feat: Support for TRUNCATE TABLE/DATABASE DDL

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -197,6 +197,7 @@ class DuckDB(Dialect):
             "CHARACTER VARYING": TokenType.TEXT,
             "EXCLUDE": TokenType.EXCEPT,
             "LOGICAL": TokenType.BOOLEAN,
+            "ONLY": TokenType.ONLY,
             "PIVOT_WIDER": TokenType.PIVOT,
             "SIGNED": TokenType.INT,
             "STRING": TokenType.VARCHAR,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -281,6 +281,7 @@ class Postgres(Dialect):
             "TEMP": TokenType.TEMPORARY,
             "CSTRING": TokenType.PSEUDO_TYPE,
             "OID": TokenType.OBJECT_IDENTIFIER,
+            "ONLY": TokenType.ONLY,
             "OPERATOR": TokenType.OPERATOR,
             "REGCLASS": TokenType.OBJECT_IDENTIFIER,
             "REGCOLLATION": TokenType.OBJECT_IDENTIFIER,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -138,6 +138,7 @@ class Redshift(Postgres):
             "TOP": TokenType.TOP,
             "UNLOAD": TokenType.COMMAND,
             "VARBYTE": TokenType.VARBINARY,
+            "ONLY": TokenType.ONLY,
         }
         KEYWORDS.pop("VALUES")
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -138,7 +138,6 @@ class Redshift(Postgres):
             "TOP": TokenType.TOP,
             "UNLOAD": TokenType.COMMAND,
             "VARBYTE": TokenType.VARBINARY,
-            "ONLY": TokenType.ONLY,
         }
         KEYWORDS.pop("VALUES")
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -682,9 +682,7 @@ class TSQL(Dialect):
             return self.expression(exp.UniqueColumnConstraint, this=this)
 
         def _parse_partition(self) -> t.Optional[exp.Partition]:
-            if not self._match_pair(TokenType.WITH, TokenType.L_PAREN) or not self._match_text_seq(
-                "PARTITIONS"
-            ):
+            if not self._match_text_seq("WITH", "(", "PARTITIONS"):
                 return None
 
             def parse_range():

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -682,10 +682,9 @@ class TSQL(Dialect):
             return self.expression(exp.UniqueColumnConstraint, this=this)
 
         def _parse_partition(self) -> t.Optional[exp.Partition]:
-            if not self._match_pair(TokenType.WITH, TokenType.L_PAREN):
-                return None
-
-            if not self._match_text_seq("PARTITIONS"):
+            if not self._match_pair(TokenType.WITH, TokenType.L_PAREN) or not self._match_text_seq(
+                "PARTITIONS"
+            ):
                 return None
 
             def parse_range():

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -681,6 +681,29 @@ class TSQL(Dialect):
 
             return self.expression(exp.UniqueColumnConstraint, this=this)
 
+        def _parse_partition(self) -> t.Optional[exp.Partition]:
+            if not self._match_pair(TokenType.WITH, TokenType.L_PAREN):
+                return None
+
+            if not self._match_text_seq("PARTITIONS"):
+                return None
+
+            def parse_range():
+                low = self._parse_bitwise()
+                high = self._parse_bitwise() if self._match_text_seq("TO") else None
+
+                return (
+                    self.expression(exp.PartitionRange, this=low, expression=high) if high else low
+                )
+
+            partition = self.expression(
+                exp.Partition, expressions=self._parse_wrapped_csv(parse_range)
+            )
+
+            self._match_r_paren()
+
+            return partition
+
     class Generator(generator.Generator):
         LIMIT_IS_TOP = True
         QUERY_HINTS = False
@@ -990,3 +1013,6 @@ class TSQL(Dialect):
                 this_sql = self.sql(this)
             expression_sql = self.sql(expression, "expression")
             return self.func(name, this_sql, expression_sql if expression_sql else None)
+
+        def partition_sql(self, expression: exp.Partition) -> str:
+            return f"WITH (PARTITIONS({self.expressions(expression, flat=True)}))"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1224,6 +1224,19 @@ class Create(DDL):
         return kind and kind.upper()
 
 
+class Truncate(Expression):
+    arg_types = {
+        "expressions": True,
+        "is_database": False,
+        "exists": False,
+        "only": False,
+        "cluster": False,
+        "identity": False,
+        "option": False,
+        "partition": False,
+    }
+
+
 # https://docs.snowflake.com/en/sql-reference/sql/create-clone
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_clone_statement
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#create_table_copy
@@ -1906,6 +1919,10 @@ class LoadData(Expression):
 
 class Partition(Expression):
     arg_types = {"expressions": True}
+
+
+class PartitionRange(Expression):
+    arg_types = {"this": True, "expression": False}
 
 
 class Fetch(Expression):
@@ -2633,6 +2650,7 @@ class Table(Expression):
         "pattern": False,
         "ordinality": False,
         "when": False,
+        "only": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1224,7 +1224,7 @@ class Create(DDL):
         return kind and kind.upper()
 
 
-class Truncate(Expression):
+class TruncateTable(Expression):
     arg_types = {
         "expressions": True,
         "is_database": False,
@@ -1922,7 +1922,7 @@ class Partition(Expression):
 
 
 class PartitionRange(Expression):
-    arg_types = {"this": True, "expression": False}
+    arg_types = {"this": True, "expression": True}
 
 
 class Fetch(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3480,15 +3480,14 @@ class Generator(metaclass=_Generator):
 
         return f"{low} TO {high}"
 
-    def truncate_sql(self, expression: exp.Truncate) -> str:
+    def truncatetable_sql(self, expression: exp.TruncateTable) -> str:
         target = "DATABASE" if expression.args.get("is_database") else "TABLE"
-        tables = self.expressions(expression)
-        tables = f" {tables}"
+        tables = f" {self.expressions(expression)}"
 
         exists = " IF EXISTS" if expression.args.get("exists") else ""
 
         on_cluster = self.sql(expression, "cluster")
-        on_cluster = f" ON CLUSTER {on_cluster}" if on_cluster else ""
+        on_cluster = f" {on_cluster}" if on_cluster else ""
 
         identity = self.sql(expression, "identity")
         identity = f" {identity} IDENTITY" if identity else ""

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5939,10 +5939,9 @@ class Parser(metaclass=_Parser):
 
         exists = self._parse_exists(not_=False)
 
-        def _parse_tables() -> t.Optional[exp.Expression]:
-            return self._parse_table(schema=True, is_db_reference=is_database)
-
-        expressions = self._parse_csv(_parse_tables)
+        expressions = self._parse_csv(
+            lambda: self._parse_table(schema=True, is_db_reference=is_database)
+        )
 
         cluster = self._parse_on_property() if self._match(TokenType.ON) else None
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -354,6 +354,7 @@ class TokenType(AutoName):
     TOP = auto()
     THEN = auto()
     TRUE = auto()
+    TRUNCATE = auto()
     UNCACHE = auto()
     UNION = auto()
     UNNEST = auto()
@@ -754,6 +755,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "TEMPORARY": TokenType.TEMPORARY,
         "THEN": TokenType.THEN,
         "TRUE": TokenType.TRUE,
+        "TRUNCATE": TokenType.TRUNCATE,
         "UNION": TokenType.UNION,
         "UNKNOWN": TokenType.UNKNOWN,
         "UNNEST": TokenType.UNNEST,
@@ -862,7 +864,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "GRANT": TokenType.COMMAND,
         "OPTIMIZE": TokenType.COMMAND,
         "PREPARE": TokenType.COMMAND,
-        "TRUNCATE": TokenType.COMMAND,
         "VACUUM": TokenType.COMMAND,
         "USER-DEFINED": TokenType.USERDEFINED,
         "FOR VERSION": TokenType.VERSION_SNAPSHOT,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -302,6 +302,7 @@ class TokenType(AutoName):
     OBJECT_IDENTIFIER = auto()
     OFFSET = auto()
     ON = auto()
+    ONLY = auto()
     OPERATOR = auto()
     ORDER_BY = auto()
     ORDER_SIBLINGS_BY = auto()

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -149,6 +149,9 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "CREATE MATERIALIZED VIEW test_view (id UInt8) TO db.table1 AS SELECT * FROM test_data"
         )
+        self.validate_identity("TRUNCATE TABLE t1 ON CLUSTER test_cluster")
+        self.validate_identity("TRUNCATE DATABASE db")
+        self.validate_identity("TRUNCATE DATABASE db ON CLUSTER test_cluster")
 
         self.validate_all(
             "SELECT arrayJoin([1,2,3])",

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -39,6 +39,9 @@ class TestDatabricks(Validator):
         )
 
         self.validate_identity("TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address)")
+        self.validate_identity(
+            "TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', city LIKE 'LA')"
+        )
 
         self.validate_all(
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -38,6 +38,8 @@ class TestDatabricks(Validator):
             "CREATE FUNCTION add_one(x INT) RETURNS INT LANGUAGE PYTHON AS $FOO$def add_one(x):\n  return x+1$FOO$"
         )
 
+        self.validate_identity("TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address)")
+
         self.validate_all(
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",
             write={

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2301,3 +2301,9 @@ SELECT
                 "tsql": UnsupportedError,
             },
         )
+
+    def test_truncate(self):
+        self.validate_identity("TRUNCATE TABLE table")
+        self.validate_identity("TRUNCATE TABLE db.schema.test")
+        self.validate_identity("TRUNCATE TABLE IF EXISTS db.schema.test")
+        self.validate_identity("TRUNCATE TABLE t1, t2, t3")

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -440,6 +440,9 @@ class TestHive(Validator):
         self.validate_identity(
             "SELECT key, value, GROUPING__ID, COUNT(*) FROM T1 GROUP BY key, value WITH ROLLUP"
         )
+        self.validate_identity(
+            "TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address = 'abc')"
+        )
 
         self.validate_all(
             "SELECT ${hiveconf:some_var}",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -794,8 +794,8 @@ class TestPostgres(Validator):
             "CREATE INDEX index_ci_pipelines_on_project_idandrefandiddesc ON public.ci_pipelines USING btree(project_id, ref, id DESC)"
         )
         self.validate_identity(
-            "TRUNCATE TABLE ONLY t1, t2*, ONLY t3, t4, t5*",
-            "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5",
+            "TRUNCATE TABLE ONLY t1, t2*, ONLY t3, t4, t5* RESTART IDENTITY CASCADE",
+            "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5 RESTART IDENTITY CASCADE",
         )
 
         with self.assertRaises(ParseError):

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -82,6 +82,7 @@ class TestPostgres(Validator):
         self.validate_identity("CAST(1 AS DECIMAL) / CAST(2 AS DECIMAL) * -100")
         self.validate_identity("EXEC AS myfunc @id = 123", check_command_warning=True)
         self.validate_identity("SELECT CURRENT_USER")
+        self.validate_identity("SELECT * FROM ONLY t1")
         self.validate_identity(
             """LAST_VALUE("col1") OVER (ORDER BY "col2" RANGE BETWEEN INTERVAL '1 DAY' PRECEDING AND '1 month' FOLLOWING)"""
         )
@@ -320,18 +321,11 @@ class TestPostgres(Validator):
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET x.a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
         )
-
-        self.validate_identity("TRUNCATE TABLE t1 CONTINUE IDENTITY")
-        self.validate_identity("TRUNCATE TABLE t1 RESTART IDENTITY")
-        self.validate_identity("TRUNCATE TABLE t1 CASCADE")
-        self.validate_identity("TRUNCATE TABLE t1 RESTRICT")
-        self.validate_identity("TRUNCATE TABLE t1 CONTINUE IDENTITY CASCADE")
-        self.validate_identity("TRUNCATE TABLE t1 RESTART IDENTITY RESTRICT")
-
-        self.validate_all(
-            "TRUNCATE TABLE ONLY t1, t2*, ONLY t3, t4, t5*",
-            write={"postgres": "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5"},
+        self.validate_identity(
+            "SELECT * FROM t1*", 
+            "SELECT * FROM t1"
         )
+
 
         self.validate_all(
             "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",
@@ -665,6 +659,12 @@ class TestPostgres(Validator):
         self.validate_identity("CREATE TABLE t (c CHAR(2) UNIQUE NOT NULL) INHERITS (t1)")
         self.validate_identity("CREATE TABLE s.t (c CHAR(2) UNIQUE NOT NULL) INHERITS (s.t1, s.t2)")
         self.validate_identity("CREATE FUNCTION x(INT) RETURNS INT SET search_path = 'public'")
+        self.validate_identity("TRUNCATE TABLE t1 CONTINUE IDENTITY")
+        self.validate_identity("TRUNCATE TABLE t1 RESTART IDENTITY")
+        self.validate_identity("TRUNCATE TABLE t1 CASCADE")
+        self.validate_identity("TRUNCATE TABLE t1 RESTRICT")
+        self.validate_identity("TRUNCATE TABLE t1 CONTINUE IDENTITY CASCADE")
+        self.validate_identity("TRUNCATE TABLE t1 RESTART IDENTITY RESTRICT")
         self.validate_identity(
             "CREATE TABLE cust_part3 PARTITION OF customers FOR VALUES WITH (MODULUS 3, REMAINDER 2)"
         )
@@ -796,6 +796,10 @@ class TestPostgres(Validator):
         )
         self.validate_identity(
             "CREATE INDEX index_ci_pipelines_on_project_idandrefandiddesc ON public.ci_pipelines USING btree(project_id, ref, id DESC)"
+        )
+        self.validate_identity(
+            "TRUNCATE TABLE ONLY t1, t2*, ONLY t3, t4, t5*",
+            "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5",
         )
 
         with self.assertRaises(ParseError):

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -321,6 +321,18 @@ class TestPostgres(Validator):
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
         )
 
+        self.validate_identity("TRUNCATE TABLE t1 CONTINUE IDENTITY")
+        self.validate_identity("TRUNCATE TABLE t1 RESTART IDENTITY")
+        self.validate_identity("TRUNCATE TABLE t1 CASCADE")
+        self.validate_identity("TRUNCATE TABLE t1 RESTRICT")
+        self.validate_identity("TRUNCATE TABLE t1 CONTINUE IDENTITY CASCADE")
+        self.validate_identity("TRUNCATE TABLE t1 RESTART IDENTITY RESTRICT")
+
+        self.validate_all(
+            "TRUNCATE TABLE ONLY t1, t2*, ONLY t3, t4, t5*",
+            write={"postgres": "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5"},
+        )
+
         self.validate_all(
             "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",
             read={

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -321,11 +321,7 @@ class TestPostgres(Validator):
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET x.a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
         )
-        self.validate_identity(
-            "SELECT * FROM t1*", 
-            "SELECT * FROM t1"
-        )
-
+        self.validate_identity("SELECT * FROM t1*", "SELECT * FROM t1")
 
         self.validate_all(
             "SELECT JSON_EXTRACT_PATH_TEXT(x, k1, k2, k3) FROM t",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -16,6 +16,7 @@ class TestSpark(Validator):
         self.validate_identity(
             "CREATE TABLE foo (col STRING) CLUSTERED BY (col) SORTED BY (col) INTO 10 BUCKETS"
         )
+        self.validate_identity("TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address)")
 
         self.validate_all(
             "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:string>)",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -27,6 +27,7 @@ class TestTSQL(Validator):
         self.validate_identity("SELECT * FROM t WHERE NOT c", "SELECT * FROM t WHERE NOT c <> 0")
         self.validate_identity("1 AND true", "1 <> 0 AND (1 = 1)")
         self.validate_identity("CAST(x AS int) OR y", "CAST(x AS INTEGER) <> 0 OR y <> 0")
+        self.validate_identity("TRUNCATE TABLE t1 WITH (PARTITIONS(1, 2 TO 5, 10 TO 20, 84))")
 
         self.validate_all(
             "SELECT IIF(cond <> 0, 'True', 'False')",

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -853,3 +853,4 @@ SELECT values
 SELECT values AS values FROM t WHERE values + 1 > 3
 SELECT truncate
 SELECT only
+TRUNCATE(a, b)

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -851,3 +851,5 @@ CAST(foo AS BPCHAR)
 values
 SELECT values
 SELECT values AS values FROM t WHERE values + 1 > 3
+SELECT truncate
+SELECT only

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -768,7 +768,6 @@ FROM base""",
             "SET -v",
             "SET @user OFF",
             "SHOW TABLES",
-            "TRUNCATE TABLE x",
             "VACUUM FREEZE my_table",
         ):
             with self.subTest(sql):


### PR DESCRIPTION
This PR aims to solve [issue 2885](https://github.com/tobymao/sqlglot/issues/2850) by supporting `TRUNCATE` natively in the AST for the following dialects:

BigQuery, Databricks, DuckDB, Clickhouse, Hive, MySQL, Postgres, Spark, Snowflake, Redshift, T-SQL, Presto.

The common / "superset" representation among all previous dialects is the following:

`TRUNCATE [TABLE | DATABASE] [IF EXISTS] [[ONLY] table_name [*], ]* [-- PROPERTIES -- ]`

Where `[-- PROPERTIES -- ]` can be:

- Postgres: `[ RESTART IDENTITY | CONTINUE IDENTITY ] [ CASCADE | RESTRICT ]`
- Databricks / Hive / Spark (similar spec): `[PARTITION partition_spec]`
- T-SQL: `[ WITH ( PARTITIONS ( { <partition_number_expression> | <range> }  [ , ...n ] ) ) ]`
- Clickhouse: `[ON CLUSTER cluster]`

Design Notes:
- Distinguish between the function `TRUNCATE(a, b)` and `TRUNCATE` DDL by returning an anonymous function if `LPAREN` is the 2nd token in the stream
- Add "ONLY" table prefix keyword in `exp.Table` which is used in [Postgres's table inheritance](https://www.postgresql.org/docs/current/tutorial-inheritance.html)
- Add `exp.PartitionRange` which is used for T-SQL's partition clause. The Databricks / Spark / Hive partition clause is already implemented in `exp.Partition`
- SQLite does not implement `TRUNCATE` DDL, it's implicitly supported as a `DELETE FROM table` DML. 

TRUNCATE DDL Docs
-------------------------

[Databricks](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-truncate-table.html), [Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-TruncateTable), [Spark](https://spark.apache.org/docs/3.0.0-preview/sql-ref-syntax-ddl-truncate-table.html), [T-SQL](https://learn.microsoft.com/en-us/sql/t-sql/statements/truncate-table-transact-sql?view=sql-server-ver16), [Clickhouse](https://clickhouse.com/docs/en/sql-reference/statements/truncate), [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/truncate-table), [DuckDB](https://duckdb.org/docs/sql/statements/delete.html), [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#truncate_table_statement), [Presto](https://prestodb.io/docs/current/sql/truncate.html), [MySQL](https://dev.mysql.com/doc/refman/8.0/en/truncate-table.html), [Postgres](https://www.postgresql.org/docs/current/sql-truncate.html), [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_TRUNCATE.html), [SQLite](https://www.techonthenet.com/sqlite/truncate.php#:~:text=SQLite%20does%20not%20have%20an,TRUNCATE%20optimizer%20handles%20the%20rest)
