### PR TITLE
Fix!: cast less aggressively

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -197,8 +197,10 @@ def _ts_or_ds_add_sql(self: BigQuery.Generator, expression: exp.TsOrDsAdd) -> st
 
 
 def _ts_or_ds_diff_sql(self: BigQuery.Generator, expression: exp.TsOrDsDiff) -> str:
-    expression.this.replace(exp.cast(expression.this, "TIMESTAMP", copy=True))
-    expression.expression.replace(exp.cast(expression.expression, "TIMESTAMP", copy=True))
+    expression.this.replace(exp.cast(expression.this, exp.DataType.Type.TIMESTAMP, copy=True))
+    expression.expression.replace(
+        exp.cast(expression.expression, exp.DataType.Type.TIMESTAMP, copy=True)
+    )
     unit = unit_to_var(expression)
     return self.func("DATE_DIFF", expression.this, expression.expression, unit)
 
@@ -214,7 +216,9 @@ def _unix_to_time_sql(self: BigQuery.Generator, expression: exp.UnixToTime) -> s
     if scale == exp.UnixToTime.MICROS:
         return self.func("TIMESTAMP_MICROS", timestamp)
 
-    unix_seconds = exp.cast(exp.Div(this=timestamp, expression=exp.func("POW", 10, scale)), "int64")
+    unix_seconds = exp.cast(
+        exp.Div(this=timestamp, expression=exp.func("POW", 10, scale)), exp.DataType.Type.BIGINT
+    )
     return self.func("TIMESTAMP_SECONDS", unix_seconds)
 
 

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -197,10 +197,8 @@ def _ts_or_ds_add_sql(self: BigQuery.Generator, expression: exp.TsOrDsAdd) -> st
 
 
 def _ts_or_ds_diff_sql(self: BigQuery.Generator, expression: exp.TsOrDsDiff) -> str:
-    expression.this.replace(exp.cast(expression.this, exp.DataType.Type.TIMESTAMP, copy=True))
-    expression.expression.replace(
-        exp.cast(expression.expression, exp.DataType.Type.TIMESTAMP, copy=True)
-    )
+    expression.this.replace(exp.cast(expression.this, exp.DataType.Type.TIMESTAMP))
+    expression.expression.replace(exp.cast(expression.expression, exp.DataType.Type.TIMESTAMP))
     unit = unit_to_var(expression)
     return self.func("DATE_DIFF", expression.this, expression.expression, unit)
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -772,11 +772,11 @@ def no_timestamp_sql(self: Generator, expression: exp.Timestamp) -> str:
         from sqlglot.optimizer.annotate_types import annotate_types
 
         target_type = annotate_types(expression).type or exp.DataType.Type.TIMESTAMP
-        return self.sql(exp.cast_unless(expression.this, target_type, target_type))
+        return self.sql(exp.cast(expression.this, target_type))
     if expression.text("expression").lower() in TIMEZONES:
         return self.sql(
             exp.AtTimeZone(
-                this=exp.cast_unless(expression.this, "timestamp", "timestamp"),
+                this=exp.cast(expression.this, "timestamp"),
                 zone=expression.expression,
             )
         )
@@ -813,11 +813,11 @@ def right_to_substring_sql(self: Generator, expression: exp.Left) -> str:
 
 
 def timestrtotime_sql(self: Generator, expression: exp.TimeStrToTime) -> str:
-    return self.sql(exp.cast_unless(expression.this, "timestamp", "timestamp"))
+    return self.sql(exp.cast(expression.this, "timestamp"))
 
 
 def datestrtodate_sql(self: Generator, expression: exp.DateStrToDate) -> str:
-    return self.sql(exp.cast_unless(expression.this, "date", "date"))
+    return self.sql(exp.cast(expression.this, "date"))
 
 
 # Used for Presto and Duckdb which use functions that don't support charset, and assume utf-8
@@ -986,9 +986,9 @@ def ts_or_ds_add_cast(expression: exp.TsOrDsAdd) -> exp.TsOrDsAdd:
     if return_type.is_type(exp.DataType.Type.DATE):
         # If we need to cast to a DATE, we cast to TIMESTAMP first to make sure we
         # can truncate timestamp strings, because some dialects can't cast them to DATE
-        this = exp.cast_unless(this, "timestamp", "timestamp")
+        this = exp.cast(this, "timestamp")
 
