### PR TITLE
Feat(clickhouse): support ON CLUSTER clause in DELETE

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1918,6 +1918,7 @@ class Delete(DML):
         "returning": False,
         "limit": False,
         "tables": False,  # Multiple-Table Syntax (MySQL)
+        "cluster": False,  # Clickhouse
     }
 
     def delete(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1266,15 +1266,17 @@ class Generator(metaclass=_Generator):
         this = f" FROM {this}" if this else ""
         using = self.sql(expression, "using")
         using = f" USING {using}" if using else ""
+        cluster = self.sql(expression, "cluster")
+        cluster = f" {cluster}" if cluster else ""
         where = self.sql(expression, "where")
         returning = self.sql(expression, "returning")
         limit = self.sql(expression, "limit")
         tables = self.expressions(expression, key="tables")
         tables = f" {tables}" if tables else ""
         if self.RETURNING_END:
-            expression_sql = f"{this}{using}{where}{returning}{limit}"
+            expression_sql = f"{this}{using}{cluster}{where}{returning}{limit}"
         else:
-            expression_sql = f"{returning}{this}{using}{where}{limit}"
+            expression_sql = f"{returning}{this}{using}{cluster}{where}{limit}"
         return self.prepend_ctes(expression, f"DELETE{tables}{expression_sql}")
 
     def drop_sql(self, expression: exp.Drop) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2713,6 +2713,7 @@ class Parser(metaclass=_Parser):
             tables=tables,
             this=self._match(TokenType.FROM) and self._parse_table(joins=True),
             using=self._match(TokenType.USING) and self._parse_table(joins=True),
+            cluster=self._match(TokenType.ON) and self._parse_on_property(),
             where=self._parse_where(),
             returning=returning or self._parse_returning(),
             limit=self._parse_limit(),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -475,6 +475,7 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("ALTER TABLE visits REPLACE PARTITION ID '201901' FROM visits_tmp")
         self.validate_identity("ALTER TABLE visits ON CLUSTER test_cluster DROP COLUMN col1")
+        self.validate_identity("DELETE FROM tbl ON CLUSTER test_cluster WHERE date = '2019-01-01'")
 
         self.assertIsInstance(
             parse_one("Tuple(select Int64)", into=exp.DataType, read="clickhouse"), exp.DataType


### PR DESCRIPTION
This PR adds the `ON CLUSTER` clause to the `DELETE` statement

https://clickhouse.com/docs/en/guides/developer/lightweight-delete