### PR TITLE
fix(tsql): Map weekday to %w

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -178,7 +178,7 @@ def _build_hashbytes(args: t.List) -> exp.Expression:
     return exp.func("HASHBYTES", *args)
 
 
-DATEPART_ONLY_FORMATS = {"DW", "HOUR", "QUARTER"}
+DATEPART_ONLY_FORMATS = {"DW", "WK", "HOUR", "QUARTER"}
 
 
 def _format_sql(self: TSQL.Generator, expression: exp.NumberToStr | exp.TimeToStr) -> str:
@@ -398,8 +398,8 @@ class TSQL(Dialect):
         "s": "%-S",
         "millisecond": "%f",
         "ms": "%f",
-        "weekday": "%W",
-        "dw": "%W",
+        "weekday": "%w",
+        "dw": "%w",
         "month": "%m",
         "mm": "%M",
         "m": "%-M",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1308,6 +1308,12 @@ WHERE
             },
         )
 
+        for fmt in ("WEEK", "WW", "WK"):
+            self.validate_identity(
+                f"SELECT DATEPART({fmt}, '2024-11-21')",
+                "SELECT DATEPART(WK, CAST('2024-11-21' AS DATETIME2))",
+            )
+
     def test_convert(self):
         self.validate_all(
             "CONVERT(NVARCHAR(200), x)",


### PR DESCRIPTION
Fixes #4435

- The Python specifier `%W` is for week number in year (1 - 52), while `%w` is for day of week (0-6)

```Python3
>>> from datetime import datetime
>>> now = datetime.now()
>>> now.strftime("%W")
47
>>> now.strftime("%w")
4
```

- The corresponding `%W` T-SQL formats:
```SQL
1> SELECT DATEPART(WEEK, CAST('2024-11-21' AS DATETIME2)), DATEPART(WK, CAST('2024-11-21' AS DATETIME2)), DATEPART(WW, CAST('2024-11-21' AS DATETIME2))
2> go

----------- ----------- -----------
     47         47          47
```

And `%w` (they're shifted by +1 i.e 1-7):
```SQL
1> SELECT DATEPART(WEEKDAY, CAST('2024-11-21' AS DATETIME2)), DATEPART(DW, CAST('2024-11-21' AS DATETIME2))
2> go

----------- -----------
      5           5
```

Docs
-----
[T-SQL DATE_PART](https://learn.microsoft.com/en-us/sql/t-sql/functions/datepart-transact-sql?view=sql-server-ver16) | [Python3 strftime](https://strftime.org/)