### PR TITLE
feat(clickhouse): Add support for APPLY query modifier

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -756,6 +756,16 @@ class ClickHouse(Dialect):
         def _parse_constraint(self) -> t.Optional[exp.Expression]:
             return super()._parse_constraint() or self._parse_projection_def()
 
+        def _parse_alias(
+            self, this: t.Optional[exp.Expression], explicit: bool = False
+        ) -> t.Optional[exp.Expression]:
+            # In clickhouse "SELECT <expr> APPLY(...)" is a query modifier,
+            # so "APPLY" shouldn't be parsed as <expr>'s alias. However, "SELECT <expr> apply" is a valid alias
+            if self._match_pair(TokenType.APPLY, TokenType.L_PAREN, advance=False):
+                return this
+
+            return super()._parse_alias(this=this, explicit=explicit)
+
     class Generator(generator.Generator):
         QUERY_HINTS = False
         STRUCT_DELIMITER = ("(", ")")

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -766,6 +766,16 @@ class ClickHouse(Dialect):
 
             return super()._parse_alias(this=this, explicit=explicit)
 
+        def _parse_projections(self) -> t.List[exp.Expression]:
+            exprs = self._parse_expressions()
+
+            # Clickhouse allows "SELECT <expr> APPLY(func) [...,]" modifier
+            while self._match_pair(TokenType.APPLY, TokenType.L_PAREN):
+                exprs[-1] = exp.Apply(this=exprs[-1], expression=self._parse_var(any_token=True))
+                self._match(TokenType.R_PAREN)
+
+            return exprs
+
     class Generator(generator.Generator):
         QUERY_HINTS = False
         STRUCT_DELIMITER = ("(", ")")

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -766,15 +766,15 @@ class ClickHouse(Dialect):
 
             return super()._parse_alias(this=this, explicit=explicit)
 
-        def _parse_projections(self) -> t.List[exp.Expression]:
-            exprs = self._parse_expressions()
+        def _parse_expression(self) -> t.Optional[exp.Expression]:
+            this = super()._parse_expression()
 
-            # Clickhouse allows "SELECT <expr> APPLY(func) [...,]" modifier
+            # Clickhouse allows "SELECT <expr> [APPLY(func)] [...]]" modifier
             while self._match_pair(TokenType.APPLY, TokenType.L_PAREN):
-                exprs[-1] = exp.Apply(this=exprs[-1], expression=self._parse_var(any_token=True))
+                this = exp.Apply(this=this, expression=self._parse_var(any_token=True))
                 self._match(TokenType.R_PAREN)
 
-            return exprs
+            return this
 
     class Generator(generator.Generator):
         QUERY_HINTS = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3103,7 +3103,6 @@ QUERY_MODIFIERS = {
     "settings": False,
     "format": False,
     "options": False,
-    "apply": False,
 }
 
 
@@ -4921,6 +4920,10 @@ class Hll(AggFunc):
 class ApproxDistinct(AggFunc):
     arg_types = {"this": True, "accuracy": False}
     _sql_names = ["APPROX_DISTINCT", "APPROX_COUNT_DISTINCT"]
