### PR TITLE
fix!: Tokenize hints as comments

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -178,7 +178,12 @@ class MySQL(Dialect):
 
     class Tokenizer(tokens.Tokenizer):
         QUOTES = ["'", '"']
-        COMMENTS = ["--", "#", ("/*", "*/")]
+        COMMENTS = [
+            "--",
+            "#",
+            ("/*", "*/"),
+            ("/*+", "*/"),
+        ]
         IDENTIFIERS = ["`"]
         STRING_ESCAPES = ["'", '"', "\\"]
         BIT_STRINGS = [("b'", "'"), ("B'", "'"), ("0b", "")]

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -178,12 +178,7 @@ class MySQL(Dialect):
 
     class Tokenizer(tokens.Tokenizer):
         QUOTES = ["'", '"']
-        COMMENTS = [
-            "--",
-            "#",
-            ("/*", "*/"),
-            ("/*+", "*/"),
-        ]
+        COMMENTS = ["--", "#", ("/*", "*/")]
         IDENTIFIERS = ["`"]
         STRING_ESCAPES = ["'", '"', "\\"]
         BIT_STRINGS = [("b'", "'"), ("B'", "'"), ("0b", "")]

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2974,11 +2974,10 @@ class Parser(metaclass=_Parser):
         # duckdb supports leading with FROM x
         from_ = self._parse_from() if self._match(TokenType.FROM, advance=False) else None
 
-        hint = self._parse_hint()
         if self._match(TokenType.SELECT):
             comments = self._prev_comments
 
-            hint = hint or self._parse_hint()
+            hint = self._parse_hint()
 
             if self._next and not self._next.token_type == TokenType.DOT:
                 all_ = self._match(TokenType.ALL)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3262,8 +3262,8 @@ class Parser(metaclass=_Parser):
         return self.expression(exp.Hint, expressions=hints)
 
     def _parse_hint(self) -> t.Optional[exp.Hint]:
-        if self._match(TokenType.HINT) and self._prev.comments:
-            return exp.maybe_parse(self._prev.comments[0], into=exp.Hint, dialect=self.dialect)
+        if self._match(TokenType.HINT) and self._prev_comments:
+            return exp.maybe_parse(self._prev_comments[0], into=exp.Hint, dialect=self.dialect)
 
         return None
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -756,6 +756,7 @@ class Parser(metaclass=_Parser):
         exp.From: lambda self: self._parse_from(joins=True),
         exp.Group: lambda self: self._parse_group(),
         exp.Having: lambda self: self._parse_having(),
+        exp.Hint: lambda self: self._parse_hint_body(),
         exp.Identifier: lambda self: self._parse_id_var(),
         exp.Join: lambda self: self._parse_join(),
         exp.Lambda: lambda self: self._parse_lambda(),
@@ -2973,10 +2974,11 @@ class Parser(metaclass=_Parser):
         # duckdb supports leading with FROM x
         from_ = self._parse_from() if self._match(TokenType.FROM, advance=False) else None
 
+        hint = self._parse_hint()
         if self._match(TokenType.SELECT):
             comments = self._prev_comments
 
-            hint = self._parse_hint()
+            hint = hint or self._parse_hint()
 
             if self._next and not self._next.token_type == TokenType.DOT:
                 all_ = self._match(TokenType.ALL)
@@ -3226,21 +3228,42 @@ class Parser(metaclass=_Parser):
 
         return this
 
-    def _parse_hint(self) -> t.Optional[exp.Hint]:
-        if self._match(TokenType.HINT):
-            hints = []
+    def _parse_hint_fallback_to_string(self) -> t.Optional[exp.Hint]:
+        start = self._curr
+        while self._curr:
+            self._advance()
+
+        end = self._tokens[self._index - 1]
+        return exp.Hint(expressions=[self._find_sql(start, end)])
+
+    def _parse_hint_function_call(self) -> t.Optional[exp.Expression]:
+        return self._parse_function_call()
+
+    def _parse_hint_body(self) -> t.Optional[exp.Hint]:
+        start_index = self._index
+        should_fallback_to_string = False
+
+        hints = []
+        try:
             for hint in iter(
                 lambda: self._parse_csv(
-                    lambda: self._parse_function() or self._parse_var(upper=True)
+                    lambda: self._parse_hint_function_call() or self._parse_var(upper=True),
                 ),
                 [],
             ):
                 hints.extend(hint)
