### PR TITLE
Feat(bigquery): handle more extract parts

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -229,6 +229,44 @@ def _build_time(args: t.List) -> exp.Func:
     return exp.Anonymous(this="TIME", expressions=args)
 
 
+# Ref(values): https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#extract
+# Ref (keys): https://docs.snowflake.com/en/sql-reference/functions-date-time#supported-date-and-time-parts
+# Ref (keys): https://docs.databricks.com/en/sql/language-manual/functions/extract.html#returns
+EXTRACT_PART_MAPPING = {
+    "WEEKDAY": "DAYOFWEEK",
+    "DOW": "DAYOFWEEK",
+    "DW": "DAYOFWEEK",
+    "D": "DAY",
+    "DD": "DAY",
+    "DAYS": "DAY",
+    "DAYOFMONTH": "DAY",
+    "YEARDAY": "DAYOFYEAR",
+    "DY": "DAYOFYEAR",
+    "DOY": "DAYOFYEAR",
+    "W": "WEEK",
+    "WK": "WEEK",
+    "WEEKOFYEAR": "WEEK",
+    "WOY": "WEEK",
+    "WY": "WEEK",
+    "WEEKS": "WEEK",
+    "MM": "MONTH",
+    "MON": "MONTH",
+    "MONS": "MONTH",
+    "MONTHS": "MONTH",
+    "Q": "QUARTER",
+    "QTR": "QUARTER",
+    "QTRS": "QUARTER",
+    "QUARTERS": "QUARTER",
+    "Y": "YEAR",
+    "YY": "YEAR",
+    "YYY": "YEAR",
+    "YYYY": "YEAR",
+    "YR": "YEAR",
+    "YEARS": "YEAR",
+    "YRS": "YEAR",
+}
+
+
 class BigQuery(Dialect):
     WEEK_OFFSET = -1
     UNNEST_COLUMN_ONLY = True
@@ -896,3 +934,8 @@ class BigQuery(Dialect):
             if expression.name == "TIMESTAMP":
                 expression.set("this", "SYSTEM_TIME")
             return super().version_sql(expression)
+
+        def extract_sql(self, expression: exp.Extract) -> str:
+            part = self.sql(expression, "this")
+            expression.set("this", exp.Var(this=EXTRACT_PART_MAPPING.get(part.upper(), part)))
+            return super().extract_sql(expression)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1435,3 +1435,61 @@ OPTIONS (
 
         with self.assertRaises(ParseError):
             transpile("SELECT JSON_OBJECT('a', 1, 'b') AS json_data", read="bigquery")
+
+    def test_time(self):
+        for dayofweek in ["DAYOFWEEK", "WEEKDAY", "DOW", "DW"]:
+            self.validate_all(
+                "EXTRACT(DAYOFWEEK FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({dayofweek} FROM x)",
+                    "bigquery": "EXTRACT(DAYOFWEEK FROM x)",
+                },
+            )
+        for day in ["DAY", "D", "DD", "DAYS", "DAYOFMONTH"]:
+            self.validate_all(
+                "EXTRACT(DAY FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({day} FROM x)",
+                    "bigquery": "EXTRACT(DAY FROM x)",
+                },
+            )
+        for dayofyear in ["DAYOFYEAR", "YEARDAY", "DY", "DOY"]:
+            self.validate_all(
+                "EXTRACT(DAYOFYEAR FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({dayofyear} FROM x)",
+                    "bigquery": "EXTRACT(DAYOFYEAR FROM x)",
+                },
+            )
+        for week in ["WEEK", "W", "WK", "WEEKOFYEAR", "WOY", "WY", "WEEKS"]:
+            self.validate_all(
+                "EXTRACT(WEEK FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({week} FROM x)",
+                    "bigquery": "EXTRACT(WEEK FROM x)",
+                },
+            )
+        for month in ["MONTH", "MM", "MON", "MONS", "MONTHS"]:
+            self.validate_all(
+                "EXTRACT(MONTH FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({month} FROM x)",
+                    "bigquery": "EXTRACT(MONTH FROM x)",
+                },
+            )
+        for quarter in ["QUARTER", "Q", "QTR", "QTRS", "QUARTERS"]:
+            self.validate_all(
+                "EXTRACT(QUARTER FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({quarter} FROM x)",
+                    "bigquery": "EXTRACT(QUARTER FROM x)",
+                },
+            )
+        for year in ["YEAR", "Y", "YY", "YYY", "YYYY", "YR", "YEARS", "YRS"]:
+            self.validate_all(
+                "EXTRACT(YEAR FROM x)",
+                read={
+                    "snowflake": f"EXTRACT({year} FROM x)",
+                    "bigquery": "EXTRACT(YEAR FROM x)",
+                },
+            )


### PR DESCRIPTION
BigQuery has more limited `part` options for `Extract` than other dialects. Map from Snowflake and Databricks `parts` to the corresponding BigQuery one. This isn't a complete mapping but seems like a reasonable starting point.