### PR TITLE
feat(bigquery): Support JSON_QUERY

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -432,6 +432,7 @@ class BigQuery(Dialect):
                 this=exp.TsOrDsToDate(this=seq_get(args, 1)), format=seq_get(args, 0)
             ),
             "GENERATE_ARRAY": exp.GenerateSeries.from_arg_list,
+            "JSON_QUERY": parser.build_extract_json_with_path(exp.JSONExtract),
             "JSON_EXTRACT_SCALAR": lambda args: exp.JSONExtractScalar(
                 this=seq_get(args, 0), expression=seq_get(args, 1) or exp.Literal.string("$")
             ),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -798,7 +798,6 @@ class Snowflake(Dialect):
             ),
             exp.GroupConcat: rename_func("LISTAGG"),
             exp.If: if_sql(name="IFF", false_value="NULL"),
-            exp.JSONExtract: lambda self, e: self.func("GET_PATH", e.this, e.expression),
             exp.JSONExtractScalar: lambda self, e: self.func(
                 "JSON_EXTRACT_PATH_TEXT", e.this, e.expression
             ),
@@ -1095,4 +1094,14 @@ class Snowflake(Dialect):
                     expression=expression.expression * -1,
                     unit=expression.unit,
                 )
+            )
+
+        def jsonextract_sql(self, expression: exp.JSONExtract):
+            this = expression.this
+
+            # JSON strings are valid coming from other dialects such as BQ
+            return self.func(
+                "GET_PATH",
+                exp.ParseJSON(this=this) if this.is_string else this,
+                expression.expression,
             )

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1565,6 +1565,14 @@ WHERE
                 "snowflake": "IFF((y) <> 0, (x) / (y), NULL)",
             },
         )
+        self.validate_all(
+            """SELECT JSON_QUERY('{"class": {"students": []}}', '$.class')""",
+            write={
+                "bigquery": """SELECT JSON_QUERY('{"class": {"students": []}}', '$.class')""",
+                "duckdb": """SELECT '{"class": {"students": []}}' -> '$.class'""",
+                "snowflake": """SELECT GET_PATH(PARSE_JSON('{"class": {"students": []}}'), 'class')""",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):


### PR DESCRIPTION
Currently SQLGlot supports `JSON_EXTRACT` which is deprecated in favor of `JSON_QUERY`:

```SQL
bigquery> SELECT JSON_QUERY('{"class": {"students": []}}', '$.class')
{"students":[]}

snowflake> SELECT GET_PATH(PARSE_JSON('{"class": {"students": []}}'), 'class');
{"students": []}

duckdb> SELECT '{"class": {"students": []}}' -> '$.class';
┌──────────────────────────────────────────────┐
│ ('{"class": {"students": []}}' -> '$.class') │
│                     json                     │
├──────────────────────────────────────────────┤
│ {"students":[]}                              │
└──────────────────────────────────────────────┘
```

This PR also improves Snowflake's `GET_PATH` as it's unable to process JSON strings (unlike BQ and DuckDB), so as an extra step the string will be parsed first.

Docs
-------
[BQ JSON_EXTRACT](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_extract) | [BQ JSON_QUERY](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_query)