### PR TITLE
feat(clickhouse): Support varlen arrays for ARRAY JOIN

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2400,6 +2400,7 @@ class Join(Expression):
         "global": False,
         "hint": False,
         "match_condition": False,  # Snowflake
+        "expressions": False,
     }
 
     @property

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2144,6 +2144,10 @@ class Generator(metaclass=_Generator):
         this = expression.this
         this_sql = self.sql(this)
 
+        exprs = self.expressions(expression)
+        if expression.args.get("expressions"):
+            this_sql = f"{this_sql},{self.seg(exprs)}"
+
         if on_sql:
             on_sql = self.indent(on_sql, skip_first=True)
             space = self.seg(" " * self.pad) if self.pretty else " "

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3400,6 +3400,10 @@ class Parser(metaclass=_Parser):
             return None
 
         kwargs: t.Dict[str, t.Any] = {"this": self._parse_table(parse_bracket=parse_bracket)}
+        if kind and kind.token_type == TokenType.ARRAY and self._match(TokenType.COMMA):
+            kwargs["expressions"] = self._parse_csv(
+                lambda: self._parse_table(parse_bracket=parse_bracket)
+            )
 
         if method:
             kwargs["method"] = method.text
@@ -3420,7 +3424,9 @@ class Parser(metaclass=_Parser):
         elif (
             not (outer_apply or cross_apply)
             and not isinstance(kwargs["this"], exp.Unnest)
-            and not (kind and kind.token_type == TokenType.CROSS)
+            and not (
+                kind and (kind.token_type == TokenType.CROSS or kind.token_type == TokenType.ARRAY)
+            )
         ):
             index = self._index
             joins: t.Optional[list] = list(self._parse_joins())

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -425,6 +425,9 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "SELECT s, arr_external FROM arrays_test ARRAY JOIN [1, 2, 3] AS arr_external"
         )
+        self.validate_identity(
+            "SELECT * FROM tbl ARRAY JOIN [1, 2, 3] AS arr_external1, ['a', 'b', 'c'] AS arr_external2, splitByString(',', 'asd,qwerty,zxc') AS arr_external3"
+        )
         self.validate_all(
             "SELECT quantile(0.5)(a)",
             read={"duckdb": "SELECT quantile(a, 0.5)"},


### PR DESCRIPTION
Fixes #4227

SQLGlot already supports Clickhouse's `ARRAY JOIN` but only for a single expression. However, CH allows varlen comma-separated arrays in the same expression and the result is the `ARRAY JOIN` of their _sum_ and not their cross product.

 For this reason, this PR adds a new `expressions` arg which stores the N-1 array expressions.

Docs
-------
[CH ARRAY JOIN](https://clickhouse.com/docs/en/sql-reference/statements/select/array-join)