### PR TITLE
fix(optimizer): Force early alias expansion in BQ & CH

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -221,6 +221,7 @@ class BigQuery(Dialect):
     SUPPORTS_SEMI_ANTI_JOIN = False
     LOG_BASE_FIRST = False
     HEX_LOWERCASE = True
+    FORCE_EARLY_ALIAS_REF_EXPANSION = True
 
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#case_sensitivity
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -102,6 +102,7 @@ class ClickHouse(Dialect):
     SUPPORTS_USER_DEFINED_TYPES = False
     SAFE_DIVISION = True
     LOG_BASE_FIRST: t.Optional[bool] = None
+    FORCE_EARLY_ALIAS_REF_EXPANSION = True
 
     UNESCAPED_SEQUENCES = {
         "\\0": "\0",

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -325,6 +325,32 @@ class Dialect(metaclass=_Dialect):
     Whether COPY statement parameters are separated by comma or whitespace
     """
 
+    FORCE_EARLY_ALIAS_REF_EXPANSION = False
+    """
+    Whether alias reference expansion (_expand_alias_refs()) should run before column qualification (_qualify_columns()).
+
+    For example:
+        WITH data AS (
+        SELECT
+            1 AS id,
+            2 AS my_id
+        )
+        SELECT
+            id AS my_id
+        FROM
+            data
+        WHERE
+            my_id = 1
+        GROUP BY
+            my_id,
+        HAVING
+            my_id = 1
+
+    In most dialects "my_id" would refer to "data.my_id" (which is done in _qualify_columns()) across the query, except:
+        - BigQuery, which will forward the alias to GROUP BY + HAVING clauses i.e it resolves to "WHERE my_id = 1 GROUP BY id HAVING id = 1"
+        - Clickhouse, which will forward the alias across the query i.e it resolves to "WHERE id = 1 GROUP BY id HAVING id = 1"
+    """
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -487,7 +487,7 @@ SELECT :with,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:expr
         sql = "WITH data AS (SELECT 1 AS id, 2 AS my_id, 'a' AS name, 'b' AS full_name) SELECT id AS my_id, CONCAT(id, name) AS full_name FROM data WHERE my_id = 1 GROUP BY my_id, full_name HAVING my_id = 1"
         self.assertEqual(
             optimizer.qualify_columns.qualify_columns(
-                parse_one(sql),
+                parse_one(sql, dialect="bigquery"),
                 schema=MappingSchema(schema=unused_schema, dialect="bigquery"),
             ).sql(),
             "WITH data AS (SELECT 1 AS id, 2 AS my_id, 'a' AS name, 'b' AS full_name) SELECT data.id AS my_id, CONCAT(data.id, data.name) AS full_name FROM data WHERE data.my_id = 1 GROUP BY data.id, CONCAT(data.id, data.name) HAVING data.id = 1",
@@ -496,7 +496,7 @@ SELECT :with,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:expr
         # Clickhouse expands overlapping alias across the entire query
         self.assertEqual(
             optimizer.qualify_columns.qualify_columns(
-                parse_one(sql),
+                parse_one(sql, dialect="clickhouse"),
                 schema=MappingSchema(schema=unused_schema, dialect="clickhouse"),
             ).sql(),
             "WITH data AS (SELECT 1 AS id, 2 AS my_id, 'a' AS name, 'b' AS full_name) SELECT data.id AS my_id, CONCAT(data.id, data.name) AS full_name FROM data WHERE data.id = 1 GROUP BY data.id, CONCAT(data.id, data.name) HAVING data.id = 1",


### PR DESCRIPTION
Fixes #3687

Take the following query:

```SQL
WITH data AS (
SELECT
    1 AS id,
    2 AS my_id
)
SELECT
    id AS my_id
FROM
    data
WHERE
    my_id = 1
GROUP BY
    my_id,
HAVING
    my_id = 1
```

In most dialects this is an incorrect query as `GROUP BY my_id` is resolved to `GROUP BY data.my_id` which is not aggregated (the overlapping alias in the projection list is resolved later in the order of operations). 

However, the exceptions to this rule which _can_ process this query are the following:
- BigQuery, which only forwards the alias only to `GROUP BY` & `HAVING` i.e resolves to:
```SQL
WITH data AS (...)
WHERE data.my_id = 1 GROUP BY data.id HAVING data.id = 1
```

- Clickhouse, which forwards the alias across the query i.e resolves to:
```SQL
WITH data AS (...)
WHERE data.id = 1 GROUP BY data.id HAVING data.id = 1
```

This PR aims to fix this by forcing the alias expansion before `_qualify_columns()` for these cases, as the 2nd call to `_expand_alias_refs()` does not expand aliases on qualified columns.