### PR TITLE
feat(clickhouse): Support for INSERT INTO TABLE FUNCTION

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1931,7 +1931,7 @@ class Insert(DDL, DML):
     arg_types = {
         "hint": False,
         "with": False,
-        "kind": False,
+        "is_function": False,
         "this": True,
         "expression": False,
         "conflict": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1931,6 +1931,7 @@ class Insert(DDL, DML):
     arg_types = {
         "hint": False,
         "with": False,
+        "kind": False,
         "this": True,
         "expression": False,
         "conflict": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1512,6 +1512,9 @@ class Generator(metaclass=_Generator):
         alternative = expression.args.get("alternative")
         alternative = f" OR {alternative}" if alternative else ""
         ignore = " IGNORE" if expression.args.get("ignore") else ""
+        kind = expression.args.get("kind")
+        if kind:
+            this = f"{this} {kind}"
 
         this = f"{this} {self.sql(expression, 'this')}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1514,8 +1514,7 @@ class Generator(metaclass=_Generator):
         ignore = " IGNORE" if expression.args.get("ignore") else ""
         kind = expression.args.get("kind")
         if kind:
-            this = f"{this} {kind}"
-
+            this = f"{this} FUNCTION"
         this = f"{this} {self.sql(expression, 'this')}"
 
         exists = " IF EXISTS" if expression.args.get("exists") else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1512,8 +1512,8 @@ class Generator(metaclass=_Generator):
         alternative = expression.args.get("alternative")
         alternative = f" OR {alternative}" if alternative else ""
         ignore = " IGNORE" if expression.args.get("ignore") else ""
-        kind = expression.args.get("kind")
-        if kind:
+        is_function = expression.args.get("is_function")
+        if is_function:
             this = f"{this} FUNCTION"
         this = f"{this} {self.sql(expression, 'this')}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2170,7 +2170,7 @@ class Parser(metaclass=_Parser):
         ignore = self._match(TokenType.IGNORE)
         local = self._match_text_seq("LOCAL")
         alternative = None
-        kind = None
+        is_function = None
 
         if self._match_text_seq("DIRECTORY"):
             this: t.Optional[exp.Expression] = self.expression(
@@ -2186,9 +2186,9 @@ class Parser(metaclass=_Parser):
             self._match(TokenType.INTO)
             comments += ensure_list(self._prev_comments)
             self._match(TokenType.TABLE)
-            kind = self._match(TokenType.FUNCTION)
+            is_function = self._match(TokenType.FUNCTION)
 
-            this = self._parse_table(schema=True) if not kind else self._parse_function()
+            this = self._parse_table(schema=True) if not is_function else self._parse_function()
 
         returning = self._parse_returning()
 
@@ -2196,7 +2196,7 @@ class Parser(metaclass=_Parser):
             exp.Insert,
             comments=comments,
             hint=hint,
-            kind=kind,
+            is_function=is_function,
             this=this,
             by_name=self._match_text_seq("BY", "NAME"),
             exists=self._parse_exists(),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2170,7 +2170,6 @@ class Parser(metaclass=_Parser):
         ignore = self._match(TokenType.IGNORE)
         local = self._match_text_seq("LOCAL")
         alternative = None
-        is_function = None
 
         if self._match_text_seq("DIRECTORY"):
             this: t.Optional[exp.Expression] = self.expression(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2186,12 +2186,9 @@ class Parser(metaclass=_Parser):
             self._match(TokenType.INTO)
             comments += ensure_list(self._prev_comments)
             self._match(TokenType.TABLE)
+            kind = self._match(TokenType.FUNCTION)
 
-            # https://clickhouse.com/docs/en/sql-reference/table-functions
-            if self._match(TokenType.FUNCTION):
-                kind = "FUNCTION"
-
-            this = self._parse_table(schema=True)
+            this = self._parse_table(schema=True) if not kind else self._parse_function()
 
         returning = self._parse_returning()
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2170,6 +2170,7 @@ class Parser(metaclass=_Parser):
         ignore = self._match(TokenType.IGNORE)
         local = self._match_text_seq("LOCAL")
         alternative = None
+        kind = None
 
         if self._match_text_seq("DIRECTORY"):
             this: t.Optional[exp.Expression] = self.expression(
@@ -2185,6 +2186,11 @@ class Parser(metaclass=_Parser):
             self._match(TokenType.INTO)
             comments += ensure_list(self._prev_comments)
             self._match(TokenType.TABLE)
+
+            # https://clickhouse.com/docs/en/sql-reference/table-functions
+            if self._match(TokenType.FUNCTION):
+                kind = "FUNCTION"
+
             this = self._parse_table(schema=True)
 
         returning = self._parse_returning()
@@ -2193,6 +2199,7 @@ class Parser(metaclass=_Parser):
             exp.Insert,
             comments=comments,
             hint=hint,
+            kind=kind,
             this=this,
             by_name=self._match_text_seq("BY", "NAME"),
             exists=self._parse_exists(),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -396,7 +396,6 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "INSERT INTO FUNCTION remote('localhost', default.simple_table) VALUES (100, 'inserted via remote()')"
         )
-
         self.validate_identity(
             """INSERT INTO TABLE FUNCTION hdfs('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
             """INSERT INTO FUNCTION hdfs('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -391,11 +391,15 @@ class TestClickhouse(Validator):
         self.validate_identity("SYSTEM STOP MERGES foo.bar", check_command_warning=True)
 
         self.validate_identity(
-            "INSERT INTO FUNCTION s3 ('url', 'CSV', 'name String, value UInt32', 'gzip') SELECT name, value FROM existing_table"
+            "INSERT INTO FUNCTION s3('url', 'CSV', 'name String, value UInt32', 'gzip') SELECT name, value FROM existing_table"
         )
         self.validate_identity(
-            """INSERT INTO TABLE FUNCTION hdfs ('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
-            """INSERT INTO FUNCTION hdfs ('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
+            "INSERT INTO FUNCTION remote('localhost', default.simple_table) VALUES (100, 'inserted via remote()')"
+        )
+
+        self.validate_identity(
+            """INSERT INTO TABLE FUNCTION hdfs('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
+            """INSERT INTO FUNCTION hdfs('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
         )
 
     def test_cte(self):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -390,6 +390,14 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("SYSTEM STOP MERGES foo.bar", check_command_warning=True)
 
+        self.validate_identity(
+            "INSERT INTO FUNCTION s3 ('url', 'CSV', 'name String, value UInt32', 'gzip') SELECT name, value FROM existing_table"
+        )
+        self.validate_identity(
+            """INSERT INTO TABLE FUNCTION hdfs ('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
+            """INSERT INTO FUNCTION hdfs ('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
+        )
+
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")


### PR DESCRIPTION
Fixes #3161 

Support `INSERT INTO [TABLE] FUNCTION ...` syntax by extending `exp.Insert` with a new `kind` argument, that for now is only filled and generated in case of `[TABLE] FUNCTION`

Docs
-------
- [ClickHouse Table Functions](https://clickhouse.com/docs/en/sql-reference/table-functions)
- [ClickHouse INSERT INTO FUNCTION](https://clickhouse.com/docs/en/sql-reference/statements/insert-into#inserting-using-a-table-function)