### PR TITLE
fix(postgres): Fix COLLATE column constraint

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -929,7 +929,8 @@ class Parser(metaclass=_Parser):
             enforced=self._match_text_seq("ENFORCED"),
         ),
         "COLLATE": lambda self: self.expression(
-            exp.CollateColumnConstraint, this=self._parse_var(any_token=True)
+            exp.CollateColumnConstraint,
+            this=self._parse_identifier() or self._parse_column(),
         ),
         "COMMENT": lambda self: self.expression(
             exp.CommentColumnConstraint, this=self._parse_string()

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -17,9 +17,6 @@ class TestPostgres(Validator):
         )
 
         self.validate_identity("SHA384(x)")
-        self.validate_identity(
-            'CREATE TABLE x (a TEXT COLLATE "de_DE")', "CREATE TABLE x (a TEXT COLLATE de_DE)"
-        )
         self.validate_identity("1.x", "1. AS x")
         self.validate_identity("|/ x", "SQRT(x)")
         self.validate_identity("||/ x", "CBRT(x)")
@@ -792,6 +789,8 @@ class TestPostgres(Validator):
         cdef.args["kind"].assert_is(exp.DataType)
         self.assertEqual(expr.sql(dialect="postgres"), "CREATE TABLE t (x INTERVAL DAY)")
 
+        self.validate_identity('CREATE TABLE x (a TEXT COLLATE "de_DE")')
+        self.validate_identity('CREATE TABLE x (a TEXT COLLATE pg_catalog."default")')
         self.validate_identity("CREATE TABLE t (col INT[3][5])")
         self.validate_identity("CREATE TABLE t (col INT[3])")
         self.validate_identity("CREATE INDEX IF NOT EXISTS ON t(c)")


### PR DESCRIPTION
Fixes #3817

Before this PR a collation column constraint was parsed as `_parse_var(any_token=True)`. Because of that:

- We're unable to parse `pg_catalog."default"`,
- The existing Postgres test showcased that `COLLATE "de_DE" -> COLLATE de_DE` which doesn't seem correct, the roundtripped query is not valid according to the docs and my local testing.

For this reason, this PR changes the parsing to either `exp.Identifier` to cover existing cases or `exp.Column` to cover the `pg_catalog."default"` case.

Docs
----------
[Postgres Collation](https://www.postgresql.org/docs/16/collation.html) | [Postgres CREATE TABLE](https://www.postgresql.org/docs/16/sql-createtable.html)