### PR TITLE
feat(snowflake): FINAL/RUNNING keywords in MATCH_RECOGNIZE MEASURES

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2226,7 +2226,10 @@ class Lateral(UDTF):
 
 
 class MatchRecognizeMeasure(Expression):
-    arg_types = {"window_frame": False, "this": True}
+    arg_types = {
+        "this": True,
+        "window_frame": False,
+    }
 
 
 class MatchRecognize(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2225,6 +2225,10 @@ class Lateral(UDTF):
     }
 
 
+class MatchRecognizeMeasure(Expression):
+    arg_types = {"window_frame": False, "this": True}
+
+
 class MatchRecognize(Expression):
     arg_types = {
         "partition_by": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2111,6 +2111,14 @@ class Generator(metaclass=_Generator):
 
         return f"{this}{sort_order}{nulls_sort_change}{with_fill}"
 
+    def matchrecognizemeasure_sql(self, expression: exp.MatchRecognizeMeasure) -> str:
+        window_frame = self.sql(expression, "window_frame")
+        window_frame = f"{window_frame} " if window_frame else ""
+
+        this = self.sql(expression, "this")
+
+        return f"{window_frame}{this}"
+
     def matchrecognize_sql(self, expression: exp.MatchRecognize) -> str:
         partition = self.partition_by_sql(expression)
         order = self.sql(expression, "order")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2739,13 +2739,10 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_match_recognize_measure(self) -> exp.MatchRecognizeMeasure:
-        if self._match_text_seq("FINAL") or self._match_text_seq("RUNNING"):
-            window_frame = self._prev.text
-        else:
-            window_frame = None
-
         return self.expression(
-            exp.MatchRecognizeMeasure, window_frame=window_frame, this=self._parse_expression()
+            exp.MatchRecognizeMeasure,
+            window_frame=self._match_texts(("FINAL", "RUNNING")) and self._prev.text.upper(),
+            this=self._parse_expression(),
         )
 
     def _parse_match_recognize(self) -> t.Optional[exp.MatchRecognize]:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2738,6 +2738,16 @@ class Parser(metaclass=_Parser):
             exp.From, comments=self._prev_comments, this=self._parse_table(joins=joins)
         )
 
+    def _parse_match_recognize_measure(self) -> exp.MatchRecognizeMeasure:
+        if self._match_text_seq("FINAL") or self._match_text_seq("RUNNING"):
+            window_frame = self._prev.text
+        else:
+            window_frame = None
+
+        return self.expression(
+            exp.MatchRecognizeMeasure, window_frame=window_frame, this=self._parse_expression()
+        )
+
     def _parse_match_recognize(self) -> t.Optional[exp.MatchRecognize]:
         if not self._match(TokenType.MATCH_RECOGNIZE):
             return None
@@ -2746,7 +2756,12 @@ class Parser(metaclass=_Parser):
 
         partition = self._parse_partition_by()
         order = self._parse_order()
-        measures = self._parse_expressions() if self._match_text_seq("MEASURES") else None
+
+        measures = (
+            self._parse_csv(self._parse_match_recognize_measure)
+            if self._match_text_seq("MEASURES")
+            else None
+        )
 
         if self._match_text_seq("ONE", "ROW", "PER", "MATCH"):
             rows = exp.var("ONE ROW PER MATCH")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1575,22 +1575,23 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
         )
 
     def test_match_recognize(self):
-        for row in (
-            "ONE ROW PER MATCH",
-            "ALL ROWS PER MATCH",
-            "ALL ROWS PER MATCH SHOW EMPTY MATCHES",
-            "ALL ROWS PER MATCH OMIT EMPTY MATCHES",
-            "ALL ROWS PER MATCH WITH UNMATCHED ROWS",
-        ):
-            for after in (
-                "AFTER MATCH SKIP",
-                "AFTER MATCH SKIP PAST LAST ROW",
-                "AFTER MATCH SKIP TO NEXT ROW",
-                "AFTER MATCH SKIP TO FIRST x",
-                "AFTER MATCH SKIP TO LAST x",
+        for window_frame in ("", "FINAL", "RUNNING"):
+            for row in (
+                "ONE ROW PER MATCH",
+                "ALL ROWS PER MATCH",
+                "ALL ROWS PER MATCH SHOW EMPTY MATCHES",
+                "ALL ROWS PER MATCH OMIT EMPTY MATCHES",
+                "ALL ROWS PER MATCH WITH UNMATCHED ROWS",
             ):
-                self.validate_identity(
-                    f"""SELECT
+                for after in (
+                    "AFTER MATCH SKIP",
+                    "AFTER MATCH SKIP PAST LAST ROW",
+                    "AFTER MATCH SKIP TO NEXT ROW",
+                    "AFTER MATCH SKIP TO FIRST x",
+                    "AFTER MATCH SKIP TO LAST x",
+                ):
+                    self.validate_identity(
+                        f"""SELECT
   *
 FROM x
 MATCH_RECOGNIZE (
@@ -1598,15 +1599,15 @@ MATCH_RECOGNIZE (
   ORDER BY
     x DESC
   MEASURES
-    y AS b
+    {window_frame}y AS b
   {row}
   {after}
   PATTERN (^ S1 S2*? ( {{- S3 -}} S4 )+ | PERMUTE(S1, S2){{1,2}} $)
   DEFINE
     x AS y
 )""",
-                    pretty=True,
-                )
+                        pretty=True,
+                    )
 
     def test_show_users(self):
         self.validate_identity("SHOW USERS")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1575,7 +1575,7 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
         )
 
     def test_match_recognize(self):
-        for window_frame in ("", "FINAL", "RUNNING"):
+        for window_frame in ("", "FINAL ", "RUNNING "):
             for row in (
                 "ONE ROW PER MATCH",
                 "ALL ROWS PER MATCH",
@@ -1590,8 +1590,11 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
                     "AFTER MATCH SKIP TO FIRST x",
                     "AFTER MATCH SKIP TO LAST x",
                 ):
-                    self.validate_identity(
-                        f"""SELECT
+                    with self.subTest(
+                        f"MATCH_RECOGNIZE with window frame {window_frame}, rows {row}, after {after}: "
+                    ):
+                        self.validate_identity(
+                            f"""SELECT
   *
 FROM x
 MATCH_RECOGNIZE (
@@ -1606,8 +1609,8 @@ MATCH_RECOGNIZE (
   DEFINE
     x AS y
 )""",
-                        pretty=True,
-                    )
+                            pretty=True,
+                        )
 
     def test_show_users(self):
         self.validate_identity("SHOW USERS")


### PR DESCRIPTION
Fixes #3282

The `MEASURES` subclause now supports the following syntax:

```
MEASURES  {FINAL | RUNNING} <expr> AS <alias> [, ... ]* 
``` 

Where each individual subclause is stored in a new expression `exp.MatchRecognizeMeasure`

Docs
--------
- [Snowflake MATCH_RECOGNIZE](https://docs.snowflake.com/en/sql-reference/constructs/match_recognize)