### PR TITLE
Refactor: get rid of 1st projection pad for leading comma formatting

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3249,11 +3249,8 @@ class Generator(metaclass=_Generator):
         num_sqls = len(expressions)
 
         # These are calculated once in case we have the leading_comma / pretty option set, correspondingly
-        if self.pretty:
-            if self.leading_comma:
-                pad = " " * len(sep)
-            else:
-                stripped_sep = sep.strip()
+        if self.pretty and not self.leading_comma:
+            stripped_sep = sep.strip()
 
         result_sqls = []
         for i, e in enumerate(expressions):
@@ -3265,7 +3262,7 @@ class Generator(metaclass=_Generator):
 
             if self.pretty:
                 if self.leading_comma:
-                    result_sqls.append(f"{sep if i > 0 else pad}{prefix}{sql}{comments}")
+                    result_sqls.append(f"{sep if i > 0 else ''}{prefix}{sql}{comments}")
                 else:
                     result_sqls.append(
                         f"{prefix}{sql}{stripped_sep if i + 1 < num_sqls else ''}{comments}"

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -69,12 +69,12 @@ class TestTranspile(unittest.TestCase):
         self.validate(
             "SELECT a, b, c FROM (SELECT a, b, c FROM t)",
             "SELECT\n"
-            "      a\n"
+            "    a\n"
             "    , b\n"
             "    , c\n"
             "FROM (\n"
             "    SELECT\n"
-            "          a\n"
+            "        a\n"
             "        , b\n"
             "        , c\n"
             "    FROM t\n"
@@ -86,13 +86,13 @@ class TestTranspile(unittest.TestCase):
         )
         self.validate(
             "SELECT FOO, BAR, BAZ",
-            "SELECT\n    FOO\n  , BAR\n  , BAZ",
+            "SELECT\n  FOO\n  , BAR\n  , BAZ",
             leading_comma=True,
             pretty=True,
         )
         self.validate(
             "SELECT FOO, /*x*/\nBAR, /*y*/\nBAZ",
-            "SELECT\n    FOO /* x */\n  , BAR /* y */\n  , BAZ",
+            "SELECT\n  FOO /* x */\n  , BAR /* y */\n  , BAZ",
             leading_comma=True,
             pretty=True,
         )


### PR DESCRIPTION
This makes it so that SQLGlot will use the following style when formatting with leading comma:

```sql
SELECT
  a
  , b
  , c
FROM t
```

Context: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1712927617277489