### PR TITLE
Refactor!: make Explode a UDTF subclass

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5643,7 +5643,7 @@ class Exp(Func):
 
 
 # https://docs.snowflake.com/en/sql-reference/functions/flatten
-class Explode(Func):
+class Explode(Func, UDTF):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -256,6 +256,7 @@ class TestDuckDB(Validator):
             parse_one("a // b", read="duckdb").assert_is(exp.IntDiv).sql(dialect="duckdb"), "a // b"
         )
 
+        self.validate_identity("SELECT UNNEST([1, 2])").selects[0].assert_is(exp.UDTF)
         self.validate_identity("'red' IN flags").args["field"].assert_is(exp.Column)
         self.validate_identity("'red' IN tbl.flags")
         self.validate_identity("CREATE TABLE tbl1 (u UNION(num INT, str TEXT))")


### PR DESCRIPTION
Not treating `Explode` as a `UDTF` seems like a weird decision, provided that it _is_ a table function (e.g. it's used to represent `EXPLODE` in Spark and `UNNEST` in DuckDB). It also leads to more complex code that needs to deal with `UDTF`s ([example](https://github.com/TobikoData/sqlmesh/blob/main/sqlmesh/core/model/definition.py#L2371-L2373)).

I searched a bit, and I found that the `Explode` expression was introduced in [this](https://github.com/tobymao/sqlglot/commit/5e6939c14e860c661c90944215fe2aafb52736ae) commit. [There was no `UDTF` node at the time](https://github.com/tobymao/sqlglot/blob/5e6939c14e860c661c90944215fe2aafb52736ae/sqlglot/expressions.py), so my hunch is that this was simply overlooked until now.