### PR TITLE
fix(clickhouse): Fix SETTINGS parsing

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -823,6 +823,7 @@ class ClickHouse(Dialect):
             exp.UnixToTime: _unix_to_time_sql,
             exp.TimestampTrunc: timestamptrunc_sql(zone=True),
             exp.Variance: rename_func("varSamp"),
+            exp.SchemaCommentProperty: lambda self, e: self.naked_property(e),
             exp.Stddev: rename_func("stddevSamp"),
         }
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -893,7 +893,7 @@ class Parser(metaclass=_Parser):
         "SECURE": lambda self: self.expression(exp.SecureProperty),
         "SET": lambda self: self.expression(exp.SetProperty, multi=False),
         "SETTINGS": lambda self: self.expression(
-            exp.SettingsProperty, expressions=self._parse_csv(self._parse_set_item)
+            exp.SettingsProperty, expressions=self._parse_csv(self._parse_assignment)
         ),
         "SHARING": lambda self: self._parse_property_assignment(exp.SharingProperty),
         "SORTKEY": lambda self: self._parse_sortkey(),
@@ -1792,7 +1792,6 @@ class Parser(metaclass=_Parser):
 
                     # exp.Properties.Location.POST_INDEX
                     extend_props(self._parse_properties())
-
                     if not index:
                         break
                     else:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -879,6 +879,9 @@ LIFETIME(MIN 0 MAX 0)""",
         self.validate_identity(
             "CREATE TABLE t (a String, b String, c UInt64, PROJECTION p1 (SELECT a, sum(c) GROUP BY a, b), PROJECTION p2 (SELECT b, sum(c) GROUP BY b)) ENGINE=MergeTree()"
         )
+        self.validate_identity(
+            """CREATE TABLE xyz (ts DATETIME, data String) ENGINE=MergeTree() ORDER BY ts SETTINGS index_granularity = 8192 COMMENT '{"key": "value"}'"""
+        )
 
     def test_agg_functions(self):
         def extract_agg_func(query):


### PR DESCRIPTION
Fixes #3858

This PR aims to fix the following problems:
- The `exp.SettingsProperty` parsing was done through `_parse_set_item` which can consume following tokens e.g. `COMMENT` as alias; According to docs, the settings are CSV key-value (integer/bool) assignments so `_parse_assignment` is a better fit.
- The `COMMENT` property should remain naked


Docs
----------
[CH Settings](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings) | [CH Comment clause](https://clickhouse.com/docs/en/operations/settings/merge-tree-settings#index_granularity) 