### PR TITLE
fix(parser): Do not parse window function arg as exp.Column

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2250,3 +2250,13 @@ SINGLE = TRUE""",
         self.validate_identity(
             "GRANT ALL PRIVILEGES ON FUNCTION mydb.myschema.ADD5(number) TO ROLE analyst"
         )
+
+    def test_window_function_arg(self):
+        query = "SELECT * FROM TABLE(db.schema.FUNC(a) OVER ())"
+
+        ast = self.parse_one(query)
+        window = ast.find(exp.Window)
+
+        self.assertEqual(ast.sql("snowflake"), query)
+        self.assertEqual(len(list(ast.find_all(exp.Column))), 1)
+        self.assertEqual(window.this.sql("snowflake"), "db.schema.FUNC(a)")


### PR DESCRIPTION
Fixes #4410

- Before this PR, this would be the AST of the following query: 

```python3
>>> ast = sqlglot.parse_one("select * from table(a.b.func2(a) over ())", read="snowflake")
>>> print(repr(ast))
Select(
  expressions=[
    Star()],
  from=From(
    this=Table(
      this=Anonymous(
        this=table,
        expressions=[
          Column(
            this=Window(
              this=Anonymous(
                this=func2,
                expressions=[
                  Column(
                    this=Identifier(this=a, quoted=False))]),
              over=OVER),
            table=Identifier(this=b, quoted=False),
            db=Identifier(this=a, quoted=False))]))))
```

- After this PR, the AST for the same query is:

```python3
>>> print(repr(ast))
Select(
  expressions=[
    Star()],
  from=From(
    this=Table(
      this=Anonymous(
        this=table,
        expressions=[
          Window(
            this=Dot(
              this=Dot(
                this=Identifier(this=a, quoted=False),
                expression=Identifier(this=b, quoted=False)),
              expression=Anonymous(
                this=func2,
                expressions=[
                  Column(
                    this=Identifier(this=a, quoted=False))])),
            over=OVER)]))))
```


Snowflake repro:
```SQL
CREATE OR REPLACE FUNCTION test_func(d number)
    RETURNS TABLE (d NUMBER)
    as
    $$
    SELECT d
    $$;



SELECT * FROM TABLE (db.schema.TEST_FUNC(1) over ());
```