### PR TITLE
fix(mssql) : adding support for TOP

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -764,6 +764,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "TEMP": TokenType.TEMPORARY,
         "TEMPORARY": TokenType.TEMPORARY,
         "THEN": TokenType.THEN,
+        "TOP": TokenType.TOP,
         "TRUE": TokenType.TRUE,
         "TRUNCATE": TokenType.TRUNCATE,
         "UNION": TokenType.UNION,

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -96,6 +96,9 @@ x"""
                     (TokenType.NUMBER, "1"),
                 ],
             )
+    def test_top_token(self):
+        tokens = Tokenizer().tokenize("TOP")
+        self.assertEqual(tokens[0].token_type,TokenType.TOP)
 
     def test_command(self):
         tokens = Tokenizer().tokenize("SHOW;")


### PR DESCRIPTION
This pr fixes the issue while using `parse_one()` with the top command present in MSSQL. 

When using the following code, `print(repr(parse_one("SELECT TOP 10 * FROM EMPLOYEES")))`, it raises an exception,

```
Traceback (most recent call last):
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\test.py", line 3, in <module>
    print(repr(parse_one("SELECT TOP 10 * FROM EMPLOYEES")))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\__init__.py", line 139, in parse_one
    result = dialect.parse(sql, **opts)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\dialects\dialect.py", line 509, in parse
    return self.parser(**opts).parse(self.tokenize(sql), sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\parser.py", line 1177, in parse
    return self._parse(
           ^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\parser.py", line 1246, in _parse
    self.raise_error("Invalid expression / Unexpected token")
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\parser.py", line 1287, in raise_error
    raise error
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 13.
  SELECT TOP 10 * FROM EMPLOYEES
```

But after the addition of a token type top in tokens.py, it correctly parses and provides the correct output,
```
Select(
  expressions=[
    Star()],
  limit=Limit(
    expression=Literal(this=10, is_string=False)),
  from=From(
    this=Table(
      this=Identifier(this=EMPLOYEES, quoted=False))))
```

This also solves the issue when using transpile and converting the query with the top command to another query language, like PostgreSQL.
Before the addition of the token, for this line of code, print(transpile("SELECT TOP 10 * FROM EMPLOYEES",write="postgres")[0]), it raised an exception.

```
Traceback (most recent call last):
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\test.py", line 5, in <module>
    print(transpile("SELECT TOP 10 * FROM EMPLOYEES",write="postgres")[0])
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\__init__.py", line 177, in transpile
    for expression in parse(sql, read, error_level=error_level)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\__init__.py", line 102, in parse
    return Dialect.get_or_raise(read or dialect).parse(sql, **opts)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\dialects\dialect.py", line 509, in parse
    return self.parser(**opts).parse(self.tokenize(sql), sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\parser.py", line 1177, in parse
    return self._parse(
           ^^^^^^^^^^^^
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\parser.py", line 1246, in _parse
    self.raise_error("Invalid expression / Unexpected token")
  File "c:\Users\HP\OneDrive\Desktop\sqlglot\sqlglot\sqlglot\parser.py", line 1287, in raise_error
    raise error
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 13.
  SELECT TOP 10 * FROM EMPLOYEES
```

But after the addition, it transformed properly and provided the correct output.
`SELECT * FROM EMPLOYEES LIMIT 10`
