### PR TITLE
fix(optimizer)!: Mark UDTF child scopes as ScopeType.SUBQUERY

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -746,7 +746,7 @@ def _traverse_udtfs(scope):
             for child_scope in _traverse_scope(
                 scope.branch(
                     expression,
-                    scope_type=ScopeType.DERIVED_TABLE,
+                    scope_type=ScopeType.SUBQUERY,
                     outer_columns=expression.alias_column_names,
                 )
             ):
@@ -754,8 +754,7 @@ def _traverse_udtfs(scope):
                 top = child_scope
                 sources[expression.alias] = child_scope
 
-            scope.derived_table_scopes.append(top)
-            scope.table_scopes.append(top)
+            scope.subquery_scopes.append(top)
 
     scope.sources.update(sources)
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -523,6 +523,10 @@ SELECT t.c1 AS c1, t.c3 AS c3 FROM FOO(bar) AS t(c1, c2, c3);
 SELECT c.f::VARCHAR(MAX) AS f, e AS e FROM a.b AS c, c.d AS e;
 SELECT CAST(c.f AS VARCHAR(MAX)) AS f, e AS e FROM a.b AS c, c.d AS e;
 
+# dialect: bigquery
+WITH cte AS (SELECT 1 AS col) SELECT * FROM cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE col = 1));
+WITH cte AS (SELECT 1 AS col) SELECT * FROM cte AS cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE cte.col = 1));
+
 --------------------------------------
 -- Window functions
 --------------------------------------


### PR DESCRIPTION
BigQuery supports [correlated join operations](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#correlated_join) which allow join RHS UDTFs to reference columns from the LHS. Example:

```
WITH cte AS (
  SELECT 1 AS col
) 
SELECT * FROM cte 
LEFT JOIN UNNEST((
   SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE col = 1
));

```


However, UDTFs currently mark their nested scopes as `ScopeType.DERIVED_TABLE` which not only seems semantically incorrect but also blocks the parent/outer scope from collecting & qualifying the `UNNEST` external columns, as would happen in a typical correlated subquery.