### PR TITLE
Feat(presto): wrap md5 string arguments in to_utf8

### DIFF
--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -581,6 +581,13 @@ class TestPresto(Validator):
             )
 
     def test_presto(self):
+        self.assertEqual(
+            exp.func("md5", exp.func("concat", exp.cast("x", "text"), exp.Literal.string("s"))).sql(
+                dialect="presto"
+            ),
+            "LOWER(TO_HEX(MD5(TO_UTF8(CONCAT(CAST(x AS VARCHAR), CAST('s' AS VARCHAR))))))",
+        )
+
         with self.assertLogs(helper_logger):
             self.validate_all(
                 "SELECT COALESCE(ELEMENT_AT(MAP_FROM_ENTRIES(ARRAY[(51, '1')]), id), quantity) FROM my_table",


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/2855

In SQLMesh's case this should suffice, because we can always infer the type of MD5's argument, due to [explicit casts](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/macros.py#L887-L893).

References:
- https://trino.io/docs/current/functions/string.html#to_utf8
- https://trino.io/docs/current/functions/binary.html#md5