### PR TITLE
feat(spark): Default naming of STRUCT fields

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -436,6 +436,14 @@ class Hive(Dialect):
             self._match(TokenType.R_BRACE)
             return self.expression(exp.Parameter, this=this, expression=expression)
 
+        def _to_prop_eq(self, expression: exp.Expression, index: int) -> exp.Expression:
+            if isinstance(expression, exp.Column):
+                key = expression.this
+            else:
+                key = exp.to_identifier(f"col{index + 1}")
+
+            return self.expression(exp.PropertyEQ, this=key, expression=expression)
+
     class Generator(generator.Generator):
         LIMIT_FETCH = "LIMIT"
         TABLESAMPLE_WITH_METHOD = False

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5112,10 +5112,13 @@ class Parser(metaclass=_Parser):
         self._match_r_paren(this)
         return self._parse_window(this)
 
+    def _to_prop_eq(self, expression: exp.Expression, index: int) -> exp.Expression:
+        return expression
+
     def _kv_to_prop_eq(self, expressions: t.List[exp.Expression]) -> t.List[exp.Expression]:
         transformed = []
 
-        for e in expressions:
+        for index, e in enumerate(expressions):
             if isinstance(e, self.KEY_VALUE_DEFINITIONS):
                 if isinstance(e, exp.Alias):
                     e = self.expression(exp.PropertyEQ, this=e.args.get("alias"), expression=e.this)
@@ -5127,6 +5130,8 @@ class Parser(metaclass=_Parser):
 
                 if isinstance(e.this, exp.Column):
                     e.this.replace(e.this.this)
+            else:
+                e = self._to_prop_eq(e, index)
 
             transformed.append(e)
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -715,9 +715,6 @@ class TestPresto(Validator):
         )
         self.validate_all(
             "SELECT ROW(1, 2)",
-            read={
-                "spark": "SELECT STRUCT(1, 2)",
-            },
             write={
                 "presto": "SELECT ROW(1, 2)",
                 "spark": "SELECT STRUCT(1, 2)",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -485,7 +485,7 @@ TBLPROPERTIES (
         )
         self.validate_all(
             "SELECT CAST(STRUCT('fooo') AS STRUCT<a: VARCHAR(2)>)",
-            write={"spark": "SELECT CAST(STRUCT('fooo') AS STRUCT<a: STRING>)"},
+            write={"spark": "SELECT CAST(STRUCT('fooo' AS col1) AS STRUCT<a: STRING>)"},
         )
         self.validate_all(
             "SELECT CAST(123456 AS VARCHAR(3))",
@@ -715,6 +715,22 @@ TBLPROPERTIES (
             "SELECT ANY_VALUE(col, true), FIRST(col, true), FIRST_VALUE(col, true) OVER ()",
             write={
                 "duckdb": "SELECT ANY_VALUE(col), FIRST(col), FIRST_VALUE(col IGNORE NULLS) OVER ()"
+            },
+        )
+
+        self.validate_all(
+            "SELECT STRUCT(1, 2)",
+            write={
+                "spark": "SELECT STRUCT(1 AS col1, 2 AS col2)",
+                "presto": "SELECT CAST(ROW(1, 2) AS ROW(col1 INTEGER, col2 INTEGER))",
+                "duckdb": "SELECT {'col1': 1, 'col2': 2}",
+            },
+        )
+        self.validate_all(
+            "SELECT STRUCT(x, 1, y AS col3, STRUCT(5)) FROM t",
+            write={
+                "spark": "SELECT STRUCT(x AS x, 1 AS col2, y AS col3, STRUCT(5 AS col1) AS col4) FROM t",
+                "duckdb": "SELECT {'x': x, 'col2': 1, 'col3': y, 'col4': {'col1': 5}} FROM t",
             },
         )
 


### PR DESCRIPTION
Fixes #3988

In Spark, STRUCT values/fields that are not explicitly named by the user are default initialized to:
- The column name itself, if the expression is a column
- The name `col_i` for other literals/nested structs, where `i` is the 1-based index position of the field in the struct:

```
spark-sql (default)> WITH t AS (SELECT 1 AS x, 2 AS y) SELECT STRUCT(x, 1, y AS col3, struct(5)) FROM t;
{"x":1,"col2":1,"col3":2,"col4":{"col1":5}}
```

This PR extends `kv_to_prop_eq` by also standardizing non-aliased expressions (`exp.Column`, `exp.Literal` etc) to key-value `exp.PropertyEQ` pairs with their respective name.