### PR TITLE
feat: add support for snowflake lambdas with type annotations closes …

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6444,11 +6444,9 @@ class Parser(metaclass=_Parser):
         lambda_types = {e.name: e.args.get("to") or False for e in expressions}
 
         for column in node.find_all(exp.Column):
-            name = column.parts[0].name
-            if name in lambda_types:
+            typ = lambda_types.get(column.parts[0].name)
+            if typ is not None:
                 dot_or_id = column.to_dot() if column.table else column.this
-
-                typ = lambda_types.get(name)
 
                 if typ:
                     dot_or_id = self.expression(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6441,16 +6441,7 @@ class Parser(metaclass=_Parser):
         if not node:
             return node
 
-        lambda_types = {}
-
-        for this in expressions:
-            if isinstance(this, exp.Cast):
-                typ = this.to
-                this = this.this
-            else:
-                typ = None
-
-            lambda_types[this.name] = typ
+        lambda_types = {e.name: e.args.get("to") or False for e in expressions}
 
         for column in node.find_all(exp.Column):
             name = column.parts[0].name

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -11,8 +11,8 @@ class TestSnowflake(Validator):
 
     def test_snowflake(self):
         self.validate_identity(
-            "transform(x, a int -> a)",
-            "TRANSFORM(x, a -> CAST(a AS INT))",
+            "transform(x, a int -> a + a + 1)",
+            "TRANSFORM(x, a -> CAST(a AS INT) + CAST(a AS INT) + 1)",
         )
 
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -10,6 +10,11 @@ class TestSnowflake(Validator):
     dialect = "snowflake"
 
     def test_snowflake(self):
+        self.validate_identity(
+            "transform(x, a int -> a)",
+            "TRANSFORM(x, a -> CAST(a AS INT))",
+        )
+
         self.validate_all(
             "ARRAY_CONSTRUCT_COMPACT(1, null, 2)",
             write={


### PR DESCRIPTION
…#3505

Snowflake allows for arguments in lambdas to have a type annotation. This is equivalent to casting the values in the lambda.

https://docs.snowflake.com/en/sql-reference/functions/transform#multiply-each-element-in-an-array-by-a-value