### PR TITLE
feat(hive, spark, db): Support for exp.GenerateSeries

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -31,6 +31,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     unit_to_str,
     var_map_sql,
+    sequence_sql,
 )
 from sqlglot.transforms import (
     remove_unique_constraints,
@@ -310,6 +311,7 @@ class Hive(Dialect):
             "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
                 this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
             ),
+            "SEQUENCE": exp.GenerateSeries.from_arg_list,
             "SIZE": exp.ArraySize.from_arg_list,
             "SPLIT": exp.RegexpSplit.from_arg_list,
             "STR_TO_MAP": lambda args: exp.StrToMap(
@@ -506,6 +508,7 @@ class Hive(Dialect):
             exp.FileFormatProperty: lambda self,
             e: f"STORED AS {self.sql(e, 'this') if isinstance(e.this, exp.InputOutputFormat) else e.name.upper()}",
             exp.FromBase64: rename_func("UNBASE64"),
+            exp.GenerateSeries: sequence_sql,
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.IsNan: rename_func("ISNAN"),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -565,15 +565,10 @@ class TestPostgres(Validator):
                 "postgres": "GENERATE_SERIES(CAST('2019-01-01' AS TIMESTAMP), CURRENT_TIMESTAMP, INTERVAL '1 DAY')",
                 "presto": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP AS TIMESTAMP), INTERVAL '1' DAY)",
                 "trino": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP AS TIMESTAMP), INTERVAL '1' DAY)",
-            },
-        )
-        self.validate_all(
-            "GENERATE_SERIES(a, b)",
-            write={
-                "postgres": "GENERATE_SERIES(a, b)",
-                "presto": "SEQUENCE(a, b)",
-                "trino": "SEQUENCE(a, b)",
-                "tsql": "GENERATE_SERIES(a, b)",
+                "hive": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP() AS TIMESTAMP), INTERVAL '1' DAY)",
+                "spark2": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP() AS TIMESTAMP), INTERVAL '1' DAY)",
+                "spark": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP() AS TIMESTAMP), INTERVAL '1' DAY)",
+                "databricks": "SEQUENCE(CAST('2019-01-01' AS TIMESTAMP), CAST(CURRENT_TIMESTAMP() AS TIMESTAMP), INTERVAL '1' DAY)",
             },
         )
         self.validate_all(
@@ -583,6 +578,20 @@ class TestPostgres(Validator):
                 "presto": "SEQUENCE(a, b)",
                 "trino": "SEQUENCE(a, b)",
                 "tsql": "GENERATE_SERIES(a, b)",
+                "hive": "SEQUENCE(a, b)",
+                "spark2": "SEQUENCE(a, b)",
+                "spark": "SEQUENCE(a, b)",
+                "databricks": "SEQUENCE(a, b)",
+            },
+            write={
+                "postgres": "GENERATE_SERIES(a, b)",
+                "presto": "SEQUENCE(a, b)",
+                "trino": "SEQUENCE(a, b)",
+                "tsql": "GENERATE_SERIES(a, b)",
+                "hive": "SEQUENCE(a, b)",
+                "spark2": "SEQUENCE(a, b)",
+                "spark": "SEQUENCE(a, b)",
+                "databricks": "SEQUENCE(a, b)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #3793

This PR adds support for the `SEQUENCE()` function across the Hive hierarchy. The generation is similar to the existing Presto/Trino, thus the code reuse. 
 

Docs
--------
[Spark 2](https://spark.apache.org/docs/2.4.0/api/sql/index.html#sequence) | [Spark 3](https://spark.apache.org/docs/latest/api/sql/#sequence) | [Databricks](https://docs.databricks.com/en/sql/language-manual/functions/sequence.html)