### PR TITLE
Fix(parser): preserve Cast expression when it's 'safe' and has a format

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5369,7 +5369,7 @@ class Parser(metaclass=_Parser):
 
             if not to:
                 to = exp.DataType.build(exp.DataType.Type.UNKNOWN)
-            if to.this in exp.DataType.TEMPORAL_TYPES:
+            if not safe and to.this in exp.DataType.TEMPORAL_TYPES:
                 this = self.expression(
                     exp.StrToDate if to.this == exp.DataType.Type.DATE else exp.StrToTime,
                     this=this,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -103,6 +103,7 @@ LANGUAGE js AS
         select_with_quoted_udf = self.validate_identity("SELECT `p.d.UdF`(data) FROM `p.d.t`")
         self.assertEqual(select_with_quoted_udf.selects[0].name, "p.d.UdF")
 
+        self.validate_identity("SAFE_CAST(some_date AS DATE FORMAT 'DD MONTH YYYY')")
         self.validate_identity("CAST(x AS STRUCT<list ARRAY<INT64>>)")
         self.validate_identity("assert.true(1 = 1)")
         self.validate_identity("SELECT ARRAY_TO_STRING(list, '--') AS text")


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/2827