### PR TITLE
feat(spark, bigquery): Add support for UNIX_SECONDS(...)

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -735,6 +735,7 @@ class BigQuery(Dialect):
         WITH_PROPERTIES_PREFIX = "OPTIONS"
         SUPPORTS_EXPLODING_PROJECTIONS = False
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+        SUPPORTS_UNIX_SECONDS = True
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -137,6 +137,7 @@ class Spark(Spark2):
         PAD_FILL_PATTERN_IS_REQUIRED = False
         SUPPORTS_CONVERT_TIMEZONE = True
         SUPPORTS_MEDIAN = True
+        SUPPORTS_UNIX_SECONDS = True
 
         TYPE_MAPPING = {
             **Spark2.Generator.TYPE_MAPPING,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6516,6 +6516,10 @@ class UnixToTimeStr(Func):
     pass
 
 
+class UnixSeconds(Func):
+    pass
+
+
 class Uuid(Func):
     _sql_names = ["UUID", "GEN_RANDOM_UUID", "GENERATE_UUID", "UUID_STRING"]
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -10,6 +10,7 @@ from sqlglot import (
     exp,
     parse,
     transpile,
+    parse_one,
 )
 from sqlglot.helper import logger as helper_logger
 from sqlglot.parser import logger as parser_logger
@@ -2116,3 +2117,22 @@ OPTIONS (
                     "snowflake": """SELECT JSON_EXTRACT_PATH_TEXT('{"name": "Jakob", "age": "6"}', 'age')""",
                 },
             )
+
+    def test_unix_seconds(self):
+        self.validate_all(
+            "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
+            read={
+                "bigquery": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
+                "spark": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
+                "databricks": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
+            },
+            write={
+                "spark": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
+                "databricks": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
+                "duckdb": "SELECT DATE_DIFF('SECONDS', CAST('1970-01-01 00:00:00+00' AS TIMESTAMPTZ), '2008-12-25 15:30:00+00')",
+                "snowflake": "SELECT TIMESTAMPDIFF(SECONDS, CAST('1970-01-01 00:00:00+00' AS TIMESTAMPTZ), '2008-12-25 15:30:00+00')",
+            },
+        )
+
+        for dialect in ("bigquery", "spark", "databricks"):
+            parse_one("UNIX_SECONDS(col)", dialect=dialect).assert_is(exp.UnixSeconds)


### PR DESCRIPTION
BigQuery and Spark3/Databricks support `UNIX_SECONDS(expr)` which returns the number of seconds since 1970-01-01 00:00:00 UTC:

```SQL
bigquery> SELECT UNIX_SECONDS(TIMESTAMP "2008-12-25 15:30:00+00") AS seconds;
seconds
1230219000

spark-sql (default)> SELECT UNIX_SECONDS(TIMESTAMP "2008-12-25 15:30:00+00") AS seconds;
seconds
1230219000
```

This PR adds `exp.UnixSeconds` to enable seamless parsing as well as transpiles the newly added node to DuckDB & Snowflake by utilizing `exp.TimestampDiff` at a `SECOND` granularity:

```SQL
duckdb> SELECT DATE_DIFF('SECONDS', CAST('1970-01-01 00:00:00+00' AS TIMESTAMPTZ), '2008-12-25 15:30:00+00') AS seconds;
┌────────────┐
│  seconds   │
│   int64    │
├────────────┤
│ 1230219000 │
└────────────┘

snowflake> SELECT TIMESTAMPDIFF(SECONDS, CAST('1970-01-01 00:00:00+00' AS TIMESTAMPTZ), '2008-12-25 15:30:00+00') AS seconds;
1230219000
```


Docs
--------
[BQ](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#unix_seconds) | [Spark3](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.unix_seconds.html) | [Databricks](https://docs.databricks.com/en/sql/language-manual/functions/unix_seconds.html#:~:text=Returns%20the%20number%20of%20seconds,00%3A00%3A00%20UTC%20.)

