### PR TITLE
fix(tsql): Convert TIMESTAMP to ROWVERSION, transpile both to BINARY

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -689,6 +689,7 @@ class BigQuery(Dialect):
             exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP",
             exp.DataType.Type.TINYINT: "INT64",
             exp.DataType.Type.VARBINARY: "BYTES",
+            exp.DataType.Type.ROWVERSION: "BYTES",
             exp.DataType.Type.VARCHAR: "STRING",
             exp.DataType.Type.VARIANT: "ANY TYPE",
         }

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -499,6 +499,7 @@ class DuckDB(Dialect):
             exp.DataType.Type.NVARCHAR: "TEXT",
             exp.DataType.Type.UINT: "UINTEGER",
             exp.DataType.Type.VARBINARY: "BLOB",
+            exp.DataType.Type.ROWVERSION: "BLOB",
             exp.DataType.Type.VARCHAR: "TEXT",
             exp.DataType.Type.TIMESTAMP_S: "TIMESTAMP_S",
             exp.DataType.Type.TIMESTAMP_MS: "TIMESTAMP_MS",

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -457,6 +457,7 @@ class Hive(Dialect):
             exp.DataType.Type.TIME: "TIMESTAMP",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
             exp.DataType.Type.VARBINARY: "BINARY",
+            exp.DataType.Type.ROWVERSION: "BINARY",
         }
 
         TRANSFORMS = {

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -222,6 +222,7 @@ class Oracle(Dialect):
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
             exp.DataType.Type.BINARY: "BLOB",
             exp.DataType.Type.VARBINARY: "BLOB",
+            exp.DataType.Type.ROWVERSION: "BLOB",
         }
 
         TRANSFORMS = {

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -431,6 +431,7 @@ class Postgres(Dialect):
             exp.DataType.Type.DOUBLE: "DOUBLE PRECISION",
             exp.DataType.Type.BINARY: "BYTEA",
             exp.DataType.Type.VARBINARY: "BYTEA",
+            exp.DataType.Type.ROWVERSION: "BYTEA",
             exp.DataType.Type.DATETIME: "TIMESTAMP",
         }
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -146,6 +146,7 @@ class Redshift(Postgres):
             exp.DataType.Type.TIMETZ: "TIME",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
             exp.DataType.Type.VARBINARY: "VARBYTE",
+            exp.DataType.Type.ROWVERSION: "VARBYTE",
         }
 
         TRANSFORMS = {

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -464,6 +464,7 @@ class TSQL(Dialect):
             "SMALLMONEY": TokenType.SMALLMONEY,
             "SQL_VARIANT": TokenType.VARIANT,
             "TOP": TokenType.TOP,
+            "TIMESTAMP": TokenType.ROWVERSION,
             "UNIQUEIDENTIFIER": TokenType.UNIQUEIDENTIFIER,
             "UPDATE STATISTICS": TokenType.COMMAND,
             "XML": TokenType.XML,
@@ -755,6 +756,7 @@ class TSQL(Dialect):
             exp.DataType.Type.TIMESTAMP: "DATETIME2",
             exp.DataType.Type.TIMESTAMPTZ: "DATETIMEOFFSET",
             exp.DataType.Type.VARIANT: "SQL_VARIANT",
+            exp.DataType.Type.ROWVERSION: "ROWVERSION",
         }
 
         TYPE_MAPPING.pop(exp.DataType.Type.NCHAR)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -349,7 +349,7 @@ class Generator(metaclass=_Generator):
         exp.DataType.Type.LONGBLOB: "BLOB",
         exp.DataType.Type.TINYBLOB: "BLOB",
         exp.DataType.Type.INET: "INET",
-        exp.DataType.Type.ROWVERSION: "BINARY",
+        exp.DataType.Type.ROWVERSION: "VARBINARY",
     }
 
     STAR_MAPPING = {

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -349,6 +349,7 @@ class Generator(metaclass=_Generator):
         exp.DataType.Type.LONGBLOB: "BLOB",
         exp.DataType.Type.TINYBLOB: "BLOB",
         exp.DataType.Type.INET: "INET",
+        exp.DataType.Type.ROWVERSION: "BINARY",
     }
 
     STAR_MAPPING = {

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -455,7 +455,6 @@ class TestTSQL(Validator):
         self.validate_identity("CAST(x AS UNIQUEIDENTIFIER)")
         self.validate_identity("CAST(x AS MONEY)")
         self.validate_identity("CAST(x AS SMALLMONEY)")
-        self.validate_identity("CAST(x AS ROWVERSION)")
         self.validate_identity("CAST(x AS IMAGE)")
         self.validate_identity("CAST(x AS SQL_VARIANT)")
         self.validate_identity("CAST(x AS BIT)")
@@ -473,6 +472,16 @@ class TestTSQL(Validator):
             "CAST(x AS DATETIME2(6))",
             write={
                 "hive": "CAST(x AS TIMESTAMP)",
+            },
+        )
+        self.validate_all(
+            "CAST(x AS ROWVERSION)",
+            read={
+                "tsql": "CAST(x AS TIMESTAMP)",
+            },
+            write={
+                "tsql": "CAST(x AS ROWVERSION)",
+                "databricks": "CAST(x AS BINARY)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -481,7 +481,7 @@ class TestTSQL(Validator):
             },
             write={
                 "tsql": "CAST(x AS ROWVERSION)",
-                "databricks": "CAST(x AS BINARY)",
+                "hive": "CAST(x AS BINARY)",
             },
         )
 


### PR DESCRIPTION
Fixes #3345

In T-SQL:
- Parse `"TIMESTAMP"` into `TokenType.ROWVERSION` as the former is deprecated in favor of the latter
- Explicitly preserve the roundtrip generation of `DataType.ROWVERSION -> "ROWVERSION"`

In all other dialects:
- Convert `DataType.ROWVERSION` to `TokenType.BINARY` by default


[T-SQL Rowversion](https://learn.microsoft.com/en-us/sql/t-sql/data-types/rowversion-transact-sql?view=sql-server-ver16)
