### PR TITLE
fix: Fixed size array parsing

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -375,6 +375,12 @@ class Dialect(metaclass=_Dialect):
     as the former is of type INT[] vs the latter which is SUPER
     """
 
+    SUPPORTS_FIXED_SIZE_ARRAYS = False
+    """
+    Whether expressions such as x::INT[5] should be parsed as fixed-size array defs/casts e.g. in DuckDB. In
+    dialects which don't support fixed size arrays such as Snowflake, this should be interpreted as a subscript/index operator
+    """
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -227,6 +227,7 @@ class DuckDB(Dialect):
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True
     SUPPORTS_ORDER_BY_ALL = True
+    SUPPORTS_FIXED_SIZE_ARRAYS = True
 
     # https://duckdb.org/docs/sql/introduction.html#creating-a-new-table
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4641,6 +4641,7 @@ class Parser(metaclass=_Parser):
         matched_array = self._match(TokenType.ARRAY)
 
         while self._curr:
+            datatype_token = self._prev.token_type
             matched_l_bracket = self._match(TokenType.L_BRACKET)
             if not matched_l_bracket and not matched_array:
                 break
@@ -4650,8 +4651,12 @@ class Parser(metaclass=_Parser):
             if (
                 values
                 and not schema
-                and this.is_type(exp.DataType.Type.ARRAY, exp.DataType.Type.MAP)
+                and (
+                    not self.dialect.SUPPORTS_FIXED_SIZE_ARRAYS or datatype_token == TokenType.ARRAY
+                )
             ):
+                # Retreating here means that we should not parse the following values as part of the data type, e.g. in DuckDB
+                # ARRAY[1] should retreat and instead be parsed into exp.Array in contrast to INT[x][y] which denotes a fixed-size array data type
                 self._retreat(index)
                 break
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -818,6 +818,7 @@ class TestDuckDB(Validator):
         )
 
         self.validate_identity("SELECT LENGTH(foo)")
+        self.validate_identity("SELECT ARRAY[1, 2, 3]", "SELECT [1, 2, 3]")
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
@@ -1154,6 +1155,12 @@ class TestDuckDB(Validator):
                 "postgres": "CAST(COL AS BIGINT[])",
                 "snowflake": "CAST(COL AS ARRAY(BIGINT))",
             },
+        )
+
+        self.validate_identity("SELECT x::INT[3][3]", "SELECT CAST(x AS INT[3][3])")
+        self.validate_identity(
+            """SELECT ARRAY[[[1]]]::INT[1][1][1]""",
+            """SELECT CAST([[[1]]] AS INT[1][1][1])""",
         )
 
     def test_encode_decode(self):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -860,6 +860,11 @@ WHERE
             },
         )
 
+        self.validate_identity(
+            """SELECT ARRAY_CONSTRUCT('foo')::VARIANT[0]""",
+            """SELECT CAST(['foo'] AS VARIANT)[0]""",
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
Fixes #3868

The recent commit https://github.com/tobymao/sqlglot/commit/2ffb07070952cde7ac9a1883cbf9b4c477c55abb introduced support for fixed-size array parsing in DuckDB; However, not all dialects [1] support fixed-size arrays so a regression was introduced in which the subscript/bracket operator was now interpreted as the array size.

Also, this commit was not working properly for higher dimension arrays so valid queries were broken after roundtripping:

```
sqlglot.parse_one("SELECT [[1], [2], [3]]::INT[1][3]", dialect="duckdb").sql("duckdb")
SELECT CAST([[1], [2], [3]] AS INT[1])[1][3]
```


This PR fixes both issues by introducing a dialect flag that enables the recent addition only for DuckDB. From a quick search, the other dialects which come close to supporting/parsing fixed-size arrays are Postgres & Redshift but neither engine actually enforces that, meaning that queries like the following are valid Postgres/Redshift:

```SQL
SELECT ARRAY[1, 2, 3, 4]::INT[1][1][1];
```

For this reason, this fix is limited to DuckDB for now and if need arises for Postgres/Redshift they can easily override that by setting the new flag.


Docs
-----------
- [DuckDB Arrays](https://duckdb.org/docs/sql/data_types/array.html)
- [[1] Snowflake Array limitations](https://docs.snowflake.com/en/sql-reference/data-types-semistructured#characteristics-of-an-array), 2nd bullet: _Snowflake does not currently support fixed-size arrays_