### PR TITLE
fix(duckdb): Parse ~~ as LIKE

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -286,7 +286,6 @@ class Postgres(Dialect):
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
-            "~~": TokenType.LIKE,
             "~~*": TokenType.ILIKE,
             "~*": TokenType.IRLIKE,
             "~": TokenType.RLIKE,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -650,6 +650,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "&&": TokenType.DAMP,
         "??": TokenType.DQMARK,
         "~~~": TokenType.GLOB,
+        "~~": TokenType.LIKE,
         "ALL": TokenType.ALL,
         "ALWAYS": TokenType.ALWAYS,
         "AND": TokenType.AND,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -867,6 +867,7 @@ class TestDuckDB(Validator):
         self.validate_identity("a ^ b", "POWER(a, b)")
         self.validate_identity("a ** b", "POWER(a, b)")
         self.validate_identity("a ~~~ b", "a GLOB b")
+        self.validate_identity("a ~~ b", "a LIKE b")
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
Fixes #4188

These two operators are aliases of each other:

```SQL
D SELECT 'a' LIKE 'b';
┌──────────────┐
│ ('a' ~~ 'b') │
├──────────────┤
│ false        │
└──────────────┘
```

This is also the case for Postgres so I moved the token to the base tokenizer.

Docs
---------
[DuckDB LIKE](https://duckdb.org/docs/sql/functions/pattern_matching.html#like)