### PR TITLE
feat(duckdb): add support for exp.ArrayJoin

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -354,6 +354,7 @@ class DuckDB(Dialect):
                 if e.expressions and e.expressions[0].find(exp.Select)
                 else inline_array_sql(self, e)
             ),
+            exp.ArrayJoin: rename_func("ARRAY_TO_STRING"),
             exp.ArrayFilter: rename_func("LIST_FILTER"),
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArgMax: arg_max_or_min_no_count("ARG_MAX"),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -666,6 +666,13 @@ class TestDuckDB(Validator):
             """SELECT i FROM GENERATE_SERIES(0, 12) AS _(i) ORDER BY i ASC""",
         )
 
+        self.validate_all(
+            "SELECT ARRAY_TO_STRING(fruits, ',') AS all_fruits FROM t",
+            read={
+                "snowflake": "SELECT ARRAY_TO_STRING(fruits, ',') AS all_fruits FROM t",
+            },
+        )
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -678,6 +678,7 @@ WHERE
             write={
                 "spark": "ARRAY_JOIN(x, '')",
                 "snowflake": "ARRAY_TO_STRING(x, '')",
+                "duckdb": "ARRAY_TO_STRING(x, '')",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Noticed this while transpiling a Snowflake query in to DuckDB;
```python
query = "SELECT ARRAY_TO_STRING(id, ',') AS ids FROM some_table;"
e = sqlglot.parse_one(query, read="snowflake")
dsql = e.sql(dialect="duckdb", pretty=True)

print(dsql)

# SELECT
#   ARRAY_JOIN(id, ',') AS ids
# FROM some_table
```