### PR TITLE
feat(duckdb): Transpile BQ's exp.ArrayToString

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -932,7 +932,7 @@ class DuckDB(Dialect):
 
         def arraytostring_sql(self, expression: exp.ArrayToString) -> str:
             this = self.sql(expression, "this")
-            null_text = expression.args.get("null")
+            null_text = self.sql(expression, "null")
 
             if null_text:
                 this = f"LIST_TRANSFORM({this}, x -> COALESCE(x, {null_text}))"

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -929,3 +929,12 @@ class DuckDB(Dialect):
                 return super().ignorenulls_sql(expression)
 
             return self.sql(expression, "this")
+
+        def arraytostring_sql(self, expression: exp.ArrayToString) -> str:
+            this = self.sql(expression, "this")
+            null_text = expression.args.get("null")
+
+            if null_text:
+                this = f"LIST_TRANSFORM({this}, x -> COALESCE(x, {null_text}))"
+
+            return self.func("ARRAY_TO_STRING", this, expression.expression)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -108,7 +108,6 @@ LANGUAGE js AS
         self.validate_identity("SELECT * FROM READ_CSV('bla.csv')")
         self.validate_identity("CAST(x AS STRUCT<list ARRAY<INT64>>)")
         self.validate_identity("assert.true(1 = 1)")
-        self.validate_identity("SELECT ARRAY_TO_STRING(list, '--') AS text")
         self.validate_identity("SELECT jsondoc['some_key']")
         self.validate_identity("SELECT `p.d.UdF`(data).* FROM `p.d.t`")
         self.validate_identity("SELECT * FROM `my-project.my-dataset.my-table`")
@@ -1476,6 +1475,20 @@ WHERE
             write={
                 "bigquery": "SELECT PARSE_DATE('%A %b %e %Y', 'Thursday Dec 25 2008')",
                 "duckdb": "SELECT CAST(STRPTIME('Thursday Dec 25 2008', '%A %b %-d %Y') AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT ARRAY_TO_STRING(['cake', 'pie', NULL], '--') AS text",
+            write={
+                "bigquery": "SELECT ARRAY_TO_STRING(['cake', 'pie', NULL], '--') AS text",
+                "duckdb": "SELECT ARRAY_TO_STRING(['cake', 'pie', NULL], '--') AS text",
+            },
+        )
+        self.validate_all(
+            "SELECT ARRAY_TO_STRING(['cake', 'pie', NULL], '--', 'MISSING') AS text",
+            write={
+                "bigquery": "SELECT ARRAY_TO_STRING(['cake', 'pie', NULL], '--', 'MISSING') AS text",
+                "duckdb": "SELECT ARRAY_TO_STRING(LIST_TRANSFORM(['cake', 'pie', NULL], x -> COALESCE(x, 'MISSING')), '--') AS text",
             },
         )
 


### PR DESCRIPTION
BigQuery's `ARRAY_TO_STRING(array_expression, delimiter[, null_text])` allows for a 3rd argument which replaces `NULL`  values with the equivalent text.

This is not available on other dialects such as DuckDB, but a custom transformation can mimic that behavior as an intermediate step:

```
[BQ] ARRAY_TO_STRING(arr, delimiter, null_text) -> [DDB] ARRAY_TO_STRING(LIST_TRANSFORM(arr, x -> COALESCE(x, null_text), delimiter) 
```

Docs
-------
[BQ ARRAY_TO_STRING](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_to_string) | [DuckDB LIST_TRANSFORM](https://duckdb.org/docs/sql/functions/list.html#list_transformlist-lambda) | [DuckDB ARRAY_TO_STRING](https://duckdb.org/docs/sql/functions/list.html#array_to_string)

 