### PR TITLE
Add `insert` as top-level statement

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -30,6 +30,7 @@ from sqlglot.expressions import (
     except_ as except_,
     from_ as from_,
     func as func,
+    insert as insert,
     intersect as intersect,
     maybe_parse as maybe_parse,
     not_ as not_,


### PR DESCRIPTION
This PR starts to export `insert` in top-level `__init__` for `sqlglot`, to make it easier to build insertion statements without having to reach into the expressions submodule.