### PR TITLE
feat(teradata): Parse RENAME TABLE as Command

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -433,6 +433,7 @@ class Parser(metaclass=_Parser):
         TokenType.RECURSIVE,
         TokenType.REFERENCES,
         TokenType.REFRESH,
+        TokenType.RENAME,
         TokenType.REPLACE,
         TokenType.RIGHT,
         TokenType.ROLLUP,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -340,6 +340,7 @@ class TokenType(AutoName):
     RANGE = auto()
     RECURSIVE = auto()
     REFRESH = auto()
+    RENAME = auto()
     REPLACE = auto()
     RETURNING = auto()
     REFERENCES = auto()
@@ -753,6 +754,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "RANGE": TokenType.RANGE,
         "RECURSIVE": TokenType.RECURSIVE,
         "REGEXP": TokenType.RLIKE,
+        "RENAME": TokenType.RENAME,
         "REPLACE": TokenType.REPLACE,
         "RETURNING": TokenType.RETURNING,
         "REFERENCES": TokenType.REFERENCES,
@@ -913,6 +915,7 @@ class Tokenizer(metaclass=_Tokenizer):
         TokenType.EXECUTE,
         TokenType.FETCH,
         TokenType.SHOW,
+        TokenType.RENAME,
     }
 
     COMMAND_PREFIX_TOKENS = {TokenType.SEMICOLON, TokenType.BEGIN}

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -1,3 +1,4 @@
+from sqlglot import exp
 from tests.dialects.test_dialect import Validator
 
 
@@ -30,6 +31,10 @@ class TestTeradata(Validator):
                 "teradata": "DATABASE tduser",
             },
         )
+
+        self.validate_identity(
+            "RENAME TABLE emp TO employee", check_command_warning=True
+        ).assert_is(exp.Command)
 
     def test_translate(self):
         self.validate_all(

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -873,3 +873,4 @@ SELECT * FROM a STRAIGHT_JOIN b
 SELECT COUNT(DISTINCT "foo bar") FROM (SELECT 1 AS "foo bar") AS t
 SELECT vector
 WITH all AS (SELECT 1 AS count) SELECT all.count FROM all
+SELECT rename


### PR DESCRIPTION
Fixes #3861


Docs
---------
[Teradata RENAME TABLE](https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Data-Definition-Language-Syntax-and-Examples/Table-Statements/RENAME-TABLE/RENAME-TABLE-Syntax-Elements/new_table_name)