### PR TITLE
Updated tokens.py

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -764,6 +764,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "TEMP": TokenType.TEMPORARY,
         "TEMPORARY": TokenType.TEMPORARY,
         "THEN": TokenType.THEN,
+        "TOP":TokenType.TOP,
         "TRUE": TokenType.TRUE,
         "TRUNCATE": TokenType.TRUNCATE,
         "UNION": TokenType.UNION,


### PR DESCRIPTION
When providing the query with the top command, the parse_one function previously raised an exception. I solved this by updating the tokens.py file and providing a new token type called top. This also solves the issue of converting the query with the top command to another query language, like PostgreSQL, which does not support the top command, and now, after this change, when using transpile, it adds the LIMIT keyword and provides the proper query.