### PR TITLE
feat(spark, databricks): Support view schema binding options

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2855,6 +2855,10 @@ class WithJournalTableProperty(Property):
     arg_types = {"this": True}
 
 
+class WithSchemaBindingProperty(Property):
+    arg_types = {"this": True}
+
+
 class WithSystemVersioningProperty(Property):
     arg_types = {
         "on": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -157,6 +157,7 @@ class Generator(metaclass=_Generator):
         exp.ViewAttributeProperty: lambda self, e: f"WITH {self.sql(e, 'this')}",
         exp.VolatileProperty: lambda *_: "VOLATILE",
         exp.WithJournalTableProperty: lambda self, e: f"WITH JOURNAL TABLE={self.sql(e, 'this')}",
+        exp.WithSchemaBindingProperty: lambda self, e: f"WITH SCHEMA {self.sql(e, 'this')}",
         exp.WithOperator: lambda self, e: f"{self.sql(e, 'this')} WITH {self.sql(e, 'op')}",
     }
 
@@ -502,6 +503,7 @@ class Generator(metaclass=_Generator):
         exp.VolatileProperty: exp.Properties.Location.POST_CREATE,
         exp.WithDataProperty: exp.Properties.Location.POST_EXPRESSION,
         exp.WithJournalTableProperty: exp.Properties.Location.POST_NAME,
+        exp.WithSchemaBindingProperty: exp.Properties.Location.POST_SCHEMA,
         exp.WithSystemVersioningProperty: exp.Properties.Location.POST_SCHEMA,
     }
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1129,6 +1129,11 @@ class Parser(metaclass=_Parser):
 
     CAST_ACTIONS: OPTIONS_TYPE = dict.fromkeys(("RENAME", "ADD"), ("FIELDS",))
 
+    SCHEMA_BINDING_OPTIONS: OPTIONS_TYPE = {
+        "TYPE": ("EVOLUTION",),
+        **dict.fromkeys(("BINDING", "COMPENSATION", "EVOLUTION"), tuple()),
+    }
+
     INSERT_ALTERNATIVES = {"ABORT", "FAIL", "IGNORE", "REPLACE", "ROLLBACK"}
 
     CLONE_KEYWORDS = {"CLONE", "COPY"}
@@ -2016,6 +2021,12 @@ class Parser(metaclass=_Parser):
 
         if self._match(TokenType.SERDE_PROPERTIES, advance=False):
             return self._parse_serde_properties(with_=True)
+
+        if self._match(TokenType.SCHEMA):
+            return self.expression(
+                exp.WithSchemaBindingProperty,
+                this=self._parse_var_from_options(self.SCHEMA_BINDING_OPTIONS),
+            )
 
         if not self._next:
             return None

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -801,3 +801,10 @@ TBLPROPERTIES (
                     self.assertEqual(query.sql(name), with_modifiers)
                 else:
                     self.assertEqual(query.sql(name), without_modifiers)
+
+    def test_schema_binding_options(self):
+        for schema_binding in ("BINDING", "COMPENSATION", "TYPE EVOLUTION", "EVOLUTION"):
+            with self.subTest(f"Test roundtrip of VIEW schema binding {schema_binding}"):
+                self.validate_identity(
+                    f"CREATE VIEW emp_v WITH SCHEMA {schema_binding} AS SELECT * FROM emp"
+                )


### PR DESCRIPTION
Fixes #3738

Add support for the `schema_binding` clause with syntax:

```SQL
WITH SCHEMA { BINDING | COMPENSATION | [ TYPE ] EVOLUTION }
```

Docs
---------
[Databricks CREATE VIEW](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-ddl-create-view.html)