### PR TITLE
fix: Fix STRPOS for Presto & Trino

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -619,7 +619,7 @@ def str_position_sql(
 
     if position:
         # Normalize third 'pos' argument into 'SUBSTR(..) + offset' across dialects
-        this = f"SUBSTR({this}, {position})"
+        this = self.func("SUBSTR", this, position)
         position_offset = f" + {position} - 1"
 
     return self.func("STRPOS", this, substr, instance) + position_offset

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -608,13 +608,18 @@ def no_map_from_entries_sql(self: Generator, expression: exp.MapFromEntries) -> 
     return ""
 
 
-def str_position_sql(self: Generator, expression: exp.StrPosition) -> str:
+def str_position_sql(
+    self: Generator, expression: exp.StrPosition, generate_instance: bool = False
+) -> str:
     this = self.sql(expression, "this")
     substr = self.sql(expression, "substr")
     position = self.sql(expression, "position")
+    instance = self.sql(expression, "instance") if generate_instance else None
+    instance = f", {instance}" if instance else ""
+
     if position:
-        return f"STRPOS(SUBSTR({this}, {position}), {substr}) + {position} - 1"
-    return f"STRPOS({this}, {substr})"
+        return f"STRPOS(SUBSTR({this}, {position}), {substr}{instance}) + {position} - 1"
+    return f"STRPOS({this}, {substr}{instance})"
 
 
 def struct_extract_sql(self: Generator, expression: exp.StructExtract) -> str:

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -401,7 +401,6 @@ class Presto(Dialect):
                 ]
             ),
             exp.SortArray: _no_sort_array,
-            exp.StrPosition: rename_func("STRPOS"),
             exp.StrToDate: lambda self, e: f"CAST({_str_to_time_sql(self, e)} AS DATE)",
             exp.StrToMap: rename_func("SPLIT_TO_MAP"),
             exp.StrToTime: _str_to_time_sql,
@@ -546,3 +545,14 @@ class Presto(Dialect):
             if kind == "VIEW" and schema.expressions:
                 expression.this.set("expressions", None)
             return super().create_sql(expression)
+
+        def strposition_sql(self, expression: exp.StrPosition) -> str:
+            this = self.sql(expression, "this")
+            substr = self.sql(expression, "substr")
+            position = self.sql(expression, "position")
+            instance = self.sql(expression, "instance")
+            instance = f", {instance}" if instance else ""
+
+            if position:
+                return f"STRPOS(SUBSTR({this}, {position}), {substr}{instance}) + {position} - 1"
+            return f"STRPOS({this}, {substr}{instance})"

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -22,6 +22,7 @@ from sqlglot.dialects.dialect import (
     rename_func,
     right_to_substring_sql,
     struct_extract_sql,
+    str_position_sql,
     timestamptrunc_sql,
     timestrtotime_sql,
     ts_or_ds_add_cast,
@@ -401,6 +402,7 @@ class Presto(Dialect):
                 ]
             ),
             exp.SortArray: _no_sort_array,
+            exp.StrPosition: lambda self, e: str_position_sql(self, e, True),
             exp.StrToDate: lambda self, e: f"CAST({_str_to_time_sql(self, e)} AS DATE)",
             exp.StrToMap: rename_func("SPLIT_TO_MAP"),
             exp.StrToTime: _str_to_time_sql,
@@ -545,14 +547,3 @@ class Presto(Dialect):
             if kind == "VIEW" and schema.expressions:
                 expression.this.set("expressions", None)
             return super().create_sql(expression)
-
-        def strposition_sql(self, expression: exp.StrPosition) -> str:
-            this = self.sql(expression, "this")
-            substr = self.sql(expression, "substr")
-            position = self.sql(expression, "position")
-            instance = self.sql(expression, "instance")
-            instance = f", {instance}" if instance else ""
-
-            if position:
-                return f"STRPOS(SUBSTR({this}, {position}), {substr}{instance}) + {position} - 1"
-            return f"STRPOS({this}, {substr}{instance})"

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -402,7 +402,7 @@ class Presto(Dialect):
                 ]
             ),
             exp.SortArray: _no_sort_array,
-            exp.StrPosition: lambda self, e: str_position_sql(self, e, True),
+            exp.StrPosition: lambda self, e: str_position_sql(self, e, generate_instance=True),
             exp.StrToDate: lambda self, e: f"CAST({_str_to_time_sql(self, e)} AS DATE)",
             exp.StrToMap: rename_func("SPLIT_TO_MAP"),
             exp.StrToTime: _str_to_time_sql,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1510,7 +1510,7 @@ class TestDialect(Validator):
             "POSITION(needle, haystack, pos)",
             write={
                 "drill": "STRPOS(SUBSTR(haystack, pos), needle) + pos - 1",
-                "presto": "STRPOS(haystack, needle, pos)",
+                "presto": "STRPOS(SUBSTR(haystack, pos), needle) + pos - 1",
                 "spark": "LOCATE(needle, haystack, pos)",
                 "clickhouse": "position(haystack, needle, pos)",
                 "snowflake": "POSITION(needle, haystack, pos)",

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -563,7 +563,7 @@ class TestHive(Validator):
             "LOCATE('a', x, 3)",
             write={
                 "duckdb": "STRPOS(SUBSTR(x, 3), 'a') + 3 - 1",
-                "presto": "STRPOS(x, 'a', 3)",
+                "presto": "STRPOS(SUBSTR(x, 3), 'a') + 3 - 1",
                 "hive": "LOCATE('a', x, 3)",
                 "spark": "LOCATE('a', x, 3)",
             },

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -177,6 +177,17 @@ class TestPresto(Validator):
                 "spark": "ARRAY_JOIN(x, '-', 'a')",
             },
         )
+        self.validate_all(
+            "STRPOS('ABC', 'A', 3)",
+            read={
+                "trino": "STRPOS('ABC', 'A', 3)",
+            },
+            write={
+                "presto": "STRPOS('ABC', 'A', 3)",
+                "trino": "STRPOS('ABC', 'A', 3)",
+                "snowflake": "POSITION('A', 'ABC')",
+            },
+        )
 
     def test_interval_plural_to_singular(self):
         # Microseconds, weeks and quarters are not supported in Presto/Trino INTERVAL literals


### PR DESCRIPTION
Fixes #3259 

Trino and Presto share the same strpos syntax: `strpos(string, substring, instance)`; This is different from all other dialects which use the 3rd argument as the starting position in the `string` to search from e.g. `strpos(string, substring, position)`. In order to preserve the start position semantics, the existing DuckDB - like pattern (wrapping the `string` with `SUBSTR` and offsetting the index by that pos) was utilized. This now correctly transpiles the faulty #3259 query while also preserving the Presto <-> Trino roundtrip if `instance` is used:


- Snowflake -> Trino/Presto (now, result in all 3 engines is 5)
```
>>> sqlglot.transpile("POSITION( 'A','ADFGAC', 3)", read="snowflake", write="presto")
["STRPOS(SUBSTR('ADFGAC', 3), 'A') + 3 - 1"]
```
