### PR TITLE
fix: Fix Hive UnixToTime regression, README stale results

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,12 @@ When the parser detects an error in the syntax, it raises a ParseError:
 
 ```python
 import sqlglot
-sqlglot.transpile("SELECT foo FROM(SELECT baz FROM t")
+sqlglot.transpile("SELECT foo FROM (SELECT baz FROM t")
 ```
 
 ```
 sqlglot.errors.ParseError: Expecting ). Line 1, Col: 33.
-  SELECT foo FROM(SELECT baz FROM t
+  SELECT foo FROM (SELECT baz FROM t
                                   ~
 ```
 
@@ -216,7 +216,7 @@ Structured syntax errors are accessible for programmatic use:
 ```python
 import sqlglot
 try:
-    sqlglot.transpile("SELECT foo FROM(SELECT baz FROM t")
+    sqlglot.transpile("SELECT foo FROM (SELECT baz FROM t")
 except sqlglot.errors.ParseError as e:
     print(e.errors)
 ```
@@ -226,7 +226,7 @@ except sqlglot.errors.ParseError as e:
   'description': 'Expecting )',
   'line': 1,
   'col': 33,
-  'start_context': 'SELECT foo FROM(SELECT baz FROM ',
+  'start_context': 'SELECT foo FROM (SELECT baz FROM ',
   'highlight': 't',
   'end_context': '',
   'into_expression': None

--- a/README.md
+++ b/README.md
@@ -202,13 +202,13 @@ When the parser detects an error in the syntax, it raises a ParseError:
 
 ```python
 import sqlglot
-sqlglot.transpile("SELECT foo( FROM bar")
+sqlglot.transpile("SELECT foo FROM(SELECT baz FROM t")
 ```
 
 ```
-sqlglot.errors.ParseError: Expecting ). Line 1, Col: 20.
-  select foo( FROM bar
-                   ~~~
+sqlglot.errors.ParseError: Expecting ). Line 1, Col: 33.
+  SELECT foo FROM(SELECT baz FROM t
+                                  ~
 ```
 
 Structured syntax errors are accessible for programmatic use:
@@ -216,7 +216,7 @@ Structured syntax errors are accessible for programmatic use:
 ```python
 import sqlglot
 try:
-    sqlglot.transpile("SELECT foo( FROM bar")
+    sqlglot.transpile("SELECT foo FROM(SELECT baz FROM t")
 except sqlglot.errors.ParseError as e:
     print(e.errors)
 ```
@@ -225,11 +225,11 @@ except sqlglot.errors.ParseError as e:
 [{
   'description': 'Expecting )',
   'line': 1,
-  'col': 20,
-  'start_context': 'SELECT foo( FROM',
-  'highlight': 'bar',
+  'col': 33,
+  'start_context': 'SELECT foo FROM(SELECT baz FROM ',
+  'highlight': 't',
   'end_context': '',
-  'into_expression': None,
+  'into_expression': None
 }]
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sqlglot.transpile("SELECT EPOCH_MS(1618088028295)", read="duckdb", write="hive")
 ```
 
 ```sql
-'SELECT FROM_UNIXTIME(1618088028295 / 1000)'
+'SELECT FROM_UNIXTIME(1618088028295 / POW(10, 3))'
 ```
 
 SQLGlot can even translate custom time formats:
@@ -206,9 +206,9 @@ sqlglot.transpile("SELECT foo( FROM bar")
 ```
 
 ```
-sqlglot.errors.ParseError: Expecting ). Line 1, Col: 13.
+sqlglot.errors.ParseError: Expecting ). Line 1, Col: 20.
   select foo( FROM bar
-              ~~~~
+                   ~~~
 ```
 
 Structured syntax errors are accessible for programmatic use:
@@ -225,10 +225,10 @@ except sqlglot.errors.ParseError as e:
 [{
   'description': 'Expecting )',
   'line': 1,
-  'col': 16,
-  'start_context': 'SELECT foo( ',
-  'highlight': 'FROM',
-  'end_context': ' bar',
+  'col': 20,
+  'start_context': 'SELECT foo( FROM',
+  'highlight': 'bar',
+  'end_context': '',
   'into_expression': None,
 }]
 ```


### PR DESCRIPTION
In the process of validating the README examples, 2 diffs with current SQLGlot results were found:

1) The first example transpiled `EPOCH_MS (DuckDB) -> FROM_UNIXTIME (Hive)` but the respective AST Node `exp.UnixToTime` was not generating properly in Hive

2) The parse error examples in the existing README have mismatches in the `col` position of the missing token (right parenthesis) and the surrounding context does not seem right. In the latest SQLGLot version, the parse error diagnostics have improved but the examples have not been updated.