### PR TITLE
feat(databricks)!: Preserve JSON/VARIANT path with operators

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
     date_delta_sql,
@@ -10,10 +12,25 @@ from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import TokenType
 
 
+def _build_json_extract(args: t.List) -> exp.JSONExtract:
+    # Transform GET_JSON_OBJECT(expr, '$.<path>') -> expr:<path>
+    this = args[0]
+    path = args[1].name.lstrip("$.")
+    return exp.JSONExtract(this=this, expression=path)
+
+
 def _timestamp_diff(
     self: Databricks.Generator, expression: exp.DatetimeDiff | exp.TimestampDiff
 ) -> str:
     return self.func("TIMESTAMPDIFF", expression.unit, expression.expression, expression.this)
+
+
+def _jsonextract_sql(
+    self: Databricks.Generator, expression: exp.JSONExtract | exp.JSONExtractScalar
+) -> str:
+    this = self.sql(expression, "this")
+    expr = self.sql(expression, "expression")
+    return f"{this}:{expr}"
 
 
 class Databricks(Spark):
@@ -31,6 +48,7 @@ class Databricks(Spark):
             "DATE_ADD": build_date_delta(exp.DateAdd),
             "DATEDIFF": build_date_delta(exp.DateDiff),
             "TIMESTAMPDIFF": build_date_delta(exp.TimestampDiff),
+            "GET_JSON_OBJECT": _build_json_extract,
         }
 
         FACTOR = {
@@ -42,6 +60,7 @@ class Databricks(Spark):
         TABLESAMPLE_SEED_KEYWORD = "REPEATABLE"
         COPY_PARAMS_ARE_WRAPPED = False
         COPY_PARAMS_EQ_REQUIRED = True
+        JSON_PATH_SINGLE_QUOTE_ESCAPE = False
 
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
@@ -65,6 +84,9 @@ class Databricks(Spark):
                     transforms.unnest_to_explode,
                 ]
             ),
+            exp.JSONExtract: _jsonextract_sql,
+            exp.JSONExtractScalar: _jsonextract_sql,
+            exp.JSONPathRoot: lambda *_: "",
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
         }
 
@@ -88,3 +110,6 @@ class Databricks(Spark):
         ) -> str:
             expression.set("this", True)  # trigger ALWAYS in super class
             return super().generatedasidentitycolumnconstraint_sql(expression)
+
+        def jsonpath_sql(self, expression: exp.JSONPath) -> str:
+            return self.expressions(expression, sep="", flat=True).lstrip(".")

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -61,6 +61,7 @@ class Databricks(Spark):
         COPY_PARAMS_ARE_WRAPPED = False
         COPY_PARAMS_EQ_REQUIRED = True
         JSON_PATH_SINGLE_QUOTE_ESCAPE = False
+        QUOTE_JSON_PATH = False
 
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
@@ -110,6 +111,3 @@ class Databricks(Spark):
         ) -> str:
             expression.set("this", True)  # trigger ALWAYS in super class
             return super().generatedasidentitycolumnconstraint_sql(expression)
