### PR TITLE
fix(duckdb): Add implicit casts to DATE_DIFF

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1257,6 +1257,13 @@ LANGUAGE js AS
             },
         )
         self.validate_all(
+            "DATE_DIFF('2021-01-01', '2020-01-01', DAY)",
+            write={
+                "bigquery": "DATE_DIFF('2021-01-01', '2020-01-01', DAY)",
+                "duckdb": "DATE_DIFF('DAY', CAST('2020-01-01' AS DATE), CAST('2021-01-01' AS DATE))",
+            },
+        )
+        self.validate_all(
             "CURRENT_DATE('UTC')",
             write={
                 "mysql": "CURRENT_DATE AT TIME ZONE 'UTC'",


### PR DESCRIPTION
BigQuery can implicitly cast/coerce string literal arguments into the appropriate date/time type, which is not the case for DuckDB.

This PR aims to fix the transpilation of `exp.DateDiff` by inserting the casts to replicate this behavior.


Docs
------------
[BigQuery DATE_DIFF](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date_diff) | [DuckDB DATE_DIFF](https://duckdb.org/docs/sql/functions/date.html#date_diffpart-startdate-enddate)