### PR TITLE
fix(snowflake): Manually escape single quotes in colon operator

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4998,7 +4998,10 @@ class Parser(metaclass=_Parser):
                 # Escape single quotes from Snowflake's colon extraction (e.g. col:"a'b") as
                 # it'll roundtrip to a string literal in GET_PATH
                 if path_sql[0] == '"':
-                    path_sql = path_sql.replace("'", "\\'")
+                    quote_end = self.dialect.QUOTE_END
+                    path_sql = path_sql.replace(
+                        quote_end, self.dialect.tokenizer_class.STRING_ESCAPES[0] + quote_end
+                    )
 
                 json_path.append(path_sql)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4993,7 +4993,14 @@ class Parser(metaclass=_Parser):
                 end_token = self._prev
 
             if path:
-                json_path.append(self._find_sql(self._tokens[start_index], end_token))
+                path_sql = self._find_sql(self._tokens[start_index], end_token)
+
+                # Escape single quotes from Snowflake's colon extraction (e.g. col:"a'b") as
+                # it'll roundtrip to a string literal in GET_PATH
+                if path_sql[0] == '"':
+                    path_sql = path_sql.replace("'", "\\'")
+
+                json_path.append(path_sql)
 
         # The VARIANT extract in Snowflake/Databricks is parsed as a JSONExtract; Snowflake uses the json_path in GET_PATH() while
         # Databricks transforms it back to the colon/dot notation

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2137,6 +2137,16 @@ SINGLE = TRUE""",
         self.validate_identity("SELECT t.$23:a.b", "SELECT GET_PATH(t.$23, 'a.b')")
         self.validate_identity("SELECT t.$17:a[0].b[0].c", "SELECT GET_PATH(t.$17, 'a[0].b[0].c')")
 
+        self.validate_all(
+            """
+            SELECT col:"customer's department"
+            """,
+            write={
+                "snowflake": """SELECT GET_PATH(col, '["customer\\'s department"]')""",
+                "postgres": "SELECT JSON_EXTRACT_PATH(col, 'customer\\'s department')",
+            },
+        )
+
     def test_alter_set_unset(self):
         self.validate_identity("ALTER TABLE tbl SET DATA_RETENTION_TIME_IN_DAYS=1")
         self.validate_identity("ALTER TABLE tbl SET DEFAULT_DDL_COLLATION='test'")


### PR DESCRIPTION
Fixes #4090

Snowflake allows JSON extraction through the colon operator such as `col:ab`, and double quotes (`col:"ab"`) can optionally be used to include special characters in the key.

This will be roundtripped/transpiled to a string literal in the respective function such as `GET_PATH(..., 'ab')`  which can break queries if single quotes are in the json key.

For this reason, this PR escapes those paths at parse time in `_parse_colon_as_variant_extract()`. Note that Databricks uses backticks for special characters so it won't be affected.
