### PR TITLE
fix(starrocks): exp.Unnest transpilation

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -191,6 +191,16 @@ def _build_with_ignore_nulls(
     return _parse
 
 
+def _select_sql(self: Hive.Generator, expression: exp.Expression) -> str:
+    return transforms.preprocess(
+        [
+            transforms.eliminate_qualify,
+            transforms.eliminate_distinct_on,
+            partial(transforms.unnest_to_explode, unnest_using_arrays_zip=False, generator=self),
+        ]
+    )(self, expression)
+
+
 class Hive(Dialect):
     ALIAS_POST_TABLESAMPLE = True
     IDENTIFIERS_CAN_START_WITH_DIGIT = True
@@ -490,13 +500,7 @@ class Hive(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.Group: transforms.preprocess([transforms.unalias_group]),
-            exp.Select: transforms.preprocess(
-                [
-                    transforms.eliminate_qualify,
-                    transforms.eliminate_distinct_on,
-                    partial(transforms.unnest_to_explode, unnest_using_arrays_zip=False),
-                ]
-            ),
+            exp.Select: _select_sql,
             exp.Property: _property_sql,
             exp.AnyValue: rename_func("FIRST"),
             exp.ApproxDistinct: approx_count_distinct_sql,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import typing as t
+from functools import partial
 
 from sqlglot import exp, generator, parser, tokens, transforms
 from sqlglot.dialects.dialect import (
@@ -493,7 +494,7 @@ class Hive(Dialect):
                 [
                     transforms.eliminate_qualify,
                     transforms.eliminate_distinct_on,
-                    transforms.unnest_to_explode,
+                    partial(transforms.unnest_to_explode, unnest_using_arrays_zip=False),
                 ]
             ),
             exp.Property: _property_sql,

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -190,6 +190,13 @@ class Spark2(Hive):
 
         TRANSFORMS = {
             **Hive.Generator.TRANSFORMS,
+            exp.Select: transforms.preprocess(
+                [
+                    transforms.eliminate_qualify,
+                    transforms.eliminate_distinct_on,
+                    transforms.unnest_to_explode,
+                ]
+            ),
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ArraySum: lambda self,
             e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -190,13 +190,6 @@ class Spark2(Hive):
 
         TRANSFORMS = {
             **Hive.Generator.TRANSFORMS,
-            exp.Select: transforms.preprocess(
-                [
-                    transforms.eliminate_qualify,
-                    transforms.eliminate_distinct_on,
-                    transforms.unnest_to_explode,
-                ]
-            ),
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ArraySum: lambda self,
             e: f"AGGREGATE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
@@ -236,6 +229,13 @@ class Spark2(Hive):
                 e.expression,
                 e.args["replacement"],
                 e.args.get("position"),
+            ),
+            exp.Select: transforms.preprocess(
+                [
+                    transforms.eliminate_qualify,
+                    transforms.eliminate_distinct_on,
+                    transforms.unnest_to_explode,
+                ]
             ),
             exp.StrToDate: _str_to_date,
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -38,7 +38,7 @@ class StarRocks(MySQL):
                 if not alias:
                     alias = exp.TableAlias(columns=[exp.to_identifier("unnest")])
                     unnest.set("alias", alias)
-                if not alias.args.get("columns"):
+                elif not alias.args.get("columns"):
                     # Starrocks defaults to naming the UNNEST column as "unnest"
                     # if it's not otherwise specified
                     alias.set("columns", [exp.to_identifier("unnest")])

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -36,12 +36,9 @@ class StarRocks(MySQL):
                 alias = unnest.args.get("alias")
 
                 if not alias:
-                    # Starrocks defaults to naming the table alias as "unnest"
-                    alias = exp.TableAlias(
-                        this=exp.to_identifier("unnest"), columns=[exp.to_identifier("unnest")]
-                    )
+                    alias = exp.TableAlias(columns=[exp.to_identifier("unnest")])
                     unnest.set("alias", alias)
-                if alias and not alias.args.get("columns"):
+                if not alias.args.get("columns"):
                     # Starrocks defaults to naming the UNNEST column as "unnest"
                     # if it's not otherwise specified
                     alias.set("columns", [exp.to_identifier("unnest")])

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -36,7 +36,10 @@ class StarRocks(MySQL):
                 alias = unnest.args.get("alias")
 
                 if not alias:
-                    alias = exp.TableAlias(columns=[exp.to_identifier("unnest")])
+                    # Starrocks defaults to naming the table alias as "unnest"
+                    alias = exp.TableAlias(
+                        this=exp.to_identifier("unnest"), columns=[exp.to_identifier("unnest")]
+                    )
                     unnest.set("alias", alias)
                 elif not alias.args.get("columns"):
                     # Starrocks defaults to naming the UNNEST column as "unnest"

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -35,6 +35,12 @@ class StarRocks(MySQL):
             if unnest:
                 alias = unnest.args.get("alias")
 
+                if not alias:
+                    # Starrocks defaults to naming the table alias as "unnest"
+                    alias = exp.TableAlias(
+                        this=exp.to_identifier("unnest"), columns=[exp.to_identifier("unnest")]
+                    )
+                    unnest.set("alias", alias)
                 if alias and not alias.args.get("columns"):
                     # Starrocks defaults to naming the UNNEST column as "unnest"
                     # if it's not otherwise specified

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5344,6 +5344,12 @@ class Explode(Func):
     is_var_len_args = True
 
 
+# https://spark.apache.org/docs/latest/api/sql/#inline
+class Inline(Func):
+    arg_types = {"this": True, "expressions": False}
+    is_var_len_args = True
+
+
 class ExplodeOuter(Explode):
     pass
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5346,8 +5346,7 @@ class Explode(Func):
 
 # https://spark.apache.org/docs/latest/api/sql/#inline
 class Inline(Func):
-    arg_types = {"this": True, "expressions": False}
-    is_var_len_args = True
+    pass
 
 
 class ExplodeOuter(Explode):

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -313,7 +313,7 @@ def unnest_to_explode(
             return zip_exprs
         return unnest_exprs
 
-    def _udtf_type(u: exp.Unnest, _has_multi_expr: bool):
+    def _udtf_type(u: exp.Unnest, _has_multi_expr: bool) -> exp.Func:
         return (
             exp.Posexplode
             if u.args.get("offset")

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1423,7 +1423,6 @@ class TestDialect(Validator):
                 "drill": "SELECT a, b FROM x CROSS JOIN UNNEST(y, z) AS t(a, b)",
                 "presto": "SELECT a, b FROM x CROSS JOIN UNNEST(y, z) AS t(a, b)",
                 "spark": "SELECT a, b FROM x LATERAL VIEW INLINE(ARRAYS_ZIP(y, z)) t AS a, b",
-                "hive": "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) t AS b",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1422,7 +1422,8 @@ class TestDialect(Validator):
             write={
                 "drill": "SELECT a, b FROM x CROSS JOIN UNNEST(y, z) AS t(a, b)",
                 "presto": "SELECT a, b FROM x CROSS JOIN UNNEST(y, z) AS t(a, b)",
-                "spark": "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) t AS b",
+                "spark": "SELECT a, b FROM x LATERAL VIEW INLINE(ARRAYS_ZIP(y, z)) t AS a, b",
+                "hive": "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) t AS b",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -50,6 +50,7 @@ class TestStarrocks(Validator):
                 "starrocks": "SELECT * FROM UNNEST(['John', 'Jane', 'Jim', 'Jamie'], [24, 25, 26, 27]) AS t(name, age)",
             },
         )
+
         # Use UNNEST to convert into multiple columns
         # see: https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/unnest/
         self.validate_all(
@@ -61,6 +62,7 @@ class TestStarrocks(Validator):
                 "starrocks": r"""SELECT id, t.type, t.scores FROM example_table, UNNEST(SPLIT(type, ';'), scores) AS t(type, scores)""",
             },
         )
+
         self.validate_all(
             r"""SELECT id, t.type, t.scores FROM example_table_2 CROSS JOIN LATERAL unnest(split(type, ";"), scores) AS t(type,scores)""",
             write={

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -35,6 +35,29 @@ class TestStarrocks(Validator):
             "SELECT student, score, t.unnest FROM tests CROSS JOIN LATERAL UNNEST(scores) AS t",
             "SELECT student, score, t.unnest FROM tests CROSS JOIN LATERAL UNNEST(scores) AS t(unnest)",
         )
+        self.validate_identity(
+            "SELECT student, score, unnest.unnest FROM tests CROSS JOIN LATERAL UNNEST(scores)",
+            "SELECT student, score, unnest.unnest FROM tests CROSS JOIN LATERAL UNNEST(scores) AS unnest(unnest)",
+        )
+        self.validate_all(
+            r"""SELECT * FROM UNNEST(array['John','Jane','Jim','Jamie'], array[24,25,26,27]) AS t(name, age)""",
+            write={
+                "postgres": "SELECT * FROM UNNEST(ARRAY['John', 'Jane', 'Jim', 'Jamie'], ARRAY[24, 25, 26, 27]) AS t(name, age)",
+                "spark": "SELECT * FROM EXPLODE(ARRAY('John', 'Jane', 'Jim', 'Jamie'), ARRAY(24, 25, 26, 27)) AS "
+                "t(name, age)",
+            },
+        )
+        # Use UNNEST to convert into multiple columns
+        # see: https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/unnest/
+        self.validate_all(
+            r"""SELECT id, t.type, t.scores FROM example_table, unnest(split(type, ";"), scores) AS t(type,scores)""",
+            write={
+                "postgres": "SELECT id, t.type, t.scores FROM example_table, UNNEST(SPLIT(type, ';'), scores) AS "
+                "t(type, scores)",
+                "spark": "SELECT id, t.type, t.scores FROM example_table LATERAL VIEW EXPLODE(SPLIT(type, CONCAT"
+                r"""('\\Q', ';'))) t AS type LATERAL VIEW EXPLODE(scores) t AS scores""",
+            },
+        )
 
         lateral_explode_sqls = [
             "SELECT id, t.col FROM tbl, UNNEST(scores) AS t(col)",


### PR DESCRIPTION
Fixes #3962 

Link the before PR: 
- https://github.com/tobymao/sqlglot/pull/3964
- https://github.com/tobymao/sqlglot/pull/3966

This PR adds support for the following:

Default initialize exp.UNNEST to include "unnest" as the default table alias if not specified
Added expression type of exp.Inline
use arrays_zip to merge multiple Lateral views
Added some ut to validate unnest transpile