-    expression.this.replace(exp.cast_unless(this, return_type, return_type))
+    expression.this.replace(exp.cast(this, return_type))
     return expression
 
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -772,11 +772,11 @@ def no_timestamp_sql(self: Generator, expression: exp.Timestamp) -> str:
         from sqlglot.optimizer.annotate_types import annotate_types
 
         target_type = annotate_types(expression).type or exp.DataType.Type.TIMESTAMP
-        return self.sql(exp.cast(expression.this, to=target_type))
+        return self.sql(exp.cast_unless(expression.this, target_type, target_type))
     if expression.text("expression").lower() in TIMEZONES:
         return self.sql(
             exp.AtTimeZone(
-                this=exp.cast(expression.this, to=exp.DataType.Type.TIMESTAMP),
+                this=exp.cast_unless(expression.this, "timestamp", "timestamp"),
                 zone=expression.expression,
             )
         )
@@ -813,11 +813,11 @@ def right_to_substring_sql(self: Generator, expression: exp.Left) -> str:
 
 
 def timestrtotime_sql(self: Generator, expression: exp.TimeStrToTime) -> str:
-    return self.sql(exp.cast(expression.this, "timestamp"))
+    return self.sql(exp.cast_unless(expression.this, "timestamp", "timestamp"))
 
 
 def datestrtodate_sql(self: Generator, expression: exp.DateStrToDate) -> str:
-    return self.sql(exp.cast(expression.this, "date"))
+    return self.sql(exp.cast_unless(expression.this, "date", "date"))
 
 
 # Used for Presto and Duckdb which use functions that don't support charset, and assume utf-8
@@ -986,9 +986,9 @@ def ts_or_ds_add_cast(expression: exp.TsOrDsAdd) -> exp.TsOrDsAdd:
     if return_type.is_type(exp.DataType.Type.DATE):
         # If we need to cast to a DATE, we cast to TIMESTAMP first to make sure we
         # can truncate timestamp strings, because some dialects can't cast them to DATE
-        this = exp.cast(this, exp.DataType.Type.TIMESTAMP)
+        this = exp.cast_unless(this, "timestamp", "timestamp")
 
-    expression.this.replace(exp.cast(this, return_type))
+    expression.this.replace(exp.cast_unless(this, return_type, return_type))
     return expression
 
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -562,7 +562,7 @@ def if_sql(
 def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
     this = expression.this
     if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
-        this.replace(exp.cast(this, "json"))
+        this.replace(exp.cast(this, exp.DataType.Type.JSON))
 
     return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
 
@@ -776,7 +776,7 @@ def no_timestamp_sql(self: Generator, expression: exp.Timestamp) -> str:
     if expression.text("expression").lower() in TIMEZONES:
         return self.sql(
             exp.AtTimeZone(
-                this=exp.cast(expression.this, "timestamp"),
+                this=exp.cast(expression.this, exp.DataType.Type.TIMESTAMP),
                 zone=expression.expression,
             )
         )
@@ -813,11 +813,11 @@ def right_to_substring_sql(self: Generator, expression: exp.Left) -> str:
 
 
 def timestrtotime_sql(self: Generator, expression: exp.TimeStrToTime) -> str:
-    return self.sql(exp.cast(expression.this, "timestamp"))
+    return self.sql(exp.cast(expression.this, exp.DataType.Type.TIMESTAMP))
 
 
 def datestrtodate_sql(self: Generator, expression: exp.DateStrToDate) -> str:
-    return self.sql(exp.cast(expression.this, "date"))
+    return self.sql(exp.cast(expression.this, exp.DataType.Type.DATE))
 
 
 # Used for Presto and Duckdb which use functions that don't support charset, and assume utf-8
@@ -986,7 +986,7 @@ def ts_or_ds_add_cast(expression: exp.TsOrDsAdd) -> exp.TsOrDsAdd:
     if return_type.is_type(exp.DataType.Type.DATE):
         # If we need to cast to a DATE, we cast to TIMESTAMP first to make sure we
         # can truncate timestamp strings, because some dialects can't cast them to DATE
-        this = exp.cast(this, "timestamp")
+        this = exp.cast(this, exp.DataType.Type.TIMESTAMP)
 
     expression.this.replace(exp.cast(this, return_type))
     return expression
@@ -1030,7 +1030,7 @@ def no_last_day_sql(self: Generator, expression: exp.LastDay) -> str:
     plus_one_month = exp.func("date_add", trunc_curr_date, 1, "month")
     minus_one_day = exp.func("date_sub", plus_one_month, 1, "day")
 
-    return self.sql(exp.cast(minus_one_day, "date"))
+    return self.sql(exp.cast(minus_one_day, exp.DataType.Type.DATE))
 
 
 def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -19,7 +19,7 @@ def _str_to_date(self: Drill.Generator, expression: exp.StrToDate) -> str:
     this = self.sql(expression, "this")
     time_format = self.format_time(expression)
     if time_format == Drill.DATE_FORMAT:
-        return self.sql(exp.cast(this, "date"))
+        return self.sql(exp.cast(this, exp.DataType.Type.DATE))
     return self.func("TO_DATE", this, time_format)
 
 

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -134,7 +134,7 @@ class Drill(Dialect):
                 [transforms.eliminate_distinct_on, transforms.eliminate_semi_and_anti_joins]
             ),
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
-            exp.TimeStrToDate: lambda self, e: self.sql(exp.cast(e.this, "date")),
+            exp.TimeStrToDate: lambda self, e: self.sql(exp.cast(e.this, exp.DataType.Type.DATE)),
             exp.TimeStrToTime: timestrtotime_sql,
             exp.TimeStrToUnix: rename_func("UNIX_TIMESTAMP"),
             exp.TimeToStr: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -421,8 +421,8 @@ class DuckDB(Dialect):
             exp.MonthsBetween: lambda self, e: self.func(
                 "DATEDIFF",
                 "'month'",
-                exp.cast(e.expression, "timestamp", copy=True),
-                exp.cast(e.this, "timestamp", copy=True),
+                exp.cast(e.expression, exp.DataType.Type.TIMESTAMP, copy=True),
+                exp.cast(e.this, exp.DataType.Type.TIMESTAMP, copy=True),
             ),
             exp.ParseJSON: rename_func("JSON"),
             exp.PercentileCont: _rename_unless_within_group("PERCENTILE_CONT", "QUANTILE_CONT"),
