### PR TITLE
feat(duckdb): Transpile Snowflake's CONVERT_TIMEZONE 3-arg version

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -867,17 +867,3 @@ class DuckDB(Dialect):
 
             # The result is TIMESTAMP array, so to match BQ's semantics we must cast it back to DATE array
             return self.sql(exp.cast(gen_series, exp.DataType.build("ARRAY<DATE>")))
-
-        def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:
-            # Transform Snowflake's CONVERT_TIMEZONE(source_tz, target_tz, ts) 3-arg version to
-            # TIMEZONE(target_tz, TIMEZONE(source_tz, ts::TIMESTAMP)) in DuckDB
-            timestamp = t.cast(exp.Expression, expression.args.get("timestamp"))
-
-            from_source_tz = self.func(
-                "TIMEZONE",
-                expression.args.get("source_tz"),
-                exp.cast(timestamp, exp.DataType.Type.TIMESTAMPNTZ),
-            )
-            to_target_tz = self.func("TIMEZONE", expression.args.get("target_tz"), from_source_tz)
-
-            return to_target_tz

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -302,6 +302,9 @@ class MySQL(Dialect):
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            "CONVERT_TZ": lambda args: exp.ConvertTimezone(
+                source_tz=seq_get(args, 1), target_tz=seq_get(args, 2), timestamp=seq_get(args, 0)
+            ),
             "DATE": lambda args: exp.TsOrDsToDate(this=seq_get(args, 0)),
             "DATE_ADD": build_date_delta_with_interval(exp.DateAdd),
             "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "mysql"),
@@ -1213,3 +1216,10 @@ class MySQL(Dialect):
             dateadd = build_date_delta_with_interval(exp.DateAdd)([start_ts, interval])
 
             return self.sql(dateadd)
+
+        def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:
+            from_tz = expression.args.get("source_tz")
+            to_tz = expression.args.get("target_tz")
+            dt = expression.args.get("timestamp")
+
+            return self.func("CONVERT_TZ", dt, from_tz, to_tz)

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
 from sqlglot.dialects.postgres import Postgres
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
+from sqlglot.parser import build_convert_timezone
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
@@ -63,6 +64,7 @@ class Redshift(Postgres):
                 unit=exp.var("month"),
                 return_type=exp.DataType.build("TIMESTAMP"),
             ),
+            "CONVERT_TIMEZONE": lambda args: build_convert_timezone(args, "UTC"),
             "DATEADD": _build_date_delta(exp.TsOrDsAdd),
             "DATE_ADD": _build_date_delta(exp.TsOrDsAdd),
             "DATEDIFF": _build_date_delta(exp.TsOrDsDiff),
@@ -155,6 +157,7 @@ class Redshift(Postgres):
         HEX_FUNC = "TO_HEX"
         PARSE_JSON_NAME = "JSON_PARSE"
         ARRAY_CONCAT_IS_VAR_LEN = False
+        SUPPORTS_CONVERT_TIMEZONE = True
 
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -122,9 +122,9 @@ def _regexpilike_sql(self: Snowflake.Generator, expression: exp.RegexpILike) -> 
     )
 
 
-def _build_convert_timezone(args: t.List) -> t.Union[exp.Anonymous, exp.AtTimeZone]:
+def _build_convert_timezone(args: t.List) -> t.Union[exp.ConvertTimezone, exp.AtTimeZone]:
     if len(args) == 3:
-        return exp.Anonymous(this="CONVERT_TIMEZONE", expressions=args)
+        return exp.ConvertTimezone.from_arg_list(args)
     return exp.AtTimeZone(this=seq_get(args, 1), zone=seq_get(args, 0))
 
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -122,12 +122,6 @@ def _regexpilike_sql(self: Snowflake.Generator, expression: exp.RegexpILike) -> 
     )
 
 
-def _build_convert_timezone(args: t.List) -> t.Union[exp.ConvertTimezone, exp.AtTimeZone]:
-    if len(args) == 3:
-        return exp.ConvertTimezone.from_arg_list(args)
-    return exp.AtTimeZone(this=seq_get(args, 1), zone=seq_get(args, 0))
-
-
 def _build_regexp_replace(args: t.List) -> exp.RegexpReplace:
     regexp_replace = exp.RegexpReplace.from_arg_list(args)
 
@@ -268,7 +262,6 @@ class Snowflake(Dialect):
             "BITXOR": binary_from_function(exp.BitwiseXor),
             "BIT_XOR": binary_from_function(exp.BitwiseXor),
             "BOOLXOR": binary_from_function(exp.Xor),
