### PR TITLE
Refactor: get rid of redundant dict_depth check in schema find

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -248,7 +248,7 @@ class MappingSchema(AbstractMappingSchema, Schema):
         schema = super().find(
             table, raise_on_missing=raise_on_missing, ensure_data_types=ensure_data_types
         )
-        if ensure_data_types and isinstance(schema, dict) and dict_depth(schema) == 1:
+        if ensure_data_types and isinstance(schema, dict):
             schema = {
                 col: self._to_data_type(dtype) if isinstance(dtype, str) else dtype
                 for col, dtype in schema.items()


### PR DESCRIPTION
The `AbstractMappingSchema.find` implementation [guarantees](https://github.com/tobymao/sqlglot/blob/main/sqlglot/schema.py#L178-L187) that we'll end up with a dictionary of depth 1, so the `dict_depth` call was unnecessary.