### PR TITLE
feat(duckdb): Transpile Spark's LATERAL VIEW EXPLODE

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1697,3 +1697,18 @@ def build_regexp_extract(args: t.List, dialect: Dialect) -> exp.RegexpExtract:
         expression=seq_get(args, 1),
         group=seq_get(args, 2) or exp.Literal.number(dialect.REGEXP_EXTRACT_DEFAULT_GROUP),
     )
+
+
+def explode_to_unnest_sql(self: Generator, expression: exp.Lateral) -> str:
+    if isinstance(expression.this, exp.Explode):
+        return self.sql(
+            exp.Join(
+                this=exp.Unnest(
+                    expressions=[expression.this.this],
+                    alias=expression.args.get("alias"),
+                    offset=isinstance(expression.this, exp.Posexplode),
+                ),
+                kind="cross",
+            )
+        )
+    return self.lateral_sql(expression)

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -35,6 +35,7 @@ from sqlglot.dialects.dialect import (
     unit_to_str,
     sha256_sql,
     build_regexp_extract,
+    explode_to_unnest_sql,
 )
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
@@ -538,6 +539,7 @@ class DuckDB(Dialect):
             exp.JSONExtract: _arrow_json_extract_sql,
             exp.JSONExtractScalar: _arrow_json_extract_sql,
             exp.JSONFormat: _json_format_sql,
+            exp.Lateral: explode_to_unnest_sql,
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.LogicalAnd: rename_func("BOOL_AND"),
             exp.MD5Digest: lambda self, e: self.func("UNHEX", self.func("MD5", e.this)),

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -30,6 +30,7 @@ from sqlglot.dialects.dialect import (
     unit_to_str,
     sequence_sql,
     build_regexp_extract,
+    explode_to_unnest_sql,
 )
 from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.mysql import MySQL
@@ -38,21 +39,6 @@ from sqlglot.tokens import TokenType
 from sqlglot.transforms import unqualify_columns
 
 DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TimestampAdd, exp.DateSub]
-
-
-def _explode_to_unnest_sql(self: Presto.Generator, expression: exp.Lateral) -> str:
-    if isinstance(expression.this, exp.Explode):
-        return self.sql(
-            exp.Join(
-                this=exp.Unnest(
-                    expressions=[expression.this.this],
-                    alias=expression.args.get("alias"),
-                    offset=isinstance(expression.this, exp.Posexplode),
-                ),
-                kind="cross",
-            )
-        )
-    return self.lateral_sql(expression)
 
 
 def _initcap_sql(self: Presto.Generator, expression: exp.Initcap) -> str:
@@ -410,7 +396,7 @@ class Presto(Dialect):
             exp.Last: _first_last_sql,
             exp.LastValue: _first_last_sql,
             exp.LastDay: lambda self, e: self.func("LAST_DAY_OF_MONTH", e.this),
-            exp.Lateral: _explode_to_unnest_sql,
+            exp.Lateral: explode_to_unnest_sql,
             exp.Left: left_to_substring_sql,
             exp.Levenshtein: rename_func("LEVENSHTEIN_DISTANCE"),
             exp.LogicalAnd: rename_func("BOOL_AND"),

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -187,6 +187,7 @@ class TestHive(Validator):
             "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) u AS b",
             write={
                 "presto": "SELECT a, b FROM x CROSS JOIN UNNEST(y) AS t(a) CROSS JOIN UNNEST(z) AS u(b)",
+                "duckdb": "SELECT a, b FROM x CROSS JOIN UNNEST(y) AS t(a) CROSS JOIN UNNEST(z) AS u(b)",
                 "hive": "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) u AS b",
                 "spark": "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) u AS b",
             },
@@ -195,6 +196,7 @@ class TestHive(Validator):
             "SELECT a FROM x LATERAL VIEW EXPLODE(y) t AS a",
             write={
                 "presto": "SELECT a FROM x CROSS JOIN UNNEST(y) AS t(a)",
+                "duckdb": "SELECT a FROM x CROSS JOIN UNNEST(y) AS t(a)",
                 "hive": "SELECT a FROM x LATERAL VIEW EXPLODE(y) t AS a",
                 "spark": "SELECT a FROM x LATERAL VIEW EXPLODE(y) t AS a",
             },
@@ -211,6 +213,7 @@ class TestHive(Validator):
             "SELECT a FROM x LATERAL VIEW EXPLODE(ARRAY(y)) t AS a",
             write={
                 "presto": "SELECT a FROM x CROSS JOIN UNNEST(ARRAY[y]) AS t(a)",
+                "duckdb": "SELECT a FROM x CROSS JOIN UNNEST([y]) AS t(a)",
                 "hive": "SELECT a FROM x LATERAL VIEW EXPLODE(ARRAY(y)) t AS a",
                 "spark": "SELECT a FROM x LATERAL VIEW EXPLODE(ARRAY(y)) t AS a",
             },


### PR DESCRIPTION
Fixes #4247

This PR reuses the existing Presto/Trino `LATERAL VIEW EXPLODE -> CROSS JOIN UNNEST` transformation in DuckDB too, e.g:

```Python
>>> sql = "WITH tmp_table(arr1, arr2) AS (SELECT * FROM VALUES (ARRAY(1,2), ARRAY('a','b'))) SELECT elem1, elem2 FROM tmp_table LATERAL VIEW EXPLODE(arr1) a1 AS elem1 LATERAL VIEW EXPLODE(arr2) a2 AS elem2"
>>> sqlglot.parse_one(sql, dialect="spark").sql("duckdb")

WITH tmp_table(arr1, arr2) AS (SELECT * FROM (VALUES ([1, 2], ['a', 'b']))) SELECT elem1, elem2 FROM tmp_table CROSS JOIN UNNEST(arr1) AS a1(elem1) CROSS JOIN UNNEST(arr2) AS a2(elem2)
```

- Spark:
```SQL
spark-sql (default)> WITH tmp_table(arr1, arr2) AS (
                   >   SELECT * FROM VALUES (ARRAY(1,2), ARRAY('a','b'))
                   > )
                   > SELECT elem1, elem2
                   > FROM
                   >   tmp_table
                   >   LATERAL VIEW EXPLODE(arr1) a1 AS elem1
                   >   LATERAL VIEW EXPLODE(arr2) a2 AS elem2;
elem1   elem2
1       a
1       b
2       a
2       b
```

- DuckDB:
```SQL
D WITH tmp_table(arr1, arr2) AS (
      SELECT * FROM (VALUES ([1, 2], ['a', 'b']))
  )
  SELECT elem1, elem2
  FROM
    tmp_table CROSS JOIN
    LATERAL UNNEST(arr1) AS a1(elem1) CROSS JOIN
    LATERAL UNNEST(arr2) AS a2(elem2);
┌───────┬───────┐
│ elem1 │ elem2 │
├───────┼───────┤
│ 1     │ a     │
│ 1     │ b     │
│ 2     │ a     │
│ 2     │ b     │
└───────┴───────┘
```

Docs
---------
[Spark -> Presto/Trino transformation](https://trino.io/docs/current/appendix/from-hive.html#use-unnest-to-expand-arrays-and-maps)