### PR TITLE
fix(duckdb)!: Fix STRUCT cast generation

### DIFF
--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1154,6 +1154,7 @@ class TestDuckDB(Validator):
         self.validate_identity("CAST(x AS BINARY)", "CAST(x AS BLOB)")
         self.validate_identity("CAST(x AS VARBINARY)", "CAST(x AS BLOB)")
         self.validate_identity("CAST(x AS LOGICAL)", "CAST(x AS BOOLEAN)")
+        self.validate_identity("""CAST({'i': 1, 's': 'foo'} AS STRUCT("s" TEXT, "i" INT))""")
         self.validate_identity(
             "CAST(ROW(1, ROW(1)) AS STRUCT(number BIGINT, row STRUCT(number BIGINT)))"
         )
@@ -1163,11 +1164,11 @@ class TestDuckDB(Validator):
         )
         self.validate_identity(
             "CAST([[STRUCT_PACK(a := 1)]] AS STRUCT(a BIGINT)[][])",
-            "CAST([[ROW(1)]] AS STRUCT(a BIGINT)[][])",
+            "CAST([[{'a': 1}]] AS STRUCT(a BIGINT)[][])",
         )
         self.validate_identity(
             "CAST([STRUCT_PACK(a := 1)] AS STRUCT(a BIGINT)[])",
-            "CAST([ROW(1)] AS STRUCT(a BIGINT)[])",
+            "CAST([{'a': 1}] AS STRUCT(a BIGINT)[])",
         )
         self.validate_identity(
             "STRUCT_PACK(a := 'b')::json",
@@ -1175,7 +1176,7 @@ class TestDuckDB(Validator):
         )
         self.validate_identity(
             "STRUCT_PACK(a := 'b')::STRUCT(a TEXT)",
-            "CAST(ROW('b') AS STRUCT(a TEXT))",
+            "CAST({'a': 'b'} AS STRUCT(a TEXT))",
         )
 
         self.validate_all(


### PR DESCRIPTION
Fixes #4365

BigQuery supports inline `STRUCT` constructors such as the following:

```SQL
bq> SELECT STRUCT<a STRING, b INTEGER>('str', 1) AS strct;
strct.a   strct.b
'str'        1
```

https://github.com/tobymao/sqlglot/pull/3751 introduced support in SQLGlot by canonicalizing those expressions to a CAST:

```Python
>> sqlglot.parse_one("SELECT STRUCT<a STRING, b INTEGER>('str', 1)", read="bigquery").sql("bigquery")
`CAST(STRUCT('str', 1) AS STRUCT<a STRING, b INTEGER>)`
```

Note thought that transpilation towards DuckDB was still not complete as it requires explicit key-value pairs to construct STRUCTs:

```SQL
D SELECT CAST(STRUCT_PACK('str', 1) AS STRUCT("a" TEXT, "b" INT));
Binder Error: Need named argument for struct pack, e.g. STRUCT_PACK(a := b)
``` 

To solve this issue efficiently, the PR was extended so that DuckDB can understand when a `STRUCT` was constructed under a `STRUCT` cast and turn that into `CAST(ROW(...) AS STRUCT(...)` instead:

```SQL
D select CAST(ROW('str', 1) AS STRUCT("a" TEXT, "b" INT));
┌────────────────────────────────────────────────────────────┐
│ CAST(main."row"('str', 1) AS STRUCT(a VARCHAR, b INTEGER)) │
│                struct(a varchar, b integer)                │
├────────────────────────────────────────────────────────────┤
│ {'a': str, 'b': 1}                                         │
└────────────────────────────────────────────────────────────┘
```

However, #4365 shows how this is prone to errors if the `ROW` field def order does not match with the cast:

```SQL
D SELECT CAST(ROW(1, 'foo') AS STRUCT("s" TEXT, "i" INT));
Conversion Error: Could not convert string 'foo' to INT32
```

To mitigate this issue, the #3751 solution can be further limited to generate a `ROW` only if the `STRUCT` being casted does not have key - value pairs; This seems enough to (1) preserve existing BQ -> DuckDB transpilation cases and (2) restore DuckDB's roundtrips which are order-agnostic:

```SQL
D SELECT CAST({'i':1, 's':'foo'} AS STRUCT("s" TEXT, "i" INT));
┌────────────────────────────────────────────────────────────────────────────┐
│ CAST(main.struct_pack(i := 1, s := 'foo') AS STRUCT(s VARCHAR, i INTEGER)) │
│                        struct(s varchar, i integer)                        │
├────────────────────────────────────────────────────────────────────────────┤
│ {'s': foo, 'i': 1}                                                         │
└────────────────────────────────────────────────────────────────────────────┘
```
