### PR TITLE
eliminate-join-marks

### DIFF
--- a/sqlglot/optimizer/eliminate_join_marks.py
+++ b/sqlglot/optimizer/eliminate_join_marks.py
@@ -1,0 +1,180 @@
+import typing as t
+import copy
+
+from sqlglot import expressions as exp
+
+
+def _update_from(
+    select: exp.Select,
+    new_join_dict: t.Dict[str, exp.Join],
+    old_join_dict: t.Dict[str, exp.Join],
+):
+    """If the from clause needs to become a new join, find an appropriate table to use as the new from.
+    updates select in place
+
+    Args:
+        select (exp.Select): The select statement to update
+        new_join_dict (Dict[str, exp.Join]): The dictionary of new joins
+        old_join_dict (Dict[str, exp.Join]): The dictionary of old joins
+    """
+    old_from = select.args["from"]
+    if not old_from.alias_or_name in new_join_dict.keys():
+        return
+    in_old_not_new = old_join_dict.keys() - new_join_dict.keys()
+    if len(in_old_not_new) >= 1:
+        new_from_name = list(old_join_dict.keys() - new_join_dict.keys())[0]
+        new_from_this = old_join_dict[new_from_name].this
+        new_from = exp.From(this=new_from_this)
+        del old_join_dict[new_from_name]
+        select.set("from", new_from)
+    else:
+        raise ValueError("Cannot determine which table to use as the new from")
+
+
+def _update_join_dict(
+    join: exp.Join, join_dict: t.Dict[str, exp.Join]
+) -> t.Dict[str, exp.Join]:
+    """Update the join dictionary with the new join.
+    If the join already exists, update the on clause.
+
+    Args:
+        join (exp.Join): The join to add to the dictionary
+        join_dict (Dict[str, exp.Join]): dictionary of joins where str is join.alias_or_name
+
+    Returns:
+        Dict[str, exp.Join]: The updated dictionary of joins
+    """
+    if join.alias_or_name in join_dict.keys():
+        join_dict[join.alias_or_name].set(
+            "on",
+            exp.And(
+                this=join_dict[join.alias_or_name].args["on"],
+                expression=join.args["on"],
+            ),
+        )
+    else:
+        join_dict[join.alias_or_name] = join
+    return join_dict
+
+
+def _clean_binary_node(node: exp.Expression):
+    """if the node is left with only one child, promote the child to the parent node.
+    transformation is done in place.
+
+    Args:
+        node (exp.Expression): The node to clean"""
+    if isinstance(node, exp.Binary):
+        if node.left is None:
+            node.replace(node.right)
+        elif node.right is None:
+            node.replace(node.left)
+
+
+def _has_join_mark(col: exp.Expression) -> bool:
+    """Check if the column has a join mark
+
+    Args:
+        col (exp.Column): The column to check
+    """
+    if not isinstance(col, exp.Column):
+        return False
+    result = col.args.get("join_mark", False)
+    if isinstance(result, bool):
+        return bool(result)
+    return False
+
+
+def _equality_to_join(
+    eq: exp.Binary, old_joins: t.Dict[str, exp.Join], old_from: exp.From
+) -> t.Optional[exp.Join]:
+    """Convert an equality predicate to a join if it contains a join mark
+
+    Args:
+        eq (exp.Binary): The equality expression to convert to a join
+
+    Returns:
+        Optional[exp.Join]: The join expression if the equality contains a join mark (otherwise None)
+    """
+    if not (isinstance(eq.left, exp.Column) or isinstance(eq.right, exp.Column)):
+        return None
+    new_eq = copy.deepcopy(eq)
+    left_has_join_mark = _has_join_mark(eq.left)
+    right_has_join_mark = _has_join_mark(eq.right)
+
+    if left_has_join_mark:
+        new_eq.left.set("join_mark", False)
+        assert isinstance(new_eq.left, exp.Column)
+        join_on = new_eq.left.table
+    elif right_has_join_mark:
+        new_eq.right.set("join_mark", False)
+        assert isinstance(new_eq.right, exp.Column)
+        join_on = new_eq.right.table
+    else:
+        return None
+
+    join_this = old_joins.get(join_on, old_from).this
+    return exp.Join(this=join_this, on=new_eq, kind="LEFT")
+
+
+def _eliminate_join_marks_from_select(select: exp.Select) -> exp.Select:
+    """Remove join marks from the where columns in this select statement
+    Converts them to joins and replaces any existing joins
+
+    Args:
+        node (exp.Select): The AST to remove join marks from
+
+    Returns:
+        exp.Select: The AST with join marks removed
+    """
+    if not select.args.get("where"):
+        return select
+    if not select.args.get("joins"):
+        return select
+    old_joins: t.Dict[str, exp.Join] = {
+        join.alias_or_name: join for join in list(select.args.get("joins", []))
+    }
+    new_joins: t.Dict[str, exp.Join] = {}
+    for node in select.find_all(exp.Column):
+        if _has_join_mark(node):
+            predicate = node.find_ancestor(exp.Predicate)
+            if not isinstance(predicate, exp.Binary):
+                continue
+            predicate_parent = predicate.parent
+            join_on = predicate.pop()
+            new_join = _equality_to_join(
+                join_on, old_joins=old_joins, old_from=select.args["from"]
+            )
+            new_joins = _update_join_dict(new_join, new_joins)
+            _clean_binary_node(predicate_parent)
+    _update_from(select, new_joins, old_joins)
+    replacement_joins = [
+        new_joins.get(join.alias_or_name, join) for join in old_joins.values()
+    ]
+    select.set("joins", replacement_joins)
+    where = select.args["where"]
+    if where:
+        if not where.this:
+            select.set("where", None)
+    return select
+
+
+def eliminate_join_marks(ast: exp.Expression) -> exp.Expression:
+    """Remove join marks from an expression
+
+    Args:
+        ast (exp.Expression): The AST to remove join marks from
+
+    Returns:
+        exp.Expression: The AST with join marks removed"""
+    select_nodes = list(ast.find_all(exp.Select))
+    select_nodes.reverse()
+    # convert inner nodes first
+    for node in select_nodes:
+        if not node.parent:
+            continue
+        replacement = _eliminate_join_marks_from_select(node)
+        node.replace(replacement)
+    # transform outer node
+    if isinstance(ast, exp.Select):
+        ast = _eliminate_join_marks_from_select(ast)
+    return ast

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -9,6 +9,7 @@ from sqlglot.optimizer.annotate_types import annotate_types
 from sqlglot.optimizer.canonicalize import canonicalize
 from sqlglot.optimizer.eliminate_ctes import eliminate_ctes
 from sqlglot.optimizer.eliminate_joins import eliminate_joins
