### PR TITLE
fix(generator): Add NULL FILTER on ARRAY_AGG only for columns

### DIFF
--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -315,6 +315,20 @@ TBLPROPERTIES (
             },
         )
         self.validate_all(
+            "SELECT ARRAY_AGG(1)",
+            write={
+                "duckdb": "SELECT ARRAY_AGG(1)",
+                "spark": "SELECT COLLECT_LIST(1)",
+            },
+        )
+        self.validate_all(
+            "SELECT ARRAY_AGG(DISTINCT STRUCT('a'))",
+            write={
+                "duckdb": "SELECT ARRAY_AGG(DISTINCT {'col1': 'a'})",
+                "spark": "SELECT COLLECT_LIST(DISTINCT STRUCT('a' AS col1))",
+            },
+        )
+        self.validate_all(
             "SELECT DATE_FORMAT(DATE '2020-01-01', 'EEEE') AS weekday",
             write={
                 "presto": "SELECT DATE_FORMAT(CAST(CAST('2020-01-01' AS DATE) AS TIMESTAMP), '%W') AS weekday",


### PR DESCRIPTION
Fixes #4300

https://github.com/tobymao/sqlglot/pull/4033 was introduced to solve the transpilation of `ARRAY_AGG` from dialects that exclude `NULL` values (e.g. Spark) to those that don't (e.g. DuckDB) by adding a `FILTER` on it.

However, this (1) doesn't have to be added if the input is not a column and (2) even if it was kept as a no-op, DuckDB seems to hit on internal errors as is reported on the issue.