+        except ParseError:
+            should_fallback_to_string = True
 
-            if not self._match_pair(TokenType.STAR, TokenType.SLASH):
-                self.raise_error("Expected */ after HINT")
+        if should_fallback_to_string or self._curr:
+            self._retreat(start_index)
+            return self._parse_hint_fallback_to_string()
 
-            return self.expression(exp.Hint, expressions=hints)
+        return self.expression(exp.Hint, expressions=hints)
+
+    def _parse_hint(self) -> t.Optional[exp.Hint]:
+        if self._match(TokenType.HINT) and self._prev.comments:
+            return exp.maybe_parse(self._prev.comments[0], into=exp.Hint, dialect=self.dialect)
 
         return None
 

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -509,6 +509,8 @@ class _Tokenizer(type):
             ),
             "{#": "#}",  # Ensure Jinja comments are tokenized correctly in all dialects
         }
+        if klass.HINT_START in klass.KEYWORDS:
+            klass._COMMENTS[klass.HINT_START] = "*/"
 
         klass._KEYWORD_TRIE = new_trie(
             key.upper()
@@ -547,6 +549,9 @@ class _Tokenizer(type):
                 string_escapes_allowed_in_raw_strings=klass.STRING_ESCAPES_ALLOWED_IN_RAW_STRINGS,
                 nested_comments=klass.NESTED_COMMENTS,
                 hint_start=klass.HINT_START,
+                tokens_preceding_hint={
+                    _TOKEN_TYPE_TO_INDEX[v] for v in klass.TOKENS_PRECEDING_HINT
+                },
             )
             token_types = RsTokenTypeSettings(
                 bit_string=_TOKEN_TYPE_TO_INDEX[TokenType.BIT_STRING],
@@ -563,6 +568,7 @@ class _Tokenizer(type):
                 var=_TOKEN_TYPE_TO_INDEX[TokenType.VAR],
                 heredoc_string_alternative=_TOKEN_TYPE_TO_INDEX[klass.HEREDOC_STRING_ALTERNATIVE],
                 hint=_TOKEN_TYPE_TO_INDEX[TokenType.HINT],
+                select=_TOKEN_TYPE_TO_INDEX[TokenType.SELECT],
             )
             klass._RS_TOKENIZER = RsTokenizer(settings, token_types)
         else:
@@ -634,6 +640,8 @@ class Tokenizer(metaclass=_Tokenizer):
     NESTED_COMMENTS = True
 
     HINT_START = "/*+"
+
+    TOKENS_PRECEDING_HINT = {TokenType.SELECT, TokenType.INSERT, TokenType.UPDATE, TokenType.DELETE}
 
     # Autofilled
     _COMMENTS: t.Dict[str, str] = {}
