### PR TITLE
fix(presto): fix DELETE DML statement for presto/trino

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -32,6 +32,7 @@ from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.mysql import MySQL
 from sqlglot.helper import apply_index_offset, seq_get
 from sqlglot.tokens import TokenType
+from sqlglot.transforms import unqualify_columns
 
 
 def _explode_to_unnest_sql(self: Presto.Generator, expression: exp.Lateral) -> str:
@@ -630,23 +631,26 @@ class Presto(Dialect):
         def delete_sql(self, expression: exp.Delete) -> str:
             """
             Presto only support DELETE FROM a table, without alias, so we need to remove the unnecessary parts.
-            If the original DELETE statement contains more than one table to be deleted, just pick the first one.
+            If the original DELETE statement contains more than one table to be deleted, we can't do anything.
             """
 
             tables = expression.args.get("tables")
             if tables:
-                target_table = tables[0]
-                expression = expression.copy()
-                del expression.args["tables"]
-                expression.set("this", target_table)
+                if len(tables) > 1:
+                    return super().delete_sql(expression)
+                else:
+                    target_table = tables[0]
+                    del expression.args["tables"]
+                    expression.set("this", target_table)
 
-            table = expression.args.get("this")
+            table = expression.this
             if isinstance(table, exp.Table):
-                table_alias = table.alias
+                table_alias = table.find(exp.TableAlias)
                 if table_alias:
-                    del table.args["alias"]
-                    for column in expression.find_all(exp.Column):
-                        if column.table == table_alias:
-                            del column.args["table"]
+                    table_alias.pop()
+
+            qualified_expression = expression.transform(unqualify_columns)
+            if isinstance(qualified_expression, exp.Delete):
+                return super().delete_sql(qualified_expression)
 
             return super().delete_sql(expression)

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -638,10 +638,9 @@ class Presto(Dialect):
             if tables:
                 if len(tables) > 1:
                     return super().delete_sql(expression)
-                else:
-                    target_table = tables[0]
-                    del expression.args["tables"]
-                    expression.set("this", target_table)
+                target_table = tables[0]
+                del expression.args["tables"]
+                expression.set("this", target_table)
 
             table = expression.this
             if isinstance(table, exp.Table):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1087,6 +1087,20 @@ LANGUAGE js AS
             },
         )
         self.validate_all(
+            "DELETE FROM db.example_table AS tb WHERE example_table.x = 1",
+            write={
+                "bigquery": "DELETE FROM db.example_table AS tb WHERE example_table.x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
+            "DELETE FROM db.example_table WHERE example_table.x = 1",
+            write={
+                "bigquery": "DELETE FROM db.example_table WHERE example_table.x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM a WHERE b IN UNNEST([1, 2, 3])",
             write={
                 "bigquery": "SELECT * FROM a WHERE b IN UNNEST([1, 2, 3])",

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1045,6 +1045,48 @@ LANGUAGE js AS
             },
         )
         self.validate_all(
+            "DELETE db.example_table WHERE x = 1",
+            write={
+                "bigquery": "DELETE db.example_table WHERE x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
+            "DELETE db.example_table tb WHERE tb.x = 1",
+            write={
+                "bigquery": "DELETE db.example_table AS tb WHERE tb.x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
+            "DELETE db.example_table AS tb WHERE tb.x = 1",
+            write={
+                "bigquery": "DELETE db.example_table AS tb WHERE tb.x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
+            "DELETE FROM db.example_table WHERE x = 1",
+            write={
+                "bigquery": "DELETE FROM db.example_table WHERE x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
+            "DELETE FROM db.example_table tb WHERE tb.x = 1",
+            write={
+                "bigquery": "DELETE FROM db.example_table AS tb WHERE tb.x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
+            "DELETE FROM db.example_table AS tb WHERE tb.x = 1",
+            write={
+                "bigquery": "DELETE FROM db.example_table AS tb WHERE tb.x = 1",
+                "presto": "DELETE FROM db.example_table WHERE x = 1",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM a WHERE b IN UNNEST([1, 2, 3])",
             write={
                 "bigquery": "SELECT * FROM a WHERE b IN UNNEST([1, 2, 3])",


### PR DESCRIPTION
# Context

- Presto/Trino only support DELETE statement with FROM keyword and only allow to delete data from one table per query.
- Don't allow to have any table alias in the target table which will be deleted.

# Documentation

- https://prestodb.io/docs/current/sql/delete.html
- https://trino.io/docs/current/sql/delete.html
- https://prestodb.io/docs/current/sql/explain.html
- https://cloud.google.com/bigquery/docs/reference/standard-sql/dml-syntax#delete_statement
- Looking for **Multi-Table Deletes** in https://dev.mysql.com/doc/refman/8.0/en/delete.html

# Reproduce

## Prerequisite
```bash
echo "connector.name=memory" > memory.properties
docker run -p 8080:8080 -it -v ./memory.properties:/opt/presto-server/etc/catalog/memory.properties --name presto prestodb/presto:latest

docker exec -it presto presto-cli

presto> create table memory.default.tbl(x int);
CREATE TABLE
presto> show create table memory.default.tbl;
           Create Table            
-----------------------------------
 CREATE TABLE memory.default.tbl ( 
    "x" integer                    
 )                                 
(1 row)
```

## Test DELETE DML statement
```bash
# normal case
presto> explain(type validate) delete from memory.default.tbl where x = 1;
 result 
--------
 true   
(1 row)

# failed cases
presto> explain(type validate) delete memory.default.tbl where x = 1;
Query 20240513_165153_00014_37tzg failed: line 1:31: mismatched input 'memory'. Expecting: 'FROM'

presto> explain(type validate) delete from memory.default.tbl t where t.x = 1;
Query 20240513_163843_00010_37tzg failed: line 1:55: mismatched input 't'. Expecting: '.', 'WHERE', <EOF>

presto> explain(type validate) delete from memory.default.tbl as t where t.x = 1;
Query 20240513_165118_00013_37tzg failed: line 1:55: mismatched input 'as'. Expecting: '.', 'WHERE', <EOF>

...
```

So, when transpiling, we have to handle the delete_sql to make Presto/Trino happy.

# Solution

- Presto only support DELETE FROM a table, without alias, so we need to remove the unnecessary parts.
- If the original DELETE statement contains more than one table to be deleted, just pick the first one.

```sql
DELETE ...
->
DELETE FROM ...
```

```sql
DELETE FROM tbl as t where t.col_x = 1;
->
DELETE FROM table where col_x =1;
```

```sql
DELETE tbl1 as z, tbl2 as t where z.id = 1;
->
DELETE FROM tble1 where id = 1
```

```sql
DELETE tbl1 as z, tbl2 as t where z.id = t.id;
->
DELETE FROM tbl1 where id = t.id  <<< FAILED CASE
```


# Test

- Add tests for bigquery dialect. Please note that bigquery can delete only a table at a time, look like presto. 
- Maybe we need more test for mysql (mysql allow delete more than one table each call).

# Discussion 

Should we raise an error if there is more than one table to be deleted when transpiling to presto/trino dialect?