### PR TITLE
Feat!: add `returning` to merge expression builder

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6893,6 +6893,7 @@ def merge(
     into: ExpOrStr,
     using: ExpOrStr,
     on: ExpOrStr,
+    returning: t.Optional[ExpOrStr] = None,
     dialect: DialectType = None,
     copy: bool = True,
     **opts,
@@ -6913,6 +6914,7 @@ def merge(
         into: The target table to merge data into.
         using: The source table to merge data from.
         on: The join condition for the merge.
+        returning: The columns to return from the merge.
         dialect: The dialect used to parse the input expressions.
         copy: Whether to copy the expression.
         **opts: Other options to use to parse the input expressions.
@@ -6920,6 +6922,9 @@ def merge(
     Returns:
         Merge: The syntax tree for the MERGE statement.
     """
+    returning_expr = (
+        maybe_parse(returning, dialect=dialect, copy=copy, **opts) if returning else None
+    )
     return Merge(
         this=maybe_parse(into, dialect=dialect, copy=copy, **opts),
         using=maybe_parse(using, dialect=dialect, copy=copy, **opts),
@@ -6928,6 +6933,7 @@ def merge(
             maybe_parse(when_expr, dialect=dialect, copy=copy, into=When, **opts)
             for when_expr in when_exprs
         ],
+        returning=returning_expr,
     )
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -11,7 +11,6 @@ SQL expressions, such as `sqlglot.expressions.select`.
 """
 
 from __future__ import annotations
-from typing_extensions import Self
 import datetime
 import math
 import numbers
@@ -36,6 +35,7 @@ from sqlglot.helper import (
 from sqlglot.tokens import Token, TokenError
 
 if t.TYPE_CHECKING:
+    from typing_extensions import Self
     from sqlglot._typing import E, Lit
     from sqlglot.dialects.dialect import DialectType
 
@@ -1368,7 +1368,7 @@ class DML(Expression):
         dialect: DialectType = None,
         copy: bool = True,
         **opts,
-    ) -> Self:
+    ) -> "Self":
         """
         Set the RETURNING expression. Not supported by all dialects.
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6838,9 +6838,7 @@ def delete(
     if where:
         delete_expr = delete_expr.where(where, dialect=dialect, copy=False, **opts)
     if returning:
-        delete_expr = t.cast(
-            Delete, delete_expr.returning(returning, dialect=dialect, copy=False, **opts)
-        )
+        delete_expr = delete_expr.returning(returning, dialect=dialect, copy=False, **opts)
     return delete_expr
 
 
@@ -6922,7 +6920,7 @@ def merge(
     Returns:
         Merge: The syntax tree for the MERGE statement.
     """
-    merge_expr = Merge(
+    merge = Merge(
         this=maybe_parse(into, dialect=dialect, copy=copy, **opts),
         using=maybe_parse(using, dialect=dialect, copy=copy, **opts),
         on=maybe_parse(on, dialect=dialect, copy=copy, **opts),
@@ -6932,9 +6930,9 @@ def merge(
         ],
     )
     if returning:
-        merge_expr = merge_expr.returning(returning, dialect=dialect, copy=False, **opts)
+        merge = merge.returning(returning, dialect=dialect, copy=False, **opts)
 
-    return merge_expr
+    return merge
 
 
 def condition(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3625,13 +3625,15 @@ class Generator(metaclass=_Generator):
         using = f"USING {self.sql(expression, 'using')}"
         on = f"ON {self.sql(expression, 'on')}"
         expressions = self.expressions(expression, sep=" ", indent=False)
+        returning = self.sql(expression, "returning")
+        if returning:
+            expressions = f"{expressions}{returning}"
+
         sep = self.sep()
-        returning = self.expressions(expression, key="returning", indent=False)
-        returning = f"RETURNING {returning}" if returning else ""
 
         return self.prepend_ctes(
             expression,
-            f"MERGE INTO {this}{table_alias}{sep}{using}{sep}{on}{sep}{expressions}{sep}{returning}",
+            f"MERGE INTO {this}{table_alias}{sep}{using}{sep}{on}{sep}{expressions}",
         )
 
     @unsupported_args("format")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6841,7 +6841,7 @@ class Parser(metaclass=_Parser):
             using=using,
             on=on,
             expressions=self._parse_when_matched(),
-            returning=self._match(TokenType.RETURNING) and self._parse_csv(self._parse_bitwise),
+            returning=self._parse_returning()        
         )
 
     def _parse_when_matched(self) -> t.List[exp.When]:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6841,7 +6841,7 @@ class Parser(metaclass=_Parser):
             using=using,
             on=on,
             expressions=self._parse_when_matched(),
-            returning=self._parse_returning()        
+            returning=self._parse_returning(),
         )
 
     def _parse_when_matched(self) -> t.List[exp.When]:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -761,6 +761,16 @@ class TestBuild(unittest.TestCase):
                 ),
                 "MERGE INTO target_table AS target USING source_table AS source ON target.id = source.id WHEN MATCHED THEN UPDATE SET target.name = source.name",
             ),
+            (
+                lambda: exp.merge(
+                    "WHEN MATCHED THEN UPDATE SET target.name = source.name",
+                    into=exp.table_("target_table").as_("target"),
+                    using=exp.table_("source_table").as_("source"),
+                    on="target.id = source.id",
+                    returning="target.*",
+                ),
+                "MERGE INTO target_table AS target USING source_table AS source ON target.id = source.id WHEN MATCHED THEN UPDATE SET target.name = source.name RETURNING target.*",
+            ),
         ]:
             with self.subTest(sql):
                 self.assertEqual(expression().sql(dialect[0] if dialect else None), sql)


### PR DESCRIPTION
Now that returning is supported, add `returning` argument to the merge expression builder. This PR also makes some fixes to make the AST representation of RETURNING in merge expressions more consistent with other SQL expressions.