### PR TITLE
fix(clickhouse): Wrap subquery if it's LHS of IS NOT NULL

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1212,3 +1212,12 @@ class ClickHouse(Dialect):
 
         def projectiondef_sql(self, expression: exp.ProjectionDef) -> str:
             return f"PROJECTION {self.sql(expression.this)} {self.wrap(expression.expression)}"
+
+        def is_sql(self, expression: exp.Is) -> str:
+            is_sql = super().is_sql(expression)
+
+            if isinstance(expression.parent, exp.Not) and isinstance(expression.this, exp.Subquery):
+                # WHERE (SELECT ...) IS NOT NULL -> NOT ((SELECT ...) IS NULL)
+                is_sql = self.wrap(is_sql)
+
+            return is_sql

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -526,6 +526,10 @@ class TestClickhouse(Validator):
             "SELECT * FROM ABC WHERE hasAny(COLUMNS('.*field') APPLY(toUInt64) APPLY(to), (SELECT groupUniqArray(toUInt64(field))))"
         )
         self.validate_identity("SELECT col apply", "SELECT col AS apply")
+        self.validate_identity(
+            "SELECT name FROM data WHERE (SELECT DISTINCT name FROM data) IS NOT NULL",
+            "SELECT name FROM data WHERE NOT ((SELECT DISTINCT name FROM data) IS NULL)",
+        )
 
     def test_clickhouse_values(self):
         values = exp.select("*").from_(


### PR DESCRIPTION
Fixes #4285

Consider the query:

```SQL
WITH data AS (SELECT 'a' AS name) 
SELECT name FROM data 
WHERE (SELECT DISTINCT name FROM data) IS NOT NULL;
```

This will be roundtripped across all dialects as:

```SQL
WITH data AS (SELECT 'a' AS name) 
SELECT name FROM data 
WHERE NOT (SELECT DISTINCT name FROM data) IS NULL;
```

Which invalid for Clickhouse in particular. Wrapping the `IS` expression restores the functionality:

```SQL
ch> with data as (select 'a' as name) SELECT name FROM data WHERE NOT (SELECT DISTINCT name FROM data) IS NULL;

Expected one of: token, Dot, Comma, ClosingRoundBracket, OR, AND, IS NOT DISTINCT FROM, IS NULL, IS NOT NULL, BETWEEN, NOT BETWEEN, LIKE, ILIKE, NOT LIKE, NOT ILIKE, REGEXP, IN, NOT IN, GLOBAL IN, GLOBAL NOT IN, MOD, DIV, alias, AS


ch> with data as (select 'a' as name) SELECT name FROM data WHERE NOT ((SELECT DISTINCT name FROM data) IS NULL);


   ┌─name─┐
1. │ a    │
   └──────┘

```


Docs
---------
[Clickhouse IS operator](https://clickhouse.com/docs/en/sql-reference/operators#is_null)
