### PR TITLE
Fix(mysql): convert VARCHAR without size to TEXT for DDLs

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -40,6 +40,7 @@ class Doris(MySQL):
 
     class Generator(MySQL.Generator):
         LAST_DAY_SUPPORTS_DATE_PART = False
+        VARCHAR_REQUIRES_SIZE = False
 
         TYPE_MAPPING = {
             **MySQL.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -73,6 +73,7 @@ class StarRocks(MySQL):
     class Generator(MySQL.Generator):
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
         JSON_TYPE_REQUIRED_FOR_EXTRACTION = False
+        VARCHAR_REQUIRES_SIZE = False
         PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
         WITH_PROPERTIES_PREFIX = "PROPERTIES"
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -82,6 +82,10 @@ class TestMySQL(Validator):
             "CREATE OR REPLACE VIEW my_view AS SELECT column1 AS `boo`, column2 AS `foo` FROM my_table WHERE column3 = 'some_value' UNION SELECT q.* FROM fruits_table, JSON_TABLE(Fruits, '$[*]' COLUMNS(id VARCHAR(255) PATH '$.$id', value VARCHAR(255) PATH '$.value')) AS q",
         )
         self.validate_identity(
+            "CREATE TABLE t (name VARCHAR)",
+            "CREATE TABLE t (name TEXT)",
+        )
+        self.validate_identity(
             "ALTER TABLE t ADD KEY `i` (`c`)",
             "ALTER TABLE t ADD INDEX `i` (`c`)",
         )
@@ -174,6 +178,10 @@ class TestMySQL(Validator):
         )
         self.validate_identity(
             "REPLACE INTO table SELECT id FROM table2 WHERE cnt > 100", check_command_warning=True
+        )
+        self.validate_identity(
+            "CAST(x AS VARCHAR)",
+            "CAST(x AS CHAR)",
         )
         self.validate_identity(
             """SELECT * FROM foo WHERE 3 MEMBER OF(info->'$.value')""",


### PR DESCRIPTION
`VARCHAR` without a size [is invalid](https://stackoverflow.com/questions/3156815/why-does-varchar-need-length-specification) in MySQL. This is not handled today, resulting in DDLs that can contain `VARCHAR` types when transpiling SQL towards MySQL. This PR addresses this issue.