+from sqlglot.optimizer.eliminate_join_marks import eliminate_join_marks
 from sqlglot.optimizer.eliminate_subqueries import eliminate_subqueries
 from sqlglot.optimizer.merge_subqueries import merge_subqueries
 from sqlglot.optimizer.normalize import normalize
@@ -31,6 +32,7 @@ RULES = (
     eliminate_subqueries,
     merge_subqueries,
     eliminate_joins,
+    eliminate_join_marks,
     eliminate_ctes,
     quote_identifiers,
     annotate_types,

--- a/tests/fixtures/optimizer/eliminate_join_marks.sql
+++ b/tests/fixtures/optimizer/eliminate_join_marks.sql
@@ -1,0 +1,41 @@
+ 
+# title: Constant in join  
+# dialect: oracle
+SELECT T1.d, T2.c FROM T1, T2 WHERE T1.x = T2.x (+) and T2.y (+) > 5;
+SELECT T1.d, T2.c FROM T1 LEFT JOIN T2 ON T1.x = T2.x AND T2.y > 5;
+  
+# title: Null in Join Predicte  
+# dialect: oracle
+SELECT T1.d, T2.c FROM T1, T2 WHERE T1.x = T2.x (+) and T2.y (+) IS NULL;
+SELECT T1.d, T2.c FROM T1 LEFT JOIN T2 ON T1.x = T2.x AND T2.y IS NULL;
+  
+# title: Null in Join Predicte 2  
+# dialect: oracle
+SELECT T1.d, T2.c FROM T1, T2 WHERE T1.x = T2.x (+) and T2.y IS NULL;
+SELECT T1.d, T2.c FROM T1 LEFT JOIN T2 ON T1.x = T2.x WHERE T2.y IS NULL;
+  
+# title: Additional where clause  
+# dialect: oracle
+SELECT T1.d, T2.c FROM T1, T2 WHERE T1.x = T2.x (+) and T1.Z > 4;
+SELECT T1.d, T2.c FROM T1 LEFT JOIN T2 ON T1.x = T2.x WHERE T1.Z > 4;
+  
+# title: various select tests 1  
+# dialect: oracle
+SELECT * FROM table1, table2 WHERE table1.column = table2.column(+);
+SELECT * FROM table1 LEFT JOIN table2 ON table1.column = table2.column;
+  
+# title: various select tests 2  
+# dialect: oracle
+SELECT * FROM table1, table2, table3, table4 WHERE table1.column = table2.column(+) and table2.column >= table3.column(+) and table1.column = table4.column(+);
+SELECT * FROM table1 LEFT JOIN table2 ON table1.column = table2.column LEFT JOIN table3 ON table2.column >= table3.column LEFT JOIN table4 ON table1.column = table4.column;
+  
+# title: various select tests 3  
+# dialect: oracle
+SELECT * FROM table1, table2, table3 WHERE table1.column = table2.column(+) and table2.column >= table3.column(+);
+SELECT * FROM table1 LEFT JOIN table2 ON table1.column = table2.column LEFT JOIN table3 ON table2.column >= table3.column;
+    
+# title: subquery  
+# dialect: oracle 
+SELECT table1.id, table2.cloumn1, table3.id FROM table1, table2, (SELECT tableInner1.id FROM tableInner1, tableInner2 WHERE tableInner1.id = tableInner2.id(+)) AS table3 WHERE table1.id = table2.id(+) and table1.id = table3.id(+);
+SELECT table1.id, table2.cloumn1, table3.id FROM table1 LEFT JOIN table2 ON table1.id = table2.id LEFT JOIN (SELECT tableInner1.id FROM tableInner1 LEFT JOIN tableInner2 ON tableInner1.id = tableInner2.id) table3 ON table1.id = table3.id;
+

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -28,7 +28,11 @@ def parse_and_optimize(func, sql, read_dialect, **kwargs):
 
 def qualify_columns(expression, **kwargs):
     expression = optimizer.qualify.qualify(
-        expression, infer_schema=True, validate_qualify_columns=False, identify=False, **kwargs
+        expression,
+        infer_schema=True,
+        validate_qualify_columns=False,
+        identify=False,
+        **kwargs,
     )
     return expression
 
@@ -110,7 +114,14 @@ class TestOptimizer(unittest.TestCase):
         }
 
     def check_file(
-        self, file, func, pretty=False, execute=False, set_dialect=False, only=None, **kwargs
+        self,
+        file,
+        func,
+        pretty=False,
+        execute=False,
+        set_dialect=False,
+        only=None,
+        **kwargs,
     ):
         with ProcessPoolExecutor() as pool:
             results = {}
