### PR TITLE
fix(starrocks): exp.Create transpilation

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -13,9 +13,20 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.mysql import MySQL
 from sqlglot.helper import seq_get
+from sqlglot.tokens import TokenType
 
 
 class StarRocks(MySQL):
+    class Tokenizer(MySQL.Tokenizer):
+        KEYWORDS = {
+            **MySQL.Tokenizer.KEYWORDS,
+            "DECIMAL64": TokenType.DECIMAL,
+            "DECIMAL128": TokenType.BIGDECIMAL,
+            "DISTRIBUTED BY HASH": TokenType.DISTRIBUTE_BY,
+            "DISTRIBUTED BY RANDOM": TokenType.DISTRIBUTE_BY,
+            "DUPLICATE KEY": TokenType.DUPLICATE_KEY,
+        }
+
     class Parser(MySQL.Parser):
         FUNCTIONS = {
             **MySQL.Parser.FUNCTIONS,
@@ -28,6 +39,66 @@ class StarRocks(MySQL):
             ),
             "REGEXP": exp.RegexpLike.from_arg_list,
         }
+
+        PROPERTY_PARSERS = {
+            **MySQL.Parser.PROPERTY_PARSERS,
+            "DISTRIBUTED BY HASH": lambda self: self._parse_distributed_by("HASH"),
+            "DISTRIBUTED BY RANDOM": lambda self: self._parse_distributed_by("RANDOM"),
+            "PROPERTIES": lambda self: self._parse_wrapped_csv(self._parse_property),
+            "DUPLICATE KEY": lambda self: self._parse_duplicate(),
+            "PARTITION BY": lambda self: self._parse_partitioned_by(),
+        }
+
+        def _parse_create(self) -> exp.Create | exp.Command:
+            create = super()._parse_create()
+
+            # Starrocks's primary is defined outside the schema, so we need to move it into the schema
+            # https://docs.starrocks.io/docs/table_design/table_types/primary_key_table/#usage
+            if (
+                isinstance(create, exp.Create)
+                and create.this
+                and isinstance(create.this, exp.Schema)
+            ):
+                props = create.args.get("properties")
+                if props:
+                    primary_key = next(
+                        (expr for expr in props.expressions if isinstance(expr, exp.PrimaryKey)),
+                        None,
+                    )
+                    if primary_key:
+                        create.this.expressions.append(primary_key)
+
+                        # Remove the PrimaryKey from properties
+                        props.expressions.remove(primary_key)
+
+            return create
+
+        def _parse_distributed_by(self, type: str) -> exp.Expression:
+            expressions = self._parse_wrapped_csv(self._parse_id_var)
+
+            # If the BUCKETS keyword not present, the number of buckets is AUTO
+            # [ BUCKETS AUTO | BUCKETS <number> ]
+            buckets = None
+            if self._match_text_seq("BUCKETS", "AUTO"):
+                pass
+            elif self._match_text_seq("BUCKETS"):
+                buckets = self._parse_number()
+
+            if self._match_text_seq("ORDER BY"):
+                order_by = self._parse_wrapped_csv(self._parse_ordered)
+            else:
+                order_by = None
+
+            return self.expression(
+                exp.DistributedByHash if type == "HASH" else exp.DistributedByRandom,
+                expressions=expressions,
+                buckets=buckets,
+                sorted_by=order_by,
+            )
+
+        def _parse_duplicate(self) -> exp.DuplicateKey:
+            expressions = self._parse_wrapped_csv(self._parse_id_var, optional=False)
+            return self.expression(exp.DuplicateKey, expressions=expressions)
 
         def _parse_unnest(self, with_alias: bool = True) -> t.Optional[exp.Unnest]:
             unnest = super()._parse_unnest(with_alias=with_alias)
@@ -52,6 +123,14 @@ class StarRocks(MySQL):
             exp.DataType.Type.TIMESTAMPTZ: "DATETIME",
         }
 
+        PROPERTIES_LOCATION = {
+            **MySQL.Generator.PROPERTIES_LOCATION,
+            exp.DistributedByHash: exp.Properties.Location.POST_SCHEMA,
+            exp.DistributedByRandom: exp.Properties.Location.POST_SCHEMA,
+            exp.DuplicateKey: exp.Properties.Location.POST_SCHEMA,
+            exp.PrimaryKey: exp.Properties.Location.UNSUPPORTED,
+        }
+
         TRANSFORMS = {
             **MySQL.Generator.TRANSFORMS,
             exp.Array: inline_array_sql,
@@ -68,5 +147,35 @@ class StarRocks(MySQL):
             exp.UnixToStr: lambda self, e: self.func("FROM_UNIXTIME", e.this, self.format_time(e)),
             exp.UnixToTime: rename_func("FROM_UNIXTIME"),
         }
