### PR TITLE
Fix: don't treat /*+ as a HINT token in dialects that don't support hints

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -317,6 +317,7 @@ class BigQuery(Dialect):
         }
         KEYWORDS.pop("DIV")
         KEYWORDS.pop("VALUES")
+        KEYWORDS.pop("/*+")
 
     class Parser(parser.Parser):
         PREFIXED_PIVOT_COLUMNS = True

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -147,6 +147,7 @@ class ClickHouse(Dialect):
             "SYSTEM": TokenType.COMMAND,
             "PREWHERE": TokenType.PREWHERE,
         }
+        KEYWORDS.pop("/*+")
 
         SINGLE_TOKENS = {
             **tokens.Tokenizer.SINGLE_TOKENS,

--- a/sqlglot/dialects/drill.py
+++ b/sqlglot/dialects/drill.py
@@ -70,6 +70,9 @@ class Drill(Dialect):
         IDENTIFIERS = ["`"]
         STRING_ESCAPES = ["\\"]
 
+        KEYWORDS = tokens.Tokenizer.KEYWORDS.copy()
+        KEYWORDS.pop("/*+")
+
     class Parser(parser.Parser):
         STRICT_CAST = False
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -220,6 +220,7 @@ class DuckDB(Dialect):
             "TIMESTAMP_US": TokenType.TIMESTAMP,
             "VARCHAR": TokenType.TEXT,
         }
+        KEYWORDS.pop("/*+")
 
         SINGLE_TOKENS = {
             **tokens.Tokenizer.SINGLE_TOKENS,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -331,6 +331,7 @@ class Postgres(Dialect):
             "REGTYPE": TokenType.OBJECT_IDENTIFIER,
             "FLOAT": TokenType.DOUBLE,
         }
+        KEYWORDS.pop("/*+")
         KEYWORDS.pop("DIV")
 
         SINGLE_TOKENS = {

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -227,7 +227,7 @@ class Presto(Dialect):
             "TDIGEST": TokenType.TDIGEST,
             "HYPERLOGLOG": TokenType.HLLSKETCH,
         }
-
+        KEYWORDS.pop("/*+")
         KEYWORDS.pop("QUALIFY")
 
     class Parser(parser.Parser):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -685,6 +685,7 @@ class Snowflake(Dialect):
             "WAREHOUSE": TokenType.WAREHOUSE,
             "STREAMLIT": TokenType.STREAMLIT,
         }
+        KEYWORDS.pop("/*+")
 
         SINGLE_TOKENS = {
             **tokens.Tokenizer.SINGLE_TOKENS,

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -106,6 +106,9 @@ class SQLite(Dialect):
         IDENTIFIERS = ['"', ("[", "]"), "`"]
         HEX_STRINGS = [("x'", "'"), ("X'", "'"), ("0x", ""), ("0X", "")]
 
+        KEYWORDS = tokens.Tokenizer.KEYWORDS.copy()
+        KEYWORDS.pop("/*+")
+
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -96,6 +96,7 @@ class Teradata(Dialect):
             "TOP": TokenType.TOP,
             "UPD": TokenType.UPDATE,
         }
+        KEYWORDS.pop("/*+")
 
         # Teradata does not support % as a modulo operator
         SINGLE_TOKENS = {**tokens.Tokenizer.SINGLE_TOKENS}

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -477,6 +477,7 @@ class TSQL(Dialect):
             "UPDATE STATISTICS": TokenType.COMMAND,
             "XML": TokenType.XML,
         }
+        KEYWORDS.pop("/*+")
 
         COMMANDS = {*tokens.Tokenizer.COMMANDS, TokenType.END}
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -76,10 +76,6 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT CURRENT_USER")
         self.validate_identity("SELECT * FROM ONLY t1")
         self.validate_identity(
-            "SELECT ARRAY[1, 2, 3] <@ ARRAY[1, 2]",
-            "SELECT ARRAY[1, 2] @> ARRAY[1, 2, 3]",
-        )
-        self.validate_identity(
             """UPDATE "x" SET "y" = CAST('0 days 60.000000 seconds' AS INTERVAL) WHERE "x"."id" IN (2, 3)"""
         )
         self.validate_identity(
@@ -134,6 +130,14 @@ class TestPostgres(Validator):
             "WHERE c.relname OPERATOR(pg_catalog.~) '^(courses)$' COLLATE pg_catalog.default AND "
             "pg_catalog.PG_TABLE_IS_VISIBLE(c.oid) "
             "ORDER BY 2, 3"
+        )
+        self.validate_identity(
+            "/*+ some comment*/ SELECT b.foo, b.bar FROM baz AS b",
+            "/* + some comment */ SELECT b.foo, b.bar FROM baz AS b",
+        )
+        self.validate_identity(
+            "SELECT ARRAY[1, 2, 3] <@ ARRAY[1, 2]",
+            "SELECT ARRAY[1, 2] @> ARRAY[1, 2, 3]",
         )
         self.validate_identity(
             "SELECT ARRAY[]::INT[] AS foo",


### PR DESCRIPTION
Fixes #3692

Tried to do this at the `_Dialect` metaclass but the code wasn't that better. There was also an issue with `KEYWORD_TRIE`, I think because the tokenizer metaclass is executed first and we [create it](https://github.com/tobymao/sqlglot/blob/main/sqlglot/tokens.py#L495-L504) while `/*+` is still in `KEYWORDS`. So I just decided to do this the simple way.