+
+
+class Apply(Func):
+    arg_types = {"this": True, "expression": True}
 
 
 class Array(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3103,6 +3103,7 @@ QUERY_MODIFIERS = {
     "settings": False,
     "format": False,
     "options": False,
+    "apply": False,
 }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2491,12 +2491,9 @@ class Generator(metaclass=_Generator):
         # are the only dialects that use LIMIT_IS_TOP and both place DISTINCT first.
         top_distinct = f"{distinct}{hint}{top}" if self.LIMIT_IS_TOP else f"{top}{hint}{distinct}"
         expressions = f"{self.sep()}{expressions}" if expressions else expressions
-        apply = self.expressions(expression, key="apply", sep=" ")
-        apply = f"{self.sep()}{apply}" if apply else ""
-
         sql = self.query_modifiers(
             expression,
-            f"SELECT{top_distinct}{kind}{expressions}{apply}",
+            f"SELECT{top_distinct}{kind}{expressions}",
             self.sql(expression, "into", comment=False),
             self.sql(expression, "from", comment=False),
         )
@@ -4339,3 +4336,9 @@ class Generator(metaclass=_Generator):
                 array_agg = f"{array_agg} FILTER(WHERE {this_sql} IS NOT NULL)"
 
         return array_agg
+
+    def apply_sql(self, expression: exp.Apply) -> str:
+        this = self.sql(expression, "this")
+        expr = self.sql(expression, "expression")
+
+        return f"{this} APPLY({expr})"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2491,9 +2491,12 @@ class Generator(metaclass=_Generator):
         # are the only dialects that use LIMIT_IS_TOP and both place DISTINCT first.
         top_distinct = f"{distinct}{hint}{top}" if self.LIMIT_IS_TOP else f"{top}{hint}{distinct}"
         expressions = f"{self.sep()}{expressions}" if expressions else expressions
+        apply = self.expressions(expression, key="apply", sep=" ")
+        apply = f"{self.sep()}{apply}" if apply else ""
+
         sql = self.query_modifiers(
             expression,
-            f"SELECT{top_distinct}{kind}{expressions}",
+            f"SELECT{top_distinct}{kind}{expressions}{apply}",
             self.sql(expression, "into", comment=False),
             self.sql(expression, "from", comment=False),
         )

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -555,6 +555,7 @@ class Parser(metaclass=_Parser):
     TRIM_TYPES = {"LEADING", "TRAILING", "BOTH"}
 
     FUNC_TOKENS = {
+        TokenType.APPLY,
         TokenType.COLLATE,
         TokenType.COMMAND,
         TokenType.CURRENT_DATE,
@@ -2959,6 +2960,9 @@ class Parser(metaclass=_Parser):
                 limit=limit,
             )
             this.comments = comments
+
+            while self._match_pair(TokenType.APPLY, TokenType.L_PAREN, advance=False):
+                this.append("apply", self._parse_function())
 
             into = self._parse_into()
             if into:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -555,7 +555,6 @@ class Parser(metaclass=_Parser):
     TRIM_TYPES = {"LEADING", "TRAILING", "BOTH"}
 
     FUNC_TOKENS = {
-        TokenType.APPLY,
         TokenType.COLLATE,
         TokenType.COMMAND,
         TokenType.CURRENT_DATE,
@@ -2960,9 +2959,6 @@ class Parser(metaclass=_Parser):
                 limit=limit,
             )
             this.comments = comments
-
-            while self._match_pair(TokenType.APPLY, TokenType.L_PAREN, advance=False):
-                this.append("apply", self._parse_function())
 
             into = self._parse_into()
             if into:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -519,6 +519,12 @@ class TestClickhouse(Validator):
         self.validate_identity("SELECT TRIM(LEADING '(' FROM '(   Hello, world!   )')")
         self.validate_identity("current_timestamp").assert_is(exp.Column)
 
+        self.validate_identity("SELECT * APPLY(sum) FROM columns_transformers")
+        self.validate_identity("SELECT COLUMNS('[jk]') APPLY(toString) FROM columns_transformers")
+        self.validate_identity(
+            "SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) FROM columns_transformers"
+        )
+
     def test_clickhouse_values(self):
         values = exp.select("*").from_(
             exp.values([exp.tuple_(1, 2, 3)], alias="subq", columns=["a", "b", "c"])

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -524,6 +524,7 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) FROM columns_transformers"
         )
+        self.validate_identity("SELECT col apply", "SELECT col AS apply")
 
     def test_clickhouse_values(self):
         values = exp.select("*").from_(

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -524,6 +524,7 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) FROM columns_transformers"
         )
+        self.validate_identity("SELECT * APPLY(sum), COLUMNS('col') APPLY(sum) APPLY(avg) FROM t")
         self.validate_identity("SELECT col apply", "SELECT col AS apply")
 
     def test_clickhouse_values(self):


### PR DESCRIPTION
Fixes #4139

Clickhouse supports the `APPLY` query modifier:

```SQL
SELECT <expr> APPLY( <func> ) FROM [db.]table_name
```

Although `apply` is still a valid alias, we shouldn't parse it as such if it's accompanied by an `L_PAREN` as is the case here, thus the overriden `_parse_alias()` in Clickhouse:

```SQL
clickhouse> select 1 apply;

   ┌─apply─┐
1. │     1 │
   └───────┘

clickhouse> with t as (Select 1 as col) select COLUMNS('col') apply(sum) from t;

   ┌─sum(col)─┐
1. │        1 │
   └──────────┘
```

Note that `APPLY` can be chained, as is shown in the docs & relevant test case

Docs
---------
[Clickhouse APPLY modifier](https://clickhouse.com/docs/en/sql-reference/statements/select#apply)