### PR TITLE
fix(bigquery)!: Support FORMAT_TIMESTAMP

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -211,7 +211,7 @@ def _build_time(args: t.List) -> exp.Func:
 
 def _build_datetime(args: t.List) -> exp.Func:
     if len(args) == 1:
-        return exp.TsOrDsToTimestamp.from_arg_list(args)
+        return exp.TsOrDsToDatetime.from_arg_list(args)
     if len(args) == 2:
         return exp.Datetime.from_arg_list(args)
     return exp.TimestampFromParts.from_arg_list(args)
@@ -302,6 +302,13 @@ def _build_levenshtein(args: t.List) -> exp.Levenshtein:
         expression=seq_get(args, 1),
         max_dist=max_dist.expression if max_dist else None,
     )
+
+
+def _build_format_time(expr_type: t.Type[exp.Expression]) -> t.Callable[[t.List], exp.TimeToStr]:
+    def _builder(args: t.List) -> exp.TimeToStr:
+        return exp.TimeToStr(this=expr_type(this=seq_get(args, 1)), format=seq_get(args, 0))
+
+    return _builder
 
 
 class BigQuery(Dialect):
@@ -462,9 +469,7 @@ class BigQuery(Dialect):
             "DATETIME_SUB": build_date_delta_with_interval(exp.DatetimeSub),
             "DIV": binary_from_function(exp.IntDiv),
             "EDIT_DISTANCE": _build_levenshtein,
-            "FORMAT_DATE": lambda args: exp.TimeToStr(
-                this=exp.TsOrDsToDate(this=seq_get(args, 1)), format=seq_get(args, 0)
-            ),
+            "FORMAT_DATE": _build_format_time(exp.TsOrDsToDate),
             "GENERATE_ARRAY": exp.GenerateSeries.from_arg_list,
             "JSON_EXTRACT_SCALAR": _build_extract_json_with_default_path(exp.JSONExtractScalar),
             "JSON_EXTRACT_ARRAY": _build_extract_json_with_default_path(exp.JSONExtractArray),
@@ -506,9 +511,8 @@ class BigQuery(Dialect):
             ),
             "TIMESTAMP_SECONDS": lambda args: exp.UnixToTime(this=seq_get(args, 0)),
             "TO_JSON_STRING": exp.JSONFormat.from_arg_list,
-            "FORMAT_DATETIME": lambda args: exp.TimeToStr(
-                this=exp.TsOrDsToTimestamp(this=seq_get(args, 1)), format=seq_get(args, 0)
-            ),
+            "FORMAT_DATETIME": _build_format_time(exp.TsOrDsToDatetime),
+            "FORMAT_TIMESTAMP": _build_format_time(exp.TsOrDsToTimestamp),
         }
 
         FUNCTION_PARSERS = {
@@ -859,7 +863,8 @@ class BigQuery(Dialect):
             exp.TsOrDsAdd: _ts_or_ds_add_sql,
             exp.TsOrDsDiff: _ts_or_ds_diff_sql,
             exp.TsOrDsToTime: rename_func("TIME"),
-            exp.TsOrDsToTimestamp: rename_func("DATETIME"),
+            exp.TsOrDsToDatetime: rename_func("DATETIME"),
+            exp.TsOrDsToTimestamp: rename_func("TIMESTAMP"),
             exp.Unhex: rename_func("FROM_HEX"),
             exp.UnixDate: rename_func("UNIX_DATE"),
             exp.UnixToTime: _unix_to_time_sql,
@@ -1048,16 +1053,20 @@ class BigQuery(Dialect):
             return super().table_parts(expression)
 
         def timetostr_sql(self, expression: exp.TimeToStr) -> str:
-            if isinstance(expression.this, exp.TsOrDsToTimestamp):
+            this = expression.this
+            if isinstance(this, exp.TsOrDsToDatetime):
                 func_name = "FORMAT_DATETIME"
+            elif isinstance(this, exp.TsOrDsToTimestamp):
+                func_name = "FORMAT_TIMESTAMP"
             else:
                 func_name = "FORMAT_DATE"
-            this = (
-                expression.this
-                if isinstance(expression.this, (exp.TsOrDsToTimestamp, exp.TsOrDsToDate))
+
+            time_expr = (
+                this
+                if isinstance(this, (exp.TsOrDsToDatetime, exp.TsOrDsToTimestamp, exp.TsOrDsToDate))
                 else expression
             )
-            return self.func(func_name, self.format_time(expression), this.this)
+            return self.func(func_name, self.format_time(expression), time_expr.this)
 
         def eq_sql(self, expression: exp.EQ) -> str:
             # Operands of = cannot be NULL in BigQuery

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -645,6 +645,7 @@ class DuckDB(Dialect):
             exp.DataType.Type.BINARY: "BLOB",
             exp.DataType.Type.BPCHAR: "TEXT",
             exp.DataType.Type.CHAR: "TEXT",
+            exp.DataType.Type.DATETIME: "TIMESTAMP",
             exp.DataType.Type.FLOAT: "REAL",
             exp.DataType.Type.NCHAR: "TEXT",
             exp.DataType.Type.NVARCHAR: "TEXT",

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -908,9 +908,6 @@ class Snowflake(Dialect):
             ),
             exp.TimestampTrunc: timestamptrunc_sql(),
             exp.TimeStrToTime: timestrtotime_sql,
-            exp.TimeToStr: lambda self, e: self.func(
-                "TO_CHAR", exp.cast(e.this, exp.DataType.Type.TIMESTAMP), self.format_time(e)
-            ),
             exp.TimeToUnix: lambda self, e: f"EXTRACT(epoch_second FROM {self.sql(e, 'this')})",
             exp.ToArray: rename_func("TO_ARRAY"),
             exp.ToChar: lambda self, e: self.function_fallback_sql(e),
@@ -1147,3 +1144,11 @@ class Snowflake(Dialect):
                 exp.ParseJSON(this=this) if this.is_string else this,
                 expression.expression,
             )
