### PR TITLE
fix!: Generation of exp.ArrayConcat for 2-arg based dialects

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -369,6 +369,12 @@ class Dialect(metaclass=_Dialect):
     Whether ORDER BY ALL is supported (expands to all the selected columns) as in DuckDB, Spark3/Databricks
     """
 
+    HAS_DISTINCT_ARRAY_CONSTRUCTORS = False
+    """
+    Whether the ARRAY constructor is context-sensitive, i.e in Redshift ARRAY[1, 2, 3] != ARRAY(1, 2, 3)
+    as the former is of type INT[] vs the latter which is SUPER
+    """
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -314,7 +314,7 @@ class DuckDB(Dialect):
             "LIST_HAS": exp.ArrayContains.from_arg_list,
             "LIST_REVERSE_SORT": _build_sort_array_desc,
             "LIST_SORT": exp.SortArray.from_arg_list,
-            "LIST_VALUE": exp.Array.from_arg_list,
+            "LIST_VALUE": lambda args: exp.Array(expressions=args),
             "MAKE_TIME": exp.TimeFromParts.from_arg_list,
             "MAKE_TIMESTAMP": _build_make_timestamp,
             "MEDIAN": lambda args: exp.PercentileCont(

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -437,6 +437,7 @@ class DuckDB(Dialect):
         COPY_HAS_INTO_KEYWORD = False
         STAR_EXCEPT = "EXCLUDE"
         PAD_FILL_PATTERN_IS_REQUIRED = True
+        ARRAY_CONCAT_IS_VAR_LEN = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -466,6 +466,7 @@ class Postgres(Dialect):
         MULTI_ARG_DISTINCT = False
         CAN_IMPLEMENT_ARRAY_ANY = True
         COPY_HAS_INTO_KEYWORD = False
+        ARRAY_CONCAT_IS_VAR_LEN = False
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,
@@ -492,7 +493,6 @@ class Postgres(Dialect):
                 if isinstance(seq_get(e.expressions, 0), exp.Select)
                 else f"{self.normalize_func('ARRAY')}[{self.expressions(e, flat=True)}]"
             ),
-            exp.ArrayConcat: rename_func("ARRAY_CAT"),
             exp.ArrayContainsAll: lambda self, e: self.binary(e, "@>"),
             exp.ArrayOverlaps: lambda self, e: self.binary(e, "&&"),
             exp.ArrayFilter: filter_array_using_unnest,
@@ -647,3 +647,6 @@ class Postgres(Dialect):
                 return self.sql(this)
 
             return super().cast_sql(expression, safe_prefix=safe_prefix)
+
+        def arrayconcat_sql(self, expression: exp.ArrayConcat, name: str = "ARRAY_CAT") -> str:
+            return super().arrayconcat_sql(expression, name=name)

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -493,6 +493,7 @@ class Postgres(Dialect):
                 if isinstance(seq_get(e.expressions, 0), exp.Select)
                 else f"{self.normalize_func('ARRAY')}[{self.expressions(e, flat=True)}]"
             ),
+            exp.ArrayConcat: lambda self, e: super().arrayconcat_sql(e, name="ARRAY_CAT"),
             exp.ArrayContainsAll: lambda self, e: self.binary(e, "@>"),
             exp.ArrayOverlaps: lambda self, e: self.binary(e, "&&"),
             exp.ArrayFilter: filter_array_using_unnest,
@@ -647,6 +648,3 @@ class Postgres(Dialect):
                 return self.sql(this)
 
             return super().cast_sql(expression, safe_prefix=safe_prefix)
-
-        def arrayconcat_sql(self, expression: exp.ArrayConcat, name: str = "ARRAY_CAT") -> str:
-            return super().arrayconcat_sql(expression, name=name)

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -153,6 +153,7 @@ class Redshift(Postgres):
         COPY_PARAMS_ARE_WRAPPED = False
         HEX_FUNC = "TO_HEX"
         PARSE_JSON_NAME = "JSON_PARSE"
+        ARRAY_CONCAT_IS_VAR_LEN = False
 
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "
@@ -169,6 +170,7 @@ class Redshift(Postgres):
 
         TRANSFORMS = {
             **Postgres.Generator.TRANSFORMS,
+            exp.Array: rename_func("ARRAY"),
             exp.Concat: concat_to_dpipe_sql,
             exp.ConcatWs: concat_ws_to_dpipe_sql,
             exp.ApproxDistinct: lambda self,
@@ -423,3 +425,6 @@ class Redshift(Postgres):
             file_format = f" FILE FORMAT {file_format}" if file_format else ""
 
             return f"SET{exprs}{location}{file_format}"
+
+        def arrayconcat_sql(self, expression: exp.ArrayConcat, name: str = "ARRAY_CONCAT") -> str:
+            return super().arrayconcat_sql(expression, name=name)

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -171,6 +171,7 @@ class Redshift(Postgres):
         TRANSFORMS = {
             **Postgres.Generator.TRANSFORMS,
             exp.Array: rename_func("ARRAY"),
+            exp.ArrayConcat: lambda self, e: super().arrayconcat_sql(e, name="ARRAY_CONCAT"),
             exp.Concat: concat_to_dpipe_sql,
             exp.ConcatWs: concat_ws_to_dpipe_sql,
             exp.ApproxDistinct: lambda self,
@@ -425,6 +426,3 @@ class Redshift(Postgres):
             file_format = f" FILE FORMAT {file_format}" if file_format else ""
 
             return f"SET{exprs}{location}{file_format}"
-
-        def arrayconcat_sql(self, expression: exp.ArrayConcat, name: str = "ARRAY_CONCAT") -> str:
-            return super().arrayconcat_sql(expression, name=name)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -701,6 +701,7 @@ class Snowflake(Dialect):
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),
             exp.Array: inline_array_sql,
+            exp.ArrayConcat: lambda self, e: super().arrayconcat_sql(e, name="ARRAY_CAT"),
             exp.ArrayContains: lambda self, e: self.func("ARRAY_CONTAINS", e.expression, e.this),
             exp.AtTimeZone: lambda self, e: self.func(
                 "CONVERT_TIMEZONE", e.args.get("zone"), e.this
@@ -1006,6 +1007,3 @@ class Snowflake(Dialect):
             tag = f" TAG {tag}" if tag else ""
 
             return f"SET{exprs}{file_format}{copy_options}{tag}"
-
-        def arrayconcat_sql(self, expression: exp.ArrayConcat, name: str = "ARRAY_CAT") -> str:
-            return super().arrayconcat_sql(expression, name=name)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -693,6 +693,7 @@ class Snowflake(Dialect):
         COPY_PARAMS_EQ_REQUIRED = True
         STAR_EXCEPT = "EXCLUDE"
         SUPPORTS_EXPLODING_PROJECTIONS = False
+        ARRAY_CONCAT_IS_VAR_LEN = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
@@ -700,7 +701,6 @@ class Snowflake(Dialect):
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),
             exp.Array: inline_array_sql,
-            exp.ArrayConcat: rename_func("ARRAY_CAT"),
             exp.ArrayContains: lambda self, e: self.func("ARRAY_CONTAINS", e.expression, e.this),
             exp.AtTimeZone: lambda self, e: self.func(
                 "CONVERT_TIMEZONE", e.args.get("zone"), e.this
@@ -1006,3 +1006,6 @@ class Snowflake(Dialect):
             tag = f" TAG {tag}" if tag else ""
 
             return f"SET{exprs}{file_format}{copy_options}{tag}"
+
+        def arrayconcat_sql(self, expression: exp.ArrayConcat, name: str = "ARRAY_CAT") -> str:
+            return super().arrayconcat_sql(expression, name=name)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -255,7 +255,7 @@ class Snowflake(Dialect):
             **parser.Parser.FUNCTIONS,
             "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
             "ARRAYAGG": exp.ArrayAgg.from_arg_list,
-            "ARRAY_CONSTRUCT": exp.Array.from_arg_list,
+            "ARRAY_CONSTRUCT": lambda args: exp.Array(expressions=args),
             "ARRAY_CONTAINS": lambda args: exp.ArrayContains(
                 this=seq_get(args, 1), expression=seq_get(args, 0)
             ),
@@ -701,7 +701,7 @@ class Snowflake(Dialect):
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),
             exp.Array: inline_array_sql,
-            exp.ArrayConcat: lambda self, e: super().arrayconcat_sql(e, name="ARRAY_CAT"),
+            exp.ArrayConcat: lambda self, e: self.arrayconcat_sql(e, name="ARRAY_CAT"),
             exp.ArrayContains: lambda self, e: self.func("ARRAY_CONTAINS", e.expression, e.this),
             exp.AtTimeZone: lambda self, e: self.func(
                 "CONVERT_TIMEZONE", e.args.get("zone"), e.this

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4790,7 +4790,7 @@ class ApproxDistinct(AggFunc):
 
 
 class Array(Func):
-    arg_types = {"expressions": False}
+    arg_types = {"expressions": False, "bracket_notation": False}
     is_var_len_args = True
 
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -117,6 +117,17 @@ def build_pad(args: t.List, is_left: bool = True):
     )
 
 
+def build_array_constructor(
+    exp_class: t.Type[E], args: t.List, bracket_kind: TokenType, dialect: Dialect
+) -> exp.Expression:
+    array_exp = exp_class(expressions=args)
+
+    if exp_class == exp.Array and dialect.HAS_DISTINCT_ARRAY_CONSTRUCTORS:
+        array_exp.set("bracket_notation", bracket_kind == TokenType.L_BRACKET)
+
+    return array_exp
+
+
 class _Parser(type):
     def __new__(cls, clsname, bases, attrs):
         klass = super().__new__(cls, clsname, bases, attrs)
@@ -144,6 +155,7 @@ class Parser(metaclass=_Parser):
 
     FUNCTIONS: t.Dict[str, t.Callable] = {
         **{name: func.from_arg_list for name, func in exp.FUNCTION_BY_NAME.items()},
+        "ARRAY": lambda args, dialect: exp.Array(expressions=args),
         "CONCAT": lambda args, dialect: exp.Concat(
             expressions=args,
             safe=not dialect.STRICT_STRING_CONCAT,
@@ -5407,11 +5419,18 @@ class Parser(metaclass=_Parser):
         if bracket_kind == TokenType.L_BRACE:
             this = self.expression(exp.Struct, expressions=self._kv_to_prop_eq(expressions))
         elif not this:
-            this = self.expression(exp.Array, expressions=expressions)
+            this = build_array_constructor(
+                exp.Array, args=expressions, bracket_kind=bracket_kind, dialect=self.dialect
+            )
         else:
             constructor_type = self.ARRAY_CONSTRUCTORS.get(this.name.upper())
             if constructor_type:
-                return self.expression(constructor_type, expressions=expressions)
+                return build_array_constructor(
+                    constructor_type,
+                    args=expressions,
+                    bracket_kind=bracket_kind,
+                    dialect=self.dialect,
+                )
 
             expressions = apply_index_offset(this, expressions, -self.dialect.INDEX_OFFSET)
             this = self.expression(exp.Bracket, this=this, expressions=expressions)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1408,12 +1408,27 @@ WHERE
                 "": "SELECT LENGTH(foo)",
             },
         )
-
         self.validate_all(
             "SELECT TIME_DIFF('12:00:00', '12:30:00', MINUTE)",
             write={
                 "duckdb": "SELECT DATE_DIFF('MINUTE', CAST('12:30:00' AS TIME), CAST('12:00:00' AS TIME))",
                 "bigquery": "SELECT TIME_DIFF('12:00:00', '12:30:00', MINUTE)",
+            },
+        )
+        self.validate_all(
+            "ARRAY_CONCAT([1, 2], [3, 4], [5, 6])",
+            write={
+                "bigquery": "ARRAY_CONCAT([1, 2], [3, 4], [5, 6])",
+                "duckdb": "ARRAY_CONCAT([1, 2], ARRAY_CONCAT([3, 4], [5, 6]))",
+                "postgres": "ARRAY_CAT(ARRAY[1, 2], ARRAY_CAT(ARRAY[3, 4], ARRAY[5, 6]))",
+                "redshift": "ARRAY_CONCAT(ARRAY(1, 2), ARRAY_CONCAT(ARRAY(3, 4), ARRAY(5, 6)))",
+                "snowflake": "ARRAY_CAT([1, 2], ARRAY_CAT([3, 4], [5, 6]))",
+                "hive": "CONCAT(ARRAY(1, 2), ARRAY(3, 4), ARRAY(5, 6))",
+                "spark2": "CONCAT(ARRAY(1, 2), ARRAY(3, 4), ARRAY(5, 6))",
+                "spark": "CONCAT(ARRAY(1, 2), ARRAY(3, 4), ARRAY(5, 6))",
+                "databricks": "CONCAT(ARRAY(1, 2), ARRAY(3, 4), ARRAY(5, 6))",
+                "presto": "CONCAT(ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6])",
+                "trino": "CONCAT(ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6])",
             },
         )
 

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -430,6 +430,9 @@ ORDER BY
         )
         self.validate_identity("SELECT JSON_PARSE('[]')")
 
+        self.validate_identity("SELECT ARRAY(1, 2, 3)")
+        self.validate_identity("SELECT ARRAY[1, 2, 3]")
+
     def test_values(self):
         # Test crazy-sized VALUES clause to UNION ALL conversion to ensure we don't get RecursionError
         values = [str(v) for v in range(0, 10000)]


### PR DESCRIPTION
While `exp.ArrayConcat` is a varlen function in many dialects, this isn't the case for all; This PR fixes this by refactoring the generation to _reduce_ the varlen version to a series of 2-arg based `ARRAY_CONCAT(x, y)` calls for those dialects.

This PR also fixes Redshift's `ARRAY(expr1, ..., exprN)` construction which differs from Postgres's `ARRAY[expr1, ..., exprN]`. 


Docs
---------
[Trino - Presto ARRAY Functions](https://trino.io/docs/current/functions/array.html)
[Postgres ARRAY Functions](https://www.postgresql.org/docs/9.1/functions-array.html)
 [Spark CONCAT](https://spark.apache.org/docs/latest/api/sql/#concat) | [Databricks CONCAT](https://docs.databricks.com/en/sql/language-manual/functions/concat.html) 
 [Redshift ARRAY](https://docs.aws.amazon.com/redshift/latest/dg/r_array.html) | [Redshift ARRAY_CONCAT](https://docs.aws.amazon.com/redshift/latest/dg/r_array_concat.html) 
 [Snowflake ARRAY_CAT](https://docs.snowflake.com/en/sql-reference/functions/array_cat) 
 [BigQuery ARRAY_CONCAT](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_concat) 
[DuckDB ARRAY_CONCAT](https://duckdb.org/docs/sql/functions/nested.html#list_concatlist1-list2)