### PR TITLE
Fix(parser): edge case where TYPE_CONVERTERS leads to type instead of column

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4199,9 +4199,19 @@ class Parser(metaclass=_Parser):
 
                 return self.expression(exp.Cast, this=this, to=data_type)
 
-            # We may have set `expressions` using the `TYPE_CONVERTERS` mapping, in which
-            # case we shouldn't really move on with the data type, but instead retreat to
-            # parse a column reference; the index difference is used as a proxy to detect this
+            # The `expressions` arg gets set by the parser when we have something like DECIMAL(38, 0)
+            # in the input SQL. In that case, we'll produce these tokens: DECIMAL ( 38 , 0 )
+            #
+            # If the index difference here is greater than 1, that means the parser itself must have
+            # consumed additional tokens such as the DECIMAL's scale and precision in the above example.
+            #
+            # If it's not greater than 1, then it must be 1, because we've consumed at least the type
+            # keyword, meaning that the `expressions` arg of the `DataType` must have gotten set by a
+            # callable in the `TYPE_CONVERTERS` mapping. For example, Snowflake converts `DECIMAL` to
+            # `DECIMAL(38, 0))` in order to facilitate the data type's transpilation.
+            #
+            # In these cases, we don't really want to return the converted type, but instead retreat
+            # and try to parse a `Column` or `Identifier` in the section below.
             if data_type.expressions and self._index - index > 1:
                 self._retreat(index2)
                 return self._parse_column_ops(data_type)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4199,7 +4199,10 @@ class Parser(metaclass=_Parser):
 
                 return self.expression(exp.Cast, this=this, to=data_type)
 
-            if data_type.expressions:
+            # We may have set `expressions` using the `TYPE_CONVERTERS` mapping, in which
+            # case we shouldn't really move on with the data type, but instead retreat to
+            # parse a column reference; the index difference is used as a proxy to detect this
+            if data_type.expressions and self._index - index > 1:
                 self._retreat(index2)
                 return self._parse_column_ops(data_type)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4199,19 +4199,19 @@ class Parser(metaclass=_Parser):
 
                 return self.expression(exp.Cast, this=this, to=data_type)
 
-            # The `expressions` arg gets set by the parser when we have something like DECIMAL(38, 0)
+            # The expressions arg gets set by the parser when we have something like DECIMAL(38, 0)
             # in the input SQL. In that case, we'll produce these tokens: DECIMAL ( 38 , 0 )
             #
             # If the index difference here is greater than 1, that means the parser itself must have
-            # consumed additional tokens such as the DECIMAL's scale and precision in the above example.
+            # consumed additional tokens such as the DECIMAL scale and precision in the above example.
             #
             # If it's not greater than 1, then it must be 1, because we've consumed at least the type
-            # keyword, meaning that the `expressions` arg of the `DataType` must have gotten set by a
-            # callable in the `TYPE_CONVERTERS` mapping. For example, Snowflake converts `DECIMAL` to
-            # `DECIMAL(38, 0))` in order to facilitate the data type's transpilation.
+            # keyword, meaning that the expressions arg of the DataType must have gotten set by a
+            # callable in the TYPE_CONVERTERS mapping. For example, Snowflake converts DECIMAL to
+            # DECIMAL(38, 0)) in order to facilitate the data type's transpilation.
             #
             # In these cases, we don't really want to return the converted type, but instead retreat
-            # and try to parse a `Column` or `Identifier` in the section below.
+            # and try to parse a Column or Identifier in the section below.
             if data_type.expressions and self._index - index > 1:
                 self._retreat(index2)
                 return self._parse_column_ops(data_type)

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -48,6 +48,7 @@ WHERE
   )""",
         )
 
+        self.validate_identity("SELECT number").selects[0].assert_is(exp.Column)
         self.validate_identity("INTERVAL '4 years, 5 months, 3 hours'")
         self.validate_identity("ALTER TABLE table1 CLUSTER BY (name DESC)")
         self.validate_identity("SELECT rename, replace")


### PR DESCRIPTION
Fixes #3565. This was a bit tricky.

Current behavior in main:

```python
>>> import sqlglot
>>> sqlglot.parse_one("select number", "snowflake")
Select(
  expressions=[
    DataType(
      this=Type.DECIMAL,
      expressions=[
        DataTypeParam(
          this=Literal(this=38, is_string=False)),
        DataTypeParam(
          this=Literal(this=0, is_string=False))],
      nested=False)])
```

In this PR:

```python
>>> import sqlglot
>>> sqlglot.parse_one("select number", "snowflake")
Select(
  expressions=[
    Column(
      this=Identifier(this=number, quoted=False))])
```

The reason we get a `DataType` node in the main branch is because `_parse_types` now [returns](https://github.com/tobymao/sqlglot/blob/main/sqlglot/parser.py#L4397-L4402) a `DECIMAL` type whose `expressions` arg gets set by the corresponding [snowflake type converter](https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/snowflake.py#L451). Moreover, for some reason we're using the existence of `expressions` in `_parse_type` as a proxy for [whether to return the data type](https://github.com/tobymao/sqlglot/blob/main/sqlglot/parser.py#L4202-L4204) vs retreating to parse a column.

This fix is a bit hacky in order to preserve the behavior as much as possible without altering the parser in a significant way.