### PR TITLE
feat(snowflake)!: Support TRY_TO_TIMESTAMP function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -41,15 +41,23 @@ def _build_datetime(
         if isinstance(value, exp.Literal):
             # Converts calls like `TO_TIME('01:02:03')` into casts
             if len(args) == 1 and value.is_string and not int_value:
-                return exp.cast(value, kind)
+                return (
+                    exp.cast(value, kind)
+                    if not safe
+                    else exp.TryCast(this=value, to=exp.DataType.build(kind))
+                )
 
             # Handles `TO_TIMESTAMP(str, fmt)` and `TO_TIMESTAMP(num, scale)` as special
             # cases so we can transpile them, since they're relatively common
             if kind == exp.DataType.Type.TIMESTAMP:
-                if int_value:
+                if int_value and not safe:
+                    # TRY_TO_TIMESTAMP('integer') is not parsed into exp.UnixToTime as
+                    # it's not easily transpilable
                     return exp.UnixToTime(this=value, scale=seq_get(args, 1))
                 if not is_float(value.this):
-                    return build_formatted_time(exp.StrToTime, "snowflake")(args)
+                    expr = build_formatted_time(exp.StrToTime, "snowflake")(args)
+                    expr.set("safe", safe)
+                    return expr
 
         if kind == exp.DataType.Type.DATE and not int_value:
             formatted_exp = build_formatted_time(exp.TsOrDsToDate, "snowflake")(args)
@@ -345,6 +353,9 @@ class Snowflake(Dialect):
             "TIMESTAMP_FROM_PARTS": build_timestamp_from_parts,
             "TRY_PARSE_JSON": lambda args: exp.ParseJSON(this=seq_get(args, 0), safe=True),
             "TRY_TO_DATE": _build_datetime("TRY_TO_DATE", exp.DataType.Type.DATE, safe=True),
+            "TRY_TO_TIMESTAMP": _build_datetime(
+                "TRY_TO_TIMESTAMP", exp.DataType.Type.TIMESTAMP, safe=True
+            ),
             "TO_DATE": _build_datetime("TO_DATE", exp.DataType.Type.DATE),
             "TO_NUMBER": lambda args: exp.ToNumber(
                 this=seq_get(args, 0),
@@ -828,7 +839,6 @@ class Snowflake(Dialect):
             exp.StrPosition: lambda self, e: self.func(
                 "POSITION", e.args.get("substr"), e.this, e.args.get("position")
             ),
-            exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
             exp.Stuff: rename_func("INSERT"),
             exp.TimeAdd: date_delta_sql("TIMEADD"),
             exp.TimestampDiff: lambda self, e: self.func(
@@ -1074,3 +1084,9 @@ class Snowflake(Dialect):
             tag = f" TAG {tag}" if tag else ""
 
             return f"SET{exprs}{file_format}{copy_options}{tag}"
+
+        def strtotime_sql(self, expression: exp.StrToTime):
+            safe_prefix = "TRY_" if expression.args.get("safe") else ""
+            return self.func(
+                f"{safe_prefix}TO_TIMESTAMP", expression.this, self.format_time(expression)
+            )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -927,6 +927,29 @@ WHERE
                 "bigquery": "GENERATE_UUID()",
             },
         )
+        self.validate_identity("TRY_TO_TIMESTAMP(foo)").assert_is(exp.Anonymous)
+        self.validate_identity("TRY_TO_TIMESTAMP('12345')").assert_is(exp.Anonymous)
+        self.validate_all(
+            "SELECT TRY_TO_TIMESTAMP('2024-01-15 12:30:00.000')",
+            write={
+                "snowflake": "SELECT TRY_CAST('2024-01-15 12:30:00.000' AS TIMESTAMP)",
+                "duckdb": "SELECT TRY_CAST('2024-01-15 12:30:00.000' AS TIMESTAMP)",
+            },
+        )
+        self.validate_all(
+            "SELECT TRY_TO_TIMESTAMP('invalid')",
+            write={
+                "snowflake": "SELECT TRY_CAST('invalid' AS TIMESTAMP)",
+                "duckdb": "SELECT TRY_CAST('invalid' AS TIMESTAMP)",
+            },
+        )
+        self.validate_all(
+            "SELECT TRY_TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/DD/yyyy hh24:mi:ss')",
+            write={
+                "snowflake": "SELECT TRY_TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/DD/yyyy hh24:mi:ss')",
+                "duckdb": "SELECT CAST(TRY_STRPTIME('04/05/2013 01:02:03', '%m/%d/%Y %H:%M:%S') AS TIMESTAMP)",
+            },
+        )
 
     def test_null_treatment(self):
         self.validate_all(


### PR DESCRIPTION
This PR adds support for Snowflake's `TRY_TO_TIMESTAMP(...)` function for the following variants:

| Variant  | Behavior |
| ------------- | ------------- |
| TRY_TO_TIMESTAMP(string_expr) | ✅  Canonicalized into a`TRY_CAST(<string_expr> AS TIMESTAMP)` expression  |
| TRY_TO_TIMESTAMP(string_expr, format)  | ✅  Parsed into an `exp.StrToTime` node |
| TRY_TO_TIMESTAMP(col) | ❌  Parsed into exp.Anonymous  |
| TRY_TO_TIMESTAMP('integer')  | ❌  Parsed into exp.Anonymous |


The behavior of the last 2 variants is because it's not trivial to transpile them accordingly:
-  For the `<integer>` version, dialects like DuckDB don't offer functions with `TRY` semantics for string -> unix time conversion
-  For the `<col>` case we'd have to dissect the data to decide which is the matching variant

Docs
--------
[Snowflake TRY_TO_TIMESTAMP](https://docs.snowflake.com/en/sql-reference/functions/try_to_timestamp) | [DuckDB TIMESTAMP Functions](https://duckdb.org/docs/sql/functions/timestamp.html#try_strptimetext-format)