### PR TITLE
fix!: Refactor exp.RegexpExtract (follow up 4326)

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -749,6 +749,13 @@ class BigQuery(Dialect):
             exp.MD5Digest: rename_func("MD5"),
             exp.Min: min_or_least,
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
+            exp.RegexpExtract: lambda self, e: self.func(
+                "REGEXP_EXTRACT",
+                e.this,
+                e.expression,
+                e.args.get("position"),
+                e.args.get("occurrence"),
+            ),
             exp.RegexpReplace: regexp_replace_sql,
             exp.RegexpLike: rename_func("REGEXP_CONTAINS"),
             exp.ReturnsProperty: _returnsproperty_sql,
@@ -1042,13 +1049,3 @@ class BigQuery(Dialect):
             if expression.name == "TIMESTAMP":
                 expression.set("this", "SYSTEM_TIME")
             return super().version_sql(expression)
-
-        @generator.unsupported_args("group", "parameters")
-        def regexpextract_sql(self, e: exp.RegexpExtract) -> str:
-            return self.func(
-                "REGEXP_EXTRACT",
-                e.this,
-                e.expression,
-                e.args.get("position"),
-                e.args.get("occurrence"),
-            )

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -26,6 +26,7 @@ from sqlglot.dialects.dialect import (
     no_timestamp_sql,
     timestampdiff_sql,
 )
+from sqlglot.generator import unsupported_args
 from sqlglot.helper import flatten, is_float, is_int, seq_get
 from sqlglot.tokens import TokenType
 
@@ -1067,7 +1068,7 @@ class Snowflake(Dialect):
 
             return self.func("OBJECT_CONSTRUCT", *flatten(zip(keys, values)))
 
-        @generator.unsupported_args("weight", "accuracy")
+        @unsupported_args("weight", "accuracy")
         def approxquantile_sql(self, expression: exp.ApproxQuantile) -> str:
             return self.func("APPROX_PERCENTILE", expression.this, expression.args.get("quantile"))
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -761,14 +761,7 @@ class TestDuckDB(Validator):
                 write="duckdb",
                 unsupported_level=ErrorLevel.IMMEDIATE,
             )
-        with self.assertRaises(UnsupportedError):
-            # duckdb has the group arg, but bq doesn't
-            transpile(
-                "SELECT REGEXP_EXTRACT(a, 'pattern', 2) from table",
-                read="duckdb",
-                write="bigquery",
-                unsupported_level=ErrorLevel.IMMEDIATE,
-            )
+
         self.validate_all(
             "SELECT REGEXP_EXTRACT(a, 'pattern') FROM t",
             read={
@@ -783,20 +776,8 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
-            "SELECT REGEXP_EXTRACT(a, 'pattern', 2) FROM t",
-            read={
-                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2) FROM t",
-                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, '', 2) FROM t",
-            },
-            write={
-                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2) FROM t",
-                "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, 'c', 2) FROM t",
-            },
-        )
-        self.validate_all(
             "SELECT REGEXP_EXTRACT(a, 'pattern', 2, 'i') FROM t",
             read={
-                "duckdb": "SELECT REGEXP_EXTRACT(a, 'pattern', 2, 'i') FROM t",
                 "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, 'i', 2) FROM t",
             },
             write={

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1763,7 +1763,6 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
             "REGEXP_SUBSTR(subject, pattern)",
             read={
                 "bigquery": "REGEXP_EXTRACT(subject, pattern)",
-                "snowflake": "REGEXP_EXTRACT(subject, pattern)",
             },
             write={
                 "bigquery": "REGEXP_EXTRACT(subject, pattern)",


### PR DESCRIPTION
Follow up of https://github.com/tobymao/sqlglot/pull/4326

- Reverted BigQuery's generator and it's unsupported args; We add default values to `group` on other dialects so we'd need to silence these warnings on each test
- Simplified DuckDB's generator
- Removed duplicated tests
- Removed decorator prefix by importing it