### PR TITLE
[WIP] feat(gh-3516): Add support for Snowflake `CREATE STREAMLIT` queries.

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -483,7 +483,7 @@ class Snowflake(Dialect):
 
         SCHEMA_KINDS = {"OBJECTS", "TABLES", "VIEWS", "SEQUENCES", "UNIQUE KEYS", "IMPORTED KEYS"}
 
-        NON_TABLE_CREATABLES = {"STORAGE INTEGRATION", "TAG", "WAREHOUSE"}
+        NON_TABLE_CREATABLES = {"STORAGE INTEGRATION", "TAG", "WAREHOUSE", "STREAMLIT"}
 
         LAMBDAS = {
             **parser.Parser.LAMBDAS,
@@ -743,6 +743,7 @@ class Snowflake(Dialect):
             "TIMESTAMP_TZ": TokenType.TIMESTAMPTZ,
             "TOP": TokenType.TOP,
             "WAREHOUSE": TokenType.WAREHOUSE,
+            "STREAMLIT": TokenType.STREAMLIT,
         }
 
         SINGLE_TOKENS = {

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -93,6 +93,7 @@ class TokenType(AutoName):
     SCHEMA = auto()
     TABLE = auto()
     WAREHOUSE = auto()
+    STREAMLIT = auto()
     VAR = auto()
     BIT_STRING = auto()
     HEX_STRING = auto()

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1206,6 +1206,7 @@ WHERE
         self.validate_identity("CREATE TABLE IDENTIFIER($foo) (col1 VARCHAR, col2 VARCHAR)")
         self.validate_identity("CREATE TAG cost_center ALLOWED_VALUES 'a', 'b'")
         self.validate_identity("CREATE WAREHOUSE x").this.assert_is(exp.Identifier)
+        self.validate_identity("CREATE STREAMLIT x").this.assert_is(exp.Identifier)
         self.validate_identity(
             "CREATE OR REPLACE TAG IF NOT EXISTS cost_center COMMENT='cost_center tag'"
         ).this.assert_is(exp.Identifier)


### PR DESCRIPTION
Add basic Snowflake support for `CREATE STREAMLIT`, as per https://docs.snowflake.com/en/sql-reference/sql/create-streamlit.

- [x] Update `tokens.py` add `TokenType.STREAMLIT`.
- [x] Update `snowflake.py` update `Tokenizer` class and add `STREAMLIT` to `NON_DB_CREATABLES`.
- [ ] Update `test_snowflake.py` add one test around basic `CREATE STREAMLIT x`.

Closes #3516.
