### PR TITLE
Feat: improve transpilation of datetime functions to Teradata

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -305,6 +305,14 @@ class Teradata(Dialect):
 
             return super().createable_sql(expression, locations)
 
+        def extract_sql(self, expression: exp.Extract) -> str:
+            this = self.sql(expression, "this")
+            if this.upper() != "QUARTER":
+                return super().extract_sql(expression)
+
+            to_char = exp.func("to_char", expression.expression, exp.Literal.string("Q"))
+            return self.sql(exp.cast(to_char, "int"))
+
         def interval_sql(self, expression: exp.Interval) -> str:
             multiplier = 0
             unit = expression.text("unit")

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -304,3 +304,17 @@ class Teradata(Dialect):
                 return f"{this_name}{this_properties}{self.sep()}{this_schema}"
 
             return super().createable_sql(expression, locations)
+
+        def interval_sql(self, expression: exp.Interval) -> str:
+            multiplier = 0
+            unit = expression.text("unit")
+
+            if unit.startswith("WEEK"):
+                multiplier = 7
+            elif unit.startswith("QUARTER"):
+                multiplier = 90
+
+            if multiplier:
+                return f"({multiplier} * {super().interval_sql(exp.Interval(this=expression.this, unit=exp.var('DAY')))})"
+
+            return super().interval_sql(expression)

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -189,6 +189,7 @@ class Teradata(Dialect):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.GEOMETRY: "ST_GEOMETRY",
+            exp.DataType.Type.DOUBLE: "DOUBLE PRECISION",
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -215,6 +215,7 @@ class Teradata(Dialect):
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
             exp.ToNumber: to_number_with_nls_param,
             exp.Use: lambda self, e: f"DATABASE {self.sql(e, 'this')}",
+            exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
         }
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1667,7 +1667,7 @@ class TestDialect(Validator):
                 "presto": "CAST(a AS DOUBLE) / b",
                 "redshift": "CAST(a AS DOUBLE PRECISION) / b",
                 "sqlite": "CAST(a AS REAL) / b",
-                "teradata": "CAST(a AS DOUBLE) / b",
+                "teradata": "CAST(a AS DOUBLE PRECISION) / b",
                 "trino": "CAST(a AS DOUBLE) / b",
                 "tsql": "CAST(a AS FLOAT) / b",
             },

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1103,7 +1103,7 @@ COMMENT='客户账户表'"""
                 "presto": "CAST(a AS DOUBLE) / NULLIF(b, 0)",
                 "redshift": "CAST(a AS DOUBLE PRECISION) / NULLIF(b, 0)",
                 "sqlite": "CAST(a AS REAL) / b",
-                "teradata": "CAST(a AS DOUBLE) / NULLIF(b, 0)",
+                "teradata": "CAST(a AS DOUBLE PRECISION) / NULLIF(b, 0)",
                 "trino": "CAST(a AS DOUBLE) / NULLIF(b, 0)",
                 "tsql": "CAST(a AS FLOAT) / NULLIF(b, 0)",
             },

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -276,3 +276,19 @@ class TestTeradata(Validator):
                 "snowflake": "SELECT DATEADD(WEEK, 5, '2023-01-01')",
             },
         )
+        self.validate_all(
+            "CAST(TO_CHAR(x, 'Q') AS INT)",
+            read={
+                "teradata": "CAST(TO_CHAR(x, 'Q') AS INT)",
+                "snowflake": "DATE_PART(QUARTER, x)",
+                "bigquery": "EXTRACT(QUARTER FROM x)",
+            },
+        )
+        self.validate_all(
+            "EXTRACT(MONTH FROM x)",
+            read={
+                "teradata": "EXTRACT(MONTH FROM x)",
+                "snowflake": "DATE_PART(MONTH, x)",
+                "bigquery": "EXTRACT(MONTH FROM x)",
+            },
+        )

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -248,3 +248,31 @@ class TestTeradata(Validator):
                 "sqlite": "SELECT DATE_SUB('2023-01-01', -5, YEAR)",
             },
         )
+        self.validate_all(
+            "SELECT (90 * INTERVAL '1' DAY)",
+            read={
+                "teradata": "SELECT (90 * INTERVAL '1' DAY)",
+                "snowflake": "SELECT INTERVAL '1' QUARTER",
+            },
+        )
+        self.validate_all(
+            "SELECT (7 * INTERVAL '1' DAY)",
+            read={
+                "teradata": "SELECT (7 * INTERVAL '1' DAY)",
+                "snowflake": "SELECT INTERVAL '1' WEEK",
+            },
+        )
+        self.validate_all(
+            "SELECT '2023-01-01' + (90 * INTERVAL '5' DAY)",
+            read={
+                "teradata": "SELECT '2023-01-01' + (90 * INTERVAL '5' DAY)",
+                "snowflake": "SELECT DATEADD(QUARTER, 5, '2023-01-01')",
+            },
+        )
+        self.validate_all(
+            "SELECT '2023-01-01' + (7 * INTERVAL '5' DAY)",
+            read={
+                "teradata": "SELECT '2023-01-01' + (7 * INTERVAL '5' DAY)",
+                "snowflake": "SELECT DATEADD(WEEK, 5, '2023-01-01')",
+            },
+        )

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -210,3 +210,12 @@ class TestTeradata(Validator):
                 "teradata": "TRYCAST('-2.5' AS DECIMAL(5, 2))",
             },
         )
+
+    def test_time(self):
+        self.validate_all(
+            "CURRENT_TIMESTAMP",
+            read={
+                "teradata": "CURRENT_TIMESTAMP",
+                "snowflake": "CURRENT_TIMESTAMP()",
+            },
+        )

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -219,3 +219,32 @@ class TestTeradata(Validator):
                 "snowflake": "CURRENT_TIMESTAMP()",
             },
         )
+
+        self.validate_all(
+            "SELECT '2023-01-01' + INTERVAL '5' YEAR",
+            read={
+                "teradata": "SELECT '2023-01-01' + INTERVAL '5' YEAR",
+                "snowflake": "SELECT DATEADD(YEAR, 5, '2023-01-01')",
+            },
+        )
+        self.validate_all(
+            "SELECT '2023-01-01' - INTERVAL '5' YEAR",
+            read={
+                "teradata": "SELECT '2023-01-01' - INTERVAL '5' YEAR",
+                "snowflake": "SELECT DATEADD(YEAR, -5, '2023-01-01')",
+            },
+        )
+        self.validate_all(
+            "SELECT '2023-01-01' - INTERVAL '5' YEAR",
+            read={
+                "teradata": "SELECT '2023-01-01' - INTERVAL '5' YEAR",
+                "sqlite": "SELECT DATE_SUB('2023-01-01', 5, YEAR)",
+            },
+        )
+        self.validate_all(
+            "SELECT '2023-01-01' + INTERVAL '5' YEAR",
+            read={
+                "teradata": "SELECT '2023-01-01' + INTERVAL '5' YEAR",
+                "sqlite": "SELECT DATE_SUB('2023-01-01', -5, YEAR)",
+            },
+        )


### PR DESCRIPTION
These fixes resolve database/syntax errors encountered when using sql transpiled to the teradata dialect

- Cast doubles to DOUBLE PRECISION to avoid syntax errors
- Use `CURRENT_TIMETAMP` to avoid syntax errors
- Implement `DATE_ADD`/`DATE_SUB` with interval addition/subtraction
- Support week/quarter intervals by translating to multiplications over days
- Support `EXTRACT(QUARTER ...)` by using `TO_CHAR` 