### PR TITLE
feat(oracle): Parse multitable inserts

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -300,7 +300,7 @@ class Oracle(Dialect):
             exp.Group: transforms.preprocess([transforms.unalias_group]),
             exp.ILike: no_ilike_sql,
             exp.Mod: rename_func("MOD"),
-            exp.MultitableInserts: lambda self, e: self.multitable_inserts_sql(e),
+            exp.MultitableInserts: lambda self, e: self.multitableinserts_sql(e),
             exp.Select: transforms.preprocess(
                 [
                     transforms.eliminate_distinct_on,
@@ -365,7 +365,7 @@ class Oracle(Dialect):
             func_name = "NVL" if expression.args.get("is_nvl") else "COALESCE"
             return rename_func(func_name)(self, expression)
 
-        def multitable_inserts_sql(self, expression: exp.MultitableInserts) -> str:
+        def multitableinserts_sql(self, expression: exp.MultitableInserts) -> str:
             kind = self.sql(expression, "kind").upper()
             inserts = []
             for conditional_insert in t.cast(t.List[exp.ConditionalInsert], expression.expressions):

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -233,7 +233,7 @@ class Oracle(Dialect):
             def conditional_insert() -> t.Optional[exp.Conditionalinsert]:
                 expression = None
                 if self._match(TokenType.WHEN):
-                    expression = self._parse_assignment()
+                    expression = self._parse_disjunction()
                     self._match(TokenType.THEN)
                 else_matched = self._match(TokenType.ELSE)
                 else_ = else_matched is not None and else_matched

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -381,5 +381,5 @@ class Oracle(Dialect):
                 buffer += insert_sql
                 inserts.append(buffer.strip())
 
-            res = f"INSERT {kind} {' '.join(inserts)} {self.sql(expression.args['source'])}"
+            res = f"INSERT {kind} {' '.join(inserts)} {self.sql(expression, 'source')}"
             return res

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -227,7 +227,7 @@ class Oracle(Dialect):
             )
 
         def _parse_multitable_inserts(self) -> exp.MultitableInserts:
-            kind = "first" if self._prev.token_type is TokenType.FIRST else "all"
+            kind = self._prev.text.upper()
             expressions = []
 
             def conditional_insert():

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -230,7 +230,7 @@ class Oracle(Dialect):
             kind = self._prev.text.upper()
             expressions = []
 
-            def conditional_insert():
+            def conditional_insert() -> t.Optional[exp.Conditionalinsert]:
                 expression = None
                 if self._match(TokenType.WHEN):
                     expression = self._parse_assignment()

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2211,8 +2211,10 @@ class Insert(DDL, DML):
             self, alias, as_, recursive=recursive, append=append, dialect=dialect, copy=copy, **opts
         )
 
+
 class ConditionalInsert(Expression):
     arg_types = {"this": True, "expression": False, "else_": True}
+
 
 class MultitableInserts(Expression):
     arg_types = {"expressions": True, "kind": True, "source": True}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2211,6 +2211,12 @@ class Insert(DDL, DML):
             self, alias, as_, recursive=recursive, append=append, dialect=dialect, copy=copy, **opts
         )
 
+class ConditionalInsert(Expression):
+    arg_types = {"this": True, "expression": False, "else_": True}
+
+class MultitableInserts(Expression):
+    arg_types = {"expressions": True, "kind": True, "source": True}
+
 
 class OnConflict(Expression):
     arg_types = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2213,7 +2213,7 @@ class Insert(DDL, DML):
 
 
 class ConditionalInsert(Expression):
-    arg_types = {"this": True, "expression": False, "else_": True}
+    arg_types = {"this": True, "expression": False, "else_": False}
 
 
 class MultitableInserts(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -534,6 +534,7 @@ class Generator(metaclass=_Generator):
         exp.From,
         exp.Insert,
         exp.Join,
+        exp.MultitableInserts,
         exp.Select,
         exp.SetOperation,
         exp.Update,
@@ -4201,9 +4202,6 @@ class Generator(metaclass=_Generator):
 
     def multitableinserts_sql(self, expression: exp.MultitableInserts) -> str:
         kind = self.sql(expression, "kind")
-        inserts = []
-        for conditional_insert in expression.expressions:
-            inserts.append(self.sql(conditional_insert))
-
-        res = f"INSERT {kind} {' '.join(inserts)} {self.sql(expression, 'source')}"
+        expressions = self.expressions(expression, new_line=True, skip_last=True, sep=" ")
+        res = f"INSERT {kind} {expressions} {self.sql(expression, 'source')}"
         return res

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2518,7 +2518,7 @@ class Parser(metaclass=_Parser):
             partition=partition,
         )
 
-    def _parse_multitable_inserts(self) -> exp.MultitableInserts:
+    def _parse_multitable_inserts(self, comments: t.Optional[t.List[str]]) -> exp.MultitableInserts:
         kind = self._prev.text.upper()
         expressions = []
 
@@ -2553,6 +2553,7 @@ class Parser(metaclass=_Parser):
         return self.expression(
             exp.MultitableInserts,
             kind=kind,
+            comments=comments,
             expressions=expressions,
             source=self._parse_table(),
         )
@@ -2575,7 +2576,8 @@ class Parser(metaclass=_Parser):
             )
         else:
             if self._match_set((TokenType.FIRST, TokenType.ALL)):
-                return self._parse_multitable_inserts()
+                comments += ensure_list(self._prev_comments)
+                return self._parse_multitable_inserts(comments)
 
             if self._match(TokenType.OR):
                 alternative = self._match_texts(self.INSERT_ALTERNATIVES) and self._prev.text

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2538,7 +2538,7 @@ class Parser(metaclass=_Parser):
                 row_format=self._parse_row_format(match_row=True),
             )
         else:
