### PR TITLE
Feat(duckdb): add support for heredoc string syntax

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -188,6 +188,11 @@ class DuckDB(Dialect):
         return super().to_json_path(path)
 
     class Tokenizer(tokens.Tokenizer):
+        HEREDOC_STRINGS = ["$"]
+
+        HEREDOC_TAG_IS_IDENTIFIER = True
+        HEREDOC_STRING_ALTERNATIVE = TokenType.PARAMETER
+
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "//": TokenType.DIV,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -266,6 +266,14 @@ class TestDuckDB(Validator):
             """SELECT '{"foo": [1, 2, 3]}' -> '$.foo' -> '$[0]'""",
         )
         self.validate_identity(
+            "SELECT $$foo$$",
+            "SELECT 'foo'",
+        )
+        self.validate_identity(
+            "SELECT $tag$foo$tag$",
+            "SELECT 'foo'",
+        )
+        self.validate_identity(
             "JSON_EXTRACT(x, '$.family')",
             "x -> '$.family'",
         )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -266,6 +266,10 @@ class TestDuckDB(Validator):
             """SELECT '{"foo": [1, 2, 3]}' -> '$.foo' -> '$[0]'""",
         )
         self.validate_identity(
+            "SELECT ($$hello)'world$$)",
+            "SELECT ('hello)''world')",
+        )
+        self.validate_identity(
             "SELECT $$foo$$",
             "SELECT 'foo'",
         )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -145,6 +145,10 @@ class TestPostgres(Validator):
             "SELECT 'Dianne''s horse'",
         )
         self.validate_identity(
+            "SELECT $$The price is $9.95$$ AS msg",
+            "SELECT 'The price is $9.95' AS msg",
+        )
+        self.validate_identity(
             "COMMENT ON TABLE mytable IS $$doc this$$", "COMMENT ON TABLE mytable IS 'doc this'"
         )
         self.validate_identity(


### PR DESCRIPTION
It seems like DuckDB also [supports](https://github.com/duckdb/duckdb/pull/10879) heredocs now.

References:
- https://duckdb.org/docs/sql/data_types/literal_types.html#dollar-quoted-string-literals
- https://duckdb.org/docs/api/python/dbapi.html#named-parameters