+
+        def duplicatekey_sql(self, expression: exp.DuplicateKey) -> str:
+            expressions = self.expressions(expression, flat=True)
+            options = self.expressions(expression, key="options", flat=True, sep=" ")
+            options = f" {options}" if options else ""
+            return f"DUPLICATE KEY ({expressions}){options}"
+
+        def distributedbyhash_sql(self, expression: exp.DistributedByHash) -> str:
+            expressions = self.expressions(expression, key="expressions", flat=True)
+            sorted_by = self.expressions(expression, key="sorted_by", flat=True)
+            sorted_by = f" ORDER BY ({sorted_by})" if sorted_by else ""
+            buckets = self.sql(expression, "buckets")
+            if expression.auto_bucket:
+                buckets = "AUTO"
+            return f"DISTRIBUTED BY HASH ({expressions}) BUCKETS {buckets}{sorted_by}"
+
+        def distributedbyrandom_sql(self, expression: exp.DistributedByRandom) -> str:
+            expressions = self.expressions(expression, flat=True)
+            sorted_by = self.expressions(expression, key="sorted_by", flat=True)
+            sorted_by = f" ORDER BY ({sorted_by})" if sorted_by else ""
+            buckets = self.sql(expression, "buckets")
+            if expression.auto_bucket:
+                buckets = "AUTO"
+            return f"DISTRIBUTED BY RANDOM ({expressions}) BUCKETS {buckets}{sorted_by}"
+
+        def property_name(self, expression: exp.Property, string_key: bool = False) -> str:
+            return super().property_name(expression, True)
+
+        def with_properties(self, properties: exp.Properties) -> str:
+            return self.properties(properties, prefix=self.seg("PROPERTIES", sep=""))
 
         TRANSFORMS.pop(exp.DateTrunc)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1396,6 +1396,7 @@ class Create(DDL):
         "clone": False,
         "concurrently": False,
         "clustered": False,
+        "dialect": False,
     }
 
     @property
@@ -2053,6 +2054,23 @@ class Credentials(Expression):
         "iam_role": False,
         "region": False,
     }
+
+
+class DistributedByHash(Expression):
+    arg_types = {"expressions": True, "buckets": False, "sorted_by": False}
+
+    @property
+    def auto_bucket(self) -> bool:
+        return self.args.get("buckets") is None
+
+
+# https://docs.starrocks.io/docs/sql-reference/sql-statements/data-definition/CREATE_TABLE/#distribution_desc
+class DistributedByRandom(DistributedByHash):
+    pass
+
+
+class DuplicateKey(Expression):
+    arg_types = {"expressions": True}
 
 
 class Prior(Expression):
@@ -2924,6 +2942,8 @@ class Properties(Expression):
         "COMMENT": SchemaCommentProperty,
         "DEFINER": DefinerProperty,
         "DISTKEY": DistKeyProperty,
+        "DISTRIBUTED_BY_HASH": DistributedByHash,
+        "DISTRIBUTED_BY_RANDOM": DistributedByRandom,
         "DISTSTYLE": DistStyleProperty,
         "ENGINE": EngineProperty,
         "EXECUTE AS": ExecuteAsProperty,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1762,6 +1762,7 @@ class Parser(metaclass=_Parser):
         begin = None
         end = None
         clone = None
+        dialect = None
 
         def extend_props(temp_props: t.Optional[exp.Properties]) -> None:
             nonlocal properties
@@ -1834,6 +1835,9 @@ class Parser(metaclass=_Parser):
                 expression = self._parse_ddl_select()
 
             if create_token.token_type == TokenType.TABLE:
+                # source dialect
+                dialect = self.dialect.__module__.split(".")[-1].upper()
+
                 # exp.Properties.Location.POST_EXPRESSION
                 extend_props(self._parse_properties())
 
@@ -1882,6 +1886,7 @@ class Parser(metaclass=_Parser):
             clone=clone,
             concurrently=concurrently,
             clustered=clustered,
+            dialect=dialect,
         )
 
     def _parse_sequence_properties(self) -> t.Optional[exp.SequenceProperties]:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -245,6 +245,7 @@ class TokenType(AutoName):
     DICTIONARY = auto()
     DISTINCT = auto()
     DISTRIBUTE_BY = auto()
+    DUPLICATE_KEY = auto()
     DIV = auto()
     DROP = auto()
     ELSE = auto()

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -4,6 +4,39 @@ from tests.dialects.test_dialect import Validator
 class TestStarrocks(Validator):
     dialect = "starrocks"
 
