### PR TITLE
Refactor!: Rename exp.RenameTable to exp.AlterRename

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1166,7 +1166,7 @@ class TSQL(Dialect):
 
         def alter_sql(self, expression: exp.Alter) -> str:
             action = seq_get(expression.args.get("actions") or [], 0)
-            if isinstance(action, exp.RenameTable):
+            if isinstance(action, exp.AlterRename):
                 return f"EXEC sp_rename '{self.sql(expression.this)}', '{action.this.name}'"
             return super().alter_sql(expression)
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1697,7 +1697,7 @@ class RenameColumn(Expression):
     arg_types = {"this": True, "to": True, "exists": False}
 
 
-class RenameTable(Expression):
+class AlterRename(Expression):
     pass
 
 
@@ -7795,7 +7795,7 @@ def rename_table(
         this=old_table,
         kind="TABLE",
         actions=[
-            RenameTable(this=new_table),
+            AlterRename(this=new_table),
         ],
     )
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3225,12 +3225,12 @@ class Generator(metaclass=_Generator):
         expressions = f"({expressions})" if expressions else ""
         return f"ALTER{compound} SORTKEY {this or expressions}"
 
-    def renametable_sql(self, expression: exp.RenameTable) -> str:
+    def alterrename_sql(self, expression: exp.AlterRename) -> str:
         if not self.RENAME_TABLE_WITH_DB:
             # Remove db from tables
             expression = expression.transform(
                 lambda n: exp.table_(n.this) if isinstance(n, exp.Table) else n
-            ).assert_is(exp.RenameTable)
+            ).assert_is(exp.AlterRename)
         this = self.sql(expression, "this")
         return f"RENAME TO {this}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6764,7 +6764,7 @@ class Parser(metaclass=_Parser):
         self._retreat(index)
         return self._parse_csv(self._parse_drop_column)
 
-    def _parse_alter_table_rename(self) -> t.Optional[exp.RenameTable | exp.RenameColumn]:
+    def _parse_alter_table_rename(self) -> t.Optional[exp.AlterRename | exp.RenameColumn]:
         if self._match(TokenType.COLUMN):
             exists = self._parse_exists()
             old_column = self._parse_column()
@@ -6777,7 +6777,7 @@ class Parser(metaclass=_Parser):
             return self.expression(exp.RenameColumn, this=old_column, to=new_column, exists=exists)
 
         self._match_text_seq("TO")
-        return self.expression(exp.RenameTable, this=self._parse_table(schema=True))
+        return self.expression(exp.AlterRename, this=self._parse_table(schema=True))
 
     def _parse_alter_table_set(self) -> exp.AlterSet:
         alter_set = self.expression(exp.AlterSet)


### PR DESCRIPTION
Fixes #4222

PS: I believe we could also consolidate `exp.RenameColumns` into `exp.AlterRename`, is this worth looking in this PR / soon?