### PR TITLE
fix!: Canonicalize exp.RegexpExtract group default value

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1374,7 +1374,7 @@ def regexp_extract_sql(self: Generator, expression: exp.RegexpExtract) -> str:
     group = expression.args.get("group")
 
     # Do not render group if it's the default value for this dialect
-    if group and group.name == f"{self.dialect.REGEXP_EXTRACT_DEFAULT_GROUP}":
+    if group and group.name == str(self.dialect.REGEXP_EXTRACT_DEFAULT_GROUP):
         group = None
 
     return self.func("REGEXP_EXTRACT", expression.this, expression.expression, group)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -401,7 +401,7 @@ class Dialect(metaclass=_Dialect):
     """Whether ArrayAgg needs to filter NULL values."""
 
     REGEXP_EXTRACT_DEFAULT_GROUP = 0
-    """The default value for the capturing group, if not otherwise specified"""
+    """The default value for the capturing group."""
 
     SET_OP_DISTINCT_BY_DEFAULT: t.Dict[t.Type[exp.Expression], t.Optional[bool]] = {
         exp.Except: True,

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1700,8 +1700,6 @@ def sequence_sql(self: Generator, expression: exp.GenerateSeries | exp.GenerateD
 
 
 def build_regexp_extract(args: t.List, dialect: DialectType) -> exp.RegexpExtract:
-    dialect = Dialect.get_or_raise(dialect)
-
     return exp.RegexpExtract(
         this=seq_get(args, 0),
         expression=seq_get(args, 1),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -361,7 +361,9 @@ class DuckDB(Dialect):
             "QUANTILE_CONT": exp.PercentileCont.from_arg_list,
             "QUANTILE_DISC": exp.PercentileDisc.from_arg_list,
             "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
-                this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                group=seq_get(args, 2) or exp.Literal.number(0),
             ),
             "REGEXP_MATCHES": exp.RegexpLike.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -34,6 +34,7 @@ from sqlglot.dialects.dialect import (
     unit_to_var,
     unit_to_str,
     sha256_sql,
+    build_regexp_extract,
 )
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
@@ -360,11 +361,7 @@ class DuckDB(Dialect):
             ),
             "QUANTILE_CONT": exp.PercentileCont.from_arg_list,
             "QUANTILE_DISC": exp.PercentileDisc.from_arg_list,
-            "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-                group=seq_get(args, 2) or exp.Literal.number(0),
-            ),
+            "REGEXP_EXTRACT": build_regexp_extract,
             "REGEXP_MATCHES": exp.RegexpLike.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -34,6 +34,7 @@ from sqlglot.dialects.dialect import (
     var_map_sql,
     sequence_sql,
     property_sql,
+    build_regexp_extract,
 )
 from sqlglot.transforms import (
     remove_unique_constraints,
@@ -194,6 +195,7 @@ class Hive(Dialect):
     SUPPORTS_USER_DEFINED_TYPES = False
     SAFE_DIVISION = True
     ARRAY_AGG_INCLUDES_NULLS = None
+    REGEXP_EXTRACT_DEFAULT_GROUP = 1
 
     # https://spark.apache.org/docs/latest/sql-ref-identifier.html#description
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
@@ -308,11 +310,7 @@ class Hive(Dialect):
             "MONTH": lambda args: exp.Month(this=exp.TsOrDsToDate.from_arg_list(args)),
             "PERCENTILE": exp.Quantile.from_arg_list,
             "PERCENTILE_APPROX": exp.ApproxQuantile.from_arg_list,
-            "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-                group=seq_get(args, 2) or exp.Literal.number(1),
-            ),
+            "REGEXP_EXTRACT": build_regexp_extract,
             "SEQUENCE": exp.GenerateSeries.from_arg_list,
             "SIZE": exp.ArraySize.from_arg_list,
             "SPLIT": exp.RegexpSplit.from_arg_list,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -309,7 +309,9 @@ class Hive(Dialect):
             "PERCENTILE": exp.Quantile.from_arg_list,
             "PERCENTILE_APPROX": exp.ApproxQuantile.from_arg_list,
             "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
-                this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                group=seq_get(args, 2) or exp.Literal.number(1),
             ),
             "SEQUENCE": exp.GenerateSeries.from_arg_list,
             "SIZE": exp.ArraySize.from_arg_list,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -29,6 +29,7 @@ from sqlglot.dialects.dialect import (
     ts_or_ds_add_cast,
     unit_to_str,
     sequence_sql,
+    build_regexp_extract,
 )
 from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.mysql import MySQL
@@ -315,11 +316,7 @@ class Presto(Dialect):
                 this=seq_get(args, 0), replace=seq_get(args, 1), charset=exp.Literal.string("utf-8")
             ),
             "NOW": exp.CurrentTimestamp.from_arg_list,
