### PR TITLE
fix!!: _parse_conjunction -> _parse_connector, AND gets higher precedence than OR

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -367,7 +367,7 @@ class ClickHouse(Dialect):
             **parser.Parser.QUERY_MODIFIER_PARSERS,
             TokenType.SETTINGS: lambda self: (
                 "settings",
-                self._advance() or self._parse_csv(self._parse_conjunction),
+                self._advance() or self._parse_csv(self._parse_connector),
             ),
             TokenType.FORMAT: lambda self: ("format", self._advance() or self._parse_id_var()),
         }
@@ -388,15 +388,15 @@ class ClickHouse(Dialect):
             "INDEX",
         }
 
-        def _parse_conjunction(self) -> t.Optional[exp.Expression]:
-            this = super()._parse_conjunction()
+        def _parse_connector(self) -> t.Optional[exp.Expression]:
+            this = super()._parse_connector()
 
             if self._match(TokenType.PLACEHOLDER):
                 return self.expression(
                     exp.If,
                     this=this,
-                    true=self._parse_conjunction(),
-                    false=self._match(TokenType.COLON) and self._parse_conjunction(),
+                    true=self._parse_connector(),
+                    false=self._match(TokenType.COLON) and self._parse_connector(),
                 )
 
             return this
@@ -461,7 +461,7 @@ class ClickHouse(Dialect):
                 # WITH <expression> AS <identifier>
                 cte = self.expression(
                     exp.CTE,
-                    this=self._parse_conjunction(),
+                    this=self._parse_connector(),
                     alias=self._parse_table_alias(),
                     scalar=True,
                 )
@@ -592,7 +592,7 @@ class ClickHouse(Dialect):
         ) -> exp.IndexColumnConstraint:
             # INDEX name1 expr TYPE type1(args) GRANULARITY value
             this = self._parse_id_var()
-            expression = self._parse_conjunction()
+            expression = self._parse_connector()
 
             index_type = self._match_text_seq("TYPE") and (
                 self._parse_function() or self._parse_var()

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -341,7 +341,7 @@ class DuckDB(Dialect):
             if self._match(TokenType.L_BRACE, advance=False):
                 return self.expression(exp.ToMap, this=self._parse_bracket())
 
-            args = self._parse_wrapped_csv(self._parse_connector)
+            args = self._parse_wrapped_csv(self._parse_assignment)
             return self.expression(exp.Map, keys=seq_get(args, 0), values=seq_get(args, 1))
 
         def _parse_struct_types(self, type_required: bool = False) -> t.Optional[exp.Expression]:

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -341,7 +341,7 @@ class DuckDB(Dialect):
             if self._match(TokenType.L_BRACE, advance=False):
                 return self.expression(exp.ToMap, this=self._parse_bracket())
 
-            args = self._parse_wrapped_csv(self._parse_conjunction)
+            args = self._parse_wrapped_csv(self._parse_connector)
             return self.expression(exp.Map, keys=seq_get(args, 0), values=seq_get(args, 1))
 
         def _parse_struct_types(self, type_required: bool = False) -> t.Optional[exp.Expression]:

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -415,7 +415,7 @@ class Hive(Dialect):
         ) -> t.Tuple[t.List[exp.Expression], t.Optional[exp.Expression]]:
             return (
                 (
-                    self._parse_csv(self._parse_connector)
+                    self._parse_csv(self._parse_assignment)
                     if self._match_set({TokenType.PARTITION_BY, TokenType.DISTRIBUTE_BY})
                     else []
                 ),

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -415,7 +415,7 @@ class Hive(Dialect):
         ) -> t.Tuple[t.List[exp.Expression], t.Optional[exp.Expression]]:
             return (
                 (
-                    self._parse_csv(self._parse_conjunction)
+                    self._parse_csv(self._parse_connector)
                     if self._match_set({TokenType.PARTITION_BY, TokenType.DISTRIBUTE_BY})
                     else []
                 ),

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -629,7 +629,7 @@ class MySQL(Dialect):
             )
 
         def _parse_chr(self) -> t.Optional[exp.Expression]:
-            expressions = self._parse_csv(self._parse_connector)
+            expressions = self._parse_csv(self._parse_assignment)
             kwargs: t.Dict[str, t.Any] = {"this": seq_get(expressions, 0)}
 
             if len(expressions) > 1:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -279,6 +279,10 @@ class MySQL(Dialect):
             **parser.Parser.CONJUNCTION,
             TokenType.DAMP: exp.And,
             TokenType.XOR: exp.Xor,
+        }
+
+        DISJUNCTION = {
+            **parser.Parser.DISJUNCTION,
             TokenType.DPIPE: exp.Or,
         }
 
