### PR TITLE
fix(snowflake): Allow SELECT keyword as JSON path key

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4534,7 +4534,11 @@ class Parser(metaclass=_Parser):
 
         while self._match(TokenType.COLON):
             start_index = self._index
-            path = self._parse_column_ops(self._parse_field(any_token=True))
+
+            # Snowflake allows reserved keywords as json keys but advance_any() excludes TokenType.SELECT from any_tokens=True
+            path = self._parse_column_ops(
+                self._parse_field(any_token=True, tokens=(TokenType.SELECT,))
+            )
 
             # The cast :: operator has a lower precedence than the extraction operator :, so
             # we rearrange the AST appropriately to avoid casting the JSON path

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -125,6 +125,10 @@ WHERE
             "SELECT a:from::STRING, a:from || ' test' ",
             "SELECT CAST(GET_PATH(a, 'from') AS TEXT), GET_PATH(a, 'from') || ' test'",
         )
+        self.validate_identity(
+            "SELECT a:select",
+            "SELECT GET_PATH(a, 'select')",
+        )
         self.validate_identity("x:from", "GET_PATH(x, 'from')")
         self.validate_identity(
             "value:values::string::int",


### PR DESCRIPTION
Fixes #3619

Snowflake allows any keyword such as `SELECT`, `FROM`, `JOIN` etc to be used as JSON path key. All of these except `SELECT` are captured with the existing `parse_field(any_token=True)`.  

The exception happens because `advance_any(any_token=True)` will _not_ advance if the next token is in `RESERVED_TOKENS` which includes `SINGLE_TOKENS` and `TokenType.SELECT`. 