### PR TITLE
fix(duckdb): we ALWAYS need to render group if params is present for RegexpExtract

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -957,15 +957,16 @@ class DuckDB(Dialect):
         @unsupported_args("position", "occurrence")
         def regexpextract_sql(self, expression: exp.RegexpExtract) -> str:
             group = expression.args.get("group")
+            params = expression.args.get("parameters")
 
-            # Do not render group if it's the default value for this dialect
-            if group and group.name == str(self.dialect.REGEXP_EXTRACT_DEFAULT_GROUP):
+            # Do not render group if there is no following argument,
+            # and it's the default value for this dialect
+            if (
+                not params
+                and group
+                and group.name == str(self.dialect.REGEXP_EXTRACT_DEFAULT_GROUP)
+            ):
                 group = None
-
             return self.func(
-                "REGEXP_EXTRACT",
-                expression.this,
-                expression.expression,
-                group,
-                expression.args.get("parameters"),
+                "REGEXP_EXTRACT", expression.this, expression.expression, group, params
             )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -785,6 +785,12 @@ class TestDuckDB(Validator):
                 "snowflake": "SELECT REGEXP_SUBSTR(a, 'pattern', 1, 1, 'i', 2) FROM t",
             },
         )
+        self.validate_identity(
+            "SELECT REGEXP_EXTRACT(a, 'pattern', 0)",
+            write_sql="SELECT REGEXP_EXTRACT(a, 'pattern')",
+        )
+        self.validate_identity("SELECT REGEXP_EXTRACT(a, 'pattern', 0, 'i')")
+        self.validate_identity("SELECT REGEXP_EXTRACT(a, 'pattern', 1, 'i')")
 
         self.validate_identity("SELECT ISNAN(x)")
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -787,7 +787,7 @@ class TestDuckDB(Validator):
         )
         self.validate_identity(
             "SELECT REGEXP_EXTRACT(a, 'pattern', 0)",
-            write_sql="SELECT REGEXP_EXTRACT(a, 'pattern')",
+            "SELECT REGEXP_EXTRACT(a, 'pattern')",
         )
         self.validate_identity("SELECT REGEXP_EXTRACT(a, 'pattern', 0, 'i')")
         self.validate_identity("SELECT REGEXP_EXTRACT(a, 'pattern', 1, 'i')")


### PR DESCRIPTION
Followup to https://github.com/tobymao/sqlglot/pull/4341

Before, roundtripping `SELECT REGEXP_EXTRACT(a, 'pattern', 0, 'i')` would result in `SELECT REGEXP_EXTRACT(a, 'pattern', 'i')`, which is incorrect (the group=0 arg is needed to fill space). So, we need to adjust our logic of when we can drop the group arg: it can only happen when there are no following args.