### PR TITLE
Fix(snowflake): convert VALUES with invalid expressions into UNION ALL

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -852,6 +852,16 @@ class Snowflake(Dialect):
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
+        UNSUPPORTED_VALUES_EXPRESSIONS = {
+            exp.Struct,
+        }
+
+        def values_sql(self, expression: exp.Values, values_as_table: bool = True) -> str:
+            if expression.find(*self.UNSUPPORTED_VALUES_EXPRESSIONS):
+                values_as_table = False
+
+            return super().values_sql(expression, values_as_table=values_as_table)
+
         def datatype_sql(self, expression: exp.DataType) -> str:
             expressions = expression.expressions
             if (

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1746,9 +1746,11 @@ class Generator(metaclass=_Generator):
         sql = f"UPDATE {this} SET {set_sql}{expression_sql}{order}{limit}"
         return self.prepend_ctes(expression, sql)
 
-    def values_sql(self, expression: exp.Values) -> str:
+    def values_sql(self, expression: exp.Values, values_as_table: bool = True) -> str:
+        values_as_table = values_as_table and self.VALUES_AS_TABLE
+
         # The VALUES clause is still valid in an `INSERT INTO ..` statement, for example
-        if self.VALUES_AS_TABLE or not expression.find_ancestor(exp.From, exp.Join):
+        if values_as_table or not expression.find_ancestor(exp.From, exp.Join):
             args = self.expressions(expression)
             alias = self.sql(expression, "alias")
             values = f"VALUES{self.seg('')}{args}"

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1416,12 +1416,23 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
                 "spark": "SELECT `c0`, `c1` FROM (VALUES (1, 2), (3, 4)) AS `t0`(`c0`, `c1`)",
             },
         )
-
         self.validate_all(
             """SELECT $1 AS "_1" FROM VALUES ('a'), ('b')""",
             write={
                 "snowflake": """SELECT $1 AS "_1" FROM (VALUES ('a'), ('b'))""",
                 "spark": """SELECT ${1} AS `_1` FROM VALUES ('a'), ('b')""",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM (SELECT OBJECT_CONSTRUCT('a', 1) AS x) AS t",
+            read={
+                "duckdb": "SELECT * FROM (VALUES ({'a': 1})) AS t(x)",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM (SELECT OBJECT_CONSTRUCT('a', 1) AS x UNION ALL SELECT OBJECT_CONSTRUCT('a', 2)) AS t",
+            read={
+                "duckdb": "SELECT * FROM (VALUES ({'a': 1}), ({'a': 2})) AS t(x)",
             },
         )
 


### PR DESCRIPTION
Snowflake doesn't support some expressions inside of the `VALUES` clause. For example, the following fails:

```sql
-- Invalid expression [OBJECT_CONSTRUCT('a', 'b')] in VALUES clause
SELECT * FROM (VALUES (OBJECT_CONSTRUCT('a', 'b'))) AS t(x)
```

Related slack [thread](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1711319137491219?thread_ts=1711222433.615919&cid=C044BRE5W4S) and reference: https://docs.snowflake.com/en/sql-reference/constructs/values

> Each expression must be a constant, or an expression that can be evaluated as a constant during compilation of the SQL statement. Most simple arithmetic expressions and string functions can be evaluated at compile time, but most other expressions cannot.
