### PR TITLE
Fix: proper parsing of unit in spark/databricks date_diff

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -50,6 +50,7 @@ class Databricks(Spark):
             "DATEADD": build_date_delta(exp.DateAdd),
             "DATE_ADD": build_date_delta(exp.DateAdd),
             "DATEDIFF": build_date_delta(exp.DateDiff),
+            "DATE_DIFF": build_date_delta(exp.DateDiff),
             "TIMESTAMPDIFF": build_date_delta(exp.TimestampDiff),
             "GET_JSON_OBJECT": _build_json_extract,
         }

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -33,7 +33,7 @@ def _build_datediff(args: t.List) -> exp.Expression:
     expression = seq_get(args, 1)
 
     if len(args) == 3:
-        unit = this
+        unit = exp.var(t.cast(exp.Expression, this).name)
         this = args[2]
 
     return exp.DateDiff(
@@ -107,6 +107,7 @@ class Spark(Spark2):
             "DATEADD": _build_dateadd,
             "TIMESTAMPADD": _build_dateadd,
             "DATEDIFF": _build_datediff,
+            "DATE_DIFF": _build_datediff,
             "TIMESTAMP_LTZ": _build_as_cast("TIMESTAMP_LTZ"),
             "TIMESTAMP_NTZ": _build_as_cast("TIMESTAMP_NTZ"),
             "TRY_ELEMENT_AT": lambda args: exp.Bracket(

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -1,4 +1,4 @@
-from sqlglot import transpile
+from sqlglot import exp, transpile
 from sqlglot.errors import ParseError
 from tests.dialects.test_dialect import Validator
 
@@ -50,6 +50,10 @@ class TestDatabricks(Validator):
         self.validate_identity(
             "COPY INTO target FROM `s3://link` FILEFORMAT = AVRO VALIDATE = ALL FILES = ('file1', 'file2') FORMAT_OPTIONS ('opt1'='true', 'opt2'='test') COPY_OPTIONS ('mergeSchema'='true')"
         )
+        self.validate_identity(
+            "DATE_DIFF(day, created_at, current_date())",
+            "DATEDIFF(DAY, created_at, CURRENT_DATE)",
+        ).args["unit"].assert_is(exp.Var)
         self.validate_identity(
             r'SELECT r"\\foo.bar\"',
             r"SELECT '\\\\foo.bar\\'",


### PR DESCRIPTION
Fixes #3700

For a followup PR: see if we can refactor the date deltas for spark/databricks. Perhaps we can use a single implementation for both.