### PR TITLE
Fix(bigquery): ensure Funcs are preserved when used as Tables

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -500,7 +500,7 @@ class BigQuery(Dialect):
                         table.set("db", exp.Identifier(this=parts[0]))
                         table.set("this", exp.Identifier(this=parts[1]))
 
-            if any("." in p.name for p in table.parts):
+            if isinstance(table.this, exp.Identifier) and any("." in p.name for p in table.parts):
                 catalog, db, this, *rest = (
                     exp.to_identifier(p, quoted=True)
                     for p in split_num_words(".".join(p.name for p in table.parts), ".", 3)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -103,6 +103,7 @@ LANGUAGE js AS
         select_with_quoted_udf = self.validate_identity("SELECT `p.d.UdF`(data) FROM `p.d.t`")
         self.assertEqual(select_with_quoted_udf.selects[0].name, "p.d.UdF")
 
+        self.validate_identity("SELECT * FROM READ_CSV('bla.csv')")
         self.validate_identity("CAST(x AS STRUCT<list ARRAY<INT64>>)")
         self.validate_identity("assert.true(1 = 1)")
         self.validate_identity("SELECT ARRAY_TO_STRING(list, '--') AS text")


### PR DESCRIPTION
Currently in main:

```python
import sqlglot
sqlglot.transpile("select * from read_csv('foo.csv')", "bigquery")[0]
# 'SELECT * FROM `foo.csv`'
```

This happens because `read_csv` is parsed in to `ReadCSV(this=Literal(this='foo.csv'))` and so `"." in part.name` is true for `this` in BigQuery's `_parse_table_parts` logic, resulting in us breaking the function. Granted, `READ_CSV` is not supported (?) in BigQuery, but this bug can happen for other function expressions too.

This branch fixes it:

```python
import sqlglot
sqlglot.transpile("select * from read_csv('foo.csv')", "bigquery")[0]
# 'SELECT * FROM read_csv('foo.csv')'
```

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1722937694107889