-            "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
-                this=seq_get(args, 0),
-                expression=seq_get(args, 1),
-                group=seq_get(args, 2) or exp.Literal.number(0),
-            ),
+            "REGEXP_EXTRACT": build_regexp_extract,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1),

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -316,7 +316,9 @@ class Presto(Dialect):
             ),
             "NOW": exp.CurrentTimestamp.from_arg_list,
             "REGEXP_EXTRACT": lambda args: exp.RegexpExtract(
-                this=seq_get(args, 0), expression=seq_get(args, 1), group=seq_get(args, 2)
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                group=seq_get(args, 2) or exp.Literal.number(0),
             ),
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -327,7 +327,14 @@ class Snowflake(Dialect):
             "NULLIFZERO": _build_if_from_nullifzero,
             "OBJECT_CONSTRUCT": _build_object_construct,
             "REGEXP_REPLACE": _build_regexp_replace,
-            "REGEXP_SUBSTR": exp.RegexpExtract.from_arg_list,
+            "REGEXP_SUBSTR": lambda args: exp.RegexpExtract(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                position=seq_get(args, 2),
+                occurrence=seq_get(args, 3),
+                parameters=seq_get(args, 4),
+                group=seq_get(args, 5) or exp.Literal.number(0),
+            ),
             "RLIKE": exp.RegexpLike.from_arg_list,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "TIMEADD": _build_date_time_add(exp.TimeAdd),
@@ -991,6 +998,11 @@ class Snowflake(Dialect):
             # Other dialects don't support all of the following parameters, so we need to
             # generate default values as necessary to ensure the transpilation is correct
             group = expression.args.get("group")
+
+            # To avoid generating all these default values, we set group to None if
+            # it's 0 (also default value) which doesn't trigger the following chain
+            group = group if not (group and group.is_number and group.to_py() == 0) else None
+
             parameters = expression.args.get("parameters") or (group and exp.Literal.string("c"))
             occurrence = expression.args.get("occurrence") or (parameters and exp.Literal.number(1))
             position = expression.args.get("position") or (occurrence and exp.Literal.number(1))

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1001,7 +1001,8 @@ class Snowflake(Dialect):
 
             # To avoid generating all these default values, we set group to None if
             # it's 0 (also default value) which doesn't trigger the following chain
-            group = group if not (group and group.is_number and group.to_py() == 0) else None
+            if group and group.name == "0":
+                group = None
 
             parameters = expression.args.get("parameters") or (group and exp.Literal.string("c"))
             occurrence = expression.args.get("occurrence") or (parameters and exp.Literal.number(1))

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -765,6 +765,21 @@ class TestHive(Validator):
                 "presto": "SELECT DATE_TRUNC('MONTH', TRY_CAST(ds AS TIMESTAMP)) AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
             },
         )
+        self.validate_all(
+            "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+            read={
+                "hive": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "spark2": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "spark": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "databricks": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+            },
+            write={
+                "hive": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+                "spark2": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+                "spark": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+                "databricks": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+            },
+        )
 
     def test_escapes(self) -> None:
         self.validate_identity("'\n'", "'\\n'")

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -766,7 +766,7 @@ class TestHive(Validator):
             },
         )
         self.validate_all(
-            "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+            "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
             read={
                 "hive": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
                 "spark2": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
@@ -774,10 +774,13 @@ class TestHive(Validator):
                 "databricks": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
             },
             write={
-                "hive": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
-                "spark2": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
-                "spark": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
-                "databricks": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+                "hive": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "spark2": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "spark": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "databricks": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "presto": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+                "trino": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
+                "duckdb": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 1)",
             },
         )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1035,16 +1035,22 @@ class TestPresto(Validator):
             },
         )
         self.validate_all(
-            "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+            "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
             read={
                 "presto": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
                 "trino": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
                 "duckdb": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "snowflake": "REGEXP_SUBSTR('abc', '(a)(b)(c)')",
             },
             write={
-                "presto": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
-                "trino": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
-                "duckdb": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+                "presto": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "trino": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "duckdb": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "snowflake": "REGEXP_SUBSTR('abc', '(a)(b)(c)')",
+                "hive": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+                "spark2": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+                "spark": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+                "databricks": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
             },
         )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1034,6 +1034,19 @@ class TestPresto(Validator):
                 "spark": "SELECT REGEXP_EXTRACT(TO_JSON(FROM_JSON('[[1, 2, 3]]', SCHEMA_OF_JSON('[[1, 2, 3]]'))), '^.(.*).$', 1)",
             },
         )
