### PR TITLE
feat(bigquery)!: Time/Datetime/Timestamp function additions

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -13,7 +13,6 @@ from sqlglot.dialects.dialect import (
     date_add_interval_sql,
     datestrtodate_sql,
     build_formatted_time,
-    build_timestamp_from_parts,
     filter_array_using_unnest,
     if_sql,
     inline_array_unless_query,
@@ -202,7 +201,7 @@ def _unix_to_time_sql(self: BigQuery.Generator, expression: exp.UnixToTime) -> s
 def _build_time(args: t.List) -> exp.Func:
     if len(args) == 1:
         return exp.TsOrDsToTime(this=args[0])
-    elif len(args) == 2:
+    if len(args) == 2:
         return exp.Time.from_arg_list(args)
     return exp.TimeFromParts.from_arg_list(args)
 
@@ -210,9 +209,9 @@ def _build_time(args: t.List) -> exp.Func:
 def _build_datetime(args: t.List) -> exp.Func:
     if len(args) == 1:
         return exp.TsOrDsToTimestamp.from_arg_list(args)
-    elif len(args) == 2:
+    if len(args) == 2:
         return exp.Datetime.from_arg_list(args)
-    return build_timestamp_from_parts(args)
+    return exp.TimestampFromParts.from_arg_list(args)
 
 
 class BigQuery(Dialect):

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -202,10 +202,17 @@ def _unix_to_time_sql(self: BigQuery.Generator, expression: exp.UnixToTime) -> s
 def _build_time(args: t.List) -> exp.Func:
     if len(args) == 1:
         return exp.TsOrDsToTime(this=args[0])
-    if len(args) == 3:
-        return exp.TimeFromParts.from_arg_list(args)
+    elif len(args) == 2:
+        return exp.Time.from_arg_list(args)
+    return exp.TimeFromParts.from_arg_list(args)
 
-    return exp.Anonymous(this="TIME", expressions=args)
+
+def _build_datetime(args: t.List) -> exp.Func:
+    if len(args) == 1:
+        return exp.TsOrDsToTimestamp.from_arg_list(args)
+    elif len(args) == 2:
+        return exp.Datetime.from_arg_list(args)
+    return build_timestamp_from_parts(args)
 
 
 class BigQuery(Dialect):
@@ -323,7 +330,7 @@ class BigQuery(Dialect):
                 unit=exp.Literal.string(str(seq_get(args, 1))),
                 this=seq_get(args, 0),
             ),
-            "DATETIME": build_timestamp_from_parts,
+            "DATETIME": _build_datetime,
             "DATETIME_ADD": build_date_delta_with_interval(exp.DatetimeAdd),
             "DATETIME_SUB": build_date_delta_with_interval(exp.DatetimeSub),
             "DIV": binary_from_function(exp.IntDiv),
@@ -661,6 +668,7 @@ class BigQuery(Dialect):
             exp.TsOrDsAdd: _ts_or_ds_add_sql,
             exp.TsOrDsDiff: _ts_or_ds_diff_sql,
             exp.TsOrDsToTime: rename_func("TIME"),
+            exp.TsOrDsToTimestamp: rename_func("DATETIME"),
             exp.Unhex: rename_func("FROM_HEX"),
             exp.UnixDate: rename_func("UNIX_DATE"),
             exp.UnixToTime: _unix_to_time_sql,

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -833,7 +833,7 @@ def no_datetime_sql(self: Generator, expression: exp.Datetime) -> str:
     expr = expression.expression
 
     if expr.name.lower() in TIMEZONES:
