### PR TITLE
feat: add support for specifying column in row_number function

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6329,7 +6329,7 @@ class Round(Func):
 
 
 class RowNumber(Func):
-    arg_types: t.Dict[str, t.Any] = {}
+    arg_types = {"this": False}
 
 
 class SafeDivide(Func):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1245,3 +1245,11 @@ LIFETIME(MIN 0 MAX 0)""",
         scopes = traverse_scope(parse_one(sql, dialect=self.dialect))
         self.assertEqual(len(scopes), 1)
         self.assertEqual(set(scopes[0].sources), {"t"})
+
+    def test_window_functions(self):
+        self.validate_identity(
+            "SELECT row_number(column1) OVER (PARTITION BY column2 ORDER BY column3) FROM table"
+        )
+        self.validate_identity(
+            "SELECT row_number() OVER (PARTITION BY column2 ORDER BY column3) FROM table"
+        )


### PR DESCRIPTION
Added support for specifying target column in `row_number` function
Some dialects such as ClickHouse allow this syntax: https://clickhouse.com/docs/en/sql-reference/window-functions/row_number