### PR TITLE
feat(bigquery): Support for GENERATE_TIMESTAMP_ARRAY, DDB transpilation

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -647,6 +647,9 @@ class Dialect(metaclass=_Dialect):
         exp.GenerateDateArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<DATE>")
         ),
+        exp.GenerateTimestampArray: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.build("ARRAY<TIMESTAMP>")
+        ),
         exp.If: lambda self, e: self._annotate_by_args(e, "true", "false"),
         exp.Interval: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
         exp.Least: lambda self, e: self._annotate_by_args(e, "expressions"),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -222,6 +222,28 @@ def _date_diff_sql(self: DuckDB.Generator, expression: exp.DateDiff) -> str:
     return self.func("DATE_DIFF", unit_to_str(expression), expr, this)
 
 
+def _generate_datetime_array_sql(
+    self: DuckDB.Generator, expression: t.Union[exp.GenerateDateArray, exp.GenerateTimestampArray]
+) -> str:
+    is_generate_date_array = isinstance(expression, exp.GenerateDateArray)
+
+    type = exp.DataType.Type.DATE if is_generate_date_array else exp.DataType.Type.TIMESTAMP
+    start = _implicit_datetime_cast(expression.args.get("start"), type=type)
+    end = _implicit_datetime_cast(expression.args.get("end"), type=type)
+
+    # BQ's GENERATE_DATE_ARRAY & GENERATE_TIMESTAMP_ARRAY are transformed to DuckDB'S GENERATE_SERIES
+    gen_series: t.Union[exp.GenerateSeries, exp.Cast] = exp.GenerateSeries(
+        start=start, end=end, step=expression.args.get("interval")
+    )
+
+    if is_generate_date_array:
+        # The GENERATE_SERIES result type is TIMESTAMP array, so to match BQ's semantics for
+        # GENERATE_DATE_ARRAY we must cast it back to DATE array
+        gen_series = exp.cast(gen_series, exp.DataType.build("ARRAY<DATE>"))
+
+    return self.sql(gen_series)
+
+
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = False
@@ -478,6 +500,8 @@ class DuckDB(Dialect):
             exp.DiToDate: lambda self,
             e: f"CAST(STRPTIME(CAST({self.sql(e, 'this')} AS TEXT), {DuckDB.DATEINT_FORMAT}) AS DATE)",
             exp.Encode: lambda self, e: encode_decode_sql(self, e, "ENCODE", replace=False),
+            exp.GenerateDateArray: _generate_datetime_array_sql,
+            exp.GenerateTimestampArray: _generate_datetime_array_sql,
             exp.Explode: rename_func("UNNEST"),
             exp.IntDiv: lambda self, e: self.binary(e, "//"),
             exp.IsInf: rename_func("ISINF"),
@@ -857,30 +881,3 @@ class DuckDB(Dialect):
                 return self.func("STRUCT_PACK", kv_sql)
 
             return self.func("STRUCT_INSERT", this, kv_sql)
-
-        def generatedatearray_sql(self, expression: exp.GenerateDateArray) -> str:
-            start = _implicit_datetime_cast(expression.args.get("start"))
-            end = _implicit_datetime_cast(expression.args.get("end"))
-
-            # BQ's GENERATE_DATE_ARRAY is transformed to DuckDB'S GENERATE_SERIES
-            gen_series = exp.GenerateSeries(
-                start=start, end=end, step=expression.args.get("interval")
-            )
-
-            # The result is TIMESTAMP array, so to match BQ's semantics we must cast it back to DATE array
-            return self.sql(exp.cast(gen_series, exp.DataType.build("ARRAY<DATE>")))
-
-        def generatetimestamparray_sql(self, expression: exp.GenerateDateArray) -> str:
-            start = _implicit_datetime_cast(
-                expression.args.get("start"), type=exp.DataType.Type.TIMESTAMP
-            )
-            end = _implicit_datetime_cast(
-                expression.args.get("end"), type=exp.DataType.Type.TIMESTAMP
-            )
-
-            # BQ's GENERATE_TIMESTAMP_ARRAY is transformed to DuckDB'S GENERATE_SERIES
-            gen_series = exp.GenerateSeries(
-                start=start, end=end, step=expression.args.get("interval")
-            )
-
-            return self.sql(gen_series)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5340,8 +5340,14 @@ class GapFill(Func):
     }
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#generate_date_array
 class GenerateDateArray(Func):
     arg_types = {"start": True, "end": True, "interval": False}
+
+
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#generate_timestamp_array
+class GenerateTimestampArray(Func):
+    arg_types = {"start": True, "end": True, "interval": True}
 
 
 class Greatest(Func):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1446,6 +1446,13 @@ WHERE
                 "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
             },
         )
+        self.validate_all(
+            "SELECT GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-07 00:00:00', INTERVAL '1' DAY)",
+            write={
+                "duckdb": "SELECT GENERATE_SERIES(CAST('2016-10-05 00:00:00' AS TIMESTAMP), CAST('2016-10-07 00:00:00' AS TIMESTAMP), INTERVAL '1' DAY)",
+                "bigquery": "SELECT GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-07 00:00:00', INTERVAL '1' DAY)",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1212,6 +1212,19 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
             exp.DataType.build("date"),
         )
 
+        self.assertEqual(
+            annotate_types(
+                optimizer.qualify.qualify(
+                    parse_one(
+                        "SELECT x FROM UNNEST(GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-06 02:00:00', interval 1 day)) AS x"
+                    )
+                )
+            )
+            .selects[0]
+            .type,
+            exp.DataType.build("timestamp"),
+        )
+
     def test_map_annotation(self):
         # ToMap annotation
         expression = annotate_types(parse_one("SELECT MAP {'x': 1}", read="duckdb"))


### PR DESCRIPTION
This PR adds support for BQ's `GENERATE_TIMESTAMP_ARRAY()`, following the implementation of `GENERATE_DATE_ARRAY()`


Docs
----------
[BQ GENERATE_TIMESTAMP_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#generate_timestamp_array) | [DuckDB GENERATE_SERIES](https://duckdb.org/docs/sql/functions/timestamp#timestamp-table-functions)