### PR TITLE
fix(duckdb): Wrap JSON_EXTRACT if it's subscripted

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -168,7 +168,7 @@ def _unix_to_time_sql(self: DuckDB.Generator, expression: exp.UnixToTime) -> str
 
 def _arrow_json_extract_sql(self: DuckDB.Generator, expression: JSON_EXTRACT_TYPE) -> str:
     arrow_sql = arrow_json_extract_sql(self, expression)
-    if not expression.same_parent and isinstance(expression.parent, exp.Binary):
+    if not expression.same_parent and isinstance(expression.parent, (exp.Binary, exp.Bracket)):
         arrow_sql = self.wrap(arrow_sql)
     return arrow_sql
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -309,6 +309,14 @@ class TestDuckDB(Validator):
             "SELECT (c -> '$.k1') = 'v1'",
         )
         self.validate_identity(
+            "SELECT JSON_EXTRACT(c, '$[*].id')[0:2]",
+            "SELECT (c -> '$[*].id')[0 : 2]",
+        )
+        self.validate_identity(
+            "SELECT JSON_EXTRACT_STRING(c, '$[*].id')[0:2]",
+            "SELECT (c ->> '$[*].id')[0 : 2]",
+        )
+        self.validate_identity(
             """SELECT '{"foo": [1, 2, 3]}' -> 'foo' -> 0""",
             """SELECT '{"foo": [1, 2, 3]}' -> '$.foo' -> '$[0]'""",
         )


### PR DESCRIPTION
Fixes #3782

Preserve precedence of `JSON_EXTRACT` / `JSON_EXTRACT_STRING` if it's followed by a subscript (legal DuckDB if the result is a `LIST`).

This PR builds on top of https://github.com/tobymao/sqlglot/pull/3478 which solved a similar issue.

Docs
-------
[DuckDB JSON Extract functions](https://duckdb.org/docs/extensions/json.html#json-extraction-functions)