### PR TITLE
Fix: improve support for identifier delimiter escaping

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -183,6 +183,7 @@ class ClickHouse(Dialect):
     class Tokenizer(tokens.Tokenizer):
         COMMENTS = ["--", "#", "#!", ("/*", "*/")]
         IDENTIFIERS = ['"', "`"]
+        IDENTIFIER_ESCAPES = ["\\"]
         STRING_ESCAPES = ["'", "\\"]
         BIT_STRINGS = [("0b", "")]
         HEX_STRINGS = [("0x", ""), ("0X", "")]

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -608,10 +608,14 @@ class Tokenizer(metaclass=_Tokenizer):
     HEREDOC_STRINGS: t.List[str | t.Tuple[str, str]] = []
     UNICODE_STRINGS: t.List[str | t.Tuple[str, str]] = []
     IDENTIFIERS: t.List[str | t.Tuple[str, str]] = ['"']
-    IDENTIFIER_ESCAPES = ['"']
     QUOTES: t.List[t.Tuple[str, str] | str] = ["'"]
     STRING_ESCAPES = ["'"]
     VAR_SINGLE_TOKENS: t.Set[str] = set()
+
+    # The strings in this list can always be used as escapes, regardless of the surrounding
+    # identifier delimiters. By default, the closing delimiter is assumed to also act as an
+    # identifier escape, e.g. if we use double-quotes, then they also act as escapes: "x"""
+    IDENTIFIER_ESCAPES: t.List[str] = []
 
     # Whether the heredoc tags follow the same lexical rules as unquoted identifiers
     HEREDOC_TAG_IS_IDENTIFIER = False
@@ -1361,7 +1365,9 @@ class Tokenizer(metaclass=_Tokenizer):
 
     def _scan_identifier(self, identifier_end: str) -> None:
         self._advance()
-        text = self._extract_string(identifier_end, escapes=self._IDENTIFIER_ESCAPES)
+        text = self._extract_string(
+            identifier_end, escapes=self._IDENTIFIER_ESCAPES | {identifier_end}
+        )
         self._add(TokenType.IDENTIFIER, text)
 
     def _scan_var(self) -> None:

--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -609,8 +609,11 @@ impl<'a> TokenizerState<'a> {
         let mut text = String::from("");
 
         loop {
+            let mut new_identifier_escapes;
             let escapes = if use_identifier_escapes {
-                &self.settings.identifier_escapes
+                new_identifier_escapes = self.settings.identifier_escapes.clone();
+                new_identifier_escapes.extend(delimiter.chars());
+                &new_identifier_escapes
             } else {
                 &self.settings.string_escapes
             };


### PR DESCRIPTION
Our current assumptions around identifier delimiter escaping were wrong -- most importantly, we used `"` as an escape for all dialects, which isn't correct. I investigated what different dialects do and this is what I came up with:

```
ClickHouse, Databricks, Hive, MySQL, Spark, SQLite: `c```
DuckDB, Postgres, Presto, Trino, Redshift, Snowflake, SQLite, T-SQL: "x"""
ClickHouse also allows:  "c\", `c\``
T-SQL also allows: [[x]]]
BigQuery, Oracle don't support escaping identifier delimiters
```

As you can see, the most common rule is that the escape character is identical to the closing identifier delimiter. ClickHouse is an exception, because it also allows `\` to be used as an escape regardless of the surrounding context.
