### PR TITLE
Fix(parser): make assignment parsing more lenient by allowing keyword in LHS

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4132,6 +4132,11 @@ class Parser(metaclass=_Parser):
 
     def _parse_assignment(self) -> t.Optional[exp.Expression]:
         this = self._parse_disjunction()
+        if not this and self._next and self._next.token_type in self.ASSIGNMENT:
+            # This allows us to parse <non-identifier token> := <expr>
+            this = exp.column(
+                t.cast(str, self._advance_any(ignore_reserved=True) and self._prev.text)
+            )
 
         while self._match_set(self.ASSIGNMENT):
             this = self.expression(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -59,6 +59,7 @@ WHERE
   )""",
         )
 
+        self.validate_identity("exclude := [foo]")
         self.validate_identity("SELECT CAST([1, 2, 3] AS VECTOR(FLOAT, 3))")
         self.validate_identity("SELECT CONNECT_BY_ROOT test AS test_column_alias")
         self.validate_identity("SELECT number").selects[0].assert_is(exp.Column)


### PR DESCRIPTION
This was motivated by a bug I discovered in SQLMesh: `@STAR(..., exclude := [...])` doesn't work for snowflake and duckdb because they map `"EXCLUDE"` to `TokenType.EXCEPT` and that's not in `ID_VAR_TOKENS`, resulting in a `ParseError`, since `_parse_conjunction()` can't consume it.