### PR TITLE
Fix(athena): Apply correct quoting to queries depending on type (DML or DDL)

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4408,10 +4408,6 @@ class AddConstraint(Expression):
     arg_types = {"expressions": True}
 
 
-class AddPartition(Expression):
-    arg_types = {"expressions": True, "exists": False}
-
-
 class DropPartition(Expression):
     arg_types = {"expressions": True, "exists": False}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4408,6 +4408,10 @@ class AddConstraint(Expression):
     arg_types = {"expressions": True}
 
 
+class AddPartition(Expression):
+    arg_types = {"expressions": True, "exists": False}
+
+
 class DropPartition(Expression):
     arg_types = {"expressions": True, "exists": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1428,17 +1428,24 @@ class Generator(metaclass=_Generator):
         return f"{unique}{primary}{amp}{index}{name}{table}{params}"
 
     def identifier_sql(self, expression: exp.Identifier) -> str:
+        return self._identifier_sql(
+            expression, self.dialect.IDENTIFIER_START, self.dialect.IDENTIFIER_END
+        )
+
+    def _identifier_sql(
+        self, expression: exp.Identifier, identifier_start: str, identifier_end: str
+    ):
         text = expression.name
         lower = text.lower()
         text = lower if self.normalize and not expression.quoted else text
-        text = text.replace(self.dialect.IDENTIFIER_END, self._escaped_identifier_end)
+        text = text.replace(identifier_end, self._escaped_identifier_end)
         if (
             expression.quoted
             or self.dialect.can_identify(text, self.identify)
             or lower in self.RESERVED_KEYWORDS
             or (not self.dialect.IDENTIFIERS_CAN_START_WITH_DIGIT and text[:1].isdigit())
         ):
-            text = f"{self.dialect.IDENTIFIER_START}{text}{self.dialect.IDENTIFIER_END}"
+            text = f"{identifier_start}{text}{identifier_end}"
         return text
 
     def hex_sql(self, expression: exp.Hex) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -592,6 +592,8 @@ class Generator(metaclass=_Generator):
         "_escaped_quote_end",
         "_escaped_identifier_end",
         "_next_name",
+        "_identifier_start",
+        "_identifier_end",
     )
 
     def __init__(
@@ -638,6 +640,9 @@ class Generator(metaclass=_Generator):
         )
 
         self._next_name = name_sequence("_t")
+
+        self._identifier_start = self.dialect.IDENTIFIER_START
+        self._identifier_end = self.dialect.IDENTIFIER_END
 
     def generate(self, expression: exp.Expression, copy: bool = True) -> str:
         """
@@ -1428,24 +1433,17 @@ class Generator(metaclass=_Generator):
         return f"{unique}{primary}{amp}{index}{name}{table}{params}"
 
     def identifier_sql(self, expression: exp.Identifier) -> str:
-        return self._identifier_sql(
-            expression, self.dialect.IDENTIFIER_START, self.dialect.IDENTIFIER_END
-        )
-
-    def _identifier_sql(
-        self, expression: exp.Identifier, identifier_start: str, identifier_end: str
-    ):
         text = expression.name
         lower = text.lower()
         text = lower if self.normalize and not expression.quoted else text
-        text = text.replace(identifier_end, self._escaped_identifier_end)
+        text = text.replace(self._identifier_end, self._escaped_identifier_end)
         if (
             expression.quoted
             or self.dialect.can_identify(text, self.identify)
             or lower in self.RESERVED_KEYWORDS
             or (not self.dialect.IDENTIFIERS_CAN_START_WITH_DIGIT and text[:1].isdigit())
         ):
-            text = f"{identifier_start}{text}{identifier_end}"
+            text = f"{self._identifier_start}{text}{self._identifier_end}"
         return text
 
     def hex_sql(self, expression: exp.Hex) -> str:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -20,7 +20,9 @@ class Validator(unittest.TestCase):
     def parse_one(self, sql, **kwargs):
         return parse_one(sql, read=self.dialect, **kwargs)
 
-    def validate_identity(self, sql, write_sql=None, pretty=False, check_command_warning=False):
+    def validate_identity(
+        self, sql, write_sql=None, pretty=False, check_command_warning=False, identify=False
+    ):
         if check_command_warning:
             with self.assertLogs(parser_logger) as cm:
                 expression = self.parse_one(sql)
@@ -28,7 +30,9 @@ class Validator(unittest.TestCase):
         else:
             expression = self.parse_one(sql)
 
-        self.assertEqual(write_sql or sql, expression.sql(dialect=self.dialect, pretty=pretty))
+        self.assertEqual(
+            write_sql or sql, expression.sql(dialect=self.dialect, pretty=pretty, identify=identify)
+        )
         return expression
 
     def validate_all(self, sql, read=None, write=None, pretty=False, identify=False):


### PR DESCRIPTION
Athena [quotes identifiers differently depending on query type](https://docs.aws.amazon.com/athena/latest/ug/reserved-words.html), presumably because it uses different execution engines for DDL vs DML.

DDL queries (except `CREATE VIEW`) use backticks `` ` `` to quote identifiers and everything else uses double quotes `"` to quote identifiers. 

Here some examples
```
# backtick quoting
create schema if not exists "foo"; #fails
create schema if not exists `foo`; #works

create external table "foo" ("id" int) location 's3://foo/'; #fails
create external table `foo` (`id` int) location 's3://foo/'; #works

drop table if exists "foo"; #fails
drop table if exists `foo`; #works

# double-quote quoting
create or replace view `foo` as select 1 as `col`; #fails
create or replace view "foo" as select 1 as "col"; #works

select 1 as `foo`; #fails
select 1 as "foo"; #works
```
