### PR TITLE
feat(bigquery): Native annotations for more math functions

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -260,11 +260,11 @@ def _annotate_math_functions(self: TypeAnnotator, expression: E) -> E:
     """
     self._annotate_args(expression)
 
-    this = expression.args.get("this")
-    input_type = this.type if this else exp.DataType.Type.UNKNOWN
+    this: exp.Expression = expression.this
+
     self._set_type(
         expression,
-        exp.DataType.Type.DOUBLE if input_type.is_type(exp.DataType.Type.INT) else input_type,
+        exp.DataType.Type.DOUBLE if this.is_type(*exp.DataType.INTEGER_TYPES) else this.type,
     )
     return expression
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -103,3 +103,87 @@ INT;
 # dialect: bigquery
 SIGN(1.5);
 DOUBLE;
+
+# dialect: bigquery
+CEIL(1);
+DOUBLE;
+
+# dialect: bigquery
+CEIL(5.5);
+DOUBLE;
+
+# dialect: bigquery
+CEIL(tbl.bignum_col);
+BIGDECIMAL;
+
+# dialect: bigquery
+FLOOR(1);
+DOUBLE;
+
+# dialect: bigquery
+FLOOR(5.5);
+DOUBLE;
+
+# dialect: bigquery
+FLOOR(tbl.bignum_col);
+BIGDECIMAL;
+
+# dialect: bigquery
+SQRT(1);
+DOUBLE;
+
+# dialect: bigquery
+SQRT(5.5);
+DOUBLE;
+
+# dialect: bigquery
+SQRT(tbl.bignum_col);
+BIGDECIMAL;
+
+# dialect: bigquery
+LN(1);
+DOUBLE;
+
+# dialect: bigquery
+LN(5.5);
+DOUBLE;
+
+# dialect: bigquery
+LN(tbl.bignum_col);
+BIGDECIMAL;
+
+# dialect: bigquery
+LOG(1);
+DOUBLE;
+
+# dialect: bigquery
+LOG(5.5);
+DOUBLE;
+
+# dialect: bigquery
+LOG(tbl.bignum_col);
+BIGDECIMAL;
+
+# dialect: bigquery
+ROUND(1);
+DOUBLE;
+
+# dialect: bigquery
+ROUND(5.5);
+DOUBLE;
+
+# dialect: bigquery
+ROUND(tbl.bignum_col);
+BIGDECIMAL;
+
+# dialect: bigquery
+EXP(1);
+DOUBLE;
+
+# dialect: bigquery
+EXP(5.5);
+DOUBLE;
+
+# dialect: bigquery
+EXP(tbl.bignum_col);
+BIGDECIMAL;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -800,7 +800,9 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
                 self.assertEqual(result.type.sql(), exp.DataType.build(expected).sql())
 
     def test_annotate_funcs(self):
-        test_schema = {"tbl": {"bin_col": "BINARY", "str_col": "STRING"}}
+        test_schema = {
+            "tbl": {"bin_col": "BINARY", "str_col": "STRING", "bignum_col": "BIGNUMERIC"}
+        }
 
         for i, (meta, sql, expected) in enumerate(
             load_sql_fixture_pairs("optimizer/annotate_functions.sql"), start=1


### PR DESCRIPTION
This is a follow up to https://github.com/tobymao/sqlglot/pull/4201

Several BigQuery functions such as `CEIL(x)`, `FLOOR(x)` etc will borrow the input type _unless_ that is an `INT`, in which case a `FLOAT64` (i.e `DataType.DOUBLE`) is returned. 

To mimic this behavior, this PR adds a new type annotation helper.

Note: The function `TRUNC(X)` is not currently supported by SQLGlot so once that's added, it must also be annotated accordingly.


Docs
-------
[BQ Mathematical Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions)