### PR TITLE
feat(databricks): Enable hex string literals

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -88,6 +88,3 @@ class Databricks(Spark):
         ) -> str:
             expression.set("this", True)  # trigger ALWAYS in super class
             return super().generatedasidentitycolumnconstraint_sql(expression)
-
-    class Tokenizer(Spark.Tokenizer):
-        HEX_STRINGS = []

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -284,4 +284,4 @@ class Spark2(Hive):
             )
 
     class Tokenizer(Hive.Tokenizer):
-        HEX_STRINGS = [("X'", "'")]
+        HEX_STRINGS = [("X'", "'"), ("x'", "'")]

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -67,6 +67,20 @@ class TestDatabricks(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT X'1A2B'",
+            read={
+                "spark2": "SELECT X'1A2B'",
+                "spark": "SELECT X'1A2B'",
+                "databricks": "SELECT x'1A2B'",
+            },
+            write={
+                "spark2": "SELECT X'1A2B'",
+                "spark": "SELECT X'1A2B'",
+                "databricks": "SELECT X'1A2B'",
+            },
+        )
+
         with self.assertRaises(ParseError):
             transpile(
                 "CREATE FUNCTION add_one(x INT) RETURNS INT LANGUAGE PYTHON AS $foo$def add_one(x):\n  return x+1$$",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -334,7 +334,7 @@ class TestMySQL(Validator):
         write_CC = {
             "bigquery": "SELECT 0xCC",
             "clickhouse": "SELECT 0xCC",
-            "databricks": "SELECT 204",
+            "databricks": "SELECT X'CC'",
             "drill": "SELECT 204",
             "duckdb": "SELECT 204",
             "hive": "SELECT 204",
@@ -355,7 +355,7 @@ class TestMySQL(Validator):
         write_CC_with_leading_zeros = {
             "bigquery": "SELECT 0x0000CC",
             "clickhouse": "SELECT 0x0000CC",
-            "databricks": "SELECT 204",
+            "databricks": "SELECT X'0000CC'",
             "drill": "SELECT 204",
             "duckdb": "SELECT 204",
             "hive": "SELECT 204",


### PR DESCRIPTION
Fixes #3521

- Removed Databricks superfluous `Tokenizer` so it can inherit Spark's `HEX_STRING`.
- Added support for lowercase `x'...'` as DB's docs mention that the prefix is case insensitive.