### PR TITLE
Refactor!: treat Nullable as an arg instead of a DataType.TYPE

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -187,9 +187,6 @@ class _Dialect(type):
         if enum not in ("", "bigquery"):
             klass.generator_class.SELECT_KINDS = ()
 
-        if enum not in ("", "clickhouse"):
-            klass.generator_class.SUPPORTS_NULLABLE_TYPES = False
-
         if enum not in ("", "athena", "presto", "trino"):
             klass.generator_class.TRY_SUPPORTED = False
             klass.generator_class.SUPPORTS_UESCAPE = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4118,7 +4118,6 @@ class DataType(Expression):
         NCHAR = auto()
         NESTED = auto()
         NULL = auto()
-        NULLABLE = auto()
         NUMMULTIRANGE = auto()
         NUMRANGE = auto()
         NVARCHAR = auto()
@@ -4312,32 +4311,19 @@ class DataType(Expression):
         Returns:
             True, if and only if there is a type in `dtypes` which is equal to this DataType.
         """
-        if (
-            not check_nullable
-            and self.this == DataType.Type.NULLABLE
-            and len(self.expressions) == 1
-        ):
-            this_type = self.expressions[0]
-        else:
-            this_type = self
-
+        self_is_nullable = self.args.get("nullable")
         for dtype in dtypes:
             other_type = DataType.build(dtype, copy=False, udt=True)
-            if (
-                not check_nullable
-                and other_type.this == DataType.Type.NULLABLE
-                and len(other_type.expressions) == 1
-            ):
-                other_type = other_type.expressions[0]
-
+            other_is_nullable = other_type.args.get("nullable")
             if (
                 other_type.expressions
-                or this_type.this == DataType.Type.USERDEFINED
+                or (check_nullable and (self_is_nullable or other_is_nullable))
+                or self.this == DataType.Type.USERDEFINED
                 or other_type.this == DataType.Type.USERDEFINED
             ):
-                matches = this_type == other_type
+                matches = self == other_type
             else:
-                matches = this_type.this == other_type.this
+                matches = self.this == other_type.this
 
             if matches:
                 return True

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -390,9 +390,6 @@ class Generator(metaclass=_Generator):
     # Whether CONVERT_TIMEZONE() is supported; if not, it will be generated as exp.AtTimeZone
     SUPPORTS_CONVERT_TIMEZONE = False
 
-    # Whether nullable types can be constructed, e.g. `Nullable(Int64)`
-    SUPPORTS_NULLABLE_TYPES = True
-
     # The name to generate for the JSONPath expression. If `None`, only `this` will be generated
     PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
 
@@ -1239,14 +1236,12 @@ class Generator(metaclass=_Generator):
         type_value = expression.this
         if type_value == exp.DataType.Type.USERDEFINED and expression.args.get("kind"):
             type_sql = self.sql(expression, "kind")
-        elif type_value != exp.DataType.Type.NULLABLE or self.SUPPORTS_NULLABLE_TYPES:
+        else:
             type_sql = (
                 self.TYPE_MAPPING.get(type_value, type_value.value)
                 if isinstance(type_value, exp.DataType.Type)
                 else type_value
             )
-        else:
-            return interior
 
         if interior:
             if expression.args.get("nested"):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4753,6 +4753,11 @@ class Parser(metaclass=_Parser):
                         check_func=check_func, schema=schema, allow_identifiers=allow_identifiers
                     )
                 )
+                if type_token == TokenType.NULLABLE and len(expressions) == 1:
+                    this = expressions[0]
+                    this.set("nullable", True)
+                    self._match_r_paren()
+                    return this
             elif type_token in self.ENUM_TYPE_TOKENS:
                 expressions = self._parse_csv(self._parse_equality)
             elif is_aggregate:

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1035,7 +1035,6 @@ FROM foo""",
         self.assertEqual(exp.DataType.build("GEOGRAPHY").sql(), "GEOGRAPHY")
         self.assertEqual(exp.DataType.build("GEOMETRY").sql(), "GEOMETRY")
         self.assertEqual(exp.DataType.build("STRUCT").sql(), "STRUCT")
-        self.assertEqual(exp.DataType.build("NULLABLE").sql(), "NULLABLE")
         self.assertEqual(exp.DataType.build("HLLSKETCH", dialect="redshift").sql(), "HLLSKETCH")
         self.assertEqual(exp.DataType.build("HSTORE", dialect="postgres").sql(), "HSTORE")
         self.assertEqual(exp.DataType.build("NULL").sql(), "NULL")


### PR DESCRIPTION
Motivation behind this PR is that nullable types are awkward to deal with: to access the wrapped type, one has to always do `data_type.this` instead of just `data_type`, meaning that the concept of nullability "leaks" into third-party code that may not care at all about it.

This refactor encodes nullability as an arg in `DataType`, so that it's less intrusive. Now, it will be taken into account when e.g. comparing data types (which can be optionally turned off by using `is_type`), and when roundtripping CH code.