+    def test_ddl(self):
+        self.validate_identity("CREATE TABLE foo (col VARCHAR(50))")
+        self.validate_all(
+            """CREATE TABLE if not exists `sample_table` (
+                        `tenantid` varchar(1048576) NULL COMMENT "",
+                        `create_day` date NOT NULL COMMENT "",
+                        `shopsite` varchar(65533) NOT NULL COMMENT "shopsite",
+                        `id` varchar(65533) NOT NULL COMMENT "shopsite id",
+                        `price` decimal128(38, 10) NULL COMMENT "test the bigdecimal",
+                        `seq` int(11) NULL COMMENT "order",
+                        `use_status` smallint(6) NULL COMMENT "0,1",
+                        `created_user` bigint(20) NULL COMMENT "create user",
+                        `created_time` datetime NULL COMMENT "create time",
+                    ) ENGINE=OLAP
+                    DUPLICATE KEY(tenantid)
+                    PRIMARY KEY(`tenantid`, `shopsite`, `id`)
+                    COMMENT "OLAP"
+                    DISTRIBUTED BY HASH(`tenantid`, `shopsite`, `id`) BUCKETS 10
+                    ORDER BY (`tenantid`, `shopsite`, `id`)
+                    PROPERTIES (
+                        "replication_num" = "1",
+                        "in_memory" = "false",
+                        "enable_persistent_index" = "false",
+                        "replicated_storage" = "false",
+                        "storage_medium" = "HDD",
+                        "compression" = "LZ4"
+                    )""",
+            write={
+                "hive": """CREATE TABLE IF NOT EXISTS `sample_table` (`tenantid` STRING COMMENT '', `create_day` DATE NOT NULL COMMENT '', `shopsite` VARCHAR(65533) NOT NULL COMMENT 'shopsite', `id` VARCHAR(65533) NOT NULL COMMENT 'shopsite id', `price` DECIMAL(10, 38) COMMENT 'test the bigdecimal', `seq` INT COMMENT 'order', `use_status` SMALLINT COMMENT '0,1', `created_user` BIGINT COMMENT 'create user', `created_time` TIMESTAMP COMMENT 'create time', PRIMARY KEY (`tenantid`, `shopsite`, `id`)) COMMENT 'OLAP' CLUSTERED BY (`tenantid`, `shopsite`, `id`) SORTED BY (`tenantid`, `shopsite`, `id`) INTO 10 BUCKETS TBLPROPERTIES ('replication_num'='1', 'in_memory'='false', 'enable_persistent_index'='false', 'replicated_storage'='false', 'storage_medium'='HDD', 'compression'='LZ4')""",
+                "starrocks": """CREATE TABLE IF NOT EXISTS `sample_table` (`tenantid` VARCHAR(1048576) NULL COMMENT '', `create_day` DATE NOT NULL COMMENT '', `shopsite` VARCHAR(65533) NOT NULL COMMENT 'shopsite', `id` VARCHAR(65533) NOT NULL COMMENT 'shopsite id', `price` BIGDECIMAL(38, 10) NULL COMMENT 'test the bigdecimal', `seq` INT(11) NULL COMMENT 'order', `use_status` SMALLINT(6) NULL COMMENT '0,1', `created_user` BIGINT(20) NULL COMMENT 'create user', `created_time` DATETIME NULL COMMENT 'create time', PRIMARY KEY (`tenantid`, `shopsite`, `id`)) ENGINE=OLAP DUPLICATE KEY (tenantid) COMMENT='OLAP' DISTRIBUTED BY HASH (`tenantid`, `shopsite`, `id`) BUCKETS 10 ORDER BY (`tenantid`, `shopsite`, `id`) PROPERTIES ('replication_num'='1', 'in_memory'='false', 'enable_persistent_index'='false', 'replicated_storage'='false', 'storage_medium'='HDD', 'compression'='LZ4')""",
+            },
+        )
+
     def test_identity(self):
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")
         self.validate_identity("SELECT APPROX_COUNT_DISTINCT(a) FROM x")


### PR DESCRIPTION
Fix #3997 

Supports starrocks create table parse and generator, generator supports starrocks and hive transpile (may need to slowly improve it).

StarRocks specifically includes:
- Supports `DISTRIBUTED BY`, `DUPLICATE KEY`, `PARTITION BY`, `PROPERTIES` to be parsed correctly
- In `_parse_create`, move exp.PrimaryKey outside the create schema to the schema

Hive specifically includes:
- Supports `DISTRIBUTED BY`, `DUPLICATE KEY`, `PARTITION BY`, `PROPERTIES` to be generated correctly
- Mark `DuplicateKey` with `UNSUPPORTED`
- Convert DataType to adapt to hive

Parse specifically includes:
- Added dialect in _parse_create so that the type of a certain engine feature (starrocks) can be processed in a targeted manner