### PR TITLE
fix(postgres): Infer FROM clause in parse_substring()

### DIFF
--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -864,6 +864,10 @@ class TestPostgres(Validator):
             "TRUNCATE TABLE ONLY t1, t2*, ONLY t3, t4, t5* RESTART IDENTITY CASCADE",
             "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5 RESTART IDENTITY CASCADE",
         )
+        self.validate_identity(
+            "SUBSTRING('abc' FOR 1)",
+            "SUBSTRING('abc' FROM 1 FOR 1)",
+        )
 
         self.validate_all(
             "CREATE TABLE x (a UUID, b BYTEA)",


### PR DESCRIPTION
Context: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1714464345865119

Postgres supports the following syntax: `SUBSTRING(<string> [from int] [for int])`, meaning that one can supply either `FROM`, `FOR` or both. 

However, our parser will only parse `for` if it has parsed `from` too, which isn't a Postgres constraint as mentioned.

[Postgres SUBSTRING ](https://www.postgresql.org/docs/9.1/functions-string.html)