### PR TITLE
Feat: parse (a,) as a tuple instead of a paren

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4301,7 +4301,7 @@ class Parser(metaclass=_Parser):
                 this = self._parse_subquery(
                     this=self._parse_set_operations(this), parse_alias=False
                 )
-            elif len(expressions) > 1:
+            elif len(expressions) > 1 or self._prev.token_type == TokenType.COMMA:
                 this = self.expression(exp.Tuple, expressions=expressions)
             else:
                 this = self.expression(exp.Paren, this=this)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -87,6 +87,9 @@ class TestParser(unittest.TestCase):
 
         self.assertIsNotNone(parse_one("date").find(exp.Column))
 
+    def test_tuple(self):
+        parse_one("(a,)").assert_is(exp.Tuple)
+
     def test_structs(self):
         cast = parse_one("cast(x as struct<int>)")
         self.assertIsInstance(cast.to.expressions[0], exp.DataType)


### PR DESCRIPTION
This is mostly a QOL addition, eg. so that we can leverage the `(a,)` syntax in SQLMesh when `[a]` can't be used (T-SQL).

Before:

```python
>>> import sqlglot
>>> sqlglot.parse_one("(a,)")
Paren(
  this=Column(
    this=Identifier(this=a, quoted=False)))
```

After:

```python
>>> import sqlglot
>>> sqlglot.parse_one("(a,)")
Tuple(
  expressions=[
    Column(
      this=Identifier(this=a, quoted=False))])
```