### PR TITLE
feat(bigquery)!: Native annotations for string functions (2)

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -330,10 +330,15 @@ class BigQuery(Dialect):
                 exp.Upper,
                 exp.Pad,
                 exp.Trim,
+                exp.RegexpExtract,
+                exp.RegexpReplace,
+                exp.Repeat,
+                exp.Substring,
             )
         },
-        exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Concat: lambda self, e: self._annotate_by_args(e, "expressions"),
+        exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.Split: lambda self, e: self._annotate_by_args(e, "this", array=True),
     }
 
     def normalize_identifier(self, expression: E) -> E:

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -267,3 +267,43 @@ STRING;
 # dialect: bigquery
 TRIM(tbl.bin_col, tbl.bin_col);
 BINARY;
+
+# dialect: bigquery
+REGEXP_EXTRACT(tbl.str_col, pattern);
+STRING;
+
+# dialect: bigquery
+REGEXP_EXTRACT(tbl.bin_col, pattern);
+BINARY;
+
+# dialect: bigquery
+REGEXP_REPLACE(tbl.str_col, pattern, replacement);
+STRING;
+
+# dialect: bigquery
+REGEXP_REPLACE(tbl.bin_col, pattern, replacement);
+BINARY;
+
+# dialect: bigquery
+REPEAT(tbl.str_col, 1);
+STRING;
+
+# dialect: bigquery
+REPEAT(tbl.bin_col, 1);
+BINARY;
+
+# dialect: bigquery
+SUBSTRING(tbl.str_col, 1);
+STRING;
+
+# dialect: bigquery
+SUBSTRING(tbl.bin_col, 1);
+BINARY;
+
+# dialect: bigquery
+SPLIT(tbl.str_col, delim);
+ARRAY<STRING>;
+
+# dialect: bigquery
+SPLIT(tbl.bin_col, delim);
+ARRAY<BINARY>;


### PR DESCRIPTION
This is a follow up to https://github.com/tobymao/sqlglot/pull/4231

This PR addresses the remaining string functions with the exception of `REGEXP_EXTRACT_ALL`, `REVERSE`, `REPLACE`  and `TRANSLATE` as they're not supported by SQLGlot yet.

Docs
-------
[BQ String Functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions)

