### PR TITLE
feat(bigquery): Support INT64(...)

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -836,6 +836,7 @@ class BigQuery(Dialect):
             exp.If: if_sql(false_value="NULL"),
             exp.ILike: no_ilike_sql,
             exp.IntDiv: rename_func("DIV"),
+            exp.Int64: rename_func("INT64"),
             exp.JSONFormat: rename_func("TO_JSON_STRING"),
             exp.Levenshtein: _levenshtein_sql,
             exp.Max: max_or_greatest,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5828,6 +5828,11 @@ class IsNan(Func):
     _sql_names = ["IS_NAN", "ISNAN"]
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#int64_for_json
+class Int64(Func):
+    pass
+
+
 class IsInf(Func):
     _sql_names = ["IS_INF", "ISINF"]
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -148,6 +148,7 @@ class Generator(metaclass=_Generator):
         exp.InputModelProperty: lambda self, e: f"INPUT{self.sql(e, 'this')}",
         exp.Intersect: lambda self, e: self.set_operations(e),
         exp.IntervalSpan: lambda self, e: f"{self.sql(e, 'this')} TO {self.sql(e, 'expression')}",
+        exp.Int64: lambda self, e: self.sql(exp.cast(e.this, exp.DataType.Type.BIGINT)),
         exp.LanguageProperty: lambda self, e: self.naked_property(e),
         exp.LocationProperty: lambda self, e: self.naked_property(e),
         exp.LogProperty: lambda _, e: f"{'NO ' if e.args.get('no') else ''}LOG",

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1606,6 +1606,14 @@ WHERE
                 "snowflake": "SELECT ts + INTERVAL '1 year, 2 month, 5 minute, 3 day'",
             },
         )
+        self.validate_all(
+            """SELECT INT64(JSON_QUERY(JSON '{"key": 2000}', '$.key'))""",
+            write={
+                "bigquery": """SELECT INT64(JSON_QUERY(PARSE_JSON('{"key": 2000}'), '$.key'))""",
+                "duckdb": """SELECT CAST(JSON('{"key": 2000}') -> '$.key' AS BIGINT)""",
+                "snowflake": """SELECT CAST(GET_PATH(PARSE_JSON('{"key": 2000}'), 'key') AS BIGINT)""",
+            },
+        )
 
     def test_errors(self):
         with self.assertRaises(TokenError):


### PR DESCRIPTION
This PR adds support for BQ's `INT64(...)` which converts a JSON number to an INT64 value:

```SQL
bigquery> WITH t AS (SELECT INT64(JSON_QUERY(JSON '{"gate": "A4", "flight_number": 2005}', "$.flight_number")) AS col) SELECT col, typeof(col) from t;
col	f0_
2005	INT64


snowflake>  WITH t AS (SELECT CAST(GET_PATH(PARSE_JSON('{"gate": "A4", "flight_number": 2005}'), 'flight_number') AS BIGINT) AS col) SELECT col, TYPEOF(col) FROM t;
COL | TYPEOF(COL)
-- | --
2005 | INTEGER

duckdb> WITH t AS (SELECT CAST(JSON('{"gate": "A4", "flight_number": 2005}') -> '$.flight_number' AS BIGINT) AS col) SELECT col, TYPEOF(col) FROM t;
┌───────┬─────────────┐
│  col  │ typeof(col) │
│ int64 │   varchar   │
├───────┼─────────────┤
│  2005 │ BIGINT      │
└───────┴─────────────┘

```

Docs
-------
[BQ INT64](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#int64_for_json)