### PR TITLE
feat(bigquery): Parse REGEXP_SUBSTR as exp.RegexpExtract

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -456,6 +456,7 @@ class BigQuery(Dialect):
             "PARSE_TIMESTAMP": _build_parse_timestamp,
             "REGEXP_CONTAINS": exp.RegexpLike.from_arg_list,
             "REGEXP_EXTRACT": _build_regexp_extract,
+            "REGEXP_SUBSTR": _build_regexp_extract,
             "SHA256": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(256)),
             "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
             "SPLIT": lambda args: exp.Split(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1788,7 +1788,6 @@ FROM persons AS p, LATERAL FLATTEN(input => p.c, path => 'contact') AS _flattene
         self.validate_all(
             "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', group)",
             read={
-                "bigquery": "REGEXP_SUBSTR(subject, pattern, 1, 1, 'c', group)",
                 "duckdb": "REGEXP_EXTRACT(subject, pattern, group)",
                 "hive": "REGEXP_EXTRACT(subject, pattern, group)",
                 "presto": "REGEXP_EXTRACT(subject, pattern, group)",


### PR DESCRIPTION
This PR parses `REGEXP_SUBSTR` into `exp.RegexpExtract`, as acccording to the docs it's a synonym for `REGEXP_EXTRACT`. For the tests:
- The cases in `bigquery.py` are organized into a single function
- The case in `snowflake.py` is wrong, probably copy-pasted from the `"snowflake"` line. It's only failing now as `REGEXP_SUBSTR` is no longer Anonymous for BQ


Docs
------
[BQ REGEXP_SUBSTR](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_substr)