### PR TITLE
fix(bigquery): Rename CONTAINS_SUBSTRING to CONTAINS_SUBSTR

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -319,7 +319,7 @@ def _build_format_time(expr_type: t.Type[exp.Expression]) -> t.Callable[[t.List]
 
 def _build_contains_substring(args: t.List) -> exp.Contains | exp.Anonymous:
     if len(args) == 3:
-        return exp.Anonymous(this="CONTAINS_SUBSTRING", expressions=args)
+        return exp.Anonymous(this="CONTAINS_SUBSTR", expressions=args)
 
     # Lowercase the operands in case of transpilation, as exp.Contains
     # is case-sensitive on other dialects
@@ -492,7 +492,7 @@ class BigQuery(Dialect):
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
-            "CONTAINS_SUBSTRING": _build_contains_substring,
+            "CONTAINS_SUBSTR": _build_contains_substring,
             "DATE": _build_date,
             "DATE_ADD": build_date_delta_with_interval(exp.DateAdd),
             "DATE_SUB": build_date_delta_with_interval(exp.DateSub),
@@ -1219,4 +1219,4 @@ class BigQuery(Dialect):
                 this = this.this
                 expr = expr.this
 
-            return self.func("CONTAINS_SUBSTRING", this, expr)
+            return self.func("CONTAINS_SUBSTR", this, expr)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1608,11 +1608,11 @@ WHERE
         )
 
         self.validate_identity(
-            "CONTAINS_SUBSTRING(a, b, json_scope => 'JSON_KEYS_AND_VALUES')"
+            "CONTAINS_SUBSTR(a, b, json_scope => 'JSON_KEYS_AND_VALUES')"
         ).assert_is(exp.Anonymous)
 
         self.validate_all(
-            """CONTAINS_SUBSTRING(a, b)""",
+            """CONTAINS_SUBSTR(a, b)""",
             read={
                 "": "CONTAINS(a, b)",
                 "spark": "CONTAINS(a, b)",
@@ -1628,7 +1628,7 @@ WHERE
                 "snowflake": "CONTAINS(LOWER(a), LOWER(b))",
                 "duckdb": "CONTAINS(LOWER(a), LOWER(b))",
                 "oracle": "CONTAINS(LOWER(a), LOWER(b))",
-                "bigquery": "CONTAINS_SUBSTRING(a, b)",
+                "bigquery": "CONTAINS_SUBSTR(a, b)",
             },
         )
 


### PR DESCRIPTION
Fixes #4456

The name `CONTAINS_SUBSTRING` was a typo from my end:

```
bq> SELECT CONTAINS_SUBSTRING('the blue house', 'Blue house') AS result;
Function not found: CONTAINS_SUBSTRING; Did you mean contains_substr? at [1:8]

bq> SELECT CONTAINS_SUBSTR('the blue house', 'Blue house') AS result;
true
```

Docs
--------
[BQ CONTAINS_SUBSTR](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#contains_substr)