### PR TITLE
feat(optimizer)!: Expand stars on BigQuery's tbl.struct_col.* selections

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -65,9 +65,6 @@ except ImportError:
 pretty = False
 """Whether to format generated SQL by default."""
 
-schema = MappingSchema()
-"""The default schema used by SQLGlot (e.g. in the optimizer)."""
-
 
 def tokenize(sql: str, read: DialectType = None, dialect: DialectType = None) -> t.List[Token]:
     """

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import inspect
 import typing as t
 
-import sqlglot
 from sqlglot import Schema, exp
 from sqlglot.dialects.dialect import DialectType
 from sqlglot.optimizer.annotate_types import annotate_types
@@ -72,7 +71,7 @@ def optimize(
     Returns:
         The optimized expression.
     """
-    schema = ensure_schema(schema or sqlglot.schema, dialect=dialect)
+    schema = ensure_schema(schema, dialect=dialect)
     possible_kwargs = {
         "db": db,
         "catalog": catalog,

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -81,7 +81,6 @@ def qualify(
             expand_alias_refs=expand_alias_refs,
             expand_stars=expand_stars,
             infer_schema=infer_schema,
-            dialect=dialect,
         )
 
     if quote_identifiers:

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -81,6 +81,7 @@ def qualify(
             expand_alias_refs=expand_alias_refs,
             expand_stars=expand_stars,
             infer_schema=infer_schema,
+            dialect=dialect,
         )
 
     if quote_identifiers:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -550,7 +550,7 @@ def _expand_stars(
                 tables = [expression.table]
                 _add_except_columns(expression.this, tables, except_columns)
                 _add_replace_columns(expression.this, tables, replace_columns)
-            elif dialect == "bigquery":
+            elif is_bigquery:
                 struct_fields = _expand_struct_stars(expression, next_alias_name)
                 if struct_fields:
                     new_selections.extend(struct_fields)

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -53,7 +53,7 @@ def qualify_columns(
     infer_schema = schema.empty if infer_schema is None else infer_schema
     dialect = Dialect.get_or_raise(schema.dialect)
     pseudocolumns = dialect.PSEUDOCOLUMNS
-    next_alias_name = name_sequence("_field_")
+    next_alias_name = name_sequence("_f_")
 
     for scope in traverse_scope(expression):
         resolver = Resolver(scope, schema, infer_schema=infer_schema)
@@ -472,7 +472,7 @@ def _expand_struct_stars(
         ]
 
         if not fld.kind.is_type(exp.DataType.Type.STRUCT):
-            # Collect the non-struct columns
+            # Collect the nested non-struct fields
             fld_keys.append(fld_id)
         else:
             stack.extend((expr, fld_id) for expr in reversed(fld.kind.expressions))

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -430,7 +430,6 @@ def _expand_struct_stars(
     # If we're expanding a nested struct (eg. t.c.f1.f2.*), start the DFS traversal from that struct
     for part in dot_parts[1:]:
         struct_fields = t.cast(exp.DataType, starting_struct.kind).expressions
-        part_found = False
 
         if not struct_fields:
             return []
@@ -442,10 +441,9 @@ def _expand_struct_stars(
 
             if fld.name == part.name and fld.kind.is_type(exp.DataType.Type.STRUCT):
                 starting_struct = fld
-                part_found = True
                 break
-
-        if not part_found:
+        else:
+            # There is no matching field in the struct
             return []
 
     # Each nested field caches its path in exp.Identifier parts e.g. tbl.f0.f1.item -> [exp.Identifier(tbl), ..., exp.Identifier(item)]

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -439,7 +439,7 @@ def _expand_struct_stars(
             if not isinstance(fld.this, exp.Identifier):
                 return []
 
-            if fld.name == part.name and fld.kind.this == exp.DataType.Type.STRUCT:
+            if fld.name == part.name and fld.kind.is_type(exp.DataType.Type.STRUCT):
                 starting_struct = fld
 
     if starting_struct.name != dot_parts[-1].name:
@@ -486,12 +486,8 @@ def _expand_struct_stars(
                 [part.copy() for part in dot_parts[:-1]], nested_fields[nested_fields_key]
             )
         )
-        new_column: exp.Column | exp.Dot = exp.column(
-            t.cast(exp.Identifier, root), table=dot_column.table
-        )
 
-        if parts:
-            new_column = exp.Dot.build([new_column, *parts])
+        new_column = exp.column(t.cast(exp.Identifier, root), table=dot_column.table, fields=parts)
 
         new_selections.append(alias(new_column, next_alias_name(), copy=False))
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -127,7 +127,9 @@ class Scope:
             if node is self.expression:
                 continue
 
-            if isinstance(node, exp.Column):
+            if isinstance(node, exp.Dot) and node.is_star:
+                self._stars.append(node)
+            elif isinstance(node, exp.Column):
                 if isinstance(node.this, exp.Star):
                     self._stars.append(node)
                 else:

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -239,12 +239,9 @@ class Scope:
         return self._subqueries
 
     @property
-    def stars(self):
+    def stars(self) -> t.List[exp.Column | exp.Dot]:
         """
-        List of star columns in this scope.
-
-        Returns:
-            list[exp.Column]: Column instances in this scope that are a star.
+        List of star expressions (columns or dots) in this scope.
         """
         self._ensure_collected()
         return self._stars

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -317,17 +317,17 @@ SELECT s.b AS b FROM (SELECT t1.b AS b FROM t1 AS t1 UNION ALL SELECT t2.b AS b 
 # dialect: bigquery
 # execute: false
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col) SELECT tbl1.col.*, tbl2.col.* FROM tbl1, tbl2;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS _field_0, tbl1.col.col2 AS _field_1, tbl1.col.lvl1.col1 AS _field_2, tbl1.col.lvl1.lvl2.col2 AS _field_3, tbl2.col.col1 AS _field_4, tbl2.col.col2 AS _field_5, tbl2.col.lvl1.col1 AS _field_6, tbl2.col.lvl1.lvl2.col2 AS _field_7 FROM tbl1 AS tbl1, tbl2 AS tbl2;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS _f_0, tbl1.col.col2 AS _f_1, tbl1.col.lvl1.col1 AS _f_2, tbl1.col.lvl1.lvl2.col2 AS _f_3, tbl2.col.col1 AS _f_4, tbl2.col.col2 AS _f_5, tbl2.col.lvl1.col1 AS _f_6, tbl2.col.lvl1.lvl2.col2 AS _f_7 FROM tbl1 AS tbl1, tbl2 AS tbl2;
 
 # dialect: bigquery
 # execute: false
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.* from tbl1;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.col1 AS _field_0, tbl1.col.lvl1.lvl2.col2 AS _field_1 FROM tbl1 AS tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.col1 AS _f_0, tbl1.col.lvl1.lvl2.col2 AS _f_1 FROM tbl1 AS tbl1;
 
 # dialect: bigquery
 # execute: false
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.* from tbl1;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.col1 AS _field_0, tbl1.col.col2 AS _field_1, tbl1.col.lvl1.col1 AS _field_2, tbl1.col.lvl1.lvl2.col2 AS _field_3, tbl1.col.col3 AS _field_4 FROM tbl1 AS tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.col1 AS _f_0, tbl1.col.col2 AS _f_1, tbl1.col.lvl1.col1 AS _f_2, tbl1.col.lvl1.lvl2.col2 AS _f_3, tbl1.col.col3 AS _f_4 FROM tbl1 AS tbl1;
 
 # dialect: bigquery
 # execute: false

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -319,11 +319,15 @@ SELECT s.b AS b FROM (SELECT t1.b AS b FROM t1 AS t1 UNION ALL SELECT t2.b AS b 
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col) SELECT tbl1.col.*, tbl2.col.* FROM tbl1, tbl2;
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS _field_0, tbl1.col.col2 AS _field_1, tbl1.col.lvl1.col1 AS _field_2, tbl1.col.lvl1.lvl2.col2 AS _field_3, tbl2.col.col1 AS _field_4, tbl2.col.col2 AS _field_5, tbl2.col.lvl1.col1 AS _field_6, tbl2.col.lvl1.lvl2.col2 AS _field_7 FROM tbl1 AS tbl1, tbl2 AS tbl2;
 
+# dialect: bigquery
+# execute: false
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.* from tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.col1 AS _field_0, tbl1.col.lvl1.lvl2.col2 AS _field_1 FROM tbl1 AS tbl1;
 
 # dialect: bigquery
 # execute: false
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col) SELECT tbl1.col.lvl1.* from tbl1;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.lvl1.col1 AS _field_0, tbl1.col.lvl1.lvl2.col2 AS _field_1 FROM tbl1 AS tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.* from tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.col1 AS _field_0, tbl1.col.col2 AS _field_1, tbl1.col.lvl1.col1 AS _field_2, tbl1.col.lvl1.lvl2.col2 AS _field_3, tbl1.col.col3 AS _field_4 FROM tbl1 AS tbl1;
 
 --------------------------------------
 -- CTEs

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -329,6 +329,12 @@ WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.* from tbl1;
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.col1 AS _field_0, tbl1.col.col2 AS _field_1, tbl1.col.lvl1.col1 AS _field_2, tbl1.col.lvl1.lvl2.col2 AS _field_3, tbl1.col.col3 AS _field_4 FROM tbl1 AS tbl1;
 
+# dialect: bigquery
+# execute: false
+# title: Cannot expand struct star with unnamed fields
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.col.* FROM tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.col.* FROM tbl1 AS tbl1;
+
 --------------------------------------
 -- CTEs
 --------------------------------------

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -314,6 +314,17 @@ SELECT s.a AS a, s.b AS b FROM (SELECT t.a AS a, t.b AS b FROM t AS t) AS s;
 SELECT * FROM (SELECT * FROM t1 UNION ALL SELECT * FROM t2) AS s(b);
 SELECT s.b AS b FROM (SELECT t1.b AS b FROM t1 AS t1 UNION ALL SELECT t2.b AS b FROM t2 AS t2) AS s;
 
+# dialect: bigquery
+# execute: false
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col) SELECT tbl1.col.*, tbl2.col.* FROM tbl1, tbl2;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS _field_0, tbl1.col.col2 AS _field_1, tbl1.col.lvl1.col1 AS _field_2, tbl1.col.lvl1.lvl2.col2 AS _field_3, tbl2.col.col1 AS _field_4, tbl2.col.col2 AS _field_5, tbl2.col.lvl1.col1 AS _field_6, tbl2.col.lvl1.lvl2.col2 AS _field_7 FROM tbl1 AS tbl1, tbl2 AS tbl2;
+
+
+# dialect: bigquery
+# execute: false
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col) SELECT tbl1.col.lvl1.* from tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.lvl1.col1 AS _field_0, tbl1.col.lvl1.lvl2.col2 AS _field_1 FROM tbl1 AS tbl1;
+
 --------------------------------------
 -- CTEs
 --------------------------------------

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -342,6 +342,18 @@ class TestOptimizer(unittest.TestCase):
                     )
                     optimizer.qualify_columns.validate_qualify_columns(expression)
 
+        # Cannot expand star as not all nested structs are aliased
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(
+                    "WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.col.* FROM tbl1",
+                    read="bigquery",
+                ),
+                dialect="bigquery",
+            ).sql(dialect="bigquery"),
+            "WITH `tbl1` AS (SELECT STRUCT(1 AS `col1`, Struct(5 AS `col1`)) AS `col`) SELECT `tbl1`.`col`.* FROM `tbl1` AS `tbl1`",
+        )
+
     def test_normalize_identifiers(self):
         self.check_file(
             "normalize_identifiers",

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -317,6 +317,18 @@ class TestOptimizer(unittest.TestCase):
             'WITH "t" AS (SELECT 1 AS "c") (SELECT "t"."c" AS "c" FROM "t" AS "t")',
         )
 
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
+                parse_one(
+                    "WITH tbl1 AS (SELECT STRUCT(1 AS `f0`, 2 as f1) AS col) SELECT tbl1.col.* from tbl1",
+                    dialect="bigquery",
+                ),
+                schema=MappingSchema(schema=None, dialect="bigquery"),
+                infer_schema=False,
+            ).sql(dialect="bigquery"),
+            "WITH tbl1 AS (SELECT STRUCT(1 AS `f0`, 2 AS f1) AS col) SELECT tbl1.col.`f0` AS _field_0, tbl1.col.f1 AS _field_1 FROM tbl1",
+        )
+
         self.check_file(
             "qualify_columns", qualify_columns, execute=True, schema=self.schema, set_dialect=True
         )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -342,18 +342,6 @@ class TestOptimizer(unittest.TestCase):
                     )
                     optimizer.qualify_columns.validate_qualify_columns(expression)
 
