### PR TITLE
fix(duckdb): Fix exp.Unnest generation for BQ's nested arrays

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -593,12 +593,12 @@ class BigQuery(Dialect):
                 return None
 
             unnest_expr = seq_get(unnest.expressions, 0)
-            if unnest_expr and not unnest.args.get("alias"):
+            if unnest_expr:
                 from sqlglot.optimizer.annotate_types import annotate_types
 
                 unnest_expr = annotate_types(unnest_expr)
 
-                # Unnesting a nested array (i.e array of structs) without UNNEST alias explodes the top-level struct fields,
+                # Unnesting a nested array (i.e array of structs) explodes the top-level struct fields,
                 # in contrast to other dialects such as DuckDB which flattens only the array by default
                 if unnest_expr.is_type(exp.DataType.Type.ARRAY):
                     if any(

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -591,15 +591,15 @@ class BigQuery(Dialect):
 
             if unnest:
                 expr = seq_get(unnest.expressions, 0)
+                if expr:
+                    from sqlglot.optimizer.annotate_types import annotate_types
 
-                # Unnesting a nested array (i.e array of structs) in BQ explodes the struct fields,
-                # in contrast to other dialects such as DuckDB which flattens only the array by default
-                if (
-                    expr
-                    and (isinstance(expr, exp.Array) or expr.is_type(exp.DataType.Type.ARRAY))
-                    and expr.find(exp.Struct)
-                ):
-                    unnest.set("nested_array", True)
+                    expr = annotate_types(expr)
+
+                    # Unnesting a nested array (i.e array of structs) in BQ explodes the top-level struct fields,
+                    # in contrast to other dialects such as DuckDB which flattens only the array by default
+                    if expr.is_type(exp.DataType.Type.ARRAY) and expr.find(exp.Struct):
+                        unnest.set("explode_array", True)
 
             return unnest
 

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -600,12 +600,11 @@ class BigQuery(Dialect):
 
                 # Unnesting a nested array (i.e array of structs) explodes the top-level struct fields,
                 # in contrast to other dialects such as DuckDB which flattens only the array by default
-                if unnest_expr.is_type(exp.DataType.Type.ARRAY):
-                    if any(
-                        array_elem.is_type(exp.DataType.Type.STRUCT)
-                        for array_elem in unnest_expr._type.expressions
-                    ):
-                        unnest.set("explode_array", True)
+                if unnest_expr.is_type(exp.DataType.Type.ARRAY) and any(
+                    array_elem.is_type(exp.DataType.Type.STRUCT)
+                    for array_elem in unnest_expr._type.expressions
+                ):
+                    unnest.set("explode_array", True)
 
             return unnest
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -886,8 +886,8 @@ class DuckDB(Dialect):
             return self.func("STRUCT_INSERT", this, kv_sql)
 
         def unnest_sql(self, expression: exp.Unnest) -> str:
-            # Transpile BQ's UNNEST of nested array which must be made recursive to explode the top-level struct fields
-            # by transforming "FROM UNNEST(...)" to DDB's "FROM (SELECT UNNEST(..., max_depth => 2))"
+            # In BigQuery, UNNESTing a nested array without alias leads to explosion of the top-level array & struct
+            # This is transpiled to DDB by transforming "FROM UNNEST(...)" to DDB's "FROM (SELECT UNNEST(..., max_depth => 2))"
             explode_array = expression.args.get("explode_array")
             if explode_array:
                 expression.expressions.append(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5348,6 +5348,7 @@ class Unnest(Func, UDTF):
         "expressions": True,
         "alias": False,
         "offset": False,
+        "nested_array": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5348,7 +5348,7 @@ class Unnest(Func, UDTF):
         "expressions": True,
         "alias": False,
         "offset": False,
-        "nested_array": False,
+        "explode_array": False,
     }
 
     @property

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1474,7 +1474,7 @@ WHERE
             "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
             write={
                 "bigquery": "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
-                "duckdb": "SELECT name, laps FROM (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}, {'name': 'Makhloufi', 'laps': [24.5, 25.4, 26.6, 26.1]}], recursive => TRUE))",
+                "duckdb": "SELECT name, laps FROM (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}, {'name': 'Makhloufi', 'laps': [24.5, 25.4, 26.6, 26.1]}], max_depth => 2))",
             },
         )
 
