### PR TITLE
fix!: Bind TABLESAMPLE to exp.Subquery

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2447,6 +2447,13 @@ class Generator(metaclass=_Generator):
     def subquery_sql(self, expression: exp.Subquery, sep: str = " AS ") -> str:
         alias = self.sql(expression, "alias")
         alias = f"{sep}{alias}" if alias else ""
+        sample = self.sql(expression, "sample")
+        if self.dialect.ALIAS_POST_TABLESAMPLE and sample:
+            alias = f"{sample}{alias}"
+
+            # Set to None so it's not generated again by self.query_modifiers()
+            expression.set("sample", None)
+
         pivots = self.expressions(expression, key="pivots", sep="", flat=True)
         sql = self.query_modifiers(expression, self.wrap(expression), alias, pivots)
         return self.prepend_ctes(expression, sql)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2986,6 +2986,7 @@ class Parser(metaclass=_Parser):
             this=this,
             pivots=self._parse_pivots(),
             alias=self._parse_table_alias() if parse_alias else None,
+            sample=self._parse_table_sample(),
         )
 
     def _implicit_unnests_to_explicit(self, this: E) -> E:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1008,6 +1008,13 @@ class TestDuckDB(Validator):
                 "duckdb": "SELECT * FROM example TABLESAMPLE RESERVOIR (3 ROWS) REPEATABLE (82)",
             },
         )
+        self.validate_all(
+            "SELECT * FROM (SELECT * FROM t) AS t1 TABLESAMPLE (1 ROWS), (SELECT * FROM t) AS t2 TABLESAMPLE (2 ROWS)",
+            write={
+                "duckdb": "SELECT * FROM (SELECT * FROM t) AS t1 TABLESAMPLE RESERVOIR (1 ROWS), (SELECT * FROM t) AS t2 TABLESAMPLE RESERVOIR (2 ROWS)",
+                "spark": "SELECT * FROM (SELECT * FROM t) TABLESAMPLE (1 ROWS) AS t1, (SELECT * FROM t) TABLESAMPLE (2 ROWS) AS t2",
+            },
+        )
 
     def test_array(self):
         self.validate_identity("ARRAY(SELECT id FROM t)")


### PR DESCRIPTION
Fixes #3992

When parsing subqueries the tralining `TABLESAMPLE` is not attached to it but to the top-level `exp.Select` statement, leading to erratic behavior such as `"sample"` arg being overwritten:

```
>>> sql = "SELECT * FROM (SELECT * FROM t) AS t1 TABLESAMPLE (1 ROWS), (SELECT * FROM t) AS t2 tablesample (2 rows)"
>>> sqlglot.parse_one(sql, read='duckdb').sql('duckdb')

SELECT * FROM (SELECT * FROM t) AS t1, (SELECT * FROM t) AS t2 USING SAMPLE RESERVOIR (2 ROWS)
```

This PR addresses this by parsing TABLESAMPLE inside `_parse_subquery()`, which binds it to the respective `exp.Subquery`.

Also, the order of subquery alias vs TABLESAMPLE generation is fixed (as is done in `table_sql()`) in order to address the issue.


