### PR TITLE
Fix: properly escape closing identifier delimiters

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -672,9 +672,7 @@ class Generator(metaclass=_Generator):
         self._escaped_quote_end: str = (
             self.dialect.tokenizer_class.STRING_ESCAPES[0] + self.dialect.QUOTE_END
         )
-        self._escaped_identifier_end: str = (
-            self.dialect.tokenizer_class.IDENTIFIER_ESCAPES[0] + self.dialect.IDENTIFIER_END
-        )
+        self._escaped_identifier_end = self.dialect.IDENTIFIER_END * 2
 
         self._next_name = name_sequence("_t")
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -46,6 +46,10 @@ class TestTSQL(Validator):
         self.validate_identity(
             "COPY INTO test_1 FROM 'path' WITH (FORMAT_NAME = test, FILE_TYPE = 'CSV', CREDENTIAL = (IDENTITY='Shared Access Signature', SECRET='token'), FIELDTERMINATOR = ';', ROWTERMINATOR = '0X0A', ENCODING = 'UTF8', DATEFORMAT = 'ymd', MAXERRORS = 10, ERRORFILE = 'errorsfolder', IDENTITY_INSERT = 'ON')"
         )
+        self.validate_identity(
+            'SELECT 1 AS "[x]"',
+            "SELECT 1 AS [[x]]]",
+        )
         self.assertEqual(
             annotate_types(self.validate_identity("SELECT 1 WHERE EXISTS(SELECT 1)")).sql("tsql"),
             "SELECT 1 WHERE EXISTS(SELECT 1)",


### PR DESCRIPTION
Only related SO thread I found is [this](https://stackoverflow.com/questions/439495/how-can-i-escape-square-brackets-in-a-like-clause) one, but I played using T-SQL and concluded that `[` after the opening bracket doesn't need to be escaped, but `]` does because it needs to be disambiguated from the closing delimiter:

```
1> SELECT 1 AS [[x]]], 1 AS "[y]"
2> GO
[x]         [y]        
----------- -----------
          1           1
```