### PR TITLE
Fix(executor): use timezone-aware object to represent datetime in UTC

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -240,5 +240,5 @@ ENV = {
         for x in range(0, len(args), 2)
         if (args[x + 1] is not None and args[x] is not None)
     },
-    "UNIXTOTIME": null_if_any(lambda arg: datetime.datetime.utcfromtimestamp(arg)),
+    "UNIXTOTIME": null_if_any(lambda arg: datetime.datetime.fromtimestamp(arg, datetime.UTC)),
 }

--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -240,5 +240,7 @@ ENV = {
         for x in range(0, len(args), 2)
         if (args[x + 1] is not None and args[x] is not None)
     },
-    "UNIXTOTIME": null_if_any(lambda arg: datetime.datetime.fromtimestamp(arg, datetime.UTC)),
+    "UNIXTOTIME": null_if_any(
+        lambda arg: datetime.datetime.fromtimestamp(arg, datetime.timezone.utc)
+    ),
 }

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -707,9 +707,15 @@ class TestExecutor(unittest.TestCase):
             ("ROUND(1.2)", 1),
             ("ROUND(1.2345, 2)", 1.23),
             ("ROUND(NULL)", None),
-            ("UNIXTOTIME(1659981729)", datetime.datetime(2022, 8, 8, 18, 2, 9)),
+            (
+                "UNIXTOTIME(1659981729)",
+                datetime.datetime(2022, 8, 8, 18, 2, 9, tzinfo=datetime.timezone.utc),
+            ),
             ("TIMESTRTOTIME('2013-04-05 01:02:03')", datetime.datetime(2013, 4, 5, 1, 2, 3)),
-            ("UNIXTOTIME(40 * 365 * 86400)", datetime.datetime(2009, 12, 22, 00, 00, 00)),
+            (
+                "UNIXTOTIME(40 * 365 * 86400)",
+                datetime.datetime(2009, 12, 22, 00, 00, 00, tzinfo=datetime.timezone.utc),
+            ),
             (
                 "STRTOTIME('08/03/2024 12:34:56', '%d/%m/%Y %H:%M:%S')",
                 datetime.datetime(2024, 3, 8, 12, 34, 56),


### PR DESCRIPTION
This fixes a warning emitted on python ≥v3.12:

```
sqlglot/sqlglot/executor/env.py:243: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
  "UNIXTOTIME": null_if_any(lambda arg: datetime.datetime.utcfromtimestamp(arg))
```