### PR TITLE
Fix(optimizer): handle subquery predicate substitution correctly in de morgan's rule

### DIFF
--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -140,6 +140,9 @@ TRUE;
 COALESCE(x, y) <> ALL (SELECT z FROM w);
 COALESCE(x, y) <> ALL (SELECT z FROM w);
 
+SELECT NOT (2 <> ALL (SELECT 2 UNION ALL SELECT 3));
+SELECT 2 = ANY(SELECT 2 UNION ALL SELECT 3);
+
 --------------------------------------
 -- Absorption
 --------------------------------------


### PR DESCRIPTION
We're not simplifying negations of `SubqueryPredicate`s correctly today:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.simplify import simplify
>>>
>>> sql = "select not (2 not in (select 2 union all select 3))"  # gets converted into NEQ(2, ALL(...))
>>> 
>>> expr = parse_one(sql, "snowflake")
>>> expr.sql("snowflake")
'SELECT NOT (2 <> ALL (SELECT 2 UNION ALL SELECT 3))'
>>> simplify(expr.copy()).sql("snowflake")
'SELECT 2 = ALL (SELECT 2 UNION ALL SELECT 3)'
```

Simply flipping the `<>` into `=` is not enough.