### PR TITLE
fix(bigquery): Do not generate null ordering on agg funcs

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -203,7 +203,8 @@ class Generator(metaclass=_Generator):
     }
 
     # Whether null ordering is supported in order by
-    # True: Full Support, None: No support, False: No support in window specifications
+    # True: Full Support, None: No support, False: No support for certain cases
+    # such as window specifications, aggregate functions etc
     NULL_ORDERING_SUPPORTED: t.Optional[bool] = True
 
     # Whether ignore nulls is inside the agg or outside.
@@ -2343,6 +2344,20 @@ class Generator(metaclass=_Generator):
             if isinstance(window, exp.Window) and window.args.get("spec"):
                 self.unsupported(
                     f"'{nulls_sort_change.strip()}' translation not supported in window functions"
+                )
+                nulls_sort_change = ""
+            elif (
+                self.NULL_ORDERING_SUPPORTED is False
+                and expression.find_ancestor(exp.AggFunc)
+                and (
+                    asc
+                    and nulls_sort_change == " NULLS LAST"
+                    or desc
+                    and nulls_sort_change == " NULLS FIRST"
+                )
+            ):
+                self.unsupported(
+                    f"'{nulls_sort_change.strip()}' translation not supported for aggregate functions with {sort_order} sort order"
                 )
                 nulls_sort_change = ""
             elif self.NULL_ORDERING_SUPPORTED is None:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2348,12 +2348,10 @@ class Generator(metaclass=_Generator):
                 nulls_sort_change = ""
             elif (
                 self.NULL_ORDERING_SUPPORTED is False
-                and expression.find_ancestor(exp.AggFunc)
+                and (isinstance(expression.find_ancestor(exp.AggFunc, exp.Select), exp.AggFunc))
                 and (
-                    asc
-                    and nulls_sort_change == " NULLS LAST"
-                    or desc
-                    and nulls_sort_change == " NULLS FIRST"
+                    (asc and nulls_sort_change == " NULLS LAST")
+                    or (desc and nulls_sort_change == " NULLS FIRST")
                 )
             ):
                 self.unsupported(


### PR DESCRIPTION
Fixes #4170

BigQuery does not allow `ASC NULLS LAST` and `DESC NULLS FIRST` ordering in aggregate functions:

```
with colors as (SELECT 1 AS id, 'red' AS color) SELECT color, array_agg(id ORDER BY id ASC NULLS LAST) AS ids FROM colors GROUP BY 1

NULLS LAST not supported with ascending sort order in aggregate functions.
```

```
with colors as (SELECT 1 AS id, 'red' AS color) SELECT color, array_agg(id ORDER BY id DESC NULLS FIRST) AS ids FROM colors GROUP BY 1

NULLS FIRST not supported with descending sort order in aggregate functions.
```

Note that BigQuery is the only dialect with `NULL_ORDERING_SUPPORTED = False` so this PR uses this as a proxy to handle this case.

