### PR TITLE
feat(clickhouse): transform function support

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -274,6 +274,7 @@ class ClickHouse(Dialect):
             "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
             "EDITDISTANCE": exp.Levenshtein.from_arg_list,
             "LEVENSHTEINDISTANCE": exp.Levenshtein.from_arg_list,
+            "TRANSFORM": lambda args: exp.Anonymous(this="TRANSFORM", expressions=args),
         }
 
         AGG_FUNCTIONS = {

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -274,8 +274,8 @@ class ClickHouse(Dialect):
             "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
             "EDITDISTANCE": exp.Levenshtein.from_arg_list,
             "LEVENSHTEINDISTANCE": exp.Levenshtein.from_arg_list,
-            "TRANSFORM": lambda args: exp.Anonymous(this="TRANSFORM", expressions=args),
         }
+        FUNCTIONS.pop("TRANSFORM")
 
         AGG_FUNCTIONS = {
             "count",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5134,8 +5134,7 @@ class Flatten(Func):
 
 # https://spark.apache.org/docs/latest/api/sql/index.html#transform
 class Transform(Func):
-    arg_types = {"this": True, "expressions": True}
-    is_var_len_args = True
+    arg_types = {"this": True, "expression": True}
 
 
 class Anonymous(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5134,7 +5134,8 @@ class Flatten(Func):
 
 # https://spark.apache.org/docs/latest/api/sql/index.html#transform
 class Transform(Func):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expressions": True}
+    is_var_len_args = True
 
 
 class Anonymous(Func):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1253,3 +1253,9 @@ LIFETIME(MIN 0 MAX 0)""",
         self.validate_identity(
             "SELECT row_number() OVER (PARTITION BY column2 ORDER BY column3) FROM table"
         )
+
+    def test_functions(self):
+        self.validate_identity("SELECT transform(foo, [1, 2], ['first', 'second']) FROM table")
+        self.validate_identity(
+            "SELECT transform(foo, [1, 2], ['first', 'second'], 'default') FROM table"
+        )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1255,7 +1255,7 @@ LIFETIME(MIN 0 MAX 0)""",
         )
 
     def test_functions(self):
-        self.validate_identity("SELECT transform(foo, [1, 2], ['first', 'second']) FROM table")
+        self.validate_identity("SELECT TRANSFORM(foo, [1, 2], ['first', 'second']) FROM table")
         self.validate_identity(
-            "SELECT transform(foo, [1, 2], ['first', 'second'], 'default') FROM table"
+            "SELECT TRANSFORM(foo, [1, 2], ['first', 'second'], 'default') FROM table"
         )


### PR DESCRIPTION
Current implementation of the `transform` function allows only to specify 2 arguments. But there are dialects other than Spark, for example, ClickHouse:

https://clickhouse.com/docs/en/sql-reference/functions/other-functions#transform

It accepts 3 or 4 arguments, and with current implementation, the parsing of such queries raises `ParseError`:

```
sqlglot.errors.ParseError: The number of provided arguments (3) is greater than the maximum number of supported arguments (2).
```

IMO, it would be better to accept a variable amount of arguments to support dialects other than Spark.

This is a breaking change since the `expression` is replaced with `expressions`.
