### PR TITLE
Fix!: refactor SET OPERATION handling to set correct defaults

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -613,7 +613,6 @@ class BigQuery(Dialect):
             return unnest
 
     class Generator(generator.Generator):
-        EXPLICIT_SET_OP = True
         INTERVAL_ALLOWS_PLURAL_FORM = False
         JOIN_HINTS = False
         QUERY_HINTS = False

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -146,6 +146,12 @@ class ClickHouse(Dialect):
 
     CREATABLE_KIND_MAPPING = {"DATABASE": "SCHEMA"}
 
+    SET_OP_DISTINCT_BY_DEFAULT: t.Dict[t.Type[exp.Expression], t.Optional[bool]] = {
+        exp.Except: False,
+        exp.Intersect: False,
+        exp.Union: None,
+    }
+
     class Tokenizer(tokens.Tokenizer):
         COMMENTS = ["--", "#", "#!", ("/*", "*/")]
         IDENTIFIERS = ['"', "`"]

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -765,7 +765,6 @@ class ClickHouse(Dialect):
         SUPPORTS_TO_NUMBER = False
         JOIN_HINTS = False
         TABLE_HINTS = False
-        EXPLICIT_SET_OP = True
         GROUPINGS_SEP = ""
         SET_OP_MODIFIERS = False
         SUPPORTS_TABLE_ALIAS_COLUMNS = False

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -388,6 +388,16 @@ class Dialect(metaclass=_Dialect):
     dialects which don't support fixed size arrays such as Snowflake, this should be interpreted as a subscript/index operator
     """
 
+    SET_OP_DISTINCT_BY_DEFAULT: t.Dict[t.Type[exp.Expression], t.Optional[bool]] = {
+        exp.Except: True,
+        exp.Intersect: True,
+        exp.Union: True,
+    }
+    """
+    Whether a set operation uses DISTINCT by default. This is `None` when either `DISTINCT` or `ALL`
+    must be explicitly specified.
+    """
+
     CREATABLE_KIND_MAPPING: dict[str, str] = {}
     """
     Helper for dialects that use a different name for the same creatable kind. For example, the Clickhouse

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -362,6 +362,7 @@ class Presto(Dialect):
         HEX_FUNC = "TO_HEX"
         PARSE_JSON_NAME = "JSON_PARSE"
         PAD_FILL_PATTERN_IS_REQUIRED = True
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -155,6 +155,7 @@ class Redshift(Postgres):
         PARSE_JSON_NAME = "JSON_PARSE"
         ARRAY_CONCAT_IS_VAR_LEN = False
         SUPPORTS_CONVERT_TIMEZONE = True
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
 
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -752,6 +752,7 @@ class Snowflake(Dialect):
         SUPPORTS_EXPLODING_PROJECTIONS = False
         ARRAY_CONCAT_IS_VAR_LEN = False
         SUPPORTS_CONVERT_TIMEZONE = True
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
@@ -995,16 +996,6 @@ class Snowflake(Dialect):
                 parameters,
                 group,
             )