@@ -961,7 +969,6 @@ class Tokenizer(metaclass=_Tokenizer):
     COMMENTS = [
         "--",
         ("/*", "*/"),
-        ("/*+", "*/"),
     ]
 
     __slots__ = (
@@ -1238,7 +1245,11 @@ class Tokenizer(metaclass=_Tokenizer):
                 self._advance(alnum=True)
             self._comments.append(self._text[comment_start_size:])
 
-        if comment_start == self.HINT_START:
+        if (
+            comment_start == self.HINT_START
+            and self.tokens
+            and self.tokens[-1].token_type in self.TOKENS_PRECEDING_HINT
+        ):
             self._add(TokenType.HINT)
 
         # Leading comment is attached to the succeeding token, whilst trailing comment to the preceding.

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -546,6 +546,7 @@ class _Tokenizer(type):
                 heredoc_tag_is_identifier=klass.HEREDOC_TAG_IS_IDENTIFIER,
                 string_escapes_allowed_in_raw_strings=klass.STRING_ESCAPES_ALLOWED_IN_RAW_STRINGS,
                 nested_comments=klass.NESTED_COMMENTS,
+                hint_start=klass.HINT_START,
             )
             token_types = RsTokenTypeSettings(
                 bit_string=_TOKEN_TYPE_TO_INDEX[TokenType.BIT_STRING],
@@ -632,6 +633,8 @@ class Tokenizer(metaclass=_Tokenizer):
 
     NESTED_COMMENTS = True
 
+    HINT_START = "/*+"
+
     # Autofilled
     _COMMENTS: t.Dict[str, str] = {}
     _FORMAT_STRINGS: t.Dict[str, t.Tuple[str, TokenType]] = {}
@@ -647,7 +650,7 @@ class Tokenizer(metaclass=_Tokenizer):
         **{f"{prefix}%}}": TokenType.BLOCK_END for prefix in ("", "+", "-")},
         **{f"{{{{{postfix}": TokenType.BLOCK_START for postfix in ("+", "-")},
         **{f"{prefix}}}}}": TokenType.BLOCK_END for prefix in ("+", "-")},
-        "/*+": TokenType.HINT,
+        HINT_START: TokenType.HINT,
         "==": TokenType.EQ,
         "::": TokenType.DCOLON,
         "||": TokenType.DPIPE,
@@ -1235,7 +1238,7 @@ class Tokenizer(metaclass=_Tokenizer):
                 self._advance(alnum=True)
             self._comments.append(self._text[comment_start_size:])
 
-        if comment_start == "/*+":
+        if comment_start == self.HINT_START:
             self._add(TokenType.HINT)
 
         # Leading comment is attached to the succeeding token, whilst trailing comment to the preceding.

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -568,7 +568,6 @@ class _Tokenizer(type):
                 var=_TOKEN_TYPE_TO_INDEX[TokenType.VAR],
                 heredoc_string_alternative=_TOKEN_TYPE_TO_INDEX[klass.HEREDOC_STRING_ALTERNATIVE],
                 hint=_TOKEN_TYPE_TO_INDEX[TokenType.HINT],
-                select=_TOKEN_TYPE_TO_INDEX[TokenType.SELECT],
             )
             klass._RS_TOKENIZER = RsTokenizer(settings, token_types)
         else:
@@ -966,10 +965,7 @@ class Tokenizer(metaclass=_Tokenizer):
     # Handle numeric literals like in hive (3L = BIGINT)
     NUMERIC_LITERALS: t.Dict[str, str] = {}
 
-    COMMENTS = [
-        "--",
-        ("/*", "*/"),
-    ]
+    COMMENTS = ["--", ("/*", "*/")]
 
     __slots__ = (
         "sql",

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -561,6 +561,7 @@ class _Tokenizer(type):
                 string=_TOKEN_TYPE_TO_INDEX[TokenType.STRING],
                 var=_TOKEN_TYPE_TO_INDEX[TokenType.VAR],
                 heredoc_string_alternative=_TOKEN_TYPE_TO_INDEX[klass.HEREDOC_STRING_ALTERNATIVE],
+                hint=_TOKEN_TYPE_TO_INDEX[TokenType.HINT],
             )
             klass._RS_TOKENIZER = RsTokenizer(settings, token_types)
         else:
@@ -954,7 +955,11 @@ class Tokenizer(metaclass=_Tokenizer):
     # Handle numeric literals like in hive (3L = BIGINT)
     NUMERIC_LITERALS: t.Dict[str, str] = {}
 
