### PR TITLE
fix(clickhouse): Allow TokenType.SELECT as a Tuple field identifier

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -332,6 +332,8 @@ class ClickHouse(Dialect):
             TokenType.SET,
         }
 
+        RESERVED_TOKENS = {*parser.Parser.RESERVED_TOKENS} - {TokenType.SELECT}
+
         AGG_FUNC_MAPPING = (
             lambda functions, suffixes: {
                 f"{f}{sfx}": (f, sfx) for sfx in (suffixes + [""]) for f in functions

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -332,7 +332,8 @@ class ClickHouse(Dialect):
             TokenType.SET,
         }
 
-        RESERVED_TOKENS = {*parser.Parser.RESERVED_TOKENS} - {TokenType.SELECT}
+        RESERVED_TOKENS = parser.Parser.RESERVED_TOKENS.copy()
+        RESERVED_TOKENS.remove(TokenType.SELECT)
 
         AGG_FUNC_MAPPING = (
             lambda functions, suffixes: {

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -332,8 +332,7 @@ class ClickHouse(Dialect):
             TokenType.SET,
         }
 
-        RESERVED_TOKENS = parser.Parser.RESERVED_TOKENS.copy()
-        RESERVED_TOKENS.remove(TokenType.SELECT)
+        RESERVED_TOKENS = parser.Parser.RESERVED_TOKENS - {TokenType.SELECT}
 
         AGG_FUNC_MAPPING = (
             lambda functions, suffixes: {

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -451,6 +451,10 @@ class TestClickhouse(Validator):
         self.validate_identity("ALTER TABLE visits REPLACE PARTITION ID '201901' FROM visits_tmp")
         self.validate_identity("ALTER TABLE visits ON CLUSTER test_cluster DROP COLUMN col1")
 
+        self.assertIsInstance(
+            parse_one("Tuple(select Int64)", into=exp.DataType, read="clickhouse"), exp.DataType
+        )
+
     def test_cte(self):
         self.validate_identity("WITH 'x' AS foo SELECT foo")
         self.validate_identity("WITH ['c'] AS field_names SELECT field_names")
@@ -548,6 +552,7 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "CREATE TABLE foo (x UInt32) TTL time_column + INTERVAL '1' MONTH DELETE WHERE column = 'value'"
         )
+        self.validate_identity("CREATE TABLE named_tuples (a Tuple(select String, i Int64))")
 
         self.validate_all(
             """


### PR DESCRIPTION
Fixes #3763


Docs
-------
[Clickhouse Tuple](https://clickhouse.com/docs/en/sql-reference/data-types/tuple)