### PR TITLE
feat: support EXPLAIN in mysql

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -187,6 +187,9 @@ class MySQL(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "CHARSET": TokenType.CHARACTER_SET,
+            # The DESCRIBE and EXPLAIN statements are synonyms.
+            # https://dev.mysql.com/doc/refman/8.4/en/explain.html
+            "EXPLAIN": TokenType.DESCRIBE,
             "FORCE": TokenType.FORCE,
             "IGNORE": TokenType.IGNORE,
             "KEY": TokenType.KEY,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1337,6 +1337,8 @@ class Parser(metaclass=_Parser):
     # Whether a PARTITION clause can follow a table reference
     SUPPORTS_PARTITION_SELECTION = False
 
+    DESCRIBE_STATEMENT_STYLES = {"ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"}
+
     __slots__ = (
         "error_level",
         "error_message_context",
@@ -2567,10 +2569,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_describe(self) -> exp.Describe:
         kind = self._match_set(self.CREATABLES) and self._prev.text
-        style = (
-            self._match_texts(("ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"))
-            and self._prev.text.upper()
-        )
+        style = self._match_texts(self.DESCRIBE_STATEMENT_STYLES) and self._prev.text.upper()
         if self._match(TokenType.DOT):
             style = None
             self._retreat(self._index - 2)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1286,6 +1286,8 @@ class Parser(metaclass=_Parser):
 
     PRIVILEGE_FOLLOW_TOKENS = {TokenType.ON, TokenType.COMMA, TokenType.L_PAREN}
 
+    DESCRIBE_STATEMENT_STYLES = {"ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"}
+
     STRICT_CAST = True
 
     PREFIXED_PIVOT_COLUMNS = False
@@ -1336,8 +1338,6 @@ class Parser(metaclass=_Parser):
 
     # Whether a PARTITION clause can follow a table reference
     SUPPORTS_PARTITION_SELECTION = False
-
-    DESCRIBE_STATEMENT_STYLES = {"ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"}
 
     __slots__ = (
         "error_level",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2567,7 +2567,10 @@ class Parser(metaclass=_Parser):
 
     def _parse_describe(self) -> exp.Describe:
         kind = self._match_set(self.CREATABLES) and self._prev.text
-        style = self._match_texts(("ANALYZE", "EXTENDED", "FORMATTED", "HISTORY")) and self._prev.text.upper()
+        style = (
+            self._match_texts(("ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"))
+            and self._prev.text.upper()
+        )
         if self._match(TokenType.DOT):
             style = None
             self._retreat(self._index - 2)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2567,7 +2567,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_describe(self) -> exp.Describe:
         kind = self._match_set(self.CREATABLES) and self._prev.text
-        style = self._match_texts(("EXTENDED", "FORMATTED", "HISTORY")) and self._prev.text.upper()
+        style = self._match_texts(("ANALYZE", "EXTENDED", "FORMATTED", "HISTORY")) and self._prev.text.upper()
         if self._match(TokenType.DOT):
             style = None
             self._retreat(self._index - 2)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2570,7 +2570,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_describe(self) -> exp.Describe:
         kind = self._match_set(self.CREATABLES) and self._prev.text
-        style = self._match_texts(self.DESCRIBE_STATEMENT_STYLES) and self._prev.text.upper()
+        style = self._match_texts(self.DESCRIBE_STYLES) and self._prev.text.upper()
         if self._match(TokenType.DOT):
             style = None
             self._retreat(self._index - 2)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1286,7 +1286,8 @@ class Parser(metaclass=_Parser):
 
     PRIVILEGE_FOLLOW_TOKENS = {TokenType.ON, TokenType.COMMA, TokenType.L_PAREN}
 
-    DESCRIBE_STATEMENT_STYLES = {"ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"}
+    # The style options for the DESCRIBE statement
+    DESCRIBE_STYLES = {"ANALYZE", "EXTENDED", "FORMATTED", "HISTORY"}
 
     STRICT_CAST = True
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1308,8 +1308,7 @@ COMMENT='客户账户表'"""
 
     def test_explain(self):
         self.validate_identity(
-            "EXPLAIN ANALYZE SELECT * FROM t",
-            "DESCRIBE ANALYZE SELECT * FROM t"
+            "EXPLAIN ANALYZE SELECT * FROM t", "DESCRIBE ANALYZE SELECT * FROM t"
         )
 
         expression = self.parse_one("EXPLAIN ANALYZE SELECT * FROM t")

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1305,3 +1305,11 @@ COMMENT='客户账户表'"""
         for sql in grant_cmds:
             with self.subTest(f"Testing MySQL's GRANT command statement: {sql}"):
                 self.validate_identity(sql, check_command_warning=True)
+
+    def test_explain(self):
+        self.validate_identity("EXPLAIN ANALYZE SELECT * FROM t", write_sql="DESCRIBE ANALYZE SELECT * FROM t")
+
+        expression = self.parse_one("EXPLAIN ANALYZE SELECT * FROM t")
+        self.assertIsInstance(expression, exp.Describe)
+        self.assertEqual(expression.text("style"), "ANALYZE")
+

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1308,7 +1308,8 @@ COMMENT='客户账户表'"""
 
     def test_explain(self):
         self.validate_identity(
-            "EXPLAIN ANALYZE SELECT * FROM t", write_sql="DESCRIBE ANALYZE SELECT * FROM t"
+            "EXPLAIN ANALYZE SELECT * FROM t",
+            "DESCRIBE ANALYZE SELECT * FROM t"
         )
 
         expression = self.parse_one("EXPLAIN ANALYZE SELECT * FROM t")

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1307,9 +1307,10 @@ COMMENT='客户账户表'"""
                 self.validate_identity(sql, check_command_warning=True)
 
     def test_explain(self):
-        self.validate_identity("EXPLAIN ANALYZE SELECT * FROM t", write_sql="DESCRIBE ANALYZE SELECT * FROM t")
+        self.validate_identity(
+            "EXPLAIN ANALYZE SELECT * FROM t", write_sql="DESCRIBE ANALYZE SELECT * FROM t"
+        )
 
         expression = self.parse_one("EXPLAIN ANALYZE SELECT * FROM t")
         self.assertIsInstance(expression, exp.Describe)
         self.assertEqual(expression.text("style"), "ANALYZE")
-


### PR DESCRIPTION
Currently EXPLAIN is not supported in sqlglot.dialects.mysql. 

Because 'The [DESCRIBE](https://dev.mysql.com/doc/refman/8.4/en/describe.html) and [EXPLAIN](https://dev.mysql.com/doc/refman/8.4/en/explain.html) statements are synonyms.', this pr supports EXPLAIN by treat it as DESCRIBE