### PR TITLE
Fix!: StrToUnix Hive parsing, Presto generation fixes

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -319,7 +319,9 @@ class Hive(Dialect):
             "TO_DATE": build_formatted_time(exp.TsOrDsToDate, "hive"),
             "TO_JSON": exp.JSONFormat.from_arg_list,
             "UNBASE64": exp.FromBase64.from_arg_list,
-            "UNIX_TIMESTAMP": build_formatted_time(exp.StrToUnix, "hive", True),
+            "UNIX_TIMESTAMP": lambda args: build_formatted_time(exp.StrToUnix, "hive", True)(
+                args or [exp.CurrentTimestamp()]
+            ),
             "YEAR": lambda args: exp.Year(this=exp.TsOrDsToDate.from_arg_list(args)),
         }
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3192,11 +3192,16 @@ class Generator(metaclass=_Generator):
     def text_width(self, args: t.Iterable) -> int:
         return sum(len(arg) for arg in args)
 
-    def format_time(self, expression: exp.Expression) -> t.Optional[str]:
+    def format_time(
+        self,
+        expression: exp.Expression,
+        inverse_time_mapping: t.Optional[t.Dict[str, str]] = None,
+        inverse_time_trie: t.Optional[t.Dict] = None,
+    ) -> t.Optional[str]:
         return format_time(
             self.sql(expression, "format"),
-            self.dialect.INVERSE_TIME_MAPPING,
-            self.dialect.INVERSE_TIME_TRIE,
+            inverse_time_mapping or self.dialect.INVERSE_TIME_MAPPING,
+            inverse_time_trie or self.dialect.INVERSE_TIME_TRIE,
         )
 
     def expressions(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -611,7 +611,7 @@ class TestDialect(Validator):
             write={
                 "duckdb": "EPOCH(STRPTIME('2020-01-01', '%Y-%m-%d'))",
                 "hive": "UNIX_TIMESTAMP('2020-01-01', 'yyyy-MM-dd')",
-                "presto": "TO_UNIXTIME(DATE_PARSE('2020-01-01', '%Y-%m-%d'))",
+                "presto": "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST('2020-01-01' AS VARCHAR), '%Y-%m-%d')), PARSE_DATETIME(CAST('2020-01-01' AS VARCHAR), 'yyyy-MM-dd')))",
                 "starrocks": "UNIX_TIMESTAMP('2020-01-01', '%Y-%m-%d')",
                 "doris": "UNIX_TIMESTAMP('2020-01-01', '%Y-%m-%d')",
             },

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -369,7 +369,7 @@ class TestHive(Validator):
             "UNIX_TIMESTAMP(x)",
             write={
                 "duckdb": "EPOCH(STRPTIME(x, '%Y-%m-%d %H:%M:%S'))",
-                "presto": "TO_UNIXTIME(DATE_PARSE(x, '%Y-%m-%d %T'))",
+                "presto": "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST(x AS VARCHAR), '%Y-%m-%d %T')), PARSE_DATETIME(CAST(x AS VARCHAR), 'yyyy-MM-dd HH:mm:ss')))",
                 "hive": "UNIX_TIMESTAMP(x)",
                 "spark": "UNIX_TIMESTAMP(x)",
                 "": "STR_TO_UNIX(x, '%Y-%m-%d %H:%M:%S')",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -246,12 +246,15 @@ TBLPROPERTIES (
         self.validate_identity("SELECT TRANSFORM(ARRAY(1, 2, 3), (x, i) -> x + i)")
         self.validate_identity("REFRESH TABLE a.b.c")
         self.validate_identity("INTERVAL -86 DAYS")
-        self.validate_identity("SELECT UNIX_TIMESTAMP()")
         self.validate_identity("TRIM('    SparkSQL   ')")
         self.validate_identity("TRIM(BOTH 'SL' FROM 'SSparkSQLS')")
         self.validate_identity("TRIM(LEADING 'SL' FROM 'SSparkSQLS')")
         self.validate_identity("TRIM(TRAILING 'SL' FROM 'SSparkSQLS')")
         self.validate_identity("SPLIT(str, pattern, lim)")
+        self.validate_identity(
+            "SELECT UNIX_TIMESTAMP()",
+            "SELECT UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+        )
         self.validate_identity(
             "SELECT CAST('2023-01-01' AS TIMESTAMP) + INTERVAL 23 HOUR + 59 MINUTE + 59 SECONDS",
             "SELECT CAST('2023-01-01' AS TIMESTAMP) + INTERVAL '23' HOUR + INTERVAL '59' MINUTE + INTERVAL '59' SECONDS",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -702,7 +702,11 @@ SOME_FUNC(arg IGNORE NULLS)
         )
 
         self.validate("STR_TO_TIME('x', 'y')", "DATE_PARSE('x', 'y')", write="presto")
-        self.validate("STR_TO_UNIX('x', 'y')", "TO_UNIXTIME(DATE_PARSE('x', 'y'))", write="presto")
+        self.validate(
+            "STR_TO_UNIX('x', 'y')",
+            "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST('x' AS VARCHAR), 'y')), PARSE_DATETIME(CAST('x' AS VARCHAR), 'y')))",
+            write="presto",
+        )
         self.validate("TIME_TO_STR(x, 'y')", "DATE_FORMAT(x, 'y')", write="presto")
         self.validate("TIME_TO_UNIX(x)", "TO_UNIXTIME(x)", write="presto")
         self.validate(


### PR DESCRIPTION
Fixes #3221

There were a couple of issues here. The first one is:

```python
>>> import sqlglot
>>> sqlglot.transpile("unix_timestamp()", "hive", "presto")
["TO_UNIXTIME(DATE_PARSE('%Y-%m-%d %T'))"]
```

This `DATE_PARSE` call is invalid in Presto / Trino - we need an argument to parse.

The second one was a bit more nuanced and I don't really like my current solution, but didn't see another way out during my investigation. Basically, `DATE_PARSE` doesn't handle time zone information, and so the following breaks in Presto:

```
-- "2024-03-26 13:52:38.634 UTC" is malformed at ".634 UTC"
select date_parse(cast(current_timestamp as varchar), '%Y-%m-%d %T');
```

The workaround I implemented it basically to try calling both `DATE_PARSE` and `PARSE_DATETIME`, because if the former fails due to encountering a time zone, the latter will parse it just fine. There was a refactor to allow `format_time` to use different time format bindings, since `PARSE_DATETIME` supports different date/time formats.

References:
- https://trino.io/docs/current/functions/datetime.html
- https://prestodb.io/docs/current/functions/datetime.html
- https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF
- https://stackoverflow.com/a/48073487
- https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html
- https://prestodb.io/docs/current/functions/conditional.html#try