### PR TITLE
Fix: copy all arg keys, including those set to None

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -277,7 +277,7 @@ class Expression(metaclass=_Expression):
                         else:
                             copy.append(k, v)
                 else:
-                    copy.set(k, vs)
+                    copy.args[k] = vs
 
         return root
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -22,6 +22,9 @@ class TestExpressions(unittest.TestCase):
                 pass
 
     def test_eq(self):
+        query = parse_one("SELECT x FROM t")
+        self.assertEqual(query, query.copy())
+
         self.assertNotEqual(exp.to_identifier("a"), exp.to_identifier("A"))
 
         self.assertEqual(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -363,6 +363,9 @@ class TestOptimizer(unittest.TestCase):
         anon_unquoted_str = parse_one("anonymous(x, y)")
         self.assertEqual(optimizer.simplify.gen(anon_unquoted_str), "ANONYMOUS x,y")
 
+        query = parse_one("SELECT x FROM t")
+        self.assertEqual(optimizer.simplify.gen(query), optimizer.simplify.gen(query.copy()))
+
         anon_unquoted_identifier = exp.Anonymous(
             this=exp.to_identifier("anonymous"), expressions=[exp.column("x"), exp.column("y")]
         )


### PR DESCRIPTION
The following behavior was observed after the latest `__deepcopy__`  changes:

```python
>>> from sqlglot.optimizer.simplify import gen
>>> from sqlglot import parse_one
>>> q = parse_one("select x from t")
>>> gen(q)
'select _,_,_,x,_,from t,_,_'
>>> gen(q.copy())
'select x,from t'
```

The root issue here is that we don't copy over arg keys with `None` values anymore due to [using](https://github.com/tobymao/sqlglot/blob/80b23201f9668a5845002c1c21b0a394003847f9/sqlglot/expressions.py#L280) the [set method](https://github.com/tobymao/sqlglot/blob/80b23201f9668a5845002c1c21b0a394003847f9/sqlglot/expressions.py#L326) for leaf nodes, meaning that the original and the copied AST may now have different `args` dicts.

(The `self.assertEqual(query, query.copy())` test passes in main - I added it to future-proof `__deepcopy__`, `__eq__`)