### PR TITLE
Fix(clickhouse): Remove RANGE data type

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -419,6 +419,8 @@ class ClickHouse(Dialect):
             TokenType.LIKE,
         }
 
+        TYPE_TOKENS = parser.Parser.TYPE_TOKENS - {TokenType.RANGE}
+
         AGG_FUNC_MAPPING = (
             lambda functions, suffixes: {
                 f"{f}{sfx}": (f, sfx) for sfx in (suffixes + [""]) for f in functions

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -25,6 +25,10 @@ class TestClickhouse(Validator):
             target_type = exp.DataType.build(nullable_type, dialect="clickhouse").sql("clickhouse")
             self.assertEqual(try_cast.sql("clickhouse"), f"CAST(x AS Nullable({target_type}))")
 
+        # confirm RANGE not parsed as datatype
+        # - `range.1` is referencing the first column of an object named `range`
+        self.validate_identity("a BETWEEN range.1 AND range.2")
+
         expr = parse_one("count(x)")
         self.assertEqual(expr.sql(dialect="clickhouse"), "COUNT(x)")
         self.assertIsNone(expr._meta)


### PR DESCRIPTION
Clickhouse supports numeric positional column references of the form `[object name].[column number]` (e.g., `table.1` refers to the first column in `table`).

If the object is named `range`, sqlglot parses the reference into the range data type:
```
>>> parse_one("a between range.1 and range.2", dialect="clickhouse").sql("clickhouse")
'a BETWEEN CAST(0.1 AS RANGE) AND CAST(0.2 AS RANGE)'
```

Clickhouse does not have a `RANGE` data type, so this PR removes it.