@@ -457,9 +457,11 @@ class DuckDB(Dialect):
                 "DATE_DIFF", exp.Literal.string(e.unit), e.expression, e.this
             ),
             exp.TimestampTrunc: timestamptrunc_sql,
-            exp.TimeStrToDate: lambda self, e: self.sql(exp.cast(e.this, "date")),
+            exp.TimeStrToDate: lambda self, e: self.sql(exp.cast(e.this, exp.DataType.Type.DATE)),
             exp.TimeStrToTime: timestrtotime_sql,
-            exp.TimeStrToUnix: lambda self, e: self.func("EPOCH", exp.cast(e.this, "timestamp")),
+            exp.TimeStrToUnix: lambda self, e: self.func(
+                "EPOCH", exp.cast(e.this, exp.DataType.Type.TIMESTAMP)
+            ),
             exp.TimeToStr: lambda self, e: self.func("STRFTIME", e.this, self.format_time(e)),
             exp.TimeToUnix: rename_func("EPOCH"),
             exp.TsOrDiToDi: lambda self,
@@ -468,8 +470,8 @@ class DuckDB(Dialect):
             exp.TsOrDsDiff: lambda self, e: self.func(
                 "DATE_DIFF",
                 f"'{e.args.get('unit') or 'DAY'}'",
-                exp.cast(e.expression, "TIMESTAMP"),
-                exp.cast(e.this, "TIMESTAMP"),
+                exp.cast(e.expression, exp.DataType.Type.TIMESTAMP),
+                exp.cast(e.this, exp.DataType.Type.TIMESTAMP),
             ),
             exp.UnixToStr: lambda self, e: self.func(
                 "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -710,7 +710,9 @@ class MySQL(Dialect):
             ),
             exp.TimestampSub: date_add_interval_sql("DATE", "SUB"),
             exp.TimeStrToUnix: rename_func("UNIX_TIMESTAMP"),
