### PR TITLE
fix(oracle): Do not normalize time units for exp.DateTrunc

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -121,7 +121,9 @@ class Oracle(Dialect):
             "TO_TIMESTAMP": build_formatted_time(exp.StrToTime, "oracle"),
             "TO_DATE": build_formatted_time(exp.StrToDate, "oracle"),
             "TRUNC": lambda args: exp.DateTrunc(
-                unit=seq_get(args, 1) or exp.Literal.string("DD"), this=seq_get(args, 0)
+                unit=seq_get(args, 1) or exp.Literal.string("DD"),
+                this=seq_get(args, 0),
+                unabbreviate=False,
             ),
         }
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5503,11 +5503,17 @@ class DateTrunc(Func):
     arg_types = {"unit": True, "this": True, "zone": False}
 
     def __init__(self, **args):
+        # Across most dialects it's safe to unabbreviate the unit (e.g. 'Q' -> 'QUARTER') except Oracle
+        # https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ROUND-and-TRUNC-Date-Functions.html
+        unabbreviate = args.pop("unabbreviate", True)
+
         unit = args.get("unit")
         if isinstance(unit, TimeUnit.VAR_LIKE):
-            args["unit"] = Literal.string(
-                (TimeUnit.UNABBREVIATED_UNIT_NAME.get(unit.name) or unit.name).upper()
-            )
+            unit_name = unit.name
+            if unabbreviate and unit_name in TimeUnit.UNABBREVIATED_UNIT_NAME:
+                unit_name = TimeUnit.UNABBREVIATED_UNIT_NAME.get(unit_name)
+
+            args["unit"] = Literal.string(unit_name.upper())
         elif isinstance(unit, Week):
             unit.set("this", Literal.string(unit.this.name.upper()))
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5509,11 +5509,11 @@ class DateTrunc(Func):
 
         unit = args.get("unit")
         if isinstance(unit, TimeUnit.VAR_LIKE):
-            unit_name = unit.name
+            unit_name = unit.name.upper()
             if unabbreviate and unit_name in TimeUnit.UNABBREVIATED_UNIT_NAME:
-                unit_name = TimeUnit.UNABBREVIATED_UNIT_NAME.get(unit_name)
+                unit_name = TimeUnit.UNABBREVIATED_UNIT_NAME[unit_name]
 
-            args["unit"] = Literal.string(unit_name.upper())
+            args["unit"] = Literal.string(unit_name)
         elif isinstance(unit, Week):
             unit.set("this", Literal.string(unit.this.name.upper()))
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -120,13 +120,6 @@ class TestOracle(Validator):
             },
         )
         self.validate_all(
-            "TRUNC(SYSDATE, 'YEAR')",
-            write={
-                "clickhouse": "DATE_TRUNC('YEAR', CURRENT_TIMESTAMP())",
-                "oracle": "TRUNC(SYSDATE, 'YEAR')",
-            },
-        )
-        self.validate_all(
             "SELECT * FROM test WHERE MOD(col1, 4) = 3",
             read={
                 "duckdb": "SELECT * FROM test WHERE col1 % 4 = 3",
@@ -632,3 +625,20 @@ WHERE
         self.validate_identity("GRANT UPDATE, TRIGGER ON TABLE t TO anita, zhi")
         self.validate_identity("GRANT EXECUTE ON PROCEDURE p TO george")
         self.validate_identity("GRANT USAGE ON SEQUENCE order_id TO sales_role")
+
+    def test_datetrunc(self):
+        self.validate_all(
+            "TRUNC(SYSDATE, 'YEAR')",
+            write={
+                "clickhouse": "DATE_TRUNC('YEAR', CURRENT_TIMESTAMP())",
+                "oracle": "TRUNC(SYSDATE, 'YEAR')",
+            },
+        )
+
+        # Make sure units are not normalized e.g 'Q' -> 'QUARTER' and 'W' -> 'WEEK'
+        # https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ROUND-and-TRUNC-Date-Functions.html
+        for unit in (
+            "'Q'",
+            "'W'",
+        ):
+            self.validate_identity(f"TRUNC(x, {unit})")


### PR DESCRIPTION
Fixes #4321

Time unit normalizations such as unabbreviation (e.g. `Q` -> `QUARTER`) take place in expression constructors so decoupling them from specific nodes & dialects is not trivial. 

To minimize damage I went with the following arg-based approach, but if similar bugs appear for other expressions and/or dialects we probably look into establishing finer granularity (per expr and per dialect).

Docs
-------
[Oracle TRUNC units](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ROUND-and-TRUNC-Date-Functions.html#GUID-8E10AB76-21DA-490F-A389-023B648DDEF8)

