### PR TITLE
feat(duckdb)!: Add support for EXPLAIN [ANALYZE] statement

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -768,7 +768,7 @@ class DuckDB(Dialect):
             "using",
             "order",
             "current_catalog",
-            "explain"
+            "explain",
         }
 
         UNWRAPPED_INTERVAL_VALUES = (exp.Literal, exp.Paren)
@@ -907,7 +907,7 @@ class DuckDB(Dialect):
                     bracket = f"({bracket})[1]"
 
             return bracket
-        
+
         def describe_sql(self, expression: exp.Describe) -> str:
             style = expression.args.get("style")
             style = f" {style}" if style else ""
@@ -917,7 +917,7 @@ class DuckDB(Dialect):
             format = f" {format}" if format else ""
 
             return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"
-        
+
         def explain_sql(self, expression: exp.Explain) -> str:
             style = expression.args.get("style")
             style = f" {style}" if style else ""
@@ -926,7 +926,7 @@ class DuckDB(Dialect):
             format = self.sql(expression, "format")
             format = f" {format}" if format else ""
 
-            return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"        
+            return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"
 
         def withingroup_sql(self, expression: exp.WithinGroup) -> str:
             expression_sql = self.sql(expression, "expression")

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -317,6 +317,7 @@ class DuckDB(Dialect):
             "CHARACTER VARYING": TokenType.TEXT,
             "DETACH": TokenType.DETACH,
             "EXCLUDE": TokenType.EXCEPT,
+            "EXPLAIN": TokenType.EXPLAIN,
             "LOGICAL": TokenType.BOOLEAN,
             "ONLY": TokenType.ONLY,
             "PIVOT_WIDER": TokenType.PIVOT,
@@ -767,6 +768,7 @@ class DuckDB(Dialect):
             "using",
             "order",
             "current_catalog",
+            "explain"
         }
 
         UNWRAPPED_INTERVAL_VALUES = (exp.Literal, exp.Paren)
@@ -905,6 +907,26 @@ class DuckDB(Dialect):
                     bracket = f"({bracket})[1]"
 
             return bracket
+        
+        def describe_sql(self, expression: exp.Describe) -> str:
+            style = expression.args.get("style")
+            style = f" {style}" if style else ""
+            partition = self.sql(expression, "partition")
+            partition = f" {partition}" if partition else ""
+            format = self.sql(expression, "format")
+            format = f" {format}" if format else ""
+
+            return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"
+        
+        def explain_sql(self, expression: exp.Explain) -> str:
+            style = expression.args.get("style")
+            style = f" {style}" if style else ""
+            partition = self.sql(expression, "partition")
+            partition = f" {partition}" if partition else ""
+            format = self.sql(expression, "format")
+            format = f" {format}" if format else ""
+
+            return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"        
 
         def withingroup_sql(self, expression: exp.WithinGroup) -> str:
             expression_sql = self.sql(expression, "expression")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1479,6 +1479,16 @@ class Describe(Expression):
         "format": False,
     }
 
+class Explain(Expression):
+    arg_types = {
+        "this": True,
+        "style": False,
+        "kind": False,
+        "expressions": False,
+        "partition": False,
+        "format": False,
+    }    
+
 
 # https://duckdb.org/docs/sql/statements/attach.html#attach
 class Attach(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1479,6 +1479,7 @@ class Describe(Expression):
         "format": False,
     }
 
+
 class Explain(Expression):
     arg_types = {
         "this": True,
@@ -1487,7 +1488,7 @@ class Explain(Expression):
         "expressions": False,
         "partition": False,
         "format": False,
-    }    
+    }
 
 
 # https://duckdb.org/docs/sql/statements/attach.html#attach

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1210,6 +1210,15 @@ class Generator(metaclass=_Generator):
         format = f" {format}" if format else ""
 
         return f"DESCRIBE{style}{format} {self.sql(expression, 'this')}{partition}"
+    
+    def explain_sql(self, expression: exp.Explain) -> str:
+        style = expression.args.get("style")
+        style = f" {style}" if style else ""
+        partition = self.sql(expression, "partition")
+        partition = f" {partition}" if partition else ""
+        format = self.sql(expression, "format")
+        format = f" {format}" if format else ""
+        return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"    
 
     def heredoc_sql(self, expression: exp.Heredoc) -> str:
         tag = self.sql(expression, "tag")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1210,7 +1210,7 @@ class Generator(metaclass=_Generator):
         format = f" {format}" if format else ""
 
         return f"DESCRIBE{style}{format} {self.sql(expression, 'this')}{partition}"
-    
+
     def explain_sql(self, expression: exp.Explain) -> str:
         style = expression.args.get("style")
         style = f" {style}" if style else ""
