### PR TITLE
fix(presto): exp.DayOfWeek

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -496,6 +496,7 @@ class DuckDB(Dialect):
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
+            exp.DayOfWeekIso: rename_func("ISODOW"),
             exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.DataType: _datatype_sql,
             exp.Date: _date_sql,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -305,7 +305,7 @@ class Presto(Dialect):
             "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "presto"),
             "DATE_PARSE": build_formatted_time(exp.StrToTime, "presto"),
             "DATE_TRUNC": date_trunc_to_time,
-            "DAY_OF_WEEK": lambda args: exp.DayOfWeekIso(this=seq_get(args, 0)),
+            "DAY_OF_WEEK": exp.DayOfWeekIso.from_arg_list,
             "ELEMENT_AT": lambda args: exp.Bracket(
                 this=seq_get(args, 0), expressions=[seq_get(args, 1)], offset=1, safe=True
             ),

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -416,7 +416,7 @@ class Presto(Dialect):
             exp.DateToDi: lambda self,
             e: f"CAST(DATE_FORMAT({self.sql(e, 'this')}, {Presto.DATEINT_FORMAT}) AS INT)",
             exp.DateSub: _date_delta_sql("DATE_ADD", negate_interval=True),
-            exp.DayOfWeekIso: lambda self, e: f"DAY_OF_WEEK({self.sql(e, 'this')})",
+            exp.DayOfWeekIso: rename_func("DAY_OF_WEEK"),
             exp.Decode: lambda self, e: encode_decode_sql(self, e, "FROM_UTF8"),
             exp.DiToDate: lambda self,
             e: f"CAST(DATE_PARSE(CAST({self.sql(e, 'this')} AS VARCHAR), {Presto.DATEINT_FORMAT}) AS DATE)",

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -305,6 +305,7 @@ class Presto(Dialect):
             "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "presto"),
             "DATE_PARSE": build_formatted_time(exp.StrToTime, "presto"),
             "DATE_TRUNC": date_trunc_to_time,
+            "DAY_OF_WEEK": lambda args: exp.DayOfWeekIso(this=seq_get(args, 0)),
             "ELEMENT_AT": lambda args: exp.Bracket(
                 this=seq_get(args, 0), expressions=[seq_get(args, 1)], offset=1, safe=True
             ),
@@ -415,6 +416,7 @@ class Presto(Dialect):
             exp.DateToDi: lambda self,
             e: f"CAST(DATE_FORMAT({self.sql(e, 'this')}, {Presto.DATEINT_FORMAT}) AS INT)",
             exp.DateSub: _date_delta_sql("DATE_ADD", negate_interval=True),
+            exp.DayOfWeekIso: lambda self, e: f"DAY_OF_WEEK({self.sql(e, 'this')})",
             exp.Decode: lambda self, e: encode_decode_sql(self, e, "FROM_UTF8"),
             exp.DiToDate: lambda self,
             e: f"CAST(DATE_PARSE(CAST({self.sql(e, 'this')} AS VARCHAR), {Presto.DATEINT_FORMAT}) AS DATE)",

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -217,6 +217,8 @@ class Spark2(Hive):
             exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, unit_to_str(e)),
             exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
+            # (DAY_OF_WEEK(datetime) % 7) + 1 is equivalent to DAYOFWEEK_ISO(datetime)
+            exp.DayOfWeekIso: lambda self, e: f"(({self.func('DAYOFWEEK', e.this)} % 7) + 1)",
             exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.FileFormatProperty: lambda self, e: f"USING {e.name.upper()}",
             exp.From: transforms.preprocess([_unalias_pivot]),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5230,6 +5230,12 @@ class DayOfWeek(Func):
     _sql_names = ["DAY_OF_WEEK", "DAYOFWEEK"]
 
 
+# https://duckdb.org/docs/sql/functions/datepart.html#part-specifiers-only-usable-as-date-part-specifiers
+# ISO day of week function in duckdb is ISODOW
+class DayOfWeekIso(Func):
+    _sql_names = ["DAYOFWEEK_ISO", "ISODOW"]
+
+
 class DayOfMonth(Func):
     _sql_names = ["DAY_OF_MONTH", "DAYOFMONTH"]
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -879,7 +879,7 @@ class TestDuckDB(Validator):
             write={"duckdb": "SELECT (90 * INTERVAL '1' DAY)"},
         )
         self.validate_all(
-            "SELECT ((DATE_TRUNC('DAY', CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP) + INTERVAL (0 - ((DAYOFWEEK(CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP)) % 7) - 1 + 7) % 7) DAY) + (7 * INTERVAL (-5) DAY))) AS t1",
+            "SELECT ((DATE_TRUNC('DAY', CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP) + INTERVAL (0 - ((ISODOW(CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP)) % 7) - 1 + 7) % 7) DAY) + (7 * INTERVAL (-5) DAY))) AS t1",
             read={
                 "presto": "SELECT ((DATE_ADD('week', -5, DATE_TRUNC('DAY', DATE_ADD('day', (0 - MOD((DAY_OF_WEEK(CAST(CAST(DATE_TRUNC('DAY', NOW()) AS DATE) AS TIMESTAMP)) % 7) - 1 + 7, 7)), CAST(CAST(DATE_TRUNC('DAY', NOW()) AS DATE) AS TIMESTAMP)))))) AS t1",
             },

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -331,9 +331,9 @@ class TestPresto(Validator):
         self.validate_all(
             "DAY_OF_WEEK(timestamp '2012-08-08 01:00:00')",
             write={
-                "spark": "DAYOFWEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "spark": "((DAYOFWEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP)) % 7) + 1)",
                 "presto": "DAY_OF_WEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "duckdb": "DAYOFWEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "duckdb": "ISODOW(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
 


### PR DESCRIPTION
Presto's day_of_week is ISO standard, which is inconsistent with other engines. Concepts:
- ISO standard: Returns the ISO day of the week from x. The value ranges from 1 (Monday) to 7 (Sunday).
- Non-ISO standard: Returns the day of the week for date/timestamp (1 = Sunday, 2 = Monday, ..., 7 = Saturday).

For reference:
|  type  |   ISO function   |    Non-ISO function     |
| :----: | :--------------: | :---------------------: |
| Spark  |        -         |        dayofweek        |
| Presto | day_of_week\|dow |            -            |
| DuckDB |      isodow      | dayofweek\|weekday\|dow |

> DuckDB's dayofweek starts from 0, which is inconsistent with others. `Day of the week (Sunday = 0, Saturday = 6)`

This PR adds support for the following:
- Spark lacks ISO standard day_of_week, use expression `((DAY_OF_WEEK(datetime) % 7) + 1)` instead
- DuckDB converts `exp.DayOfWeekIso` to `ISODOW`
- Presto parses DAY_OF_WEEK to `exp.DayOfWeekIso`, when generating to `DAY_OF_WEEK`

## Docs

[Spark  Doc](https://spark.apache.org/docs/latest/api/sql/#dayofweek) | [Presto  Doc](https://prestodb.io/docs/current/functions/datetime.html#dow-x-bigint) | [DuckDB  Doc](https://duckdb.org/docs/sql/functions/datepart.html#part-specifiers-only-usable-as-date-part-specifiers)
