### PR TITLE
Fix(tokenizer): don't treat escapes in raw strings as such for some dialects

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -91,6 +91,8 @@ def _dateadd_sql(self: Spark.Generator, expression: exp.TsOrDsAdd | exp.Timestam
 
 class Spark(Spark2):
     class Tokenizer(Spark2.Tokenizer):
+        STRING_ESCAPES_ALLOWED_IN_RAW_STRINGS = False
+
         RAW_STRINGS = [
             (prefix + q, q)
             for q in t.cast(t.List[str], Spark2.Tokenizer.QUOTES)

--- a/sqlglotrs/src/settings.rs
+++ b/sqlglotrs/src/settings.rs
@@ -76,6 +76,7 @@ pub struct TokenizerSettings {
     pub commands: HashSet<TokenType>,
     pub command_prefix_tokens: HashSet<TokenType>,
     pub heredoc_tag_is_identifier: bool,
+    pub string_escapes_allowed_in_raw_strings: bool,
 }
 
 #[pymethods]
@@ -98,6 +99,7 @@ impl TokenizerSettings {
         commands: HashSet<TokenType>,
         command_prefix_tokens: HashSet<TokenType>,
         heredoc_tag_is_identifier: bool,
+        string_escapes_allowed_in_raw_strings: bool,
     ) -> Self {
         let to_char = |v: &String| {
             if v.len() == 1 {
@@ -147,6 +149,7 @@ impl TokenizerSettings {
             commands,
             command_prefix_tokens,
             heredoc_tag_is_identifier,
+            string_escapes_allowed_in_raw_strings,
         }
     }
 }

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -25,6 +25,7 @@ class TestDatabricks(Validator):
         self.validate_identity("CREATE FUNCTION a AS b")
         self.validate_identity("SELECT ${x} FROM ${y} WHERE ${z} > 1")
         self.validate_identity("CREATE TABLE foo (x DATE GENERATED ALWAYS AS (CAST(y AS DATE)))")
+        self.validate_identity("TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address)")
         self.validate_identity(
             "CREATE TABLE IF NOT EXISTS db.table (a TIMESTAMP, b BOOLEAN GENERATED ALWAYS AS (NOT a IS NULL)) USING DELTA"
         )
@@ -37,21 +38,21 @@ class TestDatabricks(Validator):
         self.validate_identity(
             "SELECT * FROM sales UNPIVOT EXCLUDE NULLS (sales FOR quarter IN (q1 AS `Jan-Mar`))"
         )
-
         self.validate_identity(
             "CREATE FUNCTION add_one(x INT) RETURNS INT LANGUAGE PYTHON AS $$def add_one(x):\n  return x+1$$"
         )
-
         self.validate_identity(
             "CREATE FUNCTION add_one(x INT) RETURNS INT LANGUAGE PYTHON AS $FOO$def add_one(x):\n  return x+1$FOO$"
         )
-
-        self.validate_identity("TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address)")
         self.validate_identity(
             "TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', city LIKE 'LA')"
         )
         self.validate_identity(
             "COPY INTO target FROM `s3://link` FILEFORMAT = AVRO VALIDATE = ALL FILES = ('file1', 'file2') FORMAT_OPTIONS ('opt1'='true', 'opt2'='test') COPY_OPTIONS ('mergeSchema'='true')"
+        )
+        self.validate_identity(
+            r'SELECT r"\\foo.bar\"',
+            r"SELECT '\\\\foo.bar\\'",
         )
 
         self.validate_all(
@@ -67,7 +68,6 @@ class TestDatabricks(Validator):
                 "teradata": "CREATE TABLE t1 AS (SELECT c FROM t2) WITH DATA",
             },
         )
-
         self.validate_all(
             "SELECT X'1A2B'",
             read={


### PR DESCRIPTION
Fixes #3686

From Databricks' [docs](https://docs.databricks.com/en/sql/language-manual/data-types/string-type.html) (same for Spark v3):

> If the string is prefixed with r there is no escape character.