+
+        def timetostr_sql(self, expression: exp.TimeToStr) -> str:
+            this = expression.this
+
+            if this.is_string:
+                this = exp.cast(this, exp.DataType.Type.TIMESTAMP)
+
+            return self.func("TO_CHAR", this, self.format_time(expression))

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6490,6 +6490,10 @@ class TsOrDsToDate(Func):
     arg_types = {"this": True, "format": False, "safe": False}
 
 
+class TsOrDsToDatetime(Func):
+    pass
+
+
 class TsOrDsToTime(Func):
     pass
 
@@ -7793,8 +7797,8 @@ def cast(
         existing_cast_type: DataType.Type = expr.to.this
         new_cast_type: DataType.Type = data_type.this
         types_are_equivalent = type_mapping.get(
-            existing_cast_type, existing_cast_type
-        ) == type_mapping.get(new_cast_type, new_cast_type)
+            existing_cast_type, existing_cast_type.value
+        ) == type_mapping.get(new_cast_type, new_cast_type.value)
         if expr.is_type(data_type) or types_are_equivalent:
             return expr
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3896,7 +3896,14 @@ class Generator(metaclass=_Generator):
         if isinstance(this, exp.TsOrDsToTimestamp) or this.is_type(exp.DataType.Type.TIMESTAMP):
             return self.sql(this)
 
