### PR TITLE
Fix(parser): parse a column reference for the RHS of the IN clause

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4484,11 +4484,7 @@ class Parser(metaclass=_Parser):
             elif not self._match(TokenType.R_BRACKET, expression=this):
                 self.raise_error("Expecting ]")
         else:
-            field = self._parse_field()
-            if isinstance(field, exp.Identifier):
-                field = exp.Column(this=field)
-
-            this = self.expression(exp.In, this=this, field=field)
+            this = self.expression(exp.In, this=this, field=self._parse_column())
 
         return this
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -257,6 +257,7 @@ class TestDuckDB(Validator):
         )
 
         self.validate_identity("'red' IN flags").args["field"].assert_is(exp.Column)
+        self.validate_identity("'red' IN tbl.flags")
         self.validate_identity("CREATE TABLE tbl1 (u UNION(num INT, str TEXT))")
         self.validate_identity("INSERT INTO x BY NAME SELECT 1 AS y")
         self.validate_identity("SELECT 1 AS x UNION ALL BY NAME SELECT 2 AS x")


### PR DESCRIPTION
I realized that the fix in #4239 was actually incomplete, e.g. we currently fail to parse `val IN tbl.col`, because the column is qualified. This is valid DuckDB, for instance:

```
D create table foo (flags varchar[]);
D insert into foo values (['red', 'green']);
D select * from foo where 'red' in flags;
┌──────────────┐
│    flags     │
│  varchar[]   │
├──────────────┤
│ [red, green] │
└──────────────┘
D select * from foo where 'red' in foo.flags;
┌──────────────┐
│    flags     │
│  varchar[]   │
├──────────────┤
│ [red, green] │
└──────────────┘
```