### PR TITLE
fix(optimizer)!: Fix chained exp.SetOperation type annotation

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -192,9 +192,10 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         # Caches the ids of annotated sub-Expressions, to ensure we only visit them once
         self._visited: t.Set[int] = set()
 
-        # Maps an exp.SetOperation's id (e.g. UNION) to it's annotated selected columns. This is done if the exp.SetOperation is
-        # the main expression of a source scope, as selecting from it multiple times would reprocess the entire subtree
-        self._setop_cols: t.Dict[int, t.Dict[str, exp.DataType.Type]] = dict()
+        # Maps an exp.SetOperation's id (e.g. UNION) to its projection types. This is computed if the
+        # exp.SetOperation is the expression of a scope source, as selecting from it multiple times
+        # would reprocess the entire subtree to coerce the types of its operands' projections
+        self._setop_column_types: t.Dict[int, t.Dict[str, exp.DataType.Type]] = {}
 
     def _set_type(
         self, expression: exp.Expression, target_type: t.Optional[exp.DataType | exp.DataType.Type]

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -236,7 +236,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             elif isinstance(expression, exp.SetOperation) and len(expression.left.selects) == len(
                 expression.right.selects
             ):
-                selects[name] = col_types = self._setop_column_types.get(id(expression), {})
+                selects[name] = col_types = self._setop_column_types.setdefault(id(expression), {})
 
                 if not col_types:
                     # Process a chain / sub-tree of set operations

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -236,7 +236,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             elif isinstance(expression, exp.SetOperation) and len(expression.left.selects) == len(
                 expression.right.selects
             ):
-                col_types: t.Dict[str, exp.DataType.Type] = self._setop_cols.get(id(expression), {})
+                selects[name] = col_types = self._setop_column_types.get(id(expression), {})
 
                 if not col_types:
                     # Process a chain / sub-tree of set operations
@@ -272,9 +272,6 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                                 col_type, col_types.get(col_name, exp.DataType.Type.NULL)
                             )
 
-                    self._setop_cols[id(expression)] = col_types
-
-                selects[name] = col_types
             else:
                 selects[name] = {s.alias_or_name: s.type for s in expression.selects}
 

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -241,7 +241,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                 if not col_types:
                     # Process a chain / sub-tree of set operations
                     for set_op in expression.walk(
-                        prune=lambda n: not isinstance(n, exp.SetOperation)
+                        prune=lambda n: not isinstance(n, (exp.SetOperation, exp.Subquery))
                     ):
                         if not isinstance(set_op, exp.SetOperation):
                             continue

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1337,6 +1337,24 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         self.assertEqual(union_by_name.selects[0].type.this, exp.DataType.Type.BIGINT)
         self.assertEqual(union_by_name.selects[1].type.this, exp.DataType.Type.DOUBLE)
 
+        # Test chained UNIONs
+        sql = """
+            WITH t AS
+            (
+                SELECT NULL AS col
+                UNION
+                SELECT NULL AS col
+                UNION
+                SELECT 'a' AS col
+                UNION
+                SELECT NULL AS col
+                UNION
+                SELECT NULL AS col
+            )
+            SELECT col FROM t;
+        """
+        self.assertEqual(optimizer.optimize(sql).selects[0].type.this, exp.DataType.Type.VARCHAR)
+
     def test_recursive_cte(self):
         query = parse_one(
             """

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1355,6 +1355,29 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         """
         self.assertEqual(optimizer.optimize(sql).selects[0].type.this, exp.DataType.Type.VARCHAR)
 
+        # Test UNIONs with nested subqueries
+        sql = """
+            WITH t AS
+            (
+                SELECT NULL AS col
+                UNION
+                (SELECT NULL AS col UNION ALL SELECT 'a' AS col)
+            )
+            SELECT col FROM t;
+        """
+        self.assertEqual(optimizer.optimize(sql).selects[0].type.this, exp.DataType.Type.VARCHAR)
+
+        sql = """
+            WITH t AS
+            (
+                (SELECT NULL AS col UNION ALL SELECT 'a' AS col)
+                UNION
+                SELECT NULL AS col
+            )
+            SELECT col FROM t;
+        """
+        self.assertEqual(optimizer.optimize(sql).selects[0].type.this, exp.DataType.Type.VARCHAR)
+
     def test_recursive_cte(self):
         query = parse_one(
             """


### PR DESCRIPTION
Fixes #4261

Consider this repro:

```Python
>>> sql = """
WITH t AS (
SELECT NULL AS col
UNION ALL
SELECT 'a' AS col
UNION ALL
SELECT NULL AS col
)
SELECT * FROM t;
"""

>>> optimized = sqlglot.optimize(sql)
>>> optimized.selects[0].type
DataType(this=Type.NULL)
```

To annotate this query, `annotate_scope` will be called for each scope:

```
1. Scope<SELECT NULL AS "col">
2. Scope<SELECT 'a' AS "col">
3. Scope<SELECT NULL AS "col" UNION ALL SELECT 'a' AS "col">
4. Scope<SELECT NULL AS "col">
5. Scope<SELECT NULL AS "col" UNION ALL SELECT 'a' AS "col" UNION ALL SELECT NULL AS "col">
6. Scope<WITH "t" AS (SELECT NULL AS "col" UNION ALL SELECT 'a' AS "col" UNION ALL SELECT NULL AS "col") SELECT "t"."col" AS "col" FROM "t" AS "t">
```

The annotation fails because:
1. Set operations are processed only if there is least one source in the scope, so scopes (3) & (5) won't be traversed/annotated.

2. The top-level UNION (6) will be annotated, but the `left` and `right` properties of `exp.SetOperation` will only yield the very first & last `SELECT` statements of the chain thus inferring `col` as `NULL`.

This PR solves this ordering issue by:
- Iteratively visiting the child `exp.SetOperation` nodes & coercing their left - right counterparts into an intermediate result set
- For each intermediate result set, coerce it with a global result set to get the final column type mappings
