### PR TITLE
Fix(doris): postgres interval type date function

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6946,6 +6946,7 @@ def parse_identifier(name: str | Identifier, dialect: DialectType = None) -> Ide
 
 
 INTERVAL_STRING_RE = re.compile(r"\s*([0-9]+)\s*([a-zA-Z]+)\s*")
+INTERVAL_STRING_RE_three = re.compile(r"([+-]?)\s*([0-9]+)\s*([a-zA-Z]+)")
 
 
 def to_interval(interval: str | Literal) -> Interval:

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -84,6 +84,13 @@ class TestDoris(Validator):
                 "postgres": "SELECT LEAD(1, 2) OVER (ORDER BY 1)",
             },
         )
+        self.validate_all(
+            """SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH""",
+            read={
+                "doris": """SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH""",
+                "postgres": """SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'""",
+            },
+        )
 
     def test_identity(self):
         self.validate_identity("COALECSE(a, b, c, d)")


### PR DESCRIPTION
**Before you file an issue**
- Make sure you specify the "read" dialect eg. `parse_one(sql, read="postgres")`
- Make sure you specify the "write" dialect eg. `ast.sql(dialect="doris")`
- Check if the issue still exists on main:Couldn't find anything related

**Fully reproducible code snippet**
```python
import sqlglot

sql = """SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'"""

print(sqlglot.transpile(sql ,read="postgres" , write="doris")[0]);
``` 

output
```
SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'
```

Expected output
```
SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH

```





