### PR TITLE
fix(tsql): parse :: as type conversion then function

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -554,7 +554,7 @@ class TSQL(Dialect):
         }
 
         def _parse_dcolon(self) -> t.Optional[exp.Expression]:
-            return self._parse_function() or self._parse_types()
+            return self._parse_types() or self._parse_function()
 
         def _parse_options(self) -> t.Optional[t.List[exp.Expression]]:
             if not self._match(TokenType.OPTION):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1880,12 +1880,14 @@ FROM OPENJSON(@json) WITH (
     def test_scope_resolution_op(self):
         # we still want to support :: casting shorthand for tsql
         self.validate_identity("x::int", "CAST(x AS INTEGER)")
+        self.validate_identity("x::varchar", "CAST(x AS VARCHAR)")
+        self.validate_identity("x::varchar(MAX)", "CAST(x AS VARCHAR(MAX))")
 
         for lhs, rhs in (
             ("", "FOO(a, b)"),
             ("bar", "baZ(1, 2)"),
             ("LOGIN", "EricKurjan"),
-            ("GEOGRAPHY", "Point(latitude, longitude, 4326)"),
+            ("GEOGRAPHY", "Point(LATITUDE, LONGITUDE, 4326)"),
             (
                 "GEOGRAPHY",
                 "STGeomFromText('POLYGON((-122.358 47.653 , -122.348 47.649, -122.348 47.658, -122.358 47.658, -122.358 47.653))', 4326)",


### PR DESCRIPTION
Without this fix, `x::varchar(max)` is parsed as a function with argument max but not Type.VARCHAR, unlike `x::varchar` that is parsed correctly.

This fix parses the type conversion first then function for scope resolution. 

Added tests for both parsing use cases. 