### PR TITLE
feat(bigquery): Support RANGE<T> type

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4123,6 +4123,7 @@ class DataType(Expression):
         NUMRANGE = auto()
         NVARCHAR = auto()
         OBJECT = auto()
+        RANGE = auto()
         ROWVERSION = auto()
         SERIAL = auto()
         SET = auto()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -368,7 +368,6 @@ class Parser(metaclass=_Parser):
         TokenType.USERDEFINED,
         TokenType.MONEY,
         TokenType.SMALLMONEY,
-        TokenType.RANGE,
         TokenType.ROWVERSION,
         TokenType.IMAGE,
         TokenType.VARIANT,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -269,6 +269,7 @@ class Parser(metaclass=_Parser):
         TokenType.LOWCARDINALITY,
         TokenType.MAP,
         TokenType.NULLABLE,
+        TokenType.RANGE,
         *STRUCT_TYPE_TOKENS,
     }
 
@@ -367,6 +368,7 @@ class Parser(metaclass=_Parser):
         TokenType.USERDEFINED,
         TokenType.MONEY,
         TokenType.SMALLMONEY,
+        TokenType.RANGE,
         TokenType.ROWVERSION,
         TokenType.IMAGE,
         TokenType.VARIANT,


### PR DESCRIPTION
Fixes #4146


Docs
--------
[RANGE Data Type](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#range_type) | [RANGE Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/range-functions#function_list)