### PR TITLE
feat(duckdb): Parse ** and ^ operators as POW

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -289,6 +289,7 @@ class DuckDB(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "//": TokenType.DIV,
+            "**": TokenType.DSTAR,
             "ATTACH": TokenType.COMMAND,
             "BINARY": TokenType.VARBINARY,
             "BITSTRING": TokenType.BIT,
@@ -324,6 +325,13 @@ class DuckDB(Dialect):
         BITWISE = {
             **parser.Parser.BITWISE,
             TokenType.TILDA: exp.RegexpLike,
+        }
+        BITWISE.pop(TokenType.CARET)
+
+        EXPONENT = {
+            **parser.Parser.EXPONENT,
+            TokenType.CARET: exp.Pow,
+            TokenType.DSTAR: exp.Pow,
         }
 
         FUNCTIONS_WITH_ALIASED_ARGS = {*parser.Parser.FUNCTIONS_WITH_ALIASED_ARGS, "STRUCT_PACK"}

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -864,6 +864,8 @@ class TestDuckDB(Validator):
                 "redshift": UnsupportedError,
             },
         )
+        self.validate_identity("a ^ b", "POWER(a, b)")
+        self.validate_identity("a ** b", "POWER(a, b)")
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
Fixes #4186

These are all aliases:

```
D SELECT * FROM duckdb_functions() WHERE function_name IN ('**', '^', 'pow', 'power');
┌───────────────┬──────────────┬─────────────┬───────────────┬───────────────┬──────────────────────────────┬─────────┬──────┬─────────────┬────────────┬──────────────────┬─────────┬──────────────────┬──────────────────┬──────────┬──────────────┬───────────┬────────────┐
│ database_name │ database_oid │ schema_name │ function_name │ function_type │         description          │ comment │ tags │ return_type │ parameters │ parameter_types  │ varargs │ macro_definition │ has_side_effects │ internal │ function_oid │  example  │ stability  │
├───────────────┼──────────────┼─────────────┼───────────────┼───────────────┼──────────────────────────────┼─────────┼──────┼─────────────┼────────────┼──────────────────┼─────────┼──────────────────┼──────────────────┼──────────┼──────────────┼───────────┼────────────┤
│ system        │ 0            │ main        │ **            │ scalar        │ Computes x to the power of y │         │ {}   │ DOUBLE      │ [x, y]     │ [DOUBLE, DOUBLE] │         │                  │ false            │ true     │ 408          │ pow(2, 3) │ CONSISTENT │
│ system        │ 0            │ main        │ ^             │ scalar        │ Computes x to the power of y │         │ {}   │ DOUBLE      │ [x, y]     │ [DOUBLE, DOUBLE] │         │                  │ false            │ true     │ 426          │ pow(2, 3) │ CONSISTENT │
│ system        │ 0            │ main        │ pow           │ scalar        │ Computes x to the power of y │         │ {}   │ DOUBLE      │ [x, y]     │ [DOUBLE, DOUBLE] │         │                  │ false            │ true     │ 902          │ pow(2, 3) │ CONSISTENT │
│ system        │ 0            │ main        │ power         │ scalar        │ Computes x to the power of y │         │ {}   │ DOUBLE      │ [x, y]     │ [DOUBLE, DOUBLE] │         │                  │ false            │ true     │ 904          │ pow(2, 3) │ CONSISTENT │
└───────────────┴──────────────┴─────────────┴───────────────┴───────────────┴──────────────────────────────┴─────────┴──────┴─────────────┴────────────┴──────────────────┴─────────┴──────────────────┴──────────────────┴──────────┴──────────────┴───────────┴────────────┘
```