### PR TITLE
Fix: move comment from window function to Window expression

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5254,6 +5254,9 @@ class Parser(metaclass=_Parser):
     def _parse_window(
         self, this: t.Optional[exp.Expression], alias: bool = False
     ) -> t.Optional[exp.Expression]:
+        func = this
+        comments = func.comments if isinstance(func, exp.Expression) else None
+
         if self._match_pair(TokenType.FILTER, TokenType.L_PAREN):
             self._match(TokenType.WHERE)
             this = self.expression(
@@ -5299,9 +5302,16 @@ class Parser(metaclass=_Parser):
         else:
             over = self._prev.text.upper()
 
+        if comments:
+            func.comments = None  # type: ignore
+
         if not self._match(TokenType.L_PAREN):
             return self.expression(
-                exp.Window, this=this, alias=self._parse_id_var(False), over=over
+                exp.Window,
+                comments=comments,
+                this=this,
+                alias=self._parse_id_var(False),
+                over=over,
             )
 
         window_alias = self._parse_id_var(any_token=False, tokens=self.WINDOW_ALIAS_TOKENS)
@@ -5334,6 +5344,7 @@ class Parser(metaclass=_Parser):
 
         window = self.expression(
             exp.Window,
+            comments=comments,
             this=this,
             partition_by=partition,
             order=order,

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -480,6 +480,13 @@ SELECT
 FROM base""",
             pretty=True,
         )
+        self.validate(
+            """-- comment
+SOME_FUNC(arg IGNORE NULLS)
+  OVER (PARTITION BY foo ORDER BY bla) AS col""",
+            "SOME_FUNC(arg IGNORE NULLS) OVER (PARTITION BY foo ORDER BY bla) AS col /* comment */",
+            pretty=True,
+        )
 
     def test_types(self):
         self.validate("INT 1", "CAST(1 AS INT)")


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/2299

```python
>>> import sqlglot
>>>
>>> print(sqlglot.transpile("""
... SELECT
... -- comment
... SOME_FUNC(arg IGNORE NULLS)
...   OVER (PARTITION BY foo ORDER BY bla) AS col
... FROM t
... """, pretty=True)[0])
SELECT
  SOME_FUNC(arg IGNORE NULLS) OVER (PARTITION BY foo ORDER BY bla) AS col /* comment */
FROM t
```