### PR TITLE
fix(duckdb): Slice + Array bug

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4316,7 +4316,7 @@ class Parser(metaclass=_Parser):
 
                 if not isinstance(e, exp.PropertyEQ):
                     e = self.expression(
-                        exp.PropertyEQ, this=exp.to_identifier(e.name), expression=e.expression
+                        exp.PropertyEQ, this=exp.to_identifier(e.this.name), expression=e.expression
                     )
 
                 if isinstance(e.this, exp.Column):
@@ -4735,9 +4735,9 @@ class Parser(metaclass=_Parser):
             lambda: self._parse_bracket_key_value(is_map=bracket_kind == TokenType.L_BRACE)
         )
 
-        if not self._match(TokenType.R_BRACKET) and bracket_kind == TokenType.L_BRACKET:
+        if bracket_kind == TokenType.L_BRACKET and not self._match(TokenType.R_BRACKET):
             self.raise_error("Expected ]")
-        elif not self._match(TokenType.R_BRACE) and bracket_kind == TokenType.L_BRACE:
+        elif bracket_kind == TokenType.L_BRACE and not self._match(TokenType.R_BRACE):
             self.raise_error("Expected }")
 
         # https://duckdb.org/docs/sql/data_types/struct.html#creating-structs

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -701,6 +701,18 @@ class TestDuckDB(Validator):
             self.validate_identity(
                 "[x.STRING_SPLIT(' ')[1] FOR x IN ['1', '2', 3] IF x.CONTAINS('1')]"
             )
+            self.validate_identity(
+                """SELECT LIST_VALUE(1)[1]""",
+                """SELECT ([1])[1]""",
+            )
+            self.validate_identity(
+                """{'x': LIST_VALUE(1)[1]}""",
+                """{'x': ([1])[1]}""",
+            )
+            self.validate_identity(
+                """SELECT LIST_APPLY(RANGE(1, 4), i -> {'f1': LIST_VALUE(1, 2, 3)[i], 'f2': LIST_VALUE(1, 2, 3)[i]})""",
+                """SELECT LIST_APPLY(RANGE(1, 4), i -> {'f1': ([1, 2, 3])[i], 'f2': ([1, 2, 3])[i]})""",
+            )
 
             self.assertEqual(
                 cm.output,
@@ -708,6 +720,10 @@ class TestDuckDB(Validator):
                     "WARNING:sqlglot:Applying array index offset (-1)",
                     "WARNING:sqlglot:Applying array index offset (1)",
                     "WARNING:sqlglot:Applying array index offset (1)",
+                    "WARNING:sqlglot:Applying array index offset (1)",
+                    "WARNING:sqlglot:Applying array index offset (-1)",
+                    "WARNING:sqlglot:Applying array index offset (1)",
+                    "WARNING:sqlglot:Applying array index offset (-1)",
                     "WARNING:sqlglot:Applying array index offset (1)",
                     "WARNING:sqlglot:Applying array index offset (-1)",
                     "WARNING:sqlglot:Applying array index offset (1)",


### PR DESCRIPTION
Fixes #3136 

Caught 3 consecutive bugs:

- When matching `R_BRACKET` or `R_BRACE` inside `parse_bracket`, the short-circuit should be flipped, otherwise a single `parse_bracket` call can match 2 closing tokens, e.g. in `{'x': arr[i]}`, the parsing of `arr[i]` will also match the following `}` 

- When transforming `exp.Slice` to `exp.PropertyEq`, the `exp.Slice` name was used instead of `exp.Slice.this` name

- DuckDB requires wrapped arrays if the indexing is in place, i.e `SELECT [1, 2][1]` does not work, but `SELECT ([1, 2])[1]` does. The function `LIST_VALUE()` is parsed and generated as an `exp.Array` so it's also affected by this behavior; thus, the DuckDB `exp.Bracket` generation was enhanced to wrap arrays.