### PR TITLE
Adds hexadecimal literal support for Teradata

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -71,6 +71,9 @@ class Teradata(Dialect):
     }
 
     class Tokenizer(tokens.Tokenizer):
+        # Tested each of these and they work, although there is no
+        # Teradata documentation explicitly mentioning them.
+        HEX_STRINGS = [("X'", "'"), ("x'", "'"), ("0x", "")]
         # https://docs.teradata.com/r/Teradata-Database-SQL-Functions-Operators-Expressions-and-Predicates/March-2017/Comparison-Operators-and-Functions/Comparison-Operators/ANSI-Compliance
         # https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Arithmetic-Trigonometric-Hyperbolic-Operators/Functions
         KEYWORDS = {

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -388,7 +388,7 @@ class TestMySQL(Validator):
             "sqlite": "SELECT x'CC'",
             "starrocks": "SELECT x'CC'",
             "tableau": "SELECT 204",
-            "teradata": "SELECT 204",
+            "teradata": "SELECT X'CC'",
             "trino": "SELECT X'CC'",
             "tsql": "SELECT 0xCC",
         }
@@ -409,7 +409,7 @@ class TestMySQL(Validator):
             "sqlite": "SELECT x'0000CC'",
             "starrocks": "SELECT x'0000CC'",
             "tableau": "SELECT 204",
-            "teradata": "SELECT 204",
+            "teradata": "SELECT X'0000CC'",
             "trino": "SELECT X'0000CC'",
             "tsql": "SELECT 0x0000CC",
         }

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -33,6 +33,19 @@ class TestTeradata(Validator):
         )
 
         self.validate_identity(
+            "SELECT 0x1d",
+            "SELECT X'1d'"
+        )
+        self.validate_identity(
+            "SELECT X'1D'",
+            "SELECT X'1D'"
+        )
+        self.validate_identity(
+            "SELECT x'1d'",
+            "SELECT X'1d'"
+        )
+
+        self.validate_identity(
             "RENAME TABLE emp TO employee", check_command_warning=True
         ).assert_is(exp.Command)
 


### PR DESCRIPTION
I've added hexadecimal literal support to the Teradata Tokenizer similar to what is done with MySQL per the recommendation of @georgesittas. Let me know if there are additional tests I should add or other pieces of code that need to be adapted.