-            exp.TimeStrToTime: lambda self, e: self.sql(exp.cast(e.this, "datetime", copy=True)),
+            exp.TimeStrToTime: lambda self, e: self.sql(
+                exp.cast(e.this, exp.DataType.Type.DATETIME, copy=True)
+            ),
             exp.TimeToStr: _remove_ts_or_ds_to_date(
                 lambda self, e: self.func("DATE_FORMAT", e.this, self.format_time(e))
             ),

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -90,8 +90,10 @@ def _str_to_time_sql(
 def _ts_or_ds_to_date_sql(self: Presto.Generator, expression: exp.TsOrDsToDate) -> str:
     time_format = self.format_time(expression)
     if time_format and time_format not in (Presto.TIME_FORMAT, Presto.DATE_FORMAT):
-        return self.sql(exp.cast(_str_to_time_sql(self, expression), "DATE"))
-    return self.sql(exp.cast(exp.cast(expression.this, "TIMESTAMP"), "DATE"))
+        return self.sql(exp.cast(_str_to_time_sql(self, expression), exp.DataType.Type.DATE))
+    return self.sql(
+        exp.cast(exp.cast(expression.this, exp.DataType.Type.TIMESTAMP), exp.DataType.Type.DATE)
+    )
 
 
 def _ts_or_ds_add_sql(self: Presto.Generator, expression: exp.TsOrDsAdd) -> str:
@@ -447,7 +449,7 @@ class Presto(Dialect):
             # timezone involved, we wrap it in a `TRY` call and use `PARSE_DATETIME` as a fallback,
             # which seems to be using the same time mapping as Hive, as per:
             # https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html
-            value_as_text = exp.cast(expression.this, "text")
+            value_as_text = exp.cast(expression.this, exp.DataType.Type.TEXT)
             parse_without_tz = self.func("DATE_PARSE", value_as_text, self.format_time(expression))
             parse_with_tz = self.func(
                 "PARSE_DATETIME",

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -103,8 +103,8 @@ def _ts_or_ds_add_sql(self: Presto.Generator, expression: exp.TsOrDsAdd) -> str:
 
 
 def _ts_or_ds_diff_sql(self: Presto.Generator, expression: exp.TsOrDsDiff) -> str:
-    this = exp.cast(expression.this, "TIMESTAMP")
-    expr = exp.cast(expression.expression, "TIMESTAMP")
+    this = exp.cast(expression.this, exp.DataType.Type.TIMESTAMP)
+    expr = exp.cast(expression.expression, exp.DataType.Type.TIMESTAMP)
     unit = unit_to_str(expression)
     return self.func("DATE_DIFF", unit, expr, this)
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -818,7 +818,7 @@ class Snowflake(Dialect):
             exp.TimestampTrunc: timestamptrunc_sql,
             exp.TimeStrToTime: timestrtotime_sql,
             exp.TimeToStr: lambda self, e: self.func(
-                "TO_CHAR", exp.cast(e.this, "timestamp"), self.format_time(e)
+                "TO_CHAR", exp.cast(e.this, exp.DataType.Type.TIMESTAMP), self.format_time(e)
             ),
             exp.TimeToUnix: lambda self, e: f"EXTRACT(epoch_second FROM {self.sql(e, 'this')})",
             exp.ToArray: rename_func("TO_ARRAY"),

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -129,10 +129,8 @@ class Spark2(Hive):
             "DOUBLE": _build_as_cast("double"),
             "FLOAT": _build_as_cast("float"),
             "FROM_UTC_TIMESTAMP": lambda args: exp.AtTimeZone(
-                this=exp.cast_unless(
-                    seq_get(args, 0) or exp.Var(this=""),
-                    exp.DataType.build("timestamp"),
-                    exp.DataType.build("timestamp"),
+                this=exp.cast(
+                    seq_get(args, 0) or exp.Var(this=""), exp.DataType.build("timestamp")
                 ),
                 zone=seq_get(args, 1),
             ),
@@ -150,10 +148,8 @@ class Spark2(Hive):
             ),
             "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
             "TO_UTC_TIMESTAMP": lambda args: exp.FromTimeZone(
-                this=exp.cast_unless(
-                    seq_get(args, 0) or exp.Var(this=""),
-                    exp.DataType.build("timestamp"),
-                    exp.DataType.build("timestamp"),
+                this=exp.cast(
+                    seq_get(args, 0) or exp.Var(this=""), exp.DataType.build("timestamp")
                 ),
                 zone=seq_get(args, 1),
             ),

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -48,7 +48,7 @@ def _unix_to_time_sql(self: Spark2.Generator, expression: exp.UnixToTime) -> str
     timestamp = expression.this
 
     if scale is None:
-        return self.sql(exp.cast(exp.func("from_unixtime", timestamp), "timestamp"))
+        return self.sql(exp.cast(exp.func("from_unixtime", timestamp), exp.DataType.Type.TIMESTAMP))
     if scale == exp.UnixToTime.SECONDS:
         return self.func("TIMESTAMP_SECONDS", timestamp)
     if scale == exp.UnixToTime.MILLIS:
@@ -129,9 +129,7 @@ class Spark2(Hive):
             "DOUBLE": _build_as_cast("double"),
             "FLOAT": _build_as_cast("float"),
             "FROM_UTC_TIMESTAMP": lambda args: exp.AtTimeZone(
-                this=exp.cast(
-                    seq_get(args, 0) or exp.Var(this=""), exp.DataType.build("timestamp")
-                ),
+                this=exp.cast(seq_get(args, 0) or exp.Var(this=""), exp.DataType.Type.TIMESTAMP),
                 zone=seq_get(args, 1),
             ),
             "INT": _build_as_cast("int"),
@@ -148,9 +146,7 @@ class Spark2(Hive):
             ),
             "TO_UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
             "TO_UTC_TIMESTAMP": lambda args: exp.FromTimeZone(
-                this=exp.cast(
-                    seq_get(args, 0) or exp.Var(this=""), exp.DataType.build("timestamp")
-                ),
+                this=exp.cast(seq_get(args, 0) or exp.Var(this=""), exp.DataType.Type.TIMESTAMP),
                 zone=seq_get(args, 1),
             ),
             "TRUNC": lambda args: exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0)),

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -310,7 +310,7 @@ class Teradata(Dialect):
                 return super().extract_sql(expression)
 
             to_char = exp.func("to_char", expression.expression, exp.Literal.string("Q"))
