### PR TITLE
Feat: add support for ALTER COLUMN DROP NOT NULL

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,13 @@
+image: gitpod/workspace-python-3.11
+tasks:
+  - name: sqlglot
+    init: |
+      python -m venv .venv
+      source .venv/bin/activate
+      make install-dev
+
+    command: |
+      clear
+      source .venv/bin/activate
+
+

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1632,6 +1632,7 @@ class AlterColumn(Expression):
         "default": False,
         "drop": False,
         "comment": False,
+        "expression": False
     }
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1632,7 +1632,7 @@ class AlterColumn(Expression):
         "default": False,
         "drop": False,
         "comment": False,
-        "expression": False
+        "allow_null": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3028,7 +3028,7 @@ class Generator(metaclass=_Generator):
         if not drop and not allow_null:
             self.unsupported("Unsupported ALTER COLUMN syntax")
 
-        if allow_null:
+        if allow_null is not None:
             keyword = "DROP" if drop else "SET"
             return f"ALTER COLUMN {this} {keyword} NOT NULL"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3022,6 +3022,10 @@ class Generator(metaclass=_Generator):
         if comment:
             return f"ALTER COLUMN {this} COMMENT {comment}"
 
+        allow_null = self.sql(expression, "allow_null")
+        if allow_null:
+            nullability = "SET" if allow_null == "NOT NULL" else "DROP"
+            return f"ALTER COLUMN {this} {nullability} NOT NULL"
         if not expression.args.get("drop"):
             self.unsupported("Unsupported ALTER COLUMN syntax")
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3022,12 +3022,15 @@ class Generator(metaclass=_Generator):
         if comment:
             return f"ALTER COLUMN {this} COMMENT {comment}"
 
-        allow_null = self.sql(expression, "allow_null")
-        if allow_null:
-            nullability = "SET" if allow_null == "NOT NULL" else "DROP"
-            return f"ALTER COLUMN {this} {nullability} NOT NULL"
-        if not expression.args.get("drop"):
+        allow_null = expression.args.get("allow_null")
+        drop = expression.args.get("drop")
+
+        if not drop and not allow_null:
             self.unsupported("Unsupported ALTER COLUMN syntax")
+
+        if allow_null:
+            keyword = "DROP" if drop else "SET"
+            return f"ALTER COLUMN {this} {keyword} NOT NULL"
 
         return f"ALTER COLUMN {this} DROP DEFAULT"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6055,15 +6055,18 @@ class Parser(metaclass=_Parser):
             return self.expression(exp.AlterColumn, this=column, default=self._parse_conjunction())
         if self._match(TokenType.COMMENT):
             return self.expression(exp.AlterColumn, this=column, comment=self._parse_string())
-        if self._match_text_seq("DROP", "NOT" ,"NULL"):
-            return self.expression(exp.AlterColumn,
-                                   this=column,
-                                drop=True,
-                                   expression=exp.NotNullColumnConstraint)
-        if self._match_text_seq("SET", "NOT" ,"NULL"):
-            return self.expression(exp.AlterColumn,
-                                   this=column,
-                                   expression=exp.NotNullColumnConstraint)
+        if self._match_text_seq("DROP", "NOT", "NULL"):
+            return self.expression(
+                exp.AlterColumn,
+                this=column,
+                allow_null=exp.NotNullColumnConstraint(allow_null=True),
+            )
+        if self._match_text_seq("SET", "NOT", "NULL"):
+            return self.expression(
+                exp.AlterColumn,
+                this=column,
+                allow_null=exp.NotNullColumnConstraint(allow_null=False),
+            )
         self._match_text_seq("SET", "DATA")
         self._match_text_seq("TYPE")
         return self.expression(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6059,13 +6059,14 @@ class Parser(metaclass=_Parser):
             return self.expression(
                 exp.AlterColumn,
                 this=column,
-                allow_null=exp.NotNullColumnConstraint(allow_null=True),
+                drop=True,
+                allow_null=True,
             )
         if self._match_text_seq("SET", "NOT", "NULL"):
             return self.expression(
                 exp.AlterColumn,
                 this=column,
-                allow_null=exp.NotNullColumnConstraint(allow_null=False),
+                allow_null=False,
             )
         self._match_text_seq("SET", "DATA")
         self._match_text_seq("TYPE")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6055,7 +6055,15 @@ class Parser(metaclass=_Parser):
             return self.expression(exp.AlterColumn, this=column, default=self._parse_conjunction())
         if self._match(TokenType.COMMENT):
             return self.expression(exp.AlterColumn, this=column, comment=self._parse_string())
-
+        if self._match_text_seq("DROP", "NOT" ,"NULL"):
+            return self.expression(exp.AlterColumn,
+                                   this=column,
+                                drop=True,
+                                   expression=exp.NotNullColumnConstraint)
+        if self._match_text_seq("SET", "NOT" ,"NULL"):
+            return self.expression(exp.AlterColumn,
+                                   this=column,
+                                   expression=exp.NotNullColumnConstraint)
         self._match_text_seq("SET", "DATA")
         self._match_text_seq("TYPE")
         return self.expression(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1282,6 +1282,13 @@ WHERE
             read={"teradata": "CREATE MULTISET TABLE a (b INT)"},
             write={"snowflake": "CREATE TABLE a (b INT)"},
         )
+        self.validate_all(
+            """
+                ALTER TABLE a
+                ALTER COLUMN my_column DROP NOT NULL;
+            """,
+            write={"duckdb": "ALTER TABLE a ALTER COLUMN my_column DROP NOT NULL"},
+        )
 
     def test_user_defined_functions(self):
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1287,7 +1287,11 @@ WHERE
                 ALTER TABLE a
                 ALTER COLUMN my_column DROP NOT NULL;
             """,
-            write={"duckdb": "ALTER TABLE a ALTER COLUMN my_column DROP NOT NULL"},
+            write={
+                "snowflake": "ALTER TABLE a ALTER COLUMN my_column DROP NOT NULL",
+                "duckdb": "ALTER TABLE a ALTER COLUMN my_column DROP NOT NULL",
+                "postgres": "ALTER TABLE a ALTER COLUMN my_column DROP NOT NULL",
+            },
         )
 
     def test_user_defined_functions(self):


### PR DESCRIPTION
fix: #3534 
Context:
```python
class AlterColumn(Expression):
    arg_types = {
        "this": True,
        "dtype": False,
        "collate": False,
        "using": False,
        "default": False,
        "drop": False,
        "comment": False,

    }
```

The existing `AlterColumn` expression seems to assume only `SET DEFAULT ` and `NOT DEFAULT` is possible. Therefore is `drop` is True is sufficient to represent `DROP DEFAULT` and when `default` is not null it means set default. This seems to be insufficient to handle statement like `DROP NOT NULL` and `SET NOT NULL`

Few questions:
-  there are many `_match_xxx` functions, is `_match_text_seq` the most suitable one?
- I don't know if I should use things like `_parse_not_constraints` here.
- I figured I should edit the `AlterColumn` expression, but I am not sure how to add a new type for `SET NOT NULL` and `DROP NOT NULL`. I found there are `NotNullColumnConstrains`. I take a look at other expression and I thought adding a new optional arg_type `expression` seems to best fit.

# Test
Reuse the original issue example.

This is expected to work
```python
ast = parse_one(sql, read="spark")
ast.sql(write="duckdb")
```

Duckdb Syntax: https://duckdb.org/docs/sql/statements/alter_table.html
Snowflake Syntax: https://docs.snowflake.com/en/sql-reference/sql/alter-table-column