### PR TITLE
fix(presto,trino,clickhouse,bigquery): fix behavior of some hash and ecoding functions

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -25,6 +25,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     ts_or_ds_add_cast,
     unit_to_var,
+    wrap_func_by_func,
 )
 from sqlglot.helper import seq_get, split_num_words
 from sqlglot.tokens import TokenType
@@ -604,6 +605,7 @@ class BigQuery(Dialect):
             exp.GenerateSeries: rename_func("GENERATE_ARRAY"),
             exp.GroupConcat: rename_func("STRING_AGG"),
             exp.Hex: rename_func("TO_HEX"),
+            exp.UpperHex: wrap_func_by_func("UPPER", rename_func("TO_HEX")),
             exp.If: if_sql(false_value="NULL"),
             exp.ILike: no_ilike_sql,
             exp.IntDiv: rename_func("DIV"),
@@ -633,6 +635,7 @@ class BigQuery(Dialect):
                     transforms.eliminate_semi_and_anti_joins,
                 ]
             ),
+            exp.SHA: rename_func("SHA1"),
             exp.SHA2: lambda self, e: self.func(
                 "SHA256" if e.text("length") == "256" else "SHA512", e.this
             ),

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -15,6 +15,7 @@ from sqlglot.dialects.dialect import (
     build_json_extract_path,
     rename_func,
     var_map_sql,
+    wrap_func_by_func,
 )
 from sqlglot.helper import is_int, seq_get
 from sqlglot.tokens import Token, TokenType
@@ -64,6 +65,7 @@ class ClickHouse(Dialect):
     UNESCAPED_SEQUENCES = {
         "\\0": "\0",
     }
+    HEX_LOWERCASE: t.Optional[bool] = False
 
     class Tokenizer(tokens.Tokenizer):
         COMMENTS = ["--", "#", "#!", ("/*", "*/")]
@@ -146,6 +148,9 @@ class ClickHouse(Dialect):
             "TUPLE": exp.Struct.from_arg_list,
             "UNIQ": exp.ApproxDistinct.from_arg_list,
             "XOR": lambda args: exp.Xor(expressions=args),
+            "MD5": exp.MD5Digest.from_arg_list,
+            "SHA256": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(256)),
+            "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
         }
 
         AGG_FUNCTIONS = {
@@ -702,6 +707,12 @@ class ClickHouse(Dialect):
             ),
             exp.VarMap: lambda self, e: _lower_func(var_map_sql(self, e)),
             exp.Xor: lambda self, e: self.func("xor", e.this, e.expression, *e.expressions),
+            exp.MD5Digest: rename_func("MD5"),
+            exp.MD5: wrap_func_by_func("LOWER", wrap_func_by_func("HEX", rename_func("MD5"))),
+            exp.SHA: rename_func("SHA1"),
+            exp.SHA2: lambda self, e: self.func(
+                "SHA256" if e.text("length") == "256" else "SHA512", e.this
+            ),
         }
 
         PROPERTIES_LOCATION = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5177,6 +5177,10 @@ class Hex(Func):
     pass
 
 
