### PR TITLE
fix(duckdb): Preserve DATE_SUB roundtrip

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -31,9 +31,6 @@ from sqlglot.dialects.dialect import (
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
-if t.TYPE_CHECKING:
-    from sqlglot._typing import E
-
 
 def _ts_or_ds_add_sql(self: DuckDB.Generator, expression: exp.TsOrDsAdd) -> str:
     this = self.sql(expression, "this")
@@ -44,13 +41,6 @@ def _ts_or_ds_add_sql(self: DuckDB.Generator, expression: exp.TsOrDsAdd) -> str:
 def _date_delta_sql(
     self: DuckDB.Generator, expression: exp.DateAdd | exp.DateSub | exp.TimeAdd
 ) -> str:
-    if isinstance(expression, exp.DateSub):
-        subexpr = expression.expression
-        if not isinstance(subexpr, exp.Literal) or not subexpr.is_int:
-            # Preserve the DATE_SUB roundtrip; If subexpr was an integer, we'd
-            # convert to interval as in below (e.g. BigQuery -> DuckDB transpilation)
-            return self.func("DATE_SUB", f"'{expression.unit}'", subexpr, expression.this)
-
     this = self.sql(expression, "this")
     unit = unit_to_var(expression)
     op = "+" if isinstance(expression, (exp.DateAdd, exp.TimeAdd)) else "-"
@@ -87,9 +77,8 @@ def _build_sort_array_desc(args: t.List) -> exp.Expression:
     return exp.SortArray(this=seq_get(args, 0), asc=exp.false())
 
 
-# Parse part-based functions, check https://duckdb.org/docs/sql/functions/date.html#date-functions
-def _build_date_part_exp(exp_class: t.Type[E], args: t.List) -> exp.Expression:
-    return (exp_class)(this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0))
+def _build_date_diff(args: t.List) -> exp.Expression:
+    return exp.DateDiff(this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0))
 
 
 def _build_generate_series(end_exclusive: bool = False) -> t.Callable[[t.List], exp.GenerateSeries]:
@@ -238,10 +227,8 @@ class DuckDB(Dialect):
             "ARRAY_HAS": exp.ArrayContains.from_arg_list,
             "ARRAY_REVERSE_SORT": _build_sort_array_desc,
             "ARRAY_SORT": exp.SortArray.from_arg_list,
-            "DATEDIFF": lambda args: _build_date_part_exp(exp.DateDiff, args),
-            "DATE_DIFF": lambda args: _build_date_part_exp(exp.DateDiff, args),
-            "DATESUB": lambda args: _build_date_part_exp(exp.DateSub, args),
-            "DATE_SUB": lambda args: _build_date_part_exp(exp.DateSub, args),
+            "DATEDIFF": _build_date_diff,
+            "DATE_DIFF": _build_date_diff,
             "DATE_TRUNC": date_trunc_to_time,
             "DATETRUNC": date_trunc_to_time,
             "DECODE": lambda args: exp.Decode(
@@ -292,6 +279,8 @@ class DuckDB(Dialect):
             "GENERATE_SERIES": _build_generate_series(),
             "RANGE": _build_generate_series(end_exclusive=True),
         }
+
+        FUNCTIONS.pop("DATE_SUB")
 
         FUNCTION_PARSERS = parser.Parser.FUNCTION_PARSERS.copy()
         FUNCTION_PARSERS.pop("DECODE")

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -324,13 +324,13 @@ class TestDuckDB(Validator):
         self.validate_identity(
             "SELECT * FROM (PIVOT Cities ON Year USING SUM(Population) GROUP BY Country) AS pivot_alias"
         )
+        self.validate_identity("DATE_SUB('YEAR', col, '2020-01-01')").assert_is(exp.Anonymous)
+        self.validate_identity("DATESUB('YEAR', col, '2020-01-01')").assert_is(exp.Anonymous)
 
         self.validate_all("0b1010", write={"": "0 AS b1010"})
         self.validate_all("0x1010", write={"": "0 AS x1010"})
         self.validate_all("x ~ y", write={"duckdb": "REGEXP_MATCHES(x, y)"})
         self.validate_all("SELECT * FROM 'x.y'", write={"duckdb": 'SELECT * FROM "x.y"'})
-        self.validate_all("DATE_SUB('YEAR', DATE '2019-01-01', '2020-01-01')")
-        self.validate_all("DATESUB('YEAR', DATE '2019-01-01', '2020-01-01')")
         self.validate_all(
             "SELECT STRFTIME(CAST('2020-01-01' AS TIMESTAMP), CONCAT('%Y', '%m'))",
             write={

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -329,6 +329,8 @@ class TestDuckDB(Validator):
         self.validate_all("0x1010", write={"": "0 AS x1010"})
         self.validate_all("x ~ y", write={"duckdb": "REGEXP_MATCHES(x, y)"})
         self.validate_all("SELECT * FROM 'x.y'", write={"duckdb": 'SELECT * FROM "x.y"'})
+        self.validate_all("DATE_SUB('YEAR', DATE '2019-01-01', '2020-01-01')")
+        self.validate_all("DATESUB('YEAR', DATE '2019-01-01', '2020-01-01')")
         self.validate_all(
             "SELECT STRFTIME(CAST('2020-01-01' AS TIMESTAMP), CONCAT('%Y', '%m'))",
             write={


### PR DESCRIPTION
Fixes #3373

Current `DATE_SUB` support in DuckDB was limited to a [prior BigQuery -> DDB transpilation case](https://github.com/tobymao/sqlglot/pull/1705), in which BQ's interval-based `DATE_SUB` would convert to an equivalent DDB interval expression. 

However, DuckDB supports `DATE_SUB` (also `DATESUB`) natively, which this PR aims to support for it's roundtrip.