### PR TITLE
Feat(duckdb): add support for positional joins

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -199,6 +199,7 @@ class DuckDB(Dialect):
             "LOGICAL": TokenType.BOOLEAN,
             "ONLY": TokenType.ONLY,
             "PIVOT_WIDER": TokenType.PIVOT,
+            "POSITIONAL": TokenType.POSITIONAL,
             "SIGNED": TokenType.INT,
             "STRING": TokenType.VARCHAR,
             "UBIGINT": TokenType.UBIGINT,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -507,8 +507,9 @@ class Parser(metaclass=_Parser):
     }
 
     JOIN_METHODS = {
-        TokenType.NATURAL,
         TokenType.ASOF,
+        TokenType.NATURAL,
+        TokenType.POSITIONAL,
     }
 
     JOIN_SIDES = {

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -317,6 +317,7 @@ class TokenType(AutoName):
     PERCENT = auto()
     PIVOT = auto()
     PLACEHOLDER = auto()
+    POSITIONAL = auto()
     PRAGMA = auto()
     PREWHERE = auto()
     PRIMARY_KEY = auto()

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -213,6 +213,7 @@ class TestDuckDB(Validator):
             parse_one("a // b", read="duckdb").assert_is(exp.IntDiv).sql(dialect="duckdb"), "a // b"
         )
 
+        self.validate_identity("SELECT df1.*, df2.* FROM df1 POSITIONAL JOIN df2")
         self.validate_identity("MAKE_TIMESTAMP(1992, 9, 20, 13, 34, 27.123456)")
         self.validate_identity("MAKE_TIMESTAMP(1667810584123456)")
         self.validate_identity("SELECT EPOCH_MS(10) AS t")


### PR DESCRIPTION
Fixes #3109

I didn't add `TokenType.POSITIONAL` to `ID_VAR_TOKENS` on purpose since DuckDB treats it as a reserved keyword:

```
D select positional;
Error: Parser Error: syntax error at or near ";"
LINE 1: select positional;
                         ^
D select 1 positional;
Error: Parser Error: syntax error at or near "positional"
LINE 1: select 1 positional;
                 ^
D select 1 as positional;
┌────────────┐
│ positional │
│   int32    │
├────────────┤
│          1 │
└────────────┘
D with t as (select 1 as positional) select positional from t;
Error: Parser Error: syntax error at or near "from"
LINE 1: ...ect 1 as positional) select positional from t;
                                                  ^
```