### PR TITLE
Fix(trino): bring back TRIM parsing

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sqlglot import exp
-from sqlglot.dialects.dialect import merge_without_target_sql
+from sqlglot.dialects.dialect import merge_without_target_sql, trim_sql
 from sqlglot.dialects.presto import Presto
 
 
@@ -9,12 +9,19 @@ class Trino(Presto):
     SUPPORTS_USER_DEFINED_TYPES = False
     LOG_BASE_FIRST = True
 
+    class Parser(Presto.Parser):
+        FUNCTION_PARSERS = {
+            **Presto.Parser.FUNCTION_PARSERS,
+            "TRIM": lambda self: self._parse_trim(),
+        }
+
     class Generator(Presto.Generator):
         TRANSFORMS = {
             **Presto.Generator.TRANSFORMS,
             exp.ArraySum: lambda self,
             e: f"REDUCE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.Merge: merge_without_target_sql,
+            exp.Trim: trim_sql,
         }
 
         SUPPORTED_JSON_PATH_PARTS = {

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -1,0 +1,18 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestTrino(Validator):
+    dialect = "trino"
+
+    def test_trim(self):
+        self.validate_identity("SELECT TRIM('!' FROM '!foo!')")
+        self.validate_identity("SELECT TRIM(BOTH '$' FROM '$var$')")
+        self.validate_identity("SELECT TRIM(TRAILING 'ER' FROM UPPER('worker'))")
+        self.validate_identity(
+            "SELECT TRIM(LEADING FROM '  abcd')",
+            "SELECT LTRIM('  abcd')",
+        )
+        self.validate_identity(
+            "SELECT TRIM('!foo!', '!')",
+            "SELECT TRIM('!' FROM '!foo!')",
+        )


### PR DESCRIPTION
Fixes #3384

Seems like the `TRIM` parser was removed from Presto in https://github.com/tobymao/sqlglot/commit/57eb2ce9c. Presto doesn't seem to like the non-CSV syntax:

```
presto> SELECT TRIM('!' FROM '!foo!');
Query 20240430_215821_00000_x3v83 failed: line 1:17: mismatched input 'FROM'. Expecting: ',', <expression>
SELECT TRIM('!' FROM '!foo!')
```

But Trino does.

References:
- https://trino.io/docs/current/functions/string.html?highlight=trim#trim
- https://prestodb.io/docs/current/functions/string.html#trim