### PR TITLE
Fix(redshift): unqualify unnest columns

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -167,7 +167,11 @@ class Redshift(Postgres):
             exp.GroupConcat: rename_func("LISTAGG"),
             exp.ParseJSON: rename_func("JSON_PARSE"),
             exp.Select: transforms.preprocess(
-                [transforms.eliminate_distinct_on, transforms.eliminate_semi_and_anti_joins]
+                [
+                    transforms.eliminate_distinct_on,
+                    transforms.eliminate_semi_and_anti_joins,
+                    transforms.unqualify_unnest,
+                ]
             ),
             exp.SortKeyProperty: lambda self,
             e: f"{'COMPOUND ' if e.args['compound'] else ''}SORTKEY({self.format_args(*e.this)})",
@@ -203,7 +207,7 @@ class Redshift(Postgres):
                 return ""
 
             arg = self.sql(seq_get(args, 0))
-            alias = self.expressions(expression.args.get("alias"), key="columns")
+            alias = self.expressions(expression.args.get("alias"), key="columns", flat=True)
             return f"{arg} AS {alias}" if alias else arg
 
         def with_properties(self, properties: exp.Properties) -> str:

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -66,7 +66,7 @@ def qualify(
     """
     schema = ensure_schema(schema, dialect=dialect)
     expression = normalize_identifiers(expression, dialect=dialect)
-    expression = qualify_tables(expression, db=db, catalog=catalog, schema=schema)
+    expression = qualify_tables(expression, db=db, catalog=catalog, schema=schema, dialect=dialect)
 
     if isolate_tables:
         expression = isolate_table_selects(expression, schema=schema)

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -140,6 +140,26 @@ def remove_precision_parameterized_types(expression: exp.Expression) -> exp.Expr
     return expression
 
 
+def unqualify_unnest(expression: exp.Expression) -> exp.Expression:
+    """Remove references to unnest table aliases, added by the optimizer's qualify_columns step."""
+    from sqlglot.optimizer.scope import find_all_in_scope
+
+    if isinstance(expression, exp.Select):
+        unnest_aliases = {
+            unnest.alias
+            for unnest in find_all_in_scope(expression, exp.Unnest)
+            if isinstance(unnest.parent, (exp.From, exp.Join))
+        }
+        if unnest_aliases:
+            for column in expression.find_all(exp.Column):
+                if column.table in unnest_aliases:
+                    column.set("table", None)
+                elif column.db in unnest_aliases:
+                    column.set("db", None)
+
+    return expression
+
+
 def unnest_to_explode(expression: exp.Expression) -> exp.Expression:
     """Convert cross join unnest into lateral view explode."""
     if isinstance(expression, exp.Select):

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -513,6 +513,11 @@ SELECT t.c1 AS c1, t.c2 AS c2, t.c3 AS c3 FROM FOO(bar) AS t(c1, c2, c3);
 SELECT c1, c3 FROM foo(bar) AS t(c1, c2, c3);
 SELECT t.c1 AS c1, t.c3 AS c3 FROM FOO(bar) AS t(c1, c2, c3);
 
+# dialect: redshift
+# execute: false
+SELECT c.f::VARCHAR(MAX) AS f, e AS e FROM a.b AS c, c.d AS e;
+SELECT CAST(c.f AS VARCHAR(MAX)) AS f, e AS e FROM a.b AS c, c.d AS e;
+
 --------------------------------------
 -- Window functions
 --------------------------------------


### PR DESCRIPTION
Before:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.qualify import qualify
>>>
>>> print(qualify(parse_one("SELECT c.f::VARCHAR(MAX) AS f, e AS e FROM a.b AS c, c.d AS e", "redshift"), dialect="redshift", infer_schema=False).sql("redshift", pretty=True))
SELECT
  CAST("c"."f" AS VARCHAR(MAX)) AS "f",
  "_q_0"."e" AS "e"
FROM "a"."b" AS "c", "c"."d" AS   "e"
```

After:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.qualify import qualify
>>>
>>> print(qualify(parse_one("SELECT c.f::VARCHAR(MAX) AS f, e AS e FROM a.b AS c, c.d AS e", "redshift"), dialect="redshift", infer_schema=False).sql("redshift", pretty=True))
SELECT
  CAST("c"."f" AS VARCHAR(MAX)) AS "f",
  "e" AS "e"
FROM "a"."b" AS "c", "c"."d" AS "e"
```