### PR TITLE
fix(optimizer): Fix expansion of SELECT * REPLACE, RENAME

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -574,8 +574,8 @@ def _expand_stars(
 
             table_id = id(table)
             columns_to_exclude = except_columns.get(table_id) or set()
-            rename_columns_dict = rename_columns.get(table_id, {})
-            replace_columns_dict = replace_columns.get(table_id, {})
+            renamed_columns = rename_columns.get(table_id, {})
+            replaced_columns = replace_columns.get(table_id, {})
 
             if pivot:
                 if pivot_output_columns and pivot_exclude_columns:
@@ -604,8 +604,8 @@ def _expand_stars(
                         alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False)
                     )
                 else:
-                    selection_expr = replace_columns_dict.get(name) or exp.column(name, table=table)
-                    alias_ = rename_columns_dict.get(name, name)
+                    alias_ = renamed_columns.get(name, name)
+                    selection_expr = replaced_columns.get(name) or exp.column(name, table=table)
                     new_selections.append(
                         alias(selection_expr, alias_, copy=False)
                         if alias_ != name

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -272,7 +272,6 @@ class Scope:
                 ancestor = column.find_ancestor(
                     exp.Select, exp.Qualify, exp.Order, exp.Having, exp.Hint, exp.Table, exp.Star
                 )
-
                 if (
                     not ancestor
                     or column.table

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -276,15 +276,15 @@ class Scope:
                 is_except_col = False
                 if isinstance(ancestor, exp.Star):
                     except_cols = ancestor.args.get("except") or []
-                    replace_cols = ancestor.args.get("replace") or []
-                    cols = set(
+                    replace_cols = set(
                         replace_col
-                        for col in replace_cols
+                        for col in (ancestor.args.get("replace") or [])
                         for replace_col in col.find_all(exp.Column)
                     )
                     # Exclude the columns in EXCEPT() from the scope unless they're used in REPLACE, i.e in
                     # "SELECT * EXCEPT (col1) REPLACE (COALESCE(1, col1) AS col2)"", col1 must be kept in scope
-                    is_except_col = column in except_cols and column not in cols
+                    # so it can be qualified
+                    is_except_col = column in except_cols and column not in replace_cols
 
                 if (
                     not ancestor

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -273,19 +273,6 @@ class Scope:
                     exp.Select, exp.Qualify, exp.Order, exp.Having, exp.Hint, exp.Table, exp.Star
                 )
 
-                is_except_col = False
-                if isinstance(ancestor, exp.Star):
-                    except_cols = ancestor.args.get("except") or []
-                    replace_cols = set(
-                        replace_col
-                        for col in (ancestor.args.get("replace") or [])
-                        for replace_col in col.find_all(exp.Column)
-                    )
-                    # Exclude the columns in EXCEPT() from the scope unless they're used in REPLACE, i.e in
-                    # "SELECT * EXCEPT (col1) REPLACE (COALESCE(1, col1) AS col2)"", col1 must be kept in scope
-                    # so it can be qualified
-                    is_except_col = column in except_cols and column not in replace_cols
-
                 if (
                     not ancestor
                     or column.table
@@ -298,7 +285,7 @@ class Scope:
                             or column.name not in named_selects
                         )
                     )
-                    or (isinstance(ancestor, exp.Star) and not is_except_col)
+                    or (isinstance(ancestor, exp.Star) and not column.arg_key == "except")
                 ):
                     self._columns.append(column)
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -385,14 +385,14 @@ WITH player AS (SELECT player.name, player.asset.info FROM players) SELECT * FRO
 WITH player AS (SELECT players.player.name AS name, players.player.asset.info AS info FROM players AS players) SELECT player.name AS name, player.info AS info FROM player AS player;
 
 --------------------------------------
--- Except and Replace
+-- Except, Replace, Rename
 --------------------------------------
 # execute: false
-SELECT * REPLACE(a AS d) FROM x;
+SELECT * RENAME(a AS d) FROM x;
 SELECT x.a AS d, x.b AS b FROM x AS x;
 
 # execute: false
-SELECT * EXCEPT(b) REPLACE(a AS d) FROM x;
+SELECT * EXCEPT(b) RENAME(a AS d) FROM x;
 SELECT x.a AS d FROM x AS x;
 
 SELECT x.* EXCEPT(a), y.* FROM x, y;
@@ -415,6 +415,22 @@ SELECT x.a AS a, x.b AS b, y.b AS b FROM x AS x LEFT JOIN x AS y ON x.a = y.a;
 
 SELECT COALESCE(CAST(t1.a AS VARCHAR), '') AS a, t2.* EXCEPT (a) FROM x AS t1, x AS t2;
 SELECT COALESCE(CAST(t1.a AS VARCHAR), '') AS a, t2.b AS b FROM x AS t1, x AS t2;
+
+# execute: false
+SELECT * REPLACE(COALESCE(b, a) AS a, a as b) FROM x;
+SELECT COALESCE(x.b, x.a) AS a, x.a AS b FROM x AS x;
+
+# execute: false
+SELECT * REPLACE(1 AS a) RENAME(b as alias_b) FROM x;
+SELECT 1 AS a, x.b AS alias_b FROM x AS x;
+
+# execute: false
+SELECT * EXCEPT(a) REPLACE(COALESCE(a, b) AS b) RENAME(b AS new_b) FROM x;
+SELECT COALESCE(x.a, x.b) AS new_b FROM x AS x;
+
+# execute: false
+SELECT * REPLACE(1 AS a, a AS b) RENAME(b AS new_b) FROM x;
+SELECT 1 AS a, x.a AS new_b FROM x AS x;
 
 --------------------------------------
 -- Using

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -417,6 +417,14 @@ SELECT COALESCE(CAST(t1.a AS VARCHAR), '') AS a, t2.* EXCEPT (a) FROM x AS t1, x
 SELECT COALESCE(CAST(t1.a AS VARCHAR), '') AS a, t2.b AS b FROM x AS t1, x AS t2;
 
 # execute: false
+SELECT * REPLACE(2 AS a) FROM x;
+SELECT 2 AS a, x.b AS b FROM x AS x;
+
+# execute: false
+SELECT * EXCEPT (a, b) REPLACE (a AS a) FROM x;
+SELECT * EXCEPT (a, b) REPLACE (x.a AS a) FROM x AS x;
+
+# execute: false
 SELECT * REPLACE(COALESCE(b, a) AS a, a as b) FROM x;
 SELECT COALESCE(x.b, x.a) AS a, x.a AS b FROM x AS x;
 


### PR DESCRIPTION
Context from [public slack](https://app.slack.com/client/T041MTMK2JC/C044BRE5W4S)

In dialects like Snowflake the `SELECT` syntax allows the following statements (may be different per dialect):

```SQL
SELECT *
...
[ EXCLUDE {<col_name> [, ... ] }]
[ REPLACE {( <expr> AS <col_name> [, ... ] )}]
[ RENAME {<col_name> AS <col_alias>, ... )}]
```

Currently the optimizer incorrectly treats `SELECT * REPLACE`  as `SELECT * RENAME` semantically, with `RENAME` not being accounted for at all. 

This PR aims to fix this by:
- Adding support for `RENAME` which should substitute the column aliases 

- Fixing how `REPLACE` works i.e it now appends the replaced expressions directly to the selection list
```SQL
SELECT * REPLACE(1 as col) => SELECT 1 as col
```  

- The `EXCEPT`/`EXCLUDE` columns [are still not gathered ](https://github.com/tobymao/sqlglot/commit/7ee4fe73b29234f2837a212b6c872efd7f5c30ea)  in `scope.columns` _unless_ they participate in `REPLACE`. This is to solve qualification edge cases such as the following, in which we still want to keep `x.a` in the scope so it can be qualified inside of `COALESCE` before reaching `_expand_stars()`:

```SQL
SELECT * EXCLUDE(a) REPLACE(COALESCE(a, b) AS b) => SELECT COALESCE(x.a, x.b) AS b
```  