### PR TITLE
feat(clickhouse): add support for ALTER TABLE REPLACE PARTITION statement

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -878,5 +878,6 @@ class ClickHouse(Dialect):
             return f"ID {self.sql(expression.this)}"
 
         def replacepartition_sql(self, expression: exp.ReplacePartition) -> str:
-            return f"REPLACE {self.sql(expression.expression)} FROM {self.sql(expression, 'source')}"
-}"
+            return (
+                f"REPLACE {self.sql(expression.expression)} FROM {self.sql(expression, 'source')}"
+            )

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -878,5 +878,5 @@ class ClickHouse(Dialect):
             return f"ID {self.sql(expression.this)}"
 
         def replacepartition_sql(self, expression: exp.ReplacePartition) -> str:
-            source = expression.args.get("source")
-            return f"REPLACE {self.sql(expression.expression)} FROM {source}"
+            return f"REPLACE {self.sql(expression.expression)} FROM {self.sql(expression, 'source')}"
+}"

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -604,20 +604,8 @@ class ClickHouse(Dialect):
             if not partition or not self._match(TokenType.FROM):
                 return None
 
-            db = None
-            table = self._parse_id_var(any_token=False)
-
-            if self._match(TokenType.DOT):
-                db = table
-                table = self._parse_id_var(any_token=False)
-
-            if not table:
-                return None
-
             return self.expression(
-                exp.ReplacePartition,
-                expression=partition,
-                source=self.expression(exp.Table, this=table, db=db),
+                exp.ReplacePartition, expression=partition, source=self._parse_table_parts()
             )
 
     class Generator(generator.Generator):

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -353,6 +353,11 @@ class ClickHouse(Dialect):
             "CODEC": lambda self: self._parse_compress(),
         }
 
+        ALTER_PARSERS = {
+            **parser.Parser.ALTER_PARSERS,
+            "REPLACE": lambda self: self._parse_alter_table_replace(),
+        }
+
         SCHEMA_UNNAMED_CONSTRAINTS = {
             *parser.Parser.SCHEMA_UNNAMED_CONSTRAINTS,
             "INDEX",
@@ -592,6 +597,28 @@ class ClickHouse(Dialect):
                 expressions = self._parse_expressions()
 
             return self.expression(exp.Partition, expressions=expressions)
+
+        def _parse_alter_table_replace(self) -> t.Optional[exp.Expression]:
+            partition = self._parse_partition()
+
+            if not partition or not self._match(TokenType.FROM):
+                return None
+
+            db = None
+            table = self._parse_id_var(any_token=False)
+
+            if self._match(TokenType.DOT):
+                db = table
+                table = self._parse_id_var(any_token=False)
+
+            if not table:
+                return None
+
+            return self.expression(
+                exp.ReplacePartition,
+                expression=partition,
+                source=self.expression(exp.Table, this=table, db=db),
+            )
 
     class Generator(generator.Generator):
         QUERY_HINTS = False
@@ -849,3 +876,7 @@ class ClickHouse(Dialect):
 
         def partitionid_sql(self, expression: exp.PartitionId) -> str:
             return f"ID {self.sql(expression.this)}"
+
+        def replacepartition_sql(self, expression: exp.ReplacePartition) -> str:
+            source = expression.args.get("source")
+            return f"REPLACE {self.sql(expression.expression)} FROM {source}"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4191,6 +4191,11 @@ class DropPartition(Expression):
     arg_types = {"expressions": True, "exists": False}
 
 
+# https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#replace-partition
+class ReplacePartition(Expression):
+    arg_types = {"expression": True, "source": True}
+
+
 # Binary expressions like (ADD a b)
 class Binary(Condition):
     arg_types = {"this": True, "expression": True}

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -432,6 +432,13 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("ALTER TABLE visits DROP PARTITION ID '201901'")
 
+        self.validate_identity("ALTER TABLE visits REPLACE PARTITION 201901 FROM visits_tmp")
+        self.validate_identity("ALTER TABLE visits REPLACE PARTITION ALL FROM visits_tmp")
+        self.validate_identity(
+            "ALTER TABLE visits REPLACE PARTITION tuple(toYYYYMM(toDate('2019-01-25'))) FROM visits_tmp"
+        )
+        self.validate_identity("ALTER TABLE visits REPLACE PARTITION ID '201901' FROM visits_tmp")
+
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")


### PR DESCRIPTION
Added support for ClickHouse ALTER TABLE REPLACE PARTITION, which is very useful in ETL processes (which my company analyzes using sqlglot). ON CLUSTER support isn't there yet, willing to do that in the near future.

Doc reference:
https://clickhouse.com/docs/en/sql-reference/statements/alter/partition#replace-partition