+class UpperHex(Func):
+    pass
+
+
 class Xor(Connector, Func):
     arg_types = {"this": False, "expression": False, "expressions": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1296,6 +1296,19 @@ class Generator(metaclass=_Generator):
             text = f"{self.dialect.IDENTIFIER_START}{text}{self.dialect.IDENTIFIER_END}"
         return text
 
+    def hex_sql(self, expression: exp.Hex) -> str:
+        text = self.func("HEX", self.sql(expression, "this"))
+        if not self.dialect.HEX_LOWERCASE:
+            text = self.func("LOWER", text)
+
+        return text
+
+    def upperhex_sql(self, expression: exp.UpperHex) -> str:
+        text = self.func("HEX", self.sql(expression, "this"))
+        if self.dialect.HEX_LOWERCASE:
+            text = self.func("UPPER", text)
+        return text
+
     def inputoutputformat_sql(self, expression: exp.InputOutputFormat) -> str:
         input_format = self.sql(expression, "input_format")
         input_format = f"INPUTFORMAT {input_format}" if input_format else ""

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -61,6 +61,33 @@ def build_logarithm(args: t.List, dialect: Dialect) -> exp.Func:
     return (exp.Ln if dialect.parser_class.LOG_DEFAULTS_TO_LN else exp.Log)(this=this)
 
 
+def build_hex(args: t.List, dialect: Dialect) -> exp.Hex | exp.UpperHex:
+    arg = seq_get(args, 0)
+    return exp.Hex(this=arg) if dialect.HEX_LOWERCASE else exp.UpperHex(this=arg)
+
+
+def build_lower(args: t.List, dialect: Dialect) -> exp.Lower | exp.Hex:
+    # if the dialect provides HEX_UPPERCASE, LOWER(HEX(..)) can be simplified to Hex to simplify its transpilation
+    arg = seq_get(args, 0)
+    return (
+        exp.Hex(this=arg.this)
+        if (not dialect.HEX_LOWERCASE and isinstance(arg, exp.UpperHex))
+        or (dialect.HEX_LOWERCASE and isinstance(arg, exp.Hex))
+        else exp.Lower(this=arg)
+    )
+
+
+def build_upper(args: t.List, dialect: Dialect) -> exp.Upper | exp.UpperHex:
+    # if the dialect provides HEX_UPPERCASE, UPPER(HEX(..)) can be simplified to UpperHex to simplify its transpilation
+    arg = seq_get(args, 0)
+    return (
+        exp.UpperHex(this=arg.this)
+        if (not dialect.HEX_LOWERCASE and isinstance(arg, exp.UpperHex))
+        or (dialect.HEX_LOWERCASE and isinstance(arg, exp.Hex))
+        else exp.Upper(this=arg)
+    )
+
+
 def build_extract_json_with_path(expr_type: t.Type[E]) -> t.Callable[[t.List, Dialect], E]:
     def _builder(args: t.List, dialect: Dialect) -> E:
         expression = expr_type(
@@ -148,6 +175,9 @@ class Parser(metaclass=_Parser):
             length=exp.Literal.number(10),
         ),
         "VAR_MAP": build_var_map,
+        "LOWER": build_lower,
+        "UPPER": build_upper,
+        "HEX": build_hex,
     }
 
     NO_PAREN_FUNCTIONS = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -629,6 +629,7 @@ class TestBigQuery(Validator):
         self.validate_all(
             "SELECT TO_HEX(MD5(some_string))",
             read={
+                "": "SELECT MD5(some_string)",
                 "duckdb": "SELECT MD5(some_string)",
                 "spark": "SELECT MD5(some_string)",
             },
@@ -636,20 +637,71 @@ class TestBigQuery(Validator):
                 "": "SELECT MD5(some_string)",
                 "bigquery": "SELECT TO_HEX(MD5(some_string))",
                 "duckdb": "SELECT MD5(some_string)",
+                "presto": "SELECT LOWER(TO_HEX(MD5(some_string)))",
+                "trino": "SELECT LOWER(TO_HEX(MD5(some_string)))",
+                "clickhouse": "SELECT LOWER(HEX(MD5(some_string)))",
+            },
+        )
+        self.validate_all(
+            "MD5_DIGEST(x)",
+            write={
+                "": "MD5_DIGEST(x)",
+                "bigquery": "MD5(x)",
+                "hive": "UNHEX(MD5(x))",
+                "spark": "UNHEX(MD5(x))",
+                "presto": "MD5(x)",
+                "trino": "MD5(x)",
+            },
+        )
+        self.validate_all(
+            "SHA1(x)",
+            read={
+                "": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+            write={
+                "": "SHA(x)",
+                "bigquery": "SHA1(x)",
+                "presto": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+        )
+        self.validate_all(
+            "SHA1(x)",
+            read={
+                "": "SHA(x)",
             },
         )
         self.validate_all(
             "SHA256(x)",
+            read={
+                "": "SHA2(x, 256)",
+                "bigquery": "SHA256(x)",
+                "presto": "SHA256(x)",
+                "trino": "SHA256(x)",
+            },
             write={
+                "": "SHA2(x, 256)",
                 "bigquery": "SHA256(x)",
                 "spark2": "SHA2(x, 256)",
+                "presto": "SHA256(x)",
+                "trino": "SHA256(x)",
             },
         )
         self.validate_all(
             "SHA512(x)",
+            read={
+                "": "SHA2(x, 512)",
+                "bigquery": "SHA512(x)",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
+            },
             write={
+                "": "SHA2(x, 512)",
                 "bigquery": "SHA512(x)",
                 "spark2": "SHA2(x, 512)",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
             },
         )
         self.validate_all(
@@ -1474,4 +1526,32 @@ OPTIONS (
         self.validate_identity(
             "MOD((a + 1), b)",
             "MOD(a + 1, b)",
+        )
+
+    def test_encoding_functions(self):
+        self.validate_all(
+            "LOWER(TO_HEX(x))",
+            write={
+                "": "HEX(x)",
+                "bigquery": "TO_HEX(x)",
+                "presto": "LOWER(TO_HEX(x))",
+                "trino": "LOWER(TO_HEX(x))",
+                "clickhouse": "LOWER(HEX(x))",
+            },
+        )
+        self.validate_all(
+            "TO_HEX(x)",
+            read={
+                "": "HEX(x)",
+                "presto": "LOWER(TO_HEX(x))",
+                "trino": "LOWER(TO_HEX(x))",
+                "clickhouse": "LOWER(HEX(x))",
+            },
+            write={
+                "": "HEX(x)",
+                "bigquery": "TO_HEX(x)",
+                "presto": "LOWER(TO_HEX(x))",
+                "trino": "LOWER(TO_HEX(x))",
+                "clickhouse": "LOWER(HEX(x))",
+            },
         )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -863,3 +863,96 @@ LIFETIME(MIN 0 MAX 0)""",
         )
 
         parse_one("foobar(x)").assert_is(exp.Anonymous)
+
+    def test_encoding_functions(self):
+        self.validate_all(
+            "LOWER(HEX(x))",
+            read={
+                "": "HEX(x)",
+            },
+        )
+        self.validate_all(
+            "LOWER(HEX(x))",
+            read={
+                "": "LOWER(HEX(x))",
+                "bigquery": "TO_HEX(x)",
+                "presto": "LOWER(TO_HEX(x))",
+                "trino": "LOWER(TO_HEX(x))",
+                "clickhouse": "LOWER(HEX(x))",
+            },
+            write={
+                "": "HEX(x)",
+                "bigquery": "TO_HEX(x)",
+                "presto": "LOWER(TO_HEX(x))",
+                "trino": "LOWER(TO_HEX(x))",
+                "clickhouse": "LOWER(HEX(x))",
+            },
+        )
+        self.validate_all(
+            "HEX(x)",
+            read={
+                "": "UPPER(HEX(x))",
+                "presto": "TO_HEX(x)",
+                "trino": "TO_HEX(x)",
+                "clickhouse": "HEX(x)",
+            },
+            write={
+                "": "UPPER(HEX(x))",
+                "bigquery": "UPPER(TO_HEX(x))",
+                "presto": "TO_HEX(x)",
+                "trino": "TO_HEX(x)",
+                "clickhouse": "HEX(x)",
+            },
+        )
+
+    def test_hash_functions(self):
+        self.validate_all(
+            "SHA1(x)",
+            read={
+                "": "SHA(x)",
+            },
+        )
+        self.validate_all(
+            "SHA1(x)",
+            read={
+                "": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+            write={
+                "": "SHA(x)",
+                "bigquery": "SHA1(x)",
+                "presto": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+        )
+        self.validate_all(
+            "SHA256(x)",
+            read={
+                "": "SHA2(x, 256)",
+                "bigquery": "SHA256(x)",
+                "presto": "SHA256(x)",
+                "trino": "SHA256(x)",
+            },
+            write={
+                "": "SHA2(x, 256)",
+                "bigquery": "SHA256(x)",
+                "presto": "SHA256(x)",
+                "trino": "SHA256(x)",
+            },
+        )
+
+        self.validate_all(
+            "SHA512(x)",
+            read={
+                "": "SHA2(x, 512)",
+                "bigquery": "SHA512(x)",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
+            },
+            write={
+                "": "SHA2(x, 512)",
+                "bigquery": "SHA512(x)",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
+            },
+        )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1038,7 +1038,7 @@ class TestPresto(Validator):
         self.validate_all(
             "TO_HEX(x)",
             write={
-                "spark": "HEX(x)",
+                "spark": "UPPER(HEX(x))",
             },
         )
         self.validate_all(
@@ -1186,5 +1186,117 @@ MATCH_RECOGNIZE (
                 "presto": "SIGN(x)",
                 "spark": "SIGN(x)",
                 "starrocks": "SIGN(x)",
+            },
+        )
+
+    def test_encoding_functions(self):
+        self.validate_all(
+            "LOWER(TO_HEX(x))",
+            read={
+                "": "HEX(x)",
+            },
+        )
+        self.validate_all(
+            "LOWER(TO_HEX(x))",
+            read={
+                "": "LOWER(HEX(x))",
+            },
+            write={
+                "": "HEX(x)",
+                "spark": "HEX(x)",
+                "bigquery": "TO_HEX(x)",
+                "presto": "LOWER(TO_HEX(x))",
+                "trino": "LOWER(TO_HEX(x))",
+                "clickhouse": "LOWER(HEX(x))",
+            },
+        )
+        self.validate_all(
+            "TO_HEX(x)",
+            read={
+                "": "UPPER(HEX(x))",
+                "presto": "TO_HEX(x)",
+                "trino": "TO_HEX(x)",
+                "clickhouse": "HEX(x)",
+            },
+            write={
+                "": "UPPER(HEX(x))",
+                "bigquery": "UPPER(TO_HEX(x))",
+                "presto": "TO_HEX(x)",
+                "trino": "TO_HEX(x)",
+                "clickhouse": "HEX(x)",
+            },
+        )
+
+    def test_hash_functions(self):
+        self.validate_all(
+            "MD5_DIGEST(x)",
+            write={
+                "": "MD5_DIGEST(x)",
+                "bigquery": "MD5(x)",
+                "hive": "UNHEX(MD5(x))",
+                "spark": "UNHEX(MD5(x))",
+                "presto": "MD5(x)",
+                "trino": "MD5(x)",
+            },
+        )
+        self.validate_all(
+            "LOWER(TO_HEX(MD5(x)))",
+            read={
+                "": "HEX(MD5_DIGEST(x))",
+            },
+            write={
+                "": "HEX(MD5_DIGEST(x))",
+                "bigquery": "TO_HEX(MD5(x))",
+                "presto": "LOWER(TO_HEX(MD5(x)))",
+                "trino": "LOWER(TO_HEX(MD5(x)))",
+            },
+        )
+        self.validate_all(
+            "SHA1(x)",
+            read={
+                "": "SHA(x)",
+            },
+        )
+        self.validate_all(
+            "SHA1(x)",
+            read={
+                "": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+            write={
+                "": "SHA(x)",
+                "bigquery": "SHA1(x)",
+                "presto": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+        )
+        self.validate_all(
+            "SHA256(x)",
+            read={
+                "": "SHA2(x, 256)",
+                "bigquery": "SHA256(x)",
+                "presto": "SHA256(x)",
+                "trino": "SHA256(x)",
+            },
+            write={
+                "": "SHA2(x, 256)",
+                "bigquery": "SHA256(x)",
+                "presto": "SHA256(x)",
+                "trino": "SHA256(x)",
+            },
+        )
+        self.validate_all(
+            "SHA512(x)",
+            read={
+                "": "SHA2(x, 512)",
+                "bigquery": "SHA512(x)",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
+            },
+            write={
+                "": "SHA2(x, 512)",
+                "bigquery": "SHA512(x)",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
             },
         )


### PR DESCRIPTION
Fix:
 + Hash functions:
   - MD5 and MD5_Digest
   - SHA1
   - SHA2 (256 and 512)

 + Encoding function:
   - HEX: add case sensitive to HEX function

Feat:
 - Add UpperHex expression to qualify the case sensitive in some dialects (clickhouse, presto, trino, and bigquery)

Note:

1. This pull request aims to make the transpiler between dialects more correct (handle the behavior of the hex function, not just pass the query syntax). 
2. This is a prototype code, we can discuss more how to implement the solution with or without adding the `HEX_LOWERCASE` property to the dialect or adding a new `UpperHex` expression. 
3. Bigquery can simplify `TO_HEX(MD5(x))` to `exp.MD5(x)`, and I also want to facilitate `LOWER(TO_HEX(MD5(x))` to `exp.MD5(x)` in presto, but don't know how to do this currently.