### PR TITLE
Fix(tsql): adapt TimeStrToTime to avoid superfluous casts

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -17,7 +17,6 @@ from sqlglot.dialects.dialect import (
     min_or_least,
     build_date_delta,
     rename_func,
-    timestrtotime_sql,
     trim_sql,
 )
 from sqlglot.helper import seq_get
@@ -835,7 +834,9 @@ class TSQL(Dialect):
                 "HASHBYTES", exp.Literal.string(f"SHA2_{e.args.get('length', 256)}"), e.this
             ),
             exp.TemporaryProperty: lambda self, e: "",
-            exp.TimeStrToTime: lambda self, e: self.sql(exp.cast(e.this, exp.DataType.Type.DATETIME)),
+            exp.TimeStrToTime: lambda self, e: self.sql(
+                exp.cast(e.this, exp.DataType.Type.DATETIME)
+            ),
             exp.TimeToStr: _format_sql,
             exp.Trim: trim_sql,
             exp.TsOrDsAdd: date_delta_sql("DATEADD", cast=True),

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -835,7 +835,7 @@ class TSQL(Dialect):
                 "HASHBYTES", exp.Literal.string(f"SHA2_{e.args.get('length', 256)}"), e.this
             ),
             exp.TemporaryProperty: lambda self, e: "",
-            exp.TimeStrToTime: timestrtotime_sql,
+            exp.TimeStrToTime: lambda self, e: self.sql(exp.cast(e.this, exp.DataType.Type.DATETIME)),
             exp.TimeToStr: _format_sql,
             exp.Trim: trim_sql,
             exp.TsOrDsAdd: date_delta_sql("DATEADD", cast=True),


### PR DESCRIPTION
This is regarding SQLMesh issue: [#2672](https://github.com/TobikoData/sqlmesh/issues/2672)
where running `sqlmesh format`  a few times in the tsql dialect adds superfluous casts. 

This is due to the casting of `timestrtotime_sql`  to `TIMESTAMP` instead of `DATETIME` and this fix addresses it by with a lambda function that sets the type to DATETIME instead.