### PR TITLE
Feat: expose `sqlglot.expressions.delete` as a sqlglot module function

### DIFF
--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -27,6 +27,7 @@ from sqlglot.expressions import (
     cast as cast,
     column as column,
     condition as condition,
+    delete as delete,
     except_ as except_,
     from_ as from_,
     func as func,


### PR DESCRIPTION
I think it additionally makes sense to have `delete` as a top-level expression.