### PR TITLE
Fix(optimizer): propagate recursive CTE source to children scopes early

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -600,7 +600,7 @@ def _traverse_ctes(scope):
     sources = {}
 
     for cte in scope.ctes:
-        recursive_scope = None
+        cte_name = cte.alias
 
         # if the scope is a recursive cte, it must be in the form of base_case UNION recursive.
         # thus the recursive scope is the first section of the union.
@@ -609,7 +609,7 @@ def _traverse_ctes(scope):
             union = cte.this
 
             if isinstance(union, exp.Union):
-                recursive_scope = scope.branch(union.this, scope_type=ScopeType.CTE)
+                sources[cte_name] = scope.branch(union.this, scope_type=ScopeType.CTE)
 
         child_scope = None
 
@@ -623,15 +623,9 @@ def _traverse_ctes(scope):
         ):
             yield child_scope
 
-            alias = cte.alias
-            sources[alias] = child_scope
-
-            if recursive_scope:
-                child_scope.add_source(alias, recursive_scope)
-                child_scope.cte_sources[alias] = recursive_scope
-
         # append the final child_scope yielded
         if child_scope:
+            sources[cte_name] = child_scope
             scope.cte_scopes.append(child_scope)
 
     scope.sources.update(sources)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -230,6 +230,17 @@ class TestOptimizer(unittest.TestCase):
     def test_qualify_columns(self, logger):
         self.assertEqual(
             optimizer.qualify_columns.qualify_columns(
+                parse_one(
+                    "WITH RECURSIVE t AS (SELECT 1 AS x UNION ALL SELECT x + 1 FROM t AS child WHERE x < 10) SELECT * FROM t"
+                ),
+                schema={},
+                infer_schema=False,
+            ).sql(),
+            "WITH RECURSIVE t AS (SELECT 1 AS x UNION ALL SELECT child.x + 1 AS _col_0 FROM t AS child WHERE child.x < 10) SELECT t.x AS x FROM t",
+        )
+
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
                 parse_one("WITH x AS (SELECT a FROM db.y) SELECT * FROM db.x"),
                 schema={"db": {"x": {"z": "int"}, "y": {"a": "int"}}},
                 expand_stars=False,


### PR DESCRIPTION
Before:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.qualify import qualify
>>>
>>> sql = """
... with recursive t as (
...   select 1 as x
...   union all
...   select x + 1 from t as child where x < 10
... )
... select * from t
... """
>>>
>>> expr = parse_one(sql)
>>> print(qualify(expr, infer_schema=False).sql(pretty=True))
sqlglot.errors.OptimizeError: Column '"x"' could not be resolved
```

After:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.qualify import qualify
>>>
>>> sql = """
... with recursive t as (
...   select 1 as x
...   union all
...   select x + 1 from t as child where x < 10
... )
... select * from t
... """
>>>
>>> expr = parse_one(sql)
>>> print(qualify(expr, infer_schema=False).sql(pretty=True))
WITH RECURSIVE "t" AS (
  SELECT
    1 AS "x"
  UNION ALL
  SELECT
    "child"."x" + 1 AS "_col_0"
  FROM "t" AS "child"
  WHERE
    "child"."x" < 10
)
SELECT
  "t"."x" AS "x"
FROM "t" AS "t"
```