### PR TITLE
Fix!: mysql/tsql datetime precision, formatting, exp.AtTimeZone

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1246,26 +1246,22 @@ def right_to_substring_sql(self: Generator, expression: exp.Left) -> str:
 def timestrtotime_sql(
     self: Generator,
     expression: exp.TimeStrToTime,
-    include_precision: bool | t.Callable[[exp.DataType.Type], bool] = False,
+    include_precision: bool = False,
 ) -> str:
-    datatype = (
+    datatype = exp.DataType.build(
         exp.DataType.Type.TIMESTAMPTZ
         if expression.args.get("zone")
         else exp.DataType.Type.TIMESTAMP
     )
 
-    if callable(include_precision):
-        include_precision = include_precision(datatype)
-
-    datatype_built = exp.DataType.build(datatype)
     if isinstance(expression.this, exp.Literal) and include_precision:
         precision = subsecond_precision(expression.this.name)
         if precision > 0:
-            datatype_built = exp.DataType.build(
-                datatype, expressions=[exp.DataTypeParam(this=exp.Literal.number(precision))]
+            datatype = exp.DataType.build(
+                datatype.this, expressions=[exp.DataTypeParam(this=exp.Literal.number(precision))]
             )
 
-    return self.sql(exp.cast(expression.this, datatype_built, dialect=self.dialect))
+    return self.sql(exp.cast(expression.this, datatype, dialect=self.dialect))
 
 
 def datestrtodate_sql(self: Generator, expression: exp.DateStrToDate) -> str:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -686,9 +686,6 @@ class MySQL(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.ArrayAgg: rename_func("GROUP_CONCAT"),
-            exp.AtTimeZone: lambda self, e: self.func(
-                "CONVERT_TZ", e.this, exp.var("@@global.time_zone"), e.args.get("zone")
-            ),
             exp.CurrentDate: no_paren_current_date_sql,
             exp.DateDiff: _remove_ts_or_ds_to_date(
                 lambda self, e: self.func("DATEDIFF", e.this, e.expression), ("this", "expression")
@@ -1216,3 +1213,7 @@ class MySQL(Dialect):
             dt = expression.args.get("timestamp")
 
             return self.func("CONVERT_TZ", dt, from_tz, to_tz)
+
+        def attimezone_sql(self, expression: exp.AtTimeZone) -> str:
+            self.unsupported("AT TIME ZONE is not supported by MySQL")
+            return self.sql(expression.this)

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -735,7 +735,7 @@ class MySQL(Dialect):
             exp.TimeStrToTime: lambda self, e: timestrtotime_sql(
                 self,
                 e,
-                include_precision=lambda datatype: datatype != exp.DataType.Type.TIMESTAMPTZ,
+                include_precision=not e.args.get("zone"),
             ),
             exp.TimeToStr: _remove_ts_or_ds_to_date(
                 lambda self, e: self.func("DATE_FORMAT", e.this, self.format_time(e))

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from sqlglot import exp
-from sqlglot.dialects.dialect import merge_without_target_sql, trim_sql
+from sqlglot.dialects.dialect import merge_without_target_sql, trim_sql, timestrtotime_sql
 from sqlglot.dialects.presto import Presto
 
 
@@ -21,6 +21,7 @@ class Trino(Presto):
             exp.ArraySum: lambda self,
             e: f"REDUCE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.Merge: merge_without_target_sql,
+            exp.TimeStrToTime: lambda self, e: timestrtotime_sql(self, e, include_precision=True),
             exp.Trim: trim_sql,
         }
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -395,7 +395,7 @@ class TSQL(Dialect):
         "HH": "%H",
         "H": "%-H",
         "h": "%-I",
-        "S": "%f",
+        "ffffff": "%f",
         "yyyy": "%Y",
         "yy": "%y",
     }
@@ -983,7 +983,10 @@ class TSQL(Dialect):
             return super().setitem_sql(expression)
 
         def boolean_sql(self, expression: exp.Boolean) -> str:
-            if type(expression.parent) in BIT_TYPES:
+            if (
+                type(expression.parent) in BIT_TYPES
+                or expression.find_ancestor(exp.Values) is not None
+            ):
                 return "1" if expression.this else "0"
 
             return "(1 = 1)" if expression.this else "(1 = 0)"

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -983,9 +983,8 @@ class TSQL(Dialect):
             return super().setitem_sql(expression)
 
         def boolean_sql(self, expression: exp.Boolean) -> str:
-            if (
-                type(expression.parent) in BIT_TYPES
-                or expression.find_ancestor(exp.Values) is not None
+            if type(expression.parent) in BIT_TYPES or isinstance(
+                expression.find_ancestor(exp.Values, exp.Select), exp.Values
             ):
                 return "1" if expression.this else "0"
 

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -665,13 +665,15 @@ TIMEZONES = {
 
 
 def subsecond_precision(timestamp_literal: str) -> int:
-    # Given an ISO-8601 timestamp literal, eg '2023-01-01 12:13:14.123456+00:00'
-    # figure out its subsecond precision so we can construct types like DATETIME(6)
-    #
-    # Note that in practice, this is either 3 or 6 digits (3 = millisecond precision, 6 = microsecond precision)
-    # - 6 is the maximum because strftime's '%f' formats to microseconds and almost every database supports microsecond precision in timestamps
-    # - Except Presto/Trino which in most cases only supports millisecond precision but will still honour '%f' and format to microseconds (replacing the remaining 3 digits with 0's)
-    # - Python prior to 3.11 only supports 0, 3 or 6 digits in a timestamp literal. Any other amounts will throw a 'ValueError: Invalid isoformat string:' error
+    """
+    Given an ISO-8601 timestamp literal, eg '2023-01-01 12:13:14.123456+00:00'
+    figure out its subsecond precision so we can construct types like DATETIME(6)
+
+    Note that in practice, this is either 3 or 6 digits (3 = millisecond precision, 6 = microsecond precision)
+    - 6 is the maximum because strftime's '%f' formats to microseconds and almost every database supports microsecond precision in timestamps
+    - Except Presto/Trino which in most cases only supports millisecond precision but will still honour '%f' and format to microseconds (replacing the remaining 3 digits with 0's)
+    - Python prior to 3.11 only supports 0, 3 or 6 digits in a timestamp literal. Any other amounts will throw a 'ValueError: Invalid isoformat string:' error
+    """
     try:
         parsed = datetime.datetime.fromisoformat(timestamp_literal)
         subsecond_digit_count = len(str(parsed.microsecond).rstrip("0"))

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -671,6 +671,7 @@ def subsecond_precision(timestamp_literal: str) -> int:
     # Note that in practice, this is either 3 or 6 digits (3 = millisecond precision, 6 = microsecond precision)
     # - 6 is the maximum because strftime's '%f' formats to microseconds and almost every database supports microsecond precision in timestamps
     # - Except Presto/Trino which in most cases only supports millisecond precision but will still honour '%f' and format to microseconds (replacing the remaining 3 digits with 0's)
+    # - Python prior to 3.11 only supports 0, 3 or 6 digits in a timestamp literal. Any other amounts will throw a 'ValueError: Invalid isoformat string:' error
     try:
         parsed = datetime.datetime.fromisoformat(timestamp_literal)
         subsecond_digit_count = len(str(parsed.microsecond).rstrip("0"))

--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -1,4 +1,5 @@
 import typing as t
+import datetime
 
 # The generic time format is based on python time.strftime.
 # https://docs.python.org/3/library/time.html#time.strftime
@@ -661,3 +662,23 @@ TIMEZONES = {
         "Zulu",
     )
 }
+
+
+def subsecond_precision(timestamp_literal: str) -> int:
+    # Given an ISO-8601 timestamp literal, eg '2023-01-01 12:13:14.123456+00:00'
+    # figure out its subsecond precision so we can construct types like DATETIME(6)
+    #
+    # Note that in practice, this is either 3 or 6 digits (3 = millisecond precision, 6 = microsecond precision)
+    # - 6 is the maximum because strftime's '%f' formats to microseconds and almost every database supports microsecond precision in timestamps
+    # - Except Presto/Trino which in most cases only supports millisecond precision but will still honour '%f' and format to microseconds (replacing the remaining 3 digits with 0's)
+    try:
+        parsed = datetime.datetime.fromisoformat(timestamp_literal)
+        subsecond_digit_count = len(str(parsed.microsecond).rstrip("0"))
+        precision = 0
+        if subsecond_digit_count > 3:
+            precision = 6
+        elif subsecond_digit_count > 0:
+            precision = 3
+        return precision
+    except ValueError:
+        return 0

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -656,13 +656,29 @@ class TestDialect(Validator):
             },
         )
         self.validate_all(
+            "TIME_STR_TO_TIME('2020-01-01 12:13:14.123456+00:00')",
+            write={
+                "mysql": "CAST('2020-01-01 12:13:14.123456+00:00' AS DATETIME(6))",
+                "trino": "CAST('2020-01-01 12:13:14.123456+00:00' AS TIMESTAMP(6))",
+                "presto": "CAST('2020-01-01 12:13:14.123456+00:00' AS TIMESTAMP)",
+            },
+        )
+        self.validate_all(
+            "TIME_STR_TO_TIME('2020-01-01 12:13:14.123-08:00', 'America/Los_Angeles')",
+            write={
+                "mysql": "TIMESTAMP('2020-01-01 12:13:14.123-08:00')",
+                "trino": "CAST('2020-01-01 12:13:14.123-08:00' AS TIMESTAMP(3) WITH TIME ZONE)",
+                "presto": "CAST('2020-01-01 12:13:14.123-08:00' AS TIMESTAMP WITH TIME ZONE)",
+            },
+        )
+        self.validate_all(
             "TIME_STR_TO_TIME('2020-01-01 12:13:14-08:00', 'America/Los_Angeles')",
             write={
                 "bigquery": "CAST('2020-01-01 12:13:14-08:00' AS TIMESTAMP)",
                 "databricks": "CAST('2020-01-01 12:13:14-08:00' AS TIMESTAMP)",
                 "duckdb": "CAST('2020-01-01 12:13:14-08:00' AS TIMESTAMPTZ)",
                 "tsql": "CAST('2020-01-01 12:13:14-08:00' AS DATETIMEOFFSET) AT TIME ZONE 'UTC'",
-                "mysql": "CAST('2020-01-01 12:13:14-08:00' AS DATETIME)",
+                "mysql": "TIMESTAMP('2020-01-01 12:13:14-08:00')",
                 "postgres": "CAST('2020-01-01 12:13:14-08:00' AS TIMESTAMPTZ)",
                 "redshift": "CAST('2020-01-01 12:13:14-08:00' AS TIMESTAMP WITH TIME ZONE)",
                 "snowflake": "CAST('2020-01-01 12:13:14-08:00' AS TIMESTAMPTZ)",
@@ -683,7 +699,7 @@ class TestDialect(Validator):
                 "databricks": "CAST(col AS TIMESTAMP)",
                 "duckdb": "CAST(col AS TIMESTAMPTZ)",
                 "tsql": "CAST(col AS DATETIMEOFFSET) AT TIME ZONE 'UTC'",
-                "mysql": "CAST(col AS DATETIME)",
+                "mysql": "TIMESTAMP(col)",
                 "postgres": "CAST(col AS TIMESTAMPTZ)",
                 "redshift": "CAST(col AS TIMESTAMP WITH TIME ZONE)",
                 "snowflake": "CAST(col AS TIMESTAMPTZ)",
@@ -720,6 +736,13 @@ class TestDialect(Validator):
                 "presto": "DATE_FORMAT(x, '%Y-%m-%d')",
                 "redshift": "TO_CHAR(x, 'YYYY-MM-DD')",
                 "doris": "DATE_FORMAT(x, '%Y-%m-%d')",
+            },
+        )
+        self.validate_all(
+            "TIME_TO_STR(a, '%Y-%m-%d %H:%M:%S.%f')",
+            write={
+                "redshift": "TO_CHAR(a, 'YYYY-MM-DD HH24:MI:SS.US')",
+                "tsql": "FORMAT(a, 'yyyy-MM-dd HH:mm:ss.ffffff')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1,3 +1,6 @@
+import unittest
+import sys
+
 from sqlglot import expressions as exp
 from sqlglot.dialects.mysql import MySQL
 from tests.dialects.test_dialect import Validator
@@ -643,24 +646,8 @@ class TestMySQL(Validator):
             write_sql="SELECT CAST('2023-01-01 13:14:15.123456+00:00' AS DATETIME(6))",
         )
         self.validate_identity(
-            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.12345+00:00')",
-            write_sql="SELECT CAST('2023-01-01 13:14:15.12345+00:00' AS DATETIME(6))",
-        )
-        self.validate_identity(
-            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.1234+00:00')",
-            write_sql="SELECT CAST('2023-01-01 13:14:15.1234+00:00' AS DATETIME(6))",
-        )
-        self.validate_identity(
             "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.123+00:00')",
             write_sql="SELECT CAST('2023-01-01 13:14:15.123+00:00' AS DATETIME(3))",
-        )
-        self.validate_identity(
-            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.12+00:00')",
-            write_sql="SELECT CAST('2023-01-01 13:14:15.12+00:00' AS DATETIME(3))",
-        )
-        self.validate_identity(
-            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.1+00:00')",
-            write_sql="SELECT CAST('2023-01-01 13:14:15.1+00:00' AS DATETIME(3))",
         )
         self.validate_identity(
             "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15+00:00')",
@@ -682,6 +669,28 @@ class TestMySQL(Validator):
         self.validate_identity(
             "SELECT foo AT TIME ZONE 'UTC'",
             write_sql="SELECT CONVERT_TZ(foo, @@global.time_zone, 'UTC')",
+        )
+
+    @unittest.skipUnless(
+        sys.version_info >= (3, 11),
+        "Python 3.11 relaxed datetime.fromisoformat() parsing with regards to microseconds",
+    )
+    def test_mysql_time_python311(self):
+        self.validate_identity(
+            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.12345+00:00')",
+            write_sql="SELECT CAST('2023-01-01 13:14:15.12345+00:00' AS DATETIME(6))",
+        )
+        self.validate_identity(
+            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.1234+00:00')",
+            write_sql="SELECT CAST('2023-01-01 13:14:15.1234+00:00' AS DATETIME(6))",
+        )
+        self.validate_identity(
+            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.12+00:00')",
+            write_sql="SELECT CAST('2023-01-01 13:14:15.12+00:00' AS DATETIME(3))",
+        )
+        self.validate_identity(
+            "SELECT TIME_STR_TO_TIME('2023-01-01 13:14:15.1+00:00')",
+            write_sql="SELECT CAST('2023-01-01 13:14:15.1+00:00' AS DATETIME(3))",
         )
 
     def test_mysql(self):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -412,6 +412,12 @@ class TestTSQL(Validator):
             },
         )
 
+        # Check that TRUE and FALSE dont get expanded to (1=1) or (1=0) when used in a VALUES expression
+        self.validate_identity(
+            "SELECT val FROM (VALUES ((TRUE), (FALSE), (NULL))) AS t(val)",
+            write_sql="SELECT val FROM (VALUES ((1), (0), (NULL))) AS t(val)",
+        )
+
     def test_option(self):
         possible_options = [
             "HASH GROUP",

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 
 from sqlglot.time import format_time, subsecond_precision
 
@@ -14,13 +15,20 @@ class TestTime(unittest.TestCase):
         self.assertEqual(format_time("da", mapping), "db")
 
     def test_subsecond_precision(self):
-        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.123456789+00:00"))
         self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.123456+00:00"))
-        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.12345+00:00"))
-        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.1234+00:00"))
         self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.123+00:00"))
-        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.12+00:00"))
-        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.1+00:00"))
         self.assertEqual(0, subsecond_precision("2023-01-01 12:13:14+00:00"))
         self.assertEqual(0, subsecond_precision("2023-01-01 12:13:14"))
         self.assertEqual(0, subsecond_precision("garbage"))
+
+    @unittest.skipUnless(
+        sys.version_info >= (3, 11),
+        "Python 3.11 relaxed datetime.fromisoformat() parsing with regards to microseconds",
+    )
+    def test_subsecond_precision_python311(self):
+        # ref: https://docs.python.org/3/whatsnew/3.11.html#datetime
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.123456789+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.12345+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.1234+00:00"))
+        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.12+00:00"))
+        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.1+00:00"))

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sqlglot.time import format_time
+from sqlglot.time import format_time, subsecond_precision
 
 
 class TestTime(unittest.TestCase):
@@ -12,3 +12,15 @@ class TestTime(unittest.TestCase):
         self.assertEqual(format_time("aa", mapping), "c")
         self.assertEqual(format_time("aaada", mapping), "cbdb")
         self.assertEqual(format_time("da", mapping), "db")
+
+    def test_subsecond_precision(self):
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.123456789+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.123456+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.12345+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.1234+00:00"))
+        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.123+00:00"))
+        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.12+00:00"))
+        self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.1+00:00"))
+        self.assertEqual(0, subsecond_precision("2023-01-01 12:13:14+00:00"))
+        self.assertEqual(0, subsecond_precision("2023-01-01 12:13:14"))
+        self.assertEqual(0, subsecond_precision("garbage"))


### PR DESCRIPTION
## MySQL

1. Fix DATETIME subsecond precision on `exp.TimeStrToTime` when generating casts for literals

```
>>> parse_one("TIME_STR_TO_TIME('2020-01-01 12:13:14.123456+00:00')").dialect("mysql")

-- BEFORE
select CAST(TIMESTAMP('2020-01-01 12:13:14.123456') AS DATETIME)
> 2020-01-01 12:13:14

-- AFTER
select CAST(TIMESTAMP('2020-01-01 12:13:14.123456') AS DATETIME(6))
> 2020-01-01 12:13:14.123456
```

2. Raise a warning in the MySQL generator if it encounters an `exp.AtTimeZone` node.
```
>>> parse_one("select foo at time zone 'UTC' from tbl").sql(dialect="mysql")

-- BEFORE
'SELECT foo AT TIME ZONE 'UTC' FROM tbl'
! You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'TIME ZONE 'UTC'

-- AFTER
AT TIME ZONE is not supported by MySQL
'SELECT foo FROM tbl'
```

## TSQL

1. Fix '%f' strftime mapping for microseconds. When mapping `%Y-%m-%d %H:%M:%S.%f`:
```
>>> parse_one("TIME_TO_STR(a, '%Y-%m-%d %H:%M:%S.%f')").sql(dialect="tsql")

-- BEFORE
select FORMAT(a, 'yyyy-MM-dd HH:mm:ss.S')
> 2023-01-01 12:13:14.S

-- AFTER
select FORMAT(a, 'yyyy-MM-dd HH:mm:ss.ffffff')
> 2023-01-01 12:13:14.123456
```

2. Fix boolean values in `VALUES()` expression.
```
>>> parse_one("SELECT val FROM (VALUES ((TRUE), (FALSE), (NULL))) AS t(val)").sql(dialect="tsql")

-- BEFORE
'SELECT val FROM (VALUES (((1 = 1)), ((1 = 0)), (NULL))) AS t(val)'
!SQL Error [102] [S0001]: Incorrect syntax near '='.

-- AFTER
'SELECT val FROM (VALUES ((1), (0), (NULL))) AS t(val)'
```
