### PR TITLE
Fix: transform eliminate_qualify on generated columns

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -116,9 +116,11 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
         select_candidates = exp.Window if expression.is_star else (exp.Window, exp.Column)
         for expr in qualify_filters.find_all(select_candidates):
             if isinstance(expr, exp.Window):
-                for column in expr.find_all(exp.Column):
-                    if column.name in select_aliases:
-                        column.replace(select_aliases.get(column.name))
+                if select_aliases:
+                    for column in expr.find_all(exp.Column):
+                        select = select_aliases.get(column.name)
+                        if select:
+                            column.replace(select)
 
                 alias = find_new_name(expression.named_selects, "_w")
                 expression.select(exp.alias_(expr, alias), copy=False)

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -108,7 +108,7 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
         outer_selects = exp.select(*[select.alias_or_name for select in expression.selects])
         qualify_filters = expression.args["qualify"].pop().this
         select_aliases = {
-            select.alias_or_name: select.args.get("this")
+            select.alias: select.this
             for select in expression.selects
             if isinstance(select, exp.Alias)
         }

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -116,7 +116,9 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
                         if select.alias_or_name == column.name:
                             if isinstance(select, exp.Func):
                                 column.replace(select)
-                            elif isinstance(select, exp.Alias) and isinstance(select.args.get("this"), exp.Func):
+                            elif isinstance(select, exp.Alias) and isinstance(
+                                select.args.get("this"), exp.Func
+                            ):
                                 column.replace(select.args.get("this"))
 
                 alias = find_new_name(expression.named_selects, "_w")

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -116,7 +116,7 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
         select_candidates = exp.Window if expression.is_star else (exp.Window, exp.Column)
         for expr in qualify_filters.find_all(select_candidates):
             if isinstance(expr, exp.Window):
-                if select_aliases:
+                if expression_by_alias:
                     for column in expr.find_all(exp.Column):
                         select = select_aliases.get(column.name)
                         if select:

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -93,9 +93,9 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
     Some dialects don't support window functions in the WHERE clause, so we need to include them as
     projections in the subquery, in order to refer to them in the outer filter using aliases. Also,
     if a column is referenced in the QUALIFY clause but is not selected, we need to include it too,
