### PR TITLE
feat(duckdb): Parse ~~~ as GLOB

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -649,6 +649,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "<->": TokenType.LR_ARROW,
         "&&": TokenType.DAMP,
         "??": TokenType.DQMARK,
+        "~~~": TokenType.GLOB,
         "ALL": TokenType.ALL,
         "ALWAYS": TokenType.ALWAYS,
         "AND": TokenType.AND,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -866,6 +866,7 @@ class TestDuckDB(Validator):
         )
         self.validate_identity("a ^ b", "POWER(a, b)")
         self.validate_identity("a ** b", "POWER(a, b)")
+        self.validate_identity("a ~~~ b", "a GLOB b")
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
Fixes #4187

The `a GLOB b` operator is an alias of `a ~~~ b`:

```SQL
D SELECT 'best.txt' GLOB '*.txt';
┌──────────────────────────┐
│ ('best.txt' ~~~ '*.txt') │
├──────────────────────────┤
│ true                     │
└──────────────────────────┘
```

Docs
--------
[DuckDB GLOB](https://duckdb.org/docs/sql/functions/pattern_matching.html#globbing)