### PR TITLE
Fix(parser): explicitly check for identifiers in _parse_types

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4292,7 +4292,7 @@ class Parser(metaclass=_Parser):
             identifier = allow_identifiers and self._parse_id_var(
                 any_token=False, tokens=(TokenType.VAR,)
             )
-            if identifier:
+            if isinstance(identifier, exp.Identifier):
                 tokens = self.dialect.tokenize(identifier.sql(dialect=self.dialect))
 
                 if len(tokens) != 1:


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/2826