### PR TITLE
feat(BigQuery): Support JSON_VALUE()

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -182,7 +182,6 @@ LANGUAGE js AS
         self.validate_identity("SELECT y + 1 FROM x GROUP BY y + 1 ORDER BY 1")
         self.validate_identity("SELECT TIMESTAMP_SECONDS(2) AS t")
         self.validate_identity("SELECT TIMESTAMP_MILLIS(2) AS t")
-        self.validate_identity("""SELECT JSON_EXTRACT_SCALAR('{"a": 5}', '$.a')""")
         self.validate_identity("UPDATE x SET y = NULL")
         self.validate_identity("LOG(n, b)")
         self.validate_identity("SELECT COUNT(x RESPECT NULLS)")
@@ -229,9 +228,6 @@ LANGUAGE js AS
         )
         self.validate_identity(
             "SELECT LAST_VALUE(a IGNORE NULLS) OVER y FROM x WINDOW y AS (PARTITION BY CATEGORY)",
-        )
-        self.validate_identity(
-            """SELECT JSON_EXTRACT_SCALAR('5')""", """SELECT JSON_EXTRACT_SCALAR('5', '$')"""
         )
         self.validate_identity(
             "CREATE OR REPLACE VIEW test (tenant_id OPTIONS (description='Test description on table creation')) AS SELECT 1 AS tenant_id, 1 AS customer_id",
@@ -2057,5 +2053,25 @@ OPTIONS (
                 },
                 write={
                     "bigquery": f"SELECT color, ARRAY_AGG(id ORDER BY id {sort_order}) AS ids FROM colors GROUP BY 1",
+                },
+            )
+
+    def test_json_extract_scalar(self):
+        for func in ("JSON_EXTRACT_SCALAR", "JSON_VALUE"):
+            with self.subTest(f"Testing BigQuery's {func}"):
+                self.validate_all(
+                    f"SELECT {func}('5')",
+                    write={
+                        "bigquery": f"SELECT {func}('5', '$')",
+                        "duckdb": """SELECT '5' ->> '$'""",
+                    },
+                )
+
+            self.validate_all(
+                f"""SELECT {func}('{{"name": "Jakob", "age": "6"}}', '$.age')""",
+                write={
+                    "bigquery": f"""SELECT {func}('{{"name": "Jakob", "age": "6"}}', '$.age')""",
+                    "duckdb": """SELECT '{"name": "Jakob", "age": "6"}' ->> '$.age'""",
+                    "snowflake": """SELECT JSON_EXTRACT_PATH_TEXT('{"name": "Jakob", "age": "6"}', 'age')""",
                 },
             )


### PR DESCRIPTION
Currently SQLGlot supports BigQuery's `JSON_EXTRACT_SCALAR`. From the docs, this now seems deprecated, with the suggested replacement being `JSON_VALUE`:

```SQL
bigquery> WITH t AS (SELECT JSON_VALUE('{"name": "Jakob", "age": "6"}', '$.age') as col) SELECT col, typeof(col) from t;
6 | STRING

snowflake> WITH t AS (SELECT JSON_EXTRACT_PATH_TEXT('{"name": "Jakob", "age": "6"}', 'age') AS col) SELECT col, typeof(col::variant) FROM t;
6 | VARCHAR

duckdb> WITH t AS (SELECT '{"name": "Jakob", "age": "6"}' ->> '$.age' AS col) SELECT col, TYPEOF(col) FROM t;
┌─────────┬─────────────┐
│   col   │ typeof(col) │
│ varchar │   varchar   │
├─────────┼─────────────┤
│ 6       │ VARCHAR     │
└─────────┴─────────────┘
```

This PR now parses `JSON_VALUE(...)` as `exp.JsonExtractScalar`.

Docs
--------
[BQ JSON_EXTRACT_SCALAR](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_extract_scalar) | [BQ JSON_VALUE](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_value) | [Snowflake JSON_EXTRACT_PATH_TEXT](https://docs.snowflake.com/en/sql-reference/functions/json_extract_path_text#syntax)