### PR TITLE
Fix!: Redshift date format

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -48,12 +48,9 @@ class Redshift(Postgres):
     HEX_LOWERCASE = True
     HAS_DISTINCT_ARRAY_CONSTRUCTORS = True
 
-    TIME_FORMAT = "'YYYY-MM-DD HH:MI:SS'"
-    TIME_MAPPING = {
-        **Postgres.TIME_MAPPING,
-        "MON": "%b",
-        "HH": "%H",
-    }
+    # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
+    TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
+    TIME_MAPPING = {**Postgres.TIME_MAPPING, "MON": "%b", "HH24": "%H", "HH": "%I"}
 
     class Parser(Postgres.Parser):
         FUNCTIONS = {

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -582,7 +582,7 @@ class TestDialect(Validator):
                 "hive": "CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(x, 'yyyy-MM-ddTHH:mm:ss')) AS TIMESTAMP)",
                 "presto": "DATE_PARSE(x, '%Y-%m-%dT%T')",
                 "drill": "TO_TIMESTAMP(x, 'yyyy-MM-dd''T''HH:mm:ss')",
-                "redshift": "TO_TIMESTAMP(x, 'YYYY-MM-DDTHH:MI:SS')",
+                "redshift": "TO_TIMESTAMP(x, 'YYYY-MM-DDTHH24:MI:SS')",
                 "spark": "TO_TIMESTAMP(x, 'yyyy-MM-ddTHH:mm:ss')",
             },
         )

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -620,3 +620,9 @@ FROM (
             "select a.foo, b.bar, a.baz from a, b where a.baz = b.baz (+)",
             "SELECT a.foo, b.bar, a.baz FROM a, b WHERE a.baz = b.baz (+)",
         )
+
+    def test_time(self):
+        self.validate_all(
+            "TIME_TO_STR(a, '%Y-%m-%d %H:%M:%S.%f')",
+            write={"redshift": "TO_CHAR(a, 'YYYY-MM-DD HH24:MI:SS.US')"},
+        )


### PR DESCRIPTION
The Redshift dialect has a subtle bug in its timestamp formatting.

When mapping strftime strings like `%Y-%m-%d %H:%M:%S`,  the Redshift equivalent is being generated as:
```
SELECT TO_CHAR(timestamp '2023-01-01 15:13:14', 'YYYY-MM-DD HH:MI:SS.US')
> '2023-01-01 03:13:14.000000'
```
which wraps around the hours because `%H` (24-hour) is being mapped to `HH` (12-hour) [instead of](https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html) `HH24`.

The correct format string is:
```
SELECT TO_CHAR(timestamp '2023-01-01 15:13:14', 'YYYY-MM-DD HH24:MI:SS.US')
> '2023-01-01 15:13:14.000000'
```