### PR TITLE
feat(mysql): Transpile TimestampTrunc

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -869,7 +869,6 @@ class MySQL(Dialect):
             return f"CHAR({this}{using})"
 
         def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
-            this = self.sql(expression, "this")
             unit = expression.args.get("unit")
 
             # Pick an old-enough date to avoid negative timestamp diffs

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -876,7 +876,7 @@ class MySQL(Dialect):
             start_ts = "'0000-01-01 00:00:00'"
 
             # Source: https://stackoverflow.com/a/32955740
-            timestamp_diff = build_date_delta(exp.TimestampDiff)([unit, start_ts, this])
+            timestamp_diff = build_date_delta(exp.TimestampDiff)([unit, start_ts, expression.this])
             interval = exp.Interval(this=timestamp_diff, unit=unit)
             dateadd = build_date_delta_with_interval(exp.DateAdd)([start_ts, interval])
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1111,7 +1111,7 @@ COMMENT='客户账户表'"""
         )
 
     def test_timestamp_trunc(self):
-        for dialect in ("postgres", "snowflake", "duckdb"):
+        for dialect in ("postgres", "snowflake", "duckdb", "spark", "databricks"):
             for unit in (
                 "MILLISECOND",
                 "SECOND",
@@ -1121,8 +1121,11 @@ COMMENT='客户账户表'"""
             ):
                 with self.subTest(f"MySQL -> {dialect} Timestamp Trunc with unit {unit}: "):
                     self.validate_all(
-                        f"DATE_ADD('1900-01-01 00:00:00', interval TIMESTAMPDIFF({unit}, '1900-01-01 00:00:00', CAST('2001-02-16 20:38:40' AS DATETIME)) {unit})",
+                        f"DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF({unit}, '0000-01-01 00:00:00', CAST('2001-02-16 20:38:40' AS DATETIME))) {unit})",
                         read={
                             dialect: f"DATE_TRUNC({unit}, TIMESTAMP '2001-02-16 20:38:40')",
+                        },
+                        write={
+                            "mysql": f"DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF({unit}, '0000-01-01 00:00:00', CAST('2001-02-16 20:38:40' AS DATETIME))) {unit})",
                         },
                     )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1109,3 +1109,20 @@ COMMENT='客户账户表'"""
                 "tsql": "CAST(a AS FLOAT) / NULLIF(b, 0)",
             },
         )
+
+    def test_timestamp_trunc(self):
+        for dialect in ("postgres", "snowflake", "duckdb"):
+            for unit in (
+                "MILLISECOND",
+                "SECOND",
+                "DAY",
+                "MONTH",
+                "YEAR",
+            ):
+                with self.subTest(f"MySQL -> {dialect} Timestamp Trunc with unit {unit}: "):
+                    self.validate_all(
+                        f"DATE_ADD('1900-01-01 00:00:00', interval TIMESTAMPDIFF({unit}, '1900-01-01 00:00:00', CAST('2001-02-16 20:38:40' AS DATETIME)) {unit})",
+                        read={
+                            dialect: f"DATE_TRUNC({unit}, TIMESTAMP '2001-02-16 20:38:40')",
+                        },
+                    )


### PR DESCRIPTION
Fixes #3366

MySQL cannot generate `exp.TimestampTrunc` using an existing function; However, one can simulate it with a combination of date add & diff ([source](https://stackoverflow.com/a/32955740))

Docs for `DATE_TRUNC`
-----------
- [Postgres](https://www.postgresql.org/docs/current/functions-datetime.html#FUNCTIONS-DATETIME-TRUNC)
- [Presto](https://prestodb.io/docs/current/functions/datetime.html#date_trunc) 
- [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/date_trunc)
- [Databricks / Spark](https://docs.databricks.com/en/sql/language-manual/functions/date_trunc.html)