### PR TITLE
Feat: add skip limit token kwarg

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3545,9 +3545,9 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_limit(
-        self, this: t.Optional[exp.Expression] = None, top: bool = False
+        self, this: t.Optional[exp.Expression] = None, top: bool = False, skip_limit_token: bool = False
     ) -> t.Optional[exp.Expression]:
-        if self._match(TokenType.TOP if top else TokenType.LIMIT):
+        if skip_limit_token or self._match(TokenType.TOP if top else TokenType.LIMIT):
             comments = self._prev_comments
             if top:
                 limit_paren = self._match(TokenType.L_PAREN)


### PR DESCRIPTION
The way `_parse_limit` is implemented, adding a `skip_limit_token` kwarg forces us to assume 1 of 2 branches (limit/fetch). The direction is, of course, to use the limit code path because our goal is ultimately to enable an optional `@LIMIT` macro in SQLMesh. We achieve this via simple short circuit. 