### PR TITLE
fix(postgres): Fix UNIQUE consuming tokens

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -447,6 +447,9 @@ class Postgres(Dialect):
 
             return self.expression(exp.Extract, this=part, expression=value)
 
+        def _parse_unique_key(self) -> t.Optional[exp.Expression]:
+            return None
+
     class Generator(generator.Generator):
         SINGLE_STRING_INTERVAL = True
         RENAME_TABLE_WITH_DB = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1869,7 +1869,7 @@ class TitleColumnConstraint(ColumnConstraintKind):
 
 
 class UniqueColumnConstraint(ColumnConstraintKind):
-    arg_types = {"this": False, "index_type": False, "on_conflict": False}
+    arg_types = {"this": False, "index_type": False, "on_conflict": False, "nulls": False}
 
 
 class UppercaseColumnConstraint(ColumnConstraintKind):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -961,7 +961,8 @@ class Generator(metaclass=_Generator):
         index_type = f" USING {index_type}" if index_type else ""
         on_conflict = self.sql(expression, "on_conflict")
         on_conflict = f" {on_conflict}" if on_conflict else ""
-        return f"UNIQUE{this}{index_type}{on_conflict}"
+        nulls_sql = " NULLS NOT DISTINCT" if expression.args.get("nulls") else ""
+        return f"UNIQUE{nulls_sql}{this}{index_type}{on_conflict}"
 
     def createable_sql(self, expression: exp.Create, locations: t.DefaultDict) -> str:
         return self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5179,11 +5179,15 @@ class Parser(metaclass=_Parser):
 
         return self.CONSTRAINT_PARSERS[constraint](self)
 
+    def _parse_unique_key(self) -> t.Optional[exp.Expression]:
+        return self._parse_id_var(any_token=False)
+
     def _parse_unique(self) -> exp.UniqueColumnConstraint:
         self._match_text_seq("KEY")
         return self.expression(
             exp.UniqueColumnConstraint,
-            this=self._parse_schema(self._parse_id_var(any_token=False)),
+            nulls=self._match_text_seq("NULLS", "NOT", "DISTINCT"),
+            this=self._parse_schema(self._parse_unique_key()),
             index_type=self._match(TokenType.USING) and self._advance_any() and self._prev.text,
             on_conflict=self._parse_on_conflict(),
         )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -977,6 +977,10 @@ class TestPostgres(Validator):
             },
         )
 
+        self.validate_identity("CREATE TABLE tbl (col INT UNIQUE NULLS NOT DISTINCT DEFAULT 9.99)")
+        self.validate_identity("CREATE TABLE tbl (col UUID UNIQUE DEFAULT GEN_RANDOM_UUID())")
+        self.validate_identity("CREATE TABLE tbl (col UUID, UNIQUE NULLS NOT DISTINCT (col))")
+
         with self.assertRaises(ParseError):
             transpile("CREATE TABLE products (price DECIMAL CHECK price > 0)", read="postgres")
         with self.assertRaises(ParseError):


### PR DESCRIPTION
Fixes #3774

Currently `_parse_unique()` attempts to parse MySQL's `UNIQUE` constraint  (https://github.com/tobymao/sqlglot/pull/1708), which is parsed as:

```SQL
UNIQUE KEY [<key>] (<col> [,...])
```

However, Postgres's `UNIQUE` (syntax below) does not seem to define `<key>` so it must not preemptively consume an id_var for it:

```SQL
UNIQUE [NULLS NOT DISTINCT] [(<col> [, ...])]
```

For this reason, this PR:
- Turns off the `[<key>]` parsing in Postgres
- Adds support for `NOT NULLS DISTINCT` as a low-lift addition to increase DDL coverage


Docs
----------
[Postgres UNIQUE](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-UNIQUE-CONSTRAINTS) | [Postgres DEFAULT](https://www.postgresql.org/docs/current/ddl-default.html) | [MySQL UNIQUE](https://dev.mysql.com/doc/refman/8.4/en/partitioning-limitations-partitioning-keys-unique-keys.html)