### PR TITLE
Fix: handle empty string in connector comment padding

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -648,9 +648,8 @@ class Generator(metaclass=_Generator):
         return f"{self.sep(sep)}{sql}"
 
     def pad_comment(self, comment: str) -> str:
-        if comment:
-            comment = " " + comment if comment[0].strip() else comment
-            comment = comment + " " if comment[-1].strip() else comment
+        comment = " " + comment if comment[0].strip() else comment
+        comment = comment + " " if comment[-1].strip() else comment
         return comment
 
     def maybe_comment(
@@ -2846,7 +2845,8 @@ class Generator(metaclass=_Generator):
                 stack.append(expression.right)
                 if expression.comments:
                     for comment in expression.comments:
-                        op += f" /*{self.pad_comment(comment)}*/"
+                        if comment:
+                            op += f" /*{self.pad_comment(comment)}*/"
                 stack.extend((op, expression.left))
             return op
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -647,8 +647,7 @@ class Generator(metaclass=_Generator):
     def seg(self, sql: str, sep: str = " ") -> str:
         return f"{self.sep(sep)}{sql}"
 
-    @staticmethod
-    def pad_comment(comment: str) -> str:
+    def pad_comment(self, comment: str) -> str:
         if comment:
             comment = " " + comment if comment[0].strip() else comment
             comment = comment + " " if comment[-1].strip() else comment

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -647,9 +647,11 @@ class Generator(metaclass=_Generator):
     def seg(self, sql: str, sep: str = " ") -> str:
         return f"{self.sep(sep)}{sql}"
 
-    def pad_comment(self, comment: str) -> str:
-        comment = " " + comment if comment[0].strip() else comment
-        comment = comment + " " if comment[-1].strip() else comment
+    @staticmethod
+    def pad_comment(comment: str) -> str:
+        if comment:
+            comment = " " + comment if comment[0].strip() else comment
+            comment = comment + " " if comment[-1].strip() else comment
         return comment
 
     def maybe_comment(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -46,10 +46,11 @@ class TestGenerator(unittest.TestCase):
         assert parse_one("X as 1").sql(identify="safe") == 'X AS "1"'
 
     def test_pad_comment(self):
-        self.assertEqual(Generator().pad_comment(""), "")
-        self.assertEqual(Generator().pad_comment(" leading"), " leading ")
-        self.assertEqual(Generator().pad_comment("trailing "), " trailing ")
+        generator = Generator()
+        self.assertEqual(generator.pad_comment(""), "")
+        self.assertEqual(generator.pad_comment(" leading"), " leading ")
+        self.assertEqual(generator.pad_comment("trailing "), " trailing ")
         self.assertEqual(
-            Generator().pad_comment(" leading and trailing "), " leading and trailing "
+            generator.pad_comment(" leading and trailing "), " leading and trailing "
         )
-        self.assertEqual(Generator().pad_comment("no padding"), " no padding ")
+        self.assertEqual(generator.pad_comment("no padding"), " no padding ")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -50,7 +50,5 @@ class TestGenerator(unittest.TestCase):
         self.assertEqual(generator.pad_comment(""), "")
         self.assertEqual(generator.pad_comment(" leading"), " leading ")
         self.assertEqual(generator.pad_comment("trailing "), " trailing ")
-        self.assertEqual(
-            generator.pad_comment(" leading and trailing "), " leading and trailing "
-        )
+        self.assertEqual(generator.pad_comment(" leading and trailing "), " leading and trailing ")
         self.assertEqual(generator.pad_comment("no padding"), " no padding ")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -44,11 +44,3 @@ class TestGenerator(unittest.TestCase):
         assert parse_one("X").sql(identify="safe") == "X"
         assert parse_one("x as 1").sql(identify="safe") == '"x" AS "1"'
         assert parse_one("X as 1").sql(identify="safe") == 'X AS "1"'
-
-    def test_pad_comment(self):
-        generator = Generator()
-        self.assertEqual(generator.pad_comment(""), "")
-        self.assertEqual(generator.pad_comment(" leading"), " leading ")
-        self.assertEqual(generator.pad_comment("trailing "), " trailing ")
-        self.assertEqual(generator.pad_comment(" leading and trailing "), " leading and trailing ")
-        self.assertEqual(generator.pad_comment("no padding"), " no padding ")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,7 +4,6 @@ from sqlglot import exp, parse_one
 from sqlglot.expressions import Func
 from sqlglot.parser import Parser
 from sqlglot.tokens import Tokenizer
-from sqlglot.generator import Generator
 
 
 class TestGenerator(unittest.TestCase):

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -49,5 +49,7 @@ class TestGenerator(unittest.TestCase):
         self.assertEqual(Generator().pad_comment(""), "")
         self.assertEqual(Generator().pad_comment(" leading"), " leading ")
         self.assertEqual(Generator().pad_comment("trailing "), " trailing ")
-        self.assertEqual(Generator().pad_comment(" leading and trailing "), " leading and trailing ")
+        self.assertEqual(
+            Generator().pad_comment(" leading and trailing "), " leading and trailing "
+        )
         self.assertEqual(Generator().pad_comment("no padding"), " no padding ")

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,6 +4,7 @@ from sqlglot import exp, parse_one
 from sqlglot.expressions import Func
 from sqlglot.parser import Parser
 from sqlglot.tokens import Tokenizer
+from sqlglot.generator import Generator
 
 
 class TestGenerator(unittest.TestCase):
@@ -43,3 +44,10 @@ class TestGenerator(unittest.TestCase):
         assert parse_one("X").sql(identify="safe") == "X"
         assert parse_one("x as 1").sql(identify="safe") == '"x" AS "1"'
         assert parse_one("X as 1").sql(identify="safe") == 'X AS "1"'
+
+    def test_pad_comment(self):
+        self.assertEqual(Generator().pad_comment(""), "")
+        self.assertEqual(Generator().pad_comment(" leading"), " leading ")
+        self.assertEqual(Generator().pad_comment("trailing "), " trailing ")
+        self.assertEqual(Generator().pad_comment(" leading and trailing "), " leading and trailing ")
+        self.assertEqual(Generator().pad_comment("no padding"), " no padding ")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -551,6 +551,10 @@ FROM x""",
             pretty=True,
         )
 
+        self.validate("""SELECT X FROM  catalog.db.table WHERE Y 
+        --
+        AND Z""", """SELECT X FROM catalog.db.table WHERE Y AND Z""")
+
     def test_types(self):
         self.validate("INT 1", "CAST(1 AS INT)")
         self.validate("VARCHAR 'x' y", "CAST('x' AS VARCHAR) AS y")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -551,9 +551,12 @@ FROM x""",
             pretty=True,
         )
 
-        self.validate("""SELECT X FROM  catalog.db.table WHERE Y 
+        self.validate(
+            """SELECT X FROM  catalog.db.table WHERE Y 
         --
-        AND Z""", """SELECT X FROM catalog.db.table WHERE Y AND Z""")
+        AND Z""",
+            """SELECT X FROM catalog.db.table WHERE Y AND Z""",
+        )
 
     def test_types(self):
         self.validate("INT 1", "CAST(1 AS INT)")


### PR DESCRIPTION
Problem:
if comment is an empty string pad_comment fails on IndexError on comment[0]. Adding a simple check if comment is not empty 