### PR TITLE
fix(clickhouse)!: Generalize COLUMNS(...) APPLY

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -396,6 +396,7 @@ class ClickHouse(Dialect):
             **parser.Parser.FUNCTION_PARSERS,
             "ARRAYJOIN": lambda self: self.expression(exp.Explode, this=self._parse_expression()),
             "QUANTILE": lambda self: self._parse_quantile(),
+            "COLUMNS": lambda self: self._parse_columns(),
         }
 
         FUNCTION_PARSERS.pop("MATCH")
@@ -774,6 +775,14 @@ class ClickHouse(Dialect):
                 this = exp.Apply(this=this, expression=self._parse_var(any_token=True))
                 self._match(TokenType.R_PAREN)
 
+            return this
+
+        def _parse_columns(self) -> exp.Expression:
+            this: exp.Expression = self.expression(exp.Columns, this=self._parse_lambda())
+
+            while self._next and self._match_text_seq(")", "APPLY", "("):
+                self._match(TokenType.R_PAREN)
+                this = exp.Apply(this=this, expression=self._parse_var(any_token=True))
             return this
 
     class Generator(generator.Generator):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4984,6 +4984,10 @@ class ToNumber(Func):
     }
 
 
+class Columns(Func):
+    pass
+
+
 # https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16#syntax
 class Convert(Func):
     arg_types = {"this": True, "expression": True, "style": False}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4985,7 +4985,7 @@ class ToNumber(Func):
 
 
 class Columns(Func):
-    pass
+    arg_types = {"this": True, "unpack": False}
 
 
 # https://learn.microsoft.com/en-us/sql/t-sql/functions/cast-and-convert-transact-sql?view=sql-server-ver16#syntax
@@ -6245,10 +6245,6 @@ class UnixToTime(Func):
 
 
 class UnixToTimeStr(Func):
-    pass
-
-
-class UnpackColumns(Func):
     pass
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -192,7 +192,6 @@ class Generator(metaclass=_Generator):
         exp.TransientProperty: lambda *_: "TRANSIENT",
         exp.Union: lambda self, e: self.set_operations(e),
         exp.UnloggedProperty: lambda *_: "UNLOGGED",
-        exp.UnpackColumns: lambda self, e: f"*{self.sql(e.this)}",
         exp.Uuid: lambda *_: "UUID()",
         exp.UppercaseColumnConstraint: lambda *_: "UPPERCASE",
         exp.VarMap: lambda self, e: self.func("MAP", e.args["keys"], e.args["values"]),
@@ -4372,3 +4371,10 @@ class Generator(metaclass=_Generator):
         kind = f"{kind} " if kind else ""
 
         return f"{kind}{this}"
+
+    def columns_sql(self, expression: exp.Columns):
+        func = self.function_fallback_sql(expression)
+        if expression.args.get("unpack"):
+            func = f"*{func}"
+
+        return func

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7400,9 +7400,12 @@ class Parser(metaclass=_Parser):
             form=self._match(TokenType.COMMA) and self._parse_var(),
         )
 
-    def _parse_star_ops(self) -> exp.Star | exp.UnpackColumns:
+    def _parse_star_ops(self) -> t.Optional[exp.Expression]:
         if self._match_text_seq("COLUMNS", "(", advance=False):
-            return exp.UnpackColumns(this=self._parse_function())
+            this = self._parse_function()
+            if isinstance(this, exp.Columns):
+                this.set("unpack", True)
+            return this
 
         return self.expression(
             exp.Star,

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -525,6 +525,9 @@ class TestClickhouse(Validator):
             "SELECT COLUMNS('[jk]') APPLY(toString) APPLY(length) APPLY(max) FROM columns_transformers"
         )
         self.validate_identity("SELECT * APPLY(sum), COLUMNS('col') APPLY(sum) APPLY(avg) FROM t")
+        self.validate_identity(
+            "SELECT * FROM ABC WHERE hasAny(COLUMNS('.*field') APPLY(toUInt64) APPLY(to), (SELECT groupUniqArray(toUInt64(field))))"
+        )
         self.validate_identity("SELECT col apply", "SELECT col AS apply")
 
     def test_clickhouse_values(self):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -846,6 +846,18 @@ class TestDuckDB(Validator):
             "SELECT id, STRUCT_PACK(*COLUMNS('m\\d')) AS measurements FROM many_measurements",
             """SELECT id, {'_0': *COLUMNS('m\\d')} AS measurements FROM many_measurements""",
         )
+        self.validate_identity("SELECT COLUMNS(c -> c LIKE '%num%') FROM numbers")
+        self.validate_identity(
+            "SELECT MIN(COLUMNS(* REPLACE (number + id AS number))), COUNT(COLUMNS(* EXCLUDE (number))) FROM numbers"
+        )
+        self.validate_identity("SELECT COLUMNS(*) + COLUMNS(*) FROM numbers")
+        self.validate_identity("SELECT COLUMNS('(id|numbers?)') FROM numbers")
+        self.validate_identity(
+            "SELECT COALESCE(COLUMNS(['a', 'b', 'c'])) AS result FROM (SELECT NULL AS a, 42 AS b, TRUE AS c)"
+        )
+        self.validate_identity(
+            "SELECT COALESCE(*COLUMNS(['a', 'b', 'c'])) AS result FROM (SELECT NULL AS a, 42 AS b, TRUE AS c)"
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
Fixes #4157

As `COLUMNS(...)` is a function that can be used in different contexts besides the projection list, this PR adds `exp.Columns` which parses the function call _and_ the following `APPLY(...)` functions. 

The `APPLY` parsing in `clickhouse.py::_parse_expression()` is left as is to accommodate `exp.Star` and potentially any other expression that can utilize `APPLY` in the selections.