### PR TITLE
feat(presto, trino): Configurable transpilation of Snowflake VARIANT

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -43,7 +43,7 @@ class Databricks(Spark):
     class Parser(Spark.Parser):
         LOG_DEFAULTS_TO_LN = True
         STRICT_CAST = True
-        COLON_IS_JSON_EXTRACT = True
+        COLON_IS_VARIANT_EXTRACT = True
 
         FUNCTIONS = {
             **Spark.Parser.FUNCTIONS,

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -518,11 +518,6 @@ class Dialect(metaclass=_Dialect):
                     value: t.Union[bool | str | None] = None
 
                     if len(pair) == 1:
-                        if key.lower() == "normalization_strategy":
-                            raise AttributeError(
-                                "Dialect setting 'normalization_strategy' requires a value."
-                            )
-
                         # Default initialize standalone settings to True
                         value = True
                     elif len(pair) == 2:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -511,7 +511,7 @@ class Dialect(metaclass=_Dialect):
         if isinstance(dialect, str):
             try:
                 dialect_name, *kv_strings = dialect.split(",")
-                kv_pairs = [kv.split("=") for kv in kv_strings]
+                kv_pairs = (kv.split("=") for kv in kv_strings)
                 kwargs = {}
                 for pair in kv_pairs:
                     key = pair[0].strip()

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -517,8 +517,13 @@ class Dialect(metaclass=_Dialect):
                     key = pair[0].strip()
                     value: t.Union[bool | str | None] = None
 
-                    if len(pair) == 1 and not key.lower() == "normalization_strategy":
-                        # Default initialize standalone settings to True except normalization strategy
+                    if len(pair) == 1:
+                        if key.lower() == "normalization_strategy":
+                            raise AttributeError(
+                                "Dialect setting 'normalization_strategy' requires a value."
+                            )
+
+                        # Default initialize standalone settings to True
                         value = True
                     elif len(pair) == 2:
                         value = pair[1].strip()

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -176,10 +176,6 @@ def _unix_to_time_sql(self: Presto.Generator, expression: exp.UnixToTime) -> str
 def _jsonextract_sql(self: Presto.Generator, expression: exp.JSONExtract) -> str:
     is_json_extract = self.dialect.settings.get("variant_extract_is_json_extract", True)
 
-    if isinstance(is_json_extract, str):
-        # if the kwarg was set by the user it's stored in a string
-        is_json_extract = is_json_extract.lower() == "true"
-
     # Generate JSON_EXTRACT unless the user has configured that a Snowflake / Databricks
     # VARIANT extract (e.g. col:x.y) should map to dot notation (i.e ROW access) in Presto/Trino
     if not expression.args.get("variant_extract") or is_json_extract:
@@ -191,9 +187,7 @@ def _jsonextract_sql(self: Presto.Generator, expression: exp.JSONExtract) -> str
 
     # Convert the JSONPath extraction `JSON_EXTRACT(col, '$.x.y) to a ROW access col.x.y
     segments = []
-    for path_key in expression.expression.expressions:
-        if isinstance(path_key, exp.JSONPathRoot):
-            continue
+    for path_key in expression.expression.expressions[1:]:
         if not isinstance(path_key, exp.JSONPathKey):
             # Cannot transpile subscripts, wildcards etc to dot notation
             self.unsupported(f"Cannot transpile JSONPath segment '{path_key}' to ROW access")

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -241,7 +241,7 @@ class Snowflake(Dialect):
     class Parser(parser.Parser):
         IDENTIFY_PIVOT_STRINGS = True
         DEFAULT_SAMPLING_METHOD = "BERNOULLI"
-        COLON_IS_JSON_EXTRACT = True
+        COLON_IS_VARIANT_EXTRACT = True
 
         ID_VAR_TOKENS = {
             *parser.Parser.ID_VAR_TOKENS,

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -447,6 +447,7 @@ class Python(Dialect):
             exp.Is: lambda self, e: (
                 self.binary(e, "==") if isinstance(e.this, exp.Literal) else self.binary(e, "is")
             ),
+            exp.JSONExtract: lambda self, e: self.func(e.key, e.this, e.expression, *e.expressions),
             exp.JSONPath: lambda self, e: f"[{','.join(self.sql(p) for p in e.expressions[1:])}]",
             exp.JSONPathKey: lambda self, e: f"'{self.sql(e.this)}'",
             exp.JSONPathSubscript: lambda self, e: f"'{e.this}'",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5480,7 +5480,13 @@ class JSONBContains(Binary, Func):
 
 
 class JSONExtract(Binary, Func):
-    arg_types = {"this": True, "expression": True, "only_json_types": False, "expressions": False}
+    arg_types = {
+        "this": True,
+        "expression": True,
+        "only_json_types": False,
+        "expressions": False,
+        "variant_extract": False,
+    }
     _sql_names = ["JSON_EXTRACT"]
     is_var_len_args = True
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -102,13 +102,12 @@ class TestDialect(Validator):
         lowercase_mysql = Dialect.get_or_raise("mysql, normalization_strategy = lowercase")
         self.assertEqual(lowercase_mysql.normalization_strategy.value, "LOWERCASE")
 
-        for dialect in ("mysql", "presto", "bigquery", "databricks"):
-            default_dialect = Dialect.get_or_raise(dialect)
-            lowercase_dialect = Dialect.get_or_raise(f"{dialect}, normalization_strategy")
-            self.assertEqual(
-                lowercase_dialect.normalization_strategy.value,
-                default_dialect.normalization_strategy.value,
-            )
+        with self.assertRaises(AttributeError) as cm:
+            Dialect.get_or_raise("mysql, normalization_strategy")
+
+        self.assertEqual(
+            str(cm.exception), "Dialect setting 'normalization_strategy' requires a value."
+        )
 
         with self.assertRaises(ValueError) as cm:
             Dialect.get_or_raise("myqsl")

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -102,14 +102,13 @@ class TestDialect(Validator):
         lowercase_mysql = Dialect.get_or_raise("mysql, normalization_strategy = lowercase")
         self.assertEqual(lowercase_mysql.normalization_strategy.value, "LOWERCASE")
 
-        with self.assertRaises(ValueError) as cm:
-            Dialect.get_or_raise("mysql, normalization_strategy")
-
-        self.assertEqual(
-            str(cm.exception),
-            "Invalid dialect format: 'mysql, normalization_strategy'. "
-            "Please use the correct format: 'dialect [, k1 = v2 [, ...]]'.",
-        )
+        for dialect in ("mysql", "presto", "bigquery", "databricks"):
+            default_dialect = Dialect.get_or_raise(dialect)
+            lowercase_dialect = Dialect.get_or_raise(f"{dialect}, normalization_strategy")
+            self.assertEqual(
+                lowercase_dialect.normalization_strategy.value,
+                default_dialect.normalization_strategy.value,
+            )
 
         with self.assertRaises(ValueError) as cm:
             Dialect.get_or_raise("myqsl")
@@ -126,6 +125,12 @@ class TestDialect(Validator):
         )
         self.assertEqual(oracle_with_settings.normalization_strategy.value, "LOWERCASE")
         self.assertEqual(oracle_with_settings.settings, {"version": "19.5"})
+
+        bool_settings = Dialect.get_or_raise("oracle, s1=TruE, s2=1, s3=FaLse, s4=0, s5=nonbool")
+        self.assertEqual(
+            bool_settings.settings,
+            {"s1": True, "s2": True, "s3": False, "s4": False, "s5": "nonbool"},
+        )
 
     def test_compare_dialects(self):
         bigquery_class = Dialect["bigquery"]

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -105,9 +105,7 @@ class TestDialect(Validator):
         with self.assertRaises(AttributeError) as cm:
             Dialect.get_or_raise("mysql, normalization_strategy")
 
-        self.assertEqual(
-            str(cm.exception), "Dialect setting 'normalization_strategy' requires a value."
-        )
+        self.assertEqual(str(cm.exception), "'bool' object has no attribute 'upper'")
 
         with self.assertRaises(ValueError) as cm:
             Dialect.get_or_raise("myqsl")

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1195,15 +1195,15 @@ MATCH_RECOGNIZE (
 
     def test_json_vs_row_extract(self):
         for dialect in ("trino", "presto"):
-            s = parse_one("SELECT col:x:y.z", read="snowflake")
+            s = parse_one('SELECT col:x:y."special string"', read="snowflake")
 
-            dialect_json_extract_setting = f"{dialect}, VARIANT_EXTRACT_IS_JSON_EXTRACT=True"
-            dialect_row_access_setting = f"{dialect}, VARIANT_EXTRACT_IS_JSON_EXTRACT=False"
+            dialect_json_extract_setting = f"{dialect}, variant_extract_is_json_extract=True"
+            dialect_row_access_setting = f"{dialect}, variant_extract_is_json_extract=False"
 
             # By default, Snowflake VARIANT will generate JSON_EXTRACT() in Presto/Trino
-            json_extract_result = "SELECT JSON_EXTRACT(col, '$.x.y.z')"
+            json_extract_result = """SELECT JSON_EXTRACT(col, '$.x.y["special string"]')"""
             self.assertEqual(s.sql(dialect), json_extract_result)
             self.assertEqual(s.sql(dialect_json_extract_setting), json_extract_result)
 
             # If the setting is overriden to False, then generate ROW access (dot notation)
-            self.assertEqual(s.sql(dialect_row_access_setting), "SELECT col.x.y.z")
+            self.assertEqual(s.sql(dialect_row_access_setting), 'SELECT col.x.y."special string"')

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1192,3 +1192,18 @@ MATCH_RECOGNIZE (
                 "starrocks": "SIGN(x)",
             },
         )
+
+    def test_json_vs_row_extract(self):
+        for dialect in ("trino", "presto"):
+            s = parse_one("SELECT col:x:y.z", read="snowflake")
+
+            dialect_json_extract_setting = f"{dialect}, VARIANT_EXTRACT_IS_JSON_EXTRACT=True"
+            dialect_row_access_setting = f"{dialect}, VARIANT_EXTRACT_IS_JSON_EXTRACT=False"
+
+            # By default, Snowflake VARIANT will generate JSON_EXTRACT() in Presto/Trino
+            json_extract_result = "SELECT JSON_EXTRACT(col, '$.x.y.z')"
+            self.assertEqual(s.sql(dialect), json_extract_result)
+            self.assertEqual(s.sql(dialect_json_extract_setting), json_extract_result)
+
+            # If the setting is overriden to False, then generate ROW access (dot notation)
+            self.assertEqual(s.sql(dialect_row_access_setting), "SELECT col.x.y.z")


### PR DESCRIPTION
Fixes #3713

Both Snowflake and Databricks have a `VARIANT` type with similar extract notation e.g. `col:x.y` which can be used to store any data (most notably, semi-structured). Up until now, SQLGlot treated this notation as a JSON extraction which is not always correct; As the issue showcased, since Snowflake does not have a `STRUCT` data type, Iceberg represents it's `STRUCT` as a `VARIANT` column which should map to a `ROW` column in Presto/Trino instead of `JSON`.

This PR focuses on Snowflake -> Presto/Trino and attempts to lift off this restriction by introducing a new dialect setting which can make the `exp.JSONExtract` generation configurable such that it can either: 
1. Generate `JSON_EXTRACT(col, '$.x.y')` for JSON data (as was before) or 
2. Transform the JSONPath to the equivalent ROW access in dot notation `col.x.y`

Note that SQLGlot is unable to statically infer the _actual_ type of the data stored in a `VARIANT` column so transpilation to other dialects remains a best-effort attempt.


Documentation
---------------------

- [Snowflake VARIANT](https://docs.snowflake.com/en/sql-reference/data-types-semistructured#variant)
- [Snowflake VARIANT access](https://docs.snowflake.com/en/user-guide/querying-semistructured)
- [Iceberg - Snowflake STRUCT type](https://docs.snowflake.com/en/user-guide/tables-iceberg-data-types#other-data-types)
- [Databricks VARIANT](https://docs.databricks.com/en/semi-structured/variant.html)