### PR TITLE
Fix(doris): postgres interval type date function 

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6946,7 +6946,7 @@ def parse_identifier(name: str | Identifier, dialect: DialectType = None) -> Ide
 
 
 INTERVAL_STRING_RE = re.compile(r"\s*([0-9]+)\s*([a-zA-Z]+)\s*")
-INTERVAL_STRING_RE_three = re.compile(r"([+-]?)\s*([0-9]+)\s*([a-zA-Z]+)")
+INTERVAL_STRING_RE_triple = re.compile(r"\s*([+-]?)\s*([0-9]+)\s*([a-zA-Z]+)\s*")
 
 
 def to_interval(interval: str | Literal) -> Interval:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6946,6 +6946,7 @@ def parse_identifier(name: str | Identifier, dialect: DialectType = None) -> Ide
 
 
 INTERVAL_STRING_RE = re.compile(r"\s*([0-9]+)\s*([a-zA-Z]+)\s*")
+INTERVAL_STRING_RE_three = re.compile(r"([+-]?)\s*([0-9]+)\s*([a-zA-Z]+)")
 
 
 def to_interval(interval: str | Literal) -> Interval:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4355,18 +4355,28 @@ class Parser(metaclass=_Parser):
                 interval_expr = None
 
                 for value_with_sign, value, unit_name in parts:
-                    sign = '+' if not value_with_sign.strip() or value_with_sign.strip()[0] != '-' else '-'
+                    sign = (
+                        "+"
+                        if not value_with_sign.strip() or value_with_sign.strip()[0] != "-"
+                        else "-"
+                    )
                     interval_value = exp.Literal.string(value)
                     interval_unit = self.expression(exp.Var, this=unit_name.upper())
-                    current_interval = self.expression(exp.Interval, this=interval_value, unit=interval_unit)
+                    current_interval = self.expression(
+                        exp.Interval, this=interval_value, unit=interval_unit
+                    )
 
                     if interval_expr is None:
                         interval_expr = current_interval
                     else:
-                        if sign == '+':
-                            interval_expr = self.expression(exp.Sub, this=interval_expr, expression=current_interval)
+                        if sign == "+":
+                            interval_expr = self.expression(
+                                exp.Sub, this=interval_expr, expression=current_interval
+                            )
                         else:
-                            interval_expr = self.expression(exp.Add, this=interval_expr, expression=current_interval)
+                            interval_expr = self.expression(
+                                exp.Add, this=interval_expr, expression=current_interval
+                            )
 
                 return interval_expr
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4343,7 +4343,7 @@ class Parser(metaclass=_Parser):
         if this and this.is_number:
             this = exp.Literal.string(this.to_py())
         elif this and this.is_string:
-            parts = exp.INTERVAL_STRING_RE_three.findall(this.name)
+            parts = exp.INTERVAL_STRING_RE_triple.findall(this.name)
             if len(parts) == 1:
                 if unit:
                     # Unconsume the eagerly-parsed unit, since the real unit was part of the string

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -84,6 +84,13 @@ class TestDoris(Validator):
                 "postgres": "SELECT LEAD(1, 2) OVER (ORDER BY 1)",
             },
         )
+        self.validate_all(
+            """SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH""",
+            read={
+                "doris": """SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH""",
+                "postgres": """SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'""",
+            },
+        )
 
     def test_identity(self):
         self.validate_identity("COALECSE(a, b, c, d)")

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -85,10 +85,10 @@ class TestDoris(Validator):
             },
         )
         self.validate_all(
-            """SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH""",
+            """SELECT NOW() - INTERVAL '1' YEAR + INTERVAL '1' MONTH""",
             read={
-                "doris": """SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH""",
-                "postgres": """SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'""",
+                "doris": """SELECT NOW() - INTERVAL '1' YEAR + INTERVAL '1' MONTH""",
+                "postgres": """SELECT NOW() - INTERVAL '1 YEAR - 1 MONTH'""",
             },
         )
 


### PR DESCRIPTION
**Before you file an issue**
- Make sure you specify the "read" dialect eg. `parse_one(sql, read="postgres")`
- Make sure you specify the "write" dialect eg. `ast.sql(dialect="doris")`
- Check if the issue still exists on main:Couldn't find anything related

**Fully reproducible code snippet**
```python
import sqlglot

sql = """SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'"""

print(sqlglot.transpile(sql ,read="postgres" , write="doris")[0]);
``` 

output
```
SELECT NOW() - INTERVAL '1 YEAR + 1 MONTH'
```

Expected output
```
SELECT NOW() - INTERVAL '1' YEAR - INTERVAL '1' MONTH

```


```python
import sqlglot

sql = """SELECT NOW() - INTERVAL '1 YEAR - 1 MONTH'"""

print(sqlglot.transpile(sql ,read="postgres" , write="doris")[0]);
``` 

output
```
SELECT NOW() - INTERVAL '1 YEAR - 1 MONTH'
```

Expected output
```
SELECT NOW() - INTERVAL '1' YEAR + INTERVAL '1' MONTH

```

<img width="587" alt="image" src="https://github.com/user-attachments/assets/c391f02c-e39b-449f-8f95-7937c19c242e">




