### PR TITLE
Fix: Attach CTE comments before commas

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7054,7 +7054,7 @@ def update(
         )
     if with_:
         cte_list = [
-            CTE(this=maybe_parse(qry, dialect=dialect, **opts), alias=alias)
+            alias_(CTE(this=maybe_parse(qry, dialect=dialect, **opts)), alias, table=True)
             for alias, qry in with_.items()
         ]
         update_expr.set(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1197,10 +1197,8 @@ class Generator(metaclass=_Generator):
 
     def cte_sql(self, expression: exp.CTE) -> str:
         alias = expression.args.get("alias")
-        comments = expression.comments
-        if alias and comments:
-            alias.add_comments(comments)
-            expression.pop_comments()
+        if alias:
+            alias.add_comments(expression.pop_comments())
 
         alias_sql = self.sql(expression, "alias")
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1196,7 +1196,13 @@ class Generator(metaclass=_Generator):
         return f"WITH {recursive}{sql}"
 
     def cte_sql(self, expression: exp.CTE) -> str:
-        alias = self.sql(expression, "alias")
+        alias = expression.args.get("alias")
+        comments = expression.comments
+        if alias and comments:
+            alias.add_comments(comments)
+            expression.pop_comments()
+
+        alias_sql = self.sql(expression, "alias")
 
         materialized = expression.args.get("materialized")
         if materialized is False:
@@ -1204,7 +1210,7 @@ class Generator(metaclass=_Generator):
         elif materialized:
             materialized = "MATERIALIZED "
 
-        return f"{alias} AS {materialized or ''}{self.wrap(expression)}"
+        return f"{alias_sql} AS {materialized or ''}{self.wrap(expression)}"
 
     def tablealias_sql(self, expression: exp.TableAlias) -> str:
         alias = self.sql(expression, "this")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2517,6 +2517,11 @@ class Generator(metaclass=_Generator):
             self.sql(expression, "from", comment=False),
         )
 
+        # If both the CTE and SELECT clauses have comments, generate the latter earlier
+        if expression.args.get("with"):
+            sql = self.maybe_comment(sql, expression)
+            expression.pop_comments()
+
         sql = self.prepend_ctes(expression, sql)
 
         if not self.SUPPORTS_SELECT_INTO and into:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3030,14 +3030,19 @@ class Parser(metaclass=_Parser):
         comments = self._prev_comments
         recursive = self._match(TokenType.RECURSIVE)
 
+        last_comments = None
         expressions = []
         while True:
             expressions.append(self._parse_cte())
+            if last_comments:
+                expressions[-1].add_comments(last_comments)
 
             if not self._match(TokenType.COMMA) and not self._match(TokenType.WITH):
                 break
             else:
                 self._match(TokenType.WITH)
+
+            last_comments = self._prev_comments
 
         return self.expression(
             exp.With, comments=comments, expressions=expressions, recursive=recursive

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -563,7 +563,7 @@ FROM x""",
         )
         self.validate(
             """with a as /* comment */ ( select * from b) select * from a""",
-            """WITH a AS (SELECT * FROM b) /* comment */ SELECT * FROM a""",
+            """WITH a /* comment */ AS (SELECT * FROM b) SELECT * FROM a""",
         )
         self.validate(
             """
@@ -581,13 +581,13 @@ SELECT * FROM tbl1""",
 WITH tbl1 /* comment for tbl1 */ AS (
   SELECT
     1
-), tbl2 AS (
+), tbl2 /* comment for tbl2 */ AS (
   SELECT
     2
-) /* comment for tbl2 */, tbl3 AS (
+), tbl3 /* comment for tbl3 */ AS (
   SELECT
     3
-) /* comment for tbl3 */
+)
 /* comment for final select */
 SELECT
   *

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -565,6 +565,35 @@ FROM x""",
             """with a as /* comment */ ( select * from b) select * from a""",
             """WITH a AS (SELECT * FROM b) /* comment */ SELECT * FROM a""",
         )
+        self.validate(
+            """
+  -- comment at the top
+WITH
+-- comment for tbl1
+tbl1 AS (SELECT 1)
+-- comment for tbl2
+, tbl2 AS (SELECT 2)
+-- comment for tbl3
+, tbl3 AS (SELECT 3)
+-- comment for final select
+SELECT * FROM tbl1""",
+            """/* comment at the top */
+WITH tbl1 /* comment for tbl1 */ AS (
+  SELECT
+    1
+), tbl2 AS (
+  SELECT
+    2
+) /* comment for tbl2 */, tbl3 AS (
+  SELECT
+    3
+) /* comment for tbl3 */
+/* comment for final select */
+SELECT
+  *
+FROM tbl1""",
+            pretty=True,
+        )
 
     def test_types(self):
         self.validate("INT 1", "CAST(1 AS INT)")


### PR DESCRIPTION
Fixes #4216

This PR addresses 2 points:
1. On main, comments on SELECT & it's CTEs bubble up:

```SQL
sql = """
-- comment at the top
with tbl as (select 1)
-- comment for final select
select * from tbl1
"""

sqlglot.parse_one(sql).sql(pretty=True)

/* comment for final select */
/* comment at the top */
WITH tbl AS (
  SELECT
    1
)
SELECT
  *
FROM tbl1
```

After this PR, the `SELECT` generator will differentiate the two by attaching it's comments earlier:
```SQL
/* comment at the top */
WITH tbl AS (
  SELECT
    1
)
/* comment for final select */
SELECT
  *
FROM tbl1
```

2. Comments before the CTE commas are now preserved and attached to the next node, as is shown in the test case