### PR TITLE
fix: safe removal while iterating

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -348,7 +348,7 @@ def unnest_to_explode(
                 )
             )
 
-        for join in expression.args.get("joins") or []:
+        for join in list(expression.args.get("joins") or []): # support safe removal by iterating over copy list for multiple joins
             join_expr = join.this
 
             is_lateral = isinstance(join_expr, exp.Lateral)
@@ -390,6 +390,8 @@ def unnest_to_explode(
                             ),
                         ),
                     )
+                    
+        
 
     return expression
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1483,6 +1483,16 @@ class TestDialect(Validator):
                 "hive": UnsupportedError,
             },
         )
+        
+    def test_multiple_chained_unnest(self):
+        self.validate_all(
+            "SELECT * FROM x CROSS JOIN UNNEST(a) AS j(lista) CROSS JOIN UNNEST(b) AS k(listb) CROSS JOIN UNNEST(c) AS l(listc)",
+            write={
+                "presto": "SELECT * FROM x CROSS JOIN UNNEST(a) AS j(lista) CROSS JOIN UNNEST(b) AS k(listb) CROSS JOIN UNNEST(c) AS l(listc)",
+                "spark": "SELECT * FROM x LATERAL VIEW EXPLODE(a) j AS lista LATERAL VIEW EXPLODE(b) k AS listb LATERAL VIEW EXPLODE(c) l AS listc",
+                "hive": "SELECT * FROM x LATERAL VIEW EXPLODE(a) j AS lista LATERAL VIEW EXPLODE(b) k AS listb LATERAL VIEW EXPLODE(c) l AS listc",
+            },
+        )        
 
     def test_lateral_subquery(self):
         self.validate_identity(


### PR DESCRIPTION
### Bugfix: sqlglot generates incorrect expression list for Multiple Chained UNNEST.
In the `unnest_to_explode` method,  While iterating for multiple Unnest expressions, sqlglot modifies(remove join expr) the list during iteration, leading to incorrect SQL generation.
`expression.args["joins"].remove(join)`

### Repro steps:
Presto SQL:
```
SELECT * FROM x CROSS JOIN UNNEST(a) AS j(lista) CROSS JOIN UNNEST(b) AS k(listb) CROSS JOIN UNNEST(c) AS l(listc)
```

Spark SQL: sqlglot incorrect transpiled query: (Please note `CROSS JOIN EXPLODE(b, k(listb))`)
```
SELECT * FROM x CROSS JOIN EXPLODE(b, k(listb)) LATERAL VIEW EXPLODE(a) j AS lista LATERAL VIEW EXPLODE(c) l AS listc
```

After modifying the loop to iteratete over the copy list, `expression.args["joins"].remove(join)` can safely remove modify the expression list.

Spark SQL after fix:

```
SELECT * FROM x LATERAL VIEW EXPLODE(a) j AS lista LATERAL VIEW EXPLODE(b) k AS listb LATERAL VIEW EXPLODE(c) l AS listc
```

### Fix:
Iterate over a copy list to make the removal from original list safe.

**Another possible fix** 
 instead of `list()`, We can `reversed()` but this is modifying the expression order and retuning the opposite order of explode expressions, Not sure if order matters, hence sticking to. l`ist()` one.
```
SELECT * FROM x LATERAL VIEW EXPLODE(c) l AS listc LATERAL VIEW EXPLODE(b) k AS listb LATERAL VIEW EXPLODE(a) j AS lista
```

