### PR TITLE
feat(duckdb): Transpile BQ's exp.DatetimeAdd, exp.DatetimeSub

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -612,6 +612,7 @@ LANGUAGE js AS
                 write={
                     "bigquery": "SELECT DATETIME_ADD('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",
                     "databricks": "SELECT TIMESTAMPADD(MILLISECOND, 1, '2023-01-01T00:00:00')",
+                    "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS DATETIME) + INTERVAL 1 MILLISECOND",
                 },
             ),
         )
@@ -621,6 +622,7 @@ LANGUAGE js AS
                 write={
                     "bigquery": "SELECT DATETIME_SUB('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",
                     "databricks": "SELECT TIMESTAMPADD(MILLISECOND, 1 * -1, '2023-01-01T00:00:00')",
+                    "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS DATETIME) - INTERVAL 1 MILLISECOND",
                 },
             ),
         )


### PR DESCRIPTION
Transpile BQ's `DATETIME_SUB()` & `DATETIME_ADD()` to `<datetime_expr> +/- <interval_expr>` in DuckDB as is the case currently with other date/time functions.

Also, this PR merges `_ts_or_ds_add_sql()` in `_date_delta_sql()` as they have very similar control flow.


Docs
---------
[BQ DATETIME_SUB](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime_sub) | [BQ DATETIME_ADD](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime_add)