-            return self.sql(exp.cast(to_char, "int"))
+            return self.sql(exp.cast(to_char, exp.DataType.Type.INT))
 
         def interval_sql(self, expression: exp.Interval) -> str:
             multiplier = 0

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -109,7 +109,7 @@ def _build_formatted_time(
         assert len(args) == 2
 
         return exp_class(
-            this=exp.cast(args[1], "datetime"),
+            this=exp.cast(args[1], exp.DataType.Type.DATETIME),
             format=exp.Literal.string(
                 format_time(
                     args[0].name.lower(),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6888,7 +6888,7 @@ def cast(
     Args:
         expression: The expression to cast.
         to: The datatype to cast to.
-        force_cast: When `False`, SQLGlot will avoid casting `expression` if its type is `to`.
+        force_cast: When `False`, `expression` will not be cast if its type is already `to`.
         overwrite_cast: Whether to change the target type, if `expression` is a `Cast`.
         copy: Whether to copy the supplied expressions.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6871,14 +6871,7 @@ def column(
     return this
 
 
-def cast(
-    expression: ExpOrStr,
-    to: DATA_TYPE,
-    force_cast: bool = False,
-    overwrite_cast: bool = False,
-    copy: bool = True,
-    **opts,
-) -> Cast:
+def cast(expression: ExpOrStr, to: DATA_TYPE, copy: bool = True, **opts) -> Cast:
     """Cast an expression to a data type.
 
     Example:
@@ -6888,8 +6881,6 @@ def cast(
     Args:
         expression: The expression to cast.
         to: The datatype to cast to.
-        force_cast: When `False`, `expression` will not be cast if its type is already `to`.
-        overwrite_cast: Whether to change the target type, if `expression` is a `Cast`.
         copy: Whether to copy the supplied expressions.
 
     Returns:
@@ -6898,15 +6889,12 @@ def cast(
     expr = maybe_parse(expression, copy=copy, **opts)
     data_type = DataType.build(to, copy=copy, **opts)
 
-    if not force_cast and expr.is_type(data_type):
+    if expr.is_type(data_type):
         return expr
 
-    if overwrite_cast and isinstance(expr, Cast):
-        expr.set("to", data_type)
-    else:
-        expr = Cast(this=expr, to=data_type)
-
+    expr = Cast(this=expr, to=data_type)
     expr.type = data_type
+
     return expr
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6871,7 +6871,14 @@ def column(
     return this
 
 
-def cast(expression: ExpOrStr, to: DATA_TYPE, copy: bool = True, **opts) -> Cast:
+def cast(
+    expression: ExpOrStr,
+    to: DATA_TYPE,
+    force_cast: bool = False,
+    overwrite_cast: bool = False,
+    copy: bool = True,
+    **opts,
+) -> Cast:
     """Cast an expression to a data type.
 
     Example:
@@ -6881,16 +6888,26 @@ def cast(expression: ExpOrStr, to: DATA_TYPE, copy: bool = True, **opts) -> Cast
     Args:
         expression: The expression to cast.
         to: The datatype to cast to.
+        force_cast: When `False`, SQLGlot will avoid casting `expression` if its type is `to`.
+        overwrite_cast: Whether to change the target type, if `expression` is a `Cast`.
         copy: Whether to copy the supplied expressions.
 
     Returns:
         The new Cast instance.
     """
-    expression = maybe_parse(expression, copy=copy, **opts)
+    expr = maybe_parse(expression, copy=copy, **opts)
     data_type = DataType.build(to, copy=copy, **opts)
-    expression = Cast(this=expression, to=data_type)
-    expression.type = data_type
-    return expression
+
+    if not force_cast and expr.is_type(data_type):
+        return expr
+
+    if overwrite_cast and isinstance(expr, Cast):
+        expr.set("to", data_type)
+    else:
+        expr = Cast(this=expr, to=data_type)
+
+    expr.type = data_type
+    return expr
 
 
 def table_(
@@ -7417,27 +7434,6 @@ def case(
     else:
         this = None
     return Case(this=this, ifs=[])
-
-
-def cast_unless(
-    expression: ExpOrStr,
-    to: DATA_TYPE,
-    *types: DATA_TYPE,
-    **opts: t.Any,
-) -> Expression | Cast:
-    """
-    Cast an expression to a data type unless it is a specified type.
-
-    Args:
-        expression: The expression to cast.
-        to: The data type to cast to.
-        **types: The types to exclude from casting.
-        **opts: Extra keyword arguments for parsing `expression`
-    """
-    expr = maybe_parse(expression, **opts)
-    if expr.is_type(*types):
-        return expr
-    return cast(expr, to, **opts)
 
 
 def array(

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -26,6 +26,9 @@ class TestDatabricks(Validator):
         self.validate_identity("SELECT ${x} FROM ${y} WHERE ${z} > 1")
         self.validate_identity("CREATE TABLE foo (x DATE GENERATED ALWAYS AS (CAST(y AS DATE)))")
         self.validate_identity(
+            "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(CAST(foo AS TIMESTAMP), 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t"
+        )
+        self.validate_identity(
             "SELECT * FROM sales UNPIVOT INCLUDE NULLS (sales FOR quarter IN (q1 AS `Jan-Mar`))"
         )
         self.validate_identity(

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -667,11 +667,6 @@ class TestBuild(unittest.TestCase):
             ),
             (lambda: exp.cast("CAST(x AS INT)", "int"), "CAST(x AS INT)"),
             (lambda: exp.cast("CAST(x AS TEXT)", "int"), "CAST(CAST(x AS TEXT) AS INT)"),
-            (lambda: exp.cast("CAST(x AS TEXT)", "int", overwrite_cast=True), "CAST(x AS INT)"),
-            (
-                lambda: exp.cast("CAST(x AS INT)", "int", force_cast=True),
-                "CAST(CAST(x AS INT) AS INT)",
-            ),
             (
                 lambda: exp.rename_column("table1", "c1", "c2", True),
                 "ALTER TABLE table1 RENAME COLUMN IF EXISTS c1 TO c2",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -665,13 +665,12 @@ class TestBuild(unittest.TestCase):
                 "(x, y) IN ((1, 2), (3, 4))",
                 "postgres",
             ),
+            (lambda: exp.cast("CAST(x AS INT)", "int"), "CAST(x AS INT)"),
+            (lambda: exp.cast("CAST(x AS TEXT)", "int"), "CAST(CAST(x AS TEXT) AS INT)"),
+            (lambda: exp.cast("CAST(x AS TEXT)", "int", overwrite_cast=True), "CAST(x AS INT)"),
             (
-                lambda: exp.cast_unless("CAST(x AS INT)", "int", "int"),
-                "CAST(x AS INT)",
-            ),
-            (
-                lambda: exp.cast_unless("CAST(x AS TEXT)", "int", "int"),
-                "CAST(CAST(x AS TEXT) AS INT)",
+                lambda: exp.cast("CAST(x AS INT)", "int", force_cast=True),
+                "CAST(CAST(x AS INT) AS INT)",
             ),
             (
                 lambda: exp.rename_column("table1", "c1", "c2", True),


### PR DESCRIPTION
This addresses the following issue (note the additional `TIMESTAMP` added):

```python
>>> import sqlglot
>>> sql = "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(foo::TIMESTAMP, 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t"
>>> expr.sql("databricks")
"SELECT DATE_FORMAT(CAST(CAST(FROM_UTC_TIMESTAMP(CAST(foo AS TIMESTAMP), 'America/Los_Angeles') AS TIMESTAMP) AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t"
```