### PR TITLE
 Feat!(snowflake): iceberg ddl, structured types, cast rename/keep fields, drop fix

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2318,6 +2318,10 @@ class GlobalProperty(Property):
     arg_types = {}
 
 
+class IcebergProperty(Property):
+    arg_types = {}
+
+
 class InheritsProperty(Property):
     arg_types = {"expressions": True}
 
@@ -3838,6 +3842,18 @@ class DataType(Expression):
         XML = auto()
         YEAR = auto()
 
+    STRUCT_TYPES = {
+        Type.NESTED,
+        Type.OBJECT,
+        Type.STRUCT,
+    }
+
+    NESTED_TYPES = {
+        *STRUCT_TYPES,
+        Type.ARRAY,
+        Type.MAP,
+    }
+
     TEXT_TYPES = {
         Type.CHAR,
         Type.NCHAR,
@@ -4685,7 +4701,13 @@ class Case(Func):
 
 
 class Cast(Func):
-    arg_types = {"this": True, "to": True, "format": False, "safe": False}
+    arg_types = {
+        "this": True,
+        "to": True,
+        "format": False,
+        "safe": False,
+        "action": False,
+    }
 
     @property
     def name(self) -> str:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1762,6 +1762,7 @@ class Drop(Expression):
     arg_types = {
         "this": False,
         "kind": False,
+        "expressions": False,
         "exists": False,
         "temporary": False,
         "materialized": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1170,6 +1170,8 @@ class Generator(metaclass=_Generator):
 
     def drop_sql(self, expression: exp.Drop) -> str:
         this = self.sql(expression, "this")
+        expressions = self.expressions(expression, flat=True)
+        expressions = f" ({expressions})" if expressions else ""
         kind = expression.args["kind"]
         exists_sql = " IF EXISTS " if expression.args.get("exists") else " "
         temporary = " TEMPORARY" if expression.args.get("temporary") else ""
@@ -1177,9 +1179,7 @@ class Generator(metaclass=_Generator):
         cascade = " CASCADE" if expression.args.get("cascade") else ""
         constraints = " CONSTRAINTS" if expression.args.get("constraints") else ""
         purge = " PURGE" if expression.args.get("purge") else ""
-        return (
-            f"DROP{temporary}{materialized} {kind}{exists_sql}{this}{cascade}{constraints}{purge}"
-        )
+        return f"DROP{temporary}{materialized} {kind}{exists_sql}{this}{expressions}{cascade}{constraints}{purge}"
 
     def except_sql(self, expression: exp.Except) -> str:
         return self.set_operations(expression)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -95,6 +95,7 @@ class Generator(metaclass=_Generator):
         exp.ExternalProperty: lambda *_: "EXTERNAL",
         exp.GlobalProperty: lambda *_: "GLOBAL",
         exp.HeapProperty: lambda *_: "HEAP",
+        exp.IcebergProperty: lambda *_: "ICEBERG",
         exp.InheritsProperty: lambda self, e: f"INHERITS ({self.expressions(e, flat=True)})",
         exp.InlineLengthColumnConstraint: lambda self, e: f"INLINE LENGTH {self.sql(e, 'this')}",
         exp.InputModelProperty: lambda self, e: f"INPUT{self.sql(e, 'this')}",
@@ -405,6 +406,7 @@ class Generator(metaclass=_Generator):
         exp.GlobalProperty: exp.Properties.Location.POST_CREATE,
         exp.HeapProperty: exp.Properties.Location.POST_WITH,
         exp.InheritsProperty: exp.Properties.Location.POST_SCHEMA,
+        exp.IcebergProperty: exp.Properties.Location.POST_CREATE,
         exp.InputModelProperty: exp.Properties.Location.POST_SCHEMA,
         exp.IsolatedLoadingProperty: exp.Properties.Location.POST_NAME,
         exp.JournalProperty: exp.Properties.Location.POST_NAME,
@@ -2799,7 +2801,9 @@ class Generator(metaclass=_Generator):
         format_sql = f" FORMAT {format_sql}" if format_sql else ""
         to_sql = self.sql(expression, "to")
         to_sql = f" {to_sql}" if to_sql else ""
-        return f"{safe_prefix or ''}CAST({self.sql(expression, 'this')} AS{to_sql}{format_sql})"
+        action = self.sql(expression, "action")
+        action = f" {action}" if action else ""
+        return f"{safe_prefix or ''}CAST({self.sql(expression, 'this')} AS{to_sql}{format_sql}{action})"
 
     def currentdate_sql(self, expression: exp.CurrentDate) -> str:
         zone = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1432,13 +1432,22 @@ class Parser(metaclass=_Parser):
         if not kind:
             return self._parse_as_command(start)
 
+        if_exists = exists or self._parse_exists()
+        table = self._parse_table_parts(
+            schema=True, is_db_reference=self._prev.token_type == TokenType.SCHEMA
+        )
+
+        if self._match(TokenType.L_PAREN, advance=False):
+            expressions = self._parse_wrapped_csv(self._parse_types)
+        else:
+            expressions = None
+
         return self.expression(
             exp.Drop,
             comments=start.comments,
-            exists=exists or self._parse_exists(),
-            this=self._parse_table(
-                schema=True, is_db_reference=self._prev.token_type == TokenType.SCHEMA
-            ),
+            exists=if_exists,
+            this=table,
+            expressions=expressions,
             kind=kind,
             temporary=temporary,
             materialized=materialized,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -144,6 +144,7 @@ class Parser(metaclass=_Parser):
 
     STRUCT_TYPE_TOKENS = {
         TokenType.NESTED,
+        TokenType.OBJECT,
         TokenType.STRUCT,
     }
 
@@ -748,6 +749,7 @@ class Parser(metaclass=_Parser):
         "FREESPACE": lambda self: self._parse_freespace(),
         "GLOBAL": lambda self: self.expression(exp.GlobalProperty),
         "HEAP": lambda self: self.expression(exp.HeapProperty),
+        "ICEBERG": lambda self: self.expression(exp.IcebergProperty),
         "IMMUTABLE": lambda self: self.expression(
             exp.StabilityProperty, this=exp.Literal.string("IMMUTABLE")
         ),
@@ -1017,6 +1019,8 @@ class Parser(metaclass=_Parser):
     }
 
     USABLES: OPTIONS_TYPE = dict.fromkeys(("ROLE", "WAREHOUSE", "DATABASE", "SCHEMA"), tuple())
+
+    CAST_ACTIONS: OPTIONS_TYPE = dict.fromkeys(("RENAME", "ADD"), ("FIELDS",))
 
     INSERT_ALTERNATIVES = {"ABORT", "FAIL", "IGNORE", "REPLACE", "ROLLBACK"}
 
@@ -4860,7 +4864,12 @@ class Parser(metaclass=_Parser):
                 to = self.expression(exp.CharacterSet, this=self._parse_var_or_string())
 
         return self.expression(
-            exp.Cast if strict else exp.TryCast, this=this, to=to, format=fmt, safe=safe
+            exp.Cast if strict else exp.TryCast,
+            this=this,
+            to=to,
+            format=fmt,
+            safe=safe,
+            action=self._parse_var_from_options(self.CAST_ACTIONS, raise_unmatched=False),
         )
 
     def _parse_string_agg(self) -> exp.Expression:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -663,6 +663,13 @@ class TestBigQuery(Validator):
             },
         )
         self.validate_all(
+            "SELECT CAST(STRUCT(1) AS STRUCT<INT64>)",
+            write={
+                "bigquery": "SELECT CAST(STRUCT(1) AS STRUCT<INT64>)",
+                "snowflake": "SELECT CAST(OBJECT_CONSTRUCT('_0', 1) AS OBJECT)",
+            },
+        )
+        self.validate_all(
             "cast(x as date format 'MM/DD/YYYY')",
             write={
                 "bigquery": "PARSE_DATE('%m/%d/%Y', x)",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -972,7 +972,7 @@ class TestDuckDB(Validator):
                 "hive": "CAST(COL AS ARRAY<BIGINT>)",
                 "spark": "CAST(COL AS ARRAY<BIGINT>)",
                 "postgres": "CAST(COL AS BIGINT[])",
-                "snowflake": "CAST(COL AS ARRAY)",
+                "snowflake": "CAST(COL AS ARRAY(BIGINT))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -63,7 +63,7 @@ class TestPresto(Validator):
                 "duckdb": "CAST(a AS INT[])",
                 "presto": "CAST(a AS ARRAY(INTEGER))",
                 "spark": "CAST(a AS ARRAY<INT>)",
-                "snowflake": "CAST(a AS ARRAY)",
+                "snowflake": "CAST(a AS ARRAY(INT))",
             },
         )
         self.validate_all(
@@ -82,18 +82,17 @@ class TestPresto(Validator):
                 "duckdb": "CAST([1, 2] AS BIGINT[])",
                 "presto": "CAST(ARRAY[1, 2] AS ARRAY(BIGINT))",
                 "spark": "CAST(ARRAY(1, 2) AS ARRAY<BIGINT>)",
-                "snowflake": "CAST([1, 2] AS ARRAY)",
+                "snowflake": "CAST([1, 2] AS ARRAY(BIGINT))",
             },
         )
         self.validate_all(
-            "CAST(MAP(ARRAY[1], ARRAY[1]) AS MAP(INT,INT))",
+            "CAST(MAP(ARRAY['key'], ARRAY[1]) AS MAP(VARCHAR, INT))",
             write={
-                "bigquery": "CAST(MAP([1], [1]) AS MAP<INT64, INT64>)",
-                "duckdb": "CAST(MAP([1], [1]) AS MAP(INT, INT))",
-                "presto": "CAST(MAP(ARRAY[1], ARRAY[1]) AS MAP(INTEGER, INTEGER))",
-                "hive": "CAST(MAP(1, 1) AS MAP<INT, INT>)",
-                "spark": "CAST(MAP_FROM_ARRAYS(ARRAY(1), ARRAY(1)) AS MAP<INT, INT>)",
-                "snowflake": "CAST(OBJECT_CONSTRUCT(1, 1) AS OBJECT)",
+                "duckdb": "CAST(MAP(['key'], [1]) AS MAP(TEXT, INT))",
+                "presto": "CAST(MAP(ARRAY['key'], ARRAY[1]) AS MAP(VARCHAR, INTEGER))",
+                "hive": "CAST(MAP('key', 1) AS MAP<STRING, INT>)",
+                "snowflake": "CAST(OBJECT_CONSTRUCT('key', 1) AS MAP(VARCHAR, INT))",
+                "spark": "CAST(MAP_FROM_ARRAYS(ARRAY('key'), ARRAY(1)) AS MAP<STRING, INT>)",
             },
         )
         self.validate_all(
@@ -104,7 +103,7 @@ class TestPresto(Validator):
                 "presto": "CAST(MAP(ARRAY['a', 'b', 'c'], ARRAY[ARRAY[1], ARRAY[2], ARRAY[3]]) AS MAP(VARCHAR, ARRAY(INTEGER)))",
                 "hive": "CAST(MAP('a', ARRAY(1), 'b', ARRAY(2), 'c', ARRAY(3)) AS MAP<STRING, ARRAY<INT>>)",
                 "spark": "CAST(MAP_FROM_ARRAYS(ARRAY('a', 'b', 'c'), ARRAY(ARRAY(1), ARRAY(2), ARRAY(3))) AS MAP<STRING, ARRAY<INT>>)",
-                "snowflake": "CAST(OBJECT_CONSTRUCT('a', [1], 'b', [2], 'c', [3]) AS OBJECT)",
+                "snowflake": "CAST(OBJECT_CONSTRUCT('a', [1], 'b', [2], 'c', [3]) AS MAP(VARCHAR, ARRAY(INT)))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1091,6 +1091,14 @@ WHERE
         self.validate_identity(
             "CREATE ICEBERG TABLE my_iceberg_table (amount ARRAY(INT)) CATALOG='SNOWFLAKE' EXTERNAL_VOLUME='my_external_volume' BASE_LOCATION='my/relative/path/from/extvol'"
         )
+        self.validate_identity(
+            "CREATE OR REPLACE FUNCTION my_udf(location OBJECT(city VARCHAR, zipcode DECIMAL, val ARRAY(BOOLEAN))) RETURNS VARCHAR AS $$ SELECT 'foo' $$",
+            "CREATE OR REPLACE FUNCTION my_udf(location OBJECT(city VARCHAR, zipcode DECIMAL, val ARRAY(BOOLEAN))) RETURNS VARCHAR AS ' SELECT \\'foo\\' '",
+        )
+        self.validate_identity(
+            "CREATE OR REPLACE FUNCTION my_udtf(foo BOOLEAN) RETURNS TABLE(col1 ARRAY(INT)) AS $$ WITH t AS (SELECT CAST([1, 2, 3] AS ARRAY(INT)) AS c) SELECT c FROM t $$",
+            "CREATE OR REPLACE FUNCTION my_udtf(foo BOOLEAN) RETURNS TABLE (col1 ARRAY(INT)) AS ' WITH t AS (SELECT CAST([1, 2, 3] AS ARRAY(INT)) AS c) SELECT c FROM t '",
+        )
 
         self.validate_all(
             "CREATE TABLE orders_clone CLONE orders",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -40,6 +40,11 @@ WHERE
   )""",
         )
 
+        self.validate_identity("SELECT CAST(OBJECT_CONSTRUCT('a', 1) AS MAP(VARCHAR, INT))")
+        self.validate_identity("SELECT CAST(OBJECT_CONSTRUCT('a', 1) AS OBJECT(a CHAR NOT NULL))")
+        self.validate_identity("SELECT CAST([1, 2, 3] AS ARRAY(INT))")
+        self.validate_identity("SELECT CAST(obj AS OBJECT(x CHAR) RENAME FIELDS)")
+        self.validate_identity("SELECT CAST(obj AS OBJECT(x CHAR, y VARCHAR) ADD FIELDS)")
         self.validate_identity("SELECT TO_TIMESTAMP(123.4)").selects[0].assert_is(exp.Anonymous)
         self.validate_identity("SELECT TO_TIME(x) FROM t")
         self.validate_identity("SELECT TO_TIMESTAMP(x) FROM t")
@@ -1082,6 +1087,9 @@ WHERE
         )
         self.validate_identity(
             "CREATE OR REPLACE TABLE EXAMPLE_DB.DEMO.USERS (ID DECIMAL(38, 0) NOT NULL, PRIMARY KEY (ID), FOREIGN KEY (CITY_CODE) REFERENCES EXAMPLE_DB.DEMO.CITIES (CITY_CODE))"
+        )
+        self.validate_identity(
+            "CREATE ICEBERG TABLE my_iceberg_table (amount ARRAY(INT)) CATALOG='SNOWFLAKE' EXTERNAL_VOLUME='my_external_volume' BASE_LOCATION='my/relative/path/from/extvol'"
         )
 
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1074,6 +1074,9 @@ WHERE
         self.validate_identity("CREATE TABLE IDENTIFIER('foo') (COLUMN1 VARCHAR, COLUMN2 VARCHAR)")
         self.validate_identity("CREATE TABLE IDENTIFIER($foo) (col1 VARCHAR, col2 VARCHAR)")
         self.validate_identity(
+            "DROP function my_udf (OBJECT(city VARCHAR, zipcode DECIMAL, val ARRAY(BOOLEAN)))"
+        )
+        self.validate_identity(
             "CREATE TABLE orders_clone_restore CLONE orders AT (TIMESTAMP => TO_TIMESTAMP_TZ('04/05/2013 01:02:03', 'mm/dd/yyyy hh24:mi:ss'))"
         )
         self.validate_identity(


### PR DESCRIPTION
Snowflake added support Iceberg tables and structured types, so now `ARRAY(INT)` is valid. This PR:

- Adds support for `CREATE ICEBERG TABLE ...`
- Fixes the generation of structured types
- Adds support for `CAST( <source_expr> AS <target_data_type> [ RENAME FIELDS | ADD FIELDS ] )`
- Improves transpilation of `STRUCT`-like types _to_ Snowflake
- Fixes an issue with `DROP` - we weren't parsing the data type list properly

References:
- https://docs.snowflake.com/en/sql-reference/functions/cast
- https://docs.snowflake.com/en/user-guide/tables-iceberg-data-types
- https://docs.snowflake.com/en/sql-reference/data-types-structured#constructing-structured-arrays-structured-objects-and-maps
- https://docs.snowflake.com/en/sql-reference/sql/create-iceberg-table
- https://docs.snowflake.com/en/sql-reference/sql/drop-function