### PR TITLE
feat: add support for ON property in ALTER and DROP statements

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1948,6 +1948,7 @@ class Drop(Expression):
         "cascade": False,
         "constraints": False,
         "purge": False,
+        "cluster": False,
     }
 
 
@@ -4189,6 +4190,7 @@ class AlterTable(Expression):
         "exists": False,
         "only": False,
         "options": False,
+        "cluster": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1211,12 +1211,14 @@ class Generator(metaclass=_Generator):
         expressions = f" ({expressions})" if expressions else ""
         kind = expression.args["kind"]
         exists_sql = " IF EXISTS " if expression.args.get("exists") else " "
+        on_cluster = self.sql(expression, "cluster")
+        on_cluster = f" {on_cluster}" if on_cluster else ""
         temporary = " TEMPORARY" if expression.args.get("temporary") else ""
         materialized = " MATERIALIZED" if expression.args.get("materialized") else ""
         cascade = " CASCADE" if expression.args.get("cascade") else ""
         constraints = " CONSTRAINTS" if expression.args.get("constraints") else ""
         purge = " PURGE" if expression.args.get("purge") else ""
-        return f"DROP{temporary}{materialized} {kind}{exists_sql}{this}{expressions}{cascade}{constraints}{purge}"
+        return f"DROP{temporary}{materialized} {kind}{exists_sql}{this}{on_cluster}{expressions}{cascade}{constraints}{purge}"
 
     def except_sql(self, expression: exp.Except) -> str:
         return self.set_operations(expression)
@@ -3023,10 +3025,12 @@ class Generator(metaclass=_Generator):
             actions = self.expressions(expression, key="actions", flat=True)
 
         exists = " IF EXISTS" if expression.args.get("exists") else ""
+        on_cluster = self.sql(expression, "cluster")
+        on_cluster = f" {on_cluster}" if on_cluster else ""
         only = " ONLY" if expression.args.get("only") else ""
         options = self.expressions(expression, key="options")
         options = f", {options}" if options else ""
-        return f"ALTER TABLE{exists}{only} {self.sql(expression, 'this')} {actions}{options}"
+        return f"ALTER TABLE{exists}{only} {self.sql(expression, 'this')}{on_cluster} {actions}{options}"
 
     def add_column_sql(self, expression: exp.AlterTable) -> str:
         if self.ALTER_TABLE_INCLUDE_COLUMN_KEYWORD:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1510,6 +1510,8 @@ class Parser(metaclass=_Parser):
             schema=True, is_db_reference=self._prev.token_type == TokenType.SCHEMA
         )
 
+        cluster = self._parse_on_property() if self._match(TokenType.ON) else None
+
         if self._match(TokenType.L_PAREN, advance=False):
             expressions = self._parse_wrapped_csv(self._parse_types)
         else:
@@ -1527,6 +1529,7 @@ class Parser(metaclass=_Parser):
             cascade=self._match_text_seq("CASCADE"),
             constraints=self._match_text_seq("CONSTRAINTS"),
             purge=self._match_text_seq("PURGE"),
+            cluster=cluster,
         )
 
     def _parse_exists(self, not_: bool = False) -> t.Optional[bool]:
@@ -5912,6 +5915,7 @@ class Parser(metaclass=_Parser):
         exists = self._parse_exists()
         only = self._match_text_seq("ONLY")
         this = self._parse_table(schema=True)
+        cluster = self._parse_on_property() if self._match(TokenType.ON) else None
 
         if self._next:
             self._advance()
@@ -5929,6 +5933,7 @@ class Parser(metaclass=_Parser):
                     actions=actions,
                     only=only,
                     options=options,
+                    cluster=cluster,
                 )
 
         return self._parse_as_command(start)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -439,6 +439,10 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("ALTER TABLE visits REPLACE PARTITION ID '201901' FROM visits_tmp")
 
+        self.validate_identity("ALTER TABLE visits ON CLUSTER test_cluster DROP COLUMN col1")
+        self.validate_identity("DROP TABLE visits ON CLUSTER test_cluster")
+        self.validate_identity("DROP DICTIONARY foo ON CLUSTER test_cluster")
+
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -439,10 +439,6 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("ALTER TABLE visits REPLACE PARTITION ID '201901' FROM visits_tmp")
 
-        self.validate_identity("ALTER TABLE visits ON CLUSTER test_cluster DROP COLUMN col1")
-        self.validate_identity("DROP TABLE visits ON CLUSTER test_cluster")
-        self.validate_identity("DROP DICTIONARY foo ON CLUSTER test_cluster")
-
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")
@@ -874,3 +870,8 @@ LIFETIME(MIN 0 MAX 0)""",
         )
 
         parse_one("foobar(x)").assert_is(exp.Anonymous)
+
+    def test_drop_on_cluster(self):
+        for creatable in ("DATABASE", "TABLE", "VIEW", "DICTIONARY", "FUNCTION"):
+            with self.subTest(f"Test DROP {creatable} ON CLUSTER"):
+                self.validate_identity(f"DROP {creatable} test ON CLUSTER test_cluster")

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -438,6 +438,7 @@ class TestClickhouse(Validator):
             "ALTER TABLE visits REPLACE PARTITION tuple(toYYYYMM(toDate('2019-01-25'))) FROM visits_tmp"
         )
         self.validate_identity("ALTER TABLE visits REPLACE PARTITION ID '201901' FROM visits_tmp")
+        self.validate_identity("ALTER TABLE visits ON CLUSTER test_cluster DROP COLUMN col1")
 
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")


### PR DESCRIPTION
Added support for `ON` property in `ALTER` and `DROP` statements, so `ON CLUSTER` could be used with the ClickHouse dialect. A little follow-up PR to #3441. 

Documentation reference:
https://clickhouse.com/docs/en/sql-reference/statements/drop
https://clickhouse.com/docs/en/sql-reference/statements/alter/column