### PR TITLE
feat(oracle): Support for CONNECT BY [NOCYCLE]

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1839,7 +1839,7 @@ class Check(Expression):
 
 # https://docs.snowflake.com/en/sql-reference/constructs/connect-by
 class Connect(Expression):
-    arg_types = {"start": False, "connect": True}
+    arg_types = {"start": False, "connect": True, "nocycle": False}
 
 
 class Prior(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1846,8 +1846,9 @@ class Generator(metaclass=_Generator):
     def connect_sql(self, expression: exp.Connect) -> str:
         start = self.sql(expression, "start")
         start = self.seg(f"START WITH {start}") if start else ""
+        nocycle = " NOCYCLE" if expression.args.get("nocycle") else ""
         connect = self.sql(expression, "connect")
-        connect = self.seg(f"CONNECT BY {connect}")
+        connect = self.seg(f"CONNECT BY{nocycle} {connect}")
         return start + connect
 
     def prior_sql(self, expression: exp.Prior) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3505,7 +3505,7 @@ class Parser(metaclass=_Parser):
             return None
 
         self._match(TokenType.CONNECT_BY)
-        nocycle = self._match_text_seq("NOCYCLE") or None
+        nocycle = self._match_text_seq("NOCYCLE")
         self.NO_PAREN_FUNCTION_PARSERS["PRIOR"] = lambda self: self.expression(
             exp.Prior, this=self._parse_bitwise()
         )

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3505,6 +3505,7 @@ class Parser(metaclass=_Parser):
             return None
 
         self._match(TokenType.CONNECT_BY)
+        nocycle = self._match_text_seq("NOCYCLE") or None
         self.NO_PAREN_FUNCTION_PARSERS["PRIOR"] = lambda self: self.expression(
             exp.Prior, this=self._parse_bitwise()
         )
@@ -3514,7 +3515,7 @@ class Parser(metaclass=_Parser):
         if not start and self._match(TokenType.START_WITH):
             start = self._parse_conjunction()
 
-        return self.expression(exp.Connect, start=start, connect=connect)
+        return self.expression(exp.Connect, start=start, connect=connect, nocycle=nocycle)
 
     def _parse_name_as_expression(self) -> exp.Alias:
         return self.expression(

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -94,6 +94,9 @@ class TestOracle(Validator):
             "SELECT * FROM t SAMPLE (0.25)",
         )
         self.validate_identity("SELECT TO_CHAR(-100, 'L99', 'NL_CURRENCY = '' AusDollars '' ')")
+        self.validate_identity(
+            "SELECT * FROM t START WITH col CONNECT BY NOCYCLE PRIOR col1 = col2"
+        )
 
         self.validate_all(
             "CURRENT_TIMESTAMP BETWEEN TO_DATE(f.C_SDATE, 'yyyy/mm/dd') AND TO_DATE(f.C_EDATE, 'yyyy/mm/dd')",


### PR DESCRIPTION
Fixes #3237 

Oracle supports only `NOCYCLE` as an option parameter after `CONNECT BY`; Other dialects that support connect queries (such as Redshift and Snowflake, from what I could find) do not seem to specify any parameters.

Docs
------------
- [Oracle](https://docs.oracle.com/cd/B13789_01/server.101/b10759/queries003.htm)
- [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_CONNECT_BY_clause.html)
- [Snowflake](https://docs.snowflake.com/en/sql-reference/constructs/connect-by)