### PR TITLE
Feat: support non-strict qualify_columns

### DIFF
--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -27,6 +27,7 @@ def qualify(
     infer_schema: t.Optional[bool] = None,
     isolate_tables: bool = False,
     qualify_columns: bool = True,
+    allow_partial_qualification: bool = False,
     validate_qualify_columns: bool = True,
     quote_identifiers: bool = True,
     identify: bool = True,
@@ -56,6 +57,7 @@ def qualify(
         infer_schema: Whether to infer the schema if missing.
         isolate_tables: Whether to isolate table selects.
         qualify_columns: Whether to qualify columns.
+        allow_partial_qualification: Whether to allow partial qualification.
         validate_qualify_columns: Whether to validate columns.
         quote_identifiers: Whether to run the quote_identifiers step.
             This step is necessary to ensure correctness for case sensitive queries.
@@ -90,7 +92,7 @@ def qualify(
             expand_alias_refs=expand_alias_refs,
             expand_stars=expand_stars,
             infer_schema=infer_schema,
-            validate_qualify_columns=validate_qualify_columns,
+            allow_partial_qualification=allow_partial_qualification,
         )
 
     if quote_identifiers:

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -90,6 +90,7 @@ def qualify(
             expand_alias_refs=expand_alias_refs,
             expand_stars=expand_stars,
             infer_schema=infer_schema,
+            validate_qualify_columns=validate_qualify_columns,
         )
 
     if quote_identifiers:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -22,7 +22,7 @@ def qualify_columns(
     expand_alias_refs: bool = True,
     expand_stars: bool = True,
     infer_schema: t.Optional[bool] = None,
-    validate_qualify_columns: bool = True,
+    allow_partial_qualification: bool = False,
 ) -> exp.Expression:
     """
     Rewrite sqlglot AST to have fully qualified columns.
@@ -42,7 +42,7 @@ def qualify_columns(
             for most of the optimizer's rules to work; do not set to False unless you
             know what you're doing!
         infer_schema: Whether to infer the schema if missing.
-        validate_qualify_columns: Whether to validate columns.
+        allow_partial_qualification: Whether to allow partial qualification.
 
     Returns:
         The qualified expression.
@@ -70,7 +70,7 @@ def qualify_columns(
             )
 
         _convert_columns_to_dots(scope, resolver)
-        _qualify_columns(scope, resolver, validate_qualify_columns=validate_qualify_columns)
+        _qualify_columns(scope, resolver, allow_partial_qualification=allow_partial_qualification)
 
         if not schema.empty and expand_alias_refs:
             _expand_alias_refs(scope, resolver)
@@ -436,7 +436,7 @@ def _convert_columns_to_dots(scope: Scope, resolver: Resolver) -> None:
         scope.clear_cache()
 
 
-def _qualify_columns(scope: Scope, resolver: Resolver, validate_qualify_columns: bool) -> None:
+def _qualify_columns(scope: Scope, resolver: Resolver, allow_partial_qualification: bool) -> None:
     """Disambiguate columns, ensuring each column specifies a source"""
     for column in scope.columns:
         column_table = column.table
@@ -445,7 +445,7 @@ def _qualify_columns(scope: Scope, resolver: Resolver, validate_qualify_columns:
         if column_table and column_table in scope.sources:
             source_columns = resolver.get_source_columns(column_table)
             if (
-                validate_qualify_columns
+                not allow_partial_qualification
                 and source_columns
                 and column_name not in source_columns
                 and "*" not in source_columns

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -190,6 +190,11 @@ SELECT x._col_0 AS _col_0, x._col_1 AS _col_1 FROM (VALUES (1, 2)) AS x(_col_0, 
 SELECT SOME_UDF(data).* FROM t;
 SELECT SOME_UDF(t.data).* FROM t AS t;
 
+# execute: false
+# validate_qualify_columns: false
+SELECT a + 1 AS i, missing_column FROM x;
+SELECT x.a + 1 AS i, missing_column AS missing_column FROM x AS x;
+
 --------------------------------------
 -- Derived tables
 --------------------------------------

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -191,6 +191,7 @@ SELECT SOME_UDF(data).* FROM t;
 SELECT SOME_UDF(t.data).* FROM t AS t;
 
 # execute: false
+# allow_partial_qualification: true
 # validate_qualify_columns: false
 SELECT a + 1 AS i, missing_column FROM x;
 SELECT x.a + 1 AS i, missing_column AS missing_column FROM x AS x;


### PR DESCRIPTION
Wasn't sure whether to reuse the existing `validate_qualify_columns` flag name, or to create a new one. My thinking is validate_qualify_columns False = best effort qualification, and True = required qualification. This matches that behavior - let me know what you think.
