### PR TITLE
Fix: handle falsy values for replace_placeholders kwargs

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6951,7 +6951,7 @@ def replace_placeholders(expression: Expression, *args, **kwargs) -> Expression:
         if isinstance(node, Placeholder):
             if node.name:
                 new_name = kwargs.get(node.name)
-                if new_name:
+                if new_name is not None:
                     return convert(new_name)
             else:
                 try:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -313,6 +313,18 @@ class TestExpressions(unittest.TestCase):
             ).sql(),
             "SELECT * FROM (SELECT a FROM tbl1) WHERE b > 100",
         )
+        self.assertEqual(
+            exp.replace_placeholders(
+                parse_one("select * from foo WHERE x > ? AND y IS ?"), 0, False
+            ).sql(),
+            "SELECT * FROM foo WHERE x > 0 AND y IS FALSE",
+        )
+        self.assertEqual(
+            exp.replace_placeholders(
+                parse_one("select * from foo WHERE x > :int1 AND y IS :bool1"), int1=0, bool1=False
+            ).sql(),
+            "SELECT * FROM foo WHERE x > 0 AND y IS FALSE",
+        )
 
     def test_function_building(self):
         self.assertEqual(exp.func("max", 1).sql(), "MAX(1)")


### PR DESCRIPTION
Hi there

This library is indispensable, so thank you for all the work you've put in! 🙏 

I ran into this small issue, so figured I'd pass over a quick fix.  

I added a couple of unit tests to highlight the discrepancy.  The first one I added passes just fine (falsy values in args), but the second one (falsy values in kwargs) previously did not.

Thanks again  🏅   