### PR TITLE
Refactor: control ParseJSON generation logic with a flag

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -446,6 +446,7 @@ class Hive(Dialect):
         JSON_PATH_SINGLE_QUOTE_ESCAPE = True
         SUPPORTS_TO_NUMBER = False
         WITH_PROPERTIES_PREFIX = "TBLPROPERTIES"
+        PARSE_JSON_NAME = None
 
         EXPRESSIONS_WITHOUT_NESTED_CTES = {
             exp.Insert,
@@ -575,7 +576,6 @@ class Hive(Dialect):
             exp.NotForReplicationColumnConstraint: lambda *_: "",
             exp.OnProperty: lambda *_: "",
             exp.PrimaryKeyColumnConstraint: lambda *_: "PRIMARY KEY",
-            exp.ParseJSON: lambda self, e: self.sql(e.this),
             exp.WeekOfYear: rename_func("WEEKOFYEAR"),
             exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -689,6 +689,7 @@ class MySQL(Dialect):
         JSON_PATH_BRACKETED_KEY_SUPPORTED = False
         JSON_KEY_VALUE_PAIR_SEP = ","
         SUPPORTS_TO_NUMBER = False
+        PARSE_JSON_NAME = None
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
@@ -714,7 +715,6 @@ class MySQL(Dialect):
             exp.Month: _remove_ts_or_ds_to_date(),
             exp.NullSafeEQ: lambda self, e: self.binary(e, "<=>"),
             exp.NullSafeNEQ: lambda self, e: f"NOT {self.binary(e, '<=>')}",
-            exp.ParseJSON: lambda self, e: self.sql(e, "this"),
             exp.Pivot: no_pivot_sql,
             exp.Select: transforms.preprocess(
                 [

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -305,6 +305,7 @@ class Presto(Dialect):
         MULTI_ARG_DISTINCT = False
         SUPPORTS_TO_NUMBER = False
         HEX_FUNC = "TO_HEX"
+        PARSE_JSON_NAME = "JSON_PARSE"
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,
@@ -389,7 +390,6 @@ class Presto(Dialect):
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.Initcap: _initcap_sql,
-            exp.ParseJSON: rename_func("JSON_PARSE"),
             exp.Last: _first_last_sql,
             exp.LastValue: _first_last_sql,
             exp.LastDay: lambda self, e: self.func("LAST_DAY_OF_MONTH", e.this),

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -775,6 +775,7 @@ class TSQL(Dialect):
         SUPPORTS_TO_NUMBER = False
         SET_OP_MODIFIERS = False
         COPY_PARAMS_EQ_REQUIRED = True
+        PARSE_JSON_NAME = None
 
         EXPRESSIONS_WITHOUT_NESTED_CTES = {
             exp.Delete,
@@ -834,7 +835,6 @@ class TSQL(Dialect):
             exp.MD5: lambda self, e: self.func("HASHBYTES", exp.Literal.string("MD5"), e.this),
             exp.Min: min_or_least,
             exp.NumberToStr: _format_sql,
-            exp.ParseJSON: lambda self, e: self.sql(e, "this"),
             exp.Repeat: rename_func("REPLICATE"),
             exp.Select: transforms.preprocess(
                 [

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -373,6 +373,9 @@ class Generator(metaclass=_Generator):
     # Whether to quote the generated expression of exp.JsonPath
     QUOTE_JSON_PATH = True
 
+    # The name to generate for the JSONPath expression. If `None`, only `this` will be generated
+    PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
+
     TYPE_MAPPING = {
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
@@ -3996,3 +3999,9 @@ class Generator(metaclass=_Generator):
             expr = self.sql(expression, "expression")
 
         return self.scope_resolution(expr, this)
+
+    def parsejson_sql(self, expression: exp.ParseJSON) -> str:
+        if self.PARSE_JSON_NAME is None:
+            return self.sql(expression.this)
+
+        return self.func(self.PARSE_JSON_NAME, expression.this, expression.expression)

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -11,6 +11,12 @@ class TestSnowflake(Validator):
     dialect = "snowflake"
 
     def test_snowflake(self):
+        self.assertEqual(
+            # Ensures we don't fail when generating ParseJSON with the `safe` arg set to `True`
+            self.validate_identity("""SELECT TRY_PARSE_JSON('{"x: 1}')""").sql(),
+            """SELECT PARSE_JSON('{"x: 1}')""",
+        )
+
         self.validate_identity(
             "transform(x, a int -> a + a + 1)",
             "TRANSFORM(x, a -> CAST(a AS INT) + CAST(a AS INT) + 1)",


### PR DESCRIPTION
Motivation behind this was that `TRY_PARSE_JSON` sets `safe` to `True` when parsed with Snowflake, which leads to a crash when we target dialects other than duckdb/snowflake (booleans aren't generated in `Generator.sql`).

Also reduced some code duplication while at it.

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1719419364440449