### PR TITLE
Fix!: parse right-hand side of <value> IN (<query>) as a Subquery

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -856,7 +856,7 @@ class Expression(metaclass=_Expression):
         **opts,
     ) -> In:
         subquery = maybe_parse(query, copy=copy, **opts) if query else None
-        if isinstance(subquery, Query) and not isinstance(subquery, Subquery):
+        if subquery and not isinstance(subquery, Subquery):
             subquery = subquery.subquery(copy=False)
 
         return In(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -855,10 +855,14 @@ class Expression(metaclass=_Expression):
         copy: bool = True,
         **opts,
     ) -> In:
+        subquery = maybe_parse(query, copy=copy, **opts) if query else None
+        if isinstance(subquery, Query) and not isinstance(subquery, Subquery):
+            subquery = subquery.subquery(copy=False)
+
         return In(
             this=maybe_copy(self, copy),
             expressions=[convert(e, copy=copy) for e in expressions],
-            query=maybe_parse(query, copy=copy, **opts) if query else None,
+            query=subquery,
             unnest=(
                 Unnest(
                     expressions=[

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2706,7 +2706,7 @@ class Generator(metaclass=_Generator):
         is_global = " GLOBAL" if expression.args.get("is_global") else ""
 
         if query:
-            in_sql = self.wrap(self.sql(query))
+            in_sql = self.sql(query)
         elif unnest:
             in_sql = self.in_unnest_op(unnest)
         elif field:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3835,7 +3835,7 @@ class Parser(metaclass=_Parser):
             expressions = self._parse_csv(lambda: self._parse_select_or_expression(alias=alias))
 
             if len(expressions) == 1 and isinstance(expressions[0], exp.Query):
-                this = self.expression(exp.In, this=this, query=expressions[0])
+                this = self.expression(exp.In, this=this, query=expressions[0].subquery(copy=False))
             else:
                 this = self.expression(exp.In, this=this, expressions=expressions)
 


### PR DESCRIPTION
Before:

```python
>>> from sqlglot import parse_one
>>> parse_one("x in (select 1)")
In(
  this=Column(
    this=Identifier(this=x, quoted=False)),
  query=Select(
    expressions=[
      Literal(this=1, is_string=False)]))
```

After:

```python
>>> from sqlglot import parse_one
>>> parse_one("x in (select 1)")
In(
  this=Column(
    this=Identifier(this=x, quoted=False)),
  query=Subquery(
    this=Select(
      expressions=[
        Literal(this=1, is_string=False)])))
```