### PR TITLE
feat(snowflake): Support for OBJECT_INSERT, transpile to DDB

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -290,6 +290,7 @@ class Snowflake(Dialect):
             ),
             "NULLIFZERO": _build_if_from_nullifzero,
             "OBJECT_CONSTRUCT": _build_object_construct,
+            "OBJECT_INSERT": exp.ObjectInsert.from_arg_list,
             "REGEXP_REPLACE": _build_regexp_replace,
             "REGEXP_SUBSTR": exp.RegexpExtract.from_arg_list,
             "RLIKE": exp.RegexpLike.from_arg_list,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -290,7 +290,6 @@ class Snowflake(Dialect):
             ),
             "NULLIFZERO": _build_if_from_nullifzero,
             "OBJECT_CONSTRUCT": _build_object_construct,
-            "OBJECT_INSERT": exp.ObjectInsert.from_arg_list,
             "REGEXP_REPLACE": _build_regexp_replace,
             "REGEXP_SUBSTR": exp.RegexpExtract.from_arg_list,
             "RLIKE": exp.RegexpLike.from_arg_list,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5484,6 +5484,16 @@ class JSONTable(Func):
     }
 
 
+# https://docs.snowflake.com/en/sql-reference/functions/object_insert
+class ObjectInsert(Func):
+    arg_types = {
+        "this": True,
+        "key": True,
+        "value": True,
+        "update_flag": False,
+    }
+
+
 class OpenJSONColumnDef(Expression):
     arg_types = {"this": True, "kind": True, "path": False, "as_json": False}
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -827,6 +827,22 @@ WHERE
             },
         )
 
+        self.validate_all(
+            "SELECT OBJECT_INSERT(OBJECT_INSERT(OBJECT_INSERT(OBJECT_CONSTRUCT('key5', 'value5'), 'key1', 5), 'key2', 2.2), 'key3', 'value3')",
+            write={
+                "snowflake": "SELECT OBJECT_INSERT(OBJECT_INSERT(OBJECT_INSERT(OBJECT_CONSTRUCT('key5', 'value5'), 'key1', 5), 'key2', 2.2), 'key3', 'value3')",
+                "duckdb": "SELECT STRUCT_INSERT(STRUCT_INSERT(STRUCT_INSERT({'key5': 'value5'}, key1 := 5), key2 := 2.2), key3 := 'value3')",
+            },
+        )
+
+        self.validate_all(
+            "SELECT OBJECT_INSERT(OBJECT_INSERT(OBJECT_INSERT(OBJECT_CONSTRUCT(), 'key1', 5), 'key2', 2.2), 'key3', 'value3')",
+            write={
+                "snowflake": "SELECT OBJECT_INSERT(OBJECT_INSERT(OBJECT_INSERT(OBJECT_CONSTRUCT(), 'key1', 5), 'key2', 2.2), 'key3', 'value3')",
+                "duckdb": "SELECT STRUCT_INSERT(STRUCT_INSERT(STRUCT_PACK(key1 := 5), key2 := 2.2), key3 := 'value3')",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
Fixes #3802

Currently, `OBJECT_CONSTRUCT` will transpile to `STRUCT` construction in DuckDB (context https://github.com/tobymao/sqlglot/issues/1699). 

Following this convention, this PR adds support for Snowflake's `OBJECT_INSERT(object, key, value, [update_flag])` which will get transpiled to DuckDB's `STRUCT_INSERT(object, key := value)`. 

Docs
-----------
[Snowflake OBJECT_INSERT](https://docs.snowflake.com/en/sql-reference/functions/object_insert) | [Snowflake OBJECT_CONSTRUCT](https://docs.snowflake.com/en/sql-reference/functions/object_construct) | [DuckDB STRUCT](https://duckdb.org/docs/sql/data_types/struct.html)