### PR TITLE
fix(duckdb): Wrap negative time intervals

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -793,6 +793,12 @@ class DuckDB(Dialect):
             if unit.startswith("quarter"):
                 multiplier = 90
 
+            # Wrap negative intervals as DuckDB does not parse them properly, e.g
+            # "SELECT date_col + INTERVAL -5 DAY" throws a parse error
+            this = expression.this
+            if this.is_number and this.to_py() < 0:
+                expression.set("this", exp.Paren(this=this))
+
             if multiplier:
                 return f"({multiplier} * {super().interval_sql(exp.Interval(this=expression.this, unit=exp.var('DAY')))})"
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1015,6 +1015,15 @@ class TestDuckDB(Validator):
                 "spark": "SELECT * FROM (SELECT * FROM t) TABLESAMPLE (1 ROWS) AS t1, (SELECT * FROM t) TABLESAMPLE (2 ROWS) AS t2",
             },
         )
+        self.validate_all(
+            "SELECT CAST('2008-12-25' AS DATE) + INTERVAL (-5) DAY",
+            read={
+                "bigquery": "SELECT DATE_ADD(DATE '2008-12-25', INTERVAL -5 DAY)",
+            },
+            write={
+                "duckdb": "SELECT CAST('2008-12-25' AS DATE) + INTERVAL (-5) DAY",
+            },
+        )
 
     def test_array(self):
         self.validate_identity("ARRAY(SELECT id FROM t)")


### PR DESCRIPTION
DuckDB does not parse negative intervals properly, e.g:

```SQL
D SELECT CAST('2008-12-25' AS DATE) + INTERVAL -5 DAY;
Error: Parser Error: syntax error at or near "DAY"
                                                  ^
```

However, it can do so if the value is either (1) wrapped or (2) quoted:

```
D SELECT CAST('2008-12-25' AS DATE) + INTERVAL (-5) DAY;
┌────────────────────────────────────────────────────────────────────────────────────┐
│ (CAST('2008-12-25' AS DATE) + to_days(CAST(trunc(CAST(-5 AS DOUBLE)) AS INTEGER))) │
│                                     timestamp                                      │
├────────────────────────────────────────────────────────────────────────────────────┤
│ 2008-12-20 00:00:00                                                                │
└────────────────────────────────────────────────────────────────────────────────────┘

D SELECT CAST('2008-12-25' AS DATE) + INTERVAL '-5' DAY;
┌──────────────────────────────────────────────────────────────────────────────────────┐
│ (CAST('2008-12-25' AS DATE) + to_days(CAST(trunc(CAST('-5' AS DOUBLE)) AS INTEGER))) │
│                                      timestamp                                       │
├──────────────────────────────────────────────────────────────────────────────────────┤
│ 2008-12-20 00:00:00                                                                  │
└──────────────────────────────────────────────────────────────────────────────────────┘

```

This PR solves this problem by wrapping negative values at `exp.Interval` generation.