### PR TITLE
fix(duckdb)!: Combine aggregate functions with orderby from WITHIN GROUP

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -612,7 +612,7 @@ class DuckDB(Dialect):
             expression_sql = self.sql(expression, "expression")
 
             func = expression.this
-            if isinstance(func, (exp.PercentileCont, exp.PercentileDisc)):
+            if isinstance(func, exp.PERCENTILES):
                 # Make the order key the first arg and slide the fraction to the right
                 # https://duckdb.org/docs/sql/aggregates#ordered-set-aggregate-functions
                 order_col = expression.find(exp.Ordered)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5880,6 +5880,8 @@ FUNCTION_BY_NAME = {name: func for func in ALL_FUNCTIONS for name in func.sql_na
 
 JSON_PATH_PARTS = subclasses(__name__, JSONPathPart, (JSONPathPart,))
 
+PERCENTILES = (PercentileCont, PercentileDisc)
+
 
 # Helpers
 @t.overload

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -349,13 +349,10 @@ def explode_to_unnest(index_offset: int = 0) -> t.Callable[[exp.Expression], exp
     return _explode_to_unnest
 
 
-PERCENTILES = (exp.PercentileCont, exp.PercentileDisc)
-
-
 def add_within_group_for_percentiles(expression: exp.Expression) -> exp.Expression:
     """Transforms percentiles by adding a WITHIN GROUP clause to them."""
     if (
-        isinstance(expression, PERCENTILES)
+        isinstance(expression, exp.PERCENTILES)
         and not isinstance(expression.parent, exp.WithinGroup)
         and expression.expression
     ):
@@ -371,7 +368,7 @@ def remove_within_group_for_percentiles(expression: exp.Expression) -> exp.Expre
     """Transforms percentiles by getting rid of their corresponding WITHIN GROUP clause."""
     if (
         isinstance(expression, exp.WithinGroup)
-        and isinstance(expression.this, PERCENTILES)
+        and isinstance(expression.this, exp.PERCENTILES)
         and isinstance(expression.expression, exp.Order)
     ):
         quantile = expression.this.this

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -652,8 +652,14 @@ class TestDuckDB(Validator):
             "SELECT CAST('2020-05-06' AS DATE) + INTERVAL 5 DAY",
             read={"bigquery": "SELECT DATE_ADD(CAST('2020-05-06' AS DATE), INTERVAL 5 DAY)"},
         )
-        self.validate_identity("SELECT PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY y DESC) FROM t")
-        self.validate_identity("SELECT PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY y DESC) FROM t")
+        self.validate_identity(
+            "SELECT PERCENTILE_CONT(0.25) WITHIN GROUP (ORDER BY y DESC) FROM t",
+            "SELECT QUANTILE_CONT(y, 0.25 ORDER BY y DESC) FROM t",
+        )
+        self.validate_identity(
+            "SELECT PERCENTILE_DISC(0.25) WITHIN GROUP (ORDER BY y DESC) FROM t",
+            "SELECT QUANTILE_DISC(y, 0.25 ORDER BY y DESC) FROM t",
+        )
         self.validate_all(
             "SELECT QUANTILE_CONT(x, q) FROM t",
             write={

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -823,9 +823,9 @@ WHERE
         )
         self.validate_all(
             "SELECT LISTAGG(col1, ', ') WITHIN GROUP (ORDER BY col2) FROM t",
-            read={"snowflake": "SELECT LISTAGG(col1, ', ') WITHIN GROUP (ORDER BY col2) FROM t"},
             write={
                 "duckdb": "SELECT GROUP_CONCAT(col1, ', ' ORDER BY col2) FROM t",
+                "snowflake": "SELECT LISTAGG(col1, ', ') WITHIN GROUP (ORDER BY col2) FROM t",
             },
         )
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -821,6 +821,13 @@ WHERE
                 "snowflake": "CASE WHEN x = a OR (x IS NULL AND a IS NULL) THEN b WHEN x = c OR (x IS NULL AND c IS NULL) THEN d ELSE e END",
             },
         )
+        self.validate_all(
+            "SELECT LISTAGG(col1, ', ') WITHIN GROUP (ORDER BY col2) FROM t",
+            read={"snowflake": "SELECT LISTAGG(col1, ', ') WITHIN GROUP (ORDER BY col2) FROM t"},
+            write={
+                "duckdb": "SELECT GROUP_CONCAT(col1, ', ' ORDER BY col2) FROM t",
+            },
+        )
 
     def test_null_treatment(self):
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -456,7 +456,7 @@ WHERE
                 },
                 write={
                     "": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x NULLS LAST){suffix}",
-                    "duckdb": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
+                    "duckdb": f"SELECT QUANTILE_CONT(x, 0.5 ORDER BY x){suffix}",
                     "postgres": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                     "snowflake": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                 },


### PR DESCRIPTION
Fixes #3350

This PR aims to merge the aggregate function from `exp.WithinGroup` with the order by clause, as per DuckDB syntax. 

Although DuckDB still allows `PERCENTILE_CONT` & `PERCENTILE_DIST` to be defined in `WITHIN GROUP`, this PR will also convert them to their logically equivalent modes; This has the benefit that `rename_unless_within_group` is not needed anymore.


Docs
-------
- [DuckDB Aggregate Functions](https://duckdb.org/docs/sql/aggregates#ordered-set-aggregate-functions)
- [Snowflake LISTAGG + WITHIN GROUP](https://docs.snowflake.com/en/sql-reference/functions/listagg)