### PR TITLE
feat(snowflake): Transpile exp.DatetimeDiff

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -7,6 +7,7 @@ from sqlglot.dialects.dialect import (
     date_delta_sql,
     build_date_delta,
     timestamptrunc_sql,
+    timestampdiff_sql,
 )
 from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import TokenType
@@ -17,12 +18,6 @@ def _build_json_extract(args: t.List) -> exp.JSONExtract:
     this = args[0]
     path = args[1].name.lstrip("$.")
     return exp.JSONExtract(this=this, expression=path)
-
-
-def _timestamp_diff(
-    self: Databricks.Generator, expression: exp.DatetimeDiff | exp.TimestampDiff
-) -> str:
-    return self.func("TIMESTAMPDIFF", expression.unit, expression.expression, expression.this)
 
 
 def _jsonextract_sql(
@@ -80,8 +75,8 @@ class Databricks(Spark):
                 exp.Mul(this=e.expression, expression=exp.Literal.number(-1)),
                 e.this,
             ),
-            exp.DatetimeDiff: _timestamp_diff,
-            exp.TimestampDiff: _timestamp_diff,
+            exp.DatetimeDiff: timestampdiff_sql,
+            exp.TimestampDiff: timestampdiff_sql,
             exp.DatetimeTrunc: timestamptrunc_sql(),
             exp.Select: transforms.preprocess(
                 [

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1714,3 +1714,7 @@ def explode_to_unnest_sql(self: Generator, expression: exp.Lateral) -> str:
             )
         )
     return self.lateral_sql(expression)
+
+
+def timestampdiff_sql(self: Generator, expression: exp.DatetimeDiff | exp.TimestampDiff) -> str:
+    return self.func("TIMESTAMPDIFF", expression.unit, expression.expression, expression.this)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -24,6 +24,7 @@ from sqlglot.dialects.dialect import (
     map_date_part,
     no_safe_divide_sql,
     no_timestamp_sql,
+    timestampdiff_sql,
 )
 from sqlglot.helper import flatten, is_float, is_int, seq_get
 from sqlglot.tokens import TokenType
@@ -784,6 +785,7 @@ class Snowflake(Dialect):
             exp.Create: transforms.preprocess([_flatten_structured_types_unless_iceberg]),
             exp.DateAdd: date_delta_sql("DATEADD"),
             exp.DateDiff: date_delta_sql("DATEDIFF"),
+            exp.DatetimeDiff: timestampdiff_sql,
             exp.DateStrToDate: datestrtodate_sql,
             exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -648,6 +648,7 @@ LANGUAGE js AS
                 write={
                     "bigquery": "SELECT DATETIME_DIFF('2023-01-01T00:00:00', '2023-01-01T05:00:00', MILLISECOND)",
                     "databricks": "SELECT TIMESTAMPDIFF(MILLISECOND, '2023-01-01T05:00:00', '2023-01-01T00:00:00')",
+                    "snowflake": "SELECT TIMESTAMPDIFF(MILLISECOND, '2023-01-01T05:00:00', '2023-01-01T00:00:00')",
                 },
             ),
         )


### PR DESCRIPTION
Transpile BQ's `DATETIME_DIFF` into Snowflake's `TIMESTAMPDIFF`. Both functions can process different date/time types, so the solution here should be a catch-all, e.g:


- `DATETIME` -> `TIMESTAMP` diff
```SQL
bigquery> SELECT DATETIME_DIFF(DATETIME "2010-07-07 10:20:00", DATETIME "2008-12-25 15:30:00", DAY);
559

snowflake> SELECT TIMESTAMPDIFF(DAY, CAST('2008-12-25 15:30:00' AS TIMESTAMP), CAST('2010-07-07 10:20:00' AS TIMESTAMP));
559
```

- `DATE` -> `DATE` diff
```SQL
bigquery> SELECT DATETIME_DIFF(DATE "2010-07-07", DATE "2008-12-25", MONTH);
19

snowflake> SELECT TIMESTAMPDIFF(MONTH, CAST('2008-12-25' AS DATE), CAST('2010-07-07' AS DATE));
19
```


Docs
---------
[BQ DATETIME_DIFF](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime_diff) | [SF TIMESTAMPDIFF](https://docs.snowflake.com/en/sql-reference/functions/timestampdiff)