### PR TITLE
fix(snowflake): Allow non-literal expressions too in DATE functions

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -33,7 +33,6 @@ def _build_datetime(
 ) -> t.Callable[[t.List], exp.Func]:
     def _builder(args: t.List) -> exp.Func:
         value = seq_get(args, 0)
-        int_value = False
 
         if isinstance(value, exp.Literal):
             int_value = is_int(value.this)
@@ -50,7 +49,7 @@ def _build_datetime(
                 if not is_float(value.this):
                     return build_formatted_time(exp.StrToTime, "snowflake")(args)
 
-        if len(args) == 2 and kind == exp.DataType.Type.DATE and not int_value:
+        if len(args) == 2 and kind == exp.DataType.Type.DATE:
             formatted_exp = build_formatted_time(exp.TsOrDsToDate, "snowflake")(args)
             formatted_exp.set("safe", safe)
             return formatted_exp

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -50,7 +50,7 @@ def _build_datetime(
                 if not is_float(value.this):
                     return build_formatted_time(exp.StrToTime, "snowflake")(args)
 
-        if kind == exp.DataType.Type.DATE and not int_value:
+        if len(args) == 2 and kind == exp.DataType.Type.DATE and not int_value:
             formatted_exp = build_formatted_time(exp.TsOrDsToDate, "snowflake")(args)
             formatted_exp.set("safe", safe)
             return formatted_exp

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -33,6 +33,7 @@ def _build_datetime(
 ) -> t.Callable[[t.List], exp.Func]:
     def _builder(args: t.List) -> exp.Func:
         value = seq_get(args, 0)
+        int_value = False
 
         if isinstance(value, exp.Literal):
             int_value = is_int(value.this)
@@ -48,10 +49,12 @@ def _build_datetime(
                     return exp.UnixToTime(this=value, scale=seq_get(args, 1))
                 if not is_float(value.this):
                     return build_formatted_time(exp.StrToTime, "snowflake")(args)
-            if kind == exp.DataType.Type.DATE and not int_value:
-                formatted_exp = build_formatted_time(exp.TsOrDsToDate, "snowflake")(args)
-                formatted_exp.set("safe", safe)
-                return formatted_exp
+
+        if kind == exp.DataType.Type.DATE and not int_value:
+            formatted_exp = build_formatted_time(exp.TsOrDsToDate, "snowflake")(args)
+            formatted_exp.set("safe", safe)
+            return formatted_exp
+
         return exp.Anonymous(this=name, expressions=args)
 
     return _builder

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -985,6 +985,8 @@ WHERE
             "SELECT CAST('2019-02-28' AS DATE) + INTERVAL '1 day, 1 year'",
         )
 
+        self.validate_identity("TRY_TO_DATE(x)").assert_is(exp.Anonymous)
+
         self.validate_all(
             "TO_DATE(x, 'MM-DD-YYYY')",
             write={

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -985,6 +985,8 @@ WHERE
             "SELECT CAST('2019-02-28' AS DATE) + INTERVAL '1 day, 1 year'",
         )
 
+        self.validate_identity("DATE(x)").assert_is(exp.Anonymous)
+        self.validate_identity("TO_DATE(x)").assert_is(exp.Anonymous)
         self.validate_identity("TRY_TO_DATE(x)").assert_is(exp.Anonymous)
 
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -986,6 +986,13 @@ WHERE
         )
 
         self.validate_all(
+            "TO_DATE(x, 'MM-DD-YYYY')",
+            write={
+                "snowflake": "TO_DATE(x, 'mm-DD-yyyy')",
+                "duckdb": "CAST(STRPTIME(x, '%m-%d-%Y') AS DATE)",
+            },
+        )
+        self.validate_all(
             "DATE('01-01-2000', 'MM-DD-YYYY')",
             write={
                 "snowflake": "TO_DATE('01-01-2000', 'mm-DD-yyyy')",


### PR DESCRIPTION
Fixes #3160

Postfix to allow arbitrary expressions in DATE / TO_DATE / TRY_TO_DATE functions