@@ -625,7 +629,7 @@ class MySQL(Dialect):
             )
 
         def _parse_chr(self) -> t.Optional[exp.Expression]:
-            expressions = self._parse_csv(self._parse_conjunction)
+            expressions = self._parse_csv(self._parse_connector)
             kwargs: t.Dict[str, t.Any] = {"this": seq_get(expressions, 0)}
 
             if len(expressions) > 1:

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -36,6 +36,10 @@ class PRQL(Dialect):
         CONJUNCTION = {
             **parser.Parser.CONJUNCTION,
             TokenType.DAMP: exp.And,
+        }
+
+        DISJUNCTION = {
+            **parser.Parser.DISJUNCTION,
             TokenType.DPIPE: exp.Or,
         }
 
@@ -43,7 +47,7 @@ class PRQL(Dialect):
             "DERIVE": lambda self, query: self._parse_selection(query),
             "SELECT": lambda self, query: self._parse_selection(query, append=False),
             "TAKE": lambda self, query: self._parse_take(query),
-            "FILTER": lambda self, query: query.where(self._parse_conjunction()),
+            "FILTER": lambda self, query: query.where(self._parse_connector()),
             "APPEND": lambda self, query: query.union(
                 _select_all(self._parse_table()), distinct=False, copy=False
             ),
@@ -174,8 +178,8 @@ class PRQL(Dialect):
             if self._next and self._next.token_type == TokenType.ALIAS:
                 alias = self._parse_id_var(True)
                 self._match(TokenType.ALIAS)
-                return self.expression(exp.Alias, this=self._parse_conjunction(), alias=alias)
-            return self._parse_conjunction()
+                return self.expression(exp.Alias, this=self._parse_connector(), alias=alias)
+            return self._parse_connector()
 
         def _parse_table(
             self,

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -47,7 +47,7 @@ class PRQL(Dialect):
             "DERIVE": lambda self, query: self._parse_selection(query),
             "SELECT": lambda self, query: self._parse_selection(query, append=False),
             "TAKE": lambda self, query: self._parse_take(query),
-            "FILTER": lambda self, query: query.where(self._parse_connector()),
+            "FILTER": lambda self, query: query.where(self._parse_assignment()),
             "APPEND": lambda self, query: query.union(
                 _select_all(self._parse_table()), distinct=False, copy=False
             ),
@@ -178,8 +178,8 @@ class PRQL(Dialect):
             if self._next and self._next.token_type == TokenType.ALIAS:
                 alias = self._parse_id_var(True)
                 self._match(TokenType.ALIAS)
-                return self.expression(exp.Alias, this=self._parse_connector(), alias=alias)
-            return self._parse_connector()
+                return self.expression(exp.Alias, this=self._parse_assignment(), alias=alias)
+            return self._parse_assignment()
 
         def _parse_table(
             self,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -498,7 +498,7 @@ class Snowflake(Dialect):
             TokenType.ARROW: lambda self, expressions: self.expression(
                 exp.Lambda,
                 this=self._replace_lambda(
-                    self._parse_connector(),
+                    self._parse_assignment(),
                     expressions,
                 ),
                 expressions=[e.this if isinstance(e, exp.Cast) else e for e in expressions],
@@ -576,7 +576,7 @@ class Snowflake(Dialect):
                 # - https://docs.snowflake.com/en/sql-reference/functions/object_construct
                 return self._parse_slice(self._parse_string())
 
-            return self._parse_slice(self._parse_alias(self._parse_connector(), explicit=True))
+            return self._parse_slice(self._parse_alias(self._parse_assignment(), explicit=True))
 
         def _parse_lateral(self) -> t.Optional[exp.Lateral]:
             lateral = super()._parse_lateral()

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -498,7 +498,7 @@ class Snowflake(Dialect):
             TokenType.ARROW: lambda self, expressions: self.expression(
                 exp.Lambda,
                 this=self._replace_lambda(
-                    self._parse_conjunction(),
+                    self._parse_connector(),
                     expressions,
                 ),
                 expressions=[e.this if isinstance(e, exp.Cast) else e for e in expressions],
@@ -576,7 +576,7 @@ class Snowflake(Dialect):
                 # - https://docs.snowflake.com/en/sql-reference/functions/object_construct
                 return self._parse_slice(self._parse_string())
 
-            return self._parse_slice(self._parse_alias(self._parse_conjunction(), explicit=True))
+            return self._parse_slice(self._parse_alias(self._parse_connector(), explicit=True))
 
         def _parse_lateral(self) -> t.Optional[exp.Lateral]:
             lateral = super()._parse_lateral()

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -164,7 +164,7 @@ class Teradata(Dialect):
         }
 
         def _parse_translate(self, strict: bool) -> exp.Expression:
-            this = self._parse_conjunction()
+            this = self._parse_connector()
 
             if not self._match(TokenType.USING):
                 self.raise_error("Expected USING in TRANSLATE")
@@ -195,8 +195,8 @@ class Teradata(Dialect):
             this = self._parse_id_var()
             self._match(TokenType.BETWEEN)
 
-            expressions = self._parse_csv(self._parse_conjunction)
-            each = self._match_text_seq("EACH") and self._parse_conjunction()
+            expressions = self._parse_csv(self._parse_connector)
+            each = self._match_text_seq("EACH") and self._parse_connector()
 
             return self.expression(exp.RangeN, this=this, expressions=expressions, each=each)
 

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -164,7 +164,7 @@ class Teradata(Dialect):
         }
 
         def _parse_translate(self, strict: bool) -> exp.Expression:
-            this = self._parse_connector()
+            this = self._parse_assignment()
 
             if not self._match(TokenType.USING):
                 self.raise_error("Expected USING in TRANSLATE")
@@ -195,8 +195,8 @@ class Teradata(Dialect):
             this = self._parse_id_var()
             self._match(TokenType.BETWEEN)
 
-            expressions = self._parse_csv(self._parse_connector)
-            each = self._match_text_seq("EACH") and self._parse_connector()
+            expressions = self._parse_csv(self._parse_assignment)
+            each = self._match_text_seq("EACH") and self._parse_assignment()
 
             return self.expression(exp.RangeN, this=this, expressions=expressions, each=each)
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -625,7 +625,7 @@ class TSQL(Dialect):
         ) -> t.Optional[exp.Expression]:
             this = self._parse_types()
             self._match(TokenType.COMMA)
-            args = [this, *self._parse_csv(self._parse_conjunction)]
+            args = [this, *self._parse_csv(self._parse_connector)]
             convert = exp.Convert.from_arg_list(args)
             convert.set("safe", safe)
             convert.set("strict", strict)

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -625,7 +625,7 @@ class TSQL(Dialect):
         ) -> t.Optional[exp.Expression]:
             this = self._parse_types()
             self._match(TokenType.COMMA)
