### PR TITLE
Fix(snowflake): parse CREATE SEQUENCE with commas

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1678,6 +1678,7 @@ class Parser(metaclass=_Parser):
         index = self._index
 
         while self._curr:
+            self._match(TokenType.COMMA)
             if self._match_text_seq("INCREMENT"):
                 self._match_text_seq("BY")
                 self._match_text_seq("=")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1223,6 +1223,14 @@ WHERE
             "CREATE OR REPLACE FUNCTION my_udtf(foo BOOLEAN) RETURNS TABLE(col1 ARRAY(INT)) AS $$ WITH t AS (SELECT CAST([1, 2, 3] AS ARRAY(INT)) AS c) SELECT c FROM t $$",
             "CREATE OR REPLACE FUNCTION my_udtf(foo BOOLEAN) RETURNS TABLE (col1 ARRAY(INT)) AS ' WITH t AS (SELECT CAST([1, 2, 3] AS ARRAY(INT)) AS c) SELECT c FROM t '",
         )
+        self.validate_identity(
+            "CREATE SEQUENCE seq1 WITH START=1, INCREMENT=1 ORDER",
+            "CREATE SEQUENCE seq1 START=1 INCREMENT BY 1 ORDER",
+        )
+        self.validate_identity(
+            "CREATE SEQUENCE seq1 WITH START=1 INCREMENT=1 ORDER",
+            "CREATE SEQUENCE seq1 START=1 INCREMENT=1 ORDER",
+        )
 
         self.validate_all(
             "CREATE TABLE orders_clone CLONE orders",


### PR DESCRIPTION
Fixes #3435

Note that the two DDLs tested produce slightly different ASTs:

```python
>>> import sqlglot
>>> sqlglot.parse_one("CREATE SEQUENCE seq1 WITH START=1 INCREMENT=1 ORDER", "snowflake")
Create(
  this=Table(
    this=Identifier(this=seq1, quoted=False)),
  kind=SEQUENCE,
  properties=Properties(
    expressions=[
      Property(
        this=Identifier(this=START, quoted=False),
        value=Literal(this=1, is_string=False)),
      Property(
        this=Identifier(this=INCREMENT, quoted=False),
        value=Literal(this=1, is_string=False)),
      SequenceProperties(
        options=[
          Var(this=ORDER)])]))
>>> sqlglot.parse_one("CREATE SEQUENCE seq1 WITH START=1, INCREMENT=1 ORDER", "snowflake")
Create(
  this=Table(
    this=Identifier(this=seq1, quoted=False)),
  kind=SEQUENCE,
  properties=Properties(
    expressions=[
      Property(
        this=Identifier(this=START, quoted=False),
        value=Literal(this=1, is_string=False)),
      SequenceProperties(
        increment=Literal(this=1, is_string=False),
        options=[
          Var(this=ORDER)])]))
```

This happens because when we only have `KEY=VALUE` pairs separated by whitespace we don't ever reach `_parse_sequence_properties`, but when there's a comma we do [reach it](https://github.com/tobymao/sqlglot/blob/30f9d30d8ab3727a43b1e6f363f28631cbfa7f92/sqlglot/parser.py#L1754) and so the `SequenceProperties` is produced. It's not 100% clean but not sure if a refactor is high ROI right now to make the two ASTs match.