@@ -1218,7 +1218,7 @@ class Generator(metaclass=_Generator):
         partition = f" {partition}" if partition else ""
         format = self.sql(expression, "format")
         format = f" {format}" if format else ""
-        return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"    
+        return f"EXPLAIN{style}{format} {self.sql(expression, 'this')}{partition}"
 
     def heredoc_sql(self, expression: exp.Heredoc) -> str:
         tag = self.sql(expression, "tag")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2647,7 +2647,7 @@ class Parser(metaclass=_Parser):
             partition=partition,
             format=format,
         )
-    
+
     def _parse_explain(self) -> exp.Explain:
         kind = self._match_set(self.CREATABLES) and self._prev.text
         style = self._match_texts(self.EXPLAIN_STYLES) and self._prev.text.upper()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -267,6 +267,7 @@ class TokenType(AutoName):
     EXCEPT = auto()
     EXECUTE = auto()
     EXISTS = auto()
+    EXPLAIN = auto()
     FALSE = auto()
     FETCH = auto()
     FILTER = auto()

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1405,17 +1405,11 @@ class TestDuckDB(Validator):
         self.validate_identity("DETACH DATABASE db", "DETACH db")
 
     def test_explain(self):
-        self.validate_identity(
-            "EXPLAIN SELECT * FROM t"
-        )
+        self.validate_identity("EXPLAIN SELECT * FROM t")
 
-        self.validate_identity(
-            "EXPLAIN ANALYZE SELECT * FROM t"
-        )        
+        self.validate_identity("EXPLAIN ANALYZE SELECT * FROM t")
 
-        self.validate_identity(
-            "DESCRIBE SELECT * FROM t", "EXPLAIN SELECT * FROM t"
-        )        
+        self.validate_identity("DESCRIBE SELECT * FROM t", "EXPLAIN SELECT * FROM t")
 
         self.validate_identity(
             "DESCRIBE ANALYZE SELECT * FROM t", "EXPLAIN ANALYZE SELECT * FROM t"

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -854,8 +854,6 @@ class TestDuckDB(Validator):
         self.validate_identity("SELECT LENGTH(foo)")
         self.validate_identity("SELECT ARRAY[1, 2, 3]", "SELECT [1, 2, 3]")
 
-        self.validate_identity("SELECT * FROM (DESCRIBE t)")
-
         self.validate_identity("SELECT UNNEST([*COLUMNS('alias_.*')]) AS column_name")
         self.validate_identity(
             "SELECT COALESCE(*COLUMNS(*)) FROM (SELECT NULL, 2, 3) AS t(a, b, c)"
@@ -1405,3 +1403,24 @@ class TestDuckDB(Validator):
         self.validate_identity("DETACH IF EXISTS file")
 
         self.validate_identity("DETACH DATABASE db", "DETACH db")
+
+    def test_explain(self):
+        self.validate_identity(
+            "EXPLAIN SELECT * FROM t"
+        )
+
+        self.validate_identity(
+            "EXPLAIN ANALYZE SELECT * FROM t"
+        )        
+
+        self.validate_identity(
+            "DESCRIBE SELECT * FROM t", "EXPLAIN SELECT * FROM t"
+        )        
+
+        self.validate_identity(
+            "DESCRIBE ANALYZE SELECT * FROM t", "EXPLAIN ANALYZE SELECT * FROM t"
+        )
+
+        expression = self.parse_one("EXPLAIN ANALYZE SELECT * FROM t")
+        self.assertIsInstance(expression, exp.Explain)
+        self.assertEqual(expression.text("style"), "ANALYZE")


### PR DESCRIPTION
Adds support for EXPLAIN [ANALYZE] for DuckDB. Also translate DESCRIBE into EXPLAIN from other dialects. 

```python
>>> import duckdb
>>> import sqlglot 
>>> from sqlglot import exp
>>> 
>>> conn = duckdb.connect()
>>> conn.sql("CREATE TABLE t1 (id int);")
>>> query = "EXPLAIN ANALYZE SELECT * FROM t1;"
>>> parsed = sqlglot.parse_one(query, dialect="duckdb")
'EXPLAIN ANALYZE SELECT * FROM t1' contains unsupported syntax. Falling back to parsing as a 'Command'.
>>> replaced = exp.replace_tables(
...     parsed,
...     {"t2", "t1"}
... )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/mrjsj/Developer/sqlglot/sqlglot/expressions.py", line 8231, in replace_tables
    mapping = {normalize_table_name(k, dialect=dialect): v for k, v in mapping.items()}
AttributeError: 'set' object has no attribute 'items'
>>>
```

Let me know, if there's better approach - if we can somehow share the DESCRIBE/EXPLAIN like MySQL uses `TokenType.DESCRIBE` for both. However, DuckDB only supports EXPLAIN.