### PR TITLE
Fix(postgres): don't generate SchemaCommentProperty

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -528,6 +528,10 @@ class Postgres(Dialect):
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }
 
+        def schemacommentproperty_sql(self, expression: exp.SchemaCommentProperty) -> str:
+            self.unsupported("Table comments are not supported in the CREATE statement")
+            return ""
+
         def commentcolumnconstraint_sql(self, expression: exp.CommentColumnConstraint) -> str:
             self.unsupported("Column comments are not supported in the CREATE statement")
             return ""

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -317,7 +317,7 @@ class TestPostgres(Validator):
         self.validate_all(
             "CREATE TABLE t (c INT)",
             read={
-                "mysql": "CREATE TABLE t (c INT COMMENT 'comment')",
+                "mysql": "CREATE TABLE t (c INT COMMENT 'comment 1') COMMENT = 'comment 2'",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Similar to https://github.com/tobymao/sqlglot/pull/3357 - Postgres doesn't support `COMMENT` post-schema properties.

Reference: https://www.postgresql.org/docs/current/sql-createtable.html