### PR TITLE
feat(snowflake)!: Add support for TIMESTAMP_NTZ_FROM_PARTS

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -351,6 +351,8 @@ class Snowflake(Dialect):
             "TIMESTAMPDIFF": _build_datediff,
             "TIMESTAMPFROMPARTS": build_timestamp_from_parts,
             "TIMESTAMP_FROM_PARTS": build_timestamp_from_parts,
+            "TIMESTAMPNTZFROMPARTS": build_timestamp_from_parts,
+            "TIMESTAMP_NTZ_FROM_PARTS": build_timestamp_from_parts,
             "TRY_PARSE_JSON": lambda args: exp.ParseJSON(this=seq_get(args, 0), safe=True),
             "TRY_TO_DATE": _build_datetime("TRY_TO_DATE", exp.DataType.Type.DATE, safe=True),
             "TRY_TO_TIMESTAMP": _build_datetime(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6488,12 +6488,7 @@ class Uuid(Func):
 
 
 class TimestampFromParts(Func):
-    _sql_names = [
-        "TIMESTAMP_FROM_PARTS",
-        "TIMESTAMPFROMPARTS",
-        "TIMESTAMP_NTZ_FROM_PARTS",
-        "TIMESTAMPNTZFROMPARTS",
-    ]
+    _sql_names = ["TIMESTAMP_FROM_PARTS", "TIMESTAMPFROMPARTS"]
     arg_types = {
         "year": True,
         "month": True,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6488,7 +6488,12 @@ class Uuid(Func):
 
 
 class TimestampFromParts(Func):
-    _sql_names = ["TIMESTAMP_FROM_PARTS", "TIMESTAMPFROMPARTS"]
+    _sql_names = [
+        "TIMESTAMP_FROM_PARTS",
+        "TIMESTAMPFROMPARTS",
+        "TIMESTAMP_NTZ_FROM_PARTS",
+        "TIMESTAMPNTZFROMPARTS",
+    ]
     arg_types = {
         "year": True,
         "month": True,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -331,10 +331,15 @@ WHERE
                 "snowflake": "SELECT TIME_FROM_PARTS(12, 34, 56, 987654321)",
             },
         )
+        self.validate_identity(
+            "SELECT TIMESTAMPNTZFROMPARTS(2013, 4, 5, 12, 00, 00)",
+            "SELECT TIMESTAMP_FROM_PARTS(2013, 4, 5, 12, 00, 00)",
+        )
         self.validate_all(
             "SELECT TIMESTAMP_FROM_PARTS(2013, 4, 5, 12, 00, 00)",
             read={
                 "duckdb": "SELECT MAKE_TIMESTAMP(2013, 4, 5, 12, 00, 00)",
+                "snowflake": "SELECT TIMESTAMP_NTZ_FROM_PARTS(2013, 4, 5, 12, 00, 00)",
             },
             write={
                 "duckdb": "SELECT MAKE_TIMESTAMP(2013, 4, 5, 12, 00, 00)",


### PR DESCRIPTION
This PR adds support for the 6-arg version of `TIMESTAMP_NTZ_FROM_PARTS(...)` by adding it as an alias for the already supported `TIMESTAMP_FROM_PARTS(...)`; This is because by default `TIMESTAMP_*` functions map to `TIMESTAMP_NTZ_*` unless changed by the user through `TIMESTAMP_TYPE_MAPPING`.

Three outstanding questions:
1. This family of functions also expose the 2-arg version `TIMESTAMP_FROM_PARTS( <date_expr>, <time_expr>)`. Should we add them in this PR too?
2. For future reference, to support the other variations as well such as `TIMESTAMP_LTZ_FROM_PARTS`, should we create separate nodes or add an `arg` that stores the variant type?
3. As an extension of (2) and a thought for the future, although it simplifies things now, we probably shouldn't tie `TIMESTAMP_NTZ` to `TIMESTAMP` across Snowflake as it won't be flexible enough for the users that have altered the `TIMESTAMP_TYPE_MAPPING`. Maybe we can introduce a dialect setting for Snowflake that attempts to mimic this behavior?


Docs
----------
[Snowflake TIMESTAMP_FROM_PARTS](https://docs.snowflake.com/en/sql-reference/functions/timestamp_from_parts) | [Snowflake TIMESTAMP_TYPE_MAPPING](https://docs.snowflake.com/en/sql-reference/parameters#label-timestamp-type-mapping)