### PR TITLE
feat(bigquery): support EDIT_DISTANCE (Levinshtein) function

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -733,6 +733,7 @@ class BigQuery(Dialect):
             exp.ILike: no_ilike_sql,
             exp.IntDiv: rename_func("DIV"),
             exp.JSONFormat: rename_func("TO_JSON_STRING"),
+            exp.Levenshtein: rename_func("EDIT_DISTANCE"),
             exp.Max: max_or_greatest,
             exp.MD5: lambda self, e: self.func("TO_HEX", self.func("MD5", e.this)),
             exp.MD5Digest: rename_func("MD5"),

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1762,6 +1762,7 @@ class TestDialect(Validator):
         self.validate_all(
             "LEVENSHTEIN(col1, col2)",
             write={
+                "bigquery": "EDIT_DISTANCE(col1, col2)",
                 "duckdb": "LEVENSHTEIN(col1, col2)",
                 "drill": "LEVENSHTEIN_DISTANCE(col1, col2)",
                 "presto": "LEVENSHTEIN_DISTANCE(col1, col2)",
@@ -1772,6 +1773,7 @@ class TestDialect(Validator):
         self.validate_all(
             "LEVENSHTEIN(coalesce(col1, col2), coalesce(col2, col1))",
             write={
+                "bigquery": "EDIT_DISTANCE(COALESCE(col1, col2), COALESCE(col2, col1))",
                 "duckdb": "LEVENSHTEIN(COALESCE(col1, col2), COALESCE(col2, col1))",
                 "drill": "LEVENSHTEIN_DISTANCE(COALESCE(col1, col2), COALESCE(col2, col1))",
                 "presto": "LEVENSHTEIN_DISTANCE(COALESCE(col1, col2), COALESCE(col2, col1))",


### PR DESCRIPTION
Fixes #4275 .

This PR adds support for Bigquery's `EDIT_DISTANCE(...)` (Levinshtein) function for the following variants:

It implements the `EDIT_DISTANCE(col1, col2)` but not the `EDIT_DISTANCE(col1, col2, max_distance => max_distance_value)` variant.

## Docs
[Bigque EDIT_DISTANCE](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#edit_distance) | [DuckDB TEXT SIMILARITIES Functions](https://duckdb.org/docs/sql/functions/char.html#text-similarity-functions)