### PR TITLE
Fix(athena): DDL fixes

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4396,6 +4396,15 @@ class Alter(Expression):
         "not_valid": False,
     }
 
+    @property
+    def kind(self) -> t.Optional[str]:
+        kind = self.args.get("kind")
+        return kind and kind.upper()
+
+    @property
+    def actions(self) -> t.List[Expression]:
+        return self.args.get("actions") or []
+
 
 class AddConstraint(Expression):
     arg_types = {"expressions": True}


### PR DESCRIPTION
- `DESCRIBE` should be routed to Hive
- `DROP VIEW` should be routed to Trino and not Hive (but every other `DROP` appears to be Hive)
- Athena expects the table location to be in the `external_location` property if the `table_type` property is `hive`, otherwise the table location should be in `location`. So i've added this logic for generating `exp.TableLocation`
- `ALTER TABLE ADD COLUMN` is invalid SQL in Athena. It needs to be `ALTER TABLE ADD COLUMS (..)`. To generate the correct version is a slightly different AST, so I subclassed `Hive.Generator` and overrode `alter_sql()`