### PR TITLE
feat(snowflake): Transpile exp.DatetimeAdd

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -786,6 +786,7 @@ class Snowflake(Dialect):
             exp.Create: transforms.preprocess([_flatten_structured_types_unless_iceberg]),
             exp.DateAdd: date_delta_sql("DATEADD"),
             exp.DateDiff: date_delta_sql("DATEDIFF"),
+            exp.DatetimeAdd: date_delta_sql("TIMESTAMPADD"),
             exp.DatetimeDiff: timestampdiff_sql,
             exp.DateStrToDate: datestrtodate_sql,
             exp.DayOfMonth: rename_func("DAYOFMONTH"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -656,6 +656,7 @@ LANGUAGE js AS
                     "bigquery": "SELECT DATETIME_ADD('2023-01-01T00:00:00', INTERVAL '1' MILLISECOND)",
                     "databricks": "SELECT TIMESTAMPADD(MILLISECOND, '1', '2023-01-01T00:00:00')",
                     "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS DATETIME) + INTERVAL '1' MILLISECOND",
+                    "snowflake": "SELECT TIMESTAMPADD(MILLISECOND, '1', '2023-01-01T00:00:00')",
                 },
             ),
         )


### PR DESCRIPTION
BigQuery:
```SQL
SELECT DATETIME_ADD(DATETIME "2008-12-25 15:30:00", INTERVAL 10 MINUTE);
2008-12-25T15:40:00
```
Snowflake:
```SQL
SELECT TIMESTAMPADD(MINUTE, '10', CAST('2008-12-25 15:30:00' AS TIMESTAMP));
2008-12-25 15:40:00.000
```

Docs
-------
[BQ DATETIME_ADD](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime_add) | [BQ DATETIME vs TIMESTAMP](https://stackoverflow.com/questions/47713945/bigquery-datetime-vs-timestamp) | [SF TIMESTAMP_ADD](https://docs.snowflake.com/en/sql-reference/functions/timestampadd)
