### PR TITLE
Fix(redshift): add support for Oracle style outer join markers

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -115,6 +115,12 @@ class Redshift(Postgres):
             self._retreat(index)
             return None
 
+        def _parse_column(self) -> t.Optional[exp.Expression]:
+            column = super()._parse_column()
+            if column:
+                column.set("join_mark", self._match(TokenType.JOIN_MARKER))
+            return column
+
     class Tokenizer(Postgres.Tokenizer):
         BIT_STRINGS = []
         HEX_STRINGS = []
@@ -128,6 +134,7 @@ class Redshift(Postgres):
             "UNLOAD": TokenType.COMMAND,
             "VARBYTE": TokenType.VARBINARY,
             "MINUS": TokenType.EXCEPT,
+            "(+)": TokenType.JOIN_MARKER,
         }
         KEYWORDS.pop("VALUES")
 
@@ -148,6 +155,7 @@ class Redshift(Postgres):
         HEX_FUNC = "TO_HEX"
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "
+        COLUMN_JOIN_MARKS_SUPPORTED = True
 
         TYPE_MAPPING = {
             **Postgres.Generator.TYPE_MAPPING,

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -585,3 +585,9 @@ FROM (
         self.assertEqual(
             ast.sql("redshift"), "SELECT * FROM x AS a, a.b AS c, c.d.e AS f, f.g.h.i.j.k AS l"
         )
+
+    def test_join_markers(self):
+        self.validate_identity(
+            "select a.foo, b.bar, a.baz from a, b where a.baz = b.baz (+)",
+            "SELECT a.foo, b.bar, a.baz FROM a, b WHERE a.baz = b.baz (+)",
+        )


### PR DESCRIPTION
Added support for oracle style join markers `(+)`

Fixes #3611