### PR TITLE
fix(clickhouse): Generate exp.Median as lowercase

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -949,6 +949,7 @@ class ClickHouse(Dialect):
             exp.JSONPathKey: json_path_key_only_name,
             exp.JSONPathRoot: lambda *_: "",
             exp.Map: lambda self, e: _lower_func(var_map_sql(self, e)),
+            exp.Median: rename_func("median"),
             exp.Nullif: rename_func("nullIf"),
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
             exp.Pivot: no_pivot_sql,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3007,7 +3007,7 @@ FROM subquery2""",
                     "databricks": f"MEDIAN(x){suffix}",
                     "redshift": f"MEDIAN(x){suffix}",
                     "oracle": f"MEDIAN(x){suffix}",
-                    "clickhouse": f"MEDIAN(x){suffix}",
+                    "clickhouse": f"median(x){suffix}",
                     "postgres": f"PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY x){suffix}",
                 },
             )


### PR DESCRIPTION
Fixes #4354

```SQL
:) select MEDIAN(5);
Received exception:
Code: 63. DB::Exception: Unknown aggregate function MEDIAN. Maybe you meant: ['median','medianDD']. (UNKNOWN_AGGREGATE_FUNCTION)

:) select median(5);
   ┌─median(5)─┐
1. │         5 │
   └───────────┘


```