### PR TITLE
Fix(duckdb)!: map all character data type aliases to TEXT

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -207,7 +207,7 @@ class DuckDB(Dialect):
             "PIVOT_WIDER": TokenType.PIVOT,
             "POSITIONAL": TokenType.POSITIONAL,
             "SIGNED": TokenType.INT,
-            "STRING": TokenType.VARCHAR,
+            "STRING": TokenType.TEXT,
             "UBIGINT": TokenType.UBIGINT,
             "UINTEGER": TokenType.UINT,
             "USMALLINT": TokenType.USMALLINT,
@@ -216,6 +216,7 @@ class DuckDB(Dialect):
             "TIMESTAMP_MS": TokenType.TIMESTAMP_MS,
             "TIMESTAMP_NS": TokenType.TIMESTAMP_NS,
             "TIMESTAMP_US": TokenType.TIMESTAMP,
+            "VARCHAR": TokenType.TEXT,
         }
 
         SINGLE_TOKENS = {
@@ -495,6 +496,7 @@ class DuckDB(Dialect):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.BINARY: "BLOB",
+            exp.DataType.Type.BPCHAR: "TEXT",
             exp.DataType.Type.CHAR: "TEXT",
             exp.DataType.Type.FLOAT: "REAL",
             exp.DataType.Type.NCHAR: "TEXT",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1008,6 +1008,7 @@ class TestDuckDB(Validator):
         self.validate_identity("CAST(x AS CHAR)", "CAST(x AS TEXT)")
         self.validate_identity("CAST(x AS BPCHAR)", "CAST(x AS TEXT)")
         self.validate_identity("CAST(x AS STRING)", "CAST(x AS TEXT)")
+        self.validate_identity("CAST(x AS VARCHAR)", "CAST(x AS TEXT)")
         self.validate_identity("CAST(x AS INT1)", "CAST(x AS TINYINT)")
         self.validate_identity("CAST(x AS FLOAT4)", "CAST(x AS REAL)")
         self.validate_identity("CAST(x AS FLOAT)", "CAST(x AS REAL)")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -795,10 +795,10 @@ class TestTSQL(Validator):
         )
 
         self.validate_all(
-            "CREATE TABLE [#temptest] (name VARCHAR)",
+            "CREATE TABLE [#temptest] (name INTEGER)",
             read={
-                "duckdb": "CREATE TEMPORARY TABLE 'temptest' (name VARCHAR)",
-                "tsql": "CREATE TABLE [#temptest] (name VARCHAR)",
+                "duckdb": "CREATE TEMPORARY TABLE 'temptest' (name INTEGER)",
+                "tsql": "CREATE TABLE [#temptest] (name INTEGER)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
DuckDB has a [single character data type](https://duckdb.org/docs/sql/data_types/text), with aliases CHAR, BPCHAR, STRING, TEXT, VARCHAR.

SQLGlot currently maps these aliases to two different data types, `TEXT` (char, bpchar, text) and `VARCHAR` (string, varchar). Because there is only a single underlying type in DuckDB, this PR maps all aliases to `TEXT`.

We use `TEXT` instead of `VARCHAR` because DuckDB's single type is unlimited length and other sqlglot dialects rely on `TEXT` being unlimited length. 

For example, the duckdb -> tsql transpilation semantics are currently incorrect:
- tsql maps `Type.TEXT` -> `"VARCHAR(max)"` to allow unlimited length.
- Currently, sqlglot transpiles duckdb `"VARCHAR"` -> `Type.VARCHAR` -> tsql `"VARCHAR"`. Because tsql's default is length 1, this incorrectly results in a length 1 character type.
- This will now be transpiled as duckdb `"VARCHAR"` -> `Type.TEXT` -> tsql `"VARCHAR(max)"`, with unlimited length in both dialects.

