### PR TITLE
fix: Fix backtracking through try/catch exceptions

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -15,7 +15,6 @@ from sqlglot.dialects.dialect import (
     rename_func,
     var_map_sql,
 )
-from sqlglot.errors import ParseError
 from sqlglot.helper import is_int, seq_get
 from sqlglot.tokens import Token, TokenType
 
@@ -385,21 +384,20 @@ class ClickHouse(Dialect):
             return super()._parse_position(haystack_first=True)
 
         # https://clickhouse.com/docs/en/sql-reference/statements/select/with/
-        def _parse_cte(self) -> exp.CTE:
-            index = self._index
-            try:
-                # WITH <identifier> AS <subquery expression>
-                return super()._parse_cte()
-            except ParseError:
-                # WITH <expression> AS <identifier>
-                self._retreat(index)
+        def _parse_cte(self) -> exp.Expression:
+            # WITH <identifier> AS <subquery expression>
+            cte = super()._try_parse(super()._parse_cte)
 
-                return self.expression(
+            if not cte:
+                # WITH <expression> AS <identifier>
+                cte = self.expression(
                     exp.CTE,
                     this=self._parse_conjunction(),
                     alias=self._parse_table_alias(),
                     scalar=True,
                 )
+
+            return cte
 
         def _parse_join_parts(
             self,


### PR DESCRIPTION
Fixes #3175 

The issue above highlighted 2 existing bugs, which stem from using `try/catch` statements in order to backtrack from wrong paths. This was the case with Clickhouses CTE, which supports 2 different kinds of syntax and the existing code tries to reuse the base parser's `parse_cte()` or backtrack from it and parse the second "flavor". Note that this pattern is also observed in `parse_schema`.

This approach can show different behaviors according to the user set ErrorLevel e.g. with `ErrorLevel.IGNORE` there's no error raised thus `try/catch` is not activated, so the introduced function `try_parse` attempts to solve this issue in a general way . 