### PR TITLE
feat(trino): Support for LISTAGG function

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -386,9 +386,7 @@ class Presto(Dialect):
             exp.GenerateSeries: sequence_sql,
             exp.GenerateDateArray: sequence_sql,
             exp.Group: transforms.preprocess([transforms.unalias_group]),
-            exp.GroupConcat: lambda self, e: self.func(
-                "ARRAY_JOIN", self.func("ARRAY_AGG", e.this), e.args.get("separator")
-            ),
+            exp.GroupConcat: lambda self, e: self.groupconcat_sql(e),
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.Initcap: _initcap_sql,
@@ -680,3 +678,10 @@ class Presto(Dialect):
             expr = "".join(segments)
 
             return f"{this}{expr}"
+
+        def groupconcat_sql(self, expression: exp.Expression) -> str:
+            return self.func(
+                "ARRAY_JOIN",
+                self.func("ARRAY_AGG", expression.this),
+                expression.args.get("separator"),
+            )

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -386,7 +386,6 @@ class Presto(Dialect):
             exp.GenerateSeries: sequence_sql,
             exp.GenerateDateArray: sequence_sql,
             exp.Group: transforms.preprocess([transforms.unalias_group]),
-            exp.GroupConcat: lambda self, e: self.groupconcat_sql(e),
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.Initcap: _initcap_sql,
@@ -679,7 +678,7 @@ class Presto(Dialect):
 
             return f"{this}{expr}"
 
-        def groupconcat_sql(self, expression: exp.Expression) -> str:
+        def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
             return self.func(
                 "ARRAY_JOIN",
                 self.func("ARRAY_AGG", expression.this),

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -10,11 +10,15 @@ class Trino(Presto):
     SUPPORTS_USER_DEFINED_TYPES = False
     LOG_BASE_FIRST = True
 
+    class Tokenizer(Presto.Tokenizer):
+        HEX_STRINGS = [("X'", "'")]
+
     class Parser(Presto.Parser):
         FUNCTION_PARSERS = {
             **Presto.Parser.FUNCTION_PARSERS,
             "TRIM": lambda self: self._parse_trim(),
             "JSON_QUERY": lambda self: self._parse_json_query(),
+            "LISTAGG": lambda self: self._parse_string_agg(),
         }
 
         JSON_QUERY_OPTIONS: parser.OPTIONS_TYPE = {
@@ -65,5 +69,14 @@ class Trino(Presto):
 
             return self.func("JSON_QUERY", expression.this, json_path + option)
 
-    class Tokenizer(Presto.Tokenizer):
-        HEX_STRINGS = [("X'", "'")]
+        def groupconcat_sql(self, expression: exp.Expression) -> str:
+            this = expression.this
+            separator = expression.args.get("separator") or exp.Literal.string(",")
+
+            if isinstance(this, exp.Order):
+                if this.this:
+                    this = this.this.pop()
+
+                return f"LISTAGG({self.format_args(this, separator)}) WITHIN GROUP ({self.sql(expression.this)[1:]})"
+
+            return super().groupconcat_sql(expression)

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -69,7 +69,7 @@ class Trino(Presto):
 
             return self.func("JSON_QUERY", expression.this, json_path + option)
 
-        def groupconcat_sql(self, expression: exp.Expression) -> str:
+        def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
             this = expression.this
             separator = expression.args.get("separator") or exp.Literal.string(",")
 
@@ -77,6 +77,6 @@ class Trino(Presto):
                 if this.this:
                     this = this.this.pop()
 
-                return f"LISTAGG({self.format_args(this, separator)}) WITHIN GROUP ({self.sql(expression.this)[1:]})"
+                return f"LISTAGG({self.format_args(this, separator)}) WITHIN GROUP ({self.sql(expression.this).lstrip()})"
 
             return super().groupconcat_sql(expression)

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -9,6 +9,9 @@ class TestTrino(Validator):
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER)")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT CONDITIONAL WRAPPER)")
+        self.validate_identity(
+            "SELECT LISTAGG(DISTINCT col, ',') WITHIN GROUP (ORDER BY col ASC) FROM tbl"
+        )
 
     def test_trim(self):
         self.validate_identity("SELECT TRIM('!' FROM '!foo!')")


### PR DESCRIPTION
Fixes #4250

Before this PR, Trino would transpile `exp.GroupConcat` into `ARRAY_JOIN(ARRAY_AGG(...))`, which was added in https://github.com/tobymao/sqlglot/issues/2331. For Presto, this [was the recommended way](https://stackoverflow.com/questions/44142356/presto-equivalent-of-mysql-group-concat).

However, at some point `LISTAGG` [was supported](https://github.com/trinodb/trino/issues/4835) :

```
LISTAGG( expression [, separator] [ON OVERFLOW overflow_behaviour])
    WITHIN GROUP (ORDER BY sort_item, [...]) [FILTER (WHERE condition)]
```

An example:

```SQL
trino> WITH t AS (SELECT 'a' AS id UNION ALL SELECT 'b' AS id) SELECT LISTAGG(DISTINCT id, ',') WITHIN GROUP (ORDER BY id ASC) FROM t;
 _col0
-------
 a,b
(1 row)
```


This PR adds support for `LISTAGG` by:
- Reusing `parser.py::_parse_string_agg() -> exp.GroupConcat`, as it's parsing identical syntax
- Generating `LISTAGG` if there's an `exp.Order` child under it, otherwise defaults back to the existing transpilation


Docs
-------
[Trino LISTAGG](https://trino.io/docs/current/functions/aggregate.html#listagg)