-    otherwise we won't be able to refer to it in the outer query's WHERE clause. In adidion, if a
-    column is referenced in the QUALIFY clause but is newly generated in the select clause (column
-    rename or create from a function), replace the column by the original.
+    otherwise we won't be able to refer to it in the outer query's WHERE clause. Finally, if a
+    newly aliased projection is referenced in the QUALIFY clause, it will be replaced by the
+    corresponding expression to avoid creating invalid column references.
     """
     if isinstance(expression, exp.Select) and expression.args.get("qualify"):
         taken = set(expression.named_selects)

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -118,9 +118,9 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
             if isinstance(expr, exp.Window):
                 if expression_by_alias:
                     for column in expr.find_all(exp.Column):
-                        select = select_aliases.get(column.name)
-                        if select:
-                            column.replace(select)
+                        expr = expression_by_alias.get(column.name)
+                        if expr:
+                            column.replace(expr)
 
                 alias = find_new_name(expression.named_selects, "_w")
                 expression.select(exp.alias_(expr, alias), copy=False)

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -107,7 +107,7 @@ def eliminate_qualify(expression: exp.Expression) -> exp.Expression:
 
         outer_selects = exp.select(*[select.alias_or_name for select in expression.selects])
         qualify_filters = expression.args["qualify"].pop().this
-        select_aliases = {
+        expression_by_alias = {
             select.alias: select.this
             for select in expression.selects
             if isinstance(select, exp.Alias)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -111,6 +111,21 @@ class TestTransforms(unittest.TestCase):
             "SELECT x FROM y QUALIFY ROW_NUMBER() OVER (PARTITION BY p)",
             "SELECT x FROM (SELECT x, ROW_NUMBER() OVER (PARTITION BY p) AS _w, p FROM y) AS _t WHERE _w",
         )
+        self.validate(
+            eliminate_qualify,
+            "SELECT x AS z FROM y QUALIFY ROW_NUMBER() OVER (PARTITION BY z)",
+            "SELECT z FROM (SELECT x AS z, ROW_NUMBER() OVER (PARTITION BY x) AS _w, x FROM y) AS _t WHERE _w",
+        )
+        self.validate(
+            eliminate_qualify,
+            "SELECT SOME_UDF(x) AS z FROM y QUALIFY ROW_NUMBER() OVER (PARTITION BY x ORDER BY z)",
+            "SELECT z FROM (SELECT SOME_UDF(x) AS z, ROW_NUMBER() OVER (PARTITION BY x ORDER BY SOME_UDF(x)) AS _w, x FROM y) AS _t WHERE _w",
+        )
+        self.validate(
+            eliminate_qualify,
+            "SELECT x, t, x || t AS z FROM y QUALIFY ROW_NUMBER() OVER (PARTITION BY x ORDER BY z DESC)",
+            "SELECT x, t, z FROM (SELECT x, t, x || t AS z, ROW_NUMBER() OVER (PARTITION BY x ORDER BY x || t DESC) AS _w FROM y) AS _t WHERE _w",
+        )
 
     def test_remove_precision_parameterized_types(self):
         self.validate(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -126,6 +126,11 @@ class TestTransforms(unittest.TestCase):
             "SELECT x, t, x || t AS z FROM y QUALIFY ROW_NUMBER() OVER (PARTITION BY x ORDER BY z DESC)",
             "SELECT x, t, z FROM (SELECT x, t, x || t AS z, ROW_NUMBER() OVER (PARTITION BY x ORDER BY x || t DESC) AS _w FROM y) AS _t WHERE _w",
         )
+        self.validate(
+            eliminate_qualify,
+            "SELECT y.x AS x, y.t AS z FROM y QUALIFY ROW_NUMBER() OVER (PARTITION BY x ORDER BY x DESC, z)",
+            "SELECT x, z FROM (SELECT y.x AS x, y.t AS z, ROW_NUMBER() OVER (PARTITION BY y.x ORDER BY y.x DESC, y.t) AS _w, y.t FROM y) AS _t WHERE _w",
+        )
 
     def test_remove_precision_parameterized_types(self):
         self.validate(


### PR DESCRIPTION
Input:
```python
>>> sql = """
with data as (
  select 1 as id, 'a' as name
  union all
  select 1 AS ID, 'b' as name
)                
select
  id,
  concat(name, id) new_name,
from data
qualify row_number() over (partition by id order by new_name desc) = 1
"""
```

Before: 
```python
>>> from sqlglot import parse_one
>>> from sqlglot.transforms import eliminate_qualify

>>> print(sqlglot.parse_one(sql, read="bigquery").transform(eliminate_qualify).sql(dialect="bigquery", pretty=True))
SELECT
  id,
  new_name
FROM (
  WITH data AS (
    SELECT
      1 AS id,
      'a' AS name
    UNION ALL
    SELECT
      1 AS ID,
      'b' AS name
  )
  SELECT
    id,
    CONCAT(name, id) AS new_name,
    row_number() OVER (PARTITION BY id ORDER BY new_name DESC) AS _w
  FROM data
) AS _t
WHERE
  _w = 1
```
Give the generated SQL before the patch to the bigquery console and perform dry-run, output error is: `Unrecognized name: new_name at [17:49]`

After the patch:
```python
>>> from sqlglot import parse_one
>>> from sqlglot.transforms import eliminate_qualify

>>> print(sqlglot.parse_one(sql, read="bigquery").transform(eliminate_qualify).sql(dialect="bigquery", pretty=True))
SELECT
  id,
  new_name
FROM (
  WITH data AS (
    SELECT
      1 AS id,
      'a' AS name
    UNION ALL
    SELECT
      1 AS ID,
      'b' AS name
  )
  SELECT
    id,
    CONCAT(name, id) AS new_name,
    row_number() OVER (PARTITION BY id ORDER BY CONCAT(name, id) DESC) AS _w,
    name
  FROM data
) AS _t
WHERE
  _w = 1
```
The column `new_name` is replaced by `CONCAT(name, id)`, and the query can run successfully.