-            "CONVERT_TIMEZONE": _build_convert_timezone,
             "DATE": _build_datetime("DATE", exp.DataType.Type.DATE),
             "DATE_TRUNC": _date_trunc_to_time,
             "DATEADD": _build_date_time_add(exp.DateAdd),
@@ -694,6 +687,7 @@ class Snowflake(Dialect):
         STAR_EXCEPT = "EXCLUDE"
         SUPPORTS_EXPLODING_PROJECTIONS = False
         ARRAY_CONCAT_IS_VAR_LEN = False
+        SUPPORTS_CONVERT_TIMEZONE = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -132,6 +132,7 @@ class Spark(Spark2):
     class Generator(Spark2.Generator):
         SUPPORTS_TO_NUMBER = True
         PAD_FILL_PATTERN_IS_REQUIRED = False
+        SUPPORTS_CONVERT_TIMEZONE = True
 
         TYPE_MAPPING = {
             **Spark2.Generator.TYPE_MAPPING,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4557,7 +4557,7 @@ class AtIndex(Expression):
 
 
 class AtTimeZone(Expression):
-    arg_types = {"this": True, "zone": True, "source_zone": False}
+    arg_types = {"this": True, "zone": True}
 
 
 class FromTimeZone(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4840,6 +4840,10 @@ class Convert(Func):
     arg_types = {"this": True, "expression": True, "style": False}
 
 
+class ConvertTimezone(Func):
+    arg_types = {"source_tz": True, "target_tz": True, "timestamp": True}
+
+
 class GenerateSeries(Func):
     arg_types = {"start": True, "end": True, "step": False, "is_end_exclusive": False}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4557,7 +4557,7 @@ class AtIndex(Expression):
 
 
 class AtTimeZone(Expression):
-    arg_types = {"this": True, "zone": True}
+    arg_types = {"this": True, "zone": True, "source_zone": False}
 
 
 class FromTimeZone(Expression):
@@ -4841,7 +4841,7 @@ class Convert(Func):
 
 
 class ConvertTimezone(Func):
-    arg_types = {"source_tz": True, "target_tz": True, "timestamp": True}
+    arg_types = {"source_tz": False, "target_tz": True, "timestamp": True}
 
 
 class GenerateSeries(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4089,9 +4089,9 @@ class Generator(metaclass=_Generator):
 
         source_tz = expression.args.get("source_tz")
         target_tz = expression.args.get("target_tz")
-        timestamp = t.cast(exp.Expression, expression.args.get("timestamp"))
+        timestamp = expression.args.get("timestamp")
 
-        if source_tz:
+        if source_tz and timestamp:
             timestamp = exp.AtTimeZone(
                 this=exp.cast(timestamp, exp.DataType.Type.TIMESTAMPNTZ), zone=source_tz
             )

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -378,6 +378,9 @@ class Generator(metaclass=_Generator):
     # Whether ARRAY_CONCAT can be generated with varlen args or if it should be reduced to 2-arg version
     ARRAY_CONCAT_IS_VAR_LEN = True
 
+    # Whether CONVERT_TIMEZONE() is supported; if not, it will be generated as exp.AtTimeZone
+    SUPPORTS_CONVERT_TIMEZONE = False
+
     # The name to generate for the JSONPath expression. If `None`, only `this` will be generated
     PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
 
@@ -4079,3 +4082,20 @@ class Generator(metaclass=_Generator):
             rhs = self.expressions(expression)
 
         return self.func(name, expression.this, rhs)
+
+    def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:
+        if self.SUPPORTS_CONVERT_TIMEZONE:
+            return self.function_fallback_sql(expression)
+
+        source_tz = expression.args.get("source_tz")
+        target_tz = expression.args.get("target_tz")
+        timestamp = t.cast(exp.Expression, expression.args.get("timestamp"))
+
+        if source_tz:
+            timestamp = exp.AtTimeZone(
+                this=exp.cast(timestamp, exp.DataType.Type.TIMESTAMPNTZ), zone=source_tz
+            )
+
+        expr = exp.AtTimeZone(this=timestamp, zone=target_tz)
+
+        return self.sql(expr)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -128,6 +128,20 @@ def build_array_constructor(
     return array_exp
 
 
+def build_convert_timezone(
+    args: t.List, default_source_tz: t.Optional[str] = None
+) -> t.Union[exp.ConvertTimezone, exp.Anonymous]:
+    if len(args) == 2:
+        source_tz = exp.Literal.string(default_source_tz) if default_source_tz else None
+        return exp.ConvertTimezone(
+            source_tz=source_tz, target_tz=seq_get(args, 0), timestamp=seq_get(args, 1)
+        )
+    if len(args) == 3:
+        return exp.ConvertTimezone.from_arg_list(args)
+
+    return exp.Anonymous.from_arg_list(args)
+
+
 class _Parser(type):
     def __new__(cls, clsname, bases, attrs):
         klass = super().__new__(cls, clsname, bases, attrs)
@@ -166,6 +180,7 @@ class Parser(metaclass=_Parser):
             safe=not dialect.STRICT_STRING_CONCAT,
             coalesce=dialect.CONCAT_COALESCE,
         ),
+        "CONVERT_TIMEZONE": build_convert_timezone,
         "DATE_TO_DATE_STR": lambda args: exp.Cast(
             this=seq_get(args, 0),
             to=exp.DataType(this=exp.DataType.Type.TEXT),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -136,10 +136,8 @@ def build_convert_timezone(
         return exp.ConvertTimezone(
             source_tz=source_tz, target_tz=seq_get(args, 0), timestamp=seq_get(args, 1)
         )
-    if len(args) == 3:
-        return exp.ConvertTimezone.from_arg_list(args)
 
-    return exp.Anonymous.from_arg_list(args)
+    return exp.ConvertTimezone.from_arg_list(args)
 
 
 class _Parser(type):

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -433,6 +433,11 @@ ORDER BY
         self.validate_identity("SELECT ARRAY(1, 2, 3)")
         self.validate_identity("SELECT ARRAY[1, 2, 3]")
 
+        self.validate_identity(
+            """SELECT CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000')""",
+            """SELECT CONVERT_TIMEZONE('UTC', 'America/New_York', '2024-08-06 09:10:00.000')""",
+        )
+
     def test_values(self):
         # Test crazy-sized VALUES clause to UNION ALL conversion to ensure we don't get RecursionError
         values = [str(v) for v in range(0, 10000)]

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -865,6 +865,14 @@ WHERE
             """SELECT CAST(['foo'] AS VARIANT)[0]""",
         )
 
+        self.validate_all(
+            "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
+            write={
+                "snowflake": "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
+                "duckdb": "SELECT TIMEZONE('America/New_York', TIMEZONE('America/Los_Angeles', CAST('2024-08-06 09:10:00.000' AS TIMESTAMP)))",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -866,10 +866,24 @@ WHERE
         )
 
         self.validate_all(
+            "SELECT CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000')",
+            write={
+                "snowflake": "SELECT CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000')",
+                "spark": "SELECT CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000')",
+                "databricks": "SELECT CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000')",
+                "redshift": "SELECT CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000')",
+            },
+        )
+
+        self.validate_all(
             "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
             write={
                 "snowflake": "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
-                "duckdb": "SELECT TIMEZONE('America/New_York', TIMEZONE('America/Los_Angeles', CAST('2024-08-06 09:10:00.000' AS TIMESTAMP)))",
+                "spark": "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
+                "databricks": "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
+                "redshift": "SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000')",
+                "mysql": "SELECT CONVERT_TZ('2024-08-06 09:10:00.000', 'America/Los_Angeles', 'America/New_York')",
+                "duckdb": "SELECT CAST('2024-08-06 09:10:00.000' AS TIMESTAMP) AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'America/New_York'",
             },
         )
 


### PR DESCRIPTION
Fixes #3875

This PR attempts to transpile Snowflake's `CONVERT_TIMEZONE(source_tz, target_tz, timestamp_ntz)` 3-arg version to DuckDB.

Although there isn't a 1:1 mapping, the same result can be acquired by generating nested `TIMEZONE()` calls in DuckDB:

```SQL
TIMEZONE(target_tz, TIMEZONE(source_tz, timestamp_ntz::TIMESTAMP))
```

For instance:
```
Snowflake
--------------
SELECT CONVERT_TIMEZONE('AMERICA/LOS_ANGELES', 'AMERICA/NEW_YORK', '2024-08-06 09:10:00.000')
2024-08-06 12:10:00.000

DuckDB
------------
SELECT TIMEZONE('America/New_York', TIMEZONE('America/Los_Angeles', CAST('2024-08-06 09:10:00.000' AS TIMESTAMP)))
2024-08-06 12:10:00
```


Docs
--------
[Snowflake CONVERT_TIMEZONE](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone) | [DuckDB TIMEZONE](https://duckdb.org/docs/sql/functions/timestamptz.html#timezonetext-timestamp)