### PR TITLE
feat(bigquery): Native math function annotations

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -293,6 +293,14 @@ class BigQuery(Dialect):
     # All set operations require either a DISTINCT or ALL specifier
     SET_OP_DISTINCT_BY_DEFAULT = dict.fromkeys((exp.Except, exp.Intersect, exp.Union), None)
 
+    ANNOTATORS = {
+        **Dialect.ANNOTATORS,
+        exp.Abs: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.Greatest: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
+        exp.Least: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
+    }
+
     def normalize_identifier(self, expression: E) -> E:
         if (
             isinstance(expression, exp.Identifier)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -577,7 +577,6 @@ class Dialect(metaclass=_Dialect):
         exp.DataType.Type.DOUBLE: {
             exp.ApproxQuantile,
             exp.Avg,
-            exp.Div,
             exp.Exp,
             exp.Ln,
             exp.Log,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1,5 +1,5 @@
 --------------------------------------
--- Spark2 / Spark3 / Databricks functions
+-- Spark2 / Spark3 / Databricks
 --------------------------------------
 
 # dialect: spark2, spark, databricks
@@ -69,3 +69,40 @@ STRING;
 # dialect: spark2, spark, databricks
 RPAD(tbl.str_col, 1, tbl.str_col);
 STRING;
+
+
+--------------------------------------
+-- BigQuery
+--------------------------------------
+
+# dialect: bigquery
+ABS(1);
+INT;
+
+# dialect: bigquery
+ABS(1.5);
+DOUBLE;
+
+# dialect: bigquery
+GREATEST(1, 2, 3);
+INT;
+
+# dialect: bigquery
+GREATEST(1, 2.5, 3);
+DOUBLE;
+
+# dialect: bigquery
+LEAST(1, 2, 3);
+INT;
+
+# dialect: bigquery
+LEAST(1, 2.5, 3);
+DOUBLE;
+
+# dialect: bigquery
+SIGN(1);
+INT;
+
+# dialect: bigquery
+SIGN(1.5);
+DOUBLE;


### PR DESCRIPTION
This is an initial attempt bringing native BigQuery type annotation, starting from the mathematical functions.

This PR focuses on `ABS(x)`, `SIGN(x)`, `LEAST(x1, ..., xn)` and `GREATEST(x1, ..., xn)` which borrow the type of their inputs:

```SQL
select typeof(abs(1)), typeof(abs(1.5)), typeof(sign(1)), typeof(sign(1.5));

INT64 | FLOAT64 | INT64 | FLOAT64
```

As the latter functions are varlen, the result type is the coerced / common supertype according to the docs:

```SQL
select typeof(least(1, 2)), typeof(least(1, 2.5)), typeof(greatest(1, 2)), typeof(greatest(1, 2.5));

INT64 | FLOAT64 | INT64 | FLOAT64
```

Docs
--------
[ABS](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#abs) | [SIGN](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#sign) | [LEAST](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#least) | [GREATEST](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#greatest) | 