-
-        def except_op(self, expression: exp.Except) -> str:
-            if not expression.args.get("distinct"):
-                self.unsupported("EXCEPT with All is not supported in Snowflake")
-            return super().except_op(expression)
-
-        def intersect_op(self, expression: exp.Intersect) -> str:
-            if not expression.args.get("distinct"):
-                self.unsupported("INTERSECT with All is not supported in Snowflake")
-            return super().intersect_op(expression)
 
         def describe_sql(self, expression: exp.Describe) -> str:
             # Default to table if kind is unknown

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -128,6 +128,7 @@ class SQLite(Dialect):
         SUPPORTS_CREATE_TABLE_LIKE = False
         SUPPORTS_TABLE_ALIAS_COLUMNS = False
         SUPPORTS_TO_NUMBER = False
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -49,6 +49,8 @@ class StarRocks(MySQL):
             return unnest
 
     class Generator(MySQL.Generator):
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+
         CAST_MAPPING = {}
 
         TYPE_MAPPING = {

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -815,6 +815,7 @@ class TSQL(Dialect):
         SET_OP_MODIFIERS = False
         COPY_PARAMS_EQ_REQUIRED = True
         PARSE_JSON_NAME = None
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
 
         EXPRESSIONS_WITHOUT_NESTED_CTES = {
             exp.Create,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4204,7 +4204,16 @@ class Parser(metaclass=_Parser):
                 operation = exp.Intersect
 
             comments = self._prev.comments
-            distinct = self._match(TokenType.DISTINCT) or not self._match(TokenType.ALL)
+
+            if self._match(TokenType.DISTINCT):
+                distinct: t.Optional[bool] = True
+            elif self._match(TokenType.ALL):
+                distinct = False
+            else:
+                distinct = self.dialect.SET_OP_DISTINCT_BY_DEFAULT[operation]
+                if distinct is None:
+                    self.raise_error(f"Expected DISTINCT or ALL for {operation.__class__.__name__}")
+
             by_name = self._match_text_seq("BY", "NAME")
             expression = self._parse_select(nested=True, parse_set_operation=False)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4212,7 +4212,7 @@ class Parser(metaclass=_Parser):
             else:
                 distinct = self.dialect.SET_OP_DISTINCT_BY_DEFAULT[operation]
                 if distinct is None:
-                    self.raise_error(f"Expected DISTINCT or ALL for {operation.__class__.__name__}")
+                    self.raise_error(f"Expected DISTINCT or ALL for {operation.__name__}")
 
             by_name = self._match_text_seq("BY", "NAME")
             expression = self._parse_select(nested=True, parse_set_operation=False)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1541,7 +1541,7 @@ class TestDialect(Validator):
             "SELECT * FROM a INTERSECT ALL SELECT * FROM b",
             write={
                 "bigquery": "SELECT * FROM a INTERSECT ALL SELECT * FROM b",
-                "clickhouse": "SELECT * FROM a INTERSECT ALL SELECT * FROM b",
+                "clickhouse": "SELECT * FROM a INTERSECT SELECT * FROM b",
                 "duckdb": "SELECT * FROM a INTERSECT ALL SELECT * FROM b",
                 "presto": "SELECT * FROM a INTERSECT ALL SELECT * FROM b",
                 "spark": "SELECT * FROM a INTERSECT ALL SELECT * FROM b",
@@ -2728,5 +2728,28 @@ FROM subquery2""",
                 "redshift": "WITH RECURSIVE _generated_dates(date_week) AS (SELECT CAST('2020-01-01' AS DATE) AS date_week UNION ALL SELECT CAST(DATEADD(WEEK, 1, date_week) AS DATE) FROM _generated_dates WHERE CAST(DATEADD(WEEK, 1, date_week) AS DATE) <= CAST('2020-02-01' AS DATE)) SELECT * FROM (SELECT date_week FROM _generated_dates) AS _generated_dates",
                 "snowflake": "SELECT * FROM (SELECT DATEADD(WEEK, CAST(date_week AS INT), CAST('2020-01-01' AS DATE)) AS date_week FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _q(seq, key, path, index, date_week, this)) AS _q(date_week)",
                 "tsql": "WITH _generated_dates(date_week) AS (SELECT CAST('2020-01-01' AS DATE) AS date_week UNION ALL SELECT CAST(DATEADD(WEEK, 1, date_week) AS DATE) FROM _generated_dates WHERE CAST(DATEADD(WEEK, 1, date_week) AS DATE) <= CAST('2020-02-01' AS DATE)) SELECT * FROM (SELECT date_week AS date_week FROM _generated_dates) AS _generated_dates",
+            },
+        )
+
+    def test_set_operation_specifiers(self):
+        self.validate_all(
+            "SELECT 1 EXCEPT ALL SELECT 1",
+            write={
+                "": "SELECT 1 EXCEPT ALL SELECT 1",
+                "bigquery": UnsupportedError,
+                "clickhouse": "SELECT 1 EXCEPT SELECT 1",
+                "databricks": "SELECT 1 EXCEPT ALL SELECT 1",
+                "duckdb": "SELECT 1 EXCEPT ALL SELECT 1",
+                "mysql": "SELECT 1 EXCEPT ALL SELECT 1",
+                "oracle": "SELECT 1 EXCEPT ALL SELECT 1",
+                "postgres": "SELECT 1 EXCEPT ALL SELECT 1",
+                "presto": UnsupportedError,
+                "redshift": UnsupportedError,
+                "snowflake": UnsupportedError,
+                "spark": "SELECT 1 EXCEPT ALL SELECT 1",
+                "sqlite": UnsupportedError,
+                "starrocks": UnsupportedError,
+                "trino": UnsupportedError,
+                "tsql": UnsupportedError,
             },
         )


### PR DESCRIPTION
Main motivation was to address https://github.com/tobymao/sqlglot/pull/4007#issuecomment-2317930198, but later down the line I realized the way we parse & generate the `DISTINCT` and `ALL` specifiers (e.g. default values) was a bit brittle. So I took a stab at refactoring this, e.g. improved "unsupported" warnings.

<details>
  <summary>Click this to see references (docs etc)</summary>

BigQuery:
- Needs specifier for all set operations
- EXCEPT, DISTINCT don’t work with ALL
- https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#set_operators

ClickHouse:
- Needs specifier for UNION, unless union_default_mode is set
- INTERSECT, EXCEPT are ALL by default
- https://clickhouse.com/docs/en/sql-reference/statements/select/union
- https://clickhouse.com/docs/en/sql-reference/statements/select/intersect
- https://clickhouse.com/docs/en/sql-reference/statements/select/except

DataBricks, Spark:
- All set operations are DISTINCT by default
- https://docs.databricks.com/en/sql/language-manual/sql-ref-syntax-qry-select-setops.html
- https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-setops.html

DuckDB:
- All set operations are DISTINCT by default
- https://duckdb.org/docs/sql/query_syntax/setops.html

Hive:
- Seems to only support UNION?
- UNION is DISTINCT by default
- https://cwiki.apache.org/confluence/display/Hive/LanguageManual+Union#LanguageManualUnion-UnionSyntax

MySQL:
- All set operations are DISTINCT by default
- https://dev.mysql.com/doc/refman/8.4/en/set-operations.html

Oracle:
- All set operations are DISTINCT by default
- https://docs.oracle.com/cd/B19306_01/server.102/b14200/queries004.htm#i2054381

Postgres:
- All set operations are DISTINCT by default
- https://www.postgresql.org/docs/current/queries-union.html

Presto, Trino:
- All set operations are DISTINCT by default
- EXCEPT, DISTINCT don’t work with ALL
- https://prestodb.io/docs/current/sql/select.html#union-intersect-except-clause
- https://trino.io/docs/current/sql/select.html#union-clause

Redshift:
- All set operations are DISTINCT by default
- EXCEPT, DISTINCT don’t work with ALL
- https://docs.aws.amazon.com/redshift/latest/dg/r_UNION.html

Snowflake:
- All set operations are DISTINCT by default
- EXCEPT, DISTINCT don’t work with ALL
- https://docs.snowflake.com/en/sql-reference/operators-query

SQLite:
- All set operations are DISTINCT by default
- EXCEPT, DISTINCT don’t work with ALL
- https://www.sqlite.org/draft/lang_select.html

Starrocks:
- All set operations are DISTINCT by default
- EXCEPT, DISTINCT don’t work with ALL
- https://docs.starrocks.io/docs/sql-reference/sql-statements/data-manipulation/SELECT/#union

T-SQL:
- All set operations are DISTINCT by default
- EXCEPT, DISTINCT don’t work with ALL
- https://learn.microsoft.com/en-us/sql/t-sql/language-elements/set-operators-union-transact-sql?view=sql-server-ver16
- https://learn.microsoft.com/en-us/sql/t-sql/language-elements/set-operators-except-and-intersect-transact-sql?view=sql-server-ver16

</details>