-    COMMENTS = ["--", ("/*", "*/")]
+    COMMENTS = [
+        "--",
+        ("/*", "*/"),
+        ("/*+", "*/"),
+    ]
 
     __slots__ = (
         "sql",
@@ -1229,6 +1234,9 @@ class Tokenizer(metaclass=_Tokenizer):
             while not self._end and self.WHITE_SPACE.get(self._peek) is not TokenType.BREAK:
                 self._advance(alnum=True)
             self._comments.append(self._text[comment_start_size:])
+
+        if comment_start == "/*+":
+            self._add(TokenType.HINT)
 
         # Leading comment is attached to the succeeding token, whilst trailing comment to the preceding.
         # Multiple consecutive comments are preserved by appending them to the current comments list.

--- a/sqlglotrs/src/settings.rs
+++ b/sqlglotrs/src/settings.rs
@@ -19,6 +19,7 @@ pub struct TokenTypeSettings {
     pub string: TokenType,
     pub var: TokenType,
     pub heredoc_string_alternative: TokenType,
+    pub hint: TokenType,
 }
 
 #[pymethods]
@@ -38,6 +39,7 @@ impl TokenTypeSettings {
         string: TokenType,
         var: TokenType,
         heredoc_string_alternative: TokenType,
+        hint: TokenType,
     ) -> Self {
         TokenTypeSettings {
             bit_string,
@@ -53,6 +55,7 @@ impl TokenTypeSettings {
             string,
             var,
             heredoc_string_alternative,
+            hint,
         }
     }
 }

--- a/sqlglotrs/src/settings.rs
+++ b/sqlglotrs/src/settings.rs
@@ -78,6 +78,7 @@ pub struct TokenizerSettings {
     pub var_single_tokens: HashSet<char>,
     pub commands: HashSet<TokenType>,
     pub command_prefix_tokens: HashSet<TokenType>,
+    pub tokens_preceding_hint: HashSet<TokenType>,
     pub heredoc_tag_is_identifier: bool,
     pub string_escapes_allowed_in_raw_strings: bool,
     pub nested_comments: bool,
@@ -103,6 +104,7 @@ impl TokenizerSettings {
         var_single_tokens: HashSet<String>,
         commands: HashSet<TokenType>,
         command_prefix_tokens: HashSet<TokenType>,
+        tokens_preceding_hint: HashSet<TokenType>,
         heredoc_tag_is_identifier: bool,
         string_escapes_allowed_in_raw_strings: bool,
         nested_comments: bool,
@@ -155,10 +157,11 @@ impl TokenizerSettings {
             var_single_tokens: var_single_tokens_native,
             commands,
             command_prefix_tokens,
+            tokens_preceding_hint,
             heredoc_tag_is_identifier,
             string_escapes_allowed_in_raw_strings,
             nested_comments,
-            hint_start
+            hint_start,
         }
     }
 }

--- a/sqlglotrs/src/settings.rs
+++ b/sqlglotrs/src/settings.rs
@@ -81,6 +81,7 @@ pub struct TokenizerSettings {
     pub heredoc_tag_is_identifier: bool,
     pub string_escapes_allowed_in_raw_strings: bool,
     pub nested_comments: bool,
+    pub hint_start: String,
 }
 
 #[pymethods]
@@ -105,6 +106,7 @@ impl TokenizerSettings {
         heredoc_tag_is_identifier: bool,
         string_escapes_allowed_in_raw_strings: bool,
         nested_comments: bool,
+        hint_start: String,
     ) -> Self {
         let to_char = |v: &String| {
             if v.len() == 1 {
@@ -156,6 +158,7 @@ impl TokenizerSettings {
             heredoc_tag_is_identifier,
             string_escapes_allowed_in_raw_strings,
             nested_comments,
+            hint_start
         }
     }
 }

--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -395,7 +395,7 @@ impl<'a> TokenizerState<'a> {
                 .push(self.text()[comment_start_size..].to_string());
         }
 
-        if comment_start == "/*+" {
+        if comment_start == self.settings.hint_start {
             self.add(self.token_types.hint, None)?;
         }
 

--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -395,7 +395,9 @@ impl<'a> TokenizerState<'a> {
                 .push(self.text()[comment_start_size..].to_string());
         }
 
-        if comment_start == self.settings.hint_start && self.tokens.last().is_some() && self.settings.tokens_preceding_hint.contains(&self.tokens.last().unwrap().token_type) {
+        if comment_start == self.settings.hint_start
+            && self.tokens.last().is_some()
+            && self.settings.tokens_preceding_hint.contains(&self.tokens.last().unwrap().token_type) {
             self.add(self.token_types.hint, None)?;
         }
 

--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -395,6 +395,10 @@ impl<'a> TokenizerState<'a> {
                 .push(self.text()[comment_start_size..].to_string());
         }
 
+        if comment_start == "/*+" {
+            self.add(self.token_types.hint, None)?;
+        }
+
         // Leading comment is attached to the succeeding token, whilst trailing comment to the preceding.
         // Multiple consecutive comments are preserved by appending them to the current comments list.
         if Some(comment_start_line) == self.previous_token_line {

--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -395,7 +395,7 @@ impl<'a> TokenizerState<'a> {
                 .push(self.text()[comment_start_size..].to_string());
         }
 
-        if comment_start == self.settings.hint_start {
+        if comment_start == self.settings.hint_start && self.tokens.last().is_some() && self.settings.tokens_preceding_hint.contains(&self.tokens.last().unwrap().token_type) {
             self.add(self.token_types.hint, None)?;
         }
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -287,6 +287,17 @@ class TestOracle(Validator):
                 "clickhouse": "TRIM(BOTH 'h' FROM 'Hello World')",
             },
         )
+        self.validate_identity(
+            "SELECT /*+ ORDERED */* FROM tbl", "SELECT /*+ ORDERED */ * FROM tbl"
+        )
+        self.validate_identity(
+            "SELECT /* test */ /*+ ORDERED */* FROM tbl",
+            "/* test */ SELECT /*+ ORDERED */ * FROM tbl",
+        )
+        self.validate_identity(
+            "SELECT /*+ ORDERED */*/* test */ FROM tbl",
+            "SELECT /*+ ORDERED */ * /* test */ FROM tbl",
+        )
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -128,10 +128,6 @@ class TestPostgres(Validator):
             "ORDER BY 2, 3"
         )
         self.validate_identity(
-            "/*+ some comment*/ SELECT b.foo, b.bar FROM baz AS b",
-            "/* + some comment */ SELECT b.foo, b.bar FROM baz AS b",
-        )
-        self.validate_identity(
             "SELECT ARRAY[1, 2, 3] <@ ARRAY[1, 2]",
             "SELECT ARRAY[1, 2] @> ARRAY[1, 2, 3]",
         )
@@ -816,6 +812,13 @@ class TestPostgres(Validator):
                 "spark2": "WITH t AS (SELECT ARRAY(1, 2, 3) AS col) SELECT * FROM t WHERE EXISTS(col, x -> 1 <= x) AND EXISTS(col, x -> 2 = x)",
                 "spark": "WITH t AS (SELECT ARRAY(1, 2, 3) AS col) SELECT * FROM t WHERE EXISTS(col, x -> 1 <= x) AND EXISTS(col, x -> 2 = x)",
                 "databricks": "WITH t AS (SELECT ARRAY(1, 2, 3) AS col) SELECT * FROM t WHERE EXISTS(col, x -> 1 <= x) AND EXISTS(col, x -> 2 = x)",
+            },
+        )
+
+        self.validate_all(
+            "/*+ some comment*/ SELECT b.foo, b.bar FROM baz AS b",
+            write={
+                "postgres": UnsupportedError,
             },
         )
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -815,11 +815,9 @@ class TestPostgres(Validator):
             },
         )
 
