### PR TITLE
feat(trino): Support JSON_QUERY

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -33,6 +33,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.mysql import MySQL
+from sqlglot.generator import Generator
 from sqlglot.helper import apply_index_offset, seq_get
 from sqlglot.tokens import TokenType
 from sqlglot.transforms import unqualify_columns
@@ -166,7 +167,7 @@ def _unix_to_time_sql(self: Presto.Generator, expression: exp.UnixToTime) -> str
     return f"FROM_UNIXTIME(CAST({timestamp} AS DOUBLE) / POW(10, {scale}))"
 
 
-def _jsonextract_sql(self: Presto.Generator, expression: exp.JSONExtract) -> str:
+def jsonextract_sql(self: Generator, expression: exp.JSONExtract) -> str:
     is_json_extract = self.dialect.settings.get("variant_extract_is_json_extract", True)
 
     # Generate JSON_EXTRACT unless the user has configured that a Snowflake / Databricks
@@ -435,7 +436,7 @@ class Presto(Dialect):
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.Initcap: _initcap_sql,
-            exp.JSONExtract: _jsonextract_sql,
+            exp.JSONExtract: jsonextract_sql,
             exp.Last: _first_last_sql,
             exp.LastValue: _first_last_sql,
             exp.LastDay: lambda self, e: self.func("LAST_DAY_OF_MONTH", e.this),

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from sqlglot import exp
+from sqlglot import exp, parser
 from sqlglot.dialects.dialect import merge_without_target_sql, trim_sql, timestrtotime_sql
-from sqlglot.dialects.presto import Presto
+from sqlglot.dialects.presto import Presto, jsonextract_sql
+from sqlglot.tokens import TokenType
 
 
 class Trino(Presto):
@@ -13,7 +14,31 @@ class Trino(Presto):
         FUNCTION_PARSERS = {
             **Presto.Parser.FUNCTION_PARSERS,
             "TRIM": lambda self: self._parse_trim(),
+            "JSON_QUERY": lambda self: self._parse_json_query(),
         }
+
+        JSON_QUERY_OPTIONS: parser.OPTIONS_TYPE = {
+            **dict.fromkeys(
+                ("WITH", "WITHOUT"),
+                (
+                    ("CONDITIONAL", "WRAPPER"),
+                    ("CONDITIONAL", "ARRAY", "WRAPPED"),
+                    ("UNCONDITIONAL", "WRAPPER"),
+                    ("UNCONDITIONAL", "ARRAY", "WRAPPER"),
+                ),
+            ),
+        }
+
+        def _parse_json_query(self):
+            this = self._parse_bitwise()
+            self._match(TokenType.COMMA)
+
+            expr = self._parse_bitwise()
+            option = self._parse_var_from_options(self.JSON_QUERY_OPTIONS, raise_unmatched=False)
+
+            return self.expression(
+                exp.JSONExtract, this=this, expression=expr, expressions=[option], json_query=True
+            )
 
     class Generator(Presto.Generator):
         TRANSFORMS = {
@@ -23,6 +48,7 @@ class Trino(Presto):
             exp.Merge: merge_without_target_sql,
             exp.TimeStrToTime: lambda self, e: timestrtotime_sql(self, e, include_precision=True),
             exp.Trim: trim_sql,
+            exp.JSONExtract: lambda self, e: self._jsonextract_sql(e),
         }
 
         SUPPORTED_JSON_PATH_PARTS = {
@@ -30,6 +56,18 @@ class Trino(Presto):
             exp.JSONPathRoot,
             exp.JSONPathSubscript,
         }
+
+        def _jsonextract_sql(self, expression: exp.JSONExtract) -> str:
+            if not expression.args.get("json_query"):
+                return jsonextract_sql(self, expression)
+
+            this = self.sql(expression, "this")
+            json_path = self.sql(expression, "expression")
+
+            option = self.expressions(expression, flat=True)
+            option = f" {option}" if option else ""
+
+            return self.func("JSON_QUERY", this, json_path + option)
 
     class Tokenizer(Presto.Tokenizer):
         HEX_STRINGS = [("X'", "'")]

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5739,6 +5739,7 @@ class JSONExtract(Binary, Func):
         "expressions": False,
         "variant_extract": False,
         "json_query": False,
+        "option": False,
     }
     _sql_names = ["JSON_EXTRACT"]
     is_var_len_args = True

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5738,6 +5738,7 @@ class JSONExtract(Binary, Func):
         "only_json_types": False,
         "expressions": False,
         "variant_extract": False,
+        "json_query": False,
     }
     _sql_names = ["JSON_EXTRACT"]
     is_var_len_args = True

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -7,7 +7,8 @@ class TestTrino(Validator):
     def test_trino(self):
         self.validate_identity("JSON_EXTRACT(content, json_path)")
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
-        self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT UNCONDITIONAL WRAPPER)")
+        self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER)")
+        self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT CONDITIONAL WRAPPER)")
 
     def test_trim(self):
         self.validate_identity("SELECT TRIM('!' FROM '!foo!')")

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -4,6 +4,11 @@ from tests.dialects.test_dialect import Validator
 class TestTrino(Validator):
     dialect = "trino"
 
+    def test_trino(self):
+        self.validate_identity("JSON_EXTRACT(content, json_path)")
+        self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
+        self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT UNCONDITIONAL WRAPPER)")
+
     def test_trim(self):
         self.validate_identity("SELECT TRIM('!' FROM '!foo!')")
         self.validate_identity("SELECT TRIM(BOTH '$' FROM '$var$')")


### PR DESCRIPTION
Fixes #4200

This PR adds parsing support for Trino's `JSON_QUERY(...)` which is a more powerful version of `JSON_EXTRACT(...)`.

For this matter, `exp.JSONExtract` node is reused, but to differentiate between the two a new arg is introduced; This is also required because Presto's `jsonextract_sql` has the `variant_access` logic which must be preserved for Trino.

Docs
---------
[JSON_QUERY](https://trino.io/docs/current/functions/json.html#json-query) | [JSON_EXTRACT](https://trino.io/docs/current/functions/json.html#json_extract)