### PR TITLE
fix(snowflake, bigquery): Remove exp.Trim generation

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -717,7 +717,6 @@ class BigQuery(Dialect):
             exp.TimestampSub: date_add_interval_sql("TIMESTAMP", "SUB"),
             exp.TimeStrToTime: timestrtotime_sql,
             exp.Transaction: lambda *_: "BEGIN TRANSACTION",
-            exp.Trim: lambda self, e: self.func("TRIM", e.this, e.expression),
             exp.TsOrDsAdd: _ts_or_ds_add_sql,
             exp.TsOrDsDiff: _ts_or_ds_diff_sql,
             exp.TsOrDsToTime: rename_func("TIME"),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -842,7 +842,6 @@ class Snowflake(Dialect):
             exp.TimeToUnix: lambda self, e: f"EXTRACT(epoch_second FROM {self.sql(e, 'this')})",
             exp.ToArray: rename_func("TO_ARRAY"),
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
-            exp.Trim: lambda self, e: self.func("TRIM", e.this, e.expression),
             exp.TsOrDsAdd: date_delta_sql("DATEADD", cast=True),
             exp.TsOrDsDiff: date_delta_sql("DATEDIFF"),
             exp.TsOrDsToDate: lambda self, e: self.func(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2802,3 +2802,50 @@ FROM subquery2""",
 
         # Check T-SQL's ISNULL which is parsed into exp.Coalesce
         self.assertIsInstance(parse_one("ISNULL(x, y)", read="tsql").expressions, list)
+
+    def test_trim(self):
+        self.validate_all(
+            "TRIM('abc', 'a')",
+            read={
+                "bigquery": "TRIM('abc', 'a')",
+                "snowflake": "TRIM('abc', 'a')",
+            },
+            write={
+                "bigquery": "TRIM('abc', 'a')",
+                "snowflake": "TRIM('abc', 'a')",
+            },
+        )
+
+        self.validate_all(
+            "LTRIM('Hello World', 'H')",
+            read={
+                "oracle": "LTRIM('Hello World', 'H')",
+                "clickhouse": "TRIM(LEADING 'H' FROM 'Hello World')",
+                "snowflake": "LTRIM('Hello World', 'H')",
+                "bigquery": "LTRIM('Hello World', 'H')",
+                "": "LTRIM('Hello World', 'H')",
+            },
+            write={
+                "clickhouse": "TRIM(LEADING 'H' FROM 'Hello World')",
+                "oracle": "LTRIM('Hello World', 'H')",
+                "snowflake": "LTRIM('Hello World', 'H')",
+                "bigquery": "LTRIM('Hello World', 'H')",
+            },
+        )
+
+        self.validate_all(
+            "RTRIM('Hello World', 'd')",
+            read={
+                "clickhouse": "TRIM(TRAILING 'd' FROM 'Hello World')",
+                "oracle": "RTRIM('Hello World', 'd')",
+                "snowflake": "RTRIM('Hello World', 'd')",
+                "bigquery": "RTRIM('Hello World', 'd')",
+                "": "RTRIM('Hello World', 'd')",
+            },
+            write={
+                "clickhouse": "TRIM(TRAILING 'd' FROM 'Hello World')",
+                "oracle": "RTRIM('Hello World', 'd')",
+                "snowflake": "RTRIM('Hello World', 'd')",
+                "bigquery": "RTRIM('Hello World', 'd')",
+            },
+        )

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -267,22 +267,6 @@ class TestOracle(Validator):
             },
         )
         self.validate_all(
-            "LTRIM('Hello World', 'H')",
-            write={
-                "": "LTRIM('Hello World', 'H')",
-                "oracle": "LTRIM('Hello World', 'H')",
-                "clickhouse": "TRIM(LEADING 'H' FROM 'Hello World')",
-            },
-        )
-        self.validate_all(
-            "RTRIM('Hello World', 'd')",
-            write={
-                "": "RTRIM('Hello World', 'd')",
-                "oracle": "RTRIM('Hello World', 'd')",
-                "clickhouse": "TRIM(TRAILING 'd' FROM 'Hello World')",
-            },
-        )
-        self.validate_all(
             "TRIM(BOTH 'h' FROM 'Hello World')",
             write={
                 "oracle": "TRIM(BOTH 'h' FROM 'Hello World')",


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/3095


Docs
-------
[BigQuery TRIM](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#trim) | [BQ LTRIM](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#ltrim) | [BQ RTRIM](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#rtrim) | [Snowflake TRIM / LTRIM / RTRIM](https://docs.snowflake.com/en/sql-reference/functions/trim)