### PR TITLE
feat: Support for RPAD & LPAD functions

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -381,6 +381,7 @@ class DuckDB(Dialect):
         SUPPORTS_TO_NUMBER = False
         COPY_HAS_INTO_KEYWORD = False
         STAR_EXCEPT = "EXCLUDE"
+        PAD_FILL_PATTERN_IS_REQUIRED = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -447,6 +447,7 @@ class Hive(Dialect):
         SUPPORTS_TO_NUMBER = False
         WITH_PROPERTIES_PREFIX = "TBLPROPERTIES"
         PARSE_JSON_NAME = None
+        PAD_FILL_PATTERN_IS_REQUIRED = True
 
         EXPRESSIONS_WITHOUT_NESTED_CTES = {
             exp.Insert,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -690,6 +690,7 @@ class MySQL(Dialect):
         JSON_KEY_VALUE_PAIR_SEP = ","
         SUPPORTS_TO_NUMBER = False
         PARSE_JSON_NAME = None
+        PAD_FILL_PATTERN_IS_REQUIRED = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -335,6 +335,7 @@ class Presto(Dialect):
         SUPPORTS_TO_NUMBER = False
         HEX_FUNC = "TO_HEX"
         PARSE_JSON_NAME = "JSON_PARSE"
+        PAD_FILL_PATTERN_IS_REQUIRED = True
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -129,6 +129,7 @@ class Spark(Spark2):
 
     class Generator(Spark2.Generator):
         SUPPORTS_TO_NUMBER = True
+        PAD_FILL_PATTERN_IS_REQUIRED = False
 
         TYPE_MAPPING = {
             **Spark2.Generator.TYPE_MAPPING,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4795,7 +4795,7 @@ class List(Func):
 
 # String pad, kind True -> LPAD, False -> RPAD
 class Pad(Func):
-    arg_types = {"kind": True, "this": True, "expression": True, "fill_pattern": False}
+    arg_types = {"this": True, "expression": True, "fill_pattern": False, "is_left": True}
 
 
 # https://docs.snowflake.com/en/sql-reference/functions/to_char

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4793,6 +4793,11 @@ class List(Func):
     is_var_len_args = True
 
 
+# String pad, kind "L" -> LPAD, "R" -> RPAD
+class Pad(Func):
+    arg_types = {"kind": True, "this": True, "expression": True, "fill_pattern": False}
+
+
 # https://docs.snowflake.com/en/sql-reference/functions/to_char
 # https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/TO_CHAR-number.html
 class ToChar(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4793,7 +4793,7 @@ class List(Func):
     is_var_len_args = True
 
 
-# String pad, kind "L" -> LPAD, "R" -> RPAD
+# String pad, kind True -> LPAD, False -> RPAD
 class Pad(Func):
     arg_types = {"kind": True, "this": True, "expression": True, "fill_pattern": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -374,6 +374,9 @@ class Generator(metaclass=_Generator):
     # Whether to quote the generated expression of exp.JsonPath
     QUOTE_JSON_PATH = True
 
+    # Whether the text pattern/fill (3rd) parameter of RPAD()/LPAD() is optional (defaults to space)
+    PAD_FILL_PATTERN_IS_REQUIRED = False
+
     # The name to generate for the JSONPath expression. If `None`, only `this` will be generated
     PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
 
@@ -4041,3 +4044,12 @@ class Generator(metaclass=_Generator):
         end = f"{self.seg('')}{end}" if end else ""
 
         return f"CHANGES ({information}){at_before}{end}"
+
+    def pad_sql(self, expression: exp.Pad) -> str:
+        kind = self.sql(expression, "kind")
+
+        fill_pattern = self.sql(expression, "fill_pattern") or None
+        if not fill_pattern and self.PAD_FILL_PATTERN_IS_REQUIRED:
+            fill_pattern = "' '"
+
+        return self.func(f"{kind}PAD", expression.this, expression.expression, fill_pattern)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4046,7 +4046,7 @@ class Generator(metaclass=_Generator):
         return f"CHANGES ({information}){at_before}{end}"
 
     def pad_sql(self, expression: exp.Pad) -> str:
-        kind = self.sql(expression, "kind")
+        kind = "L" if expression.args.get("kind") else "R"
 
         fill_pattern = self.sql(expression, "fill_pattern") or None
         if not fill_pattern and self.PAD_FILL_PATTERN_IS_REQUIRED:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4046,10 +4046,10 @@ class Generator(metaclass=_Generator):
         return f"CHANGES ({information}){at_before}{end}"
 
     def pad_sql(self, expression: exp.Pad) -> str:
-        kind = "L" if expression.args.get("kind") else "R"
+        prefix = "L" if expression.args.get("is_left") else "R"
 
         fill_pattern = self.sql(expression, "fill_pattern") or None
         if not fill_pattern and self.PAD_FILL_PATTERN_IS_REQUIRED:
             fill_pattern = "' '"
 
-        return self.func(f"{kind}PAD", expression.this, expression.expression, fill_pattern)
+        return self.func(f"{prefix}PAD", expression.this, expression.expression, fill_pattern)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -110,10 +110,10 @@ def build_mod(args: t.List) -> exp.Mod:
 
 def build_pad(args: t.List, is_left: bool = True):
     return exp.Pad(
-        kind=is_left,
         this=seq_get(args, 0),
         expression=seq_get(args, 1),
         fill_pattern=seq_get(args, 2),
+        is_left=is_left,
     )
 
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -108,9 +108,12 @@ def build_mod(args: t.List) -> exp.Mod:
     return exp.Mod(this=this, expression=expression)
 
 
-def build_pad(kind: str, args: t.List):
+def build_pad(args: t.List, is_left: bool = True):
     return exp.Pad(
-        kind=kind, this=seq_get(args, 0), expression=seq_get(args, 1), fill_pattern=seq_get(args, 2)
+        kind=is_left,
+        this=seq_get(args, 0),
+        expression=seq_get(args, 1),
+        fill_pattern=seq_get(args, 2),
     )
 
 
@@ -165,11 +168,11 @@ class Parser(metaclass=_Parser):
         "LOG2": lambda args: exp.Log(this=exp.Literal.number(2), expression=seq_get(args, 0)),
         "LOG10": lambda args: exp.Log(this=exp.Literal.number(10), expression=seq_get(args, 0)),
         "LOWER": build_lower,
-        "LPAD": lambda args: build_pad("L", args),
-        "LEFTPAD": lambda args: build_pad("L", args),
+        "LPAD": lambda args: build_pad(args),
+        "LEFTPAD": lambda args: build_pad(args),
         "MOD": build_mod,
-        "RPAD": lambda args: build_pad("R", args),
-        "RIGHTPAD": lambda args: build_pad("R", args),
+        "RPAD": lambda args: build_pad(args, is_left=False),
+        "RIGHTPAD": lambda args: build_pad(args, is_left=False),
         "SCOPE_RESOLUTION": lambda args: exp.ScopeResolution(expression=seq_get(args, 0))
         if len(args) != 2
         else exp.ScopeResolution(this=seq_get(args, 0), expression=seq_get(args, 1)),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -108,6 +108,12 @@ def build_mod(args: t.List) -> exp.Mod:
     return exp.Mod(this=this, expression=expression)
 
 
+def build_pad(kind: str, args: t.List):
+    return exp.Pad(
+        kind=kind, this=seq_get(args, 0), expression=seq_get(args, 1), fill_pattern=seq_get(args, 2)
+    )
+
+
 class _Parser(type):
     def __new__(cls, clsname, bases, attrs):
         klass = super().__new__(cls, clsname, bases, attrs)
@@ -159,7 +165,11 @@ class Parser(metaclass=_Parser):
         "LOG2": lambda args: exp.Log(this=exp.Literal.number(2), expression=seq_get(args, 0)),
         "LOG10": lambda args: exp.Log(this=exp.Literal.number(10), expression=seq_get(args, 0)),
         "LOWER": build_lower,
+        "LPAD": lambda args: build_pad("L", args),
+        "LEFTPAD": lambda args: build_pad("L", args),
         "MOD": build_mod,
+        "RPAD": lambda args: build_pad("R", args),
+        "RIGHTPAD": lambda args: build_pad("R", args),
         "SCOPE_RESOLUTION": lambda args: exp.ScopeResolution(expression=seq_get(args, 0))
         if len(args) != 2
         else exp.ScopeResolution(this=seq_get(args, 0), expression=seq_get(args, 1)),

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2566,3 +2566,33 @@ FROM subquery2""",
             """SELECT partition.d FROM t PARTITION (d)""",
             """SELECT partition.d FROM t AS PARTITION(d)""",
         )
+
+    def test_string_functions(self):
+        for pad_func in ("LPAD", "RPAD"):
+            ch_alias = "LEFTPAD" if pad_func == "LPAD" else "RIGHTPAD"
+            for fill_pattern in ("", ", ' '"):
+                with self.subTest(f"Testing {pad_func}() with pattern {fill_pattern}"):
+                    self.validate_all(
+                        f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                        read={
+                            "snowflake": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "databricks": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "spark": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "postgres": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "clickhouse": f"SELECT {ch_alias}('bar', 5{fill_pattern})",
+                        },
+                        write={
+                            "": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "spark": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "postgres": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "clickhouse": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "snowflake": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "databricks": f"SELECT {pad_func}('bar', 5{fill_pattern})",
+                            "duckdb": f"SELECT {pad_func}('bar', 5, ' ')",
+                            "mysql": f"SELECT {pad_func}('bar', 5, ' ')",
+                            "hive": f"SELECT {pad_func}('bar', 5, ' ')",
+                            "spark2": f"SELECT {pad_func}('bar', 5, ' ')",
+                            "presto": f"SELECT {pad_func}('bar', 5, ' ')",
+                            "trino": f"SELECT {pad_func}('bar', 5, ' ')",
+                        },
+                    )


### PR DESCRIPTION
Introduce `exp.Pad` which supports the string padding functions `LPAD()`, `RPAD()`; The joint node is used because these 2 functions share the same signature but differ on the result (left/right application of padding)

Most dialects default to whitespace for the padding (3rd parameter) while DuckDB, MySQL, Presto/Trino, and Hive/Spark2  require it explicitly, so the flag `PAD_FILL_PATTERN_IS_REQUIRED` was introduced to facilitate transpilation during generation.

Docs
--------
[Databricks / Spark3](https://docs.databricks.com/en/sql/language-manual/functions/lpad.html) | [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#lpad) | [DuckDB](https://duckdb.org/docs/sql/functions/char.html#lpadstring-count-character) | [Postgres](https://www.postgresql.org/docs/9.1/functions-string.html) | [Redshift](https://docs.aws.amazon.com/redshift/latest/dg/r_LPAD.html) | [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/lpad) | [MySQL](https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#function_lpad) | [Hive / Spark2](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF) | [Presto](https://prestodb.io/docs/current/functions/string.html#lpad-string-size-padstring-varchar) | [Trino](https://trino.io/docs/current/functions/string.html#lpad)