### PR TITLE
feat(duckdb)!: Support for BQ's exp.GenerateDateArray generation

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -209,10 +209,11 @@ def _arrow_json_extract_sql(self: DuckDB.Generator, expression: JSON_EXTRACT_TYP
     return arrow_sql
 
 
-def _date_diff_sql(self: DuckDB.Generator, expression: exp.DateDiff) -> str:
-    def _implicit_date_cast(arg: exp.Expression):
-        return exp.cast(arg, exp.DataType.Type.DATE) if isinstance(arg, exp.Literal) else arg
+def _implicit_date_cast(arg: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+    return exp.cast(arg, exp.DataType.Type.DATE) if isinstance(arg, exp.Literal) else arg
 
+
+def _date_diff_sql(self: DuckDB.Generator, expression: exp.DateDiff) -> str:
     this = _implicit_date_cast(expression.this)
     expr = _implicit_date_cast(expression.expression)
 
@@ -853,3 +854,18 @@ class DuckDB(Dialect):
                 return self.func("STRUCT_PACK", kv_sql)
 
             return self.func("STRUCT_INSERT", this, kv_sql)
+
+        def generatedatearray_sql(self, expression: exp.GenerateDateArray) -> str:
+            start = _implicit_date_cast(expression.args.get("start"))
+            end = _implicit_date_cast(expression.args.get("end"))
+
+            # BigQuery has a default step/interval of 1 DAY
+            interval = expression.args.get("interval") or exp.Interval(
+                this=exp.Literal.number(1), unit=exp.var("DAY")
+            )
+
+            # BQ's GENERATE_DATE_ARRAY is transformed to DuckDB'S GENERATE_SERIES
+            gen_series = exp.GenerateSeries(start=start, end=end, step=interval)
+
+            # The result is TIMESTAMP array, so to match BQ's semantics we must cast it back to DATE array
+            return self.sql(exp.cast(gen_series, exp.DataType.build("ARRAY<DATE>")))

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -859,13 +859,10 @@ class DuckDB(Dialect):
             start = _implicit_date_cast(expression.args.get("start"))
             end = _implicit_date_cast(expression.args.get("end"))
 
-            # BigQuery has a default step/interval of 1 DAY
-            interval = expression.args.get("interval") or exp.Interval(
-                this=exp.Literal.number(1), unit=exp.var("DAY")
-            )
-
             # BQ's GENERATE_DATE_ARRAY is transformed to DuckDB'S GENERATE_SERIES
-            gen_series = exp.GenerateSeries(start=start, end=end, step=interval)
+            gen_series = exp.GenerateSeries(
+                start=start, end=end, step=expression.args.get("interval")
+            )
 
             # The result is TIMESTAMP array, so to match BQ's semantics we must cast it back to DATE array
             return self.sql(exp.cast(gen_series, exp.DataType.build("ARRAY<DATE>")))

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -170,6 +170,12 @@ class Parser(metaclass=_Parser):
             this=seq_get(args, 0),
             to=exp.DataType(this=exp.DataType.Type.TEXT),
         ),
+        "GENERATE_DATE_ARRAY": lambda args: exp.GenerateDateArray(
+            start=seq_get(args, 0),
+            end=seq_get(args, 1),
+            interval=seq_get(args, 2)
+            or exp.Interval(this=exp.Literal.number(1), unit=exp.var("DAY")),
+        ),
         "GLOB": lambda args: exp.Glob(this=seq_get(args, 1), expression=seq_get(args, 0)),
         "HEX": build_hex,
         "JSON_EXTRACT": build_extract_json_with_path(exp.JSONExtract),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1435,7 +1435,7 @@ WHERE
             "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08')",
             write={
                 "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL 1 DAY) AS DATE[])",
-                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08')",
+                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL 1 DAY)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1431,6 +1431,20 @@ WHERE
                 "trino": "CONCAT(ARRAY[1, 2], ARRAY[3, 4], ARRAY[5, 6])",
             },
         )
+        self.validate_all(
+            "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08')",
+            write={
+                "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL 1 DAY) AS DATE[])",
+                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08')",
+            },
+        )
+        self.validate_all(
+            "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
+            write={
+                "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL '1' MONTH) AS DATE[])",
+                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):


### PR DESCRIPTION
Generate BigQuery's `GENERATE_DATE_ARRAY(start, stop, interval)` to DuckDB's `GENERATE_SERIES(start, stop, interval)`

Docs
--------
[BigQuery GENERATE_DATE_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#generate_date_array) | [DuckDB GENERATE_SERIES](https://duckdb.org/docs/sql/functions/nested.html#generate_series)