### PR TITLE
Add DETACH as command to DuckDB dialect

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -316,6 +316,7 @@ class DuckDB(Dialect):
             "BPCHAR": TokenType.TEXT,
             "CHAR": TokenType.TEXT,
             "CHARACTER VARYING": TokenType.TEXT,
+            "DETACH": TokenType.COMMAND,
             "EXCLUDE": TokenType.EXCEPT,
             "LOGICAL": TokenType.BOOLEAN,
             "ONLY": TokenType.ONLY,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -382,6 +382,7 @@ class TestDuckDB(Validator):
         self.validate_identity(
             "ATTACH DATABASE ':memory:' AS new_database", check_command_warning=True
         )
+        self.validate_identity("DETACH DATABASE new_database", check_command_warning=True)
         self.validate_identity(
             "SELECT {'yes': 'duck', 'maybe': 'goose', 'huh': NULL, 'no': 'heron'}"
         )


### PR DESCRIPTION
Ref: https://duckdb.org/docs/sql/statements/attach#detach-syntax

Allow `DETACH` in DuckDB to be parsed as a command.