### PR TITLE
Fix: Unexpected row deduplication using eliminate_full_outer_join

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -629,10 +629,7 @@ def eliminate_full_outer_join(expression: exp.Expression) -> exp.Expression:
             expression.set("limit", None)
             index, full_outer_join = full_outer_joins[0]
 
-            tables = (
-                full_outer_join.alias_or_name,
-                expression.args["from"].alias_or_name,
-            )
+            tables = (expression.args["from"].alias_or_name, full_outer_join.alias_or_name)
             join_conditions = full_outer_join.args.get("on") or exp.and_(
                 *[
                     exp.column(col, tables[0]).eq(exp.column(col, tables[1]))
@@ -647,7 +644,7 @@ def eliminate_full_outer_join(expression: exp.Expression) -> exp.Expression:
                 .where(join_conditions)
             )
             expression_copy.args["joins"][index].set("side", "right")
-            expression_copy.args["where"] = exp.Where(this=exp.Exists(this=anti_join_clause).not_())
+            expression_copy = expression_copy.where(exp.Exists(this=anti_join_clause).not_())
             expression_copy.args.pop("with", None)  # remove CTEs from RIGHT side
             expression.args.pop("order", None)  # remove order by from LEFT side
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -652,7 +652,7 @@ def eliminate_full_outer_join(expression: exp.Expression) -> exp.Expression:
             expression_copy.args["joins"][index].set("side", "right")
             expression_copy.args["where"] = exp.Where(this=exp.Exists(this=anti_join_clause).not_())
             expression_copy.args.pop("with", None)  # remove CTEs from RIGHT side
-            expression.args.pop("order", None)  # remove order by from RIGHT side
+            expression.args.pop("order", None)  # remove order by from LEFT side
 
             return exp.union(expression, expression_copy, copy=False, distinct=False)
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -624,15 +624,31 @@ def eliminate_full_outer_join(expression: exp.Expression) -> exp.Expression:
             if join.side == "FULL"
         ]
 
+        
+
         if len(full_outer_joins) == 1:
+
             expression_copy = expression.copy()
             expression.set("limit", None)
             index, full_outer_join = full_outer_joins[0]
+
+            tables = (full_outer_join.find(exp.Table), expression.args.get("from").this)
+            join_conditions = full_outer_join.args.get("on") or exp.And(expressions=[
+                exp.EQ(this=exp.Column(this=col, table=tables[0]), expression=exp.Column(this=col, table=tables[1]))
+                for col in full_outer_join.args.get("using")
+            ])
+
             full_outer_join.set("side", "left")
+            anti_join_clause = (
+                exp.Select(expressions=[exp.Literal(this=1, is_string=False)])
+                .from_(expression.args.get("from"))
+                .where(join_conditions)
+                )
             expression_copy.args["joins"][index].set("side", "right")
+            expression_copy.args["where"] = exp.Where(this=exp.Exists(this=anti_join_clause).not_())
             expression_copy.args.pop("with", None)  # remove CTEs from RIGHT side
 
-            return exp.union(expression, expression_copy, copy=False)
+            return exp.union(expression, expression_copy, copy=False, distinct=False)
 
     return expression
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -630,15 +630,12 @@ def eliminate_full_outer_join(expression: exp.Expression) -> exp.Expression:
             index, full_outer_join = full_outer_joins[0]
 
             tables = (
-                full_outer_join.find(exp.Table).alias_or_name,
+                full_outer_join.alias_or_name,
                 expression.args["from"].alias_or_name,
             )
