### PR TITLE
Fix(redshift): don't transform multi-arg DISTINCT clause

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -153,6 +153,7 @@ class Redshift(Postgres):
         NVL2_SUPPORTED = True
         LAST_DAY_SUPPORTS_DATE_PART = False
         CAN_IMPLEMENT_ARRAY_ANY = False
+        MULTI_ARG_DISTINCT = True
 
         TYPE_MAPPING = {
             **Postgres.Generator.TYPE_MAPPING,

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -293,6 +293,7 @@ class TestRedshift(Validator):
         )
 
     def test_identity(self):
+        self.validate_identity("LISTAGG(DISTINCT foo, ', ')")
         self.validate_identity("CREATE MATERIALIZED VIEW orders AUTO REFRESH YES AS SELECT 1")
         self.validate_identity("SELECT DATEADD(DAY, 1, 'today')")
         self.validate_identity("SELECT * FROM #x")


### PR DESCRIPTION
Redshift's aggregation function syntax generally expects `[ DISTINCT | ALL ] expression`, but `LISTAGG` is an exception: `[DISTINCT] aggregate_expression [, 'delimiter' ]`.

I didn't address this as a special case, but rather made it so that Redshift doesn't [transpile](https://github.com/tobymao/sqlglot/commit/85073d1538de8ceef3e5c622a901efd9e6bd38e3) multi-arg `DISTINCT` expressions at all. The reason is that I played around and realized that Redshift probably doesn't support tuples ("records"?) in that context, so transpiling a query with a multi-arg `DISTINCT` expression to Redshift would yield invalid SQL anyway:

```sql
-- ERROR: could not identify an equality operator for type record
WITH tbl AS (
  SELECT 1 AS id, 'eggy' AS name UNION ALL SELECT NULL AS id, 'jake' AS name
)
SELECT COUNT(
  DISTINCT CASE WHEN id IS NULL THEN NULL WHEN name IS NULL THEN NULL ELSE (id, name) END
) AS cnt
FROM tbl
```

References:
- https://docs.aws.amazon.com/redshift/latest/dg/c_Aggregate_Functions.html
- https://docs.aws.amazon.com/redshift/latest/dg/r_LISTAGG.html