### PR TITLE
fix(tsql): Generate LOG(...) for exp.Ln

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -901,6 +901,7 @@ class TSQL(Dialect):
             exp.JSONExtract: _json_extract_sql,
             exp.JSONExtractScalar: _json_extract_sql,
             exp.LastDay: lambda self, e: self.func("EOMONTH", e.this),
+            exp.Ln: rename_func("LOG"),
             exp.Max: max_or_greatest,
             exp.MD5: lambda self, e: self.func("HASHBYTES", exp.Literal.string("MD5"), e.this),
             exp.Min: min_or_least,

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -411,6 +411,7 @@ class TestTSQL(Validator):
             },
         )
         self.validate_identity("HASHBYTES('MD2', 'x')")
+        self.validate_identity("LOG(n)")
         self.validate_identity("LOG(n, b)")
 
         self.validate_all(


### PR DESCRIPTION
Fixes #4316

In T-SQL, `LOG(n)` returns the natural logarithm. For this reason, through the dialect flag `LOG_DEFAULTS_TO_LN` it's parsed into `exp.Ln`.

However, this is not a supported T-SQL function so `exp.Ln` must be generated back to `LOG(n)`

Docs
---------
[T-SQL LOG](https://learn.microsoft.com/en-us/sql/t-sql/functions/log-transact-sql?view=sql-server-ver16)