### PR TITLE
feat(bigquery): Add parsing support for STRPOS(...)

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -26,6 +26,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     ts_or_ds_add_cast,
     unit_to_var,
+    str_position_sql,
 )
 from sqlglot.helper import seq_get, split_num_words
 from sqlglot.tokens import TokenType
@@ -492,6 +493,7 @@ class BigQuery(Dialect):
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1) or exp.Literal.string(","),
             ),
+            "STRPOS": exp.StrPosition.from_arg_list,
             "TIME": _build_time,
             "TIME_ADD": build_date_delta_with_interval(exp.TimeAdd),
             "TIME_SUB": build_date_delta_with_interval(exp.TimeSub),
@@ -845,6 +847,7 @@ class BigQuery(Dialect):
                 "DETERMINISTIC" if e.name == "IMMUTABLE" else "NOT DETERMINISTIC"
             ),
             exp.String: rename_func("STRING"),
+            exp.StrPosition: str_position_sql,
             exp.StrToDate: _str_to_datetime_sql,
             exp.StrToTime: _str_to_datetime_sql,
             exp.TimeAdd: date_add_interval_sql("TIME", "ADD"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1611,6 +1611,14 @@ WHERE
                 "snowflake": """SELECT TRANSFORM(GET_PATH(PARSE_JSON('{"arr": [1, "a"]}'), 'arr'), x -> CAST(x AS VARCHAR))""",
             },
         )
+        self.validate_all(
+            "SELECT STRPOS('foo@example.com', '@')",
+            write={
+                "bigquery": "SELECT STRPOS('foo@example.com', '@')",
+                "duckdb": "SELECT STRPOS('foo@example.com', '@')",
+                "snowflake": "SELECT POSITION('@', 'foo@example.com')",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1688,6 +1688,7 @@ class TestDialect(Validator):
                 "duckdb": "STRPOS(haystack, needle)",
                 "postgres": "STRPOS(haystack, needle)",
                 "presto": "STRPOS(haystack, needle)",
+                "bigquery": "STRPOS(haystack, needle)",
                 "spark": "LOCATE(needle, haystack)",
                 "clickhouse": "position(haystack, needle)",
                 "snowflake": "POSITION(needle, haystack)",


### PR DESCRIPTION
This PR adds parsing support for `exp.StrPosition` in BigQuery, enabling it's transpilation:

```SQL
bigquery> SELECT STRPOS('foo@example.com', '@');
4

snowflake> SELECT POSITION('@', 'foo@example.com');
4

duckdb> SELECT STRPOS('foo@example.com', '@');
┌────────────────────────────────┐
│ strpos('foo@example.com', '@') │
│             int64              │
├────────────────────────────────┤
│                              4 │
└────────────────────────────────┘

```


Docs
--------
[BQ](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#strpos) | [DuckDB](https://duckdb.org/docs/sql/functions/char.html#strposstring-search_string) | [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/position)