### PR TITLE
fix(optimizer)!: Refactor struct star expansion in BQ

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -424,7 +424,6 @@ def _expand_struct_stars(
     # First part is the table name and last part is the star so they can be dropped
     dot_parts = expression.parts[1:-1]
 
-
     # If we're expanding a nested struct eg. t.c.f1.f2.* find the last struct (f2 in this case)
     for part in dot_parts[1:]:
         for field in t.cast(exp.DataType, starting_struct.kind).expressions:

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -319,24 +319,25 @@ SELECT s.b AS b FROM (SELECT t1.b AS b FROM t1 AS t1 UNION ALL SELECT t2.b AS b 
 
 # dialect: bigquery
 # execute: false
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) as lvl1) as col) SELECT tbl1.col.*, tbl2.col.* FROM tbl1, tbl2;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS _f_0, tbl1.col.col2 AS _f_1, tbl1.col.lvl1.col1 AS _f_2, tbl1.col.lvl1.lvl2.col2 AS _f_3, tbl2.col.col1 AS _f_4, tbl2.col.col2 AS _f_5, tbl2.col.lvl1.col1 AS _f_6, tbl2.col.lvl1.lvl2.col2 AS _f_7 FROM tbl1 AS tbl1, tbl2 AS tbl2;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.*, tbl2.col.* FROM tbl1, tbl2;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS col1, tbl1.col.col2 AS col2, tbl1.col.lvl1 AS lvl1, tbl2.col.col1 AS col1, tbl2.col.col2 AS col2, tbl2.col.lvl1 AS lvl1 FROM tbl1 AS tbl1, tbl2 AS tbl2;
 
 # dialect: bigquery
 # execute: false
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.* from tbl1;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.col1 AS _f_0, tbl1.col.lvl1.lvl2.col2 AS _f_1 FROM tbl1 AS tbl1;
-
-# dialect: bigquery
-# execute: false
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) as lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.* from tbl1;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.col1 AS _f_0, tbl1.col.col2 AS _f_1, tbl1.col.lvl1.col1 AS _f_2, tbl1.col.lvl1.lvl2.col2 AS _f_3, tbl1.col.col3 AS _f_4 FROM tbl1 AS tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.* FROM tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1, 3 AS col3) AS col) SELECT tbl1.col.lvl1.col1 AS col1, tbl1.col.lvl1.lvl2 AS lvl2 FROM tbl1 AS tbl1;
 
 # dialect: bigquery
 # execute: false
 # title: Cannot expand struct star with unnamed fields
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.col.* FROM tbl1;
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.col.* FROM tbl1 AS tbl1;
+
+# dialect: bigquery
+# execute: false
+# title: Cannot expand struct star with ambiguous fields
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col1) AS col) SELECT tbl1.col.* FROM tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col1) AS col) SELECT tbl1.col.* FROM tbl1 AS tbl1;
 
 --------------------------------------
 -- CTEs

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -326,7 +326,7 @@ class TestOptimizer(unittest.TestCase):
                 schema=MappingSchema(schema=None, dialect="bigquery"),
                 infer_schema=False,
             ).sql(dialect="bigquery"),
-            "WITH tbl1 AS (SELECT STRUCT(1 AS `f0`, 2 AS f1) AS col) SELECT tbl1.col.`f0` AS _f_0, tbl1.col.f1 AS _f_1 FROM tbl1",
+            "WITH tbl1 AS (SELECT STRUCT(1 AS `f0`, 2 AS f1) AS col) SELECT tbl1.col.`f0` AS `f0`, tbl1.col.f1 AS f1 FROM tbl1",
         )
 
         self.check_file(


### PR DESCRIPTION
Let's assume we want to expand the following struct:

```
WITH
   tbl1 AS (SELECT STRUCT(1 AS fld1, Struct(3 AS fld2, Struct(4 AS fld3) AS lvl2) AS lvl1) AS col)
SELECT col.* FROM tbl1;
```

The recently merged PR would essentially flatten the struct by exploding the fields through a DFS traversal, i.e it would produce:

```
WITH
   tbl1 AS (...) # redacted CTE, same as initial query
SELECT tbl1.col.fld1 AS _f_0, 
       tbl1.col.lvl1.fld2 AS _f_2,
       tbl1.col.lvl1.lvl2.fld3 AS _f_3,
FROM tbl1
```

Even though the results are similar to what would be produced from the initial query, internally BigQuery only has to expand [the _top level_ expression](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_expression_star) and the rest of the "flattening" is performed implicitly; This is semantically equivalent to:

```
WITH
   tbl1 AS (...)
SELECT tbl1.col.fld1 AS fld1, 
       tbl1.col.lvl1 AS lvl1 
FROM tbl1
```

By changing our algorithm to perform the latter we completely remove the DFS struct traversal. Not only that, but it turns out that our `_f_` alias generation can break queries from being qualified; The following query can showcase this behavior:

```
WITH
  tbl1 AS (SELECT STRUCT(1 AS fld1, Struct(3 AS fld2, Struct(4 AS fld3) AS lvl2) AS lvl1) AS col),
  tbl2 AS (SELECT col.* FROM tbl1)
SELECT lvl1 FROM tbl2
```

In main, due to our custom `_f_` aliasing, `qualify` fails with:
```
sqlglot.errors.OptimizeError: Column '"lvl1"' could not be resolved
```

However, in this PR, `qualify` succeeds (the names are now preserved instead of generating a custom alias) and results to:
```
WITH 
`tbl1` AS (SELECT STRUCT(1 AS `fld1`, Struct(3 AS `fld2`, Struct(4 AS `fld3`) AS `lvl2`) AS `lvl1`) AS `col`), 
`tbl2` AS (SELECT `tbl1`.`col`.`fld1` AS `fld1`, `tbl1`.`col`.`lvl1` AS `lvl1` FROM `tbl1` AS `tbl1`) 
SELECT 
  `tbl2`.`lvl1` AS `lvl1` FROM `tbl2` AS `tbl2`
```