-        return self.sql(exp.cast(this, exp.DataType.Type.TIMESTAMP))
+        return self.sql(exp.cast(this, exp.DataType.Type.TIMESTAMP, dialect=self.dialect))
+
+    def tsordstodatetime_sql(self, expression: exp.TsOrDsToDatetime) -> str:
+        this = expression.this
+        if isinstance(this, exp.TsOrDsToDatetime) or this.is_type(exp.DataType.Type.DATETIME):
+            return self.sql(this)
+
+        return self.sql(exp.cast(this, exp.DataType.Type.DATETIME, dialect=self.dialect))
 
     def tsordstodate_sql(self, expression: exp.TsOrDsToDate) -> str:
         this = expression.this

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -558,27 +558,6 @@ LANGUAGE js AS
             },
         )
         self.validate_all(
-            "SELECT FORMAT_DATE('%Y%m%d', '2023-12-25')",
-            write={
-                "bigquery": "SELECT FORMAT_DATE('%Y%m%d', '2023-12-25')",
-                "duckdb": "SELECT STRFTIME(CAST('2023-12-25' AS DATE), '%Y%m%d')",
-            },
-        )
-        self.validate_all(
-            "SELECT FORMAT_DATETIME('%Y%m%d %H:%M:%S', DATETIME '2023-12-25 15:30:00')",
-            write={
-                "bigquery": "SELECT FORMAT_DATETIME('%Y%m%d %H:%M:%S', CAST('2023-12-25 15:30:00' AS DATETIME))",
-                "duckdb": "SELECT STRFTIME(CAST('2023-12-25 15:30:00' AS TIMESTAMP), '%Y%m%d %H:%M:%S')",
-            },
-        )
-        self.validate_all(
-            "SELECT FORMAT_DATETIME('%x', '2023-12-25 15:30:00')",
-            write={
-                "bigquery": "SELECT FORMAT_DATETIME('%x', '2023-12-25 15:30:00')",
-                "duckdb": "SELECT STRFTIME(CAST('2023-12-25 15:30:00' AS TIMESTAMP), '%x')",
-            },
-        )
-        self.validate_all(
             "SELECT COUNTIF(x)",
             read={
                 "clickhouse": "SELECT countIf(x)",
@@ -685,7 +664,7 @@ LANGUAGE js AS
                 write={
                     "bigquery": "SELECT DATETIME_ADD('2023-01-01T00:00:00', INTERVAL '1' MILLISECOND)",
                     "databricks": "SELECT TIMESTAMPADD(MILLISECOND, '1', '2023-01-01T00:00:00')",
-                    "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS DATETIME) + INTERVAL '1' MILLISECOND",
+                    "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS TIMESTAMP) + INTERVAL '1' MILLISECOND",
                     "snowflake": "SELECT TIMESTAMPADD(MILLISECOND, '1', '2023-01-01T00:00:00')",
                 },
             ),
@@ -696,7 +675,7 @@ LANGUAGE js AS
                 write={
                     "bigquery": "SELECT DATETIME_SUB('2023-01-01T00:00:00', INTERVAL '1' MILLISECOND)",
                     "databricks": "SELECT TIMESTAMPADD(MILLISECOND, '1' * -1, '2023-01-01T00:00:00')",
-                    "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS DATETIME) - INTERVAL '1' MILLISECOND",
+                    "duckdb": "SELECT CAST('2023-01-01T00:00:00' AS TIMESTAMP) - INTERVAL '1' MILLISECOND",
                 },
             ),
         )
@@ -706,7 +685,7 @@ LANGUAGE js AS
                 write={
                     "bigquery": "SELECT DATETIME_TRUNC('2023-01-01T01:01:01', HOUR)",
                     "databricks": "SELECT DATE_TRUNC('HOUR', '2023-01-01T01:01:01')",
-                    "duckdb": "SELECT DATE_TRUNC('HOUR', CAST('2023-01-01T01:01:01' AS DATETIME))",
+                    "duckdb": "SELECT DATE_TRUNC('HOUR', CAST('2023-01-01T01:01:01' AS TIMESTAMP))",
                 },
             ),
         )
