### PR TITLE
feat(bigquery): Support JSON_VALUE_ARRAY(...)

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -970,3 +970,8 @@ class DuckDB(Dialect):
             return self.func(
                 "REGEXP_EXTRACT", expression.this, expression.expression, group, params
             )
+
+        def jsonvaluearray_sql(self, expression: exp.JSONValueArray) -> str:
+            json_extract = exp.JSONExtract(this=expression.this, expression=expression.expression)
+
+            return self.sql(exp.cast(json_extract, to=exp.DataType.build("ARRAY<STRING>")))

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1110,3 +1110,12 @@ class Snowflake(Dialect):
                 exp.ParseJSON(this=this) if this.is_string else this,
                 expression.expression,
             )
+
+        def jsonvaluearray_sql(self, expression: exp.JSONValueArray):
+            json_extract = exp.JSONExtract(this=expression.this, expression=expression.expression)
+            ident = exp.to_identifier("x")
+            transform_lambda = exp.Lambda(
+                expressions=[ident], this=exp.cast(ident, to=exp.DataType.Type.VARCHAR)
+            )
+
+            return self.func("TRANSFORM", json_extract, transform_lambda)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5939,6 +5939,10 @@ class JSONValue(Expression):
     }
 
 
+class JSONValueArray(Func):
+    arg_types = {"this": True, "expression": False}
+
+
 # # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_TABLE.html
 class JSONTable(Func):
     arg_types = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1603,6 +1603,14 @@ WHERE
                 "snowflake": """SELECT GET_PATH(PARSE_JSON('{"class": {"students": []}}'), 'class')""",
             },
         )
+        self.validate_all(
+            """SELECT JSON_VALUE_ARRAY('{"arr": [1, "a"]}', '$.arr')""",
+            write={
+                "bigquery": """SELECT JSON_VALUE_ARRAY('{"arr": [1, "a"]}', '$.arr')""",
+                "duckdb": """SELECT CAST('{"arr": [1, "a"]}' -> '$.arr' AS TEXT[])""",
+                "snowflake": """SELECT TRANSFORM(GET_PATH(PARSE_JSON('{"arr": [1, "a"]}'), 'arr'), x -> CAST(x AS VARCHAR))""",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):


### PR DESCRIPTION
This PR adds support for `JSON_VALUE_ARRAY(expr [, json_path])` which extracts a JSON array of scalar values and converts it to `ARRAY<STRING>`:

```SQL
bigquery> WITH t AS (
  SELECT
    JSON_VALUE_ARRAY(JSON '{"arr": [1, "a"]}', '$.arr') AS arr
)
SELECT
  arr,
  typeof(arr),
  typeof(arr[0])
FROM t;

arr	f0_	f1_
"[1,a]"	ARRAY<STRING>	STRING

```

Transpilation support towards DuckDB & Snowflake is also added through the following transformations:

- DuckDB: Extracts the array and casts it to `TEXT[]`
```SQL
D WITH t AS (
    SELECT
      CAST(JSON('{"arr": [1, "a"]}') -> '$.arr' AS TEXT[]) AS arr
  )
  SELECT
    arr,
    TYPEOF(arr),
    TYPEOF(arr[1])
  FROM t;

┌───────────┬─────────────┬────────────────┐
│    arr    │ typeof(arr) │ typeof(arr[1]) │
│ varchar[] │   varchar   │    varchar     │
├───────────┼─────────────┼────────────────┤
│ [1, a]    │ VARCHAR[]   │ VARCHAR        │
└───────────┴─────────────┴────────────────┘
```

- Snowflake: Extracts the array and casts each element to `VARCHAR`
```SQL
snowflake> WITH t AS (
  SELECT
    TRANSFORM(GET_PATH(PARSE_JSON('{"arr": [1, "a"]}'), 'arr'), x -> CAST(x AS VARCHAR)) AS arr
)
SELECT
  arr,
  TYPEOF(arr),
  TYPEOF(arr[0])
FROM t;

ARR | TYPEOF(ARR) | TYPEOF(ARR[0])
["1",   "a" ] | ARRAY | VARCHAR
```

Docs
--------
[BQ JSON_VALUE_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_value_array) | [SF TRANSFORM](https://docs.snowflake.com/en/sql-reference/functions/transform) 

