### PR TITLE
Fix!(bigquery): transpile brackets to dot notation less aggressively

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -58,6 +58,7 @@ class TestBigQuery(Validator):
         select_with_quoted_udf = self.validate_identity("SELECT `p.d.UdF`(data) FROM `p.d.t`")
         self.assertEqual(select_with_quoted_udf.selects[0].name, "p.d.UdF")
 
+        self.validate_identity("SELECT jsondoc['some_key']")
         self.validate_identity("SELECT `p.d.UdF`(data).* FROM `p.d.t`")
         self.validate_identity("SELECT * FROM `my-project.my-dataset.my-table`")
         self.validate_identity("CREATE OR REPLACE TABLE `a.b.c` CLONE `a.b.d`")


### PR DESCRIPTION
We used to transpile `doc["field"]` into `doc.field` in BQ, because it doesn't support the former syntax for struct values. However, it does support it for JSON values, and so that conversion would break valid queries. This only applies said transpilation if we're sure that the left-hand side of the bracket is a `STRUCT` value.