-            join_conditions = full_outer_join.args.get("on") or exp.And(
-                expressions=[
-                    exp.EQ(
-                        this=exp.Column(this=col, table=tables[0]),
-                        expression=exp.Column(this=col, table=tables[1]),
-                    )
+            join_conditions = full_outer_join.args.get("on") or exp.and_(
+                *[
+                    exp.column(col, tables[0]).eq(exp.column(col, tables[1]))
                     for col in full_outer_join.args.get("using")
                 ]
             )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -754,21 +754,21 @@ class TestMySQL(Validator):
         )
         self.validate_all(
             # MySQL doesn't support FULL OUTER joins
-            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.x = t2.x UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.x = t2.x WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
+            "SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.x = t2.x UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.x = t2.x WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
             read={
-                "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x = t2.x",
+                "postgres": "SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x = t2.x",
             },
         )
         self.validate_all(
-            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 USING (x) UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 USING (x) WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
+            "SELECT * FROM t1 LEFT OUTER JOIN t2 USING (x) UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 USING (x) WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
             read={
-                "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 USING (x) ",
+                "postgres": "SELECT * FROM t1 FULL OUTER JOIN t2 USING (x) ",
             },
         )
         self.validate_all(
-            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 USING (x, y) UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 USING (x, y) WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x AND t1.y = t2.y)",
+            "SELECT * FROM t1 LEFT OUTER JOIN t2 USING (x, y) UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 USING (x, y) WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x AND t1.y = t2.y)",
             read={
-                "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 USING (x, y) ",
+                "postgres": "SELECT * FROM t1 FULL OUTER JOIN t2 USING (x, y) ",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -766,6 +766,12 @@ class TestMySQL(Validator):
             },
         )
         self.validate_all(
+            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 USING (x, y) UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 USING (x, y) WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x AND t1.y = t2.y)",
+            read={
+                "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 USING (x, y) ",
+            },
+        )
+        self.validate_all(
             "a XOR b",
             read={
                 "mysql": "a XOR b",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -747,14 +747,14 @@ class TestMySQL(Validator):
             },
         )
         self.validate_all(
-            "SELECT * FROM x LEFT JOIN y ON x.id = y.id UNION SELECT * FROM x RIGHT JOIN y ON x.id = y.id LIMIT 0",
+            "SELECT * FROM x LEFT JOIN y ON x.id = y.id UNION ALL SELECT * FROM x RIGHT JOIN y ON x.id = y.id WHERE NOT EXISTS(SELECT 1 FROM x WHERE x.id = y.id) LIMIT 0",
             read={
                 "postgres": "SELECT * FROM x FULL JOIN y ON x.id = y.id LIMIT 0",
             },
         )
         self.validate_all(
             # MySQL doesn't support FULL OUTER joins
-            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.x = t2.x UNION SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.x = t2.x",
+            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.x = t2.x UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.x = t2.x WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
             read={
                 "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x = t2.x",
             },

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -747,9 +747,9 @@ class TestMySQL(Validator):
             },
         )
         self.validate_all(
-            "SELECT * FROM x LEFT JOIN y ON x.id = y.id UNION ALL SELECT * FROM x RIGHT JOIN y ON x.id = y.id WHERE NOT EXISTS(SELECT 1 FROM x WHERE x.id = y.id) LIMIT 0",
+            "SELECT * FROM x LEFT JOIN y ON x.id = y.id UNION ALL SELECT * FROM x RIGHT JOIN y ON x.id = y.id WHERE NOT EXISTS(SELECT 1 FROM x WHERE x.id = y.id) ORDER BY 1 LIMIT 0",
             read={
-                "postgres": "SELECT * FROM x FULL JOIN y ON x.id = y.id LIMIT 0",
+                "postgres": "SELECT * FROM x FULL JOIN y ON x.id = y.id ORDER BY 1 LIMIT 0",
             },
         )
         self.validate_all(
@@ -757,6 +757,12 @@ class TestMySQL(Validator):
             "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 ON t1.x = t2.x UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 ON t1.x = t2.x WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
             read={
                 "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 ON t1.x = t2.x",
+            },
+        )
+        self.validate_all(
+            "WITH t1 AS (SELECT 1) SELECT * FROM t1 LEFT OUTER JOIN t2 USING (x) UNION ALL SELECT * FROM t1 RIGHT OUTER JOIN t2 USING (x) WHERE NOT EXISTS(SELECT 1 FROM t1 WHERE t1.x = t2.x)",
+            read={
+                "postgres": "WITH t1 AS (SELECT 1) SELECT * FROM t1 FULL OUTER JOIN t2 USING (x) ",
             },
         )
         self.validate_all(


### PR DESCRIPTION
The union syntax cause deduplication of rows from source tables, to achieve the intended result but avoid unintended deduplication I changed the logic to a left join + an anti join(right join + not exists) with union all.

This should be more in line with the behaviour of FULL OUTER JOINs since it keeps duplicate rows that would be present if there are duplicate rows in the two joined tables.
https://en.wikipedia.org/wiki/Join_%28SQL%29#Full_outer_join


Other possible ways to achieve this are:
- filtering for NULLS on joining condition columns in the right side of the union
- use a pure anti-join without the right join syntax (this would require table identifiers on columns selected) 
- use inner joins + more anti-joins (same requirements as the previous one)