### PR TITLE
Fix: protect against cyclic scopes

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -461,9 +461,16 @@ class Scope:
             Scope: scope instances in depth-first-search post-order
         """
         stack = [self]
+        seen_scopes = set()
         result = []
         while stack:
             scope = stack.pop()
+
+            # Scopes aren't hashable, so we use id(scope) instead.
+            if id(scope) in seen_scopes:
+                raise OptimizeError(f"Scope {scope} has a circular scope dependency")
+            seen_scopes.add(id(scope))
+
             result.append(scope)
             stack.extend(
                 itertools.chain(


### PR DESCRIPTION
This ensures that we don't hit infinite loops.

Given that this is a defensive measure, I'm not sure what the best way to test this would be. Open to suggestions on that.