### PR TITLE
fix(spark)!: Make TIMESTAMP map to Type.TIMESTAMPTZ

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -257,7 +257,6 @@ class Hive(Dialect):
             "MSCK REPAIR": TokenType.COMMAND,
             "REFRESH": TokenType.REFRESH,
             "TIMESTAMP AS OF": TokenType.TIMESTAMP_SNAPSHOT,
-            "TIMESTAMP": TokenType.TIMESTAMPTZ,
             "VERSION AS OF": TokenType.VERSION_SNAPSHOT,
             "SERDEPROPERTIES": TokenType.SERDE_PROPERTIES,
         }

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -257,6 +257,7 @@ class Hive(Dialect):
             "MSCK REPAIR": TokenType.COMMAND,
             "REFRESH": TokenType.REFRESH,
             "TIMESTAMP AS OF": TokenType.TIMESTAMP_SNAPSHOT,
+            "TIMESTAMP": TokenType.TIMESTAMPTZ,
             "VERSION AS OF": TokenType.VERSION_SNAPSHOT,
             "SERDEPROPERTIES": TokenType.SERDE_PROPERTIES,
         }

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -14,6 +14,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.hive import Hive
 from sqlglot.helper import seq_get, ensure_list
+from sqlglot.tokens import TokenType
 from sqlglot.transforms import (
     preprocess,
     remove_unique_constraints,
@@ -158,6 +159,14 @@ class Spark2(Hive):
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         ),
     }
+
+    class Tokenizer(Hive.Tokenizer):
+        HEX_STRINGS = [("X'", "'"), ("x'", "'")]
+
+        KEYWORDS = {
+            **Hive.Tokenizer.KEYWORDS,
+            "TIMESTAMP": TokenType.TIMESTAMPTZ,
+        }
 
     class Parser(Hive.Parser):
         TRIM_PATTERN_FIRST = True
@@ -337,6 +346,3 @@ class Spark2(Hive):
                     else sep
                 ),
             )
-
-    class Tokenizer(Hive.Tokenizer):
-        HEX_STRINGS = [("X'", "'"), ("x'", "'")]

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -33,7 +33,8 @@ class TestDatabricks(Validator):
             "CREATE TABLE IF NOT EXISTS db.table (a TIMESTAMP, b BOOLEAN GENERATED ALWAYS AS (NOT a IS NULL)) USING DELTA"
         )
         self.validate_identity(
-            "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(CAST(foo AS TIMESTAMP), 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t"
+            "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(foo, 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t",
+            "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(CAST(foo AS TIMESTAMP), 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t",
         )
         self.validate_identity(
             "SELECT * FROM sales UNPIVOT INCLUDE NULLS (sales FOR quarter IN (q1 AS `Jan-Mar`))"

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -405,16 +405,6 @@ class TestHive(Validator):
                 },
             )
 
-        self.validate_all(
-            "SELECT CAST(col AS TIMESTAMP)",
-            write={
-                "hive": "SELECT CAST(col AS TIMESTAMP)",
-                "spark": "SELECT CAST(col AS TIMESTAMP)",
-                "databricks": "SELECT TRY_CAST(col AS TIMESTAMP)",
-                "duckdb": "SELECT TRY_CAST(col AS TIMESTAMPTZ)",
-            },
-        )
-
     def test_order_by(self):
         self.validate_all(
             "SELECT fname, lname, age FROM person ORDER BY age DESC NULLS FIRST, fname ASC NULLS LAST, lname",
@@ -777,7 +767,7 @@ class TestHive(Validator):
                 "presto": "SELECT DATE_TRUNC('MONTH', CAST(ds AS TIMESTAMP))",
             },
             write={
-                "presto": "SELECT DATE_TRUNC('MONTH', TRY_CAST(ds AS TIMESTAMP WITH TIME ZONE))",
+                "presto": "SELECT DATE_TRUNC('MONTH', TRY_CAST(ds AS TIMESTAMP))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -405,6 +405,16 @@ class TestHive(Validator):
                 },
             )
 
