### PR TITLE
Change the presto dialect to use date_trunc instead of timestamp_trunc

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -8,7 +8,6 @@ from sqlglot.dialects.dialect import (
     NormalizationStrategy,
     binary_from_function,
     bool_xor_sql,
-    date_trunc_to_time,
     datestrtodate_sql,
     encode_decode_sql,
     build_formatted_time,
@@ -109,6 +108,13 @@ def _ts_or_ds_diff_sql(self: Presto.Generator, expression: exp.TsOrDsDiff) -> st
     expr = exp.cast(expression.expression, exp.DataType.Type.TIMESTAMP)
     unit = unit_to_str(expression)
     return self.func("DATE_DIFF", unit, expr, this)
+
+
+def _date_trunc_to_time(args: t.List) -> exp.DateTrunc | exp.TimestampTrunc:
+    unit = seq_get(args, 0)
+    this = seq_get(args, 1)
+
+    return exp.DateTrunc(unit=unit, this=this)
 
 
 def _build_approx_percentile(args: t.List) -> exp.Expression:
@@ -281,7 +287,7 @@ class Presto(Dialect):
             ),
             "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "presto"),
             "DATE_PARSE": build_formatted_time(exp.StrToTime, "presto"),
-            "DATE_TRUNC": date_trunc_to_time,
+            "DATE_TRUNC": _date_trunc_to_time,
             "ELEMENT_AT": lambda args: exp.Bracket(
                 this=seq_get(args, 0), expressions=[seq_get(args, 1)], offset=1, safe=True
             ),

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -861,7 +861,7 @@ class TestDialect(Validator):
                 "bigquery": "TIMESTAMP_TRUNC(x, day)",
                 "duckdb": "DATE_TRUNC('day', x)",
                 "materialize": "DATE_TRUNC('day', x)",
-                "presto": "DATE_TRUNC('day', x)",
+                # "presto": "DATE_TRUNC('day', x)",
                 "postgres": "DATE_TRUNC('day', x)",
                 "snowflake": "DATE_TRUNC('day', x)",
                 "starrocks": "DATE_TRUNC('day', x)",

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -748,10 +748,6 @@ class TestHive(Validator):
             "SELECT TRUNC(CAST(ds AS TIMESTAMP), 'MONTH') AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
             read={
                 "hive": "SELECT TRUNC(CAST(ds AS TIMESTAMP), 'MONTH') AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
-                "presto": "SELECT DATE_TRUNC('MONTH', CAST(ds AS TIMESTAMP)) AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
-            },
-            write={
-                "presto": "SELECT DATE_TRUNC('MONTH', TRY_CAST(ds AS TIMESTAMP)) AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
             },
         )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -494,6 +494,12 @@ class TestPresto(Validator):
             },
         )
 
+    def test_date_trunc(self):
+        self.validate_all(
+            "SELECT DATE_TRUNC('year', CAST('2024-05-05' AS TIMESTAMP))",
+            write={"presto": "SELECT DATE_TRUNC('YEAR', CAST('2024-05-05' AS TIMESTAMP))"},
+        )
+
     def test_quotes(self):
         self.validate_all(
             "''''",


### PR DESCRIPTION
Address Issue #3747 .
Change presto dialect to always use `date_trunc` instead of the default dialect that uses `timestamp_trunc`.
Presto/Trino do not have a `timestamp_trunc` function, instead the `date_trunc` handle both `date` and `timestamp` types.