### PR TITLE
feat(clickhouse): add support for partition expression

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -583,22 +583,15 @@ class ClickHouse(Dialect):
             if not self._match(TokenType.PARTITION):
                 return None
 
-            # Support for PARTITION ID '201901' syntax
             if self._match_text_seq("ID"):
-                return self.expression(
-                    exp.Partition,
-                    expressions=[
-                        self.expression(
-                            exp.PartitionId,
-                            this=self._parse_string(),
-                        )
-                    ],
-                )
+                # Corresponds to the PARTITION ID <string_value> syntax
+                expressions: t.List[exp.Expression] = [
+                    self.expression(exp.PartitionId, this=self._parse_string())
+                ]
+            else:
+                expressions = self._parse_expressions()
 
-            return self.expression(
-                exp.Partition,
-                expressions=self._parse_expressions(),
-            )
+            return self.expression(exp.Partition, expressions=expressions)
 
     class Generator(generator.Generator):
         QUERY_HINTS = False
@@ -855,4 +848,4 @@ class ClickHouse(Dialect):
             return f"PARTITION {self.expressions(expression, flat=True)}"
 
         def partitionid_sql(self, expression: exp.PartitionId) -> str:
-            return f"ID {expression.this}"
+            return f"ID {self.sql(expression.this)}"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2177,6 +2177,11 @@ class PartitionRange(Expression):
     arg_types = {"this": True, "expression": True}
 
 
+# https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#how-to-set-partition-expression
+class PartitionId(Expression):
+    arg_types = {"this": True}
+
+
 class Fetch(Expression):
     arg_types = {
         "direction": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2179,7 +2179,7 @@ class PartitionRange(Expression):
 
 # https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#how-to-set-partition-expression
 class PartitionId(Expression):
-    arg_types = {"this": True}
+    pass
 
 
 class Fetch(Expression):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -425,6 +425,13 @@ class TestClickhouse(Validator):
             },
         )
 
+        self.validate_identity("ALTER TABLE visits DROP PARTITION 201901")
+        self.validate_identity("ALTER TABLE visits DROP PARTITION ALL")
+        self.validate_identity(
+            "ALTER TABLE visits DROP PARTITION tuple(toYYYYMM(toDate('2019-01-25')))"
+        )
+        self.validate_identity("ALTER TABLE visits DROP PARTITION ID '201901'")
+
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")


### PR DESCRIPTION
ClickHouse partition expression syntax differs from the one used in base Parser, documentation reference: https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#how-to-set-partition-expression