### PR TITLE
Feat: set misc. dialect settings if available

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -410,12 +410,14 @@ class Dialect(metaclass=_Dialect):
         return expression
 
     def __init__(self, **kwargs) -> None:
-        normalization_strategy = kwargs.get("normalization_strategy")
+        normalization_strategy = kwargs.pop("normalization_strategy", None)
 
         if normalization_strategy is None:
             self.normalization_strategy = self.NORMALIZATION_STRATEGY
         else:
             self.normalization_strategy = NormalizationStrategy(normalization_strategy.upper())
+
+        self.settings = kwargs
 
     def __eq__(self, other: t.Any) -> bool:
         # Does not currently take dialect state into account

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -121,6 +121,12 @@ class TestDialect(Validator):
 
         self.assertEqual(str(cm.exception), "Unknown dialect 'asdfjasodiufjsd'.")
 
+        oracle_with_settings = Dialect.get_or_raise(
+            "oracle, normalization_strategy = lowercase, version = 19.5"
+        )
+        self.assertEqual(oracle_with_settings.normalization_strategy.value, "LOWERCASE")
+        self.assertEqual(oracle_with_settings.settings, {"version": "19.5"})
+
     def test_compare_dialects(self):
         bigquery_class = Dialect["bigquery"]
         bigquery_object = BigQuery()


### PR DESCRIPTION
This can be useful if users want to override stuff based on a dialect instance's state, e.g. version, which is currently _not_ stored even though it's extracted from the dialect string.