### PR TITLE
feat(duckdb): support flags for RegexpExtract

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -742,13 +742,6 @@ class BigQuery(Dialect):
             exp.MD5Digest: rename_func("MD5"),
             exp.Min: min_or_least,
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
-            exp.RegexpExtract: lambda self, e: self.func(
-                "REGEXP_EXTRACT",
-                e.this,
-                e.expression,
-                e.args.get("position"),
-                e.args.get("occurrence"),
-            ),
             exp.RegexpReplace: regexp_replace_sql,
             exp.RegexpLike: rename_func("REGEXP_CONTAINS"),
             exp.ReturnsProperty: _returnsproperty_sql,
@@ -1042,3 +1035,13 @@ class BigQuery(Dialect):
             if expression.name == "TIMESTAMP":
                 expression.set("this", "SYSTEM_TIME")
             return super().version_sql(expression)
+
+        @generator.unsupported_args("group", "parameters")
+        def regexpextract_sql(self, e: exp.RegexpExtract) -> str:
+            return self.func(
+                "REGEXP_EXTRACT",
+                e.this,
+                e.expression,
+                e.args.get("position"),
+                e.args.get("occurrence"),
+            )

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1698,6 +1698,7 @@ def build_regexp_extract(args: t.List, dialect: Dialect) -> exp.RegexpExtract:
         this=seq_get(args, 0),
         expression=seq_get(args, 1),
         group=seq_get(args, 2) or exp.Literal.number(dialect.REGEXP_EXTRACT_DEFAULT_GROUP),
+        parameters=seq_get(args, 3),
     )
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6221,11 +6221,11 @@ class Reduce(Func):
 class RegexpExtract(Func):
     arg_types = {
         "this": True,
-        "expression": True,
-        "position": False,
-        "occurrence": False,
-        "parameters": False,
-        "group": False,
+        "expression": True,  # The pattern
+        "position": False,  # Only start searching the string from this index
+        "occurrence": False,  # Skip the first `occurence-1` matches
+        "parameters": False,  # Flags, eg "i" for case-insensitive
+        "group": False,  # Which group to return
     }
 
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -754,12 +754,56 @@ class TestDuckDB(Validator):
         )
 
         with self.assertRaises(UnsupportedError):
+            # bq has the position arg, but duckdb doesn't
             transpile(
                 "SELECT REGEXP_EXTRACT(a, 'pattern', 1) from table",
                 read="bigquery",
                 write="duckdb",
                 unsupported_level=ErrorLevel.IMMEDIATE,
             )
+        with self.assertRaises(UnsupportedError):
+            # duckdb has the group arg, but bq doesn't
+            transpile(
+                "SELECT REGEXP_EXTRACT(a, 'pattern', 2) from table",
+                read="duckdb",
+                write="bigquery",
+                unsupported_level=ErrorLevel.IMMEDIATE,
+            )
+        self.validate_all(
+            "SELECT REGEXP_EXTRACT(a, 'pattern') FROM t",
+            read={
+                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern') FROM t",
+                "bigquery": "SELECT REGEXP_EXTRACT(a, 'pattern') FROM t",
+                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern') FROM t",
+            },
+            write={
+                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern') FROM t",
+                "bigquery": "SELECT REGEXP_EXTRACT(a, 'pattern') FROM t",
+                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern') FROM t",
+            },
+        )
+        self.validate_all(
+            "SELECT REGEXP_EXTRACT(a, 'pattern', 2) FROM t",
+            read={
+                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2) FROM t",
+                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, '', 2) FROM t",
+            },
+            write={
+                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2) FROM t",
+                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, 'c', 2) FROM t",
+            },
+        )
+        self.validate_all(
+            "SELECT REGEXP_EXTRACT(a, 'pattern', 2, 'i') FROM t",
+            read={
+                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2, 'i') FROM t",
+                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, 'i', 2) FROM t",
+            },
+            write={
+                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2, 'i') FROM t",
+                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, 'i', 2) FROM t",
+            },
+        )
 
         self.validate_identity("SELECT ISNAN(x)")
 


### PR DESCRIPTION
Now this works:
```python
import sqlglot as sg
import sqlglot.expressions as sge

e = sg.func(
    "regexp_extract",
    sge.convert("2023-04-15"),
    sge.convert(r"(\d+)-(\d+)-(\d+)"),
    sge.convert(["y", "m", "d"]),
    "i",
    dialect="duckdb",
)
e.sql("duckdb")
# REGEXP_EXTRACT('2023-04-15', '(\\d+)-(\\d+)-(\\d+)', ['y', 'm', 'd'], i)
```

I was mostly stumbling around as I made the tests pass, but I don't really understand if the tests in their current state are adequately exercising all the variations of reading and writing. If you give me some pointers I can add more as needed.