### PR TITLE
Chore: bump ruff to 0.4.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,16 +13,3 @@ ignore_errors = True
 
 [mypy-tests.dataframe.*]
 ignore_errors = False
-
-[autoflake]
-in-place = True
-expand-star-imports = True
-remove-all-unused-imports = True
-ignore-init-module-imports = True
-remove-duplicate-keys = True
-remove-unused-variables = True
-quiet = True
-
-[isort]
-profile=black
-known_first_party=sqlglot

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
             "python-dateutil",
             "pdoc",
             "pre-commit",
-            "ruff==0.3.2",
+            "ruff==0.4.3",
             "types-python-dateutil",
             "typing_extensions",
             "maturin>=1.4,<2.0",


### PR DESCRIPTION
This is the latest version, see https://github.com/astral-sh/ruff/releases/tag/v0.4.3