-        self.validate_all(
+        self.validate_identity(
             "/*+ some comment*/ SELECT b.foo, b.bar FROM baz AS b",
-            write={
-                "postgres": UnsupportedError,
-            },
+            "/* + some comment */ SELECT b.foo, b.bar FROM baz AS b",
         )
 
     def test_ddl(self):


### PR DESCRIPTION
Fixes #4425

Currently, hints are not tokenized as a single entity like we do for the comments (i.e through `_scan_comments()`), but instead the following token stream is produced:

```
>>> tokens = tokenize("SELECT /*+ hint */ * FROM t")
>>> for token in tokens:
   ... print(token)

<Token token_type: TokenType.SELECT, text: SELECT, line: 1, col: 6, start: 0, end: 5, comments: []>
<Token token_type: TokenType.HINT, text: /*+, line: 1, col: 10, start: 7, end: 9, comments: []>
<Token token_type: TokenType.VAR, text: hint, line: 1, col: 15, start: 11, end: 14, comments: []>
<Token token_type: TokenType.STAR, text: *, line: 1, col: 17, start: 16, end: 16, comments: []>
<Token token_type: TokenType.SLASH, text: /, line: 1, col: 18, start: 17, end: 17, comments: []>
<Token token_type: TokenType.STAR, text: *, line: 1, col: 20, start: 19, end: 19, comments: []>
<Token token_type: TokenType.FROM, text: FROM, line: 1, col: 25, start: 21, end: 24, comments: []>
<Token token_type: TokenType.VAR, text: t, line: 1, col: 27, start: 26, end: 26, comments: []>
```

For this reason, the hint is actually processed at parse time instead of tokenization time. This can lead to subtle bugs such as the one on the issue, where a slightly different pattern such as `SELECT /*+ hint */* FROM t` can throw off the tokenizer; In this case, we'd currently treat that as `SELECT /*+ * /*` i.e `SELECT <hint_start> * <comment_start> FROM t`.

This PR fixes this issue by:
- Treating hints as comments, so the entire hint text is processed by `scan_comments`
- Upon tokenizing a hint, we produce a `TokenType.HINT` with the payload/text attached to it's `comments`
- During parse time, we transform `TokenType.HINT` into an `exp.Hint` by parsing it's payload/text 
  