### PR TITLE
Add GitPod Config to simplify the contributor workflow

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,13 @@
+image: gitpod/workspace-python-3.11
+tasks:
+  - name: sqlglot
+    init: |
+      python -m venv .venv
+      source .venv/bin/activate
+      make install-dev
+
+    command: |
+      clear
+      source .venv/bin/activate
+
+


### PR DESCRIPTION
# Context
I encounter some frictions when I try to setup the environment. I tend to use Cloud Development Environment for other open source projects for a few reasons:
1. I don't remember which virtual env works
2. I sometimes work on different computers so I don't have the copies

This PR add a GitPod configuration (similar to .devcontainer for Github Codespace)

# Development Notes:
- I set the default image as Python 3.11 as I get error related to `setuptools_scm` with Python 3.12 (which is the default and latest support Python version)

Optionally I can also update the `Contributor.md`, but I want to know if you want to accept this PR or not first.