### PR TITLE
Refactor: exclude boolean args in Generator.format_args

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -846,7 +846,7 @@ class ClickHouse(Dialect):
         }
 
         def strtodate_sql(self, expression: exp.StrToDate) -> str:
-            strtodate_sql = super().strtodate_sql(expression)
+            strtodate_sql = self.function_fallback_sql(expression)
 
             if not isinstance(expression.parent, exp.Cast):
                 # StrToDate returns DATEs in other dialects (eg. postgres), so

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -750,10 +750,9 @@ class DuckDB(Dialect):
         def generateseries_sql(self, expression: exp.GenerateSeries) -> str:
             # GENERATE_SERIES(a, b) -> [a, b], RANGE(a, b) -> [a, b)
             if expression.args.get("is_end_exclusive"):
-                expression.set("is_end_exclusive", None)
                 return rename_func("RANGE")(self, expression)
 
-            return super().generateseries_sql(expression)
+            return self.function_fallback_sql(expression)
 
         def bracket_sql(self, expression: exp.Bracket) -> str:
             this = expression.this

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -168,16 +168,13 @@ def _serial_to_generated(expression: exp.Expression) -> exp.Expression:
 
 def _build_generate_series(args: t.List) -> exp.GenerateSeries:
     # The goal is to convert step values like '1 day' or INTERVAL '1 day' into INTERVAL '1' day
+    # Note: postgres allows calls with just two arguments -- the "step" argument defaults to 1
     step = seq_get(args, 2)
-
-    if step is None:
-        # Postgres allows calls with just two arguments -- the "step" argument defaults to 1
-        return exp.GenerateSeries.from_arg_list(args)
-
-    if step.is_string:
-        args[2] = exp.to_interval(step.this)
-    elif isinstance(step, exp.Interval) and not step.args.get("unit"):
-        args[2] = exp.to_interval(step.this.this)
+    if step is not None:
+        if step.is_string:
+            args[2] = exp.to_interval(step.this)
+        elif isinstance(step, exp.Interval) and not step.args.get("unit"):
+            args[2] = exp.to_interval(step.this.this)
 
     return exp.GenerateSeries.from_arg_list(args)
 

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -393,9 +393,6 @@ class Presto(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: rename_func("ARBITRARY"),
-            exp.ApproxDistinct: lambda self, e: self.func(
-                "APPROX_DISTINCT", e.this, e.args.get("accuracy")
-            ),
             exp.ApproxQuantile: rename_func("APPROX_PERCENTILE"),
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -223,7 +223,7 @@ class SQLite(Dialect):
                     exp.select(exp.alias_("value", column_alias)).from_(expression).subquery()
                 )
             else:
-                sql = super().generateseries_sql(expression)
+                sql = self.function_fallback_sql(expression)
 
             return sql
 

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -179,8 +179,9 @@ def apply_index_offset(
 
     if not expression.type:
         annotate_types(expression)
+
     if t.cast(exp.DataType, expression.type).this in exp.DataType.INTEGER_TYPES:
-        logger.warning("Applying array index offset (%s)", offset)
+        logger.info("Applying array index offset (%s)", offset)
         expression = simplify(expression + offset)
         return [expression]
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -851,10 +851,10 @@ class TestDuckDB(Validator):
             self.assertEqual(
                 cm.output,
                 [
-                    "WARNING:sqlglot:Applying array index offset (-1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (-1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
                 ],
             )
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1071,10 +1071,10 @@ class TestPostgres(Validator):
             self.assertEqual(
                 cm.output,
                 [
-                    "WARNING:sqlglot:Applying array index offset (-1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (-1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
                 ],
             )
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -815,10 +815,10 @@ FROM x""",
             self.assertEqual(
                 cm.output,
                 [
-                    "WARNING:sqlglot:Applying array index offset (1)",
-                    "WARNING:sqlglot:Applying array index offset (-1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
-                    "WARNING:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (-1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
+                    "INFO:sqlglot:Applying array index offset (1)",
                 ],
             )
 


### PR DESCRIPTION
Couple of quality-of-life improvements:

- Exclude boolean values in `Generator.format_args`. The motivation here was that each time we added a flag arg in an function, we needed to also exclude it from being included in the `Generator.sql` method, otherwise an error would be triggered since there's no logic to generate booleans. This PR removes the need to do this.
- Change the logging level to `INFO` for the index offset application helper. This was changed because a Slack user [reported](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1722016618281349) seeing noisy warnings in their SQLMesh project.