### PR TITLE
Fix(optimizer): unnest Subquery in the scope's _traverse_select

### DIFF
--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -458,6 +458,8 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         )
 
     def test_scope(self):
+        self.assertIn("table", build_scope(parse_one("(SELECT col FROM table)")).sources)
+
         sql = """
         WITH q AS (
           SELECT x.b FROM x


### PR DESCRIPTION
This PR aims to address the following discrepancy.

Case with parentheses wrapping around query:
```python
from sqlglot import maybe_parse
from sqlglot.optimizer import build_scope, qualify

expression = maybe_parse("WITH baz AS (SELECT id FROM external) (SELECT o.value::INT AS value FROM bar AS o LEFT JOIN baz AS m ON o.id = m.id)", dialect="duckdb")
qualified = qualify.qualify(
    expression,
    dialect="duckdb",
    **{"validate_qualify_columns": False, "identify": False},
)
scope = build_scope(qualified)
print(scope.sources)
# {'baz': Scope<SELECT external.id AS id FROM external AS external>}
```

Same top-level query, without parentheses:
```python
from sqlglot import maybe_parse
from sqlglot.optimizer import build_scope, qualify

expression = maybe_parse("WITH baz AS (SELECT id FROM external) SELECT o.value::INT AS value FROM bar AS o LEFT JOIN baz AS m ON o.id = m.id", dialect="duckdb")
qualified = qualify.qualify(
    expression,
    dialect="duckdb",
    **{"validate_qualify_columns": False, "identify": False},
)
scope = build_scope(qualified)
print(scope.sources)
# {'baz': Scope<SELECT external.id AS id FROM external AS external>, 'o': Table(
#   this=Identifier(this=bar, quoted=False),
#   alias=TableAlias(
#     this=Identifier(this=o, quoted=False))), 'm': Scope<SELECT external.id AS id FROM external AS external>}
```