### PR TITLE
Feat: add option in schema's find method to ensure types are DataTypes

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -303,3 +303,10 @@ class TestSchema(unittest.TestCase):
         schema = MappingSchema({"x": {"c": "int"}})
         self.assertTrue(schema.has_column("x", exp.column("c")))
         self.assertFalse(schema.has_column("x", exp.column("k")))
+
+    def test_find(self):
+        schema = MappingSchema({"x": {"c": "int"}})
+        found = schema.find(exp.to_table("x"))
+        self.assertEqual(found, {"c": "int"})
+        found = schema.find(exp.to_table("x"), ensure_data_types=True)
+        self.assertEqual(found, {"c": exp.DataType.build("int")})


### PR DESCRIPTION
The motivation behind this is that in SQLMesh we have a mapping schema where types are stored as strings, but [we need them](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/macros.py#L405-L420) to be `DataType`s instead.

I added this here instead of in SQLMesh to leverage the existing in-memory `DataType` cache [used](https://github.com/tobymao/sqlglot/blob/main/sqlglot/schema.py#L447-L448) in the `MappingSchema` definition.