@@ -1876,7 +1876,7 @@ OPTIONS (
             "SELECT * FROM UNNEST(ARRAY<STRUCT<device_id INT64, time DATETIME, signal INT64, state STRING>>[STRUCT(1, DATETIME '2023-11-01 09:34:01', 74, 'INACTIVE'),STRUCT(4, DATETIME '2023-11-01 09:38:01', 80, 'ACTIVE')])",
             write={
                 "bigquery": "SELECT * FROM UNNEST(CAST([STRUCT(1, CAST('2023-11-01 09:34:01' AS DATETIME), 74, 'INACTIVE'), STRUCT(4, CAST('2023-11-01 09:38:01' AS DATETIME), 80, 'ACTIVE')] AS ARRAY<STRUCT<device_id INT64, time DATETIME, signal INT64, state STRING>>))",
-                "duckdb": "SELECT * FROM (SELECT UNNEST(CAST([ROW(1, CAST('2023-11-01 09:34:01' AS TIMESTAMP), 74, 'INACTIVE'), ROW(4, CAST('2023-11-01 09:38:01' AS TIMESTAMP), 80, 'ACTIVE')] AS STRUCT(device_id BIGINT, time TIMESTAMP, signal BIGINT, state TEXT)[]), recursive => TRUE))",
+                "duckdb": "SELECT * FROM (SELECT UNNEST(CAST([ROW(1, CAST('2023-11-01 09:34:01' AS TIMESTAMP), 74, 'INACTIVE'), ROW(4, CAST('2023-11-01 09:38:01' AS TIMESTAMP), 80, 'ACTIVE')] AS STRUCT(device_id BIGINT, time TIMESTAMP, signal BIGINT, state TEXT)[]), max_depth => 2))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1470,6 +1470,13 @@ WHERE
                 "bigquery": "SELECT GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-07 00:00:00', INTERVAL '1' DAY)",
             },
         )
