### PR TITLE
feat(mysql): Parse MODIFY COLUMN

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -408,6 +408,11 @@ class MySQL(Dialect):
             "SPATIAL": lambda self: self._parse_index_constraint(kind="SPATIAL"),
         }
 
+        ALTER_PARSERS = {
+            **parser.Parser.ALTER_PARSERS,
+            "MODIFY": lambda self: self._parse_alter_table_alter(),
+        }
+
         SCHEMA_UNNAMED_CONSTRAINTS = {
             *parser.Parser.SCHEMA_UNNAMED_CONSTRAINTS,
             "FULLTEXT",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5695,10 +5695,11 @@ class Parser(metaclass=_Parser):
             return self.expression(exp.AlterColumn, this=column, comment=self._parse_string())
 
         self._match_text_seq("SET", "DATA")
+        self._match_text_seq("TYPE")
         return self.expression(
             exp.AlterColumn,
             this=column,
-            dtype=self._match_text_seq("TYPE") and self._parse_types(),
+            dtype=self._parse_types(),
             collate=self._match(TokenType.COLLATE) and self._parse_term(),
             using=self._match(TokenType.USING) and self._parse_conjunction(),
         )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -86,6 +86,9 @@ class TestMySQL(Validator):
             "ALTER TABLE test_table MODIFY COLUMN test_column LONGTEXT",
         )
         self.validate_identity(
+            "ALTER TABLE test_table MODIFY COLUMN test_column LONGTEXT",
+        )
+        self.validate_identity(
             "CREATE TABLE t (c DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP) DEFAULT CHARSET=utf8 ROW_FORMAT=DYNAMIC",
             "CREATE TABLE t (c DATETIME DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP()) DEFAULT CHARACTER SET=utf8 ROW_FORMAT=DYNAMIC",
         )


### PR DESCRIPTION
Fixes #3186 

Introduce `MODIFY COLUMN` support for MySQL, which is treated as syntactic sugar for existing `ALTER COLUMN` statements. 

Support for the following options `[FIRST | AFTER col_name]` as well as specific `column_definition` properties is not included in this PR as these span multiple statements, but a follow up PR can support these too across MySQL


Docs
--------------
- [MySQL ALTER TABLE statements](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html)
- [MySQL column_definition syntax](https://dev.mysql.com/doc/refman/8.0/en/create-table.html)