### PR TITLE
fix(duckdb): Fix STRUCT_PACK -> ROW due to is_struct_cast

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -137,10 +137,8 @@ def _struct_sql(self: DuckDB.Generator, expression: exp.Struct) -> str:
     # The transformation to ROW will take place if a cast to STRUCT / ARRAY of STRUCTs is found
     ancestor_cast = expression.find_ancestor(exp.Cast)
     is_struct_cast = ancestor_cast and any(
-        [
-            casted_type.is_type(exp.DataType.Type.STRUCT)
-            for casted_type in ancestor_cast.find_all(exp.DataType)
-        ]
+        casted_type.is_type(exp.DataType.Type.STRUCT)
+        for casted_type in ancestor_cast.find_all(exp.DataType)
     )
 
     for i, expr in enumerate(expression.expressions):

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -134,7 +134,14 @@ def _struct_sql(self: DuckDB.Generator, expression: exp.Struct) -> str:
 
     # BigQuery allows inline construction such as "STRUCT<a STRING, b INTEGER>('str', 1)" which is
     # canonicalized to "ROW('str', 1) AS STRUCT(a TEXT, b INT)" in DuckDB
-    is_struct_cast = expression.find_ancestor(exp.Cast)
+    # The transformation to ROW will take place if a cast to STRUCT / ARRAY of STRUCTs is found
+    ancestor_cast = expression.find_ancestor(exp.Cast)
+    is_struct_cast = ancestor_cast and any(
+        [
+            casted_type.is_type(exp.DataType.Type.STRUCT)
+            for casted_type in ancestor_cast.find_all(exp.DataType)
+        ]
+    )
 
     for i, expr in enumerate(expression.expressions):
         is_property_eq = isinstance(expr, exp.PropertyEQ)

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1056,7 +1056,14 @@ class TestDuckDB(Validator):
             "CAST([STRUCT_PACK(a := 1)] AS STRUCT(a BIGINT)[])",
             "CAST([ROW(1)] AS STRUCT(a BIGINT)[])",
         )
-
+        self.validate_identity(
+            "STRUCT_PACK(a := 'b')::json",
+            "CAST({'a': 'b'} AS JSON)",
+        )
+        self.validate_identity(
+            "STRUCT_PACK(a := 'b')::STRUCT(a TEXT)",
+            "CAST(ROW('b') AS STRUCT(a TEXT))",
+        )
         self.validate_all(
             "CAST(x AS VARCHAR(5))",
             write={


### PR DESCRIPTION
Fixes #3808

The recent PR https://github.com/tobymao/sqlglot/pull/3751 enabled transpilation of BQ's `STRUCT<type>(values)` to DuckDB `CAST(ROW(<values>) AS STRUCT(<struct>))`, and the core DDB generation logic was based on the `is_struct_cast` condition. However, a struct can be casted to other types such as `JSON` which will trip this condition.

This PR fixes this regression by making sure the `is_struct_cast` more explicit, i.e it now searches the `exp.Cast` for a `STRUCT` definition under it before transforming to the casted `ROW` representation  