+        self.validate_all(
+            "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+            read={
+                "presto": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "trino": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+                "duckdb": "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
+            },
+            write={
+                "presto": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+                "trino": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+                "duckdb": "REGEXP_EXTRACT('abc', '(a)(b)(c)', 0)",
+            },
+        )
 
     def test_encode_decode(self):
         self.validate_identity("FROM_UTF8(x, y)")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1717,23 +1717,11 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
                 "databricks": "REGEXP_EXTRACT(subject, pattern)",
             },
             write={
-                "hive": "REGEXP_EXTRACT(subject, pattern, 1)",
-                "spark2": "REGEXP_EXTRACT(subject, pattern, 1)",
-                "spark": "REGEXP_EXTRACT(subject, pattern, 1)",
-                "databricks": "REGEXP_EXTRACT(subject, pattern, 1)",
+                "hive": "REGEXP_EXTRACT(subject, pattern)",
+                "spark2": "REGEXP_EXTRACT(subject, pattern)",
+                "spark": "REGEXP_EXTRACT(subject, pattern)",
+                "databricks": "REGEXP_EXTRACT(subject, pattern)",
                 "snowflake": "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', 1)",
-            },
-        )
-        self.validate_all(
-            "REGEXP_SUBSTR(subject, pattern)",
-            read={
-                "presto": "REGEXP_EXTRACT(subject, pattern)",
-                "trino": "REGEXP_EXTRACT(subject, pattern)",
-            },
-            write={
-                "presto": "REGEXP_EXTRACT(subject, pattern, 0)",
-                "trino": "REGEXP_EXTRACT(subject, pattern, 0)",
-                "snowflake": "REGEXP_SUBSTR(subject, pattern)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1701,16 +1701,39 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
             "REGEXP_SUBSTR(subject, pattern)",
             read={
                 "bigquery": "REGEXP_EXTRACT(subject, pattern)",
-                "hive": "REGEXP_EXTRACT(subject, pattern)",
-                "presto": "REGEXP_EXTRACT(subject, pattern)",
-                "spark": "REGEXP_EXTRACT(subject, pattern)",
+                "snowflake": "REGEXP_EXTRACT(subject, pattern)",
             },
             write={
                 "bigquery": "REGEXP_EXTRACT(subject, pattern)",
-                "hive": "REGEXP_EXTRACT(subject, pattern)",
-                "presto": "REGEXP_EXTRACT(subject, pattern)",
                 "snowflake": "REGEXP_SUBSTR(subject, pattern)",
+            },
+        )
+        self.validate_all(
+            "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', 1)",
+            read={
+                "hive": "REGEXP_EXTRACT(subject, pattern)",
+                "spark2": "REGEXP_EXTRACT(subject, pattern)",
                 "spark": "REGEXP_EXTRACT(subject, pattern)",
+                "databricks": "REGEXP_EXTRACT(subject, pattern)",
+            },
+            write={
+                "hive": "REGEXP_EXTRACT(subject, pattern, 1)",
+                "spark2": "REGEXP_EXTRACT(subject, pattern, 1)",
+                "spark": "REGEXP_EXTRACT(subject, pattern, 1)",
+                "databricks": "REGEXP_EXTRACT(subject, pattern, 1)",
+                "snowflake": "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', 1)",
+            },
+        )
+        self.validate_all(
+            "REGEXP_SUBSTR(subject, pattern)",
+            read={
+                "presto": "REGEXP_EXTRACT(subject, pattern)",
+                "trino": "REGEXP_EXTRACT(subject, pattern)",
+            },
+            write={
+                "presto": "REGEXP_EXTRACT(subject, pattern, 0)",
+                "trino": "REGEXP_EXTRACT(subject, pattern, 0)",
+                "snowflake": "REGEXP_SUBSTR(subject, pattern)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #4039

This PR standardizes the `group` argument of `exp.RegexpExtract` across Hive hierarchy, DuckDB, Presto/Trino and Snowflake to improve it's transpilation. For quick reference:

- Presto/Trino, DuckDB and Snowflake have a default value of `0` i.e the result is the whole expression:

```
presto> select regexp_extract('abc', '(a)(b)(c)');
 _col0
-------
 abc
(1 row)

trino> select regexp_extract('abc', '(a)(b)(c)');
 _col0
-------
 abc
(1 row)


D select regexp_extract('abc', '(a)(b)(c)');
┌────────────────────────────────────┐
│ regexp_extract('abc', '(a)(b)(c)') │
│              varchar               │
├────────────────────────────────────┤
│ abc                                │
└────────────────────────────────────┘

snowflake>  select REGEXP_SUBSTR('abc', '(a)(b)(c)');
REGEXP_SUBSTR('ABC', '(A)(B)(C)')
--
abc
```

- Across the Hive hierarchy (tested Spark2 -> Databricks), the default value is 1:
```
spark-sql (default)> select regexp_extract('abc', '(a)(b)(c)');
regexp_extract(abc, (a)(b)(c), 1)
a
```

Note: Across dialects `REGEXP_EXTRACT` has different number and types of arguments; However, Presto/Trino, Hive hierarchy and DuckDB share an identical signature, so if it's of interest I can push a follow-up commit which:
1. Creates a common builder between them
2. Adds a new dialect flag e.g. `REGEXP_EXTRACT_DEFAULT_GROUP: t.Optional[int]` which will be used both in the builder and in the generator to hide the `group` generation if it's equal to the dialect's default value, as was done in Snowflake. 