### PR TITLE
Fix(postgres): don't generate CommentColumnConstraint

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -518,6 +518,7 @@ class Postgres(Dialect):
             exp.Variance: rename_func("VAR_SAMP"),
             exp.Xor: bool_xor_sql,
         }
+        TRANSFORMS.pop(exp.CommentColumnConstraint)
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,
@@ -525,6 +526,10 @@ class Postgres(Dialect):
             exp.TransientProperty: exp.Properties.Location.UNSUPPORTED,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
+
+        def commentcolumnconstraint_sql(self, expression: exp.CommentColumnConstraint) -> str:
+            self.unsupported("Column comments are not supported in the CREATE statement")
+            return ""
 
         def unnest_sql(self, expression: exp.Unnest) -> str:
             if len(expression.expressions) == 1:

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -315,6 +315,12 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT * FROM t1*", "SELECT * FROM t1")
 
         self.validate_all(
+            "CREATE TABLE t (c INT)",
+            read={
+                "mysql": "CREATE TABLE t (c INT COMMENT 'comment')",
+            },
+        )
+        self.validate_all(
             'SELECT * FROM "test_table" ORDER BY RANDOM() LIMIT 5',
             write={
                 "bigquery": "SELECT * FROM `test_table` ORDER BY RAND() NULLS LAST LIMIT 5",


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1714116556196959

It seems that postgres doesn't support this syntax:

```
georgesittas=# CREATE TABLE app (
  id INT COMMENT 'comment 1',
  appId VARCHAR(50) COMMENT 'comment 2'
)
COMMENT='app management';
ERROR:  syntax error at or near "COMMENT"
LINE 2:   id INT COMMENT 'comment 1',
                 ^
```

References: https://www.postgresql.org/docs/current/sql-createtable.html