### PR TITLE
fix(clickhouse): Fixing FORMAT being parsed as implicit alias

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -306,7 +306,7 @@ class ClickHouse(Dialect):
             TokenType.SETTINGS,
         }
 
-        ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS - {
+        ALIAS_TOKENS = parser.Parser.ALIAS_TOKENS - {
             TokenType.FORMAT,
         }
 

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -317,6 +317,10 @@ class ClickHouse(Dialect):
             TokenType.FORMAT: lambda self: ("format", self._advance() or self._parse_id_var()),
         }
 
+        EXCLUDED_IMPLICIT_ALIAS_IDS = [
+            "FORMAT",
+        ]
+
         def _parse_conjunction(self) -> t.Optional[exp.Expression]:
             this = super()._parse_conjunction()
 

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -306,6 +306,10 @@ class ClickHouse(Dialect):
             TokenType.SETTINGS,
         }
 
+        ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS - {
+            TokenType.FORMAT,
+        }
+
         LOG_DEFAULTS_TO_LN = True
 
         QUERY_MODIFIER_PARSERS = {
@@ -316,10 +320,6 @@ class ClickHouse(Dialect):
             ),
             TokenType.FORMAT: lambda self: ("format", self._advance() or self._parse_id_var()),
         }
-
-        EXCLUDED_IMPLICIT_ALIAS_IDS = [
-            "FORMAT",
-        ]
 
         def _parse_conjunction(self) -> t.Optional[exp.Expression]:
             this = super()._parse_conjunction()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1053,6 +1053,9 @@ class Parser(metaclass=_Parser):
 
     UNNEST_OFFSET_ALIAS_TOKENS = ID_VAR_TOKENS - SET_OPERATIONS
 
+    # Aliases without 'AS' might cause disambiguity
+    EXCLUDED_IMPLICIT_ALIAS_IDS: t.List[str] = []
+
     STRICT_CAST = True
 
     PREFIXED_PIVOT_COLUMNS = False
@@ -5390,6 +5393,9 @@ class Parser(metaclass=_Parser):
         )
 
         if alias:
+            if any_token is None and alias.this.upper() in self.EXCLUDED_IMPLICIT_ALIAS_IDS:
+                self._retreat(self._index - 1)
+                return this
             this = self.expression(exp.Alias, comments=comments, this=this, alias=alias)
             column = this.this
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -405,7 +405,7 @@ class Parser(metaclass=_Parser):
         TokenType.WINDOW,
     }
 
-    ALIAS_TOKENS = ID_VAR_TOKENS.copy()
+    ALIAS_TOKENS = ID_VAR_TOKENS
 
     COMMENT_TABLE_ALIAS_TOKENS = TABLE_ALIAS_TOKENS - {TokenType.IS}
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -401,6 +401,10 @@ class TestClickhouse(Validator):
             """INSERT INTO FUNCTION hdfs('hdfs://hdfs1:9000/test', 'TSV', 'name String, column2 UInt32, column3 UInt32') VALUES ('test', 1, 2)""",
         )
 
+        self.validate_identity("SELECT 1 FORMAT TabSeparated")
+        self.validate_identity("SELECT FORMAT")
+        self.validate_identity("1 AS FORMAT").assert_is(exp.Alias)
+
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -402,6 +402,7 @@ class TestClickhouse(Validator):
         )
 
         self.validate_identity("SELECT 1 FORMAT TabSeparated")
+        self.validate_identity("SELECT * FROM t FORMAT TabSeparated")
         self.validate_identity("SELECT FORMAT")
         self.validate_identity("1 AS FORMAT").assert_is(exp.Alias)
 


### PR DESCRIPTION
Fixes #3176 

Although the `FORMAT` query modifier is already supported in SQLGLot, Clickhouse containts the anti-pattern that it's both a query modifier _and_ a valid identifier (in some cases, as shown below), so before this PR it was parsed as an alias for the query of the issue #3176 . 

However, it seems that it's not allowed in an "implicit" alias i.e without `AS` token, probably in an attempt to disambiguate it in the cases above. For example:

- `SELECT 1 FORMAT <format_val>` -> Valid, `FORMAT` is the query modifier with the following var as value
- `SELECT 1 AS FORMAT` -> Valid, `FORMAT` is the alias identifier of expression `1`
- `SELECT 1 FOO` -> Valid, `FOO` is the "implicit" alias identifier of expression `1`
- `SELECT 1 FORMAT` -> Invalid

This pattern might be present in other dialects (or in other Clickhouse keywords as well), and since Clickhouse uses the base Dialect functions `parse_alias`, `parse_id_var` etc the change was added there.