### PR TITLE
Fix(snowflake)!: parse v NOT IN (subquery) as v <> ALL (subquery)

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4241,12 +4241,18 @@ class Parser(metaclass=_Parser):
             this = self.expression(exp.Not, this=this)
 
         if negate:
-            this = self.expression(exp.Not, this=this)
+            this = self._negate_range(this)
 
         if self._match(TokenType.IS):
             this = self._parse_is(this)
 
         return this
+
+    def _negate_range(self, this: t.Optional[exp.Expression] = None) -> t.Optional[exp.Expression]:
+        if not this:
+            return this
+
+        return self.expression(exp.Not, this=this)
 
     def _parse_is(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
         index = self._index - 1

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -139,6 +139,14 @@ WHERE
             "SELECT * FROM DATA AS DATA_L ASOF JOIN DATA AS DATA_R MATCH_CONDITION (DATA_L.VAL > DATA_R.VAL) ON DATA_L.ID = DATA_R.ID"
         )
         self.validate_identity(
+            "SELECT * FROM s WHERE c NOT IN (1, 2, 3)",
+            "SELECT * FROM s WHERE NOT c IN (1, 2, 3)",
+        )
+        self.validate_identity(
+            "SELECT * FROM s WHERE c NOT IN (SELECT * FROM t)",
+            "SELECT * FROM s WHERE c <> ALL (SELECT * FROM t)",
+        )
+        self.validate_identity(
             "SELECT * FROM t1 INNER JOIN t2 USING (t1.col)",
             "SELECT * FROM t1 INNER JOIN t2 USING (col)",
         )


### PR DESCRIPTION
Fixes #3890

Reference: https://docs.snowflake.com/en/sql-reference/functions/in

> In subquery form, IN is equivalent to = ANY and NOT IN is equivalent to <> ALL.