### PR TITLE
fix(parser)!: Parse VALUES & query modifiers in wrapped FROM clause

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2002,7 +2002,8 @@ class Generator(metaclass=_Generator):
             values = f"VALUES{self.seg('')}{args}"
             values = (
                 f"({values})"
-                if self.WRAP_DERIVED_VALUES and (alias or isinstance(expression.parent, exp.From))
+                if self.WRAP_DERIVED_VALUES
+                and (alias or isinstance(expression.parent, (exp.From, exp.Table)))
                 else values
             )
             return f"{values} AS {alias}" if alias else values

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2984,6 +2984,14 @@ class Parser(metaclass=_Parser):
                     if table
                     else self._parse_select(nested=True, parse_set_operation=False)
                 )
+
+                # Transform exp.Values into a exp.Table to pass through parse_query_modifiers
+                # in case a modifier (e.g. join) is following
+                if table and isinstance(this, exp.Values):
+                    alias = this.args.get("alias")
+                    this.set("alias", None)
+                    this = exp.Table(this=this, alias=alias)
+
                 this = self._parse_query_modifiers(self._parse_set_operations(this))
 
             self._match_r_paren()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2987,9 +2987,8 @@ class Parser(metaclass=_Parser):
 
                 # Transform exp.Values into a exp.Table to pass through parse_query_modifiers
                 # in case a modifier (e.g. join) is following
-                if table and isinstance(this, exp.Values):
-                    alias = this.args.get("alias")
-                    this.set("alias", None)
+                if table and isinstance(this, exp.Values) and this.alias:
+                    alias = this.args["alias"].pop()
                     this = exp.Table(this=this, alias=alias)
 
                 this = self._parse_query_modifiers(self._parse_set_operations(this))

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -797,6 +797,9 @@ class TestPostgres(Validator):
         self.validate_identity(
             "MERGE INTO target_table USING source_table AS source ON target.id = source.id WHEN MATCHED THEN DO NOTHING WHEN NOT MATCHED THEN DO NOTHING RETURNING MERGE_ACTION(), *"
         )
+        self.validate_identity(
+            "SELECT 1 FROM ((VALUES (1)) AS vals(id) LEFT OUTER JOIN tbl ON vals.id = tbl.id)"
+        )
 
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier


### PR DESCRIPTION
Fixes #4133

When parsing a `FROM` clause, we'll attempt to `_parse_table()` which in turn will call `_parse_subquery(table=True)` if the clause is wrapped. 

The nested `exp.Values` will be parsed into `this` at `_parse_select()` but the following query modifiers (e.g. joins) will not be consumed since `this` is not `exp.Query` / `exp.Table`.

This PR transforms/wraps `this` to a table to bypass this.