### PR TITLE
feat: Adding EXCLUDE constraint support

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1582,7 +1582,7 @@ class EncodeColumnConstraint(ColumnConstraintKind):
 
 # https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-EXCLUDE
 class ExcludeColumnConstraint(ColumnConstraintKind):
-    arg_types = {"this": True}
+    pass
 
 
 class WithOperator(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1580,6 +1580,27 @@ class EncodeColumnConstraint(ColumnConstraintKind):
     pass
 
 
+# https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-EXCLUDE
+class ExcludeConstraint(Expression):
+    arg_types = {
+        "using": False,
+        "exclude_elems": True,
+        "kind": False,
+        "index_params": False,
+        "predicate": False,
+    }
+
+
+class ExcludeElement(Expression):
+    arg_types = {
+        "this": True,
+        "opclass": False,
+        "order": False,
+        "nulls": False,
+        "operator": True,
+    }
+
+
 class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
     # this: True -> ALWAYS, this: False -> BY DEFAULT
     arg_types = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1581,24 +1581,12 @@ class EncodeColumnConstraint(ColumnConstraintKind):
 
 
 # https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-EXCLUDE
-class ExcludeConstraint(Expression):
-    arg_types = {
-        "using": False,
-        "exclude_elems": True,
-        "kind": False,
-        "index_params": False,
-        "predicate": False,
-    }
+class ExcludeColumnConstraint(ColumnConstraintKind):
+    arg_types = {"this": True}
 
 
-class ExcludeElement(Expression):
-    arg_types = {
-        "this": True,
-        "opclass": False,
-        "order": False,
-        "nulls": False,
-        "operator": True,
-    }
+class WithOperator(Expression):
+    arg_types = {"this": True, "op": True}
 
 
 class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
@@ -1875,14 +1863,22 @@ class Index(Expression):
     arg_types = {
         "this": False,
         "table": False,
-        "using": False,
-        "where": False,
-        "columns": False,
         "unique": False,
         "primary": False,
         "amp": False,  # teradata
+        "params": False,
+    }
+
+
+class IndexParameters(Expression):
+    arg_types = {
+        "using": False,
         "include": False,
-        "partition_by": False,  # teradata
+        "columns": False,
+        "with_storage": False,
+        "partition_by": False,
+        "tablespace": False,
+        "where": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3619,7 +3619,6 @@ class Generator(metaclass=_Generator):
         using = f" USING {using}" if using else ""
 
         exclude_elems = self.expressions(expression, "exclude_elems", flat=True)
-        exclude_elems = f"{exclude_elems}"
 
         kind = self.sql(expression, "kind")
         kind_sql = f" {kind}" if kind else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1220,7 +1220,7 @@ class Generator(metaclass=_Generator):
         include = self.expressions(expression, key="include", flat=True)
         if include:
             include = f" INCLUDE ({include})"
-        with_storage = self.expressions(expression, "with_storage", flat=True)
+        with_storage = self.expressions(expression, key="with_storage", flat=True)
         with_storage = f" WITH {with_storage}" if with_storage else ""
         tablespace = self.sql(expression, "tablespace")
         tablespace = f" USING INDEX TABLESPACE {tablespace}" if tablespace else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3619,7 +3619,7 @@ class Generator(metaclass=_Generator):
         using = f" USING {using}" if using else ""
 
         exclude_elems = self.expressions(expression, "exclude_elems", flat=True)
-        exclude_elems = f"{exclude_elems}" if exclude_elems else None
+        exclude_elems = f"{exclude_elems}"
 
         kind = self.sql(expression, "kind")
         kind_sql = f" {kind}" if kind else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3598,3 +3598,38 @@ class Generator(metaclass=_Generator):
             transformed = cast(this=value, to=to, safe=safe)
 
         return self.sql(transformed)
+
+    def excludeelement_sql(self, expression: exp.ExcludeElement) -> str:
+        this = self.sql(expression, "this")
+
+        opclass = self.sql(expression, "opclass")
+        opclass = f" {opclass}" if opclass else ""
+        order = self.sql(expression, "order")
+        order = f" {order}" if order else ""
+        nulls = self.sql(expression, "nulls")
+        nulls = f" NULLS {nulls}" if nulls else ""
+
+        operator = self.sql(expression, "operator")
+        operator = f" {operator}" if operator else ""
+
+        return f"{this}{opclass}{order}{nulls} WITH{operator}"
+
+    def excludeconstraint_sql(self, expression: exp.ExcludeConstraint) -> str:
+        using = self.sql(expression, "using")
+        using = f" USING {using}" if using else ""
+
+        exclude_elems = self.expressions(expression, "exclude_elems", flat=True)
+        exclude_elems = f"{exclude_elems}" if exclude_elems else None
+
+        kind = self.sql(expression, "kind")
+        kind_sql = f" {kind}" if kind else ""
+
+        index_params = self.expressions(expression, "index_params", flat=True)
+        if kind == "INCLUDE":
+            index_params = f"({index_params})"
+        index_params = f" {index_params}" if index_params else ""
+
+        predicate = self.sql(expression, "predicate")
+        predicate = f" WHERE ({predicate})" if predicate else ""
+
+        return f"EXCLUDE{using} ({exclude_elems}){kind_sql}{index_params}{predicate}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -880,12 +880,12 @@ class Parser(metaclass=_Parser):
 
     SCHEMA_UNNAMED_CONSTRAINTS = {
         "CHECK",
+        "EXCLUDE",
         "FOREIGN KEY",
         "LIKE",
+        "PERIOD",
         "PRIMARY KEY",
         "UNIQUE",
-        "PERIOD",
-        "EXCLUDE",
     }
 
     NO_PAREN_FUNCTION_PARSERS = {
@@ -2853,6 +2853,7 @@ class Parser(metaclass=_Parser):
         this = self._parse_conjunction()
         if self._match_texts(self.OPCLASS_FOLLOW_KEYWORDS, advance=False):
             return this
+
         if not self._match_set(self.OPTYPE_FOLLOW_TOKENS, advance=False):
             return self.expression(exp.Opclass, this=this, expression=self._parse_table_parts())
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6151,7 +6151,8 @@ class Parser(metaclass=_Parser):
             index_params = self._parse_csv(self._parse_conjunction)
         elif self._match_text_seq("USING", "INDEX", "TABLESPACE"):
             kind = "USING INDEX TABLESPACE"
-            index_params = [self._parse_id_var()]
+            tablespace = self._parse_id_var()
+            index_params = [tablespace] if tablespace else None
 
         predicate = (
             self._parse_wrapped(self._parse_conjunction) if self._match(TokenType.WHERE) else None

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -134,13 +134,13 @@ class TestPostgres(Validator):
             "CREATE TABLE t (vid INT NOT NULL, CONSTRAINT ht_vid_nid_fid_idx EXCLUDE (INT4RANGE(vid, nid) WITH &&, INT4RANGE(fid, fid, '[]') WITH &&))"
         )
         self.validate_identity(
-            "CREATE TABLE t (i INT, PRIMARY KEY (i), EXCLUDE USING gist (col varchar_pattern_ops DESC NULLS FIRST WITH &&) WITH (sp1 = 1, sp2 = 2))"
+            "CREATE TABLE t (i INT, PRIMARY KEY (i), EXCLUDE USING gist(col varchar_pattern_ops DESC NULLS LAST WITH &&) WITH (sp1 = 1, sp2 = 2))"
         )
         self.validate_identity(
-            "CREATE TABLE t (i INT, EXCLUDE USING btree (INT4RANGE(vid, nid, '[]') ASC NULLS LAST WITH &&) INCLUDE (col1, col2))"
+            "CREATE TABLE t (i INT, EXCLUDE USING btree(INT4RANGE(vid, nid, '[]') ASC NULLS FIRST WITH &&) INCLUDE (col1, col2))"
         )
         self.validate_identity(
-            "CREATE TABLE t (i INT, EXCLUDE USING gin (col1 WITH &&, col2 WITH ||) USING INDEX TABLESPACE tablespace WHERE (id > 5))"
+            "CREATE TABLE t (i INT, EXCLUDE USING gin(col1 WITH &&, col2 WITH ||) USING INDEX TABLESPACE tablespace WHERE (id > 5))"
         )
         self.validate_identity(
             "SELECT c.oid, n.nspname, c.relname "

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -131,6 +131,18 @@ class TestPostgres(Validator):
             "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss"
         )
         self.validate_identity(
+            "CREATE TABLE t (vid INT NOT NULL, CONSTRAINT ht_vid_nid_fid_idx EXCLUDE USING gist (INT4RANGE(vid, nid) WITH &&, INT4RANGE(fid, fid, '[]') WITH &&))"
+        )
+        self.validate_identity(
+            "CREATE TABLE t (i INT, PRIMARY KEY (i), EXCLUDE USING gist (col varchar_pattern_ops DESC NULLS FIRST WITH &&) WITH (sp1 = 1, sp2 = 2))"
+        )
+        self.validate_identity(
+            "CREATE TABLE t (i INT, EXCLUDE USING gist (INT4RANGE(vid, nid, '[]') ASC NULLS LAST WITH &&) INCLUDE (col1, col2))"
+        )
+        self.validate_identity(
+            "CREATE TABLE t (i INT, EXCLUDE USING gist (col1 WITH &&, col2 WITH ||) USING INDEX TABLESPACE tablespace WHERE (id > 5))"
+        )
+        self.validate_identity(
             "SELECT c.oid, n.nspname, c.relname "
             "FROM pg_catalog.pg_class AS c "
             "LEFT JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace "

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -131,16 +131,16 @@ class TestPostgres(Validator):
             "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss"
         )
         self.validate_identity(
-            "CREATE TABLE t (vid INT NOT NULL, CONSTRAINT ht_vid_nid_fid_idx EXCLUDE USING gist (INT4RANGE(vid, nid) WITH &&, INT4RANGE(fid, fid, '[]') WITH &&))"
+            "CREATE TABLE t (vid INT NOT NULL, CONSTRAINT ht_vid_nid_fid_idx EXCLUDE (INT4RANGE(vid, nid) WITH &&, INT4RANGE(fid, fid, '[]') WITH &&))"
         )
         self.validate_identity(
             "CREATE TABLE t (i INT, PRIMARY KEY (i), EXCLUDE USING gist (col varchar_pattern_ops DESC NULLS FIRST WITH &&) WITH (sp1 = 1, sp2 = 2))"
         )
         self.validate_identity(
-            "CREATE TABLE t (i INT, EXCLUDE USING gist (INT4RANGE(vid, nid, '[]') ASC NULLS LAST WITH &&) INCLUDE (col1, col2))"
+            "CREATE TABLE t (i INT, EXCLUDE USING btree (INT4RANGE(vid, nid, '[]') ASC NULLS LAST WITH &&) INCLUDE (col1, col2))"
         )
         self.validate_identity(
-            "CREATE TABLE t (i INT, EXCLUDE USING gist (col1 WITH &&, col2 WITH ||) USING INDEX TABLESPACE tablespace WHERE (id > 5))"
+            "CREATE TABLE t (i INT, EXCLUDE USING gin (col1 WITH &&, col2 WITH ||) USING INDEX TABLESPACE tablespace WHERE (id > 5))"
         )
         self.validate_identity(
             "SELECT c.oid, n.nspname, c.relname "


### PR DESCRIPTION
Fixes #3097 

The syntax for the `EXCLUDE` table constraint is the following:

```
[CONSTRAINT constraint_name] EXCLUDE [ USING index_method ] ( exclude_element WITH operator [, ... ] ) index_parameters [ WHERE ( predicate ) ]
```

where:

```
<index_method> ::= identifier (see [1])
<exclude_element> ::= { column_name | ( expression ) } [ opclass ] [ ASC | DESC ] [ NULLS { FIRST | LAST } ]
<opclass> ::= identifier (see [2])
<index_parameters> ::=  [ INCLUDE ( column_name [, ... ] ) ] 
                        [ WITH ( storage_parameter [= value] [, ... ] ) ]
                        [ USING INDEX TABLESPACE tablespace_name ]
``` 

Design Notes
-----------------
- Added `exp.ExcludeElement` that captures all information from `exclude_element WITH operator [, ... ] `
- This is an exclusively Postgres feature afaik, but the changes are added on the base Dialect. 

Docs
----------
1. [Index methods](https://www.postgresql.org/docs/current/indexes-types.html)
2. [Operator class](https://www.postgresql.org/docs/current/indexes-opclass.html)
3. [EXCLUDE constraint](https://www.postgresql.org/docs/current/sql-createtable.html)