-        # Cannot expand star as not all nested structs are aliased
-        self.assertEqual(
-            optimizer.qualify.qualify(
-                parse_one(
-                    "WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.col.* FROM tbl1",
-                    read="bigquery",
-                ),
-                dialect="bigquery",
-            ).sql(dialect="bigquery"),
-            "WITH `tbl1` AS (SELECT STRUCT(1 AS `col1`, Struct(5 AS `col1`)) AS `col`) SELECT `tbl1`.`col`.* FROM `tbl1` AS `tbl1`",
-        )
-
     def test_normalize_identifiers(self):
         self.check_file(
             "normalize_identifiers",

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -326,7 +326,7 @@ class TestOptimizer(unittest.TestCase):
                 schema=MappingSchema(schema=None, dialect="bigquery"),
                 infer_schema=False,
             ).sql(dialect="bigquery"),
-            "WITH tbl1 AS (SELECT STRUCT(1 AS `f0`, 2 AS f1) AS col) SELECT tbl1.col.`f0` AS _field_0, tbl1.col.f1 AS _field_1 FROM tbl1",
+            "WITH tbl1 AS (SELECT STRUCT(1 AS `f0`, 2 AS f1) AS col) SELECT tbl1.col.`f0` AS _f_0, tbl1.col.f1 AS _f_1 FROM tbl1",
         )
 
         self.check_file(


### PR DESCRIPTION
Fixes #3484

BigQuery supports star expansion such as `foo.bar.*` where `foo` is the table and `bar` is a struct. This is essentially a  _flatten_ operation from the specified struct and down. For example, if `bar` has a nested struct `baz`, then `foo.bar.baz.*` would cause a flatten from `baz` downwards.

In order to replicate this behavior, a DFS traversal starting from the top-level struct gathers the non-struct fields and enqueues the nested structs (if any). At every point, a name / fully qualified path is kept and prefixes the fields at that level. 

**Note**: If any nested field is _not_ aliased, then the star expansion is stopped and the star` is preserved; This is because BigQuery will alias these fields dynamically so it's not possible to qualify/target these fields statically afaict.

An example:

```
Schema
-----------
foo: 'bar' STRUCT<'f0' STRING, 'baz' STRUCT<'f1' STRING>>

Query
--------
SELECT foo.bar.* FROM foo;

Star Expansion
------------
1. Enqueue the top level struct which is bar. Current path is initiazed as empty string
2. Pop the stack's top item and (1) qualify it with the current path name if it's a field or (2) append it to the stack if it's a nested struct.
3. Pop the next item if any, repeat 2

Result
-------
SELECT foo.bar.f0, foo.bar.baz.f1 FROM foo;
```


Docs
--------
- [BigQuery Star Selection](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_expression_star)