### PR TITLE
feat(duckdb): Transpile exp.Length from other dialects

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -346,6 +346,7 @@ class BigQuery(Dialect):
             "JSON_EXTRACT_SCALAR": lambda args: exp.JSONExtractScalar(
                 this=seq_get(args, 0), expression=seq_get(args, 1) or exp.Literal.string("$")
             ),
+            "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
             "MD5": exp.MD5Digest.from_arg_list,
             "TO_HEX": _build_to_hex,
             "PARSE_DATE": lambda args: build_formatted_time(exp.StrToDate, "bigquery")(

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -755,6 +755,7 @@ class DuckDB(Dialect):
             if arg.is_type(*exp.DataType.TEXT_TYPES):
                 return self.func("LENGTH", arg)
 
+            # We need these casts to make duckdb's static type checker happy
             blob = exp.cast(arg, exp.DataType.Type.VARBINARY)
             varchar = exp.cast(arg, exp.DataType.Type.VARCHAR)
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -755,17 +755,15 @@ class DuckDB(Dialect):
             if arg.is_type(*exp.DataType.TEXT_TYPES):
                 return self.func("LENGTH", arg)
 
-            trycast_blob = exp.TryCast(this=arg, to=exp.DataType.build(exp.DataType.Type.VARBINARY))
-            trycast_varchar = exp.TryCast(
-                this=arg, to=exp.DataType.build(exp.DataType.Type.VARCHAR)
-            )
+            blob = exp.cast(arg, exp.DataType.Type.VARBINARY)
+            varchar = exp.cast(arg, exp.DataType.Type.VARCHAR)
 
             case = (
                 exp.case(self.func("TYPEOF", arg))
                 .when(
-                    "'VARCHAR'", exp.Anonymous(this="LENGTH", expressions=[trycast_varchar])
+                    "'VARCHAR'", exp.Anonymous(this="LENGTH", expressions=[varchar])
                 )  # anonymous to break length_sql recursion
-                .when("'BLOB'", self.func("OCTET_LENGTH", trycast_blob))
+                .when("'BLOB'", self.func("OCTET_LENGTH", blob))
             )
 
             return self.sql(case)

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -738,3 +738,31 @@ class DuckDB(Dialect):
             this = self.sql(expression, "this").rstrip(")")
 
             return f"{this}{expression_sql})"
+
+        def length_sql(self, expression: exp.Length) -> str:
+            arg = expression.this
+
+            if not arg.type:
+                from sqlglot.optimizer.annotate_types import annotate_types
+
+                arg = annotate_types(arg)
+
+            if arg.is_type(exp.DataType.Type.VARCHAR) or arg.is_string:
+                return self.func("LENGTH", arg)
+
+            # Dialects like BQ and Snowflake also accept binary values, so if we can't determine the
+            # arg type then attempt case-when resolution
+            trycast_blob = exp.TryCast(this=arg, to=exp.DataType.build(exp.DataType.Type.VARBINARY))
+            trycast_varchar = exp.TryCast(
+                this=arg, to=exp.DataType.build(exp.DataType.Type.VARCHAR)
+            )
+
+            case = (
+                exp.case(self.func("TYPEOF", arg))
+                .when(
+                    "'VARCHAR'", exp.Anonymous(this="LENGTH", expressions=[trycast_varchar])
+                )  # anonymous to break length_sql recursion
+                .when("'BLOB'", self.func("OCTET_LENGTH", trycast_blob))
+            )
+
+            return self.sql(case)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -282,6 +282,8 @@ class Snowflake(Dialect):
             "LAST_DAY": lambda args: exp.LastDay(
                 this=seq_get(args, 0), unit=map_date_part(seq_get(args, 1))
             ),
+            "LEN": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
+            "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
             "LISTAGG": exp.GroupConcat.from_arg_list,
             "MEDIAN": lambda args: exp.PercentileCont(
                 this=seq_get(args, 0), expression=exp.Literal.number(0.5)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5524,6 +5524,7 @@ class Right(Func):
 
 
 class Length(Func):
+    arg_types = {"this": True, "binary": False}
     _sql_names = ["LENGTH", "LEN"]
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4005,3 +4005,6 @@ class Generator(metaclass=_Generator):
             return self.sql(expression.this)
 
         return self.func(self.PARSE_JSON_NAME, expression.this, expression.expression)
+
+    def length_sql(self, expression: exp.Length) -> str:
+        return self.func("LENGTH", expression.this)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1382,8 +1382,9 @@ WHERE
                 "snowflake": "SELECT LENGTH(foo)",
             },
             write={
-                "duckdb": "SELECT CASE TYPEOF(foo) WHEN 'VARCHAR' THEN LENGTH(TRY_CAST(foo AS TEXT)) WHEN 'BLOB' THEN OCTET_LENGTH(TRY_CAST(foo AS BLOB)) END",
+                "duckdb": "SELECT CASE TYPEOF(foo) WHEN 'VARCHAR' THEN LENGTH(CAST(foo AS TEXT)) WHEN 'BLOB' THEN OCTET_LENGTH(CAST(foo AS BLOB)) END",
                 "snowflake": "SELECT LENGTH(foo)",
+                "": "SELECT LENGTH(foo)",
             },
         )
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1375,6 +1375,17 @@ WHERE
                 "bigquery": "SELECT DATETIME('2020-01-01', 'America/Los_Angeles')",
             },
         )
+        self.validate_all(
+            "SELECT LENGTH(foo)",
+            read={
+                "bigquery": "SELECT LENGTH(foo)",
+                "snowflake": "SELECT LENGTH(foo)",
+            },
+            write={
+                "duckdb": "SELECT CASE TYPEOF(foo) WHEN 'VARCHAR' THEN LENGTH(TRY_CAST(foo AS TEXT)) WHEN 'BLOB' THEN OCTET_LENGTH(TRY_CAST(foo AS BLOB)) END",
+                "snowflake": "SELECT LENGTH(foo)",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -793,6 +793,9 @@ class TestDuckDB(Validator):
             },
         )
 
+        self.validate_identity("SELECT LENGTH('baz')")
+        self.validate_identity("SELECT LENGTH(LOWER('bar'))")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -794,8 +794,6 @@ class TestDuckDB(Validator):
         )
 
         self.validate_identity("SELECT LENGTH(foo)")
-        self.validate_identity("SELECT LENGTH('baz')")
-        self.validate_identity("SELECT LENGTH(LOWER('bar'))")
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -793,6 +793,7 @@ class TestDuckDB(Validator):
             },
         )
 
+        self.validate_identity("SELECT LENGTH(foo)")
         self.validate_identity("SELECT LENGTH('baz')")
         self.validate_identity("SELECT LENGTH(LOWER('bar'))")
 


### PR DESCRIPTION
Add generation for `exp.Length` in DuckDB. 

Dialects like Snowflake and BigQuery also use `LENGTH() / LEN()` for binary values, so this PR will generate `LENGTH(<expr>)` if the type can be inferred or a case/when with `LENGTH` for `VARCHAR` and `OCTET_LENGTH` for the binary (`BLOB`) value.  