### PR TITLE
fix(bigquery): Map strftime %-d to BQ %e

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -252,6 +252,7 @@ class BigQuery(Dialect):
     TIME_MAPPING = {
         "%D": "%m/%d/%y",
         "%E6S": "%S.%f",
+        "%e": "%-d",
     }
 
     FORMAT_MAPPING = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1470,6 +1470,13 @@ WHERE
                 "bigquery": "SELECT GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-07 00:00:00', INTERVAL '1' DAY)",
             },
         )
+        self.validate_all(
+            "SELECT PARSE_DATE('%A %b %e %Y', 'Thursday Dec 25 2008')",
+            write={
+                "bigquery": "SELECT PARSE_DATE('%A %b %e %Y', 'Thursday Dec 25 2008')",
+                "duckdb": "SELECT CAST(STRPTIME('Thursday Dec 25 2008', '%A %b %-d %Y') AS DATE)",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -961,7 +961,7 @@ class TestDuckDB(Validator):
         self.validate_all(
             "STRPTIME(x, '%-m/%-d/%y %-I:%M %p')",
             write={
-                "bigquery": "PARSE_TIMESTAMP('%-m/%-d/%y %-I:%M %p', x)",
+                "bigquery": "PARSE_TIMESTAMP('%-m/%e/%y %-I:%M %p', x)",
                 "duckdb": "STRPTIME(x, '%-m/%-d/%y %-I:%M %p')",
                 "presto": "DATE_PARSE(x, '%c/%e/%y %l:%i %p')",
                 "hive": "CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(x, 'M/d/yy h:mm a')) AS TIMESTAMP)",


### PR DESCRIPTION
BigQuery uses `%d` for zero-padded days (`05`) and `%e` otherwise (`5`), in contrast to DuckDB / Python which have `%d` and `%-d` respectively.


Docs
--------
[DuckDB Format](https://duckdb.org/docs/sql/functions/dateformat.html#format-specifiers) | [BigQuery Format](https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_elements_date_time) | [Python strftime](https://strftime.org/)