### PR TITLE
fix(transforms): remove table identifier inherited from inner query when eliminating distinct on

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -183,7 +183,7 @@ def eliminate_distinct_on(expression: exp.Expression) -> exp.Expression:
         and isinstance(expression.args["distinct"].args["on"], exp.Tuple)
     ):
         distinct_cols = expression.args["distinct"].pop().args["on"].expressions
-        outer_selects = expression.selects
+        outer_selects = [field.name for field in expression.selects]
         row_number = find_new_name(expression.named_selects, "_row_number")
         window = exp.Window(this=exp.RowNumber(), partition_by=distinct_cols)
         order = expression.args.get("order")


### PR DESCRIPTION
The hard coded alias (`_t`) is set for the window subquery. 
The outer_selects can be applied using their original table identifiers, particularly in queries with subqueries or complication, which generates invalid SQL.
eg 
Sample query:
``` SQL
SELECT DISTINCT ON (id)
    table1.*
FROM
    schema1.table1
    LEFT JOIN (SELECT
                   table2.id
                 , COUNT(1) AS rule_0_count
               FROM
                   schema1.table2
               WHERE (table2.type ILIKE 'type' AND table2.timestamp > CURRENT_DATE - INTERVAL '30 day')
               GROUP BY table2.id) rule_0 ON table1.id = rule_0.id
WHERE
    (COALESCE(rule_0_count, 0) = 0 OR rule_0_count IS NULL)
```

When transpiled for Redshift returns:

``` SQL
SELECT
    table1.*
FROM
    (SELECT
         table1.*
       , ROW_NUMBER() OVER (PARTITION BY id ORDER BY id) AS _row_number
     FROM
         schema1.table1
         LEFT JOIN (SELECT
                        table2.id
                      , COUNT(1) AS rule_0_count
                    FROM
                        schema1.table2
                    WHERE (table2."type" ILIKE 'type' AND table2."timestamp" > CURRENT_DATE - INTERVAL '30 DAY')
                    GROUP BY table2.id) AS rule_0 ON table1.id = rule_0.id
     WHERE (COALESCE(rule_0_count, 0) = 0 OR rule_0_count IS NULL)) AS _t
WHERE
    _row_number = 1
```

With the additional logic to select only the `name` attribute of `expression.selects` this is avoided, without impacting other uses. 

All tests in `make check` pass