### PR TITLE
feat(duckdb): Add more Postgres operators

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -38,6 +38,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
+from sqlglot.parser import binary_range_parser
 
 DATETIME_DELTA = t.Union[
     exp.DateAdd, exp.TimeAdd, exp.DatetimeAdd, exp.TsOrDsAdd, exp.DateSub, exp.DatetimeSub
@@ -290,6 +291,7 @@ class DuckDB(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "//": TokenType.DIV,
             "**": TokenType.DSTAR,
+            "^@": TokenType.CARET_AMP,
             "ATTACH": TokenType.COMMAND,
             "BINARY": TokenType.VARBINARY,
             "BITSTRING": TokenType.BIT,
@@ -327,6 +329,12 @@ class DuckDB(Dialect):
             TokenType.TILDA: exp.RegexpLike,
         }
         BITWISE.pop(TokenType.CARET)
+
+        RANGE_PARSERS = {
+            **parser.Parser.RANGE_PARSERS,
+            TokenType.DAMP: binary_range_parser(exp.ArrayOverlaps),
+            TokenType.CARET_AMP: binary_range_parser(exp.StartsWith),
+        }
 
         EXPONENT = {
             **parser.Parser.EXPONENT,
@@ -488,7 +496,6 @@ class DuckDB(Dialect):
             **generator.Generator.TRANSFORMS,
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.Array: inline_array_unless_query,
-            exp.ArrayContainsAll: rename_func("ARRAY_HAS_ALL"),
             exp.ArrayFilter: rename_func("LIST_FILTER"),
             exp.ArraySize: rename_func("ARRAY_LENGTH"),
             exp.ArgMax: arg_max_or_min_no_count("ARG_MAX"),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -291,7 +291,7 @@ class DuckDB(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "//": TokenType.DIV,
             "**": TokenType.DSTAR,
-            "^@": TokenType.CARET_AMP,
+            "^@": TokenType.CARET_AT,
             "@>": TokenType.AT_GT,
             "<@": TokenType.LT_AT,
             "ATTACH": TokenType.COMMAND,
@@ -335,7 +335,7 @@ class DuckDB(Dialect):
         RANGE_PARSERS = {
             **parser.Parser.RANGE_PARSERS,
             TokenType.DAMP: binary_range_parser(exp.ArrayOverlaps),
-            TokenType.CARET_AMP: binary_range_parser(exp.StartsWith),
+            TokenType.CARET_AT: binary_range_parser(exp.StartsWith),
         }
 
         EXPONENT = {

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -292,6 +292,8 @@ class DuckDB(Dialect):
             "//": TokenType.DIV,
             "**": TokenType.DSTAR,
             "^@": TokenType.CARET_AMP,
+            "@>": TokenType.AT_GT,
+            "<@": TokenType.LT_AT,
             "ATTACH": TokenType.COMMAND,
             "BINARY": TokenType.VARBINARY,
             "BITSTRING": TokenType.BIT,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -286,12 +286,8 @@ class Postgres(Dialect):
 
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
-            "~~*": TokenType.ILIKE,
-            "~*": TokenType.IRLIKE,
             "~": TokenType.RLIKE,
             "@@": TokenType.DAT,
-            "@>": TokenType.AT_GT,
-            "<@": TokenType.LT_AT,
             "|/": TokenType.PIPE_SLASH,
             "||/": TokenType.DPIPE_SLASH,
             "BEGIN": TokenType.COMMAND,
@@ -385,12 +381,10 @@ class Postgres(Dialect):
 
         RANGE_PARSERS = {
             **parser.Parser.RANGE_PARSERS,
-            TokenType.AT_GT: binary_range_parser(exp.ArrayContainsAll),
             TokenType.DAMP: binary_range_parser(exp.ArrayOverlaps),
             TokenType.DAT: lambda self, this: self.expression(
                 exp.MatchAgainst, this=self._parse_bitwise(), expressions=[this]
             ),
-            TokenType.LT_AT: binary_range_parser(exp.ArrayContainsAll, reverse_args=True),
             TokenType.OPERATOR: lambda self, this: self._parse_operator(this),
         }
 
@@ -488,8 +482,6 @@ class Postgres(Dialect):
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: any_value_to_max_sql,
             exp.ArrayConcat: lambda self, e: self.arrayconcat_sql(e, name="ARRAY_CAT"),
-            exp.ArrayContainsAll: lambda self, e: self.binary(e, "@>"),
-            exp.ArrayOverlaps: lambda self, e: self.binary(e, "&&"),
             exp.ArrayFilter: filter_array_using_unnest,
             exp.ArraySize: lambda self, e: self.func("ARRAY_LENGTH", e.this, e.expression or "1"),
             exp.BitwiseXor: lambda self, e: self.binary(e, "#"),

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -288,6 +288,8 @@ class Postgres(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "~": TokenType.RLIKE,
             "@@": TokenType.DAT,
+            "@>": TokenType.AT_GT,
+            "<@": TokenType.LT_AT,
             "|/": TokenType.PIPE_SLASH,
             "||/": TokenType.DPIPE_SLASH,
             "BEGIN": TokenType.COMMAND,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -114,6 +114,8 @@ class Generator(metaclass=_Generator):
         **JSON_PATH_PART_TRANSFORMS,
         exp.AllowedValuesProperty: lambda self,
         e: f"ALLOWED_VALUES {self.expressions(e, flat=True)}",
+        exp.ArrayContainsAll: lambda self, e: self.binary(e, "@>"),
+        exp.ArrayOverlaps: lambda self, e: self.binary(e, "&&"),
         exp.AutoRefreshProperty: lambda self, e: f"AUTO REFRESH {self.sql(e, 'this')}",
         exp.BackupProperty: lambda self, e: f"BACKUP {self.sql(e, 'this')}",
         exp.CaseSpecificColumnConstraint: lambda _,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -859,6 +859,7 @@ class Parser(metaclass=_Parser):
     }
 
     RANGE_PARSERS = {
+        TokenType.AT_GT: binary_range_parser(exp.ArrayContainsAll),
         TokenType.BETWEEN: lambda self, this: self._parse_between(this),
         TokenType.GLOB: binary_range_parser(exp.Glob),
         TokenType.ILIKE: binary_range_parser(exp.ILike),
@@ -866,6 +867,7 @@ class Parser(metaclass=_Parser):
         TokenType.IRLIKE: binary_range_parser(exp.RegexpILike),
         TokenType.IS: lambda self, this: self._parse_is(this),
         TokenType.LIKE: binary_range_parser(exp.Like),
+        TokenType.LT_AT: binary_range_parser(exp.ArrayContainsAll, reverse_args=True),
         TokenType.OVERLAPS: binary_range_parser(exp.Overlaps),
         TokenType.RLIKE: binary_range_parser(exp.RegexpLike),
         TokenType.SIMILAR_TO: binary_range_parser(exp.SimilarTo),

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -60,7 +60,7 @@ class TokenType(AutoName):
     PIPE_SLASH = auto()
     DPIPE_SLASH = auto()
     CARET = auto()
-    CARET_AMP = auto()
+    CARET_AT = auto()
     TILDA = auto()
     ARROW = auto()
     DARROW = auto()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -652,8 +652,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "??": TokenType.DQMARK,
         "~~~": TokenType.GLOB,
         "~~": TokenType.LIKE,
-        "@>": TokenType.AT_GT,
-        "<@": TokenType.LT_AT,
         "~~*": TokenType.ILIKE,
         "~*": TokenType.IRLIKE,
         "ALL": TokenType.ALL,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -60,6 +60,7 @@ class TokenType(AutoName):
     PIPE_SLASH = auto()
     DPIPE_SLASH = auto()
     CARET = auto()
+    CARET_AMP = auto()
     TILDA = auto()
     ARROW = auto()
     DARROW = auto()
@@ -651,6 +652,10 @@ class Tokenizer(metaclass=_Tokenizer):
         "??": TokenType.DQMARK,
         "~~~": TokenType.GLOB,
         "~~": TokenType.LIKE,
+        "@>": TokenType.AT_GT,
+        "<@": TokenType.LT_AT,
+        "~~*": TokenType.ILIKE,
+        "~*": TokenType.IRLIKE,
         "ALL": TokenType.ALL,
         "ALWAYS": TokenType.ALWAYS,
         "AND": TokenType.AND,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -868,6 +868,18 @@ class TestDuckDB(Validator):
         self.validate_identity("a ** b", "POWER(a, b)")
         self.validate_identity("a ~~~ b", "a GLOB b")
         self.validate_identity("a ~~ b", "a LIKE b")
+        self.validate_identity("a @> b")
+        self.validate_identity("a <@ b", "b @> a")
+        self.validate_identity("a && b").assert_is(exp.ArrayOverlaps)
+        self.validate_identity("a ^@ b", "STARTS_WITH(a, b)")
+        self.validate_identity(
+            "a !~~ b",
+            "NOT a LIKE b",
+        )
+        self.validate_identity(
+            "a !~~* b",
+            "NOT a ILIKE b",
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -354,10 +354,10 @@ class TestPostgres(Validator):
         self.validate_all(
             "SELECT ARRAY[1, 2, 3] @> ARRAY[1, 2]",
             read={
-                "duckdb": "SELECT ARRAY_HAS_ALL([1, 2, 3], [1, 2])",
+                "duckdb": "SELECT [1, 2, 3] @> [1, 2]",
             },
             write={
-                "duckdb": "SELECT ARRAY_HAS_ALL([1, 2, 3], [1, 2])",
+                "duckdb": "SELECT [1, 2, 3] @> [1, 2]",
                 "mysql": UnsupportedError,
                 "postgres": "SELECT ARRAY[1, 2, 3] @> ARRAY[1, 2]",
             },
@@ -396,13 +396,6 @@ class TestPostgres(Validator):
             write={
                 "duckdb": """SELECT (data ->> '$."en-US"') AS acat FROM my_table""",
                 "postgres": "SELECT (data ->> 'en-US') AS acat FROM my_table",
-            },
-        )
-        self.validate_all(
-            "SELECT ARRAY[1, 2, 3] && ARRAY[1, 2]",
-            write={
-                "": "SELECT ARRAY_OVERLAPS(ARRAY(1, 2, 3), ARRAY(1, 2))",
-                "postgres": "SELECT ARRAY[1, 2, 3] && ARRAY[1, 2]",
             },
         )
         self.validate_all(
@@ -802,6 +795,7 @@ class TestPostgres(Validator):
         )
         self.validate_identity("SELECT OVERLAY(a PLACING b FROM 1)")
         self.validate_identity("SELECT OVERLAY(a PLACING b FROM 1 FOR 1)")
+        self.validate_identity("ARRAY[1, 2, 3] && ARRAY[1, 2]").assert_is(exp.ArrayOverlaps)
 
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier


### PR DESCRIPTION
Fixes #4189

The `^@` operator is an alias of the `STARTS_WITH(a, b)` function:

```SQL
──────────────┬────────────────────┬─────────┬──────────────────┬──────────────────┬──────────┬──────────────┬────────────────────────┬────────────┐
│ database_name │ database_oid │ schema_name │ function_name │ function_type │                   description                    │ comment │ tags │ return_type │       parameters        │  parameter_types   │ varargs │ macro_definition │ has_side_effects │ internal │ function_oid │        example         │ stability  │
├───────────────┼──────────────┼─────────────┼───────────────┼───────────────┼──────────────────────────────────────────────────┼─────────┼──────┼─────────────┼─────────────────────────┼────────────────────┼─────────┼──────────────────┼──────────────────┼──────────┼──────────────┼────────────────────────┼────────────┤
│ system        │ 0            │ main        │ ^@            │ scalar        │ Returns true if string begins with search_string │         │ {}   │ BOOLEAN     │ [string, search_string] │ [VARCHAR, VARCHAR] │         │                  │ false            │ true     │ 428          │ starts_with('abc','a') │ CONSISTENT │
│ system        │ 0            │ main        │ starts_with   │ scalar        │ Returns true if string begins with search_string │         │ {}   │ BOOLEAN     │ [string, search_string] │ [VARCHAR, VARCHAR] │         │                  │ false            │ true     │ 994          │ starts_with('abc','a') │ CONSISTENT │
└───────────────┴──────────────┴─────────────┴───────────────┴───────────────┴──────────────────────────────────────────────────┴─────────┴──────┴─────────────┴─────────────────────────┴────────────────────┴─────────┴──────────────────┴──────────────────┴──────────┴──────────────┴────────────────────────┴────────────┘
```

All other operators seem to be borrowed by Postgres, so this PR extends/moves their definitions to the base dialect.

Docs
--------
[Postgres operators](https://www.postgresql.org/docs/6.3/c09.htm) | [DuckDB Text operators/functions](https://duckdb.org/docs/sql/functions/char.html)
 