### PR TITLE
Fix: don't mutate parent nested classes if undefined in a dialect

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -112,9 +112,14 @@ class _Dialect(type):
 
         klass.INVERSE_ESCAPE_SEQUENCES = {v: k for k, v in klass.ESCAPE_SEQUENCES.items()}
 
-        klass.tokenizer_class = getattr(klass, "Tokenizer", Tokenizer)
-        klass.parser_class = getattr(klass, "Parser", Parser)
-        klass.generator_class = getattr(klass, "Generator", Generator)
+        base = seq_get(bases, 0)
+        base_tokenizer = (getattr(base, "tokenizer_class", Tokenizer),)
+        base_parser = (getattr(base, "parser_class", Parser),)
+        base_generator = (getattr(base, "generator_class", Generator),)
+
+        klass.tokenizer_class = getattr(klass, "Tokenizer", type("Tokenizer", base_tokenizer, {}))
+        klass.parser_class = getattr(klass, "Parser", type("Parser", base_parser, {}))
+        klass.generator_class = getattr(klass, "Generator", type("Generator", base_generator, {}))
 
         klass.QUOTE_START, klass.QUOTE_END = list(klass.tokenizer_class._QUOTES.items())[0]
         klass.IDENTIFIER_START, klass.IDENTIFIER_END = list(

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -117,9 +117,13 @@ class _Dialect(type):
         base_parser = (getattr(base, "parser_class", Parser),)
         base_generator = (getattr(base, "generator_class", Generator),)
 
-        klass.tokenizer_class = getattr(klass, "Tokenizer", type("Tokenizer", base_tokenizer, {}))
-        klass.parser_class = getattr(klass, "Parser", type("Parser", base_parser, {}))
-        klass.generator_class = getattr(klass, "Generator", type("Generator", base_generator, {}))
+        klass.tokenizer_class = klass.__dict__.get(
+            "Tokenizer", type("Tokenizer", base_tokenizer, {})
+        )
+        klass.parser_class = klass.__dict__.get("Parser", type("Parser", base_parser, {}))
+        klass.generator_class = klass.__dict__.get(
+            "Generator", type("Generator", base_generator, {})
+        )
 
         klass.QUOTE_START, klass.QUOTE_END = list(klass.tokenizer_class._QUOTES.items())[0]
         klass.IDENTIFIER_START, klass.IDENTIFIER_END = list(

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp, generator, parser, tokens
+from sqlglot import exp, parser, tokens
 from sqlglot.dialects.dialect import Dialect
 from sqlglot.tokens import TokenType
 
@@ -104,6 +104,3 @@ class PRQL(Dialect):
             return self.expression(
                 exp.From, comments=self._prev_comments, this=self._parse_table(joins=joins)
             )
-
-    class Generator(generator.Generator):
-        pass


### PR DESCRIPTION
There was a bug where if a class didn't override the nested classes (`Tokenizer`, `Parser`, `Generator`), we could end up overwriting attributes of the nested classes of its parent class. For example, if we got rid of PRQL's empty `Generator` override, we would end up with various broken tests because the metaclass code overwrote `Dialect.generator_class`.