### PR TITLE
fix(sqlite): Fix UNIQUE parsing

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -120,6 +120,24 @@ class SQLite(Dialect):
         }
         STRING_ALIASES = True
 
+        def _parse_field_def(self) -> t.Optional[exp.Expression]:
+            field_def = self._parse_field(any_token=True)
+
+            if not self._match_set(self.TYPE_TOKENS, advance=False):
+                # SQLite allows implicit aliases in DDLs, e.g
+                # CREATE TABLE foo (bar baz TEXT)
+                field_def = self._parse_alias(field_def)
+
+            return self._parse_column_def(field_def)
+
+        def _parse_unique(self) -> exp.UniqueColumnConstraint:
+            # Do not consume more tokens if UNIQUE is used as a standalone constraint, e.g:
+            # CREATE TABLE foo (bar TEXT UNIQUE REFERENCES baz ...)
+            if self._curr.text.upper() in self.CONSTRAINT_PARSERS:
+                return self.expression(exp.UniqueColumnConstraint)
+
+            return super()._parse_unique()
+
     class Generator(generator.Generator):
         JOIN_HINTS = False
         TABLE_HINTS = False
@@ -288,3 +306,14 @@ class SQLite(Dialect):
             this = expression.this
             this = f" {this}" if this else ""
             return f"BEGIN{this} TRANSACTION"
+
+        def alias_sql(self, expression: exp.Alias) -> str:
+            if not isinstance(expression.parent, exp.ColumnDef):
+                return super().alias_sql(expression)
+
+            # If this is a ColumnDef alias (part of DDL) then we must not
+            # generate the "AS" prefix:
+            #  - CREATE TABLE foo (bar baz TEXT) -> fine
+            #  - CREATE TABLE foo (bar AS baz TEXT) -> error
+            alias = self.sql(expression, "alias")
+            return f"{self.sql(expression, 'this')} {alias}"

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -222,3 +222,10 @@ class TestSQLite(Validator):
                 "mysql": "CREATE TABLE `x` (`Name` VARCHAR(200) NOT NULL)",
             },
         )
+
+        self.validate_identity(
+            "CREATE TABLE store (store_id INTEGER PRIMARY KEY AUTOINCREMENT, mgr_id INTEGER NOT NULL UNIQUE REFERENCES staff ON UPDATE CASCADE)"
+        )
+        self.validate_identity(
+            "CREATE TABLE tbl (col1 TEXT, col2 col2_alias TEXT, CONSTRAINT pk_cons PRIMARY KEY (col1, carcol2), CONSTRAINT fk_cons FOREIGN KEY (col2) REFERENCES tbl2 (id) ON UPDATE CASCADE ON DELETE CASCADE)"
+        )

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -226,6 +226,3 @@ class TestSQLite(Validator):
         self.validate_identity(
             "CREATE TABLE store (store_id INTEGER PRIMARY KEY AUTOINCREMENT, mgr_id INTEGER NOT NULL UNIQUE REFERENCES staff ON UPDATE CASCADE)"
         )
-        self.validate_identity(
-            "CREATE TABLE tbl (col1 TEXT, col2 col2_alias TEXT, CONSTRAINT pk_cons PRIMARY KEY (col1, carcol2), CONSTRAINT fk_cons FOREIGN KEY (col2) REFERENCES tbl2 (id) ON UPDATE CASCADE ON DELETE CASCADE)"
-        )


### PR DESCRIPTION
Fixes #4291

The following issues appear throughout these cases are the following:

1. `UNIQUE` can be used as a standalone column constraint:
```SQL
CREATE TABLE foo (bar TEXT UNIQUE REFERENCES "baz")
```

However, `parser.py::_parse_unique()` can end up consuming the following constraints, so this PR overrides it to add the appropriate lookahead.

2. ~Implicit aliases can be used in column definitions, e.g:~
```SQL
CREATE TABLE foo (bar baz TEXT) -> fine
CREATE TABLE foo (bar AS baz TEXT) -> error
```

~Which is solved by overriding `parser.py::_parse_field_def()` to also parse the alias & generating it back without the `AS` prefix.~
