### PR TITLE
[WIP] feat(gh-3502): Add Snowflake support for basic `CREATE WAREHOUSE` statements

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -855,6 +855,7 @@ class Snowflake(Dialect):
             ),
             exp.UnixToTime: rename_func("TO_TIMESTAMP"),
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
+            exp.Warehouse: lambda self, e: e.this,
             exp.WeekOfYear: rename_func("WEEKOFYEAR"),
             exp.Xor: rename_func("BOOLXOR"),
         }

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -740,6 +740,7 @@ class Snowflake(Dialect):
             "TAG": TokenType.TAG,
             "TIMESTAMP_TZ": TokenType.TIMESTAMPTZ,
             "TOP": TokenType.TOP,
+            "WAREHOUSE": TokenType.WAREHOUSE,
         }
 
         SINGLE_TOKENS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3049,6 +3049,9 @@ class Table(Expression):
         return col
 
 
+class Warehouse(Expression):
+    pass
+
 class Union(Query):
     arg_types = {
         "with": False,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3050,7 +3050,10 @@ class Table(Expression):
 
 
 class Warehouse(Expression):
-    pass
+    arg_types = {
+        "this": False,
+    }
+
 
 class Union(Query):
     arg_types = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1710,7 +1710,8 @@ class Parser(metaclass=_Parser):
                 if self._match_text_seq("WITH", "NO", "SCHEMA", "BINDING"):
                     no_schema_binding = True
             elif create_token.token_type == TokenType.WAREHOUSE:
-                this = exp.Warehouse(**this.args)
+                this = self._parse_warehouse(identifier=table_parts.this)
+                extend_props(self._parse_properties())
 
             shallow = self._match_text_seq("SHALLOW")
 
@@ -4717,6 +4718,12 @@ class Parser(metaclass=_Parser):
         self._match_r_paren()
         return self.expression(
             exp.UserDefinedFunction, this=this, expressions=expressions, wrapped=True
+        )
+
+    def _parse_warehouse(self, identifier) -> t.Optional[exp.Expression]:
+        return self.expression(
+            exp.Warehouse,
+            this=identifier
         )
 
     def _parse_introducer(self, token: Token) -> exp.Introducer | exp.Identifier:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -335,6 +335,7 @@ class Parser(metaclass=_Parser):
         TokenType.TABLE,
         TokenType.TAG,
         TokenType.VIEW,
+        TokenType.WAREHOUSE,
     }
 
     CREATABLES = {
@@ -1708,6 +1709,8 @@ class Parser(metaclass=_Parser):
             elif create_token.token_type == TokenType.VIEW:
                 if self._match_text_seq("WITH", "NO", "SCHEMA", "BINDING"):
                     no_schema_binding = True
+            elif create_token.token_type == TokenType.WAREHOUSE:
+                this = exp.Warehouse(**this.args)
 
             shallow = self._match_text_seq("SHALLOW")
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4721,10 +4721,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_warehouse(self, identifier) -> t.Optional[exp.Expression]:
-        return self.expression(
-            exp.Warehouse,
-            this=identifier
-        )
+        return self.expression(exp.Warehouse, this=identifier)
 
     def _parse_introducer(self, token: Token) -> exp.Introducer | exp.Identifier:
         literal = self._parse_primary()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -92,6 +92,7 @@ class TokenType(AutoName):
     COLUMN_DEF = auto()
     SCHEMA = auto()
     TABLE = auto()
+    WAREHOUSE = auto()
     VAR = auto()
     BIT_STRING = auto()
     HEX_STRING = auto()

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -256,8 +256,6 @@ WHERE
         )
         self.validate_identity(
             "CREATE WAREHOUSE x",
-            "CREATE OR REPLACE WAREHOUSE x",
-            "CREATE WAREHOUSE IF NOT EXISTS x",
         )
         self.validate_identity(
             "SELECT DAYOFWEEK('2016-01-02T23:39:20.123-07:00'::TIMESTAMP)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -255,6 +255,11 @@ WHERE
             "ALTER TABLE foo ADD COLUMN id INT AUTOINCREMENT START 1 INCREMENT 1",
         )
         self.validate_identity(
+            "CREATE WAREHOUSE x",
+            "CREATE OR REPLACE WAREHOUSE x",
+            "CREATE WAREHOUSE IF NOT EXISTS x",
+        )
+        self.validate_identity(
             "SELECT DAYOFWEEK('2016-01-02T23:39:20.123-07:00'::TIMESTAMP)",
             "SELECT DAYOFWEEK(CAST('2016-01-02T23:39:20.123-07:00' AS TIMESTAMP))",
         )


### PR DESCRIPTION
Add basic Snowflake support for `CREATE SNOWFLAKE` and re-learning `sqlglot` contributing.

Will likely add support in a follow-up PR for `CREATE OR REPLACE WAREHOUSE` and `CREATE WAREHOUSE IF NOT EXISTS` as I need those too, but wanted to get this PR in sooner rather than later.

- [x] Update `snowflake.py`