### PR TITLE
Chore: fix relative benchmark import, comment out sqltree

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -1,6 +1,6 @@
 import collections.abc
 
-from benchmarks.helpers import ascii_table
+from helpers import ascii_table
 
 # moz_sql_parser 3.10 compatibility
 collections.Iterable = collections.abc.Iterable
@@ -12,7 +12,7 @@ import numpy as np
 # import moz_sql_parser
 # import sqloxide
 # import sqlparse
-import sqltree
+# import sqltree
 
 import sqlglot
 
@@ -203,7 +203,7 @@ libs = [
     "sqlglot",
     "sqlglotrs",
     # "sqlfluff",
-    "sqltree",
+    # "sqltree",
     # "sqlparse",
     # "moz_sql_parser",
     # "sqloxide",

--- a/benchmarks/optimize.py
+++ b/benchmarks/optimize.py
@@ -1,7 +1,7 @@
 import typing as t
 from argparse import ArgumentParser
 
-from benchmarks.helpers import ascii_table
+from helpers import ascii_table
 from sqlglot.optimizer import optimize
 from sqlglot import parse_one
 from tests.helpers import load_sql_fixture_pairs, TPCH_SCHEMA, TPCDS_SCHEMA


### PR DESCRIPTION
Right now if one tries to run `bench.py`, python yells that the `benchmarks` module does not exist.