### PR TITLE
feat(bigquery)!: Add support for STRING function

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -767,6 +767,7 @@ class BigQuery(Dialect):
             exp.StabilityProperty: lambda self, e: (
                 "DETERMINISTIC" if e.name == "IMMUTABLE" else "NOT DETERMINISTIC"
             ),
+            exp.String: rename_func("STRING"),
             exp.StrToDate: _str_to_datetime_sql,
             exp.StrToTime: _str_to_datetime_sql,
             exp.TimeAdd: date_add_interval_sql("TIME", "ADD"),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -637,6 +637,7 @@ class Dialect(metaclass=_Dialect):
             exp.Initcap,
             exp.Lower,
             exp.Substring,
+            exp.String,
             exp.TimeToStr,
             exp.TimeToTimeStr,
             exp.Trim,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5282,6 +5282,11 @@ class ArrayToString(Func):
     _sql_names = ["ARRAY_TO_STRING", "ARRAY_JOIN"]
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#string
+class String(Func):
+    arg_types = {"this": True, "zone": False}
+
+
 class StringToArray(Func):
     arg_types = {"this": True, "expression": True, "null": False}
     _sql_names = ["STRING_TO_ARRAY", "SPLIT_BY_STRING"]

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4434,3 +4434,15 @@ class Generator(metaclass=_Generator):
     @unsupported_args("format")
     def todouble_sql(self, expression: exp.ToDouble) -> str:
         return self.sql(exp.cast(expression.this, exp.DataType.Type.DOUBLE))
+
+    def string_sql(self, expression: exp.String) -> str:
+        this = expression.this
+        zone = expression.args.get("zone")
+
+        if zone:
+            # BigQuery stores timestamps internally as UTC, so it's used as a default source timezone
+            this = exp.ConvertTimezone(
+                source_tz=exp.Literal.string("UTC"), target_tz=zone, timestamp=this
+            )
+
+        return self.sql(exp.cast(this, exp.DataType.Type.VARCHAR))

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4440,7 +4440,9 @@ class Generator(metaclass=_Generator):
         zone = expression.args.get("zone")
 
         if zone:
-            # BigQuery stores timestamps internally as UTC, so it's used as a default source timezone
+            # This is a BigQuery specific argument for STRING(<timestamp_expr>, <time_zone>)
+            # BigQuery stores timestamps internally as UTC, so ConvertTimezone is used with UTC
+            # set for source_tz to transpile the time conversion before the STRING cast
             this = exp.ConvertTimezone(
                 source_tz=exp.Literal.string("UTC"), target_tz=zone, timestamp=this
             )

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1514,6 +1514,22 @@ WHERE
                 "duckdb": "SELECT ARRAY_TO_STRING(LIST_TRANSFORM(['cake', 'pie', NULL], x -> COALESCE(x, 'MISSING')), '--') AS text",
             },
         )
+        self.validate_all(
+            "STRING(a)",
+            write={
+                "bigquery": "STRING(a)",
+                "snowflake": "CAST(a AS VARCHAR)",
+                "duckdb": "CAST(a AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "STRING('2008-12-25 15:30:00', 'America/New_York')",
+            write={
+                "bigquery": "STRING('2008-12-25 15:30:00', 'America/New_York')",
+                "snowflake": "CAST(CONVERT_TIMEZONE('UTC', 'America/New_York', '2008-12-25 15:30:00') AS VARCHAR)",
+                "duckdb": "CAST(CAST('2008-12-25 15:30:00' AS TIMESTAMP) AT TIME ZONE 'UTC' AT TIME ZONE 'America/New_York' AS TEXT)",
+            },
+        )
 
         self.validate_identity("SELECT * FROM a-b c", "SELECT * FROM a-b AS c")
 

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -875,3 +875,9 @@ TBLPROPERTIES (
                 "databricks": "SELECT * FROM db.table1 EXCEPT SELECT * FROM db.table2",
             },
         )
+
+    def test_string(self):
+        for dialect in ("hive", "spark2", "spark", "databricks"):
+            with self.subTest(f"Testing STRING() for {dialect}"):
+                query = parse_one("STRING(a)", dialect=dialect)
+                self.assertEqual(query.sql(dialect), "CAST(a AS STRING)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -307,3 +307,11 @@ ARRAY<STRING>;
 # dialect: bigquery
 SPLIT(tbl.bin_col, delim);
 ARRAY<BINARY>;
+
+# dialect: bigquery
+STRING(json_expr);
+STRING;
+
+# dialect: bigquery
+STRING(timestamp_expr, timezone);
+STRING;


### PR DESCRIPTION
This PR adds support for BQ's `STRING(...)` function, which turns input expressions into `STRING`s. There are two supported versions:
1. JSON based: `STRING(json_expr)`
2. TIMESTAMP based: `STRING(timestamp_expression[, time_zone])`

Both variants are transpiled to `CAST(... AS VARCHAR)` for all other dialects; For the (2) variant with `time_zone` supplied, the timestamp is passed through `exp.ConvertTimezone` for the timezone conversion:

```SQL
bigquery> SELECT STRING("2008-12-25 15:30:00", "America/New_York") AS string;
2008-12-25 10:30:00-05

snowflake> SELECT CAST(CONVERT_TIMEZONE('UTC', 'America/New_York', '2008-12-25 15:30:00') AS VARCHAR);
2008-12-25 10:30:00.000

duckdb> SELECT CAST(CAST('2008-12-25 15:30:00' AS TIMESTAMP) AT TIME ZONE 'UTC' AT TIME ZONE 'America/New_York' AS TEXT) AS color;
┌─────────────────────┐
│        color        │
│       varchar       │
├─────────────────────┤
│ 2008-12-25 10:30:00 │
└─────────────────────┘
```

Docs
-------
[BQ JSON STRING()](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#string_for_json) | [BQ TIMESTAMP STRING()](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#string)

 