### PR TITLE
Feat(prql): add support for AGGREGATE

### DIFF
--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -60,11 +60,13 @@ class PRQL(Dialect):
             ),
         }
 
-        FUNCTIONS = {
-            "AVERAGE": exp.Avg.from_arg_list,
-            "MIN": exp.Min.from_arg_list,
-            "MAX": exp.Max.from_arg_list,
-            "COUNT": exp.Count.from_arg_list,
+        AGG_FUNCTIONS = {
+            "MIN": exp.Min,
+            "MAX": exp.Max,
+            "COUNT": exp.Count,
+            "AVERAGE": exp.Avg,
+            "STDDEV": exp.Stddev,
+            "SUM": exp.Sum,
         }
 
         def _parse_equality(self) -> t.Optional[exp.Expression]:
@@ -159,11 +161,11 @@ class PRQL(Dialect):
                 alias = self._parse_id_var(True)
                 self._match(TokenType.ALIAS)
 
-            function = self.FUNCTIONS.get(self._curr.text.upper())
+            function = self.AGG_FUNCTIONS.get(self._curr.text.upper())
             if function:
                 self._advance()
-                args = [self._parse_id_var()]
-                func = function(args)
+                arg = exp.Star() if self._match_texts("THIS") else self._parse_id_var()
+                func = function(this=arg)
             else:
                 self.raise_error("Aggregation function is not supported in PRQL")
 

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -61,12 +61,12 @@ class PRQL(Dialect):
         }
 
         AGG_FUNCTIONS = {
-            "MIN": exp.Min,
-            "MAX": exp.Max,
-            "COUNT": exp.Count,
-            "AVERAGE": exp.Avg,
-            "STDDEV": exp.Stddev,
-            "SUM": exp.Sum,
+            "MIN": lambda arg: exp.Min(this=arg),
+            "MAX": lambda arg: exp.Max(this=arg),
+            "COUNT": lambda arg: exp.Count(this=arg),
+            "AVERAGE": lambda arg: exp.Avg(this=arg),
+            "STDDEV": lambda arg: exp.Stddev(this=arg),
+            "SUM": lambda arg: exp.func("COALESCE", exp.Sum(this=arg), 0)
         }
 
         def _parse_equality(self) -> t.Optional[exp.Expression]:
@@ -165,7 +165,7 @@ class PRQL(Dialect):
             if function:
                 self._advance()
                 arg = exp.Star() if self._match_texts("THIS") else self._parse_id_var()
-                func = function(this=arg)
+                func = function(arg)
             else:
                 self.raise_error("Aggregation function is not supported in PRQL")
 

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -66,7 +66,7 @@ class PRQL(Dialect):
             "COUNT": lambda arg: exp.Count(this=arg),
             "AVERAGE": lambda arg: exp.Avg(this=arg),
             "STDDEV": lambda arg: exp.Stddev(this=arg),
-            "SUM": lambda arg: exp.func("COALESCE", exp.Sum(this=arg), 0)
+            "SUM": lambda arg: exp.func("COALESCE", exp.Sum(this=arg), 0),
         }
 
         def _parse_equality(self) -> t.Optional[exp.Expression]:

--- a/tests/dialects/test_prql.py
+++ b/tests/dialects/test_prql.py
@@ -66,3 +66,16 @@ class TestPRQL(Validator):
             "from x filter (a > 1 || null != b || c != null)",
             "SELECT * FROM x WHERE (a > 1 OR NOT b IS NULL OR NOT c IS NULL)",
         )
+        self.validate_identity("from a aggregate { average x }", "SELECT AVG(x) FROM a")
+        self.validate_identity(
+            "from a aggregate { average x, min y, ct = sum z }",
+            "SELECT AVG(x), MIN(y), COALESCE(SUM(z), 0) AS ct FROM a",
+        )
+        self.validate_identity(
+            "from a aggregate { average x, min y, sum z }",
+            "SELECT AVG(x), MIN(y), COALESCE(SUM(z), 0) FROM a",
+        )
+        self.validate_identity(
+            "from a aggregate { min y, b = stddev x, max z }",
+            "SELECT MIN(y), STDDEV(x) AS b, MAX(z) FROM a",
+        )

--- a/tests/dialects/test_prql.py
+++ b/tests/dialects/test_prql.py
@@ -79,3 +79,7 @@ class TestPRQL(Validator):
             "from a aggregate { min y, b = stddev x, max z }",
             "SELECT MIN(y), STDDEV(x) AS b, MAX(z) FROM a",
         )
+        self.validate_identity(
+            "from a derive { t = this.time }",
+            "SELECT *, time AS t FROM a",
+        )

--- a/tests/dialects/test_prql.py
+++ b/tests/dialects/test_prql.py
@@ -79,7 +79,3 @@ class TestPRQL(Validator):
             "from a aggregate { min y, b = stddev x, max z }",
             "SELECT MIN(y), STDDEV(x) AS b, MAX(z) FROM a",
         )
-        self.validate_identity(
-            "from a derive { t = this.time }",
-            "SELECT *, time AS t FROM a",
-        )


### PR DESCRIPTION
1. `AGGREGATE`: https://prql-lang.org/book/reference/stdlib/transforms/aggregate.html
2. Add support for `this` keyword: https://prql-lang.org/book/reference/syntax/keywords.html
