### PR TITLE
feat!: Support MEDIAN() function

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -431,6 +431,7 @@ class ClickHouse(Dialect):
             **parser.Parser.FUNCTION_PARSERS,
             "ARRAYJOIN": lambda self: self.expression(exp.Explode, this=self._parse_expression()),
             "QUANTILE": lambda self: self._parse_quantile(),
+            "MEDIAN": lambda self: self._parse_quantile(),
             "COLUMNS": lambda self: self._parse_columns(),
         }
 
@@ -950,6 +951,9 @@ class ClickHouse(Dialect):
             exp.Map: lambda self, e: _lower_func(var_map_sql(self, e)),
             exp.Nullif: rename_func("nullIf"),
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
+            exp.PercentileCont: lambda self, e: self.sql(
+                exp.Quantile(this=e.this, quantile=e.expression)
+            ),
             exp.Pivot: no_pivot_sql,
             exp.Quantile: _quantile_sql,
             exp.RegexpLike: lambda self, e: self.func("match", e.this, e.expression),

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -951,9 +951,6 @@ class ClickHouse(Dialect):
             exp.Map: lambda self, e: _lower_func(var_map_sql(self, e)),
             exp.Nullif: rename_func("nullIf"),
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
-            exp.PercentileCont: lambda self, e: self.sql(
-                exp.Quantile(this=e.this, quantile=e.expression)
-            ),
             exp.Pivot: no_pivot_sql,
             exp.Quantile: _quantile_sql,
             exp.RegexpLike: lambda self, e: self.func("match", e.this, e.expression),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -374,9 +374,6 @@ class DuckDB(Dialect):
             "LIST_VALUE": lambda args: exp.Array(expressions=args),
             "MAKE_TIME": exp.TimeFromParts.from_arg_list,
             "MAKE_TIMESTAMP": _build_make_timestamp,
-            "MEDIAN": lambda args: exp.PercentileCont(
-                this=seq_get(args, 0), expression=exp.Literal.number(0.5)
-            ),
             "QUANTILE_CONT": exp.PercentileCont.from_arg_list,
             "QUANTILE_DISC": exp.PercentileDisc.from_arg_list,
             "REGEXP_EXTRACT": build_regexp_extract,
@@ -494,6 +491,7 @@ class DuckDB(Dialect):
         STAR_EXCEPT = "EXCLUDE"
         PAD_FILL_PATTERN_IS_REQUIRED = True
         ARRAY_CONCAT_IS_VAR_LEN = False
+        SUPPORTS_MEDIAN = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -491,7 +491,6 @@ class DuckDB(Dialect):
         STAR_EXCEPT = "EXCLUDE"
         PAD_FILL_PATTERN_IS_REQUIRED = True
         ARRAY_CONCAT_IS_VAR_LEN = False
-        SUPPORTS_MEDIAN = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -460,6 +460,7 @@ class Hive(Dialect):
         WITH_PROPERTIES_PREFIX = "TBLPROPERTIES"
         PARSE_JSON_NAME = None
         PAD_FILL_PATTERN_IS_REQUIRED = True
