### PR TITLE
feat(snowflake): Transpile non-UNNEST exp.GenerateDateArray refs

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -198,43 +198,58 @@ def _flatten_structured_types_unless_iceberg(expression: exp.Expression) -> exp.
     return expression
 
 
-def _unnest_generate_date_array(expression: exp.Expression) -> exp.Expression:
+def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
+    generate_date_array = unnest.expressions[0]
+    start = generate_date_array.args.get("start")
+    end = generate_date_array.args.get("end")
+    step = generate_date_array.args.get("step")
+
+    if not start or not end or not isinstance(step, exp.Interval) or step.name != "1":
+        return
+
+    unit = step.args.get("unit")
+
+    unnest_alias = unnest.args.get("alias")
+    if unnest_alias:
+        unnest_alias = unnest_alias.copy()
+        sequence_value_name = seq_get(unnest_alias.columns, 0) or "value"
+    else:
+        sequence_value_name = "value"
+
+    # We'll add the next sequence value to the starting date and project the result
+    date_add = _build_date_time_add(exp.DateAdd)(
+        [unit, exp.cast(sequence_value_name, "int"), exp.cast(start, "date")]
+    ).as_(sequence_value_name)
+
+    # We use DATEDIFF to compute the number of sequence values needed
+    number_sequence = Snowflake.Parser.FUNCTIONS["ARRAY_GENERATE_RANGE"](
+        [exp.Literal.number(0), _build_datediff([unit, start, end]) + 1]
+    )
+
+    unnest.set("expressions", [number_sequence])
+    unnest.replace(exp.select(date_add).from_(unnest.copy()).subquery(unnest_alias))
+
+
+def _transform_generate_date_array(expression: exp.Expression) -> exp.Expression:
     if isinstance(expression, exp.Select):
-        for unnest in expression.find_all(exp.Unnest):
-            if (
-                isinstance(unnest.parent, (exp.From, exp.Join))
-                and len(unnest.expressions) == 1
-                and isinstance(unnest.expressions[0], exp.GenerateDateArray)
-            ):
-                generate_date_array = unnest.expressions[0]
-                start = generate_date_array.args.get("start")
-                end = generate_date_array.args.get("end")
-                step = generate_date_array.args.get("step")
+        for generate_date_array in expression.find_all(exp.GenerateDateArray):
+            parent = generate_date_array.parent
 
-                if not start or not end or not isinstance(step, exp.Interval) or step.name != "1":
-                    continue
-
-                unit = step.args.get("unit")
-
-                unnest_alias = unnest.args.get("alias")
-                if unnest_alias:
-                    unnest_alias = unnest_alias.copy()
-                    sequence_value_name = seq_get(unnest_alias.columns, 0) or "value"
-                else:
-                    sequence_value_name = "value"
-
-                # We'll add the next sequence value to the starting date and project the result
-                date_add = _build_date_time_add(exp.DateAdd)(
-                    [unit, exp.cast(sequence_value_name, "int"), exp.cast(start, "date")]
-                ).as_(sequence_value_name)
-
-                # We use DATEDIFF to compute the number of sequence values needed
-                number_sequence = Snowflake.Parser.FUNCTIONS["ARRAY_GENERATE_RANGE"](
-                    [exp.Literal.number(0), _build_datediff([unit, start, end]) + 1]
+            # If GENERATE_DATE_ARRAY is used directly as an array (e.g passed into ARRAY_LENGTH), the transformed Snowflake
+            # query is the following (it'll be unnested properly on the next iteration due to copy):
+            # SELECT ref(GENERATE_DATE_ARRAY(...)) -> SELECT ref((SELECT ARRAY_AGG(*) FROM UNNEST(GENERATE_DATE_ARRAY(...))))
+            if not isinstance(parent, exp.Unnest):
+                unnest = exp.Unnest(expressions=[generate_date_array.copy()])
+                generate_date_array.replace(
+                    exp.select(exp.ArrayAgg(this=exp.Star())).from_(unnest).subquery()
                 )
 
-                unnest.set("expressions", [number_sequence])
-                unnest.replace(exp.select(date_add).from_(unnest.copy()).subquery(unnest_alias))
+            if (
+                isinstance(parent, exp.Unnest)
+                and isinstance(parent.parent, (exp.From, exp.Join))
+                and len(parent.expressions) == 1
+            ):
+                _unnest_generate_date_array(parent)
 
     return expression
 
@@ -893,7 +908,7 @@ class Snowflake(Dialect):
                     transforms.eliminate_distinct_on,
                     transforms.explode_to_unnest(),
                     transforms.eliminate_semi_and_anti_joins,
-                    _unnest_generate_date_array,
+                    _transform_generate_date_array,
                 ]
             ),
             exp.SafeDivide: lambda self, e: no_safe_divide_sql(self, e, "IFF"),

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2854,6 +2854,13 @@ FROM subquery2""",
             },
         )
 
+        self.validate_all(
+            "SELECT ARRAY_LENGTH(GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK))",
+            write={
+                "snowflake": "SELECT ARRAY_SIZE((SELECT ARRAY_AGG(*) FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this))))",
+            },
+        )
+
     def test_set_operation_specifiers(self):
         self.validate_all(
             "SELECT 1 EXCEPT ALL SELECT 1",


### PR DESCRIPTION
Currently, transpilation of BQ's `GENERATE_DATE_ARRAY` to Snowflake is supported only if it's `UNNEST`ed (introduced by https://github.com/tobymao/sqlglot/pull/3899), e.g:


1. Supported:
```Python3
>>> import sqlglot
>>> sqlglot.parse_one("SELECT * FROM UNNEST(GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK))", read="bigquery").sql("snowflake")
"SELECT * FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this))"


bigquery> SELECT * FROM UNNEST(GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK)); 
f0_
2020-01-01
2020-01-08
2020-01-15
2020-01-22
2020-01-29

snowflake> SELECT * FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this));
--
2020-01-01
2020-01-08
2020-01-15
2020-01-22
2020-01-29
```

2. Not supported:
```Python3
>>> sqlglot.parse_one("SELECT GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK)", read="bigquery").sql("snowflake")
"SELECT GENERATE_DATE_ARRAY(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1 WEEK')"
```

This PR adds support for (2) by reusing (1) and aggregating it into an array, thus producing the following subquery:
```Python3
>>> sqlglot.parse_one("SELECT GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK)", read="bigquery").sql("snowflake")
"SELECT (SELECT ARRAY_AGG(*) FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this)))"

bigquery> SELECT GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK);
f0_
2020-01-01
2020-01-08
2020-01-15
2020-01-22
2020-01-29

snowflake> SELECT (SELECT ARRAY_AGG(*) FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this)));
--
["2020-01-01", "2020-01-08", "2020-01-15", "2020-01-22", "2020-01-29"]
```




