### PR TITLE
Refactor(optimizer)!: switch off CSV file schema inference by default

### DIFF
--- a/sqlglot/executor/__init__.py
+++ b/sqlglot/executor/__init__.py
@@ -74,7 +74,9 @@ def execute(
         raise ExecuteError("Tables must support the same table args as schema")
 
     now = time.time()
-    expression = optimize(sql, schema, leave_tables_isolated=True, dialect=read)
+    expression = optimize(
+        sql, schema, leave_tables_isolated=True, infer_csv_schemas=True, dialect=read
+    )
 
     logger.debug("Optimization finished: %f", time.time() - now)
     logger.debug("Optimized SQL: %s", expression.sql(pretty=True))

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -30,6 +30,7 @@ def qualify(
     validate_qualify_columns: bool = True,
     quote_identifiers: bool = True,
     identify: bool = True,
+    infer_csv_schemas: bool = False,
 ) -> exp.Expression:
     """
     Rewrite sqlglot AST to have normalized and qualified tables and columns.
@@ -60,13 +61,21 @@ def qualify(
             This step is necessary to ensure correctness for case sensitive queries.
             But this flag is provided in case this step is performed at a later time.
         identify: If True, quote all identifiers, else only necessary ones.
+        infer_csv_schemas: Whether to scan READ_CSV calls in order to infer the CSVs' schemas.
 
     Returns:
         The qualified expression.
     """
     schema = ensure_schema(schema, dialect=dialect)
     expression = normalize_identifiers(expression, dialect=dialect)
-    expression = qualify_tables(expression, db=db, catalog=catalog, schema=schema, dialect=dialect)
+    expression = qualify_tables(
+        expression,
+        db=db,
+        catalog=catalog,
+        schema=schema,
+        dialect=dialect,
+        infer_csv_schemas=infer_csv_schemas,
+    )
 
     if isolate_tables:
         expression = isolate_table_selects(expression, schema=schema)

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -18,6 +18,7 @@ def qualify_tables(
     db: t.Optional[str | exp.Identifier] = None,
     catalog: t.Optional[str | exp.Identifier] = None,
     schema: t.Optional[Schema] = None,
+    infer_csv_schemas: bool = False,
     dialect: DialectType = None,
 ) -> E:
     """
@@ -39,6 +40,7 @@ def qualify_tables(
         db: Database name
         catalog: Catalog name
         schema: A schema to populate
+        infer_csv_schemas: Whether to scan READ_CSV calls in order to infer the CSVs' schemas.
         dialect: The dialect to parse catalog and schema into.
 
     Returns:
@@ -102,7 +104,7 @@ def qualify_tables(
                         "alias", exp.TableAlias(this=exp.to_identifier(next_alias_name()))
                     )
 
-                if schema and isinstance(source.this, exp.ReadCSV):
+                if infer_csv_schemas and schema and isinstance(source.this, exp.ReadCSV):
                     with csv_reader(source.this) as reader:
                         header = next(reader)
                         columns = next(reader)

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -343,6 +343,11 @@ WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.co
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col1) AS col) SELECT tbl1.col.* FROM tbl1;
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col1) AS col) SELECT tbl1.col.* FROM tbl1 AS tbl1;
 
+# title: CSV files are not scanned by default
+# execute: false
+SELECT * FROM READ_CSV('file.csv');
+SELECT * FROM READ_CSV('file.csv') AS _q_0;
+
 --------------------------------------
 -- CTEs
 --------------------------------------

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -622,7 +622,7 @@ SELECT
   "_q_0"."n_comment" AS "n_comment"
 FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') AS "_q_0"
 """.strip(),
-            optimizer.optimize(expression).sql(pretty=True),
+            optimizer.optimize(expression, infer_csv_schemas=True).sql(pretty=True),
         )
 
     def test_scope(self):


### PR DESCRIPTION
Whenever the optimizer sees a `READ_CSV` call, it 1) scans the corresponding CSV file and 2) infers the table's schema based on the CSV's header. There were two problems with these:

1. The first argument in `READ_CSV` may not exist in the local file system, e.g. it can be a hive partitioning path or a gcs bucket. In this case, the `open` call would produce a `FileNotFoundError` and the optimizer would crash. A SQLMesh user actually [had](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1722937694107889) this issue.
2. There are additional options supported by the `READ_CSV` call that affect the resulting schema, e.g.:

```
normalize_names - Boolean value that specifies whether or not column names should be normalized, removing any non-alphanumeric characters from them.

filename - Whether or not an extra filename column should be included in the result.

all_varchar - Option to skip type detection for CSV parsing and assume all columns to be of type VARCHAR.

columns - A struct that specifies the column names and column types contained within the CSV file (e.g., {'col1': 'INTEGER', 'col2': 'VARCHAR'}). Using this option implies that auto detection is not used.

header - Specifies that the file contains a header line with the names of each column in the file.

names - The column names as a list, see example.

types or dtypes - The column types as either a list (by position) or a struct (by name). Example here.
```

Not having logic to deal with these means there are cases where the produced schema can be incorrect.

For the above reasons, this PR switches the schema inference off by default, exposing a new flag in `qualify` and `qualify_tables` that can be set to activate it again - `infer_csv_schemas`.