### PR TITLE
feat(oracle): Support for INSERT hint

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1828,6 +1828,7 @@ class Index(Expression):
 
 class Insert(DDL, DML):
     arg_types = {
+        "hint": False,
         "with": False,
         "this": True,
         "expression": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1451,6 +1451,7 @@ class Generator(metaclass=_Generator):
         return f"{sql})"
 
     def insert_sql(self, expression: exp.Insert) -> str:
+        hint = self.sql(expression, "hint")
         overwrite = expression.args.get("overwrite")
 
         if isinstance(expression.this, exp.Directory):
@@ -1481,7 +1482,7 @@ class Generator(metaclass=_Generator):
         else:
             expression_sql = f"{returning}{expression_sql}{on_conflict}"
 
-        sql = f"INSERT{alternative}{ignore}{this}{by_name}{exists}{partition_sql}{where}{expression_sql}"
+        sql = f"INSERT{hint}{alternative}{ignore}{this}{by_name}{exists}{partition_sql}{where}{expression_sql}"
         return self.prepend_ctes(expression, sql)
 
     def intersect_sql(self, expression: exp.Intersect) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2061,6 +2061,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_insert(self) -> exp.Insert:
         comments = ensure_list(self._prev_comments)
+        hint = self._parse_hint()
         overwrite = self._match(TokenType.OVERWRITE)
         ignore = self._match(TokenType.IGNORE)
         local = self._match_text_seq("LOCAL")
@@ -2087,6 +2088,7 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.Insert,
             comments=comments,
+            hint=hint,
             this=this,
             by_name=self._match_text_seq("BY", "NAME"),
             exists=self._parse_exists(),

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -210,6 +210,8 @@ class TestOracle(Validator):
         self.validate_identity(
             "SELECT /*+ LEADING(e j) */ * FROM employees e, departments d, job_history j WHERE e.department_id = d.department_id AND e.hire_date = j.start_date"
         )
+        self.validate_identity("INSERT /*+ APPEND */ INTO IAP_TBL (id, col1) VALUES (2, 'test2')")
+        self.validate_identity("INSERT /*+ APPEND_VALUES */ INTO dest_table VALUES (i, 'Value')")
 
     def test_xml_table(self):
         self.validate_identity("XMLTABLE('x')")


### PR DESCRIPTION
Fixes #3074 

Extend `parse_insert` to also parse hints as per Oracle syntax

![oracle_insert](https://github.com/tobymao/sqlglot/assets/16211491/5f0f36ef-91d6-4ddf-ae3f-fbfd099172ff)


Docs
--------

- https://oracle-base.com/articles/misc/append-hint
- https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/INSERT.html#GUID-903F8043-0254-4EE9-ACC1-CB8AC0AF3423