### PR TITLE
fix(optimizer): Fix & annotate merge_subqueries

### DIFF
--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -1,11 +1,20 @@
+from __future__ import annotations
+
 import itertools
+import typing as t
 
 from sqlglot import expressions as exp
 from sqlglot.helper import find_new_name
-from sqlglot.optimizer.scope import build_scope
+from sqlglot.optimizer.scope import Scope, build_scope
+
+if t.TYPE_CHECKING:
+    from sqlglot._typing import E
+
+    ExistingCTEsMapping = t.Dict[E, str]
+    TakenNameMaping = t.Dict[t.Any, t.Union[Scope, E]]
 
 
-def eliminate_subqueries(expression):
+def eliminate_subqueries(expression: exp.Expression) -> exp.Expression:
     """
     Rewrite derived tables as CTES, deduplicating if possible.
 
@@ -38,7 +47,7 @@ def eliminate_subqueries(expression):
     # Map of alias->Scope|Table
     # These are all aliases that are already used in the expression.
     # We don't want to create new CTEs that conflict with these names.
-    taken = {}
+    taken: TakenNameMaping = {}
 
     # All CTE aliases in the root scope are taken
     for scope in root.cte_scopes:
@@ -56,7 +65,7 @@ def eliminate_subqueries(expression):
 
     # Map of Expression->alias
     # Existing CTES in the root expression. We'll use this for deduplication.
-    existing_ctes = {}
+    existing_ctes: ExistingCTEsMapping = {}
 
     with_ = root.expression.args.get("with")
     recursive = False
@@ -95,7 +104,7 @@ def eliminate_subqueries(expression):
     return expression
 
 
-def _eliminate(scope, existing_ctes, taken):
+def _eliminate(scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMaping):
     if scope.is_derived_table:
         return _eliminate_derived_table(scope, existing_ctes, taken)
 
@@ -103,7 +112,9 @@ def _eliminate(scope, existing_ctes, taken):
         return _eliminate_cte(scope, existing_ctes, taken)
 
 
-def _eliminate_derived_table(scope, existing_ctes, taken):
+def _eliminate_derived_table(
+    scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMaping
+) -> t.Optional[exp.Expression]:
     # This makes sure that we don't:
     # - drop the "pivot" arg from a pivoted subquery
     # - eliminate a lateral correlated subquery
@@ -121,7 +132,9 @@ def _eliminate_derived_table(scope, existing_ctes, taken):
     return cte
 
 
-def _eliminate_cte(scope, existing_ctes, taken):
+def _eliminate_cte(
+    scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMaping
+) -> t.Optional[exp.Expression]:
     parent = scope.expression.parent
     name, cte = _new_cte(scope, existing_ctes, taken)
 
@@ -140,7 +153,9 @@ def _eliminate_cte(scope, existing_ctes, taken):
     return cte
 
 
-def _new_cte(scope, existing_ctes, taken):
+def _new_cte(
+    scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMaping
+) -> t.Tuple[str, t.Optional[exp.Expression]]:
     """
     Returns:
         tuple of (name, cte)

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -446,3 +446,21 @@ SELECT
   1 AS a;
 WITH q AS (SELECT x.a AS a FROM x AS x ORDER BY x.a) SELECT q.a AS a FROM q AS q UNION ALL SELECT 1 AS a;
 
+# title: Consecutive inner - outer conflicting names
+WITH tbl AS (select 1 as id)
+SELECT
+  id
+FROM (
+  SELECT OTBL.id
+  FROM (
+    SELECT OTBL.id
+    FROM (
+      SELECT OTBL.id
+      FROM tbl AS OTBL
+      LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
+    ) AS OTBL
+    LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
+  ) AS OTBL
+  LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
+) AS ITBL;
+WITH tbl AS (SELECT 1 AS id) SELECT OTBL.id AS id FROM tbl AS OTBL LEFT OUTER JOIN tbl AS ITBL_2 ON OTBL.id = ITBL_2.id LEFT OUTER JOIN tbl AS ITBL_3 ON OTBL.id = ITBL_3.id LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id;


