### PR TITLE
feat(mysql): Support for multi arg GROUP_CONCAT

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -319,11 +319,7 @@ class MySQL(Dialect):
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
             "CHAR": lambda self: self._parse_chr(),
-            "GROUP_CONCAT": lambda self: self.expression(
-                exp.GroupConcat,
-                this=self._parse_lambda(),
-                separator=self._match(TokenType.SEPARATOR) and self._parse_field(),
-            ),
+            "GROUP_CONCAT": lambda self: self._parse_group_concat(),
             # https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
             "VALUES": lambda self: self.expression(
                 exp.Anonymous, this="VALUES", expressions=[self._parse_id_var()]
@@ -616,6 +612,44 @@ class MySQL(Dialect):
                 kwargs["charset"] = self._parse_var()
 
             return self.expression(exp.Chr, **kwargs)
+
+        def _parse_group_concat(self) -> t.Optional[exp.Expression]:
+            def concat_exprs(node, exprs):
+                if node and isinstance(node, exp.Distinct):
+                    exprs = node.expressions
+                    concat_exprs = (
+                        [self.expression(exp.Concat, expressions=exprs)]
+                        if len(exprs) > 1
+                        else exprs
+                    )
+                    return self.expression(exp.Distinct, expressions=concat_exprs)
+                return (
+                    exprs[0] if len(exprs) == 1 else self.expression(exp.Concat, expressions=args)
+                )
+
+            args = self._parse_csv(self._parse_lambda)
+            if len(args) > 1 and isinstance(args[-1], exp.Order):
+                # Case #1 (Only Order By): GROUP_CONCAT(a, b, c ORDER BY d ...)
+                # Order By has consumed only 'c', undo it and put all concatenated exprs in it's place
+                order = args[-1]
+                args.pop()
+                args.append(order.this)
+                order.set("this", concat_exprs(None, args))
+                this = order
+            elif len(args) == 1 and isinstance(args[0], exp.Order):
+                # Case #2 (Distinct + Order By): GROUP_CONCAT([DISTINCT] a, b, c ORDER BY d ...)
+                order = args[0]
+                if isinstance(order.this, exp.Distinct):
+                    order.set("this", concat_exprs(order.this, order.this.expressions))
+                this = order
+            else:
+                # Case #3 (Only Distinct): GROUP_CONCAT([DISTINCT] a, b, c ...)
+                # Case #4 (Only exprs): GROUP_CONCAT(a, b, c, ...)
+                this = concat_exprs(args[0], args)
+
+            separator = self._parse_field() if self._match(TokenType.SEPARATOR) else None
+
+            return self.expression(exp.GroupConcat, this=this, separator=separator)
 
     class Generator(generator.Generator):
         LOCKING_READS_SUPPORTED = True

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -618,11 +618,15 @@ class MySQL(Dialect):
                 node: t.Optional[exp.Expression], exprs: t.List[exp.Expression]
             ) -> exp.Expression:
                 if isinstance(node, exp.Distinct) and len(node.expressions) > 1:
-                    concat_exprs = [self.expression(exp.Concat, expressions=node.expressions)]
+                    concat_exprs = [
+                        self.expression(exp.Concat, expressions=node.expressions, safe=True)
+                    ]
                     node.set("expressions", concat_exprs)
                     return node
                 return (
-                    exprs[0] if len(exprs) == 1 else self.expression(exp.Concat, expressions=args)
+                    exprs[0]
+                    if len(exprs) == 1
+                    else self.expression(exp.Concat, expressions=args, safe=True)
                 )
 
             args = self._parse_csv(self._parse_lambda)

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -623,11 +623,9 @@ class MySQL(Dialect):
                     ]
                     node.set("expressions", concat_exprs)
                     return node
-                return (
-                    exprs[0]
-                    if len(exprs) == 1
-                    else self.expression(exp.Concat, expressions=args, safe=True)
-                )
+                if len(exprs) == 1:
+                    return exprs[0]
+                return self.expression(exp.Concat, expressions=args, safe=True)
 
             args = self._parse_csv(self._parse_lambda)
 

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -636,7 +636,7 @@ class MySQL(Dialect):
                     args[-1] = order.this
                     order.set("this", concat_exprs(order.this, args))
 
