### PR TITLE
Feat(postgres): add COMMENT ON MATERIALIZED VIEW

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1536,7 +1536,13 @@ class SwapTable(Expression):
 
 
 class Comment(Expression):
-    arg_types = {"this": True, "kind": True, "expression": True, "exists": False}
+    arg_types = {
+        "this": True,
+        "kind": True,
+        "expression": True,
+        "exists": False,
+        "materialized": False,
+    }
 
 
 class Comprehension(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2877,7 +2877,7 @@ class Generator(metaclass=_Generator):
     def comment_sql(self, expression: exp.Comment) -> str:
         this = self.sql(expression, "this")
         kind = expression.args["kind"]
-        materialized = "MATERIALIZED" if expression.args.get("materialized") else ""
+        materialized = " MATERIALIZED" if expression.args.get("materialized") else ""
         exists_sql = " IF EXISTS " if expression.args.get("exists") else " "
         expression_sql = self.sql(expression, "expression")
         return f"COMMENT{exists_sql}ON{materialized} {kind} {this} IS {expression_sql}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2877,9 +2877,10 @@ class Generator(metaclass=_Generator):
     def comment_sql(self, expression: exp.Comment) -> str:
         this = self.sql(expression, "this")
         kind = expression.args["kind"]
+        materialized = "MATERIALIZED" if expression.args.get("materialized") else ""
         exists_sql = " IF EXISTS " if expression.args.get("exists") else " "
         expression_sql = self.sql(expression, "expression")
-        return f"COMMENT{exists_sql}ON {kind} {this} IS {expression_sql}"
+        return f"COMMENT{exists_sql}ON{materialized} {kind} {this} IS {expression_sql}"
 
     def mergetreettlaction_sql(self, expression: exp.MergeTreeTTLAction) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1405,7 +1405,12 @@ class Parser(metaclass=_Parser):
         self._match(TokenType.IS)
 
         return self.expression(
-            exp.Comment, this=this, kind=kind.text, expression=self._parse_string(), exists=exists, materialized=materialized
+            exp.Comment,
+            this=this,
+            kind=kind.text,
+            expression=self._parse_string(),
+            exists=exists,
+            materialized=materialized,
         )
 
     def _parse_to_table(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1388,6 +1388,7 @@ class Parser(metaclass=_Parser):
 
         self._match(TokenType.ON)
 
+        materialized = self._match_text_seq("MATERIALIZED")
         kind = self._match_set(self.CREATABLES) and self._prev
         if not kind:
             return self._parse_as_command(start)
@@ -1404,7 +1405,7 @@ class Parser(metaclass=_Parser):
         self._match(TokenType.IS)
 
         return self.expression(
-            exp.Comment, this=this, kind=kind.text, expression=self._parse_string(), exists=exists
+            exp.Comment, this=this, kind=kind.text, expression=self._parse_string(), exists=exists, materialized=materialized
         )
 
     def _parse_to_table(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -50,6 +50,7 @@ class TestPostgres(Validator):
         self.validate_identity("STRING_AGG(DISTINCT x, ',' ORDER BY y DESC)")
         self.validate_identity("SELECT CASE WHEN SUBSTRING('abcdefg') IN ('ab') THEN 1 ELSE 0 END")
         self.validate_identity("COMMENT ON TABLE mytable IS 'this'")
+        self.validate_identity("COMMENT ON MATERIALIZED VIEW my_view IS 'this'")
         self.validate_identity("SELECT e'\\xDEADBEEF'")
         self.validate_identity("SELECT CAST(e'\\176' AS BYTEA)")
         self.validate_identity("SELECT * FROM x WHERE SUBSTRING('Thomas' FROM '...$') IN ('mas')")


### PR DESCRIPTION
With postgresql you can add a comment on a materialized view as described in the [documentation](https://www.postgresql.org/docs/current/sql-comment.html), this PR adds this possibility.