### PR TITLE
fix(mysql): Parse REPLACE statement as Command

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -251,7 +251,7 @@ class MySQL(Dialect):
             "@@": TokenType.SESSION_PARAMETER,
         }
 
-        COMMANDS = tokens.Tokenizer.COMMANDS - {TokenType.SHOW}
+        COMMANDS = {*tokens.Tokenizer.COMMANDS, TokenType.REPLACE} - {TokenType.SHOW}
 
     class Parser(parser.Parser):
         FUNC_TOKENS = {

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -474,6 +474,8 @@ class TSQL(Dialect):
             "OPTION": TokenType.OPTION,
         }
 
+        COMMANDS = {*tokens.Tokenizer.COMMANDS, TokenType.END}
+
     class Parser(parser.Parser):
         SET_REQUIRES_ASSIGNMENT_DELIMITER = False
         LOG_DEFAULTS_TO_LN = True
@@ -522,11 +524,6 @@ class TSQL(Dialect):
         RETURNS_TABLE_TOKENS = parser.Parser.ID_VAR_TOKENS - {
             TokenType.TABLE,
             *parser.Parser.TYPE_TOKENS,
-        }
-
-        STATEMENT_PARSERS = {
-            **parser.Parser.STATEMENT_PARSERS,
-            TokenType.END: lambda self: self._parse_command(),
         }
 
         def _parse_options(self) -> t.Optional[t.List[exp.Expression]]:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1471,7 +1471,7 @@ class Parser(metaclass=_Parser):
         if self._match_set(self.STATEMENT_PARSERS):
             return self.STATEMENT_PARSERS[self._prev.token_type](self)
 
-        if self._match_set(Tokenizer.COMMANDS):
+        if self._match_set(self.dialect.tokenizer.COMMANDS):
             return self._parse_command()
 
         expression = self._parse_expression()

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -149,6 +149,9 @@ class TestMySQL(Validator):
             "SELECT * FROM t1, t2, t3 FOR SHARE OF t1 NOWAIT FOR UPDATE OF t2, t3 SKIP LOCKED"
         )
         self.validate_identity(
+            "REPLACE INTO table SELECT id FROM table2 WHERE cnt > 100", check_command_warning=True
+        )
+        self.validate_identity(
             """SELECT * FROM foo WHERE 3 MEMBER OF(info->'$.value')""",
             """SELECT * FROM foo WHERE 3 MEMBER OF(JSON_EXTRACT(info, '$.value'))""",
         )


### PR DESCRIPTION
Fixes #3423 

From what I was able to find the `REPLACE` statement is supported by MySQL. The different syntax flavors would require intricate parsing, so to unblock the issue (and since it's not a rather popular statement ?) I opted to parse it as command for now.

This PR also fixes the following bug: The base parser's `parser.py::_parse_statement()` function would only check the `tokenizer.py::COMMANDS` set instead of the current dialects tokenizer. This meant that adding/removing tokens from `<dialect>.py::COMMANDS` would yield no difference on the parsing.

After enabling `COMMANDS` to work across all dialects, I also went ahead and removed any unnecessary `_parse_command()` calls, as is the case for T-SQL.