### PR TITLE
feat(clickhouse): Parse window functions in ParameterizedAggFuncs

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -477,19 +477,17 @@ class ClickHouse(Dialect):
                 is_combined = parts and parts[1]
                 params = self._parse_func_params(func)
 
+                kwargs = {
+                    "this": func.this,
+                    "expressions": func.expressions,
+                }
                 if is_combined:
+                    kwargs["parts"] = parts
                     exp_class = exp.CombinedParameterizedAgg if params else exp.CombinedAggFunc
                 else:
                     exp_class = exp.ParameterizedAgg if params else exp.AnonymousAggFunc
 
-                kwargs = {
-                    "exp_class": exp_class,
-                    "this": func.this,
-                    "expressions": func.expressions,
-                }
-
-                if is_combined:
-                    kwargs["parts"] = parts
+                kwargs["exp_class"] = exp_class
                 if params:
                     kwargs["params"] = params
 

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -505,7 +505,7 @@ class ClickHouse(Dialect):
                 func = self.expression(**kwargs)
 
                 if isinstance(expr, exp.Window):
-                    # The window's func was parsed as Anonymous in base parser, fix it's
+                    # The window's func was parsed as Anonymous in base parser, fix its
                     # type to be CH style CombinedAnonymousAggFunc / AnonymousAggFunc
                     expr.set("this", func)
                 elif params:

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -493,17 +493,14 @@ class ClickHouse(Dialect):
 
                 func = self.expression(**kwargs)
 
-                # Params have blocked super()._parse_function() from parsing the following window
-                # (if that exists) as they're standing between the function call and the window spec
-                if params:
-                    func = self._parse_window(func)
-
                 # The window's func was parsed as Anonymous in base parser, fix it's
                 # type to be CH style CombinedAnonymousAggFunc / AnonymousAggFunc
                 if isinstance(expr, exp.Window):
                     expr.set("this", func)
                 elif parts or params:
-                    expr = func
+                    # Params have blocked super()._parse_function() from parsing the following window
+                    # (if that exists) as they're standing between the function call and the window spec
+                    expr = self._parse_window(func) if params else func
 
             return expr
 

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -476,20 +476,20 @@ class ClickHouse(Dialect):
 
                 if params:
                     if parts and parts[1]:
-                        return self.expression(
+                        func = self.expression(
                             exp.CombinedParameterizedAgg,
                             this=func.this,
                             expressions=func.expressions,
                             params=params,
                             parts=parts,
                         )
-                    return self.expression(
+                    func = self.expression(
                         exp.ParameterizedAgg,
                         this=func.this,
                         expressions=func.expressions,
                         params=params,
                     )
-
+                    return self._parse_window(func)
                 if parts:
                     if parts[1]:
                         return self.expression(

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -497,10 +497,12 @@ class ClickHouse(Dialect):
                 # type to be CH style CombinedAnonymousAggFunc / AnonymousAggFunc
                 if isinstance(expr, exp.Window):
                     expr.set("this", func)
-                elif parts or params:
+                elif params:
                     # Params have blocked super()._parse_function() from parsing the following window
                     # (if that exists) as they're standing between the function call and the window spec
-                    expr = self._parse_window(func) if params else func
+                    expr = self._parse_window(func)
+                elif parts:
+                    expr = func
 
             return expr
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -832,7 +832,7 @@ LIFETIME(MIN 0 MAX 0)""",
 
     def test_agg_functions(self):
         def extract_agg_func(query):
-            return parse_one(query, read="clickhouse").args.get("expressions")[0].this
+            return parse_one(query, read="clickhouse").selects[0].this
 
         self.assertIsInstance(
             extract_agg_func("select quantileGK(100, 0.95) OVER (PARTITION BY id) FROM table"),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -93,6 +93,9 @@ class TestClickhouse(Validator):
         self.validate_identity("""SELECT JSONExtractString('{"x": {"y": 1}}', 'x', 'y')""")
         self.validate_identity("SELECT * FROM table LIMIT 1 BY a, b")
         self.validate_identity("SELECT * FROM table LIMIT 2 OFFSET 1 BY a, b")
+        self.validate_identity(
+            "SELECT id, quantileGK(100, 0.95)(reading) OVER (PARTITION BY id ORDER BY id RANGE BETWEEN 30000 PRECEDING AND CURRENT ROW) AS window FROM table"
+        )
 
         self.validate_identity(
             "SELECT $1$foo$1$",


### PR DESCRIPTION
Fixes #3344

Clickhouse defines it's own `_parse_function()` which reuses (and extends) `parser.py::_parse_function()`. The latter will also parse the following window function provided that the next tokens are matched e.g. `aggfunc(...) OVER ...`.

However, for CH's parameterized aggregation functions, the nested params will be _between_ the function call and the rest of the window spec, which will cause `parser.py::_parse_function()` to miss the window specification as it can't match the appropriate window tokens right after the function call. For this case, CH must retry to parse it _after_ having parsed the params. 