### PR TITLE
Fix: attach comments to Commands

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -512,6 +512,7 @@ class Generator(metaclass=_Generator):
 
     # Expressions whose comments are separated from them for better formatting
     WITH_SEPARATED_COMMENTS: t.Tuple[t.Type[exp.Expression], ...] = (
+        exp.Command,
         exp.Create,
         exp.Delete,
         exp.Drop,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1478,7 +1478,10 @@ class Parser(metaclass=_Parser):
     def _parse_command(self) -> exp.Command:
         self._warn_unsupported()
         return self.expression(
-            exp.Command, this=self._prev.text.upper(), expression=self._parse_string()
+            exp.Command,
+            comments=self._prev_comments,
+            this=self._prev.text.upper(),
+            expression=self._parse_string(),
         )
 
     def _try_parse(self, parse_method: t.Callable[[], T], retreat: bool = False) -> t.Optional[T]:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1427,6 +1427,12 @@ WHERE
             transpile("DATE_ADD(x, day)", read="bigquery")
 
     def test_warnings(self):
+        with self.assertLogs(parser_logger) as cm:
+            self.validate_identity(
+                "/* some comment */ DECLARE foo DATE DEFAULT DATE_SUB(current_date, INTERVAL 2 day)"
+            )
+            self.assertIn("contains unsupported syntax", cm.output[0])
+
         with self.assertLogs(helper_logger) as cm:
             self.validate_identity(
                 "WITH cte(c) AS (SELECT * FROM t) SELECT * FROM cte",


### PR DESCRIPTION
Current behavior:

```python
>>> import sqlglot
>>> sqlglot.transpile("/* some comment */ DECLARE foo DATE DEFAULT DATE_SUB(current_date, INTERVAL 2 day)", "bigquery")
'DECLARE foo DATE DEFAULT DATE_SUB(current_date, INTERVAL 2 day)' contains unsupported syntax. Falling back to parsing as a 'Command'.
['DECLARE foo DATE DEFAULT DATE_SUB(current_date, INTERVAL 2 day)']
```

On this PR the comment is preserved and prepended to the `Command`'s SQL.

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1720648294228409