### PR TITLE
fix(duckdb): Transpile UDFs from Databricks

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -456,6 +456,8 @@ class DuckDB(Dialect):
             ),
             exp.RegexpLike: rename_func("REGEXP_MATCHES"),
             exp.RegexpSplit: rename_func("STR_SPLIT_REGEX"),
+            exp.Return: lambda self, e: self.sql(e, "this"),
+            exp.ReturnsProperty: lambda self, e: "TABLE" if isinstance(e.this, exp.Schema) else "",
             exp.Rand: rename_func("RANDOM"),
             exp.SafeDivide: no_safe_divide_sql,
             exp.Split: rename_func("STR_SPLIT"),
@@ -617,6 +619,7 @@ class DuckDB(Dialect):
         # can be transpiled to DuckDB, so we explicitly override them accordingly
         PROPERTIES_LOCATION[exp.LikeProperty] = exp.Properties.Location.POST_SCHEMA
         PROPERTIES_LOCATION[exp.TemporaryProperty] = exp.Properties.Location.POST_CREATE
+        PROPERTIES_LOCATION[exp.ReturnsProperty] = exp.Properties.Location.POST_ALIAS
 
         def strtotime_sql(self, expression: exp.StrToTime) -> str:
             if expression.args.get("safe"):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -997,6 +997,7 @@ class Generator(metaclass=_Generator):
             expression_sql = f"{begin}{self.sep()}{expression_sql}{end}"
 
             if self.CREATE_FUNCTION_RETURN_AS or not isinstance(expression.expression, exp.Return):
+                postalias_props_sql = ""
                 if properties_locs.get(exp.Properties.Location.POST_ALIAS):
                     postalias_props_sql = self.properties(
                         exp.Properties(
@@ -1004,9 +1005,8 @@ class Generator(metaclass=_Generator):
                         ),
                         wrapped=False,
                     )
-                    expression_sql = f" AS {postalias_props_sql}{expression_sql}"
-                else:
-                    expression_sql = f" AS{expression_sql}"
+                postalias_props_sql = f" {postalias_props_sql}" if postalias_props_sql else ""
+                expression_sql = f" AS{postalias_props_sql}{expression_sql}"
 
         postindex_props_sql = ""
         if properties_locs.get(exp.Properties.Location.POST_INDEX):

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -98,6 +98,22 @@ class TestDatabricks(Validator):
                 read="databricks",
             )
 
+        self.validate_all(
+            "CREATE OR REPLACE FUNCTION func(a BIGINT, b BIGINT) RETURNS TABLE (a INT) RETURN SELECT a",
+            write={
+                "databricks": "CREATE OR REPLACE FUNCTION func(a BIGINT, b BIGINT) RETURNS TABLE (a INT) RETURN SELECT a",
+                "duckdb": "CREATE OR REPLACE FUNCTION func(a, b) AS TABLE SELECT a",
+            },
+        )
+
+        self.validate_all(
+            "CREATE OR REPLACE FUNCTION func(a BIGINT, b BIGINT) RETURNS BIGINT RETURN a",
+            write={
+                "databricks": "CREATE OR REPLACE FUNCTION func(a BIGINT, b BIGINT) RETURNS BIGINT RETURN a",
+                "duckdb": "CREATE OR REPLACE FUNCTION func(a, b) AS a",
+            },
+        )
+
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):
         self.validate_identity("SELECT c1:price, c1:price.foo, c1:price.bar[1]")


### PR DESCRIPTION
Fixes #3764

A UDF in Databricks can be defined as:

```SQL
CREATE FUNCTION 
  <func_name>(<schema def>) 
RETURNS 
  [type | TABLE(<schema def>)] 
RETURN 
  <return_expr>
```

The `RETURNS` clause is parsed into an `exp.ReturnsProperty` node while the `RETURN` expression is parsed into `exp.Return`. The distinction between scalar and table UDF is determined by the `RETURNS` expression i.e returning a single type or a schema definition.

In DuckDB, a UDF (`MACRO` or `FUNCTION` are synonyms) can be defined as:

```SQL
CREATE [MACRO | FUNCTION] 
  <func_name>(col_value[, ...]) 
AS [TABLE] 
 <return_expr>
```

The distinction between scalar and UDF is determined by the `AS [TABLE]` clause

To fix the Databricks -> DuckDB transpilation, this PR:
- Overrides `exp.Return` transformation to avoid generating the `RETURN` keyword
- Overrides `exp.ReturnsProperty` transformation to generate `AS TABLE` if an `exp.Schema` is defined in it or an empty string otherwise
- Refactors the `postalias_sql` generation in `create_sql()` to accommodate for the potential empty string coming from `exp.ReturnsProperty`

Docs
---------
[Databricks UDF](https://www.databricks.com/blog/2021/10/20/introducing-sql-user-defined-functions.html) | [DuckDB UDF](https://duckdb.org/docs/sql/statements/create_macro.html)