### PR TITLE
fix: add return type

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -295,7 +295,7 @@ class Expression(metaclass=_Expression):
 
         return root
 
-    def copy(self):
+    def copy(self) -> Self:
         """
         Returns a deep copy of the expression.
         """

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -524,7 +524,9 @@ def _expand_struct_stars(
         this = field.this.copy()
         root, *parts = [part.copy() for part in itertools.chain(dot_parts, [this])]
         new_column = exp.column(
-            t.cast(exp.Identifier, root), table=dot_column.args.get("table"), fields=parts
+            t.cast(exp.Identifier, root),
+            table=dot_column.args.get("table"),
+            fields=t.cast(t.List[exp.Identifier], parts),
         )
         new_selections.append(alias(new_column, this, copy=False))
 


### PR DESCRIPTION
The `copy` method on `Expression`s does not have a return type specified. This PR adds one (and makes one additional change that was necessitated by the addition of the return type).