### PR TITLE
fix(redshift): Add unsupported warnings for UNNEST

### DIFF
--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -858,6 +858,18 @@ class TestDuckDB(Validator):
         self.validate_identity(
             "SELECT COALESCE(*COLUMNS(['a', 'b', 'c'])) AS result FROM (SELECT NULL AS a, 42 AS b, TRUE AS c)"
         )
+        self.validate_all(
+            "SELECT * FROM UNNEST(STRUCT(123 AS a))",
+            write={
+                "redshift": UnsupportedError,
+            },
+        )
+        self.validate_all(
+            "SELECT UNNEST(foo) AS x",
+            write={
+                "redshift": UnsupportedError,
+            },
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -859,12 +859,6 @@ class TestDuckDB(Validator):
             "SELECT COALESCE(*COLUMNS(['a', 'b', 'c'])) AS result FROM (SELECT NULL AS a, 42 AS b, TRUE AS c)"
         )
         self.validate_all(
-            "SELECT * FROM UNNEST(STRUCT(123 AS a))",
-            write={
-                "redshift": UnsupportedError,
-            },
-        )
-        self.validate_all(
             "SELECT UNNEST(foo) AS x",
             write={
                 "redshift": UnsupportedError,


### PR DESCRIPTION
Fixes #4169

Redshift supports [implicit unnest of an array](https://stackoverflow.com/a/72870096) but not an `UNNEST` function as other dialects. This PR adds unsupported warnings for the following cases:
- If an `exp.Unnest` is used with a _known_ non-array type
- If an `exp.Unnest` is not used under a `FROM` or `JOIN` clause
- If we attempt to transpile an `exp.Explode` node coming from Spark/DuckDB etc.