### PR TITLE
Fix(duckdb): get rid of TEXT length to facilitate transpilation

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -313,9 +313,11 @@ class DuckDB(Dialect):
             ),
         }
 
-        TYPE_CONVERTER = {
+        TYPE_CONVERTERS = {
             # https://duckdb.org/docs/sql/data_types/numeric
             exp.DataType.Type.DECIMAL: build_default_decimal_type(precision=18, scale=3),
+            # https://duckdb.org/docs/sql/data_types/text
+            exp.DataType.Type.TEXT: lambda dtype: exp.DataType.build("TEXT"),
         }
 
         def _parse_table_sample(self, as_modifier: bool = False) -> t.Optional[exp.TableSample]:

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -446,7 +446,7 @@ class Snowflake(Dialect):
             "LOCATION": lambda self: self._parse_location_property(),
         }
 
-        TYPE_CONVERTER = {
+        TYPE_CONVERTERS = {
             # https://docs.snowflake.com/en/sql-reference/data-types-numeric#number
             exp.DataType.Type.DECIMAL: build_default_decimal_type(precision=38, scale=0),
         }

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1066,7 +1066,7 @@ class Parser(metaclass=_Parser):
         exp.DataType.Type.JSON: lambda self, this, _: self.expression(exp.ParseJSON, this=this),
     }
 
-    TYPE_CONVERTER: t.Dict[exp.DataType.Type, t.Callable[[exp.DataType], exp.DataType]] = {}
+    TYPE_CONVERTERS: t.Dict[exp.DataType.Type, t.Callable[[exp.DataType], exp.DataType]] = {}
 
     DDL_SELECT_TOKENS = {TokenType.SELECT, TokenType.WITH, TokenType.L_PAREN}
 
@@ -4472,8 +4472,8 @@ class Parser(metaclass=_Parser):
             )
             self._match(TokenType.R_BRACKET)
 
-        if self.TYPE_CONVERTER and isinstance(this.this, exp.DataType.Type):
-            converter = self.TYPE_CONVERTER.get(this.this)
+        if self.TYPE_CONVERTERS and isinstance(this.this, exp.DataType.Type):
+            converter = self.TYPE_CONVERTERS.get(this.this)
             if converter:
                 this = converter(t.cast(exp.DataType, this))
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1037,6 +1037,13 @@ class TestDuckDB(Validator):
         )
 
         self.validate_all(
+            "CAST(x AS VARCHAR(5))",
+            write={
+                "duckdb": "CAST(x AS TEXT)",
+                "postgres": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
             "CAST(x AS DECIMAL(38, 0))",
             read={
                 "snowflake": "CAST(x AS NUMBER)",


### PR DESCRIPTION
Another improvement based on https://github.com/tobymao/sqlglot/commit/2e434501f50167b30f6e5fd4334fa70c4dde220b