### PR TITLE
feat: Add support for CONTAINS(...)

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5460,6 +5460,10 @@ class ConcatWs(Concat):
     _sql_names = ["CONCAT_WS"]
 
 
+class Contains(Func):
+    arg_types = {"this": True, "expression": True}
+
+
 # https://docs.oracle.com/cd/B13789_01/server.101/b10759/operators004.htm#i1035022
 class ConnectByRoot(Func):
     pass

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1615,6 +1615,31 @@ WHERE
             },
         )
 
+        self.validate_identity(
+            "CONTAINS_SUBSTRING(a, b, json_scope => 'JSON_KEYS_AND_VALUES')"
+        ).assert_is(exp.Anonymous)
+
+        self.validate_all(
+            """CONTAINS_SUBSTRING(a, b)""",
+            read={
+                "": "CONTAINS(a, b)",
+                "spark": "CONTAINS(a, b)",
+                "databricks": "CONTAINS(a, b)",
+                "snowflake": "CONTAINS(a, b)",
+                "duckdb": "CONTAINS(a, b)",
+                "oracle": "CONTAINS(a, b)",
+            },
+            write={
+                "": "CONTAINS(LOWER(a), LOWER(b))",
+                "spark": "CONTAINS(LOWER(a), LOWER(b))",
+                "databricks": "CONTAINS(LOWER(a), LOWER(b))",
+                "snowflake": "CONTAINS(LOWER(a), LOWER(b))",
+                "duckdb": "CONTAINS(LOWER(a), LOWER(b))",
+                "oracle": "CONTAINS(LOWER(a), LOWER(b))",
+                "bigquery": "CONTAINS_SUBSTRING(a, b)",
+            },
+        )
+
     def test_errors(self):
         with self.assertRaises(TokenError):
             transpile("'\\'", read="bigquery")


### PR DESCRIPTION
This PR adds support for BQ's `CONTAINS_SUBSTR(...)` along with `CONTAINS(...)` which is the popular variant across other dialects.

Other design choices:
- BQ also supports a 3rd arg regarding JSON search which is currently parsed as `exp.Anonymous` since it differs from other dialects
- Because BQ performs the substring check in a case-insensitive manner, it wraps the operands with `exp.Lower` to aid the transpilation (or unwraps them during roundtrip)

```SQL
bigquery> SELECT CONTAINS_SUBSTR('blue', 'Blue') AS result;
true


spark-sql (default)> SELECT CONTAINS('blue', 'Blue') AS case_sensitive, CONTAINS(LOWER('blue'), LOWER('Blue')) AS case_insensitive;
case_sensitive  case_insensitive
false   true


snowflake> SELECT CONTAINS('blue', 'Blue') AS case_sensitive, CONTAINS(LOWER('blue'), LOWER('Blue')) AS case_insensitive;
FALSE | TRUE


duckdb>  SELECT CONTAINS('blue', 'Blue') AS case_sensitive, CONTAINS(LOWER('blue'), LOWER('Blue')) AS case_insensitive;
┌────────────────┬──────────────────┐
│ case_sensitive │ case_insensitive │
│    boolean     │     boolean      │
├────────────────┼──────────────────┤
│ false          │ true             │
└────────────────┴──────────────────┘
```


Docs
---------
[BQ](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#contains_substr) | [Spark3 / DB](https://docs.databricks.com/en/sql/language-manual/functions/contains.html) | [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/contains) | [DuckDB](https://duckdb.org/docs/sql/functions/char.html#containsstring-search_string) | [Oracle](https://docs.oracle.com/en/database/other-databases/nosql-database/24.1/sqlreferencefornosql/contains_function.html)