### PR TITLE
feat(optimizer): Fixture file for function annotations

### DIFF
--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1,0 +1,71 @@
+--------------------------------------
+-- Spark2 / Spark3 / Databricks functions
+--------------------------------------
+
+# dialect: spark2, spark, databricks
+SUBSTRING(tbl.str_col, 0, 0);
+STRING;
+
+# dialect: spark2, spark, databricks
+SUBSTRING(tbl.bin_col, 0, 0);
+BINARY;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.bin_col, tbl.bin_col);
+BINARY;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.bin_col, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, tbl.bin_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, unknown);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.bin_col, unknown);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+CONCAT(unknown, unknown);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.bin_col, 1, tbl.bin_col);
+BINARY;
+
+# dialect: spark2, spark, databricks
+RPAD(tbl.bin_col, 1, tbl.bin_col);
+BINARY;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.bin_col, 1, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+RPAD(tbl.bin_col, 1, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.str_col, 1, tbl.bin_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+RPAD(tbl.str_col, 1, tbl.bin_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.str_col, 1, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+RPAD(tbl.str_col, 1, tbl.str_col);
+STRING;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -57,8 +57,8 @@ def simplify(expression, **kwargs):
 def annotate_functions(expression, **kwargs):
     from sqlglot.dialects import Dialect
 
-    dialect = kwargs["dialect"]
-    schema = kwargs["schema"]
+    dialect = kwargs.get("dialect")
+    schema = kwargs.get("schema")
 
     annotators = Dialect.get_or_raise(dialect).ANNOTATORS
     annotated = annotate_types(expression, annotators=annotators, schema=schema)


### PR DESCRIPTION
This PR introduces the `annotate_functions.sql` fixture file which abstracts away the type inference & check of functions, further supporting dialect-aware annotation & it's testing.