### PR TITLE
feat: include table alias in bigquery unnest

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -48,7 +48,11 @@ def _derived_table_values_to_unnest(self: BigQuery.Generator, expression: exp.Va
         ]
         structs.append(exp.Struct(expressions=expressions))
 
-    return self.unnest_sql(exp.Unnest(expressions=[exp.array(*structs, copy=False)]))
+    # Due to `UNNEST_COLUMN_ONLY`, it is expected that the table alias be contained in the columns expression
+    alias_name_only = exp.TableAlias(columns=[alias.this]) if alias else None
+    return self.unnest_sql(
+        exp.Unnest(expressions=[exp.array(*structs, copy=False)], alias=alias_name_only)
+    )
 
 
 def _returnsproperty_sql(self: BigQuery.Generator, expression: exp.ReturnsProperty) -> str:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1014,20 +1014,21 @@ class TestBigQuery(Validator):
             },
         )
         self.validate_all(
-            "SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)])",
+            "SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)]) AS tab",
             read={
-                "bigquery": "SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)])",
+                "bigquery": "SELECT cola, colb FROM UNNEST([STRUCT(1 AS cola, 'test' AS colb)]) as tab",
                 "snowflake": "SELECT cola, colb FROM (VALUES (1, 'test')) AS tab(cola, colb)",
                 "spark": "SELECT cola, colb FROM VALUES (1, 'test') AS tab(cola, colb)",
             },
         )
         self.validate_all(
-            "SELECT * FROM UNNEST([STRUCT(1 AS id)]) CROSS JOIN UNNEST([STRUCT(1 AS id)])",
+            "SELECT * FROM UNNEST([STRUCT(1 AS id)]) AS t1 CROSS JOIN UNNEST([STRUCT(1 AS id)]) AS t2",
             read={
-                "bigquery": "SELECT * FROM UNNEST([STRUCT(1 AS id)]) CROSS JOIN UNNEST([STRUCT(1 AS id)])",
+                "bigquery": "SELECT * FROM UNNEST([STRUCT(1 AS id)]) AS t1 CROSS JOIN UNNEST([STRUCT(1 AS id)]) AS t2",
                 "postgres": "SELECT * FROM (VALUES (1)) AS t1(id) CROSS JOIN (VALUES (1)) AS t2(id)",
             },
         )
+
         self.validate_all(
             "SELECT REGEXP_EXTRACT(abc, 'pattern(group)') FROM table",
             write={


### PR DESCRIPTION
<img width="435" alt="Screenshot 2024-03-16 at 12 42 51 PM" src="https://github.com/tobymao/sqlglot/assets/6326532/09b90ecd-6f88-43f3-a962-e7f8c0695825">

BigQuery supports a table alias when doing unnest (which is used instead of `VALUES`) but it just doesn't support column names in that table alias. This makes it so we still output the table alias.

Looking for feedback on `UNNEST_COLUMN_ONLY`. I don't fully understand the purpose of this flag. My current fix leaves this enabled for BigQuery but makes it work by making the alias a column but this is more of a hack. Just wasn't sure what the best way to fix because I don't fully understand `UNNEST_COLUMN_ONLY`. 