+        SUPPORTS_MEDIAN = False
 
         EXPRESSIONS_WITHOUT_NESTED_CTES = {
             exp.Insert,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -704,6 +704,7 @@ class MySQL(Dialect):
         PAD_FILL_PATTERN_IS_REQUIRED = True
         WRAP_DERIVED_VALUES = False
         VARCHAR_REQUIRES_SIZE = True
+        SUPPORTS_MEDIAN = False
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -324,6 +324,7 @@ class Oracle(Dialect):
         SUPPORTS_SELECT_INTO = True
         TZ_TO_WITH_TIME_ZONE = True
         QUERY_HINT_SEP = " "
+        SUPPORTS_MEDIAN = True
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -324,7 +324,6 @@ class Oracle(Dialect):
         SUPPORTS_SELECT_INTO = True
         TZ_TO_WITH_TIME_ZONE = True
         QUERY_HINT_SEP = " "
-        SUPPORTS_MEDIAN = True
 
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -471,6 +471,7 @@ class Postgres(Dialect):
         CAN_IMPLEMENT_ARRAY_ANY = True
         COPY_HAS_INTO_KEYWORD = False
         ARRAY_CONCAT_IS_VAR_LEN = False
+        SUPPORTS_MEDIAN = False
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -317,6 +317,7 @@ class Presto(Dialect):
         PARSE_JSON_NAME = "JSON_PARSE"
         PAD_FILL_PATTERN_IS_REQUIRED = True
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+        SUPPORTS_MEDIAN = False
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -157,6 +157,7 @@ class Redshift(Postgres):
         ARRAY_CONCAT_IS_VAR_LEN = False
         SUPPORTS_CONVERT_TIMEZONE = True
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+        SUPPORTS_MEDIAN = True
 
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -331,9 +331,6 @@ class Snowflake(Dialect):
             "LEN": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
             "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
             "LISTAGG": exp.GroupConcat.from_arg_list,
-            "MEDIAN": lambda args: exp.PercentileCont(
-                this=seq_get(args, 0), expression=exp.Literal.number(0.5)
-            ),
             "NULLIFZERO": _build_if_from_nullifzero,
             "OBJECT_CONSTRUCT": _build_object_construct,
             "REGEXP_REPLACE": _build_regexp_replace,
@@ -770,6 +767,7 @@ class Snowflake(Dialect):
         ARRAY_CONCAT_IS_VAR_LEN = False
         SUPPORTS_CONVERT_TIMEZONE = True
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+        SUPPORTS_MEDIAN = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -136,6 +136,7 @@ class Spark(Spark2):
         SUPPORTS_TO_NUMBER = True
         PAD_FILL_PATTERN_IS_REQUIRED = False
         SUPPORTS_CONVERT_TIMEZONE = True
+        SUPPORTS_MEDIAN = True
 
         TYPE_MAPPING = {
             **Spark2.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -138,6 +138,7 @@ class SQLite(Dialect):
         SUPPORTS_TABLE_ALIAS_COLUMNS = False
         SUPPORTS_TO_NUMBER = False
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+        SUPPORTS_MEDIAN = False
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6135,6 +6135,10 @@ class MD5Digest(Func):
     _sql_names = ["MD5_DIGEST"]
 
 
+class Median(AggFunc):
+    pass
+
+
 class Min(AggFunc):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -434,7 +434,7 @@ class Generator(metaclass=_Generator):
     SUPPORTS_CONVERT_TIMEZONE = False
 
     # Whether MEDIAN(expr) is supported; if not, it will be generated as PERCENTILE_CONT(expr, 0.5)
-    SUPPORTS_MEDIAN = False
+    SUPPORTS_MEDIAN = True
 
     # The name to generate for the JSONPath expression. If `None`, only `this` will be generated
     PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -433,6 +433,9 @@ class Generator(metaclass=_Generator):
     # Whether CONVERT_TIMEZONE() is supported; if not, it will be generated as exp.AtTimeZone
     SUPPORTS_CONVERT_TIMEZONE = False
 
+    # Whether MEDIAN(expr) is supported; if not, it will be generated as PERCENTILE_CONT(expr, 0.5)
+    SUPPORTS_MEDIAN = False
+
     # The name to generate for the JSONPath expression. If `None`, only `this` will be generated
     PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
 
@@ -4455,3 +4458,11 @@ class Generator(metaclass=_Generator):
             )
 
         return self.sql(exp.cast(this, exp.DataType.Type.VARCHAR))
+
+    def median_sql(self, expression: exp.Median):
+        if not self.SUPPORTS_MEDIAN:
+            return self.sql(
+                exp.PercentileCont(this=expression.this, expression=exp.Literal.number(0.5))
+            )
+
+        return self.function_fallback_sql(expression)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -428,8 +428,13 @@ class TestClickhouse(Validator):
         )
         self.validate_all(
             "SELECT quantile(0.5)(a)",
-            read={"duckdb": "SELECT quantile(a, 0.5)"},
-            write={"clickhouse": "SELECT quantile(0.5)(a)"},
+            read={
+                "duckdb": "SELECT quantile(a, 0.5)",
+                "clickhouse": "SELECT median(a)",
+            },
+            write={
+                "clickhouse": "SELECT quantile(0.5)(a)",
+            },
         )
         self.validate_all(
             "SELECT quantiles(0.5, 0.4)(a)",

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2991,7 +2991,7 @@ FROM subquery2""",
             " OVER ()",
         ):
             self.validate_all(
-                f"PERCENTILE_CONT(x, 0.5){suffix}",
+                f"MEDIAN(x){suffix}",
                 read={
                     "snowflake": f"MEDIAN(x){suffix}",
                     "duckdb": f"MEDIAN(x){suffix}",
@@ -3001,19 +3001,13 @@ FROM subquery2""",
                     "oracle": f"MEDIAN(x){suffix}",
                 },
                 write={
-                    "": f"PERCENTILE_CONT(x, 0.5){suffix}",
-                },
-            )
-            self.validate_all(
-                f"MEDIAN(x){suffix}",
-                write={
                     "snowflake": f"MEDIAN(x){suffix}",
                     "duckdb": f"MEDIAN(x){suffix}",
                     "spark": f"MEDIAN(x){suffix}",
                     "databricks": f"MEDIAN(x){suffix}",
                     "redshift": f"MEDIAN(x){suffix}",
                     "oracle": f"MEDIAN(x){suffix}",
-                    "clickhouse": f"quantile(0.5)(x){suffix}",
+                    "clickhouse": f"MEDIAN(x){suffix}",
                     "postgres": f"PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                 },
             )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2984,3 +2984,36 @@ FROM subquery2""",
                         "tsql": 'SELECT 1 AS [x"]',
                     },
                 )
+
+    def test_median(self):
+        for suffix in (
+            "",
+            " OVER ()",
+        ):
+            self.validate_all(
+                f"PERCENTILE_CONT(x, 0.5){suffix}",
+                read={
+                    "snowflake": f"MEDIAN(x){suffix}",
+                    "duckdb": f"MEDIAN(x){suffix}",
+                    "spark": f"MEDIAN(x){suffix}",
+                    "databricks": f"MEDIAN(x){suffix}",
+                    "redshift": f"MEDIAN(x){suffix}",
+                    "oracle": f"MEDIAN(x){suffix}",
+                },
+                write={
+                    "": f"PERCENTILE_CONT(x, 0.5){suffix}",
+                },
+            )
+            self.validate_all(
+                f"MEDIAN(x){suffix}",
+                write={
+                    "snowflake": f"MEDIAN(x){suffix}",
+                    "duckdb": f"MEDIAN(x){suffix}",
+                    "spark": f"MEDIAN(x){suffix}",
+                    "databricks": f"MEDIAN(x){suffix}",
+                    "redshift": f"MEDIAN(x){suffix}",
+                    "oracle": f"MEDIAN(x){suffix}",
+                    "clickhouse": f"quantile(0.5)(x){suffix}",
+                    "postgres": f"PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
+                },
+            )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -752,14 +752,6 @@ class TestDuckDB(Validator):
                 "snowflake": "SELECT PERCENTILE_DISC(q) WITHIN GROUP (ORDER BY x) FROM t",
             },
         )
-        self.validate_all(
-            "SELECT MEDIAN(x) FROM t",
-            write={
-                "duckdb": "SELECT QUANTILE_CONT(x, 0.5) FROM t",
-                "postgres": "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x) FROM t",
-                "snowflake": "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x) FROM t",
-            },
-        )
 
         with self.assertRaises(UnsupportedError):
             transpile(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -524,21 +524,11 @@ WHERE
             self.validate_all(
                 f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                 read={
-                    "snowflake": f"SELECT MEDIAN(x){suffix}",
                     "postgres": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                 },
                 write={
                     "": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x NULLS LAST){suffix}",
                     "duckdb": f"SELECT QUANTILE_CONT(x, 0.5 ORDER BY x){suffix}",
-                    "postgres": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
-                    "snowflake": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
-                },
-            )
-            self.validate_all(
-                f"SELECT MEDIAN(x){suffix}",
-                write={
-                    "": f"SELECT PERCENTILE_CONT(x, 0.5){suffix}",
-                    "duckdb": f"SELECT QUANTILE_CONT(x, 0.5){suffix}",
                     "postgres": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                     "snowflake": f"SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                 },


### PR DESCRIPTION
Fixes #4315

This PR adds support for `MEDIAN(<expr>)` across major dialects (DuckDB, Spark3, Databricks, Snowflake, Redshift, Clickhouse, Oracle). For the dialects that don't support it, the transpilation remains as `PERCENTILE_CONT(<expr>, 0.5)` which is a best-effort attempt.

Note: BigQuery supports `PERCENTILE_CONT(...)` only as a window function

Docs
---------
- [Oracle MEDIAN](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/MEDIAN.html) | [DuckDB](https://duckdb.org/docs/sql/functions/aggregates.html#medianx) | [Clickhouse MEDIAN/QUANTILE](https://clickhouse.com/docs/en/sql-reference/aggregate-functions/reference/quantile#quantile) | [Redshift MEDIAN](https://docs.aws.amazon.com/redshift/latest/dg/r_MEDIAN.html) | [Spark/Databricks MEDIAN](https://docs.databricks.com/en/sql/language-manual/functions/median.html) | [Snowflake MEDIAN](https://docs.snowflake.com/en/sql-reference/functions/median) 

- [BigQuery PERCENTILE_CONT](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#percentile_cont) | [Postgres PERCENTILE_CONT](https://www.postgresql.org/docs/9.4/functions-aggregate.html#FUNCTIONS-ORDEREDSET-TABLE)

