### PR TITLE
feat(snowflake): Transpile exp.TimestampSub

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1089,12 +1089,10 @@ class Snowflake(Dialect):
             )
 
         def timestampsub_sql(self, expression: exp.TimestampSub):
-            expr = expression.expression
-            if isinstance(expr, exp.Literal):
-                expr = expr.to_py()
-
             return self.sql(
                 exp.TimestampAdd(
-                    this=expression.this, expression=exp.Neg(this=expr), unit=expression.unit
+                    this=expression.this,
+                    expression=expression.expression * -1,
+                    unit=expression.unit,
                 )
             )

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1087,3 +1087,14 @@ class Snowflake(Dialect):
             return self.func(
                 f"{safe_prefix}TO_TIMESTAMP", expression.this, self.format_time(expression)
             )
+
+        def timestampsub_sql(self, expression: exp.TimestampSub):
+            expr = expression.expression
+            if isinstance(expr, exp.Literal):
+                expr = expr.to_py()
+
+            return self.sql(
+                exp.TimestampAdd(
+                    this=expression.this, expression=exp.Neg(this=expr), unit=expression.unit
+                )
+            )

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -697,14 +697,14 @@ LANGUAGE js AS
             write={
                 "bigquery": "SELECT TIMESTAMP_SUB(CAST('2008-12-25 15:30:00+00' AS TIMESTAMP), INTERVAL '10' MINUTE)",
                 "mysql": "SELECT DATE_SUB(TIMESTAMP('2008-12-25 15:30:00+00'), INTERVAL '10' MINUTE)",
-                "snowflake": "SELECT TIMESTAMPADD(MINUTE, -10, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
+                "snowflake": "SELECT TIMESTAMPADD(MINUTE, '10' * -1, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
             },
         )
         self.validate_all(
             'SELECT TIMESTAMP_SUB(TIMESTAMP "2008-12-25 15:30:00+00", INTERVAL col MINUTE)',
             write={
                 "bigquery": "SELECT TIMESTAMP_SUB(CAST('2008-12-25 15:30:00+00' AS TIMESTAMP), INTERVAL col MINUTE)",
-                "snowflake": "SELECT TIMESTAMPADD(MINUTE, -col, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
+                "snowflake": "SELECT TIMESTAMPADD(MINUTE, col * -1, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -697,6 +697,14 @@ LANGUAGE js AS
             write={
                 "bigquery": "SELECT TIMESTAMP_SUB(CAST('2008-12-25 15:30:00+00' AS TIMESTAMP), INTERVAL '10' MINUTE)",
                 "mysql": "SELECT DATE_SUB(TIMESTAMP('2008-12-25 15:30:00+00'), INTERVAL '10' MINUTE)",
+                "snowflake": "SELECT TIMESTAMPADD(MINUTE, -10, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
+            },
+        )
+        self.validate_all(
+            'SELECT TIMESTAMP_SUB(TIMESTAMP "2008-12-25 15:30:00+00", INTERVAL col MINUTE)',
+            write={
+                "bigquery": "SELECT TIMESTAMP_SUB(CAST('2008-12-25 15:30:00+00' AS TIMESTAMP), INTERVAL col MINUTE)",
+                "snowflake": "SELECT TIMESTAMPADD(MINUTE, -col, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Snowflake does not have a `TIMESTAMP_SUB` function, but it's `TIMESTAMP_ADD` can be reused by negating the value. After this PR, the transpilation is the following:

- BigQuery:
```SQL
WITH t AS (SELECT 20 AS col)
SELECT
    TIMESTAMP_SUB(TIMESTAMP "2008-12-25 15:30:00+00", INTERVAL 10 MINUTE),
    TIMESTAMP_SUB(TIMESTAMP "2008-12-25 15:30:00+00", INTERVAL col MINUTE)
FROM t;

2008-12-25 15:20:00 UTC | 2008-12-25 15:10:00 UTC
```
- Snowflake:
```SQL
WITH t AS (SELECT 20 AS col) 
SELECT 
    TIMESTAMPADD(MINUTE, -10, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ)), 
    TIMESTAMPADD(MINUTE, -col, CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ)) 
from t;

2008-12-25 15:20:00.000 +0000 | 2008-12-25 15:10:00.000 +0000
```

Docs
---------
[BQ TIMESTAMP_SUB](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp_sub) | [SF TIMESTAMP_ADD](https://docs.snowflake.com/en/sql-reference/functions/timestampadd)


