### PR TITLE
feat(snowflake)!: Transpile BQ's TIMESTAMP() function

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -336,6 +336,7 @@ class Presto(Dialect):
             exp.DataType.Type.STRUCT: "ROW",
             exp.DataType.Type.TEXT: "VARCHAR",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
+            exp.DataType.Type.TIMESTAMPNTZ: "TIMESTAMP",
             exp.DataType.Type.TIMETZ: "TIME",
         }
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -23,6 +23,7 @@ from sqlglot.dialects.dialect import (
     var_map_sql,
     map_date_part,
     no_safe_divide_sql,
+    no_timestamp_sql,
 )
 from sqlglot.helper import flatten, is_float, is_int, seq_get
 from sqlglot.tokens import TokenType
@@ -840,6 +841,7 @@ class Snowflake(Dialect):
             ),
             exp.Stuff: rename_func("INSERT"),
             exp.TimeAdd: date_delta_sql("TIMEADD"),
+            exp.Timestamp: no_timestamp_sql,
             exp.TimestampDiff: lambda self, e: self.func(
                 "TIMESTAMPDIFF", e.unit, e.expression, e.this
             ),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -371,7 +371,16 @@ LANGUAGE js AS
             write={
                 "bigquery": "TIMESTAMP(x)",
                 "duckdb": "CAST(x AS TIMESTAMPTZ)",
+                "snowflake": "CAST(x AS TIMESTAMPTZ)",
                 "presto": "CAST(x AS TIMESTAMP WITH TIME ZONE)",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP('2008-12-25 15:30:00', 'America/Los_Angeles')",
+            write={
+                "bigquery": "SELECT TIMESTAMP('2008-12-25 15:30:00', 'America/Los_Angeles')",
+                "duckdb": "SELECT CAST('2008-12-25 15:30:00' AS TIMESTAMP) AT TIME ZONE 'America/Los_Angeles'",
+                "snowflake": "SELECT CONVERT_TIMEZONE('America/Los_Angeles', CAST('2008-12-25 15:30:00' AS TIMESTAMP))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -414,13 +414,6 @@ class TestPresto(Validator):
             "CAST(x AS TIMESTAMP)",
             read={"mysql": "TIMESTAMP(x)"},
         )
-        self.validate_all(
-            "TIMESTAMP(x, 'America/Los_Angeles')",
-            write={
-                "duckdb": "CAST(x AS TIMESTAMP) AT TIME ZONE 'America/Los_Angeles'",
-                "presto": "AT_TIMEZONE(CAST(x AS TIMESTAMP), 'America/Los_Angeles')",
-            },
-        )
         # this case isn't really correct, but it's a fall back for mysql's version
         self.validate_all(
             "TIMESTAMP(x, '12:00:00')",


### PR DESCRIPTION
BigQuery supports `TIMESTAMP(<expr>[, zone])` function for `TIMESTAMP` construction. Today, this is parsed in BQ and transpiled to other dialects (DuckDB, Presto/Trino) through the `no_timestamp_sql` helper which generates either a cast (1-arg version) or an `AT TIME ZONE` expression if a `zone` is present (2-arg version).

However, the 2-arg version transpilation does not seem correct; BigQuery's `TIMESTAMP`s are always stored at UTC which is not the case for other dialects. In main branch, these are the transpilations & their results today:

```SQL
bigquery> SELECT TIMESTAMP('2008-12-25 15:30:00', 'America/Los_Angeles')
2008-12-25 23:30:00 UTC

presto> SELECT AT_TIMEZONE(CAST('2008-12-25 15:30:00' AS TIMESTAMP), 'America/Los_Angeles');
2008-12-25 07:30:00.000 America/Los_Angeles

duckdb> SELECT CAST('2008-12-25 15:30:00' AS TIMESTAMP) AT TIME ZONE 'America/Los_Angeles';
2008-12-26 01:30:00+02
```

This PR:
- Fixes this by changing `exp.AtTimeZone` to `exp.ConvertTimezone`, which will first evaluate the timestamp at the user-inputted `zone` and _then_ convert it to UTC
- Adds `no_timestamp_sql` to Snowflake to enable the transpilation path

The new transpilations and their results on this branch are the following:

```SQL
duckdb> SELECT CAST('2008-12-25 15:30:00' AS TIMESTAMP) AT TIME ZONE 'America/Los_Angeles' AT TIME ZONE 'UTC';
2008-12-25 23:30:00

snowflake> SELECT CONVERT_TIMEZONE('America/Los_Angeles', 'UTC', CAST('2008-12-25 15:30:00' AS TIMESTAMP));
2008-12-25 23:30:00.000

 presto> SELECT AT_TIMEZONE(AT_TIMEZONE(CAST('2008-12-25 15:30:00' AS TIMESTAMP), 'America/Los_Angeles'), 'UTC');
2008-12-25 15:30:00.000 UTC
```

Note that although DuckDB & Snowflake now match BQ's results, Presto/Trino are still off; The reason for that is that the first `AT_TIMEZONE` does a `<session zone> -> <zone>` conversion instead of pushing the `zone` into the timestamp which would allow for the `UTC` conversion to work. 

Docs
--------
[BigQuery TIMESTAMP](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp) | [Snowflake CONVERT_TIMEZONE](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone)
