### PR TITLE
Feat(snowflake): add support for a a couple of missing clauses in PIVOT clause

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4537,7 +4537,7 @@ class PivotAlias(Alias):
     pass
 
 
-# Represent's Snowflakes ANY [ ORDER BY ... ] syntax
+# Represents Snowflake's ANY [ ORDER BY ... ] syntax
 # https://docs.snowflake.com/en/sql-reference/constructs/pivot
 class PivotAny(Expression):
     arg_types = {"this": False}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4538,6 +4538,12 @@ class PivotAlias(Alias):
     pass
 
 
+# Represent's Snowflakes ANY [ ORDER BY ... ] syntax
+# https://docs.snowflake.com/en/sql-reference/constructs/pivot
+class PivotAny(Expression):
+    arg_types = {"this": False}
+
+
 class Aliases(Expression):
     arg_types = {"this": True, "expressions": True}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3859,6 +3859,8 @@ class Pivot(Expression):
         "group": False,
         "columns": False,
         "include_nulls": False,
+        "default_on_null": False,
+        "order": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3860,7 +3860,6 @@ class Pivot(Expression):
         "columns": False,
         "include_nulls": False,
         "default_on_null": False,
-        "order": False,
     }
 
     @property

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1836,7 +1836,9 @@ class Generator(metaclass=_Generator):
             nulls = " INCLUDE NULLS " if include_nulls else " EXCLUDE NULLS "
         else:
             nulls = ""
-        return f"{direction}{nulls}({expressions} FOR {field}){alias}"
+        default_on_null = self.sql(expression, "default_on_null")
+        default_on_null = f" {default_on_null}" if default_on_null else ""
+        return f"{direction}{nulls}({expressions} FOR {field}{default_on_null}){alias}"
 
     def version_sql(self, expression: exp.Version) -> str:
         this = f"FOR {expression.name}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -119,6 +119,7 @@ class Generator(metaclass=_Generator):
         exp.OnUpdateColumnConstraint: lambda self, e: f"ON UPDATE {self.sql(e, 'this')}",
         exp.OutputModelProperty: lambda self, e: f"OUTPUT{self.sql(e, 'this')}",
         exp.PathColumnConstraint: lambda self, e: f"PATH {self.sql(e, 'this')}",
+        exp.PivotAny: lambda self, e: f"ANY{self.sql(e, 'this')}",
         exp.ProjectionPolicyColumnConstraint: lambda self,
         e: f"PROJECTION POLICY {self.sql(e, 'this')}",
         exp.RemoteWithConnectionModelProperty: lambda self,
@@ -1830,14 +1831,19 @@ class Generator(metaclass=_Generator):
         alias = self.sql(expression, "alias")
         alias = f" AS {alias}" if alias else ""
         direction = self.seg("UNPIVOT" if expression.unpivot else "PIVOT")
+
         field = self.sql(expression, "field")
+        if field and isinstance(expression.args.get("field"), exp.PivotAny):
+            field = f"IN ({field})"
+
         include_nulls = expression.args.get("include_nulls")
         if include_nulls is not None:
             nulls = " INCLUDE NULLS " if include_nulls else " EXCLUDE NULLS "
         else:
             nulls = ""
+
         default_on_null = self.sql(expression, "default_on_null")
-        default_on_null = f" {default_on_null}" if default_on_null else ""
+        default_on_null = f" DEFAULT ON NULL ({default_on_null})" if default_on_null else ""
         return f"{direction}{nulls}({expressions} FOR {field}{default_on_null}){alias}"
 
     def version_sql(self, expression: exp.Version) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3727,7 +3727,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_pivot_in(self) -> exp.In:
         def _parse_aliased_expression() -> t.Optional[exp.Expression]:
-            this = self._parse_assignment()
+            this = self._parse_select_or_expression()
 
             self._match(TokenType.ALIAS)
             alias = self._parse_field()
@@ -3741,10 +3741,13 @@ class Parser(metaclass=_Parser):
         if not self._match_pair(TokenType.IN, TokenType.L_PAREN):
             self.raise_error("Expecting IN (")
 
-        aliased_expressions = self._parse_csv(_parse_aliased_expression)
+        if self._match_pair(TokenType.ANY, TokenType.ORDER_BY):
+            expressions = self._parse_csv(self._parse_ordered)
+        else:
+            expressions = self._parse_csv(_parse_aliased_expression)
 
         self._match_r_paren()
-        return self.expression(exp.In, this=value, expressions=aliased_expressions)
+        return self.expression(exp.In, this=value, expressions=expressions)
 
     def _parse_pivot(self) -> t.Optional[exp.Pivot]:
         index = self._index
@@ -3781,6 +3784,9 @@ class Parser(metaclass=_Parser):
             self.raise_error("Expecting FOR")
 
         field = self._parse_pivot_in()
+        default_on_null = self._match_text_seq("DEFAULT", "ON", "NULL") and self._parse_wrapped(
+            self._parse_bitwise
+        )
 
         self._match_r_paren()
 
@@ -3790,6 +3796,7 @@ class Parser(metaclass=_Parser):
             field=field,
             unpivot=unpivot,
             include_nulls=include_nulls,
+            default_on_null=default_on_null,
         )
 
         if not self._match_set((TokenType.PIVOT, TokenType.UNPIVOT), advance=False):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -115,6 +115,18 @@ WHERE
         self.validate_identity("SELECT MATCH_CONDITION")
         self.validate_identity("SELECT * REPLACE (CAST(col AS TEXT) AS scol) FROM t")
         self.validate_identity(
+            "SELECT * FROM quarterly_sales PIVOT(SUM(amount) FOR quarter IN ('2023_Q1', '2023_Q2', '2023_Q3', '2023_Q4', '2024_Q1') DEFAULT ON NULL (0)) ORDER BY empid"
+        )
+        self.validate_identity(
+            "SELECT * FROM quarterly_sales PIVOT(SUM(amount) FOR quarter IN (SELECT DISTINCT quarter FROM ad_campaign_types_by_quarter WHERE television = TRUE ORDER BY quarter)) ORDER BY empid"
+        )
+        self.validate_identity(
+            "SELECT * FROM quarterly_sales PIVOT(SUM(amount) FOR IN (ANY ORDER BY quarter)) ORDER BY empid"
+        )
+        self.validate_identity(
+            "SELECT * FROM quarterly_sales PIVOT(SUM(amount) FOR IN (ANY)) ORDER BY empid"
+        )
+        self.validate_identity(
             "MERGE INTO my_db AS ids USING (SELECT new_id FROM my_model WHERE NOT col IS NULL) AS new_ids ON ids.type = new_ids.type AND ids.source = new_ids.source WHEN NOT MATCHED THEN INSERT VALUES (new_ids.new_id)"
         )
         self.validate_identity(


### PR DESCRIPTION
Reference: https://docs.snowflake.com/en/sql-reference/constructs/pivot#syntax