### PR TITLE
fix(oracle)!: Decouple NVL() from COALESCE()

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -107,6 +107,7 @@ class Oracle(Dialect):
             "TO_TIMESTAMP": build_formatted_time(exp.StrToTime, "oracle"),
             "TO_DATE": build_formatted_time(exp.StrToDate, "oracle"),
         }
+        FUNCTIONS.pop("NVL")
 
         FUNCTION_PARSERS: t.Dict[str, t.Callable] = {
             **parser.Parser.FUNCTION_PARSERS,

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -88,7 +88,7 @@ class TestOracle(Validator):
         self.validate_identity(
             "SELECT * FROM T ORDER BY I OFFSET NVL(:variable1, 10) ROWS FETCH NEXT NVL(:variable2, 10) ROWS ONLY",
         )
-        self.parse_one("NVL(x, y)").assert_is(exp.Anonymous)
+        self.validate_identity("NVL(x, y)").assert_is(exp.Anonymous)
         self.validate_identity(
             "SELECT * FROM t SAMPLE (.25)",
             "SELECT * FROM t SAMPLE (0.25)",

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -86,9 +86,9 @@ class TestOracle(Validator):
             "SELECT DISTINCT col1, col2 FROM table",
         )
         self.validate_identity(
-            "SELECT * FROM T ORDER BY I OFFSET nvl(:variable1, 10) ROWS FETCH NEXT nvl(:variable2, 10) ROWS ONLY",
-            "SELECT * FROM T ORDER BY I OFFSET COALESCE(:variable1, 10) ROWS FETCH NEXT COALESCE(:variable2, 10) ROWS ONLY",
+            "SELECT * FROM T ORDER BY I OFFSET NVL(:variable1, 10) ROWS FETCH NEXT NVL(:variable2, 10) ROWS ONLY",
         )
+        self.parse_one("NVL(x, y)").assert_is(exp.Anonymous)
         self.validate_identity(
             "SELECT * FROM t SAMPLE (.25)",
             "SELECT * FROM t SAMPLE (0.25)",
@@ -187,13 +187,6 @@ class TestOracle(Validator):
             write={
                 "oracle": "SELECT CAST(NULL AS VARCHAR2(2328 BYTE)) AS COL1",
                 "spark": "SELECT CAST(NULL AS VARCHAR(2328)) AS COL1",
-            },
-        )
-        self.validate_all(
-            "NVL(NULL, 1)",
-            write={
-                "": "COALESCE(NULL, 1)",
-                "oracle": "COALESCE(NULL, 1)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #3733

In Oracle, these two functions have [different behaviors](https://stackoverflow.com/a/34830327), with the main one being that NVL implicitly converts the args to the same type; This means that SQLGlot cannot canonicalize`NVL()` to `COALESCE()` without type annotation & schema.

This PR aims to decouple them by removing the alias from `exp.Coalesce` and treating `NVL()` as an anonymous function. This should not be the case for Redshift, which does treat `NVL()` & `COALESCE()` as exactly the same function.

Docs
---------
[Oracle NVL](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/NVL.html) | [Oracle COALESCE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/COALESCE.html) | [Redshift NVL/COALESCE](https://docs.aws.amazon.com/redshift/latest/dg/r_NVL_function.html)
