### PR TITLE
feat(bigquery): Support MAKE_INTERVAL

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1724,3 +1724,14 @@ def explode_to_unnest_sql(self: Generator, expression: exp.Lateral) -> str:
 
 def timestampdiff_sql(self: Generator, expression: exp.DatetimeDiff | exp.TimestampDiff) -> str:
     return self.func("TIMESTAMPDIFF", expression.unit, expression.expression, expression.this)
+
+
+def no_make_interval_sql(self: Generator, expression: exp.MakeInterval, sep: str = ", ") -> str:
+    args = []
+    for unit, value in expression.args.items():
+        if isinstance(value, exp.Kwarg):
+            value = value.expression
+
+        args.append(f"{value} {unit}")
+
+    return f"INTERVAL '{self.format_args(*args, sep=sep)}'"

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -35,6 +35,7 @@ from sqlglot.dialects.dialect import (
     sha256_sql,
     build_regexp_extract,
     explode_to_unnest_sql,
+    no_make_interval_sql,
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import seq_get
@@ -558,6 +559,7 @@ class DuckDB(Dialect):
             exp.Lateral: explode_to_unnest_sql,
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.LogicalAnd: rename_func("BOOL_AND"),
+            exp.MakeInterval: lambda self, e: no_make_interval_sql(self, e, sep=" "),
             exp.MD5Digest: lambda self, e: self.func("UNHEX", self.func("MD5", e.this)),
             exp.MonthsBetween: lambda self, e: self.func(
                 "DATEDIFF",

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -25,6 +25,7 @@ from sqlglot.dialects.dialect import (
     no_safe_divide_sql,
     no_timestamp_sql,
     timestampdiff_sql,
+    no_make_interval_sql,
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import flatten, is_float, is_int, seq_get
@@ -866,6 +867,7 @@ class Snowflake(Dialect):
             exp.LogicalAnd: rename_func("BOOLAND_AGG"),
             exp.LogicalOr: rename_func("BOOLOR_AGG"),
             exp.Map: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
+            exp.MakeInterval: no_make_interval_sql,
             exp.Max: max_or_greatest,
             exp.Min: min_or_least,
             exp.ParseJSON: lambda self, e: self.func(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5589,6 +5589,17 @@ class MonthsBetween(Func):
     arg_types = {"this": True, "expression": True, "roundoff": False}
 
 
+class MakeInterval(Func):
+    arg_types = {
+        "year": False,
+        "month": False,
+        "day": False,
+        "hour": False,
+        "minute": False,
+        "second": False,
+    }
+
+
 class LastDay(Func, TimeUnit):
     _sql_names = ["LAST_DAY", "LAST_DAY_OF_MONTH"]
     arg_types = {"this": True, "unit": False}

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1619,6 +1619,14 @@ WHERE
                 "snowflake": "SELECT POSITION('@', 'foo@example.com')",
             },
         )
+        self.validate_all(
+            "SELECT ts + MAKE_INTERVAL(1, 2, minute => 5, day => 3)",
+            write={
+                "bigquery": "SELECT ts + MAKE_INTERVAL(1, 2, day => 3, minute => 5)",
+                "duckdb": "SELECT ts + INTERVAL '1 year 2 month 5 minute 3 day'",
+                "snowflake": "SELECT ts + INTERVAL '1 year, 2 month, 5 minute, 3 day'",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):


### PR DESCRIPTION
This PR adds support for BQ's `MAKE_INTERVAL` and enables transpilation towards DuckDB & Snowflake by serializing the units into `INTERVAL '<units>'` expressions:

```SQL
bigquery> SELECT CAST('2024-01-01 10:00:00' AS DATETIME) + MAKE_INTERVAL(1, 2, minute => 5, day => 3);
2025-03-04T10:05:00

snowflake> SELECT CAST('2024-01-01 10:00:00' AS TIMESTAMP) + INTERVAL '1 year, 2 month, 5 minute, 3 day';
2025-03-04 10:05:00.000

duckdb> SELECT CAST('2024-01-01 10:00:00' AS TIMESTAMP) + INTERVAL '1 year 2 month 5 minute 3 day';
┌────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (CAST('2024-01-01 10:00:00' AS TIMESTAMP) + CAST('1 year 2 month 5 minute 3 day' AS INTERVAL)) │
│                                           timestamp                                            │
├────────────────────────────────────────────────────────────────────────────────────────────────┤
│ 2025-03-04 10:05:00                                                                            │
└────────────────────────────────────────────────────────────────────────────────────────────────┘
```


Docs
--------
[BQ MAKE_INTERVAL](https://cloud.google.com/bigquery/docs/reference/standard-sql/interval_functions#make_interval) | [Snowflake INTERVAL](https://docs.snowflake.com/en/sql-reference/data-types-datetime#interval-constants) | [DuckDB INTERVAL](https://duckdb.org/docs/sql/data_types/interval.html#:~:text=An%20INTERVAL%20can%20be%20constructed,of%20these%20three%20basis%20units.)

