### PR TITLE
feat(bigquery): Native annotations for string functions (1)

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -321,7 +321,19 @@ class BigQuery(Dialect):
             expr_type: lambda self, e: _annotate_math_functions(self, e)
             for expr_type in (exp.Floor, exp.Ceil, exp.Log, exp.Ln, exp.Sqrt, exp.Exp, exp.Round)
         },
+        **{
+            expr_type: lambda self, e: self._annotate_by_args(e, "this")
+            for expr_type in (
+                exp.Left,
+                exp.Right,
+                exp.Lower,
+                exp.Upper,
+                exp.Pad,
+                exp.Trim,
+            )
+        },
         exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.Concat: lambda self, e: self._annotate_by_args(e, "expressions"),
     }
 
     def normalize_identifier(self, expression: E) -> E:

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -187,3 +187,83 @@ DOUBLE;
 # dialect: bigquery
 EXP(tbl.bignum_col);
 BIGDECIMAL;
+
+# dialect: bigquery
+CONCAT(tbl.str_col, tbl.str_col);
+STRING;
+
+# dialect: bigquery
+CONCAT(tbl.bin_col, tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+LEFT(tbl.str_col, 1);
+STRING;
+
+# dialect: bigquery
+LEFT(tbl.bin_col, 1);
+BINARY;
+
+# dialect: bigquery
+RIGHT(tbl.str_col, 1);
+STRING;
+
+# dialect: bigquery
+RIGHT(tbl.bin_col, 1);
+BINARY;
+
+# dialect: bigquery
+LOWER(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+LOWER(tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+UPPER(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+UPPER(tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+LPAD(tbl.str_col, 1, tbl.str_col);
+STRING;
+
+# dialect: bigquery
+LPAD(tbl.bin_col, 1, tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+RPAD(tbl.str_col, 1, tbl.str_col);
+STRING;
+
+# dialect: bigquery
+RPAD(tbl.bin_col, 1, tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+LTRIM(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+LTRIM(tbl.bin_col, tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+RTRIM(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+RTRIM(tbl.bin_col, tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+TRIM(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+TRIM(tbl.bin_col, tbl.bin_col);
+BINARY;


### PR DESCRIPTION
Follow up on https://github.com/tobymao/sqlglot/pull/4212 to increase native BQ annotation.

According to the docs, these `STRING` / `BYTES` (i.e `BINARY`) functions are input type dependent:

1. CONCAT 
2. LEFT / RIGHT
3. LOWER / UPPER
4. LPAD / RPAD
5. LTRIM / RTRIM / TRIM 
6. REGEXP_EXTRACT, REGEXP_REPLACE, REGEXP_SUBSTR, REPEAT, REPLACE, REVERSE, SUBSTR, TRANSLATE
7. REGEXP_EXTRACT_ALL, SPLIT (these return `ARRAY<STRING>` / `ARRAY<BYTES>` instead of scalar values)

To limit the scope, this PR addresses (1) - (5) and the next one will cover the rest.

Note: Unlike Spark, BQ functions with multiple inputs such as `CONCAT` do not allow mixed types so it's sufficient to annotate according to one of them e.g. `this`  

Docs
--------
[BQ String Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions)  

