### PR TITLE
feat: COPY TO/FROM statement

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -18,6 +18,7 @@ def _timestamp_diff(
 
 class Databricks(Spark):
     SAFE_DIVISION = False
+    COPY_PARAMS_ARE_CSV = False
 
     class Parser(Spark.Parser):
         LOG_DEFAULTS_TO_LN = True
@@ -38,6 +39,8 @@ class Databricks(Spark):
 
     class Generator(Spark.Generator):
         TABLESAMPLE_SEED_KEYWORD = "REPEATABLE"
+        COPY_PARAMS_ARE_WRAPPED = False
+        COPY_PARAMS_EQ_REQUIRED = True
 
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -318,6 +318,9 @@ class Dialect(metaclass=_Dialect):
     UNICODE_START: t.Optional[str] = None
     UNICODE_END: t.Optional[str] = None
 
+    # Separator of COPY statement parameters
+    COPY_PARAMS_SEP: t.Optional[TokenType] = None
+
     @classmethod
     def get_or_raise(cls, dialect: DialectType) -> Dialect:
         """

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -319,7 +319,7 @@ class Dialect(metaclass=_Dialect):
     UNICODE_END: t.Optional[str] = None
 
     # Separator of COPY statement parameters
-    COPY_PARAMS_SEP: t.Optional[TokenType] = None
+    COPY_PARAMS_ARE_CSV: bool = True
 
     @classmethod
     def get_or_raise(cls, dialect: DialectType) -> Dialect:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -319,7 +319,7 @@ class Dialect(metaclass=_Dialect):
     UNICODE_END: t.Optional[str] = None
 
     # Separator of COPY statement parameters
-    COPY_PARAMS_ARE_CSV: bool = True
+    COPY_PARAMS_ARE_CSV = True
 
     @classmethod
     def get_or_raise(cls, dialect: DialectType) -> Dialect:

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -161,6 +161,7 @@ class DuckDB(Dialect):
     SAFE_DIVISION = True
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True
+    COPY_PARAMS_SEP = TokenType.COMMA
 
     # https://duckdb.org/docs/sql/introduction.html#creating-a-new-table
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -161,7 +161,6 @@ class DuckDB(Dialect):
     SAFE_DIVISION = True
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True
-    COPY_PARAMS_SEP = TokenType.COMMA
 
     # https://duckdb.org/docs/sql/introduction.html#creating-a-new-table
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
@@ -366,6 +365,7 @@ class DuckDB(Dialect):
         MULTI_ARG_DISTINCT = False
         CAN_IMPLEMENT_ARRAY_ANY = True
         SUPPORTS_TO_NUMBER = False
+        COPY_HAS_INTO_KEYWORD = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -210,6 +210,7 @@ class Postgres(Dialect):
     CONCAT_COALESCE = True
     NULL_ORDERING = "nulls_are_large"
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
+    COPY_PARAMS_SEP: t.Optional[TokenType] = TokenType.COMMA
 
     TIME_MAPPING = {
         "AM": "%p",

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -210,7 +210,6 @@ class Postgres(Dialect):
     CONCAT_COALESCE = True
     NULL_ORDERING = "nulls_are_large"
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
-    COPY_PARAMS_SEP: t.Optional[TokenType] = TokenType.COMMA
 
     TIME_MAPPING = {
         "AM": "%p",
@@ -418,6 +417,7 @@ class Postgres(Dialect):
         LIKE_PROPERTY_INSIDE_SCHEMA = True
         MULTI_ARG_DISTINCT = False
         CAN_IMPLEMENT_ARRAY_ANY = True
+        COPY_HAS_INTO_KEYWORD = False
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -38,6 +38,7 @@ class Redshift(Postgres):
 
     SUPPORTS_USER_DEFINED_TYPES = False
     INDEX_OFFSET = 0
+    COPY_PARAMS_SEP = None
 
     TIME_FORMAT = "'YYYY-MM-DD HH:MI:SS'"
     TIME_MAPPING = {

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -38,7 +38,7 @@ class Redshift(Postgres):
 
     SUPPORTS_USER_DEFINED_TYPES = False
     INDEX_OFFSET = 0
-    COPY_PARAMS_SEP = None
+    COPY_PARAMS_ARE_CSV = False
 
     TIME_FORMAT = "'YYYY-MM-DD HH:MI:SS'"
     TIME_MAPPING = {
@@ -139,6 +139,7 @@ class Redshift(Postgres):
         LAST_DAY_SUPPORTS_DATE_PART = False
         CAN_IMPLEMENT_ARRAY_ANY = False
         MULTI_ARG_DISTINCT = True
+        COPY_PARAMS_ARE_WRAPPED = False
 
         TYPE_MAPPING = {
             **Postgres.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -289,6 +289,7 @@ class Snowflake(Dialect):
     SUPPORTS_SEMI_ANTI_JOIN = False
     PREFER_CTE_ALIAS_COLUMN = True
     TABLESAMPLE_SIZE_IS_PERCENT = True
+    COPY_PARAMS_ARE_CSV = False
 
     TIME_MAPPING = {
         "YYYY": "%Y",
@@ -745,6 +746,8 @@ class Snowflake(Dialect):
         JSON_KEY_VALUE_PAIR_SEP = ","
         INSERT_OVERWRITE = " OVERWRITE INTO"
         STRUCT_DELIMITER = ("(", ")")
+        COPY_PARAMS_ARE_WRAPPED = False
+        COPY_PARAMS_EQ_REQUIRED = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -336,6 +336,7 @@ class TSQL(Dialect):
     LOG_BASE_FIRST = False
     TYPED_DIVISION = True
     CONCAT_COALESCE = True
+    COPY_PARAMS_SEP = TokenType.COMMA
 
     TIME_MAPPING = {
         "year": "%Y",

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -336,7 +336,6 @@ class TSQL(Dialect):
     LOG_BASE_FIRST = False
     TYPED_DIVISION = True
     CONCAT_COALESCE = True
-    COPY_PARAMS_SEP = TokenType.COMMA
 
     TIME_MAPPING = {
         "year": "%Y",
@@ -729,6 +728,7 @@ class TSQL(Dialect):
         JSON_PATH_BRACKETED_KEY_SUPPORTED = False
         SUPPORTS_TO_NUMBER = False
         OUTER_UNION_MODIFIERS = False
+        COPY_PARAMS_EQ_REQUIRED = True
 
         EXPRESSIONS_WITHOUT_NESTED_CTES = {
             exp.Delete,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1961,13 +1961,10 @@ class CopyParameter(Expression):
 
 class Copy(Expression):
     arg_types = {
-        "into": False,
         "this": True,
         "kind": True,
         "files": True,
         "credentials": False,
-        "with_token": False,
-        "wrapped": False,
         "format": False,
         "params": False,
     }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1956,7 +1956,7 @@ class Connect(Expression):
 
 
 class CopyParameter(Expression):
-    arg_types = {"this": True, "value": False}
+    arg_types = {"this": True, "expression": False}
 
 
 class Copy(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1955,6 +1955,34 @@ class Connect(Expression):
     arg_types = {"start": False, "connect": True, "nocycle": False}
 
 
+class CopyParameter(Expression):
+    arg_types = {"this": True, "value": False}
+
+
+class Copy(Expression):
+    arg_types = {
+        "into": False,
+        "this": True,
+        "kind": True,
+        "files": True,
+        "credentials": False,
+        "with_token": False,
+        "wrapped": False,
+        "format": False,
+        "params": False,
+    }
+
+
+class Credentials(Expression):
+    arg_types = {
+        "credentials": False,
+        "encryption": False,
+        "storage": False,
+        "iam_role": False,
+        "region": False,
+    }
+
+
 class Prior(Expression):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3757,3 +3757,53 @@ class Generator(metaclass=_Generator):
         if self.pretty:
             return string.replace("\n", self.SENTINEL_LINE_BREAK)
         return string
+
+    def copyparameter_sql(self, expression: exp.CopyParameter) -> str:
+        option = self.sql(expression, "this")
+        value = self.sql(expression, "value")
+        value = f" {value}" if value else ""
+
+        return f"{option}{value}"
+
+    def copy_sql(self, expression: exp.Copy) -> str:
+        this = self.sql(expression, "this")
+        this = f" INTO {this}" if expression.args.get("into") else f" {this}"
+
+        credentials = self.sql(expression, "credentials")
+        credentials = f" {credentials}" if credentials else ""
+
+        kind = " FROM " if expression.args.get("kind") else " TO "
+        files = self.expressions(expression, "files", flat=True)
+
+        sep = ", " if self.dialect.COPY_PARAMS_SEP else " "
+        params = self.expressions(expression, "params", flat=True, sep=sep)
+        if params:
+            params = self.wrap(params) if expression.args.get("wrapped") else params
+            params = f" WITH {params}" if expression.args.get("with_token") else f" {params}"
+
+        return f"COPY{this}{kind}{files}{credentials}{params}"
+
+    def credentials_sql(self, expression: exp.Credentials) -> str:
+        cred_expr = expression.args.get("credentials")
+        if isinstance(cred_expr, exp.Literal):
+            # Redshift case: CREDENTIALS <string>
+            credentials = self.sql(expression, "credentials")
+            credentials = f"CREDENTIALS {credentials}"
+        else:
+            # Snowflake case: CREDENTIALS = (...)
+            credentials = self.expressions(expression, "credentials", flat=True, sep=" ")
+            credentials = f"CREDENTIALS = ({credentials})" if credentials else ""
+
+        storage = self.sql(expression, "storage")
+        storage = f" {storage}" if storage else ""
+
+        encryption = self.expressions(expression, "encryption", flat=True, sep=" ")
+        encryption = f"ENCRYPTION = ({encryption})" if encryption else ""
+
+        iam_role = self.sql(expression, "iam_role")
+        iam_role = f"IAM_ROLE {iam_role}" if iam_role else ""
+
+        region = self.sql(expression, "region")
+        region = f" REGION {region}" if region else ""
+
+        return f"{credentials}{storage}{encryption}{iam_role}{region}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3769,7 +3769,7 @@ class Generator(metaclass=_Generator):
 
     def copyparameter_sql(self, expression: exp.CopyParameter) -> str:
         option = self.sql(expression, "this")
-        value = self.sql(expression, "value")
+        value = self.sql(expression, "expression")
 
         if not value:
             return option

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6313,7 +6313,7 @@ class Parser(metaclass=_Parser):
                 self._match(TokenType.ALIAS)
                 value = self._parse_unquoted_field()
 
-            param = self.expression(exp.CopyParameter, this=option, value=value)
+            param = self.expression(exp.CopyParameter, this=option, expression=value)
             options.append(param)
 
             if sep:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -627,6 +627,7 @@ class Parser(metaclass=_Parser):
         TokenType.CACHE: lambda self: self._parse_cache(),
         TokenType.COMMENT: lambda self: self._parse_comment(),
         TokenType.COMMIT: lambda self: self._parse_commit_or_rollback(),
+        TokenType.COPY: lambda self: self._parse_copy(),
         TokenType.CREATE: lambda self: self._parse_create(),
         TokenType.DELETE: lambda self: self._parse_delete(),
         TokenType.DESC: lambda self: self._parse_describe(),
@@ -1764,14 +1765,19 @@ class Parser(metaclass=_Parser):
             ),
         )
 
-    def _parse_property_assignment(self, exp_class: t.Type[E], **kwargs: t.Any) -> E:
-        self._match(TokenType.EQ)
-        self._match(TokenType.ALIAS)
+    def _parse_unquoted_field(self):
         field = self._parse_field()
         if isinstance(field, exp.Identifier) and not field.quoted:
             field = exp.var(field)
 
-        return self.expression(exp_class, this=field, **kwargs)
+        return field
+
+    def _parse_property_assignment(self, exp_class: t.Type[E], **kwargs: t.Any) -> E:
+        self._match(TokenType.EQ)
+        self._match(TokenType.ALIAS)
+        this = self._parse_unquoted_field()
+
+        return self.expression(exp_class, this=this, **kwargs)
 
     def _parse_properties(self, before: t.Optional[bool] = None) -> t.Optional[exp.Properties]:
         properties = []
@@ -6292,3 +6298,94 @@ class Parser(metaclass=_Parser):
         op = self._parse_var(any_token=True)
 
         return self.expression(exp.WithOperator, this=this, op=op)
+
+    def _parse_copy_parameters(self) -> t.List[exp.CopyParameter]:
+        sep = self.dialect.COPY_PARAMS_SEP
+
+        options = []
+        while self._curr and not self._match(TokenType.R_PAREN, advance=False):
+            option = self._parse_unquoted_field()
+            value = None
+            # Some options are defined as functions with the values as params
+            if not isinstance(option, exp.Func):
+                # Different dialects might separate options and values by white space, "=" and "AS"
+                eq = self._match(TokenType.EQ)
+                self._match(TokenType.ALIAS)
+                value = self._parse_unquoted_field()
+                if eq:
+                    option = exp.EQ(this=option, expression=value)
+                    value = None
+
+            param = self.expression(exp.CopyParameter, this=option, value=value)
+            options.append(param)
+
+            if sep:
+                self._match(sep)
+
+        return options
+
+    def _parse_credentials(self) -> t.Optional[exp.Credentials]:
+        def parse_options():
+            opts = []
+            self._match(TokenType.EQ)
+            self._match(TokenType.L_PAREN)
+            while not self._match(TokenType.R_PAREN):
+                opts.append(self._parse_conjunction())
+            return opts
+
+        expr = self.expression(exp.Credentials)
+
+        if self._match_text_seq("STORAGE_INTEGRATION", advance=False):
+            expr.set("storage", self._parse_conjunction())
+        if self._match_text_seq("CREDENTIALS"):
+            # Snowflake supports CREDENTIALS = (...), while Redshift CREDENTIALS <string>
+            creds = parse_options() if self._match(TokenType.EQ) else self._parse_field()
+            expr.set("credentials", creds)
+        if self._match_text_seq("ENCRYPTION"):
+            expr.set("encryption", parse_options())
+        if self._match_text_seq("IAM_ROLE"):
+            expr.set("iam_role", self._parse_field())
+        if self._match_text_seq("REGION"):
+            expr.set("region", self._parse_field())
+
+        return expr
+
+    def _parse_copy(self):
+        start = self._prev
+
+        into = self._match_text_seq("INTO")
+
+        this = (
+            self._parse_conjunction()
+            if self._match(TokenType.L_PAREN, advance=False)
+            else self._parse_table(schema=True)
+        )
+
+        if self._match(TokenType.FROM):
+            kind = True
+        elif self._match_text_seq("TO"):
+            kind = False
+
+        files = self._parse_csv(self._parse_conjunction)
+        credentials = self._parse_credentials()
+
+        with_token = self._match_text_seq("WITH")
+        wrapped = self._match(TokenType.L_PAREN, advance=False)
+
+        params = self._parse_wrapped(self._parse_copy_parameters, optional=True)
+
+        # Fallback case
+        if self._curr:
+            return self._parse_as_command(start)
+
+        return self.expression(
+            exp.Copy,
+            into=into,
+            this=this,
+            kind=kind,
+            credentials=credentials,
+            with_token=with_token,
+            wrapped=wrapped,
+            files=files,
+            params=params,
+        )

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -223,6 +223,7 @@ class TokenType(AutoName):
     COMMIT = auto()
     CONNECT_BY = auto()
     CONSTRAINT = auto()
+    COPY = auto()
     CREATE = auto()
     CROSS = auto()
     CUBE = auto()
@@ -647,6 +648,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "COMMIT": TokenType.COMMIT,
         "CONNECT BY": TokenType.CONNECT_BY,
         "CONSTRAINT": TokenType.CONSTRAINT,
+        "COPY": TokenType.COPY,
         "CREATE": TokenType.CREATE,
         "CROSS": TokenType.CROSS,
         "CUBE": TokenType.CUBE,
@@ -867,7 +869,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "ANALYZE": TokenType.COMMAND,
         "CALL": TokenType.COMMAND,
         "COMMENT": TokenType.COMMENT,
-        "COPY": TokenType.COMMAND,
         "EXPLAIN": TokenType.COMMAND,
         "GRANT": TokenType.COMMAND,
         "OPTIMIZE": TokenType.COMMAND,

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -47,6 +47,9 @@ class TestDatabricks(Validator):
         self.validate_identity(
             "TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', city LIKE 'LA')"
         )
+        self.validate_identity(
+            "COPY INTO target FROM `s3://link` FILEFORMAT = AVRO VALIDATE = ALL FILES = ('file1', 'file2') FORMAT_OPTIONS(opt1 = TRUE, opt2 = 'test') COPY_OPTIONS(opt3 = 5)"
+        )
 
         self.validate_all(
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -725,12 +725,12 @@ class TestDuckDB(Validator):
         )
 
         self.validate_identity(
-            "COPY lineitem FROM 'lineitem.ndjson' (FORMAT JSON, DELIMITER ',', AUTO_DETECT TRUE, COMPRESSION SNAPPY, CODEC ZSTD, FORCE_NOT_NULL(col1, col2))"
+            "COPY lineitem FROM 'lineitem.ndjson' WITH (FORMAT JSON, DELIMITER ',', AUTO_DETECT TRUE, COMPRESSION SNAPPY, CODEC ZSTD, FORCE_NOT_NULL(col1, col2))"
         )
         self.validate_identity(
-            "COPY (SELECT 42 AS a, 'hello' AS b) TO 'query.json' (FORMAT JSON, ARRAY TRUE)"
+            "COPY (SELECT 42 AS a, 'hello' AS b) TO 'query.json' WITH (FORMAT JSON, ARRAY TRUE)"
         )
-        self.validate_identity("COPY lineitem (l_orderkey) TO 'orderkey.tbl' (DELIMITER '|')")
+        self.validate_identity("COPY lineitem (l_orderkey) TO 'orderkey.tbl' WITH (DELIMITER '|')")
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -724,6 +724,14 @@ class TestDuckDB(Validator):
             """SELECT i FROM GENERATE_SERIES(0, 12) AS _(i) ORDER BY i ASC""",
         )
 
+        self.validate_identity(
+            "COPY lineitem FROM 'lineitem.ndjson' (FORMAT JSON, DELIMITER ',', AUTO_DETECT TRUE, COMPRESSION SNAPPY, CODEC ZSTD, FORCE_NOT_NULL(col1, col2))"
+        )
+        self.validate_identity(
+            "COPY (SELECT 42 AS a, 'hello' AS b) TO 'query.json' (FORMAT JSON, ARRAY TRUE)"
+        )
+        self.validate_identity("COPY lineitem (l_orderkey) TO 'orderkey.tbl' (DELIMITER '|')")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -660,6 +660,16 @@ class TestPostgres(Validator):
         )
         self.assertIsInstance(self.parse_one("id::UUID"), exp.Cast)
 
+        self.validate_identity(
+            "COPY tbl (col1, col2) FROM 'file' WITH (FORMAT format, HEADER MATCH, FREEZE TRUE)"
+        )
+        self.validate_identity(
+            "COPY tbl (col1, col2) TO 'file' WITH (FORMAT format, HEADER MATCH, FREEZE TRUE)"
+        )
+        self.validate_identity(
+            "COPY (SELECT * FROM t) TO 'file' WITH (FORMAT format, HEADER MATCH, FREEZE TRUE)"
+        )
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -362,8 +362,10 @@ class TestRedshift(Validator):
             "CREATE TABLE sales (salesid INTEGER NOT NULL) DISTKEY(listid) COMPOUND SORTKEY(listid, sellerid) DISTSTYLE AUTO"
         )
         self.validate_identity(
-            "COPY customer FROM 's3://mybucket/customer' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole'",
-            check_command_warning=True,
+            "COPY customer FROM 's3://mybucket/customer' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole' REGION 'us-east-1' FORMAT orc",
+        )
+        self.validate_identity(
+            "COPY customer FROM 's3://mybucket/mydata' CREDENTIALS 'aws_iam_role=arn:aws:iam::<aws-account-id>:role/<role-name>;master_symmetric_key=<root-key>' emptyasnull blanksasnull timeformat 'YYYY-MM-DD HH:MI:SS'"
         )
         self.validate_identity(
             "UNLOAD ('select * from venue') TO 's3://mybucket/unload/' IAM_ROLE 'arn:aws:iam::0123456789012:role/MyRedshiftRole'",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -102,6 +102,9 @@ WHERE
             "SELECT * FROM DATA AS DATA_L ASOF JOIN DATA AS DATA_R MATCH_CONDITION (DATA_L.VAL > DATA_R.VAL) ON DATA_L.ID = DATA_R.ID"
         )
         self.validate_identity(
+            "COPY INTO mytable (col1, col2) FROM 's3://mybucket/data/files' FILES = ('file1', 'file2') PATTERN = 'pattern' FILE_FORMAT = (FORMAT_NAME = my_csv_format) PARSE_HEADER = TRUE"
+        )
+        self.validate_identity(
             "REGEXP_REPLACE('target', 'pattern', '\n')",
             "REGEXP_REPLACE('target', 'pattern', '\\n')",
         )
@@ -878,10 +881,6 @@ WHERE
         self.validate_identity("SELECT * FROM @namespace.%table_name/path/to/file.json.gz")
         self.validate_identity("SELECT * FROM '@external/location' (FILE_FORMAT => 'path.to.csv')")
         self.validate_identity("PUT file:///dir/tmp.csv @%table", check_command_warning=True)
-        self.validate_identity(
-            'COPY INTO NEW_TABLE ("foo", "bar") FROM (SELECT $1, $2, $3, $4 FROM @%old_table)',
-            check_command_warning=True,
-        )
         self.validate_identity(
             "SELECT * FROM @foo/bar (FILE_FORMAT => ds_sandbox.test.my_csv_format, PATTERN => 'test') AS bla"
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -29,6 +29,9 @@ class TestTSQL(Validator):
         self.validate_identity("1 AND true", "1 <> 0 AND (1 = 1)")
         self.validate_identity("CAST(x AS int) OR y", "CAST(x AS INTEGER) <> 0 OR y <> 0")
         self.validate_identity("TRUNCATE TABLE t1 WITH (PARTITIONS(1, 2 TO 5, 10 TO 20, 84))")
+        self.validate_identity(
+            "COPY INTO test_1 FROM 'path' WITH (FILE_TYPE = 'CSV', CREDENTIAL = (IDENTITY = 'Shared Access Signature', SECRET = 'token'), FIELDTERMINATOR = ';', ROWTERMINATOR = '0X0A', ENCODING = 'UTF8', DATEFORMAT = 'ymd', MAXERRORS = 10, ERRORFILE = 'errorsfolder', IDENTITY_INSERT = 'ON')"
+        )
 
         self.validate_all(
             "SELECT IIF(cond <> 0, 'True', 'False')",

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -869,3 +869,4 @@ TRUNCATE(a, b)
 SELECT enum
 SELECT unlogged
 SELECT name
+SELECT copy


### PR DESCRIPTION
Introduce end-to-end support for `COPY TO` / `COPY FROM` statement

Design notes:

- Dialects parse `COPY` parameters parameters using different separators from each other. Introduced a new dialect flag to control that behavior at parse/generation
- Introduce parsing of external location credentials (Snowflake & Redshift). These might appear in other statements e.g. Redshift's `UNLOAD` but I couldn't find existing support
- Copy parameters are parsed in a best effort catch-all manner, as each dialect specifies a long list. There's a fallback to `exp.Command` if current parsing fails to pick up more nuanced options

Docs
------
- [DuckDB](https://duckdb.org/docs/sql/statements/copy.html)
- [T-SQL](https://learn.microsoft.com/en-us/sql/t-sql/statements/copy-into-transact-sql?view=azure-sqldw-latest)
- [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html)
- [Snowflake](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#syntax)
- [Postgres](https://www.postgresql.org/docs/current/sql-copy.html)
- [Databricks](https://docs.databricks.com/en/sql/language-manual/delta-copy-into.html)