### PR TITLE
fix(teradata): use timestamp with time zone over timestamptz

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -223,11 +223,13 @@ class Teradata(Dialect):
         TABLESAMPLE_KEYWORDS = "SAMPLE"
         LAST_DAY_SUPPORTS_DATE_PART = False
         CAN_IMPLEMENT_ARRAY_ANY = True
+        TZ_TO_WITH_TIME_ZONE = True
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.GEOMETRY: "ST_GEOMETRY",
             exp.DataType.Type.DOUBLE: "DOUBLE PRECISION",
+            exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
         }
 
         PROPERTIES_LOCATION = {
@@ -254,7 +256,7 @@ class Teradata(Dialect):
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
             exp.ToNumber: to_number_with_nls_param,
             exp.Use: lambda self, e: f"DATABASE {self.sql(e, 'this')}",
-            exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
+            exp.CurrentTimestamp: lambda self, e: "CURRENT_TIMESTAMP" if not e.this else f"CURRENT_TIMESTAMP({self.sql(e, 'this')})",
             exp.DateAdd: _date_add_sql("+"),
             exp.DateSub: _date_add_sql("-"),
             exp.Quarter: lambda self, e: self.sql(exp.Extract(this="QUARTER", expression=e.this)),

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -12,7 +12,6 @@ class TestTeradata(Validator):
                 "teradata": "RANDOM(l, u)",
             },
         )
-
         self.validate_identity("TO_NUMBER(expr, fmt, nlsparam)")
         self.validate_identity("SELECT TOP 10 * FROM tbl")
         self.validate_identity("SELECT * FROM tbl SAMPLE 5")
@@ -220,6 +219,8 @@ class TestTeradata(Validator):
         )
 
     def test_time(self):
+        self.validate_identity("CAST(CURRENT_TIMESTAMP(6) AS TIMESTAMP WITH TIME ZONE)")
+
         self.validate_all(
             "CURRENT_TIMESTAMP",
             read={


### PR DESCRIPTION
fixes [3722](https://github.com/tobymao/sqlglot/issues/3722)

after making the change, `current_timestamp` in my example sql no longer retained it's precision. I'm not sure why this happened but modifying the current timestamp transform seemed to fix it.

regarding this change: current_timestamp can have a precision of 0-6, but `current_timestamp()` (with no arguments) is not valid sql.
documentation reference: https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Functions-Expressions-and-Predicates/Built-In-Functions/CURRENT_TIMESTAMP/CURRENT_TIMESTAMP-Function-Syntax so I tried to represent this in the transform