### PR TITLE
fix(duckdb): Allow DESCRIBE as a _parse_select() path

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2848,6 +2848,8 @@ class Parser(metaclass=_Parser):
             table = self._match(TokenType.TABLE)
             this = self._parse_select() or self._parse_string() or self._parse_table()
             return self.expression(exp.Summarize, this=this, table=table)
+        elif self._match(TokenType.DESCRIBE):
+            this = self._parse_describe()
         else:
             this = None
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -819,6 +819,8 @@ class TestDuckDB(Validator):
 
         self.validate_identity("SELECT LENGTH(foo)")
 
+        self.validate_identity("SELECT * FROM (DESCRIBE t)")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
Fixes #3869


Docs
---------
[DuckDB Describe](https://duckdb.org/docs/guides/meta/describe.html)