### PR TITLE
feat(presto, trino): Add support for exp.TimestampAdd

### DIFF
--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -405,6 +405,14 @@ class TestPresto(Validator):
         )
         self.validate_identity("DATE_ADD('DAY', 1, y)")
 
+        self.validate_all(
+            "SELECT DATE_ADD('MINUTE', 30, col)",
+            write={
+                "presto": "SELECT DATE_ADD('MINUTE', 30, col)",
+                "trino": "SELECT DATE_ADD('MINUTE', 30, col)",
+            },
+        )
+
     def test_ddl(self):
         self.validate_all(
             "CREATE TABLE test WITH (FORMAT = 'PARQUET') AS SELECT 1",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -684,6 +684,8 @@ TBLPROPERTIES (
             write={
                 "spark": "SELECT DATE_ADD(MONTH, 20, col)",
                 "databricks": "SELECT DATE_ADD(MONTH, 20, col)",
+                "presto": "SELECT DATE_ADD('MONTH', 20, col)",
+                "trino": "SELECT DATE_ADD('MONTH', 20, col)",
             },
         )
 


### PR DESCRIPTION
Fixes #3762 

Transpile `exp.TimestampAdd` to Presto/Trino's `DATE_ADD()` which can accept any datetime expr; The result returned is of the same type. 

For the same reason, I also went ahead and factored out the generation of `exp.DateAdd | exp.TimestampAdd | exp.DateSub`
 
Docs
--------
[Presto DATE_ADD](https://prestodb.io/docs/current/functions/datetime.html#date_add-unit-value-timestamp-same-as-input) | [Trino DATE_ADD](https://trino.io/docs/current/functions/datetime.html#date_add)