### PR TITLE
fix: Do not preemptively consume SELECT [ALL] if ALL is connected

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -376,6 +376,7 @@ class Parser(metaclass=_Parser):
 
     # Tokens that can represent identifiers
     ID_VAR_TOKENS = {
+        TokenType.ALL,
         TokenType.VAR,
         TokenType.ANTI,
         TokenType.APPLY,
@@ -2742,8 +2743,12 @@ class Parser(metaclass=_Parser):
             comments = self._prev_comments
 
             hint = self._parse_hint()
-            all_ = self._match(TokenType.ALL)
-            distinct = self._match_set(self.DISTINCT_TOKENS)
+
+            if self._next and not self._next.token_type == TokenType.DOT:
+                all_ = self._match(TokenType.ALL)
+                distinct = self._match_set(self.DISTINCT_TOKENS)
+            else:
+                all_, distinct = False, False
 
             kind = (
                 self._match(TokenType.ALIAS)

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -871,3 +871,4 @@ SELECT unnest
 SELECT * FROM a STRAIGHT_JOIN b
 SELECT COUNT(DISTINCT "foo bar") FROM (SELECT 1 AS "foo bar") AS t
 SELECT vector
+WITH all AS (SELECT 1 AS count) SELECT all.count FROM all


### PR DESCRIPTION
Fixes #3819, #3821

In Spark/Databricks (and also other dialects such as Presto/Trino from a quick test) the `ALL` keyword can be both a `SELECT` modifier and an identifier.  

This PR attempts to fix the preemptive consumption of `ALL` in `_parse_select()` if it's connected, i.e it deduplicates `SELECT ALL FROM <x>` from `SELECT all.col FROM all`.

Note: This is also is true `DISTINCT` in Spark/Databricks e.g. the following works but didn't want to increase this PR's scope yet:

```SQL
WITH distinct AS (SELECT 1 AS col) SELECT distinct.col FROM distinct"
```

Docs
--------
[Databricks SELECT](https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select.html)