+        self.validate_all(
+            "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
+            write={
+                "bigquery": "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
+                "duckdb": "SELECT name, laps FROM (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}, {'name': 'Makhloufi', 'laps': [24.5, 25.4, 26.6, 26.1]}], recursive => TRUE))",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):
@@ -1869,7 +1876,7 @@ OPTIONS (
             "SELECT * FROM UNNEST(ARRAY<STRUCT<device_id INT64, time DATETIME, signal INT64, state STRING>>[STRUCT(1, DATETIME '2023-11-01 09:34:01', 74, 'INACTIVE'),STRUCT(4, DATETIME '2023-11-01 09:38:01', 80, 'ACTIVE')])",
             write={
                 "bigquery": "SELECT * FROM UNNEST(CAST([STRUCT(1, CAST('2023-11-01 09:34:01' AS DATETIME), 74, 'INACTIVE'), STRUCT(4, CAST('2023-11-01 09:38:01' AS DATETIME), 80, 'ACTIVE')] AS ARRAY<STRUCT<device_id INT64, time DATETIME, signal INT64, state STRING>>))",
-                "duckdb": "SELECT * FROM UNNEST(CAST([ROW(1, CAST('2023-11-01 09:34:01' AS TIMESTAMP), 74, 'INACTIVE'), ROW(4, CAST('2023-11-01 09:38:01' AS TIMESTAMP), 80, 'ACTIVE')] AS STRUCT(device_id BIGINT, time TIMESTAMP, signal BIGINT, state TEXT)[]))",
+                "duckdb": "SELECT * FROM (SELECT UNNEST(CAST([ROW(1, CAST('2023-11-01 09:34:01' AS TIMESTAMP), 74, 'INACTIVE'), ROW(4, CAST('2023-11-01 09:38:01' AS TIMESTAMP), 80, 'ACTIVE')] AS STRUCT(device_id BIGINT, time TIMESTAMP, signal BIGINT, state TEXT)[]), recursive => TRUE))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1470,13 +1470,6 @@ WHERE
                 "bigquery": "SELECT GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-07 00:00:00', INTERVAL '1' DAY)",
             },
         )
-        self.validate_all(
-            "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
-            write={
-                "bigquery": "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
-                "duckdb": "SELECT name, laps FROM (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}, {'name': 'Makhloufi', 'laps': [24.5, 25.4, 26.6, 26.1]}], max_depth => 2))",
-            },
-        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):
@@ -1869,7 +1862,7 @@ OPTIONS (
             "SELECT * FROM UNNEST(ARRAY<STRUCT<x INT64>>[])",
             write={
                 "bigquery": "SELECT * FROM UNNEST(CAST([] AS ARRAY<STRUCT<x INT64>>))",
-                "duckdb": "SELECT * FROM UNNEST(CAST([] AS STRUCT(x BIGINT)[]))",
+                "duckdb": "SELECT * FROM (SELECT UNNEST(CAST([] AS STRUCT(x BIGINT)[]), max_depth => 2))",
             },
         )
         self.validate_all(
@@ -1904,3 +1897,36 @@ OPTIONS (
         ]:
             with self.subTest(value):
                 self.assertEqual(exp.convert(value).sql(dialect=self.dialect), expected)
+
+    def test_unnest(self):
+        # UNNESTing a nested array without alias is transpiled to a recursive DuckDB UNNEST
+        self.validate_all(
+            "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
+            write={
+                "bigquery": "SELECT name, laps FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps), STRUCT('Makhloufi' AS name, [24.5, 25.4, 26.6, 26.1] AS laps)])",
+                "duckdb": "SELECT name, laps FROM (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}, {'name': 'Makhloufi', 'laps': [24.5, 25.4, 26.6, 26.1]}], max_depth => 2))",
+            },
+        )
+        self.validate_all(
+            "WITH Races AS (SELECT '800M' AS race) SELECT race, name, laps FROM Races AS r CROSS JOIN UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)])",
+            write={
+                "bigquery": "WITH Races AS (SELECT '800M' AS race) SELECT race, name, laps FROM Races AS r CROSS JOIN UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)])",
+                "duckdb": "WITH Races AS (SELECT '800M' AS race) SELECT race, name, laps FROM Races AS r CROSS JOIN (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}], max_depth => 2))",
+            },
+        )
+
+        # UNNESTing a nested array with alias preserves the STRUCT and is thus transpiled as-is to DuckDB
+        self.validate_all(
+            "SELECT participant FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)]) AS participant",
+            write={
+                "bigquery": "SELECT participant FROM UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)]) AS participant",
+                "duckdb": "SELECT participant FROM UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}]) AS _t0(participant)",
+            },
+        )
+        self.validate_all(
+            "WITH Races AS (SELECT '800M' AS race) SELECT race, participant FROM Races AS r CROSS JOIN UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)]) AS participant",
+            write={
+                "bigquery": "WITH Races AS (SELECT '800M' AS race) SELECT race, participant FROM Races AS r CROSS JOIN UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)]) AS participant",
+                "duckdb": "WITH Races AS (SELECT '800M' AS race) SELECT race, participant FROM Races AS r CROSS JOIN UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}]) AS _t0(participant)",
+            },
+        )


### PR DESCRIPTION
In BigQuery `UNNEST`ing a nested array (i.e array of structs) explodes the struct fields, e.g.:

```SQL
BQ> SELECT name, age FROM UNNEST([STRUCT('Foo' AS name, 25 AS age), STRUCT('Bar' AS name, 34 AS age)]);

name	age
----------------
Foo	 25
Bar	 34
```

On main branch the `UNNEST()` is transpiled as-is, leading to invalid DuckDB:
```SQL
D> SELECT name, age FROM UNNEST([{'name': 'Foo', 'age': 25}, {'name': 'Bar', 'age': 34}]);

Error: Binder Error: Referenced column "name" not found in FROM clause!
```

This is because DuckDB's `UNNEST()` will always unnest one level by default, so the result is the underlying struct(s):
```SQL
D> SELECT * FROM UNNEST([{'name': 'Foo', 'age': 25}, {'name': 'Bar', 'age': 34}]);

{'name': Foo, 'age': 25}    
{'name': Bar, 'age': 34}
```

This PR fixes this issue by using DuckDB's _recursive_ specifier which matches BQ's semantics by unnesting both the array and the top-level struct:

```SQL
D> SELECT name, age FROM (SELECT UNNEST([{'name': 'Foo', 'age': 25}, {'name': 'Bar', 'age': 34}], max_depth => 2));

name       age
varchar   int32
----------------
Foo        25
Bar        34
```


Docs
--------
[BigQuery UNNEST](https://cloud.google.com/bigquery/docs/arrays) | [DuckDB UNNEST](https://duckdb.org/docs/sql/query_syntax/unnest.html)