-            args = [this, *self._parse_csv(self._parse_connector)]
+            args = [this, *self._parse_csv(self._parse_assignment)]
             convert = exp.Convert.from_arg_list(args)
             convert.set("safe", safe)
             convert.set("strict", strict)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3979,10 +3979,24 @@ class Parser(metaclass=_Parser):
         return self._parse_alias(self._parse_connector())
 
     def _parse_connector(self) -> t.Optional[exp.Expression]:
-        return self._parse_tokens(self._parse_disjunction, self.ASSIGNMENT)
+        this = self._parse_conjunction()
 
-    def _parse_disjunction(self) -> t.Optional[exp.Expression]:
-        return self._parse_tokens(self._parse_conjunction, self.DISJUNCTION)
+        if self._match(TokenType.COLON_EQ):
+            this = self.expression(
+                exp.PropertyEQ,
+                this=this,
+                comments=self._prev_comments,
+                expression=self._parse_connector(),
+            )
+
+        while self._match_set(self.DISJUNCTION):
+            this = self.expression(
+                self.DISJUNCTION[self._prev.token_type],
+                this=this,
+                comments=self._prev_comments,
+                expression=self._parse_conjunction(),
+            )
+        return this
 
     def _parse_conjunction(self) -> t.Optional[exp.Expression]:
         return self._parse_tokens(self._parse_equality, self.CONJUNCTION)

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -222,6 +222,9 @@ class TestMySQL(Validator):
         self.validate_identity("CHAR(77, 121, 83, 81, '76')")
         self.validate_identity("CHAR(77, 77.3, '77.3' USING utf8mb4)")
         self.validate_identity("SELECT * FROM t1 PARTITION(p0)")
+        self.validate_identity("SELECT @var1 := 1, @var2")
+        self.validate_identity("SELECT @var1, @var2 := @var1")
+        self.validate_identity("SELECT @var1 := COUNT(*) FROM t1")
 
     def test_types(self):
         for char_type in MySQL.Generator.CHAR_CAST_MAPPING:

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -113,6 +113,9 @@ a AND b;
 A XOR A;
 FALSE;
 
+TRUE AND TRUE OR TRUE AND FALSE;
+TRUE;
+
 --------------------------------------
 -- Absorption
 --------------------------------------


### PR DESCRIPTION
As discussed in Slack:

Seems like all dialects give AND higher precedence than OR.

We're still a bit loose on precedence, and there are certainly other precedence bugs. So longer term, we might want to consider how we configure and parse precedence per dialect.

But for now, AND/OR are of course super common, so patching in this little fix.
