### PR TITLE
Refactor(clickhouse)!: attach INTERPOLATE expressions to WithFill

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2472,17 +2472,17 @@ class Offset(Expression):
 
 
 class Order(Expression):
-    arg_types = {
-        "this": False,
-        "expressions": True,
-        "interpolate": False,
-        "siblings": False,
-    }
+    arg_types = {"this": False, "expressions": True, "siblings": False}
 
 
 # https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier
 class WithFill(Expression):
-    arg_types = {"from": False, "to": False, "step": False}
+    arg_types = {
+        "from": False,
+        "to": False,
+        "step": False,
+        "interpolate": False,
+    }
 
 
 # hive specific sorts

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2183,15 +2183,7 @@ class Generator(metaclass=_Generator):
         this = self.sql(expression, "this")
         this = f"{this} " if this else this
         siblings = "SIBLINGS " if expression.args.get("siblings") else ""
-        order = self.op_expressions(f"{this}ORDER {siblings}BY", expression, flat=this or flat)  # type: ignore
-        interpolated_values = [
-            f"{self.sql(named_expression, 'alias')} AS {self.sql(named_expression, 'this')}"
-            for named_expression in expression.args.get("interpolate") or []
-        ]
-        interpolate = (
-            f" INTERPOLATE ({', '.join(interpolated_values)})" if interpolated_values else ""
-        )
-        return f"{order}{interpolate}"
+        return self.op_expressions(f"{this}ORDER {siblings}BY", expression, flat=this or flat)  # type: ignore
 
     def withfill_sql(self, expression: exp.WithFill) -> str:
         from_sql = self.sql(expression, "from")
@@ -2200,7 +2192,14 @@ class Generator(metaclass=_Generator):
         to_sql = f" TO {to_sql}" if to_sql else ""
         step_sql = self.sql(expression, "step")
         step_sql = f" STEP {step_sql}" if step_sql else ""
-        return f"WITH FILL{from_sql}{to_sql}{step_sql}"
+        interpolated_values = [
+            f"{self.sql(named_expression, 'alias')} AS {self.sql(named_expression, 'this')}"
+            for named_expression in expression.args.get("interpolate") or []
+        ]
+        interpolate = (
+            f" INTERPOLATE ({', '.join(interpolated_values)})" if interpolated_values else ""
+        )
+        return f"WITH FILL{from_sql}{to_sql}{step_sql}{interpolate}"
 
     def cluster_sql(self, expression: exp.Cluster) -> str:
         return self.op_expressions("CLUSTER BY", expression)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4008,7 +4008,6 @@ class Parser(metaclass=_Parser):
             exp.Order,
             this=this,
             expressions=self._parse_csv(self._parse_ordered),
-            interpolate=self._parse_interpolate(),
             siblings=siblings,
         )
 
@@ -4053,6 +4052,7 @@ class Parser(metaclass=_Parser):
                     "from": self._match(TokenType.FROM) and self._parse_bitwise(),
                     "to": self._match_text_seq("TO") and self._parse_bitwise(),
                     "step": self._match_text_seq("STEP") and self._parse_bitwise(),
+                    "interpolate": self._parse_interpolate(),
                 },
             )
         else:


### PR DESCRIPTION
The `INTERPOLATE` list can only appear after a `WITH FILL` clause, so this PR modifies the AST accordingly. This will enable us to parse the whole `WITH FILL` syntax using a simple `maybe_parse(..., into=exp.Ordered)`, which may come in handy in SQLMesh (context: `ORDER BY` physical table [property](https://github.com/TobikoData/sqlmesh/pull/3019/files#diff-3a65217abd7bfdec09572b0392317d88128cda9d14ea6aa0009699eea6f2b5f0R268)).

Tested the following queries against a local ClickHouse server:

```sql
georges-mbp.home :) SELECT n, source, inter FROM (
   SELECT toFloat32(number % 10) AS n, 'original' AS source, number as inter
   FROM numbers(10) WHERE number % 3 = 1
) ORDER BY n INTERPOLATE (inter AS inter + 1);

Syntax error: failed at position 163 ('INTERPOLATE') (line 4, col 14): [...]

Expected one of: token, Dot, OR, AND, IS NOT DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, alias, AS, Comma, LIMIT, OFFSET, FETCH, SETTINGS, UNION, EXCEPT, INTERSECT, INTO OUTFILE, FORMAT, end of query
```
If you do this instead, it works:

```sql
georges-mbp.home :) SELECT n, source, inter FROM (
   SELECT toFloat32(number % 10) AS n, 'original' AS source, number as inter
   FROM numbers(10) WHERE number % 3 = 1
) ORDER BY n WITH FILL FROM 0 TO 5.51 STEP 0.5
INTERPOLATE ( inter AS inter + 1 )
```

References:
- https://clickhouse.com/docs/en/sql-reference/statements/select/order-by#order-by-expr-with-fill-modifier
- https://github.com/ClickHouse/ClickHouse/pull/35349/files#diff-2b8b7105a51cdc855d8a1d12d2d7e2c2cf3eaa178e131be1b217bd855d0dd071R250-R266