### PR TITLE
Fix(clickhouse)!: dont parse right-hand side operands of ARRAY JOIN as Tables

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -607,17 +607,7 @@ class ClickHouse(Dialect):
                 # https://clickhouse.com/docs/en/sql-reference/statements/select/array-join
                 if join.kind == "ARRAY":
                     for table in join.find_all(exp.Table):
-                        if not table.db:
-                            this = table.this
-                            if isinstance(this, exp.Identifier):
-                                this = exp.column(this)
-
-                            # If they RHS is aliased, we'll produce `Alias(Column(...))`
-                            alias = table.args.get("alias")
-                            if isinstance(alias, exp.TableAlias):
-                                this = exp.alias_(this, alias.this)
-
-                            table.replace(this)
+                        table.replace(table.to_column())
 
             return join
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3214,10 +3214,18 @@ class Table(Expression):
 
     def to_column(self, copy: bool = True) -> Alias | Column | Dot:
         parts = self.parts
-        col = column(*reversed(parts[0:4]), fields=parts[4:], copy=copy)  # type: ignore
+        last_part = parts[-1]
+
+        if isinstance(last_part, Identifier):
+            col = column(*reversed(parts[0:4]), fields=parts[4:], copy=copy)  # type: ignore
+        else:
+            # This branch will be reached if a function or array is wrapped in a `Table`
+            col = last_part
+
         alias = self.args.get("alias")
         if alias:
             col = alias_(col, alias.this, copy=copy)
+
         return col
 
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -421,14 +421,6 @@ class TestClickhouse(Validator):
                 " GROUP BY loyalty ORDER BY loyalty ASC"
             },
         )
-        self.validate_identity("SELECT s, arr FROM arrays_test ARRAY JOIN arr")
-        self.validate_identity("SELECT s, arr, a FROM arrays_test LEFT ARRAY JOIN arr AS a")
-        self.validate_identity(
-            "SELECT s, arr_external FROM arrays_test ARRAY JOIN [1, 2, 3] AS arr_external"
-        )
-        self.validate_identity(
-            "SELECT * FROM tbl ARRAY JOIN [1, 2, 3] AS arr_external1, ['a', 'b', 'c'] AS arr_external2, splitByString(',', 'asd,qwerty,zxc') AS arr_external3"
-        )
         self.validate_all(
             "SELECT quantile(0.5)(a)",
             read={"duckdb": "SELECT quantile(a, 0.5)"},
@@ -1104,3 +1096,30 @@ LIFETIME(MIN 0 MAX 0)""",
     def test_grant(self):
         self.validate_identity("GRANT SELECT(x, y) ON db.table TO john WITH GRANT OPTION")
         self.validate_identity("GRANT INSERT(x, y) ON db.table TO john")
+
+    def test_array_join(self):
+        expr = self.validate_identity(
+            "SELECT * FROM arrays_test ARRAY JOIN arr1, arr2 AS foo, ['a', 'b', 'c'] AS elem"
+        )
+        joins = expr.args["joins"]
+        self.assertEqual(len(joins), 1)
+
+        join = joins[0]
+        self.assertEqual(join.kind, "ARRAY")
+        self.assertIsInstance(join.this, exp.Column)
+
+        self.assertEqual(len(join.expressions), 2)
+        self.assertIsInstance(join.expressions[0], exp.Alias)
+        self.assertIsInstance(join.expressions[0].this, exp.Column)
+
+        self.assertIsInstance(join.expressions[1], exp.Alias)
+        self.assertIsInstance(join.expressions[1].this, exp.Array)
+
+        self.validate_identity("SELECT s, arr FROM arrays_test ARRAY JOIN arr")
+        self.validate_identity("SELECT s, arr, a FROM arrays_test LEFT ARRAY JOIN arr AS a")
+        self.validate_identity(
+            "SELECT s, arr_external FROM arrays_test ARRAY JOIN [1, 2, 3] AS arr_external"
+        )
+        self.validate_identity(
+            "SELECT * FROM arrays_test ARRAY JOIN [1, 2, 3] AS arr_external1, ['a', 'b', 'c'] AS arr_external2, splitByString(',', 'asd,qwerty,zxc') AS arr_external3"
+        )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1099,7 +1099,7 @@ LIFETIME(MIN 0 MAX 0)""",
 
     def test_array_join(self):
         expr = self.validate_identity(
-            "SELECT * FROM arrays_test ARRAY JOIN arr1, arr2 AS foo, ['a', 'b', 'c'] AS elem"
+            "SELECT * FROM arrays_test ARRAY JOIN arr1, arrays_test.arr2 AS foo, ['a', 'b', 'c'] AS elem"
         )
         joins = expr.args["joins"]
         self.assertEqual(len(joins), 1)

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -196,6 +196,11 @@ SELECT SOME_UDF(t.data).* FROM t AS t;
 SELECT a + 1 AS i, missing_column FROM x;
 SELECT x.a + 1 AS i, missing_column AS missing_column FROM x AS x;
 
+# execute: false
+# dialect: clickhouse
+SELECT s, arr FROM arrays_test LEFT ARRAY JOIN arr;
+SELECT arrays_test.s AS s, arrays_test.arr AS arr FROM arrays_test AS arrays_test LEFT ARRAY JOIN arrays_test.arr;
+
 --------------------------------------
 -- Derived tables
 --------------------------------------

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -198,8 +198,8 @@ SELECT x.a + 1 AS i, missing_column AS missing_column FROM x AS x;
 
 # execute: false
 # dialect: clickhouse
-SELECT s, arr FROM arrays_test LEFT ARRAY JOIN arr;
-SELECT arrays_test.s AS s, arrays_test.arr AS arr FROM arrays_test AS arrays_test LEFT ARRAY JOIN arrays_test.arr;
+SELECT s, arr1, arr2 FROM arrays_test LEFT ARRAY JOIN arr1, arrays_test.arr2;
+SELECT arrays_test.s AS s, arrays_test.arr1 AS arr1, arrays_test.arr2 AS arr2 FROM arrays_test AS arrays_test LEFT ARRAY JOIN arrays_test.arr1, arrays_test.arr2;
 
 --------------------------------------
 -- Derived tables


### PR DESCRIPTION
Fixes #4254

Reference: https://clickhouse.com/docs/en/sql-reference/statements/select/array-join

<img width="1502" alt="Screenshot 2024-10-17 at 3 20 48 PM" src="https://github.com/user-attachments/assets/dd445607-8410-4ae1-9843-8c0095496b2b">
<img width="1507" alt="Screenshot 2024-10-17 at 3 20 59 PM" src="https://github.com/user-attachments/assets/1be86f69-1524-460e-a0bc-b20a8575bff6">