### PR TITLE
Fix(tsql): regression related to CTEs in CREATE VIEW AS statements

### DIFF
--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -807,6 +807,7 @@ class TestTSQL(Validator):
                 f"UNIQUE {clustered_keyword} ([internal_id] ASC))",
             )
 
+        self.validate_identity("CREATE VIEW t AS WITH cte AS (SELECT 1 AS c) SELECT c FROM cte")
         self.validate_identity(
             "ALTER TABLE tbl SET SYSTEM_VERSIONING=ON(HISTORY_TABLE=db.tbl, DATA_CONSISTENCY_CHECK=OFF, HISTORY_RETENTION_PERIOD=5 DAYS)"
         )


### PR DESCRIPTION
Accidentally introduced a regression in https://github.com/tobymao/sqlglot/pull/3848, wasn't aware that `CREATE VIEW` requires CTEs to [come after](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-view-transact-sql?view=sql-server-ver16#syntax) the `CREATE VIEW` keywords.