-        # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIME)
+        # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIMESTAMP)
         this = exp.cast(this, exp.DataType.Type.TIMESTAMPTZ)
         this = exp.cast(exp.AtTimeZone(this=this, zone=expr), exp.DataType.Type.TIMESTAMP)
         return self.sql(this)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -803,19 +803,45 @@ def timestamptrunc_sql(zone: bool = False) -> t.Callable[[Generator, exp.Timesta
 
 
 def no_timestamp_sql(self: Generator, expression: exp.Timestamp) -> str:
-    if not expression.expression:
+    zone = expression.args.get("zone")
+    if not zone:
         from sqlglot.optimizer.annotate_types import annotate_types
 
         target_type = annotate_types(expression).type or exp.DataType.Type.TIMESTAMP
         return self.sql(exp.cast(expression.this, target_type))
-    if expression.text("expression").lower() in TIMEZONES:
+    if zone.name.lower() in TIMEZONES:
         return self.sql(
             exp.AtTimeZone(
                 this=exp.cast(expression.this, exp.DataType.Type.TIMESTAMP),
-                zone=expression.expression,
+                zone=zone,
             )
         )
-    return self.func("TIMESTAMP", expression.this, expression.expression)
+    return self.func("TIMESTAMP", expression.this, zone)
+
+
+def no_time_sql(self: Generator, expression: exp.Time) -> str:
+    # Transpile BQ's TIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIME)
+    this = exp.cast(expression.this, exp.DataType.Type.TIMESTAMPTZ)
+    expr = exp.cast(
+        exp.AtTimeZone(this=this, zone=expression.args.get("zone")), exp.DataType.Type.TIME
+    )
+    return self.sql(expr)
+
+
+def no_datetime_sql(self: Generator, expression: exp.Datetime) -> str:
+    this = expression.this
+    expr = expression.expression
+
+    if expr.name.lower() in TIMEZONES:
+        # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIME)
+        this = exp.cast(this, exp.DataType.Type.TIMESTAMPTZ)
+        this = exp.cast(exp.AtTimeZone(this=this, zone=expr), exp.DataType.Type.TIMESTAMP)
+        return self.sql(this)
+
+    this = exp.cast(this, exp.DataType.Type.DATE)
+    expr = exp.cast(expr, exp.DataType.Type.TIME)
+
+    return self.sql(exp.cast(exp.Add(this=this, expression=expr), exp.DataType.Type.TIMESTAMP))
 
 
 def locate_to_strposition(args: t.List) -> exp.Expression:

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -15,11 +15,13 @@ from sqlglot.dialects.dialect import (
     build_default_decimal_type,
     date_trunc_to_time,
     datestrtodate_sql,
+    no_datetime_sql,
     encode_decode_sql,
     build_formatted_time,
     inline_array_unless_query,
     no_comment_column_constraint_sql,
     no_safe_divide_sql,
+    no_time_sql,
     no_timestamp_sql,
     pivot_column_names,
     regexp_extract_sql,
@@ -407,6 +409,7 @@ class DuckDB(Dialect):
                 "DATE_DIFF", f"'{e.args.get('unit') or 'DAY'}'", e.expression, e.this
             ),
             exp.DateStrToDate: datestrtodate_sql,
+            exp.Datetime: no_datetime_sql,
             exp.DateToDi: lambda self,
             e: f"CAST(STRFTIME({self.sql(e, 'this')}, {DuckDB.DATEINT_FORMAT}) AS INT)",
             exp.Decode: lambda self, e: encode_decode_sql(self, e, "DECODE", replace=False),
@@ -457,6 +460,7 @@ class DuckDB(Dialect):
             ),
             exp.Struct: _struct_sql,
             exp.TimeAdd: _date_delta_sql,
+            exp.Time: no_time_sql,
             exp.Timestamp: no_timestamp_sql,
             exp.TimestampDiff: lambda self, e: self.func(
                 "DATE_DIFF", exp.Literal.string(e.unit), e.expression, e.this

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -111,6 +111,7 @@ class SQLite(Dialect):
             **parser.Parser.FUNCTIONS,
             "EDITDIST3": exp.Levenshtein.from_arg_list,
             "STRFTIME": _build_strftime,
+            "DATETIME": lambda args: exp.Anonymous(this="DATETIME", expressions=args),
         }
         STRING_ALIASES = True
 

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -112,6 +112,7 @@ class SQLite(Dialect):
             "EDITDIST3": exp.Levenshtein.from_arg_list,
             "STRFTIME": _build_strftime,
             "DATETIME": lambda args: exp.Anonymous(this="DATETIME", expressions=args),
+            "TIME": lambda args: exp.Anonymous(this="TIME", expressions=args),
         }
         STRING_ALIASES = True
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5065,6 +5065,12 @@ class DateTrunc(Func):
         return self.args["unit"]
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime
+# expression can either be time_expr or time_zone
+class Datetime(Func):
+    arg_types = {"this": True, "expression": False}
+
+
 class DatetimeAdd(Func, IntervalOp):
     arg_types = {"this": True, "expression": True, "unit": False}
 
@@ -5115,7 +5121,7 @@ class Extract(Func):
 
 
 class Timestamp(Func):
-    arg_types = {"this": False, "expression": False, "with_tz": False}
+    arg_types = {"this": False, "zone": False, "with_tz": False}
 
 
 class TimestampAdd(Func, TimeUnit):
@@ -5831,6 +5837,11 @@ class StddevPop(AggFunc):
 
 class StddevSamp(AggFunc):
     pass
