### PR TITLE
feat(duckdb): Support for exp.TimeDiff generation

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -32,6 +32,7 @@ from sqlglot.dialects.dialect import (
     timestamptrunc_sql,
     timestrtotime_sql,
     unit_to_var,
+    unit_to_str,
 )
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
@@ -79,6 +80,16 @@ def _date_sql(self: DuckDB.Generator, expression: exp.Date) -> str:
         result = self.func("STRPTIME", date_str, "'%d/%m/%Y %Z'")
 
     return result
+
+
+# BigQuery -> DuckDB conversion for the TIME_DIFF function
+def _timediff_sql(self: DuckDB.Generator, expression: exp.TimeDiff) -> str:
+    this = exp.cast(expression.this, exp.DataType.Type.TIME)
+    expr = exp.cast(expression.expression, exp.DataType.Type.TIME)
+
+    # Although the 2 dialects share similar signatures, BQ seems to inverse
+    # the sign of the result so the start/end time operands are flipped
+    return self.func("DATE_DIFF", unit_to_str(expression), expr, this)
 
 
 def _array_sort_sql(self: DuckDB.Generator, expression: exp.ArraySort) -> str:
@@ -498,6 +509,7 @@ class DuckDB(Dialect):
             exp.Struct: _struct_sql,
             exp.TimeAdd: _date_delta_sql,
             exp.Time: no_time_sql,
+            exp.TimeDiff: _timediff_sql,
             exp.Timestamp: no_timestamp_sql,
             exp.TimestampDiff: lambda self, e: self.func(
                 "DATE_DIFF", exp.Literal.string(e.unit), e.expression, e.this

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1403,6 +1403,14 @@ WHERE
             },
         )
 
+        self.validate_all(
+            "SELECT TIME_DIFF('12:00:00', '12:30:00', MINUTE)",
+            write={
+                "duckdb": "SELECT DATE_DIFF('MINUTE', CAST('12:30:00' AS TIME), CAST('12:00:00' AS TIME))",
+                "bigquery": "SELECT TIME_DIFF('12:00:00', '12:30:00', MINUTE)",
+            },
+        )
+
     def test_errors(self):
         with self.assertRaises(TokenError):
             transpile("'\\'", read="bigquery")


### PR DESCRIPTION
Generate BQ's `exp.TimeDiff` into DuckDB's `DATE_DIFF()`. Although both functions have similar signatures and should be calculating the partitions between `end_time - start_time`, BQ seems to inverse the operands which is more accurately documented on 3rd party pages.

Docs
-------------
[BigQuery TIME_DIFF official docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time_diff) | [BigQuery TIME_DIFF unofficial docs](https://count.co/sql-resources/bigquery-standard-sql/time_diff) | [DuckDB DATE_DIFF](https://duckdb.org/docs/sql/functions/timestamp.html#date_diffpart-startdate-enddate)