### PR TITLE
Chore: fetch all history to allow workflow script to skip sqlglotrs deployments

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,6 +15,8 @@ jobs:
       deploy: ${{ steps.check_deploy.outputs.deploy }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - id: check_deploy
         run: |
           bash ./.github/workflows/should_deploy_sqlglotrs.sh


### PR DESCRIPTION
Been seeing this weird situation for some time now, where the `should_deploy_sqlglotrs` script incorrectly shows that `Cargo.toml` changed in the same commit as the one being tagged. E.g., this corresponds to the latest version bump:

![image](https://github.com/user-attachments/assets/ee39ab79-e7b7-4e92-b8ba-749b249b03a2)

One possible cause is documented in the `actions/checkout@v3` repo:

> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags. Refer [here](https://docs.github.com/actions/using-workflows/events-that-trigger-workflows) to learn which commit $GITHUB_SHA points to for different events.

If we don't have full history, then the script can't really look into past commits to determine whether the `Cargo.toml` file was modified since the last deployment. This PR updates this so that we use the `fetch-depth: 0` option they mention.