### PR TITLE
Refactor(clickhouse)!: improve transpilation of nullable/non-nullable data types

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -957,13 +957,21 @@ class ClickHouse(Dialect):
             else:
                 dtype = super().datatype_sql(expression)
 
+            # This section makes the type `Nullable` if the following conditions hold:
+            # - It's marked as nullable - this ensures we won't wrap ClickHouse types with `Nullable`
+            #   and change their semantics
+            # - It's not the key type of a `Map`. This is because ClickHouse enforces the following
+            #   constraint on the map's key/value types: "Type of Map key must be a type, that can
+            #   be represented by integer or String or FixedString (possibly LowCardinality) or UUID
+            #   or IPv6"
+            # - It's not a non-nullable type, e.g. `Nullable(Array(...))` is not a valid type
             parent = expression.parent
             if (
                 expression.args.get("nullable") in (None, True)
-                and not isinstance(parent, exp.DataType)
                 and not (
-                    isinstance(parent, exp.ColumnDef)
-                    and isinstance(parent.parent, (exp.ColumnDef, exp.DataType))
+                    isinstance(parent, exp.DataType)
+                    and parent.is_type(exp.DataType.Type.MAP)
+                    and expression.index in (None, 0)
                 )
                 and not expression.is_type(*self.NON_NULLABLE_TYPES)
             ):

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -957,13 +957,12 @@ class ClickHouse(Dialect):
             else:
                 dtype = super().datatype_sql(expression)
 
-            # This section makes the type `Nullable` if the following conditions hold:
+            # This section changes the type to `Nullable(...)` if the following conditions hold:
             # - It's marked as nullable - this ensures we won't wrap ClickHouse types with `Nullable`
             #   and change their semantics
             # - It's not the key type of a `Map`. This is because ClickHouse enforces the following
