### PR TITLE
feat(clickhouse): Fix roundtrips of DATE/TIMESTAMP functions

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -25,9 +25,6 @@ from sqlglot.tokens import Token, TokenType
 
 DATEΤΙΜΕ_DELTA = t.Union[exp.DateAdd, exp.DateDiff, exp.DateSub, exp.TimestampSub, exp.TimestampAdd]
 
-if t.TYPE_CHECKING:
-    pass
-
 
 def _build_date_format(args: t.List) -> exp.TimeToStr:
     expr = build_formatted_time(exp.TimeToStr, "clickhouse")(args)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -842,13 +842,17 @@ def time_format(
 
 
 def build_date_delta(
-    exp_class: t.Type[E], unit_mapping: t.Optional[t.Dict[str, str]] = None
+    exp_class: t.Type[E],
+    unit_mapping: t.Optional[t.Dict[str, str]] = None,
+    default_unit: t.Optional[str] = "DAY",
 ) -> t.Callable[[t.List], E]:
     def _builder(args: t.List) -> E:
         unit_based = len(args) == 3
         this = args[2] if unit_based else seq_get(args, 0)
-        unit = args[0] if unit_based else exp.Literal.string("DAY")
-        unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
+        unit = None
+        if unit_based or default_unit:
+            unit = args[0] if unit_based else exp.Literal.string(default_unit)
+            unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
         return exp_class(this=this, expression=seq_get(args, 1), unit=unit)
 
     return _builder

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -882,16 +882,24 @@ LIFETIME(MIN 0 MAX 0)""",
                 self.validate_identity(f"DROP {creatable} test ON CLUSTER test_cluster")
 
     def test_datetime_funcs(self):
-        # Function aliases are roundtripped back to one name e.g. DATE_SUB(), DATESUB() -> DATE_SUB()
-        func_names = (("DATE_SUB", "DATESUB"), ("DATE_ADD", "DATEADD"))
-        for funcs in func_names:
-            # Functions of type <func>(date, unit)
-            for func in (*funcs, ("TIMESTAMP_ADD", "TIMESTAMPADD")):
-                with self.subTest(f"Test 2-arg date-time {func}"):
-                    self.validate_identity(f"SELECT {funcs[0]}(date, INTERVAL '3' YEAR)")
+        # Each datetime func has an alias that is roundtripped to the original name e.g. (DATE_SUB, DATESUB) -> DATE_SUB
+        datetime_funcs = (("DATE_SUB", "DATESUB"), ("DATE_ADD", "DATEADD"))
 
-        for funcs in (*func_names, ("DATE_DIFF", "DATEDIFF"), ("TIMESTAMP_SUB", "TIMESTAMPSUB")):
-            # Functions of type <func>(unit, value, date)
-            for func in funcs:
-                with self.subTest(f"Test 3-arg date-time function {func}"):
-                    self.validate_identity(f"SELECT {funcs[0]}(SECOND, 1, bar)")
+        # 2-arg functions of type <func>(date, unit)
+        for func in (*datetime_funcs, ("TIMESTAMP_ADD", "TIMESTAMPADD")):
+            func_name = func[0]
+            for func_alias in func:
+                self.validate_identity(
+                    f"""SELECT {func_alias}(date, INTERVAL '3' YEAR)""",
+                    f"""SELECT {func_name}(date, INTERVAL '3' YEAR)""",
+                )
+
+        # 3-arg functions of type <func>(unit, value, date)
+        for func in (*datetime_funcs, ("DATE_DIFF", "DATEDIFF"), ("TIMESTAMP_SUB", "TIMESTAMPSUB")):
+            func_name = func[0]
+            for func_alias in func:
+                with self.subTest(f"Test 3-arg date-time function {func_alias}"):
+                    self.validate_identity(
+                        f"SELECT {func_alias}(SECOND, 1, bar)",
+                        f"SELECT {func_name}(SECOND, 1, bar)",
+                    )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -880,3 +880,18 @@ LIFETIME(MIN 0 MAX 0)""",
         for creatable in ("DATABASE", "TABLE", "VIEW", "DICTIONARY", "FUNCTION"):
             with self.subTest(f"Test DROP {creatable} ON CLUSTER"):
                 self.validate_identity(f"DROP {creatable} test ON CLUSTER test_cluster")
+
+    def test_datetime_funcs(self):
+        # Function aliases are roundtripped back to one name e.g. DATE_SUB(), DATESUB() -> DATE_SUB()
+        func_names = (("DATE_SUB", "DATESUB"), ("DATE_ADD", "DATEADD"))
+        for funcs in func_names:
+            # Functions of type <func>(date, unit)
+            for func in (*funcs, ("TIMESTAMP_ADD", "TIMESTAMPADD")):
+                with self.subTest(f"Test 2-arg date-time {func}"):
+                    self.validate_identity(f"SELECT {funcs[0]}(date, INTERVAL '3' YEAR)")
+
+        for funcs in (*func_names, ("DATE_DIFF", "DATEDIFF"), ("TIMESTAMP_SUB", "TIMESTAMPSUB")):
+            # Functions of type <func>(unit, value, date)
+            for func in funcs:
+                with self.subTest(f"Test 3-arg date-time function {func}"):
+                    self.validate_identity(f"SELECT {funcs[0]}(SECOND, 1, bar)")


### PR DESCRIPTION
Fixes #3679

This PR aims to fix the roundtrip for the following CH datetime functions and their aliases:

`DATE_SUB`, `DATE_ADD`, `DATE_DIFF`, `TIMESTAMP_ADD`, `TIMESTAMP_SUB`

These functions (except `DATE_DIFF`) support either one or both of the following versions

- 2-arg based version `<func>(date, INTERVAL unit)`, supported by `DATE_ADD`, `DATE_SUB`, `TIMESTAMP_SUB`
- 3-arg based version `<func>(unit, value, date)`, supported by `DATE_ADD`, `DATE_SUB`, `TIMESTAMP_ADD`

The exception to that is `DATE_DIFF` which parses into `date_diff('unit', startdate, enddate, [timezone])`; Note that support for `timezone` was not added in this PR.