-            if self._match(TokenType.FIRST) or self._match(TokenType.ALL):
+            if self._match_set((TokenType.FIRST, TokenType.ALL)):
                 return self._parse_multitable_inserts()
 
             if self._match(TokenType.OR):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2520,8 +2520,8 @@ class Parser(metaclass=_Parser):
 
     def _parse_multitable_inserts(self) -> exp.MultitableInserts:
         raise NotImplementedError
-    
-    def _parse_insert(self) -> exp.Insert:
+
+    def _parse_insert(self) -> t.Union[exp.Insert, exp.MultitableInserts]:
         comments = ensure_list(self._prev_comments)
         hint = self._parse_hint()
         overwrite = self._match(TokenType.OVERWRITE)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2518,6 +2518,9 @@ class Parser(metaclass=_Parser):
             partition=partition,
         )
 
+    def _parse_multitable_inserts(self) -> exp.MultitableInserts:
+        raise NotImplementedError
+    
     def _parse_insert(self) -> exp.Insert:
         comments = ensure_list(self._prev_comments)
         hint = self._parse_hint()
@@ -2535,6 +2538,9 @@ class Parser(metaclass=_Parser):
                 row_format=self._parse_row_format(match_row=True),
             )
         else:
+            if self._match(TokenType.FIRST) or self._match(TokenType.ALL):
+                return self._parse_multitable_inserts()
+
             if self._match(TokenType.OR):
                 alternative = self._match_texts(self.INSERT_ALTERNATIVES) and self._prev.text
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -461,3 +461,79 @@ WHERE
                     self.validate_identity(
                         f"CREATE VIEW view AS SELECT * FROM tbl WITH {restriction}{constraint_name}"
                     )
+
+    def test_multitable_inserts(self):
+        self.maxDiff = None
+        self.validate_identity(
+            "INSERT ALL "
+            "INTO dest_tab1 (id, description) VALUES (id, description) "
+            "INTO dest_tab2 (id, description) VALUES (id, description) "
+            "INTO dest_tab3 (id, description) VALUES (id, description) "
+            "SELECT id, description FROM source_tab"
+        )
+
+        self.validate_identity(
+            "INSERT ALL "
+            "INTO pivot_dest (id, day, val) VALUES (id, 'mon', mon_val) "
+            "INTO pivot_dest (id, day, val) VALUES (id, 'tue', tue_val) "
+            "INTO pivot_dest (id, day, val) VALUES (id, 'wed', wed_val) "
+            "INTO pivot_dest (id, day, val) VALUES (id, 'thu', thu_val) "
+            "INTO pivot_dest (id, day, val) VALUES (id, 'fri', fri_val) "
+            "SELECT * "
+            "FROM pivot_source"
+        )
+            
+        self.validate_identity(
+            "INSERT ALL "
+            "WHEN id <= 3 THEN "
+            "INTO dest_tab1 (id, description) VALUES (id, description) "
+            "WHEN id BETWEEN 4 AND 7 THEN "
+            "INTO dest_tab2 (id, description) VALUES (id, description) "
+            "WHEN id >= 8 THEN "
+            "INTO dest_tab3 (id, description) VALUES (id, description) "
+            "SELECT id, description "
+            "FROM source_tab"
+        )
+
+        self.validate_identity(
+            "INSERT ALL "
+            "WHEN id <= 3 THEN "
+            "INTO dest_tab1 (id, description) VALUES (id, description) "
+            "WHEN id BETWEEN 4 AND 7 THEN "
+            "INTO dest_tab2 (id, description) VALUES (id, description) "
+            "WHEN 1 = 1 THEN "
+            "INTO dest_tab3 (id, description) VALUES (id, description) "
+            "SELECT id, description "
+            "FROM source_tab"
+        )
+
+        self.validate_identity(
+            "INSERT FIRST "
+            "WHEN id <= 3 THEN "
+            "INTO dest_tab1 (id, description) VALUES (id, description) "
+            "WHEN id <= 5 THEN "
+            "INTO dest_tab2 (id, description) VALUES (id, description) "
+            "ELSE "
+            "INTO dest_tab3 (id, description) VALUES (id, description) "
+            "SELECT id, description "
+            "FROM source_tab"
+        )
+
+        self.validate_identity(
+            "INSERT FIRST "
+            "WHEN id <= 3 THEN "
+            "INTO dest_tab1 (id, description) VALUES (id, description) "
+            "ELSE "
+            "INTO dest_tab2 (id, description) VALUES (id, description) "
+            "INTO dest_tab3 (id, description) VALUES (id, description) "
+            "SELECT id, description "
+            "FROM source_tab"
+        )
+
+        self.validate_identity(
+            "INSERT FIRST "
+            "WHEN salary > 4000 THEN INTO emp2 "
+            "WHEN salary > 5000 THEN INTO emp3 "
+            "WHEN salary > 6000 THEN INTO emp4 "
+            "SELECT salary FROM employees"
+        )

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -531,7 +531,7 @@ WHERE
         )
 
         self.validate_identity(
-            "INSERT FIRST "
+            "/* COMMENT */ INSERT FIRST "
             "WHEN salary > 4000 THEN INTO emp2 "
             "WHEN salary > 5000 THEN INTO emp3 "
             "WHEN salary > 6000 THEN INTO emp4 "

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -482,7 +482,7 @@ WHERE
             "SELECT * "
             "FROM pivot_source"
         )
-            
+
         self.validate_identity(
             "INSERT ALL "
             "WHEN id <= 3 THEN "


### PR DESCRIPTION
Adds support for parsing multitable insert statements in Oracle SQL. Test cases are converted from the official example SQL queries.

Ref: https://oracle-base.com/articles/9i/multitable-inserts