### PR TITLE
fix(oracle): Revert NVL() being parsed into exp.Anonymous

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -107,8 +107,10 @@ class Oracle(Dialect):
             "TO_CHAR": _build_timetostr_or_tochar,
             "TO_TIMESTAMP": build_formatted_time(exp.StrToTime, "oracle"),
             "TO_DATE": build_formatted_time(exp.StrToDate, "oracle"),
+            "NVL": lambda args: exp.Coalesce(
+                this=seq_get(args, 0), expressions=args[1:], is_nvl=True
+            ),
         }
-        FUNCTIONS.pop("NVL")
 
         NO_PAREN_FUNCTION_PARSERS = {
             **parser.Parser.NO_PAREN_FUNCTION_PARSERS,
@@ -313,3 +315,7 @@ class Oracle(Dialect):
             value = f" CONSTRAINT {value}" if value else ""
 
             return f"{option}{value}"
+
+        def coalesce_sql(self, expression: exp.Coalesce) -> str:
+            func_name = "NVL" if expression.args.get("is_nvl") else "COALESCE"
+            return rename_func(func_name)(self, expression)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5087,7 +5087,7 @@ class Ceil(Func):
 
 
 class Coalesce(Func):
-    arg_types = {"this": True, "expressions": False}
+    arg_types = {"this": True, "expressions": False, "is_nvl": False}
     is_var_len_args = True
     _sql_names = ["COALESCE", "IFNULL", "NVL"]
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1302,7 +1302,7 @@ class Generator(metaclass=_Generator):
     def fetch_sql(self, expression: exp.Fetch) -> str:
         direction = expression.args.get("direction")
         direction = f" {direction}" if direction else ""
-        count = expression.args.get("count")
+        count = self.sql(expression, "count")
         count = f" {count}" if count else ""
         if expression.args.get("percent"):
             count = f"{count} PERCENT"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -222,6 +222,7 @@ class Parser(metaclass=_Parser):
         "UNNEST": lambda args: exp.Unnest(expressions=ensure_list(seq_get(args, 0))),
         "UPPER": build_upper,
         "VAR_MAP": build_var_map,
+        "COALESCE": lambda args: exp.Coalesce(this=seq_get(args, 0), expressions=args[1:]),
     }
 
     NO_PAREN_FUNCTIONS = {

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -89,7 +89,6 @@ class TestOracle(Validator):
         self.validate_identity(
             "SELECT * FROM T ORDER BY I OFFSET NVL(:variable1, 10) ROWS FETCH NEXT NVL(:variable2, 10) ROWS ONLY",
         )
-        self.validate_identity("NVL(x, y)").assert_is(exp.Anonymous)
         self.validate_identity(
             "SELECT * FROM t SAMPLE (.25)",
             "SELECT * FROM t SAMPLE (0.25)",
@@ -251,6 +250,15 @@ class TestOracle(Validator):
         self.validate_identity(
             """SELECT * FROM t ORDER BY a ASC NULLS LAST, b ASC NULLS FIRST, c DESC NULLS LAST, d DESC NULLS FIRST""",
             """SELECT * FROM t ORDER BY a ASC, b ASC NULLS FIRST, c DESC NULLS LAST, d DESC""",
+        )
+
+        self.validate_all(
+            "NVL(NULL, 1)",
+            write={
+                "oracle": "NVL(NULL, 1)",
+                "": "COALESCE(NULL, 1)",
+                "clickhouse": "COALESCE(NULL, 1)",
+            },
         )
 
     def test_join_marker(self):


### PR DESCRIPTION
Fixes #3952

https://github.com/tobymao/sqlglot/pull/3734 fixed Oracle's `NVL()` roundtripping to `COALESCE()` which was incorrect due to differences in semantics between the two; The solution at the time was to parse `NVL()` as an `exp.Anonymous` function in order to preserve the RTT.

However, this also broke transpilation. To maintain the Oracle RTT _and_ to re-enable transpilation, a new arg is introduced in `exp.Coalesce` which signals if `exp.Coalesce` was built by parsing `NVL()` in Oracle.  

Docs
---------
[Clickhouse Coalesce/ifNull](https://clickhouse.com/docs/en/sql-reference/functions/functions-for-nulls#coalesce) | [Oracle NVL](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/NVL.html) | [Oracle COALESCE](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/COALESCE.html)