### PR TITLE
feat(postgres): Support FROM ROWS FROM (...)

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3043,6 +3043,7 @@ class Table(Expression):
         "only": False,
         "partition": False,
         "changes": False,
+        "rows_from": False,
     }
 
     @property

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1754,7 +1754,7 @@ class Generator(metaclass=_Generator):
         changes = self.sql(expression, "changes")
         changes = f" {changes}" if changes else ""
 
-        rows_from = self.expressions(expression, key="rows_from", sep=", ")
+        rows_from = self.expressions(expression, key="rows_from")
         if rows_from:
             table = f"ROWS FROM {self.wrap(rows_from)}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1754,6 +1754,10 @@ class Generator(metaclass=_Generator):
         changes = self.sql(expression, "changes")
         changes = f" {changes}" if changes else ""
 
+        rows_from = self.expressions(expression, key="rows_from", sep=", ")
+        if rows_from:
+            table = f"ROWS FROM {self.wrap(rows_from)}"
+
         return f"{only}{table}{changes}{partition}{version}{file_format}{alias}{hints}{pivots}{joins}{laterals}{ordinality}"
 
     def tablesample_sql(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3375,11 +3375,17 @@ class Parser(metaclass=_Parser):
         bracket = parse_bracket and self._parse_bracket(None)
         bracket = self.expression(exp.Table, this=bracket) if bracket else None
 
+        rows_from = self._match_text_seq("ROWS", "FROM") and self._parse_wrapped_csv(
+            self._parse_table
+        )
+        rows_from = self.expression(exp.Table, rows_from=rows_from) if rows_from else None
+
         only = self._match(TokenType.ONLY)
 
         this = t.cast(
             exp.Expression,
             bracket
+            or rows_from
             or self._parse_bracket(
                 self._parse_table_parts(schema=schema, is_db_reference=is_db_reference)
             ),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -100,9 +100,6 @@ class TestPostgres(Validator):
             "SELECT * FROM JSON_ARRAY_ELEMENTS('[1,true, [2,false]]') WITH ORDINALITY AS kv_json(a, b)"
         )
         self.validate_identity(
-            """SELECT * FROM table, ROWS FROM (FUNC1(col1) AS alias1("col1" TEXT), FUNC2(col2) AS alias2("col2" INT)) WITH ORDINALITY AS alias3("col3" INT, "col4" TEXT)"""
-        )
-        self.validate_identity(
             "SELECT SUM(x) OVER a, SUM(y) OVER b FROM c WINDOW a AS (PARTITION BY d), b AS (PARTITION BY e)"
         )
         self.validate_identity(
@@ -1133,3 +1130,12 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(boxcrate AS JSON)) AS x(tbox)
 CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) AS y(boxes)"""
 
         self.validate_all(expected_postgres, read={"trino": trino_input}, pretty=True)
+
+    def test_rows_from(self):
+        self.validate_identity("""SELECT * FROM ROWS FROM (FUNC1(col1, col2))""")
+        self.validate_identity(
+            """SELECT * FROM ROWS FROM (FUNC1(col1) AS alias1("col1" TEXT), FUNC2(col2) AS alias2("col2" INT)) WITH ORDINALITY"""
+        )
+        self.validate_identity(
+            """SELECT * FROM table1, ROWS FROM (FUNC1(col1) AS alias1("col1" TEXT)) WITH ORDINALITY AS alias3("col3" INT, "col4" TEXT)"""
+        )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -100,6 +100,9 @@ class TestPostgres(Validator):
             "SELECT * FROM JSON_ARRAY_ELEMENTS('[1,true, [2,false]]') WITH ORDINALITY AS kv_json(a, b)"
         )
         self.validate_identity(
+            """SELECT * FROM table, ROWS FROM (FUNC1(col1) AS alias1("col1" TEXT), FUNC2(col2) AS alias2("col2" INT)) WITH ORDINALITY AS alias3("col3" INT, "col4" TEXT)"""
+        )
+        self.validate_identity(
             "SELECT SUM(x) OVER a, SUM(y) OVER b FROM c WINDOW a AS (PARTITION BY d), b AS (PARTITION BY e)"
         )
         self.validate_identity(


### PR DESCRIPTION
[Public slack context](https://app.slack.com/client/T041MTMK2JC/C044BRE5W4S)

This PR adds support for the `ROWS FROM` clause which is stored in `exp.Table`:
```
FROM ROWS FROM ( function_name ( [ argument [, ...] ] ) [ AS ( column_definition [, ...] ) ] [, ...] )
                [ WITH ORDINALITY ] [ [ AS ] alias [ ( column_alias [, ...] ) ]
```

Note that the parser (`_parse_table()`) already supports Postgres's `from_item` set functions, which are also parsed as `exp.Table`:

```
FROM function_name ( [ argument [, ...] ] )
                [ WITH ORDINALITY ] [ [ AS ] alias [ ( column_alias [, ...] ) ] ]
```

Thus, a straightforward solution was to recursively parse & generate `ROWS FROM`'s params as comma-separated set functions (i.e other `exp.Table`s).


Docs
----------
- [Postgres SELECT syntax](https://www.postgresql.org/docs/current/sql-select.html)