### PR TITLE
Fix: parse struct(...)[] type properly

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4796,7 +4796,11 @@ class Parser(metaclass=_Parser):
 
             if self._match_set((TokenType.L_BRACKET, TokenType.L_PAREN)):
                 values = self._parse_csv(self._parse_assignment)
-                self._match_set((TokenType.R_BRACKET, TokenType.R_PAREN))
+                if not values and is_struct:
+                    values = None
+                    self._retreat(self._index - 1)
+                else:
+                    self._match_set((TokenType.R_BRACKET, TokenType.R_PAREN))
 
         if type_token in self.TIMESTAMPS:
             if self._match_text_seq("WITH", "TIME", "ZONE"):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -18,6 +18,16 @@ class TestDuckDB(Validator):
             "WITH _data AS (SELECT [STRUCT(1 AS a, 2 AS b), STRUCT(2 AS a, 3 AS b)] AS col) SELECT col.b FROM _data, UNNEST(_data.col) AS col WHERE col.a = 1",
         )
 
+        struct_array_type = exp.maybe_parse(
+            "STRUCT(k TEXT, v STRUCT(v_str TEXT, v_int INT, v_int_arr INT[]))[]",
+            into=exp.DataType,
+            dialect="duckdb",
+        )
+        self.assertEqual(
+            struct_array_type.sql("duckdb"),
+            "STRUCT(k TEXT, v STRUCT(v_str TEXT, v_int INT, v_int_arr INT[]))[]",
+        )
+
         self.validate_all(
             "CAST(x AS UUID)",
             write={


### PR DESCRIPTION
@VaggelisD I think empty structs aren't allowed ([context](https://github.com/tobymao/sqlglot/commit/a2a6efb45dc0f380747aa4afdaa19122389f3c28#diff-63eb8dd82d3561bc414e3e13cf59516bd6584c5766a10072157a8a5aee4ad85fR4496-R4499)), for example `STRUCT<...>[]` is invalid BigQuery. The logic I linked was problematic because we'd consume `[]` and `values` would also be an empty list so we'd generate a `CAST(STRUCT() AS STRUCT<...>)` in DucKDB when trying to parse a type that is an array of structs.

This is needed to fix https://github.com/TobikoData/sqlmesh/pull/3129.