+
+
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time
+class Time(Func):
+    arg_types = {"this": False, "zone": False}
 
 
 class TimeToStr(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -143,7 +143,7 @@ class Generator(metaclass=_Generator):
         exp.TemporaryProperty: lambda *_: "TEMPORARY",
         exp.TagColumnConstraint: lambda self, e: f"TAG ({self.expressions(e, flat=True)})",
         exp.TitleColumnConstraint: lambda self, e: f"TITLE {self.sql(e, 'this')}",
-        exp.Timestamp: lambda self, e: self.func("TIMESTAMP", e.this, e.expression),
+        exp.Timestamp: lambda self, e: self.func("TIMESTAMP", e.this, e.args.get("zone")),
         exp.ToMap: lambda self, e: f"MAP {self.sql(e, 'this')}",
         exp.ToTableProperty: lambda self, e: f"TO {self.sql(e.this)}",
         exp.TransformModelProperty: lambda self, e: self.func("TRANSFORM", *e.expressions),

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -197,11 +197,13 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         exp.DataType.Type.JSON: {
             exp.ParseJSON,
         },
+        exp.DataType.Type.TIME: {
+            exp.Time,
+        },
         exp.DataType.Type.TIMESTAMP: {
             exp.CurrentTime,
             exp.CurrentTimestamp,
             exp.StrToTime,
-            exp.Time,
             exp.TimeAdd,
             exp.TimeStrToTime,
             exp.TimeSub,

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -158,6 +158,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         },
         exp.DataType.Type.DATETIME: {
             exp.CurrentDatetime,
+            exp.Datetime,
             exp.DatetimeAdd,
             exp.DatetimeSub,
         },
@@ -200,6 +201,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             exp.CurrentTime,
             exp.CurrentTimestamp,
             exp.StrToTime,
+            exp.Time,
             exp.TimeAdd,
             exp.TimeStrToTime,
             exp.TimeSub,

--- a/sqlglot/optimizer/canonicalize.py
+++ b/sqlglot/optimizer/canonicalize.py
@@ -42,7 +42,7 @@ def replace_date_funcs(node: exp.Expression) -> exp.Expression:
         and not node.args.get("zone")
     ):
         return exp.cast(node.this, to=exp.DataType.Type.DATE)
-    if isinstance(node, exp.Timestamp) and not node.expression:
+    if isinstance(node, exp.Timestamp) and not node.args.get("zone"):
         if not node.type:
             from sqlglot.optimizer.annotate_types import annotate_types
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1345,6 +1345,34 @@ WHERE
                 "bigquery": "SELECT CAST(x AS DATETIME)",
             },
         )
+        self.validate_all(
+            "SELECT TIME(foo, 'America/Los_Angeles')",
+            write={
+                "duckdb": "SELECT CAST(CAST(foo AS TIMESTAMPTZ) AT TIME ZONE 'America/Los_Angeles' AS TIME)",
+                "bigquery": "SELECT TIME(foo, 'America/Los_Angeles')",
+            },
+        )
+        self.validate_all(
+            "SELECT DATETIME('2020-01-01')",
+            write={
+                "duckdb": "SELECT CAST('2020-01-01' AS TIMESTAMP)",
+                "bigquery": "SELECT DATETIME('2020-01-01')",
+            },
+        )
+        self.validate_all(
+            "SELECT DATETIME('2020-01-01', TIME '23:59:59')",
+            write={
+                "duckdb": "SELECT CAST(CAST('2020-01-01' AS DATE) + CAST('23:59:59' AS TIME) AS TIMESTAMP)",
+                "bigquery": "SELECT DATETIME('2020-01-01', CAST('23:59:59' AS TIME))",
+            },
+        )
+        self.validate_all(
+            "SELECT DATETIME('2020-01-01', 'America/Los_Angeles')",
+            write={
+                "duckdb": "SELECT CAST(CAST('2020-01-01' AS TIMESTAMPTZ) AT TIME ZONE 'America/Los_Angeles' AS TIMESTAMP)",
+                "bigquery": "SELECT DATETIME('2020-01-01', 'America/Los_Angeles')",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):


### PR DESCRIPTION
The aim of this PR is to extend support for the following time functions in BigQuery and enable transpilation towards DuckDB:

`TIME`:
- Introduce `exp.Time` for `TIME(timestamp, [time_zone])`  roundtrip
- Enable transpilation to other dialects by generating `<timestamp> AT TIME ZONE <time_zone>` 

`TIMESTAMP`:
- Rename `expression` to `zone` as the 2nd parameter is always `time_zone`

`DATETIME`:
- Introduce `exp.Datetime` for `DATETIME(date_expr, [time_expr | time_zone])` roundtrip
- Enable transpilation to other dialects by generating `<date_expr> AT TIME ZONE <time_zone>` if the expression is `time_zone`, otherwise generate `<date_expr> + <time_expr>` 


[BQ TIME](https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time) | [BQ TIMESTAMP](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp) |  [BQ DATETIME](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime) | [DuckDB AT TIME ZONE](https://duckdb.org/docs/sql/functions/timestamptz.html#at-time-zone)