### PR TITLE
fea(tsql): Parse ODBC datetime columns

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5616,11 +5616,7 @@ class Parser(metaclass=_Parser):
         """
         self._match(TokenType.VAR)
         exp_class = self.ODBC_DATETIME_LITERALS[self._prev.text.lower()]
-        expression = self.expression(
-            exp_class=exp_class,
-            this=exp.Literal.string(self._curr.text),
-        )
-        self._match(TokenType.STRING)
+        expression = self.expression(exp_class=exp_class, this=self._parse_string())
         if not self._match(TokenType.R_BRACE):
             self.raise_error("Expected }")
         return expression

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5608,8 +5608,8 @@ class Parser(metaclass=_Parser):
     def _parse_odbc_datetime_literal(self) -> exp.Expression:
         """
         Parses a datetime column in ODBC format. We parse the column into the corresponding
-        types, for example `{d'yyyy-mm-dd'}` will be parsed as a `Date` column, isexactly
-        the same as we did for `DATE('yyyy-mm-dd')`.
+        types, for example `{d'yyyy-mm-dd'}` will be parsed as a `Date` column, exactly the
+        same as we did for `DATE('yyyy-mm-dd')`.
 
         Reference:
         https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/date-time-and-timestamp-literals

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -860,7 +860,6 @@ class TestParser(unittest.TestCase):
         self,
     ):
         for value, cls in [
-            ("DATE('2024-01-01')", exp.Date),
             ("{d'2024-01-01'}", exp.Date),
             ("{t'12:00:00'}", exp.Time),
             ("{ts'2024-01-01 12:00:00'}", exp.Timestamp),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -855,9 +855,7 @@ class TestParser(unittest.TestCase):
             self.assertIsInstance(collate_node, exp.Collate)
             self.assertIsInstance(collate_node.expression, collate_pair[1])
 
-    def test_odbc_date_literals(
-        self,
-    ):
+    def test_odbc_date_literals(self):
         for value, cls in [
             ("{d'2024-01-01'}", exp.Date),
             ("{t'12:00:00'}", exp.Time),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,7 +2,6 @@ import time
 import unittest
 from unittest.mock import patch
 
-
 from sqlglot import Parser, exp, parse, parse_one
 from sqlglot.errors import ErrorLevel, ParseError
 from sqlglot.parser import logger as parser_logger

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,6 +2,7 @@ import time
 import unittest
 from unittest.mock import patch
 
+
 from sqlglot import Parser, exp, parse, parse_one
 from sqlglot.errors import ErrorLevel, ParseError
 from sqlglot.parser import logger as parser_logger
@@ -854,3 +855,17 @@ class TestParser(unittest.TestCase):
             ).find(exp.Collate)
             self.assertIsInstance(collate_node, exp.Collate)
             self.assertIsInstance(collate_node.expression, collate_pair[1])
+
+    def test_odbc_date_literals(
+        self,
+    ):
+        for value, cls in [
+            ("DATE('2024-01-01')", exp.Date),
+            ("{d'2024-01-01'}", exp.Date),
+            ("{t'12:00:00'}", exp.Time),
+            ("{ts'2024-01-01 12:00:00'}", exp.Timestamp),
+        ]:
+            sql = f"INSERT INTO tab(ds) VALUES ({value})"
+            expr = parse_one(sql)
+            self.assertIsInstance(expr, exp.Insert)
+            self.assertIsInstance(expr.expression.expressions[0].expressions[0], cls)


### PR DESCRIPTION
Datetime columns can be specified in ODBC format: https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/date-time-and-timestamp-literals

Our use case only requires us to be able to parse it, for us it is fine if the output sql is `DATE('yyyy-mm-dd')` instead of `{d'yyyy-mm-dd'}`.