### PR TITLE
fix(postgres): Fix ARROW/DARROW column operators

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1019,7 +1019,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
 
 
 def build_json_extract_path(
-    expr_type: t.Type[F], zero_based_indexing: bool = True
+    expr_type: t.Type[F], zero_based_indexing: bool = True, arrow_req_json_type: bool = False
 ) -> t.Callable[[t.List], F]:
     def _builder(args: t.List) -> F:
         segments: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
@@ -1039,7 +1039,11 @@ def build_json_extract_path(
 
         # This is done to avoid failing in the expression validator due to the arg count
         del args[2:]
-        return expr_type(this=seq_get(args, 0), expression=exp.JSONPath(expressions=segments))
+        return expr_type(
+            this=seq_get(args, 0),
+            expression=exp.JSONPath(expressions=segments),
+            only_json_types=arrow_req_json_type,
+        )
 
     return _builder
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -357,6 +357,16 @@ class Postgres(Dialect):
 
         JSON_ARROWS_REQUIRE_JSON_TYPE = True
 
+        COLUMN_OPERATORS = {
+            **parser.Parser.COLUMN_OPERATORS,
+            TokenType.ARROW: lambda self, this, path: build_json_extract_path(
+                exp.JSONExtract, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
+            )([this, path]),
+            TokenType.DARROW: lambda self, this, path: build_json_extract_path(
+                exp.JSONExtractScalar, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
+            )([this, path]),
+        }
+
         def _parse_operator(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
             while True:
                 if not self._match(TokenType.L_PAREN):

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -108,6 +108,8 @@ class TestPostgres(Validator):
         self.validate_identity(
             "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss"
         )
+        self.validate_identity("SELECT ('data' -> 'en-US') AS acat FROM my_table")
+        self.validate_identity("SELECT ('data' ->> 'en-US') AS acat FROM my_table")
         self.validate_identity(
             "SELECT c.oid, n.nspname, c.relname "
             "FROM pg_catalog.pg_class AS c "


### PR DESCRIPTION
Fixes #3185 

Fix the following issue by overriding Postgres's `COLUMN_OPERATORS` for `TokenType.ARROW` and `TokenType.DARROW` to build `JsonExtractPath` & `JsonExtractPathScalar` expressions instead of calling `to_json_path`