### PR TITLE
Fix(postgres): setting un-suffixed FLOAT as DOUBLE (#3551)

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -336,6 +336,7 @@ class Postgres(Dialect):
             "REGPROCEDURE": TokenType.OBJECT_IDENTIFIER,
             "REGROLE": TokenType.OBJECT_IDENTIFIER,
             "REGTYPE": TokenType.OBJECT_IDENTIFIER,
+            "FLOAT": TokenType.DOUBLE,
         }
 
         SINGLE_TOKENS = {

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -717,6 +717,9 @@ class TestPostgres(Validator):
         self.validate_identity(
             "COPY (SELECT * FROM t) TO 'file' WITH (FORMAT format, HEADER MATCH, FREEZE TRUE)"
         )
+        self.validate_identity("cast(a as FLOAT)", "CAST(a AS DOUBLE PRECISION)")
+        self.validate_identity("cast(a as FLOAT8)", "CAST(a AS DOUBLE PRECISION)")
+        self.validate_identity("cast(a as FLOAT4)", "CAST(a AS REAL)")
 
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier


### PR DESCRIPTION
fix #3551 
Redshift inherits from Postgres and hence haven't added any testcases to Redshift.