### PR TITLE
Fix(athena): Case sensitivity in CTAS property names

### DIFF
--- a/sqlglot/dialects/athena.py
+++ b/sqlglot/dialects/athena.py
@@ -48,7 +48,7 @@ def _location_property_sql(self: Athena.Generator, e: exp.LocationProperty):
             ),
             None,
         )
-        if table_type_property and table_type_property.text("value") == "iceberg":
+        if table_type_property and table_type_property.text("value").lower() == "iceberg":
             prop_name = "location"
 
     return f"{prop_name}={self.sql(e, 'this')}"
@@ -132,6 +132,7 @@ class Athena(Trino):
         TRANSFORMS = {
             **Trino.Generator.TRANSFORMS,
             exp.FileFormatProperty: lambda self, e: f"format={self.sql(e, 'this')}",
+            exp.PartitionedByProperty: lambda self, e: f"partitioned_by={self.sql(e, 'this')}",
             exp.LocationProperty: _location_property_sql,
         }
 

--- a/tests/dialects/test_athena.py
+++ b/tests/dialects/test_athena.py
@@ -62,8 +62,12 @@ class TestAthena(Validator):
 
         # CTAS goes to the Trino engine, where the table properties cant be encased in single quotes like they can for Hive
         # ref: https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html#ctas-table-properties
+        # They're also case sentitive and need to be lowercase, otherwise you get eg "Table properties [FORMAT] are not supported."
         self.validate_identity(
-            "CREATE TABLE foo WITH (table_type='ICEBERG', external_location='s3://foo/') AS SELECT * FROM a"
+            "CREATE TABLE foo WITH (table_type='ICEBERG', location='s3://foo/', format='orc', partitioning=ARRAY['bucket(id, 5)']) AS SELECT * FROM a"
+        )
+        self.validate_identity(
+            "CREATE TABLE foo WITH (table_type='HIVE', external_location='s3://foo/', format='parquet', partitioned_by=ARRAY['ds']) AS SELECT * FROM a"
         )
         self.validate_identity(
             "CREATE TABLE foo AS WITH foo AS (SELECT a, b FROM bar) SELECT * FROM foo"


### PR DESCRIPTION
It turns out Athena table properties are case sensitive on the Trino engine and need to be lowercase.

```
CREATE TABLE "test_table" WITH (PARTITIONED_BY=ARRAY['ds'], ...) AS SELECT ...
```
Fails with `Table properties [PARTITIONED_BY] are not supported.`

```
CREATE TABLE "test_table" WITH (partitioned_by=ARRAY['ds'], ...) AS SELECT ...
```
Succeeds