### PR TITLE
Fix(tsql): Keep CTE's attached to the query when emulating IF NOT EXISTS

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1103,9 +1103,10 @@ class TSQL(Dialect):
 
             if exists:
                 identifier = self.sql(exp.Literal.string(exp.table_name(table) if table else ""))
-                sql = self.sql(exp.Literal.string(sql))
+                sql_with_ctes = self.prepend_ctes(expression, sql)
+                sql_literal = self.sql(exp.Literal.string(sql_with_ctes))
                 if kind == "SCHEMA":
-                    sql = f"""IF NOT EXISTS (SELECT * FROM information_schema.schemata WHERE schema_name = {identifier}) EXEC({sql})"""
+                    return f"""IF NOT EXISTS (SELECT * FROM information_schema.schemata WHERE schema_name = {identifier}) EXEC({sql_literal})"""
                 elif kind == "TABLE":
                     assert table
                     where = exp.and_(
@@ -1113,10 +1114,10 @@ class TSQL(Dialect):
                         exp.column("table_schema").eq(table.db) if table.db else None,
                         exp.column("table_catalog").eq(table.catalog) if table.catalog else None,
                     )
-                    sql = f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE {where}) EXEC({sql})"""
+                    return f"""IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE {where}) EXEC({sql_literal})"""
                 elif kind == "INDEX":
                     index = self.sql(exp.Literal.string(expression.this.text("this")))
-                    sql = f"""IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = object_id({identifier}) AND name = {index}) EXEC({sql})"""
+                    return f"""IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = object_id({identifier}) AND name = {index}) EXEC({sql_literal})"""
             elif expression.args.get("replace"):
                 sql = sql.replace("CREATE OR REPLACE ", "CREATE OR ALTER ", 1)
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -921,6 +921,12 @@ class TestTSQL(Validator):
             },
         )
         self.validate_all(
+            "IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'baz' AND table_schema = 'bar' AND table_catalog = 'foo') EXEC('WITH cte1 AS (SELECT 1 AS col_a), cte2 AS (SELECT 1 AS col_b) SELECT * INTO foo.bar.baz FROM (SELECT col_a FROM cte1 UNION ALL SELECT col_b FROM cte2) AS temp')",
+            read={
+                "": "CREATE TABLE IF NOT EXISTS foo.bar.baz AS WITH cte1 AS (SELECT 1 AS col_a), cte2 AS (SELECT 1 AS col_b) SELECT col_a FROM cte1 UNION ALL SELECT col_b FROM cte2"
+            },
+        )
+        self.validate_all(
             "CREATE OR ALTER VIEW a.b AS SELECT 1",
             read={
                 "": "CREATE OR REPLACE VIEW a.b AS SELECT 1",


### PR DESCRIPTION
Prior to this change, something like:
```
CREATE TABLE IF NOT EXISTS foo AS (WITH cte1 AS (...), cte2 AS (...) SELECT ... FROM cte1... etc)
```

Would be turned into:
```
WITH cte1 AS (...), cte2 AS (...) IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'foo') EXEC('SELECT * INTO foo FROM (SELECT ... FROM cte1...etc) AS temp')
```

Instead of:
```
IF NOT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'foo') 
EXEC('WITH cte1 AS (...), cte2 AS (...) SELECT * INTO foo FROM (SELECT ... FROM cte1...etc) AS temp')
```

The problem is that the CTE's were being removed from the sql literal in `EXEC` and being prepended to the `IF NOT EXISTS` check.

This caused the following error to be thrown: `SQL Error [156] [S0001]: Incorrect syntax near the keyword 'IF'.`

I've updated the code to prepend the CTE's to the SQL literal instead and return immediately so they dont get prepended again