### PR TITLE
fix: Parse LTRIM/RTRIM functions as positional exp.Trim

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -20,6 +20,7 @@ from sqlglot.dialects.dialect import (
     var_map_sql,
     timestamptrunc_sql,
     unit_to_var,
+    trim_sql,
 )
 from sqlglot.generator import Generator
 from sqlglot.helper import is_int, seq_get
@@ -875,6 +876,7 @@ class ClickHouse(Dialect):
             exp.SHA2: sha256_sql,
             exp.UnixToTime: _unix_to_time_sql,
             exp.TimestampTrunc: timestamptrunc_sql(zone=True),
+            exp.Trim: trim_sql,
             exp.Variance: rename_func("varSamp"),
             exp.SchemaCommentProperty: lambda self, e: self.naked_property(e),
             exp.Stddev: rename_func("stddevSamp"),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1295,7 +1295,7 @@ def trim_sql(self: Generator, expression: exp.Trim) -> str:
     collation = self.sql(expression, "collation")
 
     # Use TRIM/LTRIM/RTRIM syntax if the expression isn't database-specific
-    if not remove_chars and not collation:
+    if not remove_chars:
         return self.trim_sql(expression)
 
     trim_type = f"{trim_type} " if trim_type else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2648,11 +2648,13 @@ class Generator(metaclass=_Generator):
         trim_type = self.sql(expression, "position")
 
         if trim_type == "LEADING":
-            return self.func("LTRIM", expression.this)
+            func_name = "LTRIM"
         elif trim_type == "TRAILING":
-            return self.func("RTRIM", expression.this)
+            func_name = "RTRIM"
         else:
-            return self.func("TRIM", expression.this, expression.expression)
+            func_name = "TRIM"
+
+        return self.func(func_name, expression.this, expression.expression)
 
     def convert_concat_args(self, expression: exp.Concat | exp.ConcatWs) -> t.List[exp.Expression]:
         args = expression.expressions

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -140,6 +140,14 @@ def build_convert_timezone(
     return exp.ConvertTimezone.from_arg_list(args)
 
 
+def build_trim(args: t.List, is_left: bool = True):
+    return exp.Trim(
+        this=seq_get(args, 0),
+        expression=seq_get(args, 1),
+        position="LEADING" if is_left else "TRAILING",
+    )
+
+
 class _Parser(type):
     def __new__(cls, clsname, bases, attrs):
         klass = super().__new__(cls, clsname, bases, attrs)
@@ -200,9 +208,11 @@ class Parser(metaclass=_Parser):
         "LOWER": build_lower,
         "LPAD": lambda args: build_pad(args),
         "LEFTPAD": lambda args: build_pad(args),
+        "LTRIM": lambda args: build_trim(args),
         "MOD": build_mod,
-        "RPAD": lambda args: build_pad(args, is_left=False),
         "RIGHTPAD": lambda args: build_pad(args, is_left=False),
+        "RPAD": lambda args: build_pad(args, is_left=False),
+        "RTRIM": lambda args: build_trim(args, is_left=False),
         "SCOPE_RESOLUTION": lambda args: exp.ScopeResolution(expression=seq_get(args, 0))
         if len(args) != 2
         else exp.ScopeResolution(this=seq_get(args, 0), expression=seq_get(args, 1)),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -492,6 +492,8 @@ class TestClickhouse(Validator):
                 "postgres": "INSERT INTO t (col1, col2) VALUES ('abcd', 1234)",
             },
         )
+        self.validate_identity("SELECT TRIM(TRAILING ')' FROM '(   Hello, world!   )')")
+        self.validate_identity("SELECT TRIM(LEADING '(' FROM '(   Hello, world!   )')")
 
     def test_clickhouse_values(self):
         values = exp.select("*").from_(

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -251,13 +251,28 @@ class TestOracle(Validator):
             """SELECT * FROM t ORDER BY a ASC NULLS LAST, b ASC NULLS FIRST, c DESC NULLS LAST, d DESC NULLS FIRST""",
             """SELECT * FROM t ORDER BY a ASC, b ASC NULLS FIRST, c DESC NULLS LAST, d DESC""",
         )
-
         self.validate_all(
             "NVL(NULL, 1)",
             write={
                 "oracle": "NVL(NULL, 1)",
                 "": "COALESCE(NULL, 1)",
                 "clickhouse": "COALESCE(NULL, 1)",
+            },
+        )
+        self.validate_all(
+            "LTRIM('Hello World', 'H')",
+            write={
+                "oracle": "TRIM(LEADING 'H' FROM 'Hello World')",
+                "clickhouse": "TRIM(LEADING 'H' FROM 'Hello World')",
+                "": "LTRIM('Hello World', 'H')",
+            },
+        )
+        self.validate_all(
+            "RTRIM('Hello World', 'd')",
+            write={
+                "oracle": "TRIM(TRAILING 'd' FROM 'Hello World')",
+                "clickhouse": "TRIM(TRAILING 'd' FROM 'Hello World')",
+                "": "RTRIM('Hello World', 'd')",
             },
         )
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -676,17 +676,25 @@ class TestPostgres(Validator):
             },
         )
         self.validate_all(
-            """'{"a":1,"b":2}'::json->'b'""",
-            write={
-                "postgres": """CAST('{"a":1,"b":2}' AS JSON) -> 'b'""",
-                "redshift": """JSON_EXTRACT_PATH_TEXT('{"a":1,"b":2}', 'b')""",
-            },
-        )
-        self.validate_all(
             "TRIM(BOTH 'as' FROM 'as string as')",
             write={
                 "postgres": "TRIM(BOTH 'as' FROM 'as string as')",
                 "spark": "TRIM(BOTH 'as' FROM 'as string as')",
+            },
+        )
+        self.validate_identity(
+            """SELECT TRIM(LEADING ' XXX ' COLLATE "de_DE")""",
+            """SELECT LTRIM(' XXX ' COLLATE "de_DE")""",
+        )
+        self.validate_identity(
+            """SELECT TRIM(TRAILING ' XXX ' COLLATE "de_DE")""",
+            """SELECT RTRIM(' XXX ' COLLATE "de_DE")""",
+        )
+        self.validate_all(
+            """'{"a":1,"b":2}'::json->'b'""",
+            write={
+                "postgres": """CAST('{"a":1,"b":2}' AS JSON) -> 'b'""",
+                "redshift": """JSON_EXTRACT_PATH_TEXT('{"a":1,"b":2}', 'b')""",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #3957

Docs
------
[Oracle RTRIM](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/RTRIM.html) | [Clickhouse TRIM](https://clickhouse.com/docs/en/sql-reference/functions/string-functions#trim)