### PR TITLE
fix(spark): Custom annotation for SUBSTRING()

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -4,6 +4,7 @@ import typing as t
 
 from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
+    Dialect,
     binary_from_function,
     build_formatted_time,
     is_parse_json,
@@ -111,6 +112,11 @@ def temporary_storage_provider(expression: exp.Expression) -> exp.Expression:
 
 
 class Spark2(Hive):
+    ANNOTATORS = {
+        **Dialect.ANNOTATORS,
+        exp.Substring: lambda self, e: self._annotate_by_args(e, "this"),
+    }
+
     class Parser(Hive.Parser):
         TRIM_PATTERN_FIRST = True
 

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -4,7 +4,6 @@ import typing as t
 
 from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
-    Dialect,
     binary_from_function,
     build_formatted_time,
     is_parse_json,
@@ -113,7 +112,7 @@ def temporary_storage_provider(expression: exp.Expression) -> exp.Expression:
 
 class Spark2(Hive):
     ANNOTATORS = {
-        **Dialect.ANNOTATORS,
+        **Hive.ANNOTATORS,
         exp.Substring: lambda self, e: self._annotate_by_args(e, "this"),
     }
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1355,13 +1355,16 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
                 ("'str_literal'", "STRING"),
                 ("CAST('str_literal' AS BINARY)", "BINARY"),
             ):
-                expr, type = expr_type_pair
-                ast = parse_one(f"SELECT substring({expr}, 2, 3) AS x FROM tbl", read=dialect)
+                with self.subTest(
+                    f"Testing {dialect}'s SUBSTRING() result type for {expr_type_pair}"
+                ):
+                    expr, type = expr_type_pair
+                    ast = parse_one(f"SELECT substring({expr}, 2, 3) AS x FROM tbl", read=dialect)
 
-                subst_type = (
-                    optimizer.optimize(ast, schema={"tbl": {"col": type}}, dialect=dialect)
-                    .expressions[0]
-                    .type
-                )
+                    subst_type = (
+                        optimizer.optimize(ast, schema={"tbl": {"col": type}}, dialect=dialect)
+                        .expressions[0]
+                        .type
+                    )
 
-                self.assertEqual(subst_type.sql(dialect), exp.DataType.build(type).sql(dialect))
+                    self.assertEqual(subst_type.sql(dialect), exp.DataType.build(type).sql(dialect))

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1347,7 +1347,6 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         self.assertEqual(110, normalization_distance(gen_expr(10), max_=100))
 
     def test_custom_annotators(self):
-
         # In Spark hierarchy, SUBSTRING result type is dependent on input expr type
         for dialect in ("spark2", "spark", "databricks"):
             for expr_type_pair in (


### PR DESCRIPTION
Fixes #4002

Could not test HiveQL but the docs mention only `STRING` as the return type, so this PR is limited to Spark2+:

- Spark 2:
```
scala> spark.sql("select substring(cast('thing' as binary), 1, 2), substring('thing', 1, 2)")
res4: org.apache.spark.sql.DataFrame = [substring(CAST(thing AS BINARY), 1, 2): binary, substring(thing, 1, 2): string]
```

- Spark 3:
```
spark-sql (default)> select typeof(substring('thing', 1, 2)), typeof(substring(cast('thing' as binary), 1, 2));
string  binary
```

- Databricks
```
select typeof(substring(cast('thing' as binary), 1, 2)) as bin, typeof(substring('thing', 1, 2)) as str; 

bin	str
binary	string
```



Docs
--------
[Databricks SUBSTRING](https://docs.databricks.com/en/sql/language-manual/functions/substr.html) | [HiveQL Builtin Functions](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF) 