### PR TITLE
Fix(tsql): quote hash sign as well for quoted temporary tables

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -913,7 +913,7 @@ class TSQL(Dialect):
                 isinstance(prop, exp.TemporaryProperty)
                 for prop in (properties.expressions if properties else [])
             ):
-                sql = f"#{sql}"
+                sql = f"[#{sql[1:]}" if sql.startswith("[") else f"#{sql}"
 
             return sql
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -780,6 +780,14 @@ class TestTSQL(Validator):
             "CREATE PROCEDURE foo AS BEGIN DELETE FROM bla WHERE foo < CURRENT_TIMESTAMP - 7 END",
             "CREATE PROCEDURE foo AS BEGIN DELETE FROM bla WHERE foo < GETDATE() - 7 END",
         )
+
+        self.validate_all(
+            "CREATE TABLE [#temptest] (name VARCHAR)",
+            read={
+                "duckdb": "CREATE TEMPORARY TABLE 'temptest' (name VARCHAR)",
+                "tsql": "CREATE TABLE [#temptest] (name VARCHAR)",
+            },
+        )
         self.validate_all(
             "CREATE TABLE tbl (id INTEGER IDENTITY PRIMARY KEY)",
             read={


### PR DESCRIPTION
Fixes #3399

FYI I've verified that running `CREATE TABLE [#foo bar] (name VARCHAR)` produces a temp table by querying `select * from tempdb..sysobjects` - see https://stackoverflow.com/a/7075562/17518317.