### PR TITLE
Fix: don't evaluate Rand twice when ordering by it

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2091,7 +2091,7 @@ class Generator(metaclass=_Generator):
                     self.unsupported(
                         f"'{nulls_sort_change.strip()}' translation not supported with positional ordering"
                     )
-                else:
+                elif not isinstance(expression.this, exp.Rand):
                     null_sort_order = " DESC" if nulls_sort_change == " NULLS FIRST" else ""
                     this = f"CASE WHEN {this} IS NULL THEN 1 ELSE 0 END{null_sort_order}, {this}"
                 nulls_sort_change = ""

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -311,6 +311,15 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT * FROM t1*", "SELECT * FROM t1")
 
         self.validate_all(
+            'SELECT * FROM "test_table" ORDER BY RANDOM() LIMIT 5',
+            write={
+                "bigquery": "SELECT * FROM `test_table` ORDER BY RAND() NULLS LAST LIMIT 5",
+                "duckdb": 'SELECT * FROM "test_table" ORDER BY RANDOM() LIMIT 5',
+                "postgres": 'SELECT * FROM "test_table" ORDER BY RANDOM() LIMIT 5',
+                "tsql": "SELECT TOP 5 * FROM [test_table] ORDER BY RAND()",
+            },
+        )
+        self.validate_all(
             "SELECT (data -> 'en-US') AS acat FROM my_table",
             write={
                 "duckdb": """SELECT (data -> '$."en-US"') AS acat FROM my_table""",


### PR DESCRIPTION
See #3232