### PR TITLE
feat(trino): Support ListAgg function with overflow clause

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -18,7 +18,7 @@ class Trino(Presto):
             **Presto.Parser.FUNCTION_PARSERS,
             "TRIM": lambda self: self._parse_trim(),
             "JSON_QUERY": lambda self: self._parse_json_query(),
-            "LISTAGG": lambda self: self._parse_string_agg(),
+            "LISTAGG": lambda self: self._parse_listagg(),
         }
 
         JSON_QUERY_OPTIONS: parser.OPTIONS_TYPE = {
@@ -68,15 +68,3 @@ class Trino(Presto):
             option = f" {option}" if option else ""
 
             return self.func("JSON_QUERY", expression.this, json_path + option)
-
-        def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
-            this = expression.this
-            separator = expression.args.get("separator") or exp.Literal.string(",")
-
-            if isinstance(this, exp.Order):
-                if this.this:
-                    this = this.this.pop()
-
-                return f"LISTAGG({self.format_args(this, separator)}) WITHIN GROUP ({self.sql(expression.this).lstrip()})"
-
-            return super().groupconcat_sql(expression)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5769,6 +5769,17 @@ class GroupConcat(AggFunc):
     arg_types = {"this": True, "separator": False}
 
 
+class ListAgg(AggFunc):
+    arg_types = {
+        "this": True,
+        "separator": False,
+        "overflow_behaviour": False,
+        "truncation_indicator": False,
+        "count_option": False,
+        "order": False,
+    }
+
+
 class Hex(Func):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4466,3 +4466,18 @@ class Generator(metaclass=_Generator):
             )
 
         return self.function_fallback_sql(expression)
+
+    def listagg_sql(self, expression: exp.ListAgg) -> str:
+        args = expression.args
+        listagg = f"LISTAGG({args['this']}"
+        if args.get("separator"):
+            listagg += f", {args['separator']}"
+
+        if args.get("overflow_behaviour"):
+            listagg += f" ON OVERFLOW {args['overflow_behaviour']}"
+            if args.get("truncation_indicator"):
+                listagg += f" {args['truncation_indicator']} {args['count_option']} COUNT"
+
+        listagg += f") WITHIN GROUP ({self.sql(args['order']).lstrip()})"
+
+        return listagg

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7558,7 +7558,7 @@ class Parser(metaclass=_Parser):
         count_option = None
 
         if self._match(TokenType.DISTINCT):
-            args: t.List[t.Optional[exp.Expression]] = [
+            args: t.List[exp.Expression] = [
                 self.expression(exp.Distinct, expressions=[self._parse_assignment()])
             ]
             if self._match(TokenType.COMMA):

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -9,9 +9,6 @@ class TestTrino(Validator):
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER)")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT CONDITIONAL WRAPPER)")
-        self.validate_identity(
-            "SELECT LISTAGG(DISTINCT col, ',') WITHIN GROUP (ORDER BY col ASC) FROM tbl"
-        )
 
     def test_trim(self):
         self.validate_identity("SELECT TRIM('!' FROM '!foo!')")
@@ -56,4 +53,19 @@ class TestTrino(Validator):
         self.validate_identity("ALTER VIEW people RENAME TO users")
         self.validate_identity(
             "ALTER VIEW people SET AUTHORIZATION alice", check_command_warning=True
+        )
+
+    def test_listagg(self):
+        self.validate_identity(
+            "SELECT LISTAGG(DISTINCT col, ',') WITHIN GROUP (ORDER BY col ASC) FROM tbl"
+        )
+        self.validate_identity("SELECT LISTAGG(col) WITHIN GROUP (ORDER BY col DESC) FROM tbl")
+        self.validate_identity(
+            "SELECT LISTAGG(col, '; ' ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY col ASC) FROM tbl"
+        )
+        self.validate_identity(
+            "SELECT LISTAGG(col, '; ' ON OVERFLOW TRUNCATE '...' WITH COUNT) WITHIN GROUP (ORDER BY col ASC) FROM tbl"
+        )
+        self.validate_identity(
+            "SELECT LISTAGG(col, '; ' ON OVERFLOW TRUNCATE '...' WITHOUT COUNT) WITHIN GROUP (ORDER BY col ASC) FROM tbl"
         )


### PR DESCRIPTION
Added support for the `ON OVERFLOW` clause in the `ListAgg` function in Trino. According to the [Trino documentation](https://trino.io/docs/current/functions/aggregate.html#listagg), this functionality allows handling overflow situations during aggregation.

During testing, calling 
```
sqlglot.parse_one("SELECT LISTAGG(DISTINCT col ON OVERFLOW ERROR) WITHIN GROUP (ORDER BY col asc) FROM tbl", dialect="trino")
```
caused the error `sqlglot.errors.ParseError: Expecting )`. 

This error has been resolved by adding the appropriate parsing for the ListAgg function.