### PR TITLE
feat: Support NORMALIZE() function

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5850,6 +5850,10 @@ class Nvl2(Func):
     arg_types = {"this": True, "true": True, "false": False}
 
 
+class Normalize(Func):
+    arg_types = {"this": True, "form": False}
+
+
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict#mlpredict_function
 class Predict(Func):
     arg_types = {"this": True, "expression": True, "params_struct": False}

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1096,6 +1096,7 @@ class Parser(metaclass=_Parser):
         "JSON_OBJECTAGG": lambda self: self._parse_json_object(agg=True),
         "JSON_TABLE": lambda self: self._parse_json_table(),
         "MATCH": lambda self: self._parse_match_against(),
+        "NORMALIZE": lambda self: self._parse_normalize(),
         "OPENJSON": lambda self: self._parse_open_json(),
         "POSITION": lambda self: self._parse_position(),
         "PREDICT": lambda self: self._parse_predict(),
@@ -7312,4 +7313,11 @@ class Parser(metaclass=_Parser):
             credentials=credentials,
             files=files,
             params=params,
+        )
+
+    def _parse_normalize(self) -> exp.Normalize:
+        return self.expression(
+            exp.Normalize,
+            this=self._parse_bitwise(),
+            form=self._match(TokenType.COMMA) and self._parse_var(),
         )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2760,3 +2760,22 @@ FROM subquery2""",
                 "tsql": UnsupportedError,
             },
         )
+
+    def test_normalize(self):
+        for form in ("", ", nfkc"):
+            with self.subTest(f"Testing NORMALIZE('str'{form}) roundtrip"):
+                self.validate_all(
+                    f"SELECT NORMALIZE('str'{form})",
+                    read={
+                        "presto": f"SELECT NORMALIZE('str'{form})",
+                        "trino": f"SELECT NORMALIZE('str'{form})",
+                        "bigquery": f"SELECT NORMALIZE('str'{form})",
+                    },
+                    write={
+                        "presto": f"SELECT NORMALIZE('str'{form})",
+                        "trino": f"SELECT NORMALIZE('str'{form})",
+                        "bigquery": f"SELECT NORMALIZE('str'{form})",
+                    },
+                )
+
+        self.assertIsInstance(parse_one("NORMALIZE('str', NFD)").args.get("form"), exp.Var)


### PR DESCRIPTION
Fixes #4037

Parse `NORMALIZE(text[, form])` into the new `exp.Normalize` node. This function signature exists in BigQuery, Trino and Presto from my research; Other dialects also support normalization functions but with different signatures. 

Docs
---------
[Presto](https://prestodb.io/docs/current/functions/string.html#unicode-functions) | [Trino](https://trino.io/docs/current/functions/string.html#unicode-functions) | [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#normalize)