### PR TITLE
fix(presto, trino): Fix StrToUnix transpilation

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -587,11 +587,20 @@ class Presto(Dialect):
             # timezone involved, we wrap it in a `TRY` call and use `PARSE_DATETIME` as a fallback,
             # which seems to be using the same time mapping as Hive, as per:
             # https://joda-time.sourceforge.net/apidocs/org/joda/time/format/DateTimeFormat.html
-            value_as_text = exp.cast(expression.this, exp.DataType.Type.TEXT)
+            this = expression.this
+            value_as_text = exp.cast(this, exp.DataType.Type.TEXT)
+            value_as_timestamp = (
+                exp.cast(this, exp.DataType.Type.TIMESTAMP) if this.is_string else this
+            )
+
             parse_without_tz = self.func("DATE_PARSE", value_as_text, self.format_time(expression))
+
+            formatted_value = self.func(
+                "DATE_FORMAT", value_as_timestamp, self.format_time(expression)
+            )
             parse_with_tz = self.func(
                 "PARSE_DATETIME",
-                value_as_text,
+                formatted_value,
                 self.format_time(expression, Hive.INVERSE_TIME_MAPPING, Hive.INVERSE_TIME_TRIE),
             )
             coalesced = self.func("COALESCE", self.func("TRY", parse_without_tz), parse_with_tz)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -628,7 +628,7 @@ class TestDialect(Validator):
             write={
                 "duckdb": "EPOCH(STRPTIME('2020-01-01', '%Y-%m-%d'))",
                 "hive": "UNIX_TIMESTAMP('2020-01-01', 'yyyy-MM-dd')",
-                "presto": "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST('2020-01-01' AS VARCHAR), '%Y-%m-%d')), PARSE_DATETIME(CAST('2020-01-01' AS VARCHAR), 'yyyy-MM-dd')))",
+                "presto": "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST('2020-01-01' AS VARCHAR), '%Y-%m-%d')), PARSE_DATETIME(DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP), '%Y-%m-%d'), 'yyyy-MM-dd')))",
                 "starrocks": "UNIX_TIMESTAMP('2020-01-01', '%Y-%m-%d')",
                 "doris": "UNIX_TIMESTAMP('2020-01-01', '%Y-%m-%d')",
             },

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -372,7 +372,7 @@ class TestHive(Validator):
             "UNIX_TIMESTAMP(x)",
             write={
                 "duckdb": "EPOCH(STRPTIME(x, '%Y-%m-%d %H:%M:%S'))",
-                "presto": "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST(x AS VARCHAR), '%Y-%m-%d %T')), PARSE_DATETIME(CAST(x AS VARCHAR), 'yyyy-MM-dd HH:mm:ss')))",
+                "presto": "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST(x AS VARCHAR), '%Y-%m-%d %T')), PARSE_DATETIME(DATE_FORMAT(x, '%Y-%m-%d %T'), 'yyyy-MM-dd HH:mm:ss')))",
                 "hive": "UNIX_TIMESTAMP(x)",
                 "spark": "UNIX_TIMESTAMP(x)",
                 "": "STR_TO_UNIX(x, '%Y-%m-%d %H:%M:%S')",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -764,7 +764,7 @@ FROM x""",
         self.validate("STR_TO_TIME('x', 'y')", "DATE_PARSE('x', 'y')", write="presto")
         self.validate(
             "STR_TO_UNIX('x', 'y')",
-            "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST('x' AS VARCHAR), 'y')), PARSE_DATETIME(CAST('x' AS VARCHAR), 'y')))",
+            "TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST('x' AS VARCHAR), 'y')), PARSE_DATETIME(DATE_FORMAT(CAST('x' AS TIMESTAMP), 'y'), 'y')))",
             write="presto",
         )
         self.validate("TIME_TO_STR(x, 'y')", "DATE_FORMAT(x, 'y')", write="presto")


### PR DESCRIPTION
Fixes #3796

This PR is an attempt to make the transformation introduced in https://github.com/tobymao/sqlglot/pull/3225 more robust, as it seems that we're currently unable to parse timestamps with fractions of second and/or timezone.

To achieve this, the value is now passed through `DATE_PARSE` in an attempt to canonicalize it (e.g. strip milliseconds, timezone etc) before it is inputted to `PARSE_DATETIME`.

This is a before vs after demo:

- Spark:
```SQL
SELECT FROM_UNIXTIME(CURRENT_TIMESTAMP)
```


- Presto before (unable to execute locally on v451): 
```SQL
SELECT TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST(CURRENT_TIMESTAMP AS VARCHAR), '%Y-%m-%d %T')), PARSE_DATETIME(CAST(CURRENT_TIMESTAMP AS VARCHAR), 'yyyy-MM-dd HH:mm:ss')))
```

- Presto after:
```SQL
SELECT TO_UNIXTIME(COALESCE(TRY(DATE_PARSE(CAST(CURRENT_TIMESTAMP AS VARCHAR), '%Y-%m-%d %T')), PARSE_DATETIME(DATE_FORMAT(CURRENT_TIMESTAMP, '%Y-%m-%d %T'), 'yyyy-MM-dd HH:mm:ss')))
``` 