### PR TITLE
fix(databricks): avoid inserting bogus `USING PARQUET` DDL when creating temporary tables

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -10,6 +10,11 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import TokenType
+from sqlglot.transforms import (
+    remove_unique_constraints,
+    preprocess,
+    move_partitioned_by_to_schema_columns,
+)
 
 
 def _build_json_extract(args: t.List) -> exp.JSONExtract:
@@ -69,6 +74,12 @@ class Databricks(Spark):
 
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,
+            exp.Create: preprocess(
+                [
+                    remove_unique_constraints,
+                    move_partitioned_by_to_schema_columns,
+                ]
+            ),
             exp.DateAdd: date_delta_sql("DATEADD"),
             exp.DateDiff: date_delta_sql("DATEDIFF"),
             exp.DatetimeAdd: lambda self, e: self.func(

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -179,7 +179,7 @@ class TestTSQL(Validator):
                 "hive": "CREATE TEMPORARY TABLE mytemptable (a INT)",
                 "spark2": "CREATE TEMPORARY TABLE mytemptable (a INT) USING PARQUET",
                 "spark": "CREATE TEMPORARY TABLE mytemptable (a INT) USING PARQUET",
-                "databricks": "CREATE TEMPORARY TABLE mytemptable (a INT) USING PARQUET",
+                "databricks": "CREATE TEMPORARY TABLE mytemptable (a INT)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #4142.