### PR TITLE
feat(spark): Custom annotation for more string functions

### DIFF
--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1378,25 +1378,31 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         self.assertEqual(18, normalization_distance(gen_expr(3), max_=100))
         self.assertEqual(110, normalization_distance(gen_expr(10), max_=100))
 
-    def test_custom_annotators(self):
+    def test_spark_annotators(self):
+        """Test Spark annotators, mainly built-in string/binary functions"""
+
+        schema = {"tbl": {"bin_col": "BINARY", "str_col": "STRING"}}
+
+        def _assert_func_return_type(func: str, dialect: str, target_type: str):
+            ast = parse_one(f"SELECT {func} FROM tbl", read=dialect)
+            optimized = optimizer.optimize(ast, schema=schema, dialect=dialect)
+            self.assertEqual(
+                optimized.expressions[0].type.sql(dialect),
+                exp.DataType.build(target_type).sql(dialect),
+            )
+
         # In Spark hierarchy, SUBSTRING result type is dependent on input expr type
         for dialect in ("spark2", "spark", "databricks"):
-            for expr_type_pair in (
-                ("col", "STRING"),
-                ("col", "BINARY"),
-                ("'str_literal'", "STRING"),
-                ("CAST('str_literal' AS BINARY)", "BINARY"),
-            ):
-                with self.subTest(
-                    f"Testing {dialect}'s SUBSTRING() result type for {expr_type_pair}"
-                ):
-                    expr, type = expr_type_pair
-                    ast = parse_one(f"SELECT substring({expr}, 2, 3) AS x FROM tbl", read=dialect)
+            _assert_func_return_type("SUBSTRING(str_col, 0, 0)", dialect, "STRING")
+            _assert_func_return_type("SUBSTRING(bin_col, 0, 0)", dialect, "BINARY")
 
-                    subst_type = (
-                        optimizer.optimize(ast, schema={"tbl": {"col": type}}, dialect=dialect)
-                        .expressions[0]
-                        .type
-                    )
+            _assert_func_return_type("CONCAT(bin_col, bin_col)", dialect, "BINARY")
+            _assert_func_return_type("CONCAT(bin_col, str_col)", dialect, "STRING")
+            _assert_func_return_type("CONCAT(str_col, bin_col)", dialect, "STRING")
+            _assert_func_return_type("CONCAT(str_col, str_col)", dialect, "STRING")
 
-                    self.assertEqual(subst_type.sql(dialect), exp.DataType.build(type).sql(dialect))
+            for func in ("LPAD", "RPAD"):
+                _assert_func_return_type(f"{func}(bin_col, 1, bin_col)", dialect, "BINARY")
+                _assert_func_return_type(f"{func}(bin_col, 1, str_col)", dialect, "STRING")
+                _assert_func_return_type(f"{func}(str_col, 1, bin_col)", dialect, "STRING")
+                _assert_func_return_type(f"{func}(str_col, 1, str_col)", dialect, "STRING")


### PR DESCRIPTION
This is a follow up on https://github.com/tobymao/sqlglot/pull/4004, as during my investigation for `SUBSTRING` I came across other Spark string functions (`CONCAT`, `LPAD`, `RPAD`) which are input type dependent.

Although it's not documented clearly, these functions will return a `BINARY` only if all their "string" operands are `BINARY`, otherwise they return a `STRING`:

```
spark-sql (default)> with tbl as (select cast('test' as binary) as bin_col, 'str' as str_col) 
select 
 typeof(concat(bin_col, bin_col)), 
 typeof(concat(str_col, bin_col)), 
 typeof(concat(bin_col, str_col)), 
 typeof(concat(str_col, str_col)) 
from tbl;

binary  string  string  string
```

```
spark-sql (default)> with tbl as (select cast('test' as binary) as bin_col, 'str' as str_col) 
select 
 typeof(lpad(bin_col, 1, bin_col)), 
 typeof(lpad(str_col, 1, bin_col)), 
 typeof(lpad(bin_col, 1, str_col)), 
 typeof(lpad(str_col, 1, str_col))
from tbl;

binary  string  string  string
```


Docs
---------
[Databricks LPAD](https://docs.databricks.com/en/sql/language-manual/functions/lpad.html) | [Databricks CONCAT](https://docs.databricks.com/en/sql/language-manual/functions/concat.html)
