### PR TITLE
feat(postgres): Support JSONB_EXISTS

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -536,6 +536,7 @@ class DuckDB(Dialect):
             exp.IntDiv: lambda self, e: self.binary(e, "//"),
             exp.IsInf: rename_func("ISINF"),
             exp.IsNan: rename_func("ISNAN"),
+            exp.JSONBExists: rename_func("JSON_EXISTS"),
             exp.JSONExtract: _arrow_json_extract_sql,
             exp.JSONExtractScalar: _arrow_json_extract_sql,
             exp.JSONFormat: _json_format_sql,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -370,6 +370,7 @@ class Postgres(Dialect):
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
             "DATE_PART": lambda self: self._parse_date_part(),
+            "JSONB_EXISTS": lambda self: self._parse_jsonb_exists(),
         }
 
         BITWISE = {
@@ -442,6 +443,14 @@ class Postgres(Dialect):
 
         def _parse_unique_key(self) -> t.Optional[exp.Expression]:
             return None
+
+        def _parse_jsonb_exists(self) -> exp.JSONBExists:
+            return self.expression(
+                exp.JSONBExists,
+                this=self._parse_bitwise(),
+                path=self._match(TokenType.COMMA)
+                and self.dialect.to_json_path(self._parse_bitwise()),
+            )
 
     class Generator(generator.Generator):
         SINGLE_STRING_INTERVAL = True

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5960,6 +5960,11 @@ class JSONBContains(Binary, Func):
     _sql_names = ["JSONB_CONTAINS"]
 
 
+class JSONBExists(Func):
+    arg_types = {"this": True, "path": True}
+    _sql_names = ["JSONB_EXISTS"]
+
+
 class JSONExtract(Binary, Func):
     arg_types = {
         "this": True,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -797,6 +797,14 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT OVERLAY(a PLACING b FROM 1 FOR 1)")
         self.validate_identity("ARRAY[1, 2, 3] && ARRAY[1, 2]").assert_is(exp.ArrayOverlaps)
 
+        self.validate_all(
+            """SELECT JSONB_EXISTS('{"a": [1,2,3]}', 'a')""",
+            write={
+                "postgres": """SELECT JSONB_EXISTS('{"a": [1,2,3]}', 'a')""",
+                "duckdb": """SELECT JSON_EXISTS('{"a": [1,2,3]}', '$.a')""",
+            },
+        )
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(


### PR DESCRIPTION
Fixes #4299

Postgres's `JSONB_EXISTS` is not properly documented but it can be queried & used as following:

```SQL
vaggelisd=# select proname,prosrc from pg_proc where proname= 'jsonb_exists';
   proname    |    prosrc
--------------+--------------
 jsonb_exists | jsonb_exists
(1 row)

vaggelisd=# \sf jsonb_exists
CREATE OR REPLACE FUNCTION pg_catalog.jsonb_exists(jsonb, text)
 RETURNS boolean
 LANGUAGE internal
 IMMUTABLE PARALLEL SAFE STRICT
AS $function$jsonb_exists$function$


vaggelisd=# SELECT JSONB_EXISTS('{"a": [1,2,3]}', 'a');
 jsonb_exists
--------------
 t
(1 row)

vaggelisd=# SELECT JSONB_EXISTS('{"a": [1,2,3]}', 'b');
 jsonb_exists
--------------
 f
(1 row)

```

Docs
-----------
[Postgres JSONB_EXISTS](https://stackoverflow.com/questions/43862936/postgresql-where-in-jsonb) | [Postgres JSON vs JSONB](https://stackoverflow.com/questions/68820299/json-vs-jsonb-postgresql) | [DuckDB JSON_EXISTS](https://duckdb.org/docs/data/json/json_functions)
