### PR TITLE
Refactor(optimizer): Optimize USING expansion

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -147,7 +147,7 @@ def _pop_table_column_aliases(derived_tables: t.List[exp.CTE | exp.Subquery]) ->
 def _expand_using(scope: Scope, resolver: Resolver) -> t.Dict[str, t.Any]:
     columns = {}
 
-    def _gather_source_columns(source_name: str):
+    def _gather_source_columns(source_name: str) -> None:
         for column_name in resolver.get_source_columns(source_name):
             if column_name not in columns:
                 columns[column_name] = source_name

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -145,6 +145,13 @@ def _pop_table_column_aliases(derived_tables: t.List[exp.CTE | exp.Subquery]) ->
 
 
 def _expand_using(scope: Scope, resolver: Resolver) -> t.Dict[str, t.Any]:
+    columns = {}
+
+    def _gather_source_columns(source_name: str):
+        for column_name in resolver.get_source_columns(source_name):
+            if column_name not in columns:
+                columns[column_name] = source_name
+
     joins = list(scope.find_all(exp.Join))
     names = {join.alias_or_name for join in joins}
     ordered = [key for key in scope.selected_sources if key not in names]
@@ -152,22 +159,20 @@ def _expand_using(scope: Scope, resolver: Resolver) -> t.Dict[str, t.Any]:
     # Mapping of automatically joined column names to an ordered set of source names (dict).
     column_tables: t.Dict[str, t.Dict[str, t.Any]] = {}
 
+    for source_name in ordered:
+        _gather_source_columns(source_name)
+
     for i, join in enumerate(joins):
         source_table = ordered[-1]
+        if source_table:
+            _gather_source_columns(source_table)
+
         join_table = join.alias_or_name
         ordered.append(join_table)
 
         using = join.args.get("using")
         if not using:
             continue
-
-        columns = {}
-
-        for source_name in scope.selected_sources:
-            if source_name in ordered[:-1]:
-                for column_name in resolver.get_source_columns(source_name):
-                    if column_name not in columns:
-                        columns[column_name] = source_name
 
         join_columns = resolver.get_source_columns(join_table)
         conditions = []

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -412,6 +412,22 @@ class TestOptimizer(unittest.TestCase):
             ).sql("postgres"),
             "SELECT a.b_id AS b_id FROM a AS a JOIN b AS b ON a.b_id = b.b_id JOIN c AS c ON b.c_id = c.c_id",
         )
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(
+                    "SELECT A.b_id FROM A JOIN B ON A.b_id=B.b_id JOIN C ON B.b_id = C.b_id JOIN D USING(d_id)",
+                    dialect="postgres",
+                ),
+                schema={
+                    "A": {"b_id": "int"},
+                    "B": {"b_id": "int", "d_id": "int"},
+                    "C": {"b_id": "int"},
+                    "D": {"d_id": "int"},
+                },
+                quote_identifiers=False,
+            ).sql("postgres"),
+            "SELECT a.b_id AS b_id FROM a AS a JOIN b AS b ON a.b_id = b.b_id JOIN c AS c ON b.b_id = c.b_id JOIN d AS d ON b.d_id = d.d_id",
+        )
 
         self.check_file(
             "qualify_columns",


### PR DESCRIPTION
This PR is an optimization follow-up on https://github.com/tobymao/sqlglot/pull/4113

When processing multiple joins such as `A JOIN B JOIN C USING(col)`, we gather the columns from the previous sources (`A`, `B` etc) to expand `USING (col)` to `ON c.col = <source>.col`. Previously, this operation would happen from scratch on each iteration, which can be avoided. A few key observations:

1. The `ordered` list is constructed as a subset of `scope.selected_sources`; It can have `[0, N]` elements before the join loop
2. At each iteration, we'll add the current `join_table` to `ordered`; It is implied that `join_table` is a member of `scope.selected_sources` as it participates in the scope's `JOIN` clause(s) so (1) continues to hold

The combination of (1) and (2) means that we can avoid checking if `source_name` is both in `scope.selected_sources` _and_ `ordered`; Besides that, (2) drives incremental construction of `columns` at each iteration.

This PR also adds one more test case of a longer JOIN chain; This is to ensure that columns from all intermediate join tables are gathered, even if there is no `USING` clause. 