-            #   constraint on the map's key/value types: "Type of Map key must be a type, that can
-            #   be represented by integer or String or FixedString (possibly LowCardinality) or UUID
-            #   or IPv6"
+            #   constraint: "Type of Map key must be a type, that can be represented by integer or
+            #   String or FixedString (possibly LowCardinality) or UUID or IPv6"
             # - It's not a non-nullable type, e.g. `Nullable(Array(...))` is not a valid type
             parent = expression.parent
             if (

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -966,7 +966,7 @@ class ClickHouse(Dialect):
             # - It's not a composite type, e.g. `Nullable(Array(...))` is not a valid type
             parent = expression.parent
             if (
-                expression.args.get("nullable") in (None, True)
+                expression.args.get("nullable") is not False
                 and not (
                     isinstance(parent, exp.DataType)
                     and parent.is_type(exp.DataType.Type.MAP)

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -963,7 +963,7 @@ class ClickHouse(Dialect):
             # - It's not the key type of a `Map`. This is because ClickHouse enforces the following
             #   constraint: "Type of Map key must be a type, that can be represented by integer or
             #   String or FixedString (possibly LowCardinality) or UUID or IPv6"
-            # - It's not a non-nullable type, e.g. `Nullable(Array(...))` is not a valid type
+            # - It's not a composite type, e.g. `Nullable(Array(...))` is not a valid type
             parent = expression.parent
             if (
                 expression.args.get("nullable") in (None, True)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -183,6 +183,9 @@ class _Dialect(type):
         if enum not in ("", "bigquery"):
             klass.generator_class.SELECT_KINDS = ()
 
+        if enum not in ("", "clickhouse"):
+            klass.generator_class.SUPPORTS_NULLABLE_TYPES = False
+
         if enum not in ("", "athena", "presto", "trino"):
             klass.generator_class.TRY_SUPPORTED = False
             klass.generator_class.SUPPORTS_UESCAPE = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3961,6 +3961,8 @@ class DataTypeParam(Expression):
         return self.this.name
 
 
+# The `nullable` arg is helpful when transpiling types from other dialects to ClickHouse, which
+# assumes non-nullable types by default. Values `None` and `True` mean the type is nullable.
 class DataType(Expression):
     arg_types = {
         "this": True,
@@ -3969,6 +3971,7 @@ class DataType(Expression):
         "values": False,
         "prefix": False,
         "kind": False,
+        "nullable": False,
     }
 
     class Type(AutoName):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -447,7 +447,7 @@ LANGUAGE js AS
             write={
                 "bigquery": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE), MONTH)",
                 "duckdb": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE))",
-                "clickhouse": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE))",
+                "clickhouse": "SELECT LAST_DAY(CAST('2008-11-25' AS Nullable(DATE)))",
                 "mysql": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE))",
                 "oracle": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE))",
                 "postgres": "SELECT CAST(DATE_TRUNC('MONTH', CAST('2008-11-25' AS DATE)) + INTERVAL '1 MONTH' - INTERVAL '1 DAY' AS DATE)",

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -219,19 +219,19 @@ class TestDialect(Validator):
         self.validate_all(
             "CAST(MAP('a', '1') AS MAP(TEXT, TEXT))",
             write={
-                "clickhouse": "CAST(map('a', '1') AS Map(String, String))",
+                "clickhouse": "CAST(map('a', '1') AS Map(String, Nullable(String)))",
             },
         )
         self.validate_all(
             "CAST(ARRAY(1, 2) AS ARRAY<TINYINT>)",
             write={
-                "clickhouse": "CAST([1, 2] AS Array(Int8))",
+                "clickhouse": "CAST([1, 2] AS Array(Nullable(Int8)))",
             },
         )
         self.validate_all(
             "CAST((1, 2, 3, 4) AS STRUCT<a: TINYINT, b: SMALLINT, c: INT, d: BIGINT>)",
             write={
-                "clickhouse": "CAST((1, 2, 3, 4) AS Tuple(a Int8, b Int16, c Int32, d Int64))",
+                "clickhouse": "CAST((1, 2, 3, 4) AS Tuple(a Nullable(Int8), b Nullable(Int16), c Nullable(Int32), d Nullable(Int64)))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -160,7 +160,7 @@ class TestDialect(Validator):
             "CAST(a AS TEXT)",
             write={
                 "bigquery": "CAST(a AS STRING)",
-                "clickhouse": "CAST(a AS String)",
+                "clickhouse": "CAST(a AS Nullable(String))",
                 "drill": "CAST(a AS VARCHAR)",
                 "duckdb": "CAST(a AS TEXT)",
                 "materialize": "CAST(a AS TEXT)",
@@ -181,7 +181,7 @@ class TestDialect(Validator):
             "CAST(a AS BINARY(4))",
             write={
                 "bigquery": "CAST(a AS BYTES)",
-                "clickhouse": "CAST(a AS BINARY(4))",
+                "clickhouse": "CAST(a AS Nullable(BINARY(4)))",
                 "drill": "CAST(a AS VARBINARY(4))",
                 "duckdb": "CAST(a AS BLOB(4))",
                 "materialize": "CAST(a AS BYTEA(4))",
@@ -201,7 +201,7 @@ class TestDialect(Validator):
             "CAST(a AS VARBINARY(4))",
             write={
                 "bigquery": "CAST(a AS BYTES)",
-                "clickhouse": "CAST(a AS String)",
+                "clickhouse": "CAST(a AS Nullable(String))",
                 "duckdb": "CAST(a AS BLOB(4))",
                 "materialize": "CAST(a AS BYTEA(4))",
                 "mysql": "CAST(a AS VARBINARY(4))",
@@ -229,9 +229,9 @@ class TestDialect(Validator):
             },
         )
         self.validate_all(
-            "CAST((1, 2) AS STRUCT<a: TINYINT, b: SMALLINT, c: INT, d: BIGINT>)",
+            "CAST((1, 2, 3, 4) AS STRUCT<a: TINYINT, b: SMALLINT, c: INT, d: BIGINT>)",
             write={
-                "clickhouse": "CAST((1, 2) AS Tuple(a Int8, b Int16, c Int32, d Int64))",
+                "clickhouse": "CAST((1, 2, 3, 4) AS Tuple(a Int8, b Int16, c Int32, d Int64))",
             },
         )
         self.validate_all(
@@ -328,19 +328,9 @@ class TestDialect(Validator):
                 "redshift": "CAST(a AS DOUBLE PRECISION)",
             },
             write={
-                "duckdb": "CAST(a AS DOUBLE)",
-                "drill": "CAST(a AS DOUBLE)",
-                "postgres": "CAST(a AS DOUBLE PRECISION)",
-                "redshift": "CAST(a AS DOUBLE PRECISION)",
-                "doris": "CAST(a AS DOUBLE)",
-            },
-        )
-
-        self.validate_all(
-            "CAST(a AS DOUBLE)",
-            write={
                 "bigquery": "CAST(a AS FLOAT64)",
-                "clickhouse": "CAST(a AS Float64)",
+                "clickhouse": "CAST(a AS Nullable(Float64))",
+                "doris": "CAST(a AS DOUBLE)",
                 "drill": "CAST(a AS DOUBLE)",
                 "duckdb": "CAST(a AS DOUBLE)",
                 "materialize": "CAST(a AS DOUBLE PRECISION)",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -912,12 +912,12 @@ class TestDuckDB(Validator):
             "EPOCH_MS(x)",
             write={
                 "bigquery": "TIMESTAMP_MILLIS(x)",
+                "clickhouse": "fromUnixTimestamp64Milli(CAST(x AS Nullable(Int64)))",
                 "duckdb": "EPOCH_MS(x)",
+                "mysql": "FROM_UNIXTIME(x / POWER(10, 3))",
+                "postgres": "TO_TIMESTAMP(CAST(x AS DOUBLE PRECISION) / 10 ^ 3)",
                 "presto": "FROM_UNIXTIME(CAST(x AS DOUBLE) / POW(10, 3))",
                 "spark": "TIMESTAMP_MILLIS(x)",
-                "clickhouse": "fromUnixTimestamp64Milli(CAST(x AS Int64))",
-                "postgres": "TO_TIMESTAMP(CAST(x AS DOUBLE PRECISION) / 10 ^ 3)",
-                "mysql": "FROM_UNIXTIME(x / POWER(10, 3))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1664,7 +1664,7 @@ WHERE
             },
             write={
                 "bigquery": "LAST_DAY(CAST(CURRENT_TIMESTAMP() AS DATE))",
-                "clickhouse": "LAST_DAY(CAST(CURRENT_TIMESTAMP() AS DATE))",
+                "clickhouse": "LAST_DAY(CAST(CURRENT_TIMESTAMP() AS Nullable(DATE)))",
                 "duckdb": "LAST_DAY(CAST(CURRENT_TIMESTAMP AS DATE))",
                 "mysql": "LAST_DAY(DATE(CURRENT_TIMESTAMP()))",
                 "postgres": "CAST(DATE_TRUNC('MONTH', CAST(CURRENT_TIMESTAMP AS DATE)) + INTERVAL '1 MONTH' - INTERVAL '1 DAY' AS DATE)",
@@ -1679,7 +1679,7 @@ WHERE
             "EOMONTH(GETDATE(), -1)",
             write={
                 "bigquery": "LAST_DAY(DATE_ADD(CAST(CURRENT_TIMESTAMP() AS DATE), INTERVAL -1 MONTH))",
-                "clickhouse": "LAST_DAY(DATE_ADD(MONTH, -1, CAST(CURRENT_TIMESTAMP() AS DATE)))",
+                "clickhouse": "LAST_DAY(DATE_ADD(MONTH, -1, CAST(CURRENT_TIMESTAMP() AS Nullable(DATE))))",
                 "duckdb": "LAST_DAY(CAST(CURRENT_TIMESTAMP AS DATE) + INTERVAL (-1) MONTH)",
                 "mysql": "LAST_DAY(DATE_ADD(CURRENT_TIMESTAMP(), INTERVAL -1 MONTH))",
                 "postgres": "CAST(DATE_TRUNC('MONTH', CAST(CURRENT_TIMESTAMP AS DATE) + INTERVAL '-1 MONTH') + INTERVAL '1 MONTH' - INTERVAL '1 DAY' AS DATE)",


### PR DESCRIPTION
The transpilation of data types from other dialects to ClickHouse is currently incomplete, because we don't take nullability into account. Additionally, transpiling `Nullable(T)` from ClickHouse into other dialects is incorrect, because they don't support the `Nullable` type constructor.

Simple example that demonstrates the former issue:

```
D with t as (select 1 as c union all select null as c) select cast(c as int) from t;
┌────────────────────┐
│ CAST(c AS INTEGER) │
│       int32        │
├────────────────────┤
│                  1 │
│                    │
└────────────────────┘
```

Transpiling this query (DuckDB) to ClickHouse yields:

```sql
WITH t AS (SELECT 1 AS c UNION ALL SELECT NULL AS c) SELECT CAST(c AS Int32) FROM t
```

... which fails to be executed in ClickHouse's engine, since `Int32` is not nullable by default:

```
georges-mbp :) WITH t AS (SELECT 1 AS c UNION ALL SELECT NULL AS c) SELECT CAST(c AS Int32) FROM t;

WITH t AS
    (
        SELECT 1 AS c
        UNION ALL
        SELECT NULL AS c
    )
SELECT CAST(c, 'Int32')
FROM t

Query id: ...

┌─CAST(c, 'Int32')─┐
│                1 │
└──────────────────┘
→ Progress: 0.00 rows, 0.00 B (0.00 rows/s., 0.00 B/s.)
1 row in set. Elapsed: 0.046 sec.

Received exception:
Code: 349. DB::Exception: Cannot convert NULL value to non-Nullable type: while executing 'FUNCTION CAST(c :: 0, 'Int32' :: 1) -> CAST(c, 'Int32') Int32 : 2'. (CANNOT_INSERT_NULL_IN_ORDINARY_COLUMN)
```