### PR TITLE
fix: bq datetime to timestamp

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -323,6 +323,7 @@ class BigQuery(Dialect):
             "BEGIN TRANSACTION": TokenType.BEGIN,
             "BYTES": TokenType.BINARY,
             "CURRENT_DATETIME": TokenType.CURRENT_DATETIME,
+            "DATETIME": TokenType.TIMESTAMP,
             "DECLARE": TokenType.COMMAND,
             "ELSEIF": TokenType.COMMAND,
             "EXCEPTION": TokenType.COMMAND,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1098,6 +1098,13 @@ WHERE
                 "postgres": "SELECT x % 10",
             },
         )
+        self.validate_all(
+            "SELECT CAST(x AS DATETIME)",
+            write={
+                "": "SELECT CAST(x AS TIMESTAMP)",
+                "bigquery": "SELECT CAST(x AS DATETIME)",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -743,7 +743,7 @@ class TestDuckDB(Validator):
             "SELECT MAKE_DATE(2016, 12, 25)", read={"bigquery": "SELECT DATE(2016, 12, 25)"}
         )
         self.validate_all(
-            "SELECT CAST(CAST('2016-12-25 23:59:59' AS DATETIME) AS DATE)",
+            "SELECT CAST(CAST('2016-12-25 23:59:59' AS TIMESTAMP) AS DATE)",
             read={"bigquery": "SELECT DATE(DATETIME '2016-12-25 23:59:59')"},
         )
         self.validate_all(


### PR DESCRIPTION
Prior to this change if a query is parsed that contains a `DATETIME` with BigQuery dialect then it would be internally represented as a `DATETIME` data type. BigQuery `DATETIME` directly maps to the SQLGlot `TIMESTAMP` data type (a timestamp without time zone). 

This PR changes this behavior to parse a BigQuery `DATETIME` into SQLGlot `TIMESTAMP`. 

I didn't represent this change as breaking since this should be change to just the SQLGlot representation. Output SQL from BigQuery should remain the same. 