### PR TITLE
feat(duckdb, spark, databricks): Support for ORDER BY ALL

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -356,6 +356,11 @@ class Dialect(metaclass=_Dialect):
     EXPAND_ALIAS_REFS_EARLY_ONLY_IN_GROUP_BY = False
     """Whether alias reference expansion before qualification should only happen for the GROUP BY clause."""
 
+    SUPPORTS_ORDER_BY_ALL = False
+    """
+    Whether ORDER BY ALL is supported (expands to all the selected columns) as in DuckDB, Spark3/Databricks
+    """
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -172,6 +172,7 @@ class DuckDB(Dialect):
     SAFE_DIVISION = True
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True
+    SUPPORTS_ORDER_BY_ALL = True
 
     # https://duckdb.org/docs/sql/introduction.html#creating-a-new-table
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -90,6 +90,8 @@ def _dateadd_sql(self: Spark.Generator, expression: exp.TsOrDsAdd | exp.Timestam
 
 
 class Spark(Spark2):
+    SUPPORTS_ORDER_BY_ALL = True
+
     class Tokenizer(Spark2.Tokenizer):
         STRING_ESCAPES_ALLOWED_IN_RAW_STRINGS = False
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3842,6 +3842,9 @@ class Parser(metaclass=_Parser):
         if not this:
             return None
 
+        if this.name.upper() == "ALL" and self.dialect.SUPPORTS_ORDER_BY_ALL:
+            this = exp.var("ALL")
+
         asc = self._match(TokenType.ASC)
         desc = self._match(TokenType.DESC) or (asc and False)
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1164,6 +1164,13 @@ class TestDialect(Validator):
             },
         )
 
+        order_by_all_sql = "SELECT * FROM t ORDER BY ALL"
+        self.validate_identity(order_by_all_sql).find(exp.Ordered).this.assert_is(exp.Column)
+
+        for dialect in ("duckdb", "spark", "databricks"):
+            with self.subTest(f"Testing ORDER BY ALL in {dialect}"):
+                parse_one(order_by_all_sql, read=dialect).find(exp.Ordered).this.assert_is(exp.Var)
+
     def test_json(self):
         self.validate_all(
             """JSON_EXTRACT(x, '$["a b"]')""",


### PR DESCRIPTION
Fixes #3755

For the dialects that support `ORDER BY ALL` such as DuckDB, Databricks, Spark3 (tested on 3.4+) parse `ALL` as an `exp.Var` and not as a column.

Docs
--------
[DuckDB ORDER BY](https://duckdb.org/docs/sql/query_syntax/orderby.html) | [Databricks ORDER BY](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-orderby.html)