@@ -2211,5 +2190,36 @@ OPTIONS (
                 "duckdb": "REGEXP_EXTRACT_ALL('a1_a2a3_a4A5a6', '(a)[0-9]', 1)",
                 "spark": "REGEXP_EXTRACT_ALL('a1_a2a3_a4A5a6', '(a)[0-9]')",
                 "databricks": "REGEXP_EXTRACT_ALL('a1_a2a3_a4A5a6', '(a)[0-9]')",
+            },
+        )
+
+    def test_format_temporal(self):
+        self.validate_all(
+            "SELECT FORMAT_DATE('%Y%m%d', '2023-12-25')",
+            write={
+                "bigquery": "SELECT FORMAT_DATE('%Y%m%d', '2023-12-25')",
+                "duckdb": "SELECT STRFTIME(CAST('2023-12-25' AS DATE), '%Y%m%d')",
+            },
+        )
+        self.validate_all(
+            "SELECT FORMAT_DATETIME('%Y%m%d %H:%M:%S', DATETIME '2023-12-25 15:30:00')",
+            write={
+                "bigquery": "SELECT FORMAT_DATETIME('%Y%m%d %H:%M:%S', CAST('2023-12-25 15:30:00' AS DATETIME))",
+                "duckdb": "SELECT STRFTIME(CAST('2023-12-25 15:30:00' AS TIMESTAMP), '%Y%m%d %H:%M:%S')",
+            },
+        )
+        self.validate_all(
+            "SELECT FORMAT_DATETIME('%x', '2023-12-25 15:30:00')",
+            write={
+                "bigquery": "SELECT FORMAT_DATETIME('%x', '2023-12-25 15:30:00')",
+                "duckdb": "SELECT STRFTIME(CAST('2023-12-25 15:30:00' AS TIMESTAMP), '%x')",
+            },
+        )
+        self.validate_all(
+            """SELECT FORMAT_TIMESTAMP("%b-%d-%Y", TIMESTAMP "2050-12-25 15:30:55+00")""",
+            write={
+                "bigquery": "SELECT FORMAT_TIMESTAMP('%b-%d-%Y', CAST('2050-12-25 15:30:55+00' AS TIMESTAMP))",
+                "duckdb": "SELECT STRFTIME(CAST(CAST('2050-12-25 15:30:55+00' AS TIMESTAMPTZ) AS TIMESTAMP), '%b-%d-%Y')",
+                "snowflake": "SELECT TO_CHAR(CAST(CAST('2050-12-25 15:30:55+00' AS TIMESTAMPTZ) AS TIMESTAMP), 'mon-DD-yyyy')",
             },
         )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -251,7 +251,7 @@ class TestClickhouse(Validator):
             },
             write={
                 "clickhouse": "SELECT CAST('2020-01-01' AS Nullable(DateTime)) + INTERVAL '500' MICROSECOND",
-                "duckdb": "SELECT CAST('2020-01-01' AS DATETIME) + INTERVAL '500' MICROSECOND",
+                "duckdb": "SELECT CAST('2020-01-01' AS TIMESTAMP) + INTERVAL '500' MICROSECOND",
                 "postgres": "SELECT CAST('2020-01-01' AS TIMESTAMP) + INTERVAL '500 MICROSECOND'",
             },
         )


### PR DESCRIPTION
This PR adds support for BQ's `FORMAT_TIMESTAMP` through `exp.TimeToStr`:

```SQL
bigquery> SELECT FORMAT_TIMESTAMP("%b-%d-%Y", TIMESTAMP "2050-12-25 15:30:55+00");
Dec-25-2050

snowflake> SELECT TO_CHAR(CAST(CAST('2050-12-25 15:30:55+00' AS TIMESTAMPTZ) AS TIMESTAMP), 'mon-DD-yyyy');
Dec-25-2050

duckdb> SELECT STRFTIME(CAST('2050-12-25 15:30:55+00' AS TIMESTAMP), '%b-%d-%Y');
┌───────────────────────────────────────────────────────────────────┐
│ strftime(CAST('2050-12-25 15:30:55+00' AS TIMESTAMP), '%b-%d-%Y') │
│                              varchar                              │
├───────────────────────────────────────────────────────────────────┤
│ Dec-25-2050                                                       │
└───────────────────────────────────────────────────────────────────┘
```

Regarding the changes in this PR:
1. For BQ, `FORMAT_DATETIME` was deduplicated from `FORMAT_TIMESTAMP` by introducing `exp.TsOrDsToDatetime`
2. For `exp.cast(...)`, a bug was solved regarding the `types_are_equivalent` check; Note how `get` will either retrieve a `str` or a `DataType.Type` (the default value), so the comparison might be incorrect as stringifying `DataType`s will prepend them with the `Type.<type>` enum prefix (e.g comparing `Type.TIMESTAMP` with `DATETIME` for DuckDB). To fix this we must retrieve either the `TYPE_MAPPING` or stringify the `value` of the enum type
3. For DuckDB, `Type.DATETIME` now maps to `TIMESTAMP` as these are aliases (this enables redundant cast eliminations from bullet 2)


Docs
--------
[BQ FORMAT_TIMESTAMP](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#format_timestamp) | [DuckDB TIMESTAMP type](https://duckdb.org/docs/sql/data_types/timestamp.html) | [Snowflake TO_CHAR](https://docs.snowflake.com/en/sql-reference/functions/to_char)
