### PR TITLE
fix: Fix COLLATE's RHS parsing

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4376,7 +4376,8 @@ class Parser(metaclass=_Parser):
                 # fallback to Identifier / Var
                 if isinstance(expr, exp.Column) and len(expr.parts) == 1:
                     ident = expr.this
-                    this.set("expression", ident if ident.quoted else exp.var(ident.name))
+                    if isinstance(ident, exp.Identifier):
+                        this.set("expression", ident if ident.quoted else exp.var(ident.name))
 
         return this
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4360,7 +4360,25 @@ class Parser(metaclass=_Parser):
         return this
 
     def _parse_term(self) -> t.Optional[exp.Expression]:
-        return self._parse_tokens(self._parse_factor, self.TERM)
+        this = self._parse_factor()
+
+        while self._match_set(self.TERM):
+            klass = self.TERM[self._prev.token_type]
+            comments = self._prev_comments
+            expression = self._parse_factor()
+
+            this = self.expression(klass, this=this, comments=comments, expression=expression)
+
+            if isinstance(this, exp.Collate):
+                expr = this.expression
+
+                # Preserve collations such as pg_catalog."default" (Postgres) as columns, otherwise
+                # fallback to Identifier / Var
+                if isinstance(expr, exp.Column) and len(expr.parts) == 1:
+                    ident = expr.this
+                    this.set("expression", ident if ident.quoted else exp.var(ident.name))
+
+        return this
 
     def _parse_factor(self) -> t.Optional[exp.Expression]:
         parse_method = self._parse_exponent if self.EXPONENT else self._parse_unary

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -903,3 +903,18 @@ class TestParser(unittest.TestCase):
 
     def test_parse_prop_eq(self):
         self.assertIsInstance(parse_one("x(a := b and c)").expressions[0], exp.PropertyEQ)
+
+    def test_collate(self):
+        collates = [
+            ('pg_catalog."default"', exp.Column),
+            ('"en_DE"', exp.Identifier),
+            ("LATIN1_GENERAL_BIN", exp.Var),
+            ("'en'", exp.Literal),
+        ]
+
+        for collate_pair in collates:
+            collate_node = parse_one(
+                f"""SELECT * FROM t WHERE foo LIKE '%bar%' COLLATE {collate_pair[0]}"""
+            ).find(exp.Collate)
+            self.assertIsInstance(collate_node, exp.Collate)
+            self.assertIsInstance(collate_node.expression, collate_pair[1])


### PR DESCRIPTION
Fixes #3880

`COLLATE` should have a higher precedence than constructs such as `LIKE` but it's not possible to override it's parsing. For this reason, this PR unrolls `_parse_term` and transforms `COLLATE`'s RHS into an `exp.Var` (instead of `exp.Column`) if it's an unquoted identifier.