### PR TITLE
fix(bigquery): Early expand only aliased names in GROUP BY

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -248,7 +248,10 @@ def _expand_alias_refs(scope: Scope, resolver: Resolver, expand_only_groupby: bo
             if not isinstance(column, exp.Column):
                 continue
 
-            # BigQuery should expand aliased expressions only if the alias is used as a standalone name
+            # BigQuery's GROUP BY allows alias expansion only for standalone names, e.g:
+            #   SELECT FUNC(col) AS col FROM t GROUP BY col --> Can be expanded
+            #   SELECT FUNC(col) AS col FROM t GROUP BY FUNC(col)  --> Shouldn't be expanded, will result to FUNC(FUNC(col))
+            # This not required for the HAVING clause as it can evaluate expressions using both the alias & the table columns
             if expand_only_groupby and is_group_by and column.parent is not node:
                 continue
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -602,7 +602,7 @@ SELECT :with,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:expr
             "WITH data AS (SELECT 1 AS id, 2 AS my_id, 'a' AS name, 'b' AS full_name) SELECT data.id AS my_id, CONCAT(data.id, data.name) AS full_name FROM data WHERE data.id = 1 GROUP BY data.id, CONCAT(data.id, data.name) HAVING data.id = 1",
         )
 
-        # Edge case: BigQuery shouldn't expand aliases that are reusing input column names in expressions
+        # Edge case: BigQuery shouldn't expand aliases in complex expressions
         sql = "WITH data AS (SELECT 1 AS id) SELECT FUNC(id) AS id FROM data GROUP BY FUNC(id)"
         self.assertEqual(
             optimizer.qualify_columns.qualify_columns(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -602,6 +602,16 @@ SELECT :with,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:expr
             "WITH data AS (SELECT 1 AS id, 2 AS my_id, 'a' AS name, 'b' AS full_name) SELECT data.id AS my_id, CONCAT(data.id, data.name) AS full_name FROM data WHERE data.id = 1 GROUP BY data.id, CONCAT(data.id, data.name) HAVING data.id = 1",
         )
 
+        # Edge case: BigQuery shouldn't expand aliases that are reusing input column names in expressions
+        sql = "WITH data AS (SELECT 1 AS id) SELECT FUNC(id) AS id FROM data GROUP BY FUNC(id)"
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
+                parse_one(sql, dialect="bigquery"),
+                schema=MappingSchema(schema=unused_schema, dialect="bigquery"),
+            ).sql(),
+            "WITH data AS (SELECT 1 AS id) SELECT FUNC(data.id) AS id FROM data GROUP BY FUNC(data.id)",
+        )
+
     def test_optimize_joins(self):
         self.check_file(
             "optimize_joins",


### PR DESCRIPTION
[Public Slack context](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1728475163266849)

This is a follow up fix on https://github.com/tobymao/sqlglot/pull/3699, which introduced early alias expansion for BQ and Clickhouse.

As a recap, BigQuery allows `GROUP BY` to refer to `SELECT` aliases. From the [docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_values): 

_GROUP BY clauses may also refer to aliases. If a query contains aliases in the SELECT clause, those aliases override names in the corresponding FROM clause._

So the early expansion was necessary to replace the references with the aliased expressions instead of qualifying them, as is explained in the PR. However, it seems that BQ allows this only for grouped _names_ and not _expressions_:

```SQL
bigquery> with t as (select 2 as id) select id + 1 as col from t group by col;
col
3

bigquery> with t as (select 2 as id) select id + 1 as col from t group by col + 0;
Syntax error: Unexpected identifier "col" at [1:1]
```


This means that if an alias is part of an _expression_, BQ will infer it as a column. In contrast, up until now, the early alias expansion was performed blindly so the aliased expression would replace any referenced instance in the `GROUP BY` clause. This can lead to bugs such as this example with conflicting column & alias names:

```SQL
>>> sql = """
SELECT
  FUNC(col) AS col
FROM tbl
GROUP BY
  FUNC(col)
"""

>>> qualify_columns(parse_one(sql, dialect="bigquery"), schema=MappingSchema({"tbl": {"col": "TIMESTAMP"}}, dialect="bigquery")).sql("bigquery")

SELECT
  FUNC(`tbl`.`col`) AS `col`
FROM `tbl` AS `tbl`
GROUP BY
  FUNC(FUNC(`tbl`.`col`))
```


This PR fixes this by not allowing the expansion to happen for grouped _expressions_, but only for grouped _names_; In the previous example, the expression is preserved as is:

```SQL
>>> qualify_columns(parse_one(sql, dialect="bigquery"), schema=MappingSchema({"tbl": {"col": "TIMESTAMP"}}, dialect="bigquery")).sql("bigquery")

SELECT
  FUNC(`tbl`.`col`) AS `col`
FROM `tbl` AS `tbl`
GROUP BY
  FUNC(`tbl`.`col`)
```

The `expand_only_groupby` is a proxy for BQ instead of having to add `dialect` to `expand_alias_refs(...)`.

Docs
--------
[BQ GROUP BY](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_values) | [GROUP BY with clashing names](https://freedium.cfd/https://hanqi01.medium.com/how-badly-named-sql-column-aliases-confuse-when-using-group-by-and-order-by-261541f86f9a)