-                this = order or (args and concat_exprs(args[0], args))
+                this = order or concat_exprs(args[0], args)
             else:
                 this = None
 

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -616,7 +616,7 @@ class MySQL(Dialect):
         def _parse_group_concat(self) -> t.Optional[exp.Expression]:
             def concat_exprs(
                 node: t.Optional[exp.Expression], exprs: t.List[exp.Expression]
-            ) -> t.Optional[exp.Expression]:
+            ) -> exp.Expression:
                 if isinstance(node, exp.Distinct) and len(node.expressions) > 1:
                     concat_exprs = [self.expression(exp.Concat, expressions=node.expressions)]
                     node.set("expressions", concat_exprs)

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -724,6 +724,16 @@ class TestMySQL(Validator):
             },
         )
         self.validate_all(
+            "GROUP_CONCAT(a, b, c SEPARATOR ',')",
+            write={
+                "mysql": "GROUP_CONCAT(CONCAT(a, b, c) SEPARATOR ',')",
+                "sqlite": "GROUP_CONCAT(a || b || c, ',')",
+                "tsql": "STRING_AGG(CONCAT(a, b, c), ',')",
+                "postgres": "STRING_AGG(CONCAT(a, b, c), ',')",
+                "presto": "ARRAY_JOIN(ARRAY_AGG(CONCAT(CAST(a AS VARCHAR), CAST(b AS VARCHAR), CAST(c AS VARCHAR))), ',')",
+            },
+        )
+        self.validate_all(
             "GROUP_CONCAT(a, b, c SEPARATOR '')",
             write={
                 "mysql": "GROUP_CONCAT(CONCAT(a, b, c) SEPARATOR '')",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -723,6 +723,42 @@ class TestMySQL(Validator):
                 "postgres": "STRING_AGG(DISTINCT x, '' ORDER BY y DESC NULLS LAST)",
             },
         )
+        self.validate_all(
+            "GROUP_CONCAT(a, b, c SEPARATOR '')",
+            write={
+                "mysql": "GROUP_CONCAT(CONCAT(a, b, c) SEPARATOR '')",
+                "sqlite": "GROUP_CONCAT(a || b || c, '')",
+                "tsql": "STRING_AGG(CONCAT(a, b, c), '')",
+                "postgres": "STRING_AGG(CONCAT(a, b, c), '')",
+            },
+        )
+        self.validate_all(
+            "GROUP_CONCAT(DISTINCT a, b, c SEPARATOR '')",
+            write={
+                "mysql": "GROUP_CONCAT(DISTINCT CONCAT(a, b, c) SEPARATOR '')",
+                "sqlite": "GROUP_CONCAT(DISTINCT a || b || c, '')",
+                "tsql": "STRING_AGG(CONCAT(a, b, c), '')",
+                "postgres": "STRING_AGG(DISTINCT CONCAT(a, b, c), '')",
+            },
+        )
+        self.validate_all(
+            "GROUP_CONCAT(a, b, c ORDER BY d SEPARATOR '')",
+            write={
+                "mysql": "GROUP_CONCAT(CONCAT(a, b, c) ORDER BY d SEPARATOR '')",
+                "sqlite": "GROUP_CONCAT(a || b || c, '')",
+                "tsql": "STRING_AGG(CONCAT(a, b, c), '') WITHIN GROUP (ORDER BY d)",
+                "postgres": "STRING_AGG(CONCAT(a, b, c), '' ORDER BY d NULLS FIRST)",
+            },
+        )
+        self.validate_all(
+            "GROUP_CONCAT(DISTINCT a, b, c ORDER BY d SEPARATOR '')",
+            write={
+                "mysql": "GROUP_CONCAT(DISTINCT CONCAT(a, b, c) ORDER BY d SEPARATOR '')",
+                "sqlite": "GROUP_CONCAT(DISTINCT a || b || c, '')",
+                "tsql": "STRING_AGG(CONCAT(a, b, c), '') WITHIN GROUP (ORDER BY d)",
+                "postgres": "STRING_AGG(DISTINCT CONCAT(a, b, c), '' ORDER BY d NULLS FIRST)",
+            },
+        )
         self.validate_identity(
             "CREATE TABLE z (a INT) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET=utf8 COLLATE=utf8_bin COMMENT='x'"
         )


### PR DESCRIPTION
Fixes #3142 

Change MySQL parsing for `exp.GroupConcat` to reduce/normalize the list of expressions into an `exp.Concat` node, thus making it easily transpilable to other dialects which only accept a single expression.   

Docs
------------
- https://dev.mysql.com/doc/refman/8.3/en/aggregate-functions.html#function_group-concat