### PR TITLE
fix(redshift)!: Normalize time units in their full singular form

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -53,13 +53,14 @@ DATE_PART_MAPPING = {
     "DD": "DAY",
     "DAYS": "DAY",
     "DAYOFMONTH": "DAY",
+    "DAY OF WEEK": "DAYOFWEEK",
     "WEEKDAY": "DAYOFWEEK",
     "DOW": "DAYOFWEEK",
     "DW": "DAYOFWEEK",
     "WEEKDAY_ISO": "DAYOFWEEKISO",
     "DOW_ISO": "DAYOFWEEKISO",
     "DW_ISO": "DAYOFWEEKISO",
-    "YEARDAY": "DAYOFYEAR",
+    "DAY OF YEAR": "DAYOFYEAR",
     "DOY": "DAYOFYEAR",
     "DY": "DAYOFYEAR",
     "W": "WEEK",
@@ -90,9 +91,20 @@ DATE_PART_MAPPING = {
     "SECS": "SECOND",
     "MS": "MILLISECOND",
     "MSEC": "MILLISECOND",
+    "MSECS": "MILLISECOND",
+    "MSECOND": "MILLISECOND",
+    "MSECONDS": "MILLISECOND",
+    "MILLISEC": "MILLISECOND",
+    "MILLISECS": "MILLISECOND",
+    "MILLISECON": "MILLISECOND",
     "MILLISECONDS": "MILLISECOND",
     "US": "MICROSECOND",
     "USEC": "MICROSECOND",
+    "USECS": "MICROSECOND",
+    "MICROSEC": "MICROSECOND",
+    "MICROSECS": "MICROSECOND",
+    "USECOND": "MICROSECOND",
+    "USECONDS": "MICROSECOND",
     "MICROSECONDS": "MICROSECOND",
     "NS": "NANOSECOND",
     "NSEC": "NANOSECOND",
@@ -107,6 +119,16 @@ DATE_PART_MAPPING = {
     "EPOCH_NANOSECONDS": "EPOCH_NANOSECOND",
     "TZH": "TIMEZONE_HOUR",
     "TZM": "TIMEZONE_MINUTE",
+    "DEC": "DECADE",
+    "DECS": "DECADE",
+    "DECADES": "DECADE",
+    "MIL": "MILLENIUM",
+    "MILS": "MILLENIUM",
+    "MILLENIA": "MILLENIUM",
+    "C": "CENTURY",
+    "CENT": "CENTURY",
+    "CENTS": "CENTURY",
+    "CENTURIES": "CENTURY",
 }
 
 
@@ -1136,17 +1158,21 @@ def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[
 
 
 @t.overload
-def map_date_part(part: exp.Expression) -> exp.Var:
+def map_date_part(
+    part: exp.Expression, part_mapping: t.Dict[str, str] = DATE_PART_MAPPING
+) -> exp.Var:
     pass
 
 
 @t.overload
-def map_date_part(part: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+def map_date_part(
+    part: t.Optional[exp.Expression], part_mapping: t.Dict[str, str] = DATE_PART_MAPPING
+) -> t.Optional[exp.Expression]:
     pass
 
 
-def map_date_part(part):
-    mapped = DATE_PART_MAPPING.get(part.name.upper()) if part else None
+def map_date_part(part, part_mapping: t.Dict[str, str] = DATE_PART_MAPPING):
+    mapped = part_mapping.get(part.name.upper()) if part else None
     return exp.var(mapped) if mapped else part
 
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -109,6 +109,7 @@ DATE_PART_MAPPING = {
     "TZM": "TIMEZONE_MINUTE",
 }
 
+
 class Dialects(str, Enum):
     """Dialects supported by SQLGLot."""
 
@@ -1133,6 +1134,7 @@ def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[
         return unit
     return exp.Var(this=default) if default else None
 
+
 @t.overload
 def map_date_part(part: exp.Expression) -> exp.Var:
     pass
@@ -1146,6 +1148,7 @@ def map_date_part(part: t.Optional[exp.Expression]) -> t.Optional[exp.Expression
 def map_date_part(part):
     mapped = DATE_PART_MAPPING.get(part.name.upper()) if part else None
     return exp.var(mapped) if mapped else part
+
 
 def no_last_day_sql(self: Generator, expression: exp.LastDay) -> str:
     trunc_curr_date = exp.func("date_trunc", "month", expression.this)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -37,6 +37,78 @@ UNESCAPED_SEQUENCES = {
 }
 
 
+DATE_PART_MAPPING = {
+    "Y": "YEAR",
+    "YY": "YEAR",
+    "YYY": "YEAR",
+    "YYYY": "YEAR",
+    "YR": "YEAR",
+    "YEARS": "YEAR",
+    "YRS": "YEAR",
+    "MM": "MONTH",
+    "MON": "MONTH",
+    "MONS": "MONTH",
+    "MONTHS": "MONTH",
+    "D": "DAY",
+    "DD": "DAY",
+    "DAYS": "DAY",
+    "DAYOFMONTH": "DAY",
+    "WEEKDAY": "DAYOFWEEK",
+    "DOW": "DAYOFWEEK",
+    "DW": "DAYOFWEEK",
+    "WEEKDAY_ISO": "DAYOFWEEKISO",
+    "DOW_ISO": "DAYOFWEEKISO",
+    "DW_ISO": "DAYOFWEEKISO",
+    "YEARDAY": "DAYOFYEAR",
+    "DOY": "DAYOFYEAR",
+    "DY": "DAYOFYEAR",
+    "W": "WEEK",
+    "WK": "WEEK",
+    "WEEKOFYEAR": "WEEK",
+    "WOY": "WEEK",
+    "WY": "WEEK",
+    "WEEK_ISO": "WEEKISO",
+    "WEEKOFYEARISO": "WEEKISO",
+    "WEEKOFYEAR_ISO": "WEEKISO",
+    "Q": "QUARTER",
+    "QTR": "QUARTER",
+    "QTRS": "QUARTER",
+    "QUARTERS": "QUARTER",
+    "H": "HOUR",
+    "HH": "HOUR",
+    "HR": "HOUR",
+    "HOURS": "HOUR",
+    "HRS": "HOUR",
+    "M": "MINUTE",
+    "MI": "MINUTE",
+    "MIN": "MINUTE",
+    "MINUTES": "MINUTE",
+    "MINS": "MINUTE",
+    "S": "SECOND",
+    "SEC": "SECOND",
+    "SECONDS": "SECOND",
+    "SECS": "SECOND",
+    "MS": "MILLISECOND",
+    "MSEC": "MILLISECOND",
+    "MILLISECONDS": "MILLISECOND",
+    "US": "MICROSECOND",
+    "USEC": "MICROSECOND",
+    "MICROSECONDS": "MICROSECOND",
+    "NS": "NANOSECOND",
+    "NSEC": "NANOSECOND",
+    "NANOSEC": "NANOSECOND",
+    "NSECOND": "NANOSECOND",
+    "NSECONDS": "NANOSECOND",
+    "NANOSECS": "NANOSECOND",
+    "EPOCH": "EPOCH_SECOND",
+    "EPOCH_SECONDS": "EPOCH_SECOND",
+    "EPOCH_MILLISECONDS": "EPOCH_MILLISECOND",
+    "EPOCH_MICROSECONDS": "EPOCH_MICROSECOND",
+    "EPOCH_NANOSECONDS": "EPOCH_NANOSECOND",
+    "TZH": "TIMEZONE_HOUR",
+    "TZM": "TIMEZONE_MINUTE",
+}
+
 class Dialects(str, Enum):
     """Dialects supported by SQLGLot."""
 
@@ -1061,6 +1133,19 @@ def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[
         return unit
     return exp.Var(this=default) if default else None
 
+@t.overload
+def map_date_part(part: exp.Expression) -> exp.Var:
+    pass
+
+
+@t.overload
+def map_date_part(part: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+    pass
+
+
+def map_date_part(part):
+    mapped = DATE_PART_MAPPING.get(part.name.upper()) if part else None
+    return exp.var(mapped) if mapped else part
 
 def no_last_day_sql(self: Generator, expression: exp.LastDay) -> str:
     trunc_curr_date = exp.func("date_trunc", "month", expression.this)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -37,101 +37,6 @@ UNESCAPED_SEQUENCES = {
 }
 
 
-DATE_PART_MAPPING = {
-    "Y": "YEAR",
-    "YY": "YEAR",
-    "YYY": "YEAR",
-    "YYYY": "YEAR",
-    "YR": "YEAR",
-    "YEARS": "YEAR",
-    "YRS": "YEAR",
-    "MM": "MONTH",
-    "MON": "MONTH",
-    "MONS": "MONTH",
-    "MONTHS": "MONTH",
-    "D": "DAY",
-    "DD": "DAY",
-    "DAYS": "DAY",
-    "DAYOFMONTH": "DAY",
-    "DAY OF WEEK": "DAYOFWEEK",
-    "WEEKDAY": "DAYOFWEEK",
-    "DOW": "DAYOFWEEK",
-    "DW": "DAYOFWEEK",
-    "WEEKDAY_ISO": "DAYOFWEEKISO",
-    "DOW_ISO": "DAYOFWEEKISO",
-    "DW_ISO": "DAYOFWEEKISO",
-    "DAY OF YEAR": "DAYOFYEAR",
-    "DOY": "DAYOFYEAR",
-    "DY": "DAYOFYEAR",
-    "W": "WEEK",
-    "WK": "WEEK",
-    "WEEKOFYEAR": "WEEK",
-    "WOY": "WEEK",
-    "WY": "WEEK",
-    "WEEK_ISO": "WEEKISO",
-    "WEEKOFYEARISO": "WEEKISO",
-    "WEEKOFYEAR_ISO": "WEEKISO",
-    "Q": "QUARTER",
-    "QTR": "QUARTER",
-    "QTRS": "QUARTER",
-    "QUARTERS": "QUARTER",
-    "H": "HOUR",
-    "HH": "HOUR",
-    "HR": "HOUR",
-    "HOURS": "HOUR",
-    "HRS": "HOUR",
-    "M": "MINUTE",
-    "MI": "MINUTE",
-    "MIN": "MINUTE",
-    "MINUTES": "MINUTE",
-    "MINS": "MINUTE",
-    "S": "SECOND",
-    "SEC": "SECOND",
-    "SECONDS": "SECOND",
-    "SECS": "SECOND",
-    "MS": "MILLISECOND",
-    "MSEC": "MILLISECOND",
-    "MSECS": "MILLISECOND",
-    "MSECOND": "MILLISECOND",
-    "MSECONDS": "MILLISECOND",
-    "MILLISEC": "MILLISECOND",
-    "MILLISECS": "MILLISECOND",
-    "MILLISECON": "MILLISECOND",
-    "MILLISECONDS": "MILLISECOND",
-    "US": "MICROSECOND",
-    "USEC": "MICROSECOND",
-    "USECS": "MICROSECOND",
-    "MICROSEC": "MICROSECOND",
-    "MICROSECS": "MICROSECOND",
-    "USECOND": "MICROSECOND",
-    "USECONDS": "MICROSECOND",
-    "MICROSECONDS": "MICROSECOND",
-    "NS": "NANOSECOND",
-    "NSEC": "NANOSECOND",
-    "NANOSEC": "NANOSECOND",
-    "NSECOND": "NANOSECOND",
-    "NSECONDS": "NANOSECOND",
-    "NANOSECS": "NANOSECOND",
-    "EPOCH": "EPOCH_SECOND",
-    "EPOCH_SECONDS": "EPOCH_SECOND",
-    "EPOCH_MILLISECONDS": "EPOCH_MILLISECOND",
-    "EPOCH_MICROSECONDS": "EPOCH_MICROSECOND",
-    "EPOCH_NANOSECONDS": "EPOCH_NANOSECOND",
-    "TZH": "TIMEZONE_HOUR",
-    "TZM": "TIMEZONE_MINUTE",
-    "DEC": "DECADE",
-    "DECS": "DECADE",
-    "DECADES": "DECADE",
-    "MIL": "MILLENIUM",
-    "MILS": "MILLENIUM",
-    "MILLENIA": "MILLENIUM",
-    "C": "CENTURY",
-    "CENT": "CENTURY",
-    "CENTS": "CENTURY",
-    "CENTURIES": "CENTURY",
-}
-
-
 class Dialects(str, Enum):
     """Dialects supported by SQLGLot."""
 
@@ -411,6 +316,11 @@ class Dialect(metaclass=_Dialect):
         ) SELECT c FROM y;
     """
 
+    COPY_PARAMS_ARE_CSV = True
+    """
+    Whether COPY statement parameters are separated by comma or whitespace
+    """
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer
@@ -441,6 +351,100 @@ class Dialect(metaclass=_Dialect):
     BYTE_END: t.Optional[str] = None
     UNICODE_START: t.Optional[str] = None
     UNICODE_END: t.Optional[str] = None
+
+    DATE_PART_MAPPING = {
+        "Y": "YEAR",
+        "YY": "YEAR",
+        "YYY": "YEAR",
+        "YYYY": "YEAR",
+        "YR": "YEAR",
+        "YEARS": "YEAR",
+        "YRS": "YEAR",
+        "MM": "MONTH",
+        "MON": "MONTH",
+        "MONS": "MONTH",
+        "MONTHS": "MONTH",
+        "D": "DAY",
+        "DD": "DAY",
+        "DAYS": "DAY",
+        "DAYOFMONTH": "DAY",
+        "DAY OF WEEK": "DAYOFWEEK",
+        "WEEKDAY": "DAYOFWEEK",
+        "DOW": "DAYOFWEEK",
+        "DW": "DAYOFWEEK",
+        "WEEKDAY_ISO": "DAYOFWEEKISO",
+        "DOW_ISO": "DAYOFWEEKISO",
+        "DW_ISO": "DAYOFWEEKISO",
+        "DAY OF YEAR": "DAYOFYEAR",
+        "DOY": "DAYOFYEAR",
+        "DY": "DAYOFYEAR",
+        "W": "WEEK",
+        "WK": "WEEK",
+        "WEEKOFYEAR": "WEEK",
+        "WOY": "WEEK",
+        "WY": "WEEK",
+        "WEEK_ISO": "WEEKISO",
+        "WEEKOFYEARISO": "WEEKISO",
+        "WEEKOFYEAR_ISO": "WEEKISO",
+        "Q": "QUARTER",
+        "QTR": "QUARTER",
+        "QTRS": "QUARTER",
+        "QUARTERS": "QUARTER",
+        "H": "HOUR",
+        "HH": "HOUR",
+        "HR": "HOUR",
+        "HOURS": "HOUR",
+        "HRS": "HOUR",
+        "M": "MINUTE",
+        "MI": "MINUTE",
+        "MIN": "MINUTE",
+        "MINUTES": "MINUTE",
+        "MINS": "MINUTE",
+        "S": "SECOND",
+        "SEC": "SECOND",
+        "SECONDS": "SECOND",
+        "SECS": "SECOND",
+        "MS": "MILLISECOND",
+        "MSEC": "MILLISECOND",
+        "MSECS": "MILLISECOND",
+        "MSECOND": "MILLISECOND",
+        "MSECONDS": "MILLISECOND",
+        "MILLISEC": "MILLISECOND",
+        "MILLISECS": "MILLISECOND",
+        "MILLISECON": "MILLISECOND",
+        "MILLISECONDS": "MILLISECOND",
+        "US": "MICROSECOND",
+        "USEC": "MICROSECOND",
+        "USECS": "MICROSECOND",
+        "MICROSEC": "MICROSECOND",
+        "MICROSECS": "MICROSECOND",
+        "USECOND": "MICROSECOND",
+        "USECONDS": "MICROSECOND",
+        "MICROSECONDS": "MICROSECOND",
+        "NS": "NANOSECOND",
+        "NSEC": "NANOSECOND",
+        "NANOSEC": "NANOSECOND",
+        "NSECOND": "NANOSECOND",
+        "NSECONDS": "NANOSECOND",
+        "NANOSECS": "NANOSECOND",
+        "EPOCH_SECOND": "EPOCH",
+        "EPOCH_SECONDS": "EPOCH",
+        "EPOCH_MILLISECONDS": "EPOCH_MILLISECOND",
+        "EPOCH_MICROSECONDS": "EPOCH_MICROSECOND",
+        "EPOCH_NANOSECONDS": "EPOCH_NANOSECOND",
+        "TZH": "TIMEZONE_HOUR",
+        "TZM": "TIMEZONE_MINUTE",
+        "DEC": "DECADE",
+        "DECS": "DECADE",
+        "DECADES": "DECADE",
+        "MIL": "MILLENIUM",
+        "MILS": "MILLENIUM",
+        "MILLENIA": "MILLENIUM",
+        "C": "CENTURY",
+        "CENT": "CENTURY",
+        "CENTS": "CENTURY",
+        "CENTURIES": "CENTURY",
+    }
 
     @classmethod
     def get_or_raise(cls, dialect: DialectType) -> Dialect:
@@ -1158,21 +1162,21 @@ def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[
 
 
 @t.overload
-def map_date_part(
-    part: exp.Expression, part_mapping: t.Dict[str, str] = DATE_PART_MAPPING
-) -> exp.Var:
+def map_date_part(part: exp.Expression, dialect: DialectType = Dialect) -> exp.Var:
     pass
 
 
 @t.overload
 def map_date_part(
-    part: t.Optional[exp.Expression], part_mapping: t.Dict[str, str] = DATE_PART_MAPPING
+    part: t.Optional[exp.Expression], dialect: DialectType = Dialect
 ) -> t.Optional[exp.Expression]:
     pass
 
 
-def map_date_part(part, part_mapping: t.Dict[str, str] = DATE_PART_MAPPING):
-    mapped = part_mapping.get(part.name.upper()) if part else None
+def map_date_part(part, dialect: DialectType = Dialect):
+    mapped = (
+        Dialect.get_or_raise(dialect).DATE_PART_MAPPING.get(part.name.upper()) if part else None
+    )
     return exp.var(mapped) if mapped else part
 
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -15,17 +15,22 @@ from sqlglot.dialects.dialect import (
     map_date_part,
 )
 from sqlglot.dialects.postgres import Postgres
+from sqlglot.dialects import dialect
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
+DATE_PART_MAPPING = {**dialect.DATE_PART_MAPPING, "EPOCH": "EPOCH"}
+
 
 def _build_date_delta(expr_type: t.Type[E]) -> t.Callable[[t.List], E]:
     def _builder(args: t.List) -> E:
         expr = expr_type(
-            this=seq_get(args, 2), expression=seq_get(args, 1), unit=map_date_part(seq_get(args, 0))
+            this=seq_get(args, 2),
+            expression=seq_get(args, 1),
+            unit=map_date_part(seq_get(args, 0), part_mapping=DATE_PART_MAPPING),
         )
         if expr_type is exp.TsOrDsAdd:
             expr.set("return_type", exp.DataType.build("TIMESTAMP"))

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -24,7 +24,9 @@ if t.TYPE_CHECKING:
 
 def _build_date_delta(expr_type: t.Type[E]) -> t.Callable[[t.List], E]:
     def _builder(args: t.List) -> E:
-        expr = expr_type(this=seq_get(args, 2), expression=seq_get(args, 1), unit=map_date_part(seq_get(args, 0)))
+        expr = expr_type(
+            this=seq_get(args, 2), expression=seq_get(args, 1), unit=map_date_part(seq_get(args, 0))
+        )
         if expr_type is exp.TsOrDsAdd:
             expr.set("return_type", exp.DataType.build("TIMESTAMP"))
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -12,6 +12,7 @@ from sqlglot.dialects.dialect import (
     json_extract_segments,
     no_tablesample_sql,
     rename_func,
+    map_date_part,
 )
 from sqlglot.dialects.postgres import Postgres
 from sqlglot.helper import seq_get
@@ -23,7 +24,7 @@ if t.TYPE_CHECKING:
 
 def _build_date_delta(expr_type: t.Type[E]) -> t.Callable[[t.List], E]:
     def _builder(args: t.List) -> E:
-        expr = expr_type(this=seq_get(args, 2), expression=seq_get(args, 1), unit=seq_get(args, 0))
+        expr = expr_type(this=seq_get(args, 2), expression=seq_get(args, 1), unit=map_date_part(seq_get(args, 0)))
         if expr_type is exp.TsOrDsAdd:
             expr.set("return_type", exp.DataType.build("TIMESTAMP"))
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -15,14 +15,11 @@ from sqlglot.dialects.dialect import (
     map_date_part,
 )
 from sqlglot.dialects.postgres import Postgres
-from sqlglot.dialects import dialect
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
-
-DATE_PART_MAPPING = {**dialect.DATE_PART_MAPPING, "EPOCH": "EPOCH"}
 
 
 def _build_date_delta(expr_type: t.Type[E]) -> t.Callable[[t.List], E]:
@@ -30,7 +27,7 @@ def _build_date_delta(expr_type: t.Type[E]) -> t.Callable[[t.List], E]:
         expr = expr_type(
             this=seq_get(args, 2),
             expression=seq_get(args, 1),
-            unit=map_date_part(seq_get(args, 0), part_mapping=DATE_PART_MAPPING),
+            unit=map_date_part(seq_get(args, 0)),
         )
         if expr_type is exp.TsOrDsAdd:
             expr.set("return_type", exp.DataType.build("TIMESTAMP"))

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -260,7 +260,7 @@ class TestRedshift(Validator):
             },
         )
         self.validate_all(
-            "DATEDIFF('day', a, b)",
+            "DATEDIFF(days, a, b)",
             write={
                 "bigquery": "DATE_DIFF(CAST(b AS DATETIME), CAST(a AS DATETIME), DAY)",
                 "duckdb": "DATE_DIFF('DAY', CAST(a AS TIMESTAMP), CAST(b AS TIMESTAMP))",

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -259,8 +259,14 @@ class TestRedshift(Validator):
                 "postgres": "COALESCE(a, b, c, d)",
             },
         )
-        self.validate_all(
+
+        self.validate_identity(
             "DATEDIFF(days, a, b)",
+            "DATEDIFF(DAY, a, b)",
+        )
+
+        self.validate_all(
+            "DATEDIFF('day', a, b)",
             write={
                 "bigquery": "DATE_DIFF(CAST(b AS DATETIME), CAST(a AS DATETIME), DAY)",
                 "duckdb": "DATE_DIFF('DAY', CAST(a AS TIMESTAMP), CAST(b AS TIMESTAMP))",

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -306,6 +306,14 @@ class TestRedshift(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT EXTRACT(EPOCH FROM CURRENT_DATE)",
+            write={
+                "snowflake": "SELECT DATE_PART(EPOCH, CURRENT_DATE)",
+                "redshift": "SELECT EXTRACT(EPOCH FROM CURRENT_DATE)",
+            },
+        )
+
     def test_identity(self):
         self.validate_identity("LISTAGG(DISTINCT foo, ', ')")
         self.validate_identity("CREATE MATERIALIZED VIEW orders AUTO REFRESH YES AS SELECT 1")


### PR DESCRIPTION
Fixes #3651

Normalize Redshift's units from plural/abbreviation to their full singular form during parse time. This is already happening at Snowflake, so the existing infrastructure is moved out to `dialect.py` as most of these mappings are similar between dialects.