### PR TITLE
feat: Add SUBSTR parsing support

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6023,6 +6023,7 @@ class Split(Func):
 # Start may be omitted in the case of postgres
 # https://www.postgresql.org/docs/9.1/functions-string.html @ Table 9-6
 class Substring(Func):
+    _sql_names = ["SUBSTRING", "SUBSTR"]
     arg_types = {"this": True, "start": False, "length": False}
 
 


### PR DESCRIPTION
Use of SUBSTR (i.e. Spark, Oracle, etc.) currently doesn't get parsed.