### PR TITLE
Fix(clickhouse): generate ON CLUSTER for transpiled CREATE SCHEMA

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -892,6 +892,7 @@ class ClickHouse(Dialect):
         # There's no list in docs, but it can be found in Clickhouse code
         # see `ClickHouse/src/Parsers/ParserCreate*.cpp`
         ON_CLUSTER_TARGETS = {
+            "SCHEMA",  # Transpiled CREATE SCHEMA may have OnCluster property set
             "DATABASE",
             "TABLE",
             "VIEW",

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -622,6 +622,14 @@ class TestClickhouse(Validator):
         )
         self.assertEqual(create_with_cluster.sql("clickhouse"), "CREATE DATABASE foo ON CLUSTER c")
 
+        # Transpiled CREATE SCHEMA may have OnCluster property set
+        create_with_cluster = exp.Create(
+            this=db_table_expr,
+            kind="SCHEMA",
+            properties=exp.Properties(expressions=[exp.OnCluster(this=exp.to_identifier("c"))]),
+        )
+        self.assertEqual(create_with_cluster.sql("clickhouse"), "CREATE DATABASE foo ON CLUSTER c")
+
         ctas_with_comment = exp.Create(
             this=exp.table_("foo"),
             kind="TABLE",


### PR DESCRIPTION
In Clickhouse, the second-level object name is `DATABASE` instead of `SCHEMA`.

When generating the `ON CLUSTER` property, we condition on the creatable kind. For Clickhouse this is `DATABASE`, but for other dialects it is `SCHEMA`.

This PR adds `SCHEMA` to the set of creatable kinds with the `ON CLUSTER` property so it will be generated for transpiled statements.