### PR DESCRIPTION
Fixes #4245

Consider this minimum repro, for the optimizer rules `[qualify, eliminate_subqueries, merge_subqueries]`:

```SQL
WITH tbl AS (select 1 as id)
SELECT
  id
FROM (
  SELECT OTBL.id
  FROM (
    SELECT OTBL.id
    FROM (
      SELECT OTBL.id
      FROM tbl AS OTBL
      LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
    ) AS OTBL
    LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
  ) AS OTBL
  LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
) AS ITBL
```

After `eliminate_subqueries`, the derived tables have been lifted up as CTEs:

```SQL
WITH tbl AS (
  SELECT
    1 AS id
), otbl AS (
  SELECT
    otbl.id AS id
  FROM tbl AS otbl
  LEFT OUTER JOIN tbl AS itbl
    ON otbl.id = itbl.id
), otbl_2 AS (
  SELECT
    otbl.id AS id
  FROM otbl AS otbl
  LEFT OUTER JOIN tbl AS itbl
    ON otbl.id = itbl.id
), itbl AS (
  SELECT
    otbl.id AS id
  FROM otbl_2 AS otbl
  LEFT OUTER JOIN tbl AS itbl
    ON otbl.id = itbl.id
)
SELECT
  itbl.id AS id
FROM itbl AS itbl
```


The `merge_ctes` subrule of `merge_subqueries` will attempt to merge each inner scope/CTE to the outer scope, 
which (ignoring the OptimizerError) would ideally generate the following:

```SQL
WITH tbl AS (
  SELECT
    1 AS id
)
SELECT
  otbl.id AS id
FROM tbl AS otbl
LEFT OUTER JOIN tbl AS itbl_2
  ON otbl.id = itbl_2.id
LEFT OUTER JOIN tbl AS itbl_3
  ON otbl.id = itbl_3.id
LEFT OUTER JOIN tbl AS itbl
  ON otbl.id = itbl.id
```

To safely move parts from the inner scopes outwards the helper function `_rename_inner_sources()` is used, which attempts to rename the inner sources in case of name collisions. The bug in this procedure has to do with the fact that the `taken` set is built only from the _outer_ sources. For the example above, this is what happens in the function call that leads to the OptimizerError:

``` 
Upon entering _rename_inner_sources(outer_scope, inner_scope, alias):
----------------------------
@param alias: otbl
@param outer_scope: Scope<SELECT otbl.id AS id FROM otbl_2 AS otbl LEFT JOIN tbl AS itbl ON itbl.id = otbl.id>
Outer selected sources / taken set: {'otbl', 'itbl'}

@param inner_scope: Scope<SELECT otbl.id AS id FROM tbl AS otbl LEFT JOIN tbl AS itbl_2 ON itbl_2.id = otbl.id LEFT JOIN tbl AS itbl ON itbl.id = otbl.id>
Inner selected sources: {'itbl_2', 'otbl', 'itbl'} 

conflicts:  (outer_sources ∩ inner_sources) - alias = {'itbl'}

Upon leaving
----------------------------
new_name = find_new_name(taken={'otbl', 'itbl'}, conflict='itbl') -> 'itbl_2'

Renamed inner scope: Scope<SELECT otbl.id AS id FROM tbl AS otbl LEFT JOIN tbl AS itbl_2 ON itbl_2.id = otbl.id LEFT JOIN tbl AS itbl_2 ON itbl_2.id = otbl.id> 
```

Notice how `itbl_2` was already an _inner_ source but was incorrectly generated again to replace `ITBL` as it wasn't a part of `taken`, leading to duplicate aliases.

This PR solves this by extending the `taken` set to be the union of outer & inner selected sources. Also, as most of the code in these rules is old, this PR extends them with type hints.