### PR TITLE
fix(mysql)!: Preserve roundtrip of %a, %W time formats

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -173,7 +173,7 @@ class MySQL(Dialect):
         "%k": "%-H",
         "%l": "%-I",
         "%T": "%H:%M:%S",
-        "%W": "%a",
+        "%W": "%A",
     }
 
     class Tokenizer(tokens.Tokenizer):

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -240,10 +240,7 @@ class Presto(Dialect):
     TABLESAMPLE_SIZE_IS_PERCENT = True
     LOG_BASE_FIRST: t.Optional[bool] = None
 
-    TIME_MAPPING = {
-        **MySQL.TIME_MAPPING,
-        "%W": "%A",
-    }
+    TIME_MAPPING = MySQL.TIME_MAPPING
 
     # https://github.com/trinodb/trino/issues/17
     # https://github.com/trinodb/trino/issues/12289

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -539,9 +539,16 @@ class TestMySQL(Validator):
             },
         )
         self.validate_all(
-            "SELECT DATE_FORMAT('2009-10-04 22:23:00', '%W %M %Y')",
+            "SELECT DATE_FORMAT('2024-08-22 14:53:12', '%a')",
             write={
-                "mysql": "SELECT DATE_FORMAT('2009-10-04 22:23:00', '%W %M %Y')",
+                "mysql": "SELECT DATE_FORMAT('2024-08-22 14:53:12', '%a')",
+                "snowflake": "SELECT TO_CHAR(CAST('2024-08-22 14:53:12' AS TIMESTAMP), 'DY')",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FORMAT('2009-10-04 22:23:00', '%a %M %Y')",
+            write={
+                "mysql": "SELECT DATE_FORMAT('2009-10-04 22:23:00', '%a %M %Y')",
                 "snowflake": "SELECT TO_CHAR(CAST('2009-10-04 22:23:00' AS TIMESTAMP), 'DY mmmm yyyy')",
             },
         )
@@ -555,7 +562,7 @@ class TestMySQL(Validator):
         self.validate_all(
             "SELECT DATE_FORMAT('1900-10-04 22:23:00', '%d %y %a %d %m %b')",
             write={
-                "mysql": "SELECT DATE_FORMAT('1900-10-04 22:23:00', '%d %y %W %d %m %b')",
+                "mysql": "SELECT DATE_FORMAT('1900-10-04 22:23:00', '%d %y %a %d %m %b')",
                 "snowflake": "SELECT TO_CHAR(CAST('1900-10-04 22:23:00' AS TIMESTAMP), 'DD yy DY DD mm mon')",
             },
         )


### PR DESCRIPTION
Fixes #4011 

For reference:

```
Python's strftime:
- Uses %a for abbreviated weekday (Mon, Sun)
- Uses %A for full weekday (Monday, Sunday)

MySQL's format:
- Uses %a for abbreviated weekday (Mon, Sun)
- Uses %W for full weekday (Monday, Sunday)

Snowflake's format for conversion functions:
- Uses DY for abbreviated weekday (Mon, Sun)
- Does not have a full weekday element
```

This PR fixes the following issues:
1. SQLGlot would change the `%a` to `%W` during MySQL's RTT:

```
sqlglot.parse_one("SELECT DATE_FORMAT('2024-08-22 14:53:12', '%a')", read="mysql").write("mysql")
SELECT DATE_FORMAT('2024-08-22 14:53:12', '%W')
```

2. SQLGlot would transpile MySQL's `%W` (full weekday) to Snowflake's `DY` (abbreviated weekday); The correct transpilation is `%a -> DY`, whereas `%W` does not have a proper Snowflake counterpart for conversion functions

Docs
--------
[Python strftime](https://strftime.org/) | [MySQL Date formats](https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format) | [Snowflake formats in conversion functions](https://docs.snowflake.com/en/sql-reference/functions-conversion#label-date-time-format-conversion)