### PR TITLE
fix(optimizer): convert TsOrDsToDate to Cast more conservatively

### DIFF
--- a/sqlglot/optimizer/canonicalize.py
+++ b/sqlglot/optimizer/canonicalize.py
@@ -40,6 +40,8 @@ def replace_date_funcs(node: exp.Expression) -> exp.Expression:
         isinstance(node, (exp.Date, exp.TsOrDsToDate))
         and not node.expressions
         and not node.args.get("zone")
+        and node.this.is_string
+        and is_iso_date(node.this.name)
     ):
         return exp.cast(node.this, to=exp.DataType.Type.DATE)
     if isinstance(node, exp.Timestamp) and not node.args.get("zone"):
@@ -88,6 +90,12 @@ def remove_redundant_casts(expression: exp.Expression) -> exp.Expression:
         isinstance(expression, exp.Cast)
         and expression.this.type
         and expression.to.this == expression.this.type.this
+    ):
+        return expression.this
+    if (
+        isinstance(expression, (exp.Date, exp.TsOrDsToDate))
+        and expression.this.type
+        and expression.this.type.this == exp.DataType.Type.DATE
     ):
         return expression.this
     return expression

--- a/tests/fixtures/optimizer/canonicalize.sql
+++ b/tests/fixtures/optimizer/canonicalize.sql
@@ -52,6 +52,10 @@ SELECT "x"."a" AS "a" FROM "x" AS "x" WHERE CASE WHEN COALESCE("x"."b" <> 0, 1 <
 DATE('2023-01-01');
 CAST('2023-01-01' AS DATE);
 
+-- Some dialects only allow dates
+DATE('2023-01-01 00:00:00');
+DATE('2023-01-01 00:00:00');
+
 TIMESTAMP('2023-01-01');
 CAST('2023-01-01' AS TIMESTAMP);
 


### PR DESCRIPTION
Some dialects (presto/trino) are strict about casting to date.