### PR TITLE
fix(optimizer)!: Preserve DPipe in simplify_concat

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4866,7 +4866,7 @@ class Chr(Func):
 
 
 class Concat(Func):
-    arg_types = {"expressions": True, "safe": False, "coalesce": False}
+    arg_types = {"expressions": True, "safe": False, "coalesce": False, "dpipe_source": False}
     is_var_len_args = True
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2536,6 +2536,11 @@ class Generator(metaclass=_Generator):
         if not self.SUPPORTS_SINGLE_ARG_CONCAT and len(expressions) == 1:
             return self.sql(expressions[0])
 
+        if expression.args.get("dpipe_source"):
+            from sqlglot.dialects.dialect import concat_to_dpipe_sql
+
+            return concat_to_dpipe_sql(self, expression)
+
         return self.func("CONCAT", *expressions)
 
     def concatws_sql(self, expression: exp.ConcatWs) -> str:

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -767,6 +767,8 @@ def simplify_concat(expression):
         args = {
             "safe": expression.args.get("safe"),
             "coalesce": expression.args.get("coalesce"),
+            "dpipe_source": isinstance(expression, exp.DPipe)
+            or expression.args.get("dpipe_source"),
         }
 
     new_args = []

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -869,7 +869,7 @@ CONCAT_WS(sep, 'a', 'b');
 CONCAT_WS(sep, 'a', 'b');
 
 'a' || 'b' || x;
-CONCAT('ab', x);
+'ab' || x;
 
 CONCAT(a, b) IN (SELECT * FROM foo WHERE cond);
 CONCAT(a, b) IN (SELECT * FROM foo WHERE cond);

--- a/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
+++ b/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
@@ -822,7 +822,7 @@ WITH "salesreturns" AS (
 ), "x" AS (
   SELECT
     'store channel' AS "channel",
-    CONCAT('store', "ssr"."s_store_id") AS "id",
+    'store' || "ssr"."s_store_id" AS "id",
     "ssr"."sales" AS "sales",
     "ssr"."returns1" AS "returns1",
     "ssr"."profit" - "ssr"."profit_loss" AS "profit"
@@ -830,7 +830,7 @@ WITH "salesreturns" AS (
   UNION ALL
   SELECT
     'catalog channel' AS "channel",
-    CONCAT('catalog_page', "csr"."cp_catalog_page_id") AS "id",
+    'catalog_page' || "csr"."cp_catalog_page_id" AS "id",
     "csr"."sales" AS "sales",
     "csr"."returns1" AS "returns1",
     "csr"."profit" - "csr"."profit_loss" AS "profit"
@@ -838,7 +838,7 @@ WITH "salesreturns" AS (
   UNION ALL
   SELECT
     'web channel' AS "channel",
-    CONCAT('web_site', "wsr"."web_site_id") AS "id",
+    'web_site' || "wsr"."web_site_id" AS "id",
     "wsr"."sales" AS "sales",
     "wsr"."returns1" AS "returns1",
     "wsr"."profit" - "wsr"."profit_loss" AS "profit"
@@ -10927,7 +10927,7 @@ WITH "date_dim_2" AS (
 ), "x" AS (
   SELECT
     'store channel' AS "channel",
-    CONCAT('store', "ssr"."store_id") AS "id",
+    'store' || "ssr"."store_id" AS "id",
     "ssr"."sales" AS "sales",
     "ssr"."returns1" AS "returns1",
     "ssr"."profit" AS "profit"
@@ -10935,7 +10935,7 @@ WITH "date_dim_2" AS (
   UNION ALL
   SELECT
     'catalog channel' AS "channel",
-    CONCAT('catalog_page', "csr"."catalog_page_id") AS "id",
+    'catalog_page' || "csr"."catalog_page_id" AS "id",
     "csr"."sales" AS "sales",
     "csr"."returns1" AS "returns1",
     "csr"."profit" AS "profit"
@@ -10943,7 +10943,7 @@ WITH "date_dim_2" AS (
   UNION ALL
   SELECT
     'web channel' AS "channel",
-    CONCAT('web_site', "wsr"."web_site_id") AS "id",
+    'web_site' || "wsr"."web_site_id" AS "id",
     "wsr"."sales" AS "sales",
     "wsr"."returns1" AS "returns1",
     "wsr"."profit" AS "profit"
@@ -11368,7 +11368,7 @@ ORDER  BY c_customer_id
 LIMIT 100;
 SELECT
   "customer"."c_customer_id" AS "customer_id",
-  CONCAT("customer"."c_last_name", ', ', "customer"."c_first_name") AS "customername"
+  "customer"."c_last_name" || ', ' || "customer"."c_first_name" AS "customername"
 FROM "customer" AS "customer"
 JOIN "customer_address" AS "customer_address"
   ON "customer"."c_current_addr_sk" = "customer_address"."ca_address_sk"
@@ -12743,4 +12743,3 @@ ORDER BY
   "sm_type",
   "cc_name"
 LIMIT 100;
-


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/2439

The `simplify_concat` rule would merge a list of binary `exp.DPipe` concatenations into one `exp.Concat` function call while constant folding any running string literals on the way. That (optimized) expression would then be generated as `CONCAT(a, b, ...)` which might not have the same semantics as `a || b` in every dialect e.g. `tsvector` in Postgres.

This PR aims to preserve `exp.DPipe` by tagging any `exp.Concat` expressions generated by `simplify_concat` with `dpipe_source=True`, which will cause them to be generated back as a list of (now optimized) binary `exp.DPipe` concatenations