-
-        def jsonpath_sql(self, expression: exp.JSONPath) -> str:
-            return self.expressions(expression, sep="", flat=True).lstrip(".")

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp, transforms
+from sqlglot import exp, transforms, jsonpath
 from sqlglot.dialects.dialect import (
     date_delta_sql,
     build_date_delta,
@@ -36,6 +36,9 @@ def _jsonextract_sql(
 class Databricks(Spark):
     SAFE_DIVISION = False
     COPY_PARAMS_ARE_CSV = False
+
+    class JSONPathTokenizer(jsonpath.JSONPathTokenizer):
+        IDENTIFIERS = ["`", '"']
 
     class Parser(Spark.Parser):
         LOG_DEFAULTS_TO_LN = True

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -9,7 +9,7 @@ from sqlglot import exp
 from sqlglot.errors import ParseError
 from sqlglot.generator import Generator
 from sqlglot.helper import AutoName, flatten, is_int, seq_get
-from sqlglot.jsonpath import JSONPathTokenizer
+from sqlglot.jsonpath import JSONPathTokenizer, parse as parse_json_path
 from sqlglot.parser import Parser
 from sqlglot.time import TIMEZONES, format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
@@ -626,9 +626,8 @@ class Dialect(metaclass=_Dialect):
             path_text = path.name
             if path.is_number:
                 path_text = f"[{path_text}]"
-
             try:
-                return self.jsonpath_tokenizer.parse(path_text)
+                return parse_json_path(path_text, self)
             except ParseError as e:
                 logger.warning(f"Invalid JSON path syntax. {str(e)}")
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -663,7 +663,7 @@ class Dialect(metaclass=_Dialect):
     def jsonpath_tokenizer(self) -> JSONPathTokenizer:
         if not hasattr(self, "_jsonpath_tokenizer"):
             self._jsonpath_tokenizer = self.jsonpath_tokenizer_class(dialect=self)
-        return self.jsonpath_tokenizer_class(dialect=self)
+        return self._jsonpath_tokenizer
 
     def parser(self, **opts) -> Parser:
         return self.parser_class(dialect=self, **opts)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -9,7 +9,7 @@ from sqlglot import exp
 from sqlglot.errors import ParseError
 from sqlglot.generator import Generator
 from sqlglot.helper import AutoName, flatten, is_int, seq_get
-from sqlglot.jsonpath import parse as parse_json_path
+from sqlglot.jsonpath import JSONPathTokenizer
 from sqlglot.parser import Parser
 from sqlglot.time import TIMEZONES, format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
@@ -125,11 +125,15 @@ class _Dialect(type):
 
         base = seq_get(bases, 0)
         base_tokenizer = (getattr(base, "tokenizer_class", Tokenizer),)
+        base_jsonpath_tokenizer = (getattr(base, "jsonpath_tokenizer_class", JSONPathTokenizer),)
         base_parser = (getattr(base, "parser_class", Parser),)
         base_generator = (getattr(base, "generator_class", Generator),)
 
         klass.tokenizer_class = klass.__dict__.get(
             "Tokenizer", type("Tokenizer", base_tokenizer, {})
+        )
+        klass.jsonpath_tokenizer_class = klass.__dict__.get(
+            "JSONPathTokenizer", type("JSONPathTokenizer", base_jsonpath_tokenizer, {})
         )
         klass.parser_class = klass.__dict__.get("Parser", type("Parser", base_parser, {}))
         klass.generator_class = klass.__dict__.get(
@@ -324,6 +328,7 @@ class Dialect(metaclass=_Dialect):
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer
+    jsonpath_tokenizer_class = JSONPathTokenizer
     parser_class = Parser
     generator_class = Generator
 
@@ -623,7 +628,7 @@ class Dialect(metaclass=_Dialect):
                 path_text = f"[{path_text}]"
 
             try:
-                return parse_json_path(path_text)
+                return self.jsonpath_tokenizer.parse(path_text)
             except ParseError as e:
                 logger.warning(f"Invalid JSON path syntax. {str(e)}")
 
@@ -654,6 +659,12 @@ class Dialect(metaclass=_Dialect):
         if not hasattr(self, "_tokenizer"):
             self._tokenizer = self.tokenizer_class(dialect=self)
         return self._tokenizer
+
+    @property
+    def jsonpath_tokenizer(self) -> JSONPathTokenizer:
+        if not hasattr(self, "_jsonpath_tokenizer"):
+            self._jsonpath_tokenizer = self.jsonpath_tokenizer_class(dialect=self)
+        return self.jsonpath_tokenizer_class(dialect=self)
 
     def parser(self, **opts) -> Parser:
         return self.parser_class(dialect=self, **opts)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -368,6 +368,9 @@ class Generator(metaclass=_Generator):
     # The keywords to use when prefixing & separating WITH based properties
     WITH_PROPERTIES_PREFIX = "WITH"
 
+    # Whether to quote the generated expression of exp.JsonPath
+    QUOTE_JSON_PATH = True
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -2655,7 +2658,10 @@ class Generator(metaclass=_Generator):
 
     def jsonpath_sql(self, expression: exp.JSONPath) -> str:
         path = self.expressions(expression, sep="", flat=True).lstrip(".")
-        return f"{self.dialect.QUOTE_START}{path}{self.dialect.QUOTE_END}"
+        if self.QUOTE_JSON_PATH:
+            path = f"{self.dialect.QUOTE_START}{path}{self.dialect.QUOTE_END}"
+
+        return path
 
     def json_path_part(self, expression: int | str | exp.JSONPathPart) -> str:
         if isinstance(expression, exp.JSONPathPart):

--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -34,6 +34,7 @@ class JSONPathTokenizer(Tokenizer):
 
     IDENTIFIER_ESCAPES = ["\\"]
     STRING_ESCAPES = ["\\"]
+    IDENTIFIERS = ["`", '"']
 
 
 def parse(path: str) -> exp.JSONPath:

--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -8,6 +8,7 @@ from sqlglot.tokens import Token, Tokenizer, TokenType
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import Lit
+    from sqlglot.dialects.dialect import DialectType
 
 
 class JSONPathTokenizer(Tokenizer):
@@ -35,144 +36,148 @@ class JSONPathTokenizer(Tokenizer):
     IDENTIFIER_ESCAPES = ["\\"]
     STRING_ESCAPES = ["\\"]
 
-    def parse(self, path: str) -> exp.JSONPath:
-        """Takes in a JSON path string and parses it into a JSONPath expression."""
-        tokens = self.tokenize(path)
-        size = len(tokens)
 
-        i = 0
+def parse(path: str, dialect: DialectType = None) -> exp.JSONPath:
+    """Takes in a JSON path string and parses it into a JSONPath expression."""
+    from sqlglot.dialects import Dialect
 
-        def _curr() -> t.Optional[TokenType]:
-            return tokens[i].token_type if i < size else None
+    jsonpath_tokenizer = Dialect.get_or_raise(dialect).jsonpath_tokenizer
+    tokens = jsonpath_tokenizer.tokenize(path)
+    size = len(tokens)
 
-        def _prev() -> Token:
-            return tokens[i - 1]
+    i = 0
 
-        def _advance() -> Token:
-            nonlocal i
-            i += 1
-            return _prev()
+    def _curr() -> t.Optional[TokenType]:
+        return tokens[i].token_type if i < size else None
 
-        def _error(msg: str) -> str:
-            return f"{msg} at index {i}: {path}"
+    def _prev() -> Token:
+        return tokens[i - 1]
 
-        @t.overload
-        def _match(token_type: TokenType, raise_unmatched: Lit[True] = True) -> Token:
-            pass
+    def _advance() -> Token:
+        nonlocal i
+        i += 1
+        return _prev()
 
-        @t.overload
-        def _match(token_type: TokenType, raise_unmatched: Lit[False] = False) -> t.Optional[Token]:
-            pass
+    def _error(msg: str) -> str:
+        return f"{msg} at index {i}: {path}"
 
-        def _match(token_type, raise_unmatched=False):
-            if _curr() == token_type:
-                return _advance()
-            if raise_unmatched:
-                raise ParseError(_error(f"Expected {token_type}"))
-            return None
+    @t.overload
+    def _match(token_type: TokenType, raise_unmatched: Lit[True] = True) -> Token:
+        pass
 
-        def _parse_literal() -> t.Any:
-            token = _match(TokenType.STRING) or _match(TokenType.IDENTIFIER)
-            if token:
-                return token.text
-            if _match(TokenType.STAR):
-                return exp.JSONPathWildcard()
-            if _match(TokenType.PLACEHOLDER) or _match(TokenType.L_PAREN):
-                script = _prev().text == "("
-                start = i
+    @t.overload
+    def _match(token_type: TokenType, raise_unmatched: Lit[False] = False) -> t.Optional[Token]:
+        pass
 
-                while True:
-                    if _match(TokenType.L_BRACKET):
-                        _parse_bracket()  # nested call which we can throw away
-                    if _curr() in (TokenType.R_BRACKET, None):
-                        break
-                    _advance()
+    def _match(token_type, raise_unmatched=False):
+        if _curr() == token_type:
+            return _advance()
+        if raise_unmatched:
+            raise ParseError(_error(f"Expected {token_type}"))
+        return None
 
-                expr_type = exp.JSONPathScript if script else exp.JSONPathFilter
-                return expr_type(this=path[tokens[start].start : tokens[i].end])
+    def _parse_literal() -> t.Any:
+        token = _match(TokenType.STRING) or _match(TokenType.IDENTIFIER)
+        if token:
+            return token.text
+        if _match(TokenType.STAR):
+            return exp.JSONPathWildcard()
+        if _match(TokenType.PLACEHOLDER) or _match(TokenType.L_PAREN):
+            script = _prev().text == "("
+            start = i
 
-            number = "-" if _match(TokenType.DASH) else ""
+            while True:
+                if _match(TokenType.L_BRACKET):
+                    _parse_bracket()  # nested call which we can throw away
+                if _curr() in (TokenType.R_BRACKET, None):
+                    break
+                _advance()
 
-            token = _match(TokenType.NUMBER)
-            if token:
-                number += token.text
+            expr_type = exp.JSONPathScript if script else exp.JSONPathFilter
+            return expr_type(this=path[tokens[start].start : tokens[i].end])
 
-            if number:
-                return int(number)
+        number = "-" if _match(TokenType.DASH) else ""
 
-            return False
+        token = _match(TokenType.NUMBER)
+        if token:
+            number += token.text
 
-        def _parse_slice() -> t.Any:
-            start = _parse_literal()
-            end = _parse_literal() if _match(TokenType.COLON) else None
-            step = _parse_literal() if _match(TokenType.COLON) else None
+        if number:
+            return int(number)
 
-            if end is None and step is None:
-                return start
+        return False
 
-            return exp.JSONPathSlice(start=start, end=end, step=step)
+    def _parse_slice() -> t.Any:
+        start = _parse_literal()
+        end = _parse_literal() if _match(TokenType.COLON) else None
+        step = _parse_literal() if _match(TokenType.COLON) else None
 
-        def _parse_bracket() -> exp.JSONPathPart:
-            literal = _parse_slice()
+        if end is None and step is None:
+            return start
 
-            if isinstance(literal, str) or literal is not False:
-                indexes = [literal]
-                while _match(TokenType.COMMA):
-                    literal = _parse_slice()
+        return exp.JSONPathSlice(start=start, end=end, step=step)
 
-                    if literal:
-                        indexes.append(literal)
+    def _parse_bracket() -> exp.JSONPathPart:
+        literal = _parse_slice()
 
-                if len(indexes) == 1:
-                    if isinstance(literal, str):
-                        node: exp.JSONPathPart = exp.JSONPathKey(this=indexes[0])
-                    elif isinstance(literal, exp.JSONPathPart) and isinstance(
-                        literal, (exp.JSONPathScript, exp.JSONPathFilter)
-                    ):
-                        node = exp.JSONPathSelector(this=indexes[0])
-                    else:
-                        node = exp.JSONPathSubscript(this=indexes[0])
+        if isinstance(literal, str) or literal is not False:
+            indexes = [literal]
+            while _match(TokenType.COMMA):
+                literal = _parse_slice()
+
+                if literal:
+                    indexes.append(literal)
+
+            if len(indexes) == 1:
+                if isinstance(literal, str):
+                    node: exp.JSONPathPart = exp.JSONPathKey(this=indexes[0])
+                elif isinstance(literal, exp.JSONPathPart) and isinstance(
+                    literal, (exp.JSONPathScript, exp.JSONPathFilter)
+                ):
+                    node = exp.JSONPathSelector(this=indexes[0])
                 else:
-                    node = exp.JSONPathUnion(expressions=indexes)
+                    node = exp.JSONPathSubscript(this=indexes[0])
             else:
-                raise ParseError(_error("Cannot have empty segment"))
+                node = exp.JSONPathUnion(expressions=indexes)
+        else:
+            raise ParseError(_error("Cannot have empty segment"))
 
-            _match(TokenType.R_BRACKET, raise_unmatched=True)
+        _match(TokenType.R_BRACKET, raise_unmatched=True)
 
-            return node
+        return node
 
-        # We canonicalize the JSON path AST so that it always starts with a
-        # "root" element, so paths like "field" will be generated as "$.field"
-        _match(TokenType.DOLLAR)
-        expressions: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
+    # We canonicalize the JSON path AST so that it always starts with a
+    # "root" element, so paths like "field" will be generated as "$.field"
+    _match(TokenType.DOLLAR)
+    expressions: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
 
-        while _curr():
-            if _match(TokenType.DOT) or _match(TokenType.COLON):
-                recursive = _prev().text == ".."
+    while _curr():
+        if _match(TokenType.DOT) or _match(TokenType.COLON):
+            recursive = _prev().text == ".."
 
-                if _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
-                    value: t.Optional[str | exp.JSONPathWildcard] = _prev().text
-                elif _match(TokenType.STAR):
-                    value = exp.JSONPathWildcard()
-                else:
-                    value = None
-
-                if recursive:
-                    expressions.append(exp.JSONPathRecursive(this=value))
-                elif value:
-                    expressions.append(exp.JSONPathKey(this=value))
-                else:
-                    raise ParseError(_error("Expected key name or * after DOT"))
-            elif _match(TokenType.L_BRACKET):
-                expressions.append(_parse_bracket())
-            elif _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
-                expressions.append(exp.JSONPathKey(this=_prev().text))
+            if _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
+                value: t.Optional[str | exp.JSONPathWildcard] = _prev().text
             elif _match(TokenType.STAR):
-                expressions.append(exp.JSONPathWildcard())
+                value = exp.JSONPathWildcard()
             else:
-                raise ParseError(_error(f"Unexpected {tokens[i].token_type}"))
+                value = None
 
-        return exp.JSONPath(expressions=expressions)
+            if recursive:
+                expressions.append(exp.JSONPathRecursive(this=value))
+            elif value:
+                expressions.append(exp.JSONPathKey(this=value))
+            else:
+                raise ParseError(_error("Expected key name or * after DOT"))
+        elif _match(TokenType.L_BRACKET):
+            expressions.append(_parse_bracket())
+        elif _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
+            expressions.append(exp.JSONPathKey(this=_prev().text))
+        elif _match(TokenType.STAR):
+            expressions.append(exp.JSONPathWildcard())
+        else:
+            raise ParseError(_error(f"Unexpected {tokens[i].token_type}"))
+
+    return exp.JSONPath(expressions=expressions)
 
 
 JSON_PATH_PART_TRANSFORMS: t.Dict[t.Type[exp.Expression], t.Callable[..., str]] = {

--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -34,147 +34,145 @@ class JSONPathTokenizer(Tokenizer):
 
     IDENTIFIER_ESCAPES = ["\\"]
     STRING_ESCAPES = ["\\"]
-    IDENTIFIERS = ["`", '"']
 
+    def parse(self, path: str) -> exp.JSONPath:
+        """Takes in a JSON path string and parses it into a JSONPath expression."""
+        tokens = self.tokenize(path)
+        size = len(tokens)
 
-def parse(path: str) -> exp.JSONPath:
-    """Takes in a JSON path string and parses it into a JSONPath expression."""
-    tokens = JSONPathTokenizer().tokenize(path)
-    size = len(tokens)
+        i = 0
 
-    i = 0
+        def _curr() -> t.Optional[TokenType]:
+            return tokens[i].token_type if i < size else None
 
-    def _curr() -> t.Optional[TokenType]:
-        return tokens[i].token_type if i < size else None
+        def _prev() -> Token:
+            return tokens[i - 1]
 
-    def _prev() -> Token:
-        return tokens[i - 1]
+        def _advance() -> Token:
+            nonlocal i
+            i += 1
+            return _prev()
 
-    def _advance() -> Token:
-        nonlocal i
-        i += 1
-        return _prev()
+        def _error(msg: str) -> str:
+            return f"{msg} at index {i}: {path}"
 
-    def _error(msg: str) -> str:
-        return f"{msg} at index {i}: {path}"
+        @t.overload
+        def _match(token_type: TokenType, raise_unmatched: Lit[True] = True) -> Token:
+            pass
 
-    @t.overload
-    def _match(token_type: TokenType, raise_unmatched: Lit[True] = True) -> Token:
-        pass
+        @t.overload
+        def _match(token_type: TokenType, raise_unmatched: Lit[False] = False) -> t.Optional[Token]:
+            pass
 
-    @t.overload
-    def _match(token_type: TokenType, raise_unmatched: Lit[False] = False) -> t.Optional[Token]:
-        pass
+        def _match(token_type, raise_unmatched=False):
+            if _curr() == token_type:
+                return _advance()
+            if raise_unmatched:
+                raise ParseError(_error(f"Expected {token_type}"))
+            return None
 
-    def _match(token_type, raise_unmatched=False):
-        if _curr() == token_type:
-            return _advance()
-        if raise_unmatched:
-            raise ParseError(_error(f"Expected {token_type}"))
-        return None
+        def _parse_literal() -> t.Any:
+            token = _match(TokenType.STRING) or _match(TokenType.IDENTIFIER)
+            if token:
+                return token.text
+            if _match(TokenType.STAR):
+                return exp.JSONPathWildcard()
+            if _match(TokenType.PLACEHOLDER) or _match(TokenType.L_PAREN):
+                script = _prev().text == "("
+                start = i
 
-    def _parse_literal() -> t.Any:
-        token = _match(TokenType.STRING) or _match(TokenType.IDENTIFIER)
-        if token:
-            return token.text
-        if _match(TokenType.STAR):
-            return exp.JSONPathWildcard()
-        if _match(TokenType.PLACEHOLDER) or _match(TokenType.L_PAREN):
-            script = _prev().text == "("
-            start = i
+                while True:
+                    if _match(TokenType.L_BRACKET):
+                        _parse_bracket()  # nested call which we can throw away
+                    if _curr() in (TokenType.R_BRACKET, None):
+                        break
+                    _advance()
 
-            while True:
-                if _match(TokenType.L_BRACKET):
-                    _parse_bracket()  # nested call which we can throw away
-                if _curr() in (TokenType.R_BRACKET, None):
-                    break
-                _advance()
+                expr_type = exp.JSONPathScript if script else exp.JSONPathFilter
+                return expr_type(this=path[tokens[start].start : tokens[i].end])
 
-            expr_type = exp.JSONPathScript if script else exp.JSONPathFilter
-            return expr_type(this=path[tokens[start].start : tokens[i].end])
+            number = "-" if _match(TokenType.DASH) else ""
 
-        number = "-" if _match(TokenType.DASH) else ""
+            token = _match(TokenType.NUMBER)
+            if token:
+                number += token.text
 
-        token = _match(TokenType.NUMBER)
-        if token:
-            number += token.text
+            if number:
+                return int(number)
 
-        if number:
-            return int(number)
+            return False
 
-        return False
+        def _parse_slice() -> t.Any:
+            start = _parse_literal()
+            end = _parse_literal() if _match(TokenType.COLON) else None
+            step = _parse_literal() if _match(TokenType.COLON) else None
 
-    def _parse_slice() -> t.Any:
-        start = _parse_literal()
-        end = _parse_literal() if _match(TokenType.COLON) else None
-        step = _parse_literal() if _match(TokenType.COLON) else None
+            if end is None and step is None:
+                return start
 
-        if end is None and step is None:
-            return start
+            return exp.JSONPathSlice(start=start, end=end, step=step)
 
-        return exp.JSONPathSlice(start=start, end=end, step=step)
+        def _parse_bracket() -> exp.JSONPathPart:
+            literal = _parse_slice()
 
-    def _parse_bracket() -> exp.JSONPathPart:
-        literal = _parse_slice()
+            if isinstance(literal, str) or literal is not False:
+                indexes = [literal]
+                while _match(TokenType.COMMA):
+                    literal = _parse_slice()
 
-        if isinstance(literal, str) or literal is not False:
-            indexes = [literal]
-            while _match(TokenType.COMMA):
-                literal = _parse_slice()
+                    if literal:
+                        indexes.append(literal)
 
-                if literal:
-                    indexes.append(literal)
-
-            if len(indexes) == 1:
-                if isinstance(literal, str):
-                    node: exp.JSONPathPart = exp.JSONPathKey(this=indexes[0])
-                elif isinstance(literal, exp.JSONPathPart) and isinstance(
-                    literal, (exp.JSONPathScript, exp.JSONPathFilter)
-                ):
-                    node = exp.JSONPathSelector(this=indexes[0])
+                if len(indexes) == 1:
+                    if isinstance(literal, str):
+                        node: exp.JSONPathPart = exp.JSONPathKey(this=indexes[0])
+                    elif isinstance(literal, exp.JSONPathPart) and isinstance(
+                        literal, (exp.JSONPathScript, exp.JSONPathFilter)
+                    ):
+                        node = exp.JSONPathSelector(this=indexes[0])
+                    else:
+                        node = exp.JSONPathSubscript(this=indexes[0])
                 else:
-                    node = exp.JSONPathSubscript(this=indexes[0])
+                    node = exp.JSONPathUnion(expressions=indexes)
             else:
-                node = exp.JSONPathUnion(expressions=indexes)
-        else:
-            raise ParseError(_error("Cannot have empty segment"))
+                raise ParseError(_error("Cannot have empty segment"))
 
-        _match(TokenType.R_BRACKET, raise_unmatched=True)
+            _match(TokenType.R_BRACKET, raise_unmatched=True)
 
-        return node
+            return node
 
-    # We canonicalize the JSON path AST so that it always starts with a
-    # "root" element, so paths like "field" will be generated as "$.field"
-    _match(TokenType.DOLLAR)
-    expressions: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
+        # We canonicalize the JSON path AST so that it always starts with a
+        # "root" element, so paths like "field" will be generated as "$.field"
+        _match(TokenType.DOLLAR)
+        expressions: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
 
-    while _curr():
-        if _match(TokenType.DOT) or _match(TokenType.COLON):
-            recursive = _prev().text == ".."
+        while _curr():
+            if _match(TokenType.DOT) or _match(TokenType.COLON):
+                recursive = _prev().text == ".."
 
-            if _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
-                value: t.Optional[str | exp.JSONPathWildcard] = _prev().text
+                if _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
+                    value: t.Optional[str | exp.JSONPathWildcard] = _prev().text
+                elif _match(TokenType.STAR):
+                    value = exp.JSONPathWildcard()
+                else:
+                    value = None
+
+                if recursive:
+                    expressions.append(exp.JSONPathRecursive(this=value))
+                elif value:
+                    expressions.append(exp.JSONPathKey(this=value))
+                else:
+                    raise ParseError(_error("Expected key name or * after DOT"))
+            elif _match(TokenType.L_BRACKET):
+                expressions.append(_parse_bracket())
+            elif _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
+                expressions.append(exp.JSONPathKey(this=_prev().text))
             elif _match(TokenType.STAR):
-                value = exp.JSONPathWildcard()
+                expressions.append(exp.JSONPathWildcard())
             else:
-                value = None
+                raise ParseError(_error(f"Unexpected {tokens[i].token_type}"))
 
-            if recursive:
-                expressions.append(exp.JSONPathRecursive(this=value))
-            elif value:
-                expressions.append(exp.JSONPathKey(this=value))
-            else:
-                raise ParseError(_error("Expected key name or * after DOT"))
-        elif _match(TokenType.L_BRACKET):
-            expressions.append(_parse_bracket())
-        elif _match(TokenType.VAR) or _match(TokenType.IDENTIFIER):
-            expressions.append(exp.JSONPathKey(this=_prev().text))
-        elif _match(TokenType.STAR):
-            expressions.append(exp.JSONPathWildcard())
-        else:
-            raise ParseError(_error(f"Unexpected {tokens[i].token_type}"))
-
-    return exp.JSONPath(expressions=expressions)
+        return exp.JSONPath(expressions=expressions)
 
 
 JSON_PATH_PART_TRANSFORMS: t.Dict[t.Type[exp.Expression], t.Callable[..., str]] = {

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -96,33 +96,30 @@ class TestDatabricks(Validator):
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):
+        self.validate_identity("SELECT c1:price, c1:price.foo, c1:price.bar[1]")
         self.validate_identity(
-            """SELECT c1 : price FROM VALUES ('{ "price": 5 }') AS T(c1)""",
+            """SELECT c1:item[1].price FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)"""
+        )
+        self.validate_identity(
+            """SELECT c1:item[*].price FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)"""
+        )
+        self.validate_identity(
+            """SELECT FROM_JSON(c1:item[*].price, 'ARRAY<DOUBLE>')[0] FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)"""
+        )
+        self.validate_identity(
+            """SELECT INLINE(FROM_JSON(c1:item[*], 'ARRAY<STRUCT<model STRING, price DOUBLE>>')) FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)"""
+        )
+        self.validate_identity(
+            """SELECT c1:['price'] FROM VALUES ('{ "price": 5 }') AS T(c1)""",
+            """SELECT c1:price FROM VALUES ('{ "price": 5 }') AS T(c1)""",
+        )
+        self.validate_identity(
             """SELECT GET_JSON_OBJECT(c1, '$.price') FROM VALUES ('{ "price": 5 }') AS T(c1)""",
+            """SELECT c1:price FROM VALUES ('{ "price": 5 }') AS T(c1)""",
         )
         self.validate_identity(
-            """SELECT c1:['price'] FROM VALUES('{ "price": 5 }') AS T(c1)""",
-            """SELECT GET_JSON_OBJECT(c1, '$.price') FROM VALUES ('{ "price": 5 }') AS T(c1)""",
-        )
-        self.validate_identity(
-            """SELECT c1:item[1].price FROM VALUES('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-            """SELECT GET_JSON_OBJECT(c1, '$.item[1].price') FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-        )
-        self.validate_identity(
-            """SELECT c1:item[*].price FROM VALUES('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-            """SELECT GET_JSON_OBJECT(c1, '$.item[*].price') FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-        )
-        self.validate_identity(
-            """SELECT from_json(c1:item[*].price, 'ARRAY<DOUBLE>')[0] FROM VALUES('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-            """SELECT FROM_JSON(GET_JSON_OBJECT(c1, '$.item[*].price'), 'ARRAY<DOUBLE>')[0] FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-        )
-        self.validate_identity(
-            """SELECT inline(from_json(c1:item[*], 'ARRAY<STRUCT<model STRING, price DOUBLE>>')) FROM VALUES('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-            """SELECT INLINE(FROM_JSON(GET_JSON_OBJECT(c1, '$.item[*]'), 'ARRAY<STRUCT<model STRING, price DOUBLE>>')) FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)""",
-        )
-        self.validate_identity(
-            "SELECT c1 : price",
-            "SELECT GET_JSON_OBJECT(c1, '$.price')",
+            """SELECT raw:`zip code`, raw:`fb:testid`, raw:store['bicycle'], raw:store["zip code"]""",
+            """SELECT raw:["zip code"], raw:["fb:testid"], raw:store.bicycle, raw:store["zip code"]""",
         )
 
     def test_datediff(self):

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -28,7 +28,7 @@ class TestRedshift(Validator):
             """SELECT JSON_EXTRACT_PATH_TEXT('{ "farm": {"barn": { "color": "red", "feed stocked": true }}}', 'farm', 'barn', 'color')""",
             write={
                 "bigquery": """SELECT JSON_EXTRACT_SCALAR('{ "farm": {"barn": { "color": "red", "feed stocked": true }}}', '$.farm.barn.color')""",
-                "databricks": """SELECT GET_JSON_OBJECT('{ "farm": {"barn": { "color": "red", "feed stocked": true }}}', '$.farm.barn.color')""",
+                "databricks": """SELECT '{ "farm": {"barn": { "color": "red", "feed stocked": true }}}':farm.barn.color""",
                 "duckdb": """SELECT '{ "farm": {"barn": { "color": "red", "feed stocked": true }}}' ->> '$.farm.barn.color'""",
                 "postgres": """SELECT JSON_EXTRACT_PATH_TEXT('{ "farm": {"barn": { "color": "red", "feed stocked": true }}}', 'farm', 'barn', 'color')""",
                 "presto": """SELECT JSON_EXTRACT_SCALAR('{ "farm": {"barn": { "color": "red", "feed stocked": true }}}', '$.farm.barn.color')""",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -337,7 +337,7 @@ WHERE
             """SELECT PARSE_JSON('{"fruit":"banana"}'):fruit""",
             write={
                 "bigquery": """SELECT JSON_EXTRACT(PARSE_JSON('{"fruit":"banana"}'), '$.fruit')""",
-                "databricks": """SELECT GET_JSON_OBJECT('{"fruit":"banana"}', '$.fruit')""",
+                "databricks": """SELECT '{"fruit":"banana"}':fruit""",
                 "duckdb": """SELECT JSON('{"fruit":"banana"}') -> '$.fruit'""",
                 "mysql": """SELECT JSON_EXTRACT('{"fruit":"banana"}', '$.fruit')""",
                 "presto": """SELECT JSON_EXTRACT(JSON_PARSE('{"fruit":"banana"}'), '$.fruit')""",

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -9,6 +9,7 @@ from tests.helpers import FIXTURES_DIR
 
 class TestJsonpath(unittest.TestCase):
     maxDiff = None
+    jsonpath_tokenizer = jsonpath.JSONPathTokenizer()
 
     def test_jsonpath(self):
         expected_expressions = [
@@ -25,7 +26,9 @@ class TestJsonpath(unittest.TestCase):
             exp.JSONPathSelector(this=exp.JSONPathScript(this="@.x)")),
         ]
         self.assertEqual(
-            jsonpath.parse("$.*.a[0]['x'][*, 'y', 1].z[?(@.a == 'b'), 1:][1:5][1,?@.a][(@.x)]"),
+            self.jsonpath_tokenizer.parse(
+                "$.*.a[0]['x'][*, 'y', 1].z[?(@.a == 'b'), 1:][1:5][1,?@.a][(@.x)]"
+            ),
             exp.JSONPath(expressions=expected_expressions),
         )
 
@@ -36,7 +39,7 @@ class TestJsonpath(unittest.TestCase):
             ("$[((@.length-1))]", "$[((@.length-1))]"),
         ):
             with self.subTest(f"{selector} -> {expected}"):
-                self.assertEqual(jsonpath.parse(selector).sql(), f"'{expected}'")
+                self.assertEqual(self.jsonpath_tokenizer.parse(selector).sql(), f"'{expected}'")
 
     def test_cts_file(self):
         with open(os.path.join(FIXTURES_DIR, "jsonpath", "cts.json")) as file:
@@ -131,9 +134,9 @@ class TestJsonpath(unittest.TestCase):
             with self.subTest(f"{selector.strip()} /* {test['name']} */"):
                 if test.get("invalid_selector"):
                     try:
-                        jsonpath.parse(selector)
+                        self.jsonpath_tokenizer.parse(selector)
                     except (ParseError, TokenError):
                         pass
                 else:
-                    path = jsonpath.parse(selector)
+                    path = self.jsonpath_tokenizer.parse(selector)
                     self.assertEqual(path.sql(), f"'{overrides.get(selector, selector)}'")


### PR DESCRIPTION
Fixes #3673

This PR aims to preserve the JSON/Variant access in Databricks using operators instead of JSON functions + JSONPath by:
- Adding `IDENTIFIERS` in `jsonpath.py` to be able to parse keys with special chars (see [example](https://docs.databricks.com/en/semi-structured/variant.html#extract-a-top-level-variant-field))
- Manually parsing `GET_JSON_OBJECT()` -> `exp.JSONExtract` 
- Changing the generation of `exp.JSONExtract` & `exp.JSONExtractScalar` (only in DB) to the operator-based syntax

Docs
--------
[DB querying VARIANT](https://docs.databricks.com/en/semi-structured/variant.html#query-variant-data) | [DB path expression](https://docs.databricks.com/en/sql/language-manual/sql-ref-json-path-expression.html) | [DB JSON functions](https://docs.databricks.com/en/sql/language-manual/sql-ref-functions-builtin.html#json-functions)