### PR TITLE
Fix(tsql): only use target table name when generating sp_rename

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1056,10 +1056,5 @@ class TSQL(Dialect):
         def altertable_sql(self, expression: exp.AlterTable) -> str:
             actions = expression.args["actions"]
             if isinstance(actions[0], exp.RenameTable):
-                table = self.sql(expression.this)
-                target = actions[0].this
-                target = self.sql(
-                    exp.table_(target.this) if isinstance(target, exp.Table) else target
-                )
-                return f"EXEC sp_rename '{table}', '{target}'"
+                return f"EXEC sp_rename '{self.sql(expression.this)}', '{actions[0].this.name}'"
             return super().altertable_sql(expression)

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1078,6 +1078,14 @@ class TestDuckDB(Validator):
                 "tsql": "EXEC sp_rename 'db.t1', 't2'",
             },
         )
+        self.validate_all(
+            'ALTER TABLE "db"."t1" RENAME TO "db"."t2"',
+            write={
+                "snowflake": 'ALTER TABLE "db"."t1" RENAME TO "db"."t2"',
+                "duckdb": 'ALTER TABLE "db"."t1" RENAME TO "t2"',
+                "tsql": "EXEC sp_rename '[db].[t1]', 't2'",
+            },
+        )
 
     def test_timestamps_with_units(self):
         self.validate_all(


### PR DESCRIPTION
Before:

```python
>>> from sqlglot import parse_one
>>> parse_one('ALTER TABLE "test_schema"."test_table"  RENAME TO "new_name"').sql(dialect="tsql")
"EXEC sp_rename '[test_schema].[test_table]', '[new_name]'"
```

This renames the table and adds the literal `[` and `]` characters, so we'd access the table as `[[new_name]]]` afterwards.

After:

```python
>>> from sqlglot import parse_one
>>> parse_one('ALTER TABLE "test_schema"."test_table"  RENAME TO "new_name"').sql(dialect="tsql")
"EXEC sp_rename '[test_schema].[test_table]', 'new_name'"
```