### PR TITLE
Refactor: use _parse_var_from_options for USE statement parser

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -416,8 +416,8 @@ class MySQL(Dialect):
             "SPATIAL",
         }
 
-        PROFILE_TYPES: t.Dict[str, t.Sequence[t.Sequence[str] | str]] = {
-            **{profile: tuple() for profile in ("ALL", "CPU", "IPC", "MEMORY", "SOURCE", "SWAPS")},
+        PROFILE_TYPES: parser.OPTIONS_TYPE = {
+            **dict.fromkeys(("ALL", "CPU", "IPC", "MEMORY", "SOURCE", "SWAPS"), tuple()),
             "BLOCK": ("IO",),
             "CONTEXT": ("SWITCHES",),
             "PAGE": ("FAULTS",),

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -66,10 +66,9 @@ BIT_TYPES = {exp.EQ, exp.NEQ, exp.Is, exp.In, exp.Select, exp.Alias}
 # Unsupported options:
 # - OPTIMIZE FOR ( @variable_name { UNKNOWN | = <literal_constant> } [ , ...n ] )
 # - TABLE HINT
-OPTIONS: t.Dict[str, t.Sequence[t.Sequence[str] | str]] = {
-    **{
-        option: tuple()
-        for option in (
+OPTIONS: parser.OPTIONS_TYPE = {
+    **dict.fromkeys(
+        (
             "DISABLE_OPTIMIZED_PLAN_FORCING",
             "FAST",
             "IGNORE_NONCLUSTERED_COLUMNSTORE_INDEX",
@@ -81,8 +80,9 @@ OPTIONS: t.Dict[str, t.Sequence[t.Sequence[str] | str]] = {
             "NO_PERFORMANCE_SPOOL",
             "QUERYTRACEON",
             "RECOMPILE",
-        )
-    },
+        ),
+        tuple(),
+    ),
     "CONCAT": ("UNION",),
     "DISABLE": ("EXTERNALPUSHDOWN", "SCALEOUTEXECUTION"),
     "EXPAND": ("VIEWS",),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -17,6 +17,8 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger("sqlglot")
 
+OPTIONS_TYPE = t.Dict[str, t.Sequence[t.Sequence[str] | str]]
+
 
 def build_var_map(args: t.List) -> exp.StarMap | exp.VarMap:
     if len(args) == 1 and args[0].is_star:
@@ -630,8 +632,7 @@ class Parser(metaclass=_Parser):
         TokenType.TRUNCATE: lambda self: self._parse_truncate_table(),
         TokenType.USE: lambda self: self.expression(
             exp.Use,
-            kind=self._match_texts(("ROLE", "WAREHOUSE", "DATABASE", "SCHEMA"))
-            and exp.var(self._prev.text),
+            kind=self._parse_var_from_options(self.USABLES, raise_unmatched=False),
             this=self._parse_table(schema=False),
         ),
     }
@@ -947,7 +948,7 @@ class Parser(metaclass=_Parser):
     PRE_VOLATILE_TOKENS = {TokenType.CREATE, TokenType.REPLACE, TokenType.UNIQUE}
 
     TRANSACTION_KIND = {"DEFERRED", "IMMEDIATE", "EXCLUSIVE"}
-    TRANSACTION_CHARACTERISTICS: t.Dict[str, t.Sequence[t.Sequence[str] | str]] = {
+    TRANSACTION_CHARACTERISTICS: OPTIONS_TYPE = {
         "ISOLATION": (
             ("LEVEL", "REPEATABLE", "READ"),
             ("LEVEL", "READ", "COMMITTED"),
@@ -956,6 +957,8 @@ class Parser(metaclass=_Parser):
         ),
         "READ": ("WRITE", "ONLY"),
     }
+
+    USABLES: OPTIONS_TYPE = dict.fromkeys(("ROLE", "WAREHOUSE", "DATABASE", "SCHEMA"), tuple())
 
     INSERT_ALTERNATIVES = {"ABORT", "FAIL", "IGNORE", "REPLACE", "ROLLBACK"}
 
@@ -5690,7 +5693,7 @@ class Parser(metaclass=_Parser):
         return set_
 
     def _parse_var_from_options(
-        self, options: t.Dict[str, t.Sequence[t.Sequence[str] | str]]
+        self, options: OPTIONS_TYPE, raise_unmatched: bool = True
     ) -> t.Optional[exp.Var]:
         start = self._curr
         if not start:
@@ -5699,6 +5702,7 @@ class Parser(metaclass=_Parser):
         option = start.text.upper()
         continuations = options.get(option)
 
+        index = self._index
         self._advance()
         for keywords in continuations or []:
             if isinstance(keywords, str):
@@ -5708,8 +5712,12 @@ class Parser(metaclass=_Parser):
                 option = f"{option} {' '.join(keywords)}"
                 break
         else:
-            if continuations:
-                self.raise_error(f"Unknown option {option}")
+            if continuations or continuations is None:
+                if raise_unmatched:
+                    self.raise_error(f"Unknown option {option}")
+
+                self._retreat(index)
+                return None
 
         return exp.var(option)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -17,7 +17,7 @@ if t.TYPE_CHECKING:
 
 logger = logging.getLogger("sqlglot")
 
-OPTIONS_TYPE = t.Dict[str, t.Sequence[t.Sequence[str] | str]]
+OPTIONS_TYPE = t.Dict[str, t.Sequence[t.Union[t.Sequence[str], str]]]
 
 
 def build_var_map(args: t.List) -> exp.StarMap | exp.VarMap:

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -196,10 +196,10 @@ SET LOCAL variable = value
 @"x"
 COMMIT
 USE db
-USE role x
-USE warehouse x
-USE database x
-USE schema x.y
+USE ROLE x
+USE WAREHOUSE x
+USE DATABASE x
+USE SCHEMA x.y
 NOT 1
 NOT NOT 1
 SELECT * FROM test


### PR DESCRIPTION
The refactor here isn't that important, but I figured I'd open a PR to show how one can use `_parse_var_from_options` with a `raise_unmatched` flag if we need to be lenient.