+        self.validate_all(
+            "SELECT CAST(col AS TIMESTAMP)",
+            write={
+                "hive": "SELECT CAST(col AS TIMESTAMP)",
+                "spark": "SELECT CAST(col AS TIMESTAMP)",
+                "databricks": "SELECT TRY_CAST(col AS TIMESTAMP)",
+                "duckdb": "SELECT TRY_CAST(col AS TIMESTAMPTZ)",
+            },
+        )
+
     def test_order_by(self):
         self.validate_all(
             "SELECT fname, lname, age FROM person ORDER BY age DESC NULLS FIRST, fname ASC NULLS LAST, lname",
@@ -761,13 +771,13 @@ class TestHive(Validator):
             },
         )
         self.validate_all(
-            "SELECT TRUNC(CAST(ds AS TIMESTAMP), 'MONTH') AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
+            "SELECT TRUNC(CAST(ds AS TIMESTAMP), 'MONTH')",
             read={
-                "hive": "SELECT TRUNC(CAST(ds AS TIMESTAMP), 'MONTH') AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
-                "presto": "SELECT DATE_TRUNC('MONTH', CAST(ds AS TIMESTAMP)) AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
+                "hive": "SELECT TRUNC(CAST(ds AS TIMESTAMP), 'MONTH')",
+                "presto": "SELECT DATE_TRUNC('MONTH', CAST(ds AS TIMESTAMP))",
             },
             write={
-                "presto": "SELECT DATE_TRUNC('MONTH', TRY_CAST(ds AS TIMESTAMP)) AS mm FROM tbl WHERE ds BETWEEN '2023-10-01' AND '2024-02-29'",
+                "presto": "SELECT DATE_TRUNC('MONTH', TRY_CAST(ds AS TIMESTAMP WITH TIME ZONE))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1266,22 +1266,27 @@ COMMENT='客户账户表'"""
         )
 
     def test_timestamp_trunc(self):
-        for dialect in ("postgres", "snowflake", "duckdb", "spark", "databricks"):
+        hive_dialects = ("spark", "databricks")
+        for dialect in ("postgres", "snowflake", "duckdb", *hive_dialects):
             for unit in (
-                "MILLISECOND",
                 "SECOND",
                 "DAY",
                 "MONTH",
                 "YEAR",
             ):
                 with self.subTest(f"MySQL -> {dialect} Timestamp Trunc with unit {unit}: "):
+                    cast = (
+                        "TIMESTAMP('2001-02-16 20:38:40')"
+                        if dialect in hive_dialects
+                        else "CAST('2001-02-16 20:38:40' AS DATETIME)"
+                    )
                     self.validate_all(
-                        f"DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF({unit}, '0000-01-01 00:00:00', CAST('2001-02-16 20:38:40' AS DATETIME))) {unit})",
+                        f"DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF({unit}, '0000-01-01 00:00:00', {cast})) {unit})",
                         read={
                             dialect: f"DATE_TRUNC({unit}, TIMESTAMP '2001-02-16 20:38:40')",
                         },
                         write={
-                            "mysql": f"DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF({unit}, '0000-01-01 00:00:00', CAST('2001-02-16 20:38:40' AS DATETIME))) {unit})",
+                            "mysql": f"DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF({unit}, '0000-01-01 00:00:00', {cast})) {unit})",
                         },
                     )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -354,7 +354,7 @@ class TestPresto(Validator):
             },
         )
         self.validate_all(
-            "((DAY_OF_WEEK(CAST(TRY_CAST('2012-08-08 01:00:00' AS TIMESTAMP) AS DATE)) % 7) + 1)",
+            "((DAY_OF_WEEK(CAST(CAST(TRY_CAST('2012-08-08 01:00:00' AS TIMESTAMP WITH TIME ZONE) AS TIMESTAMP) AS DATE)) % 7) + 1)",
             read={
                 "spark": "DAYOFWEEK(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
@@ -406,7 +406,7 @@ class TestPresto(Validator):
             },
         )
         self.validate_all(
-            "SELECT AT_TIMEZONE(CAST('2012-10-31 00:00' AS TIMESTAMP), 'America/Sao_Paulo')",
+            "SELECT AT_TIMEZONE(CAST(CAST('2012-10-31 00:00' AS TIMESTAMP WITH TIME ZONE) AS TIMESTAMP), 'America/Sao_Paulo')",
             read={
                 "spark": "SELECT FROM_UTC_TIMESTAMP(TIMESTAMP '2012-10-31 00:00', 'America/Sao_Paulo')",
             },

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -765,6 +765,16 @@ TBLPROPERTIES (
             },
         )
 
+        self.validate_all(
+            "SELECT CAST(col AS TIMESTAMP)",
+            write={
+                "spark2": "SELECT CAST(col AS TIMESTAMP)",
+                "spark": "SELECT CAST(col AS TIMESTAMP)",
+                "databricks": "SELECT TRY_CAST(col AS TIMESTAMP)",
+                "duckdb": "SELECT TRY_CAST(col AS TIMESTAMPTZ)",
+            },
+        )
+
     def test_bool_or(self):
         self.validate_all(
             "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",


### PR DESCRIPTION
Fixes #4442

Spark defines it's `TIMESTAMP` to be a configurable session variable, with it's default value being timestamp with local time zone (`TIMESTAMP_LTZ`):

```SQL
spark-sql (default)> SELECT CAST('2024-11-27 15:03:20.603467+03' AS TIMESTAMP);
2024-11-27 14:03:20.603467

duckdb> SELECT CAST('2024-11-27 15:03:20.603467+03' AS TIMESTAMP);
┌────────────────────────────────────────────────────┐
│ CAST('2024-11-27 15:03:20.603467+03' AS TIMESTAMP) │
│                     timestamp                      │
├────────────────────────────────────────────────────┤
│ 2024-11-27 12:03:20.603467                         │
└────────────────────────────────────────────────────┘

duckdb> SELECT CAST('2024-11-27 15:03:20.603467+03' AS TIMESTAMPTZ);
┌───────────────────────────────────────────────────────────────────┐
│ CAST('2024-11-27 15:03:20.603467+03' AS TIMESTAMP WITH TIME ZONE) │
│                     timestamp with time zone                      │
├───────────────────────────────────────────────────────────────────┤
│ 2024-11-27 14:03:20.603467+02                                     │
└───────────────────────────────────────────────────────────────────┘
```


This PR maps Hive's `"TIMESTAMP" <-> Type.TIMESTAMPTZ`; This makes it so that:
- `TIMESTAMP` is roundtripped, thus preserving the session value. If the token was instead mapped to `Type.TIMESTAMP_LTZ`, we'd run the risk of breaking workloads that have reconfigured it to `TIMESTAMP_NTZ`
- Transpilation towards dialects is timezone-aware, as is shown above



Docs
--------
[Spark types](https://spark.apache.org/docs/3.5.2/sql-ref-datatypes.html)