### PR TITLE
fix(transpile): Starrocks filter transpile

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -106,6 +106,7 @@ class StarRocks(MySQL):
             exp.TimeStrToDate: rename_func("TO_DATE"),
             exp.UnixToStr: lambda self, e: self.func("FROM_UNIXTIME", e.this, self.format_time(e)),
             exp.UnixToTime: rename_func("FROM_UNIXTIME"),
+            exp.ArrayFilter: rename_func("ARRAY_FILTER"),
         }
 
         TRANSFORMS.pop(exp.DateTrunc)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1788,6 +1788,13 @@ class TestDialect(Validator):
             },
         )
         self.validate_all(
+            "FILTER(the_array, x -> x > 0)",
+            write={
+                "presto": "FILTER(the_array, x -> x > 0)",
+                "starrocks": "ARRAY_FILTER(the_array, x -> x > 0)",
+            },
+        )
+        self.validate_all(
             "a / b",
             write={
                 "bigquery": "a / b",


### PR DESCRIPTION
filter to array_filter should be converted as SR supports same.

Reference: https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/array_filter/  