### PR TITLE
Feat(postgres): add support for anonymos index DDL syntax

### DIFF
--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -710,6 +710,7 @@ class TestPostgres(Validator):
         cdef.args["kind"].assert_is(exp.DataType)
         self.assertEqual(expr.sql(dialect="postgres"), "CREATE TABLE t (x INTERVAL DAY)")
 
+        self.validate_identity("CREATE INDEX IF NOT EXISTS ON t(c)")
         self.validate_identity("CREATE INDEX et_vid_idx ON et(vid) INCLUDE (fid)")
         self.validate_identity("CREATE INDEX idx_x ON x USING BTREE(x, y) WHERE (NOT y IS NULL)")
         self.validate_identity("CREATE TABLE test (elems JSONB[])")


### PR DESCRIPTION
The index name can be omitted in the `CREATE INDEX` DDL for Postgres, which is not currently supported by SQLGlot.

Reference: https://www.postgresql.org/docs/current/sql-createindex.html
Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1714510786163729?thread_ts=1714460372.303889&cid=C044BRE5W4S