@@ -330,7 +341,11 @@ class TestOptimizer(unittest.TestCase):
         )
 
         self.check_file(
-            "qualify_columns", qualify_columns, execute=True, schema=self.schema, set_dialect=True
+            "qualify_columns",
+            qualify_columns,
+            execute=True,
+            schema=self.schema,
+            set_dialect=True,
         )
         self.check_file(
             "qualify_columns_ddl", qualify_columns, schema=self.schema, set_dialect=True
@@ -342,7 +357,8 @@ class TestOptimizer(unittest.TestCase):
 
     def test_pushdown_cte_alias_columns(self):
         self.check_file(
-            "pushdown_cte_alias_columns", optimizer.qualify_columns.pushdown_cte_alias_columns
+            "pushdown_cte_alias_columns",
+            optimizer.qualify_columns.pushdown_cte_alias_columns,
         )
 
     def test_qualify_columns__invalid(self):
@@ -404,7 +420,8 @@ class TestOptimizer(unittest.TestCase):
         self.assertEqual(optimizer.simplify.gen(query), optimizer.simplify.gen(query.copy()))
 
         anon_unquoted_identifier = exp.Anonymous(
-            this=exp.to_identifier("anonymous"), expressions=[exp.column("x"), exp.column("y")]
+            this=exp.to_identifier("anonymous"),
+            expressions=[exp.column("x"), exp.column("y")],
         )
         self.assertEqual(optimizer.simplify.gen(anon_unquoted_identifier), "ANONYMOUS(x,y)")
 
@@ -415,7 +432,10 @@ class TestOptimizer(unittest.TestCase):
             anon_invalid = exp.Anonymous(this=5)
             optimizer.simplify.gen(anon_invalid)
 
-        self.assertIn("Anonymous.this expects a str or an Identifier, got 'int'.", str(e.exception))
+        self.assertIn(
+            "Anonymous.this expects a str or an Identifier, got 'int'.",
+            str(e.exception),
+        )
 
         sql = parse_one(
             """
@@ -472,6 +492,13 @@ SELECT :with,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:expr
             "eliminate_joins",
             optimizer.eliminate_joins.eliminate_joins,
             pretty=True,
+        )
+
+    def test_eliminate_join_marks(self):
+        self.check_file(
+            "eliminate_join_marks",
+            optimizer.eliminate_join_marks.eliminate_join_marks,
+            pretty=False,
         )
 
     def test_eliminate_ctes(self):
@@ -905,7 +932,8 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
 
         # Check that x.cola AS cola and y.colb AS colb have types CHAR and TEXT, respectively
         for d, t in zip(
-            cte_select.find_all(exp.Subquery), [exp.DataType.Type.CHAR, exp.DataType.Type.TEXT]
+            cte_select.find_all(exp.Subquery),
+            [exp.DataType.Type.CHAR, exp.DataType.Type.TEXT],
         ):
             self.assertEqual(d.this.expressions[0].this.type.this, t)
 
@@ -1019,7 +1047,8 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
 
         for (func, col), target_type in tests.items():
             expression = annotate_types(
-                parse_one(f"SELECT {func}(x.{col}) AS _col_0 FROM x AS x"), schema=schema
+                parse_one(f"SELECT {func}(x.{col}) AS _col_0 FROM x AS x"),
+                schema=schema,
             )
             self.assertEqual(expression.expressions[0].type.this, target_type)
 
@@ -1034,7 +1063,13 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         self.assertEqual(exp.DataType.Type.INT, expression.selects[1].type.this)
 
     def test_nested_type_annotation(self):
-        schema = {"order": {"customer_id": "bigint", "item_id": "bigint", "item_price": "numeric"}}
+        schema = {
+            "order": {
+                "customer_id": "bigint",
+                "item_id": "bigint",
+                "item_price": "numeric",
+            }
+        }
         sql = """
             SELECT ARRAY_AGG(DISTINCT order.item_id) FILTER (WHERE order.item_price > 10) AS items,
             FROM order AS order
@@ -1056,7 +1091,8 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
 
         self.assertEqual(expression.selects[0].type.sql(dialect="bigquery"), "STRUCT<`f` STRING>")
         self.assertEqual(
-            expression.selects[1].type.sql(dialect="bigquery"), "ARRAY<STRUCT<`f` STRING>>"
+            expression.selects[1].type.sql(dialect="bigquery"),
+            "ARRAY<STRUCT<`f` STRING>>",
         )
 
         expression = annotate_types(
@@ -1205,7 +1241,8 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
 
         self.assertEqual(
             optimizer.optimize(
-                parse_one("SELECT * FROM a"), schema=MappingSchema(schema, dialect="bigquery")
+                parse_one("SELECT * FROM a"),
+                schema=MappingSchema(schema, dialect="bigquery"),
             ),
             parse_one('SELECT "a"."a" AS "a", "a"."b" AS "b" FROM "a" AS "a"'),
         )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -880,10 +880,12 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(parse_one("a IS DISTINCT FROM b OR c IS DISTINCT FROM d"), exp.Or)
 
     def test_trailing_comments(self):
-        expressions = parse("""
+        expressions = parse(
+            """
         select * from x;
         -- my comment
-        """)
+        """
+        )
 
         self.assertEqual(
             ";\n".join(e.sql() for e in expressions), "SELECT * FROM x;\n/* my comment */"


### PR DESCRIPTION
Creation of eliminate_join_marks.py in optimizer.
For converting (+) oracle join marks into left joins.