### PR TITLE
Adds parsing for STORED token in generated columns

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -96,6 +96,7 @@ def _generated_to_auto_increment(expression: exp.Expression) -> exp.Expression:
 
     return expression
 
+
 class SQLite(Dialect):
     # https://sqlite.org/forum/forumpost/5e575586ac5c711b?raw
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -96,7 +96,6 @@ def _generated_to_auto_increment(expression: exp.Expression) -> exp.Expression:
 
     return expression
 
-
 class SQLite(Dialect):
     # https://sqlite.org/forum/forumpost/5e575586ac5c711b?raw
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1861,6 +1861,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
         "minvalue": False,
         "maxvalue": False,
         "cycle": False,
+        "stored": False,
     }
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1862,6 +1862,7 @@ class GeneratedAsIdentityColumnConstraint(ColumnConstraintKind):
         "maxvalue": False,
         "cycle": False,
         "stored": False,
+        "virtual": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1007,8 +1007,8 @@ class Generator(metaclass=_Generator):
         minvalue = f" MINVALUE {minvalue}" if minvalue else ""
         maxvalue = expression.args.get("maxvalue")
         maxvalue = f" MAXVALUE {maxvalue}" if maxvalue else ""
-        stored = expression.args.get("stored")
-        stored = " STORED" if stored else ""
+        stored = " STORED" if expression.args.get("stored") else ""
+        virtual = " VIRTUAL" if expression.args.get("virtual") else ""
         cycle = expression.args.get("cycle")
         cycle_sql = ""
 
@@ -1024,7 +1024,7 @@ class Generator(metaclass=_Generator):
         expr = self.sql(expression, "expression")
         expr = f"({expr})" if expr else "IDENTITY"
 
-        return f"GENERATED{this} AS {expr}{sequence_opts}{stored}"
+        return f"GENERATED{this} AS {expr}{sequence_opts}{stored}{virtual}"
 
     def generatedasrowcolumnconstraint_sql(
         self, expression: exp.GeneratedAsRowColumnConstraint

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1007,6 +1007,8 @@ class Generator(metaclass=_Generator):
         minvalue = f" MINVALUE {minvalue}" if minvalue else ""
         maxvalue = expression.args.get("maxvalue")
         maxvalue = f" MAXVALUE {maxvalue}" if maxvalue else ""
+        stored = expression.args.get("stored")
+        stored = " STORED" if stored else ""
         cycle = expression.args.get("cycle")
         cycle_sql = ""
 
@@ -1022,7 +1024,7 @@ class Generator(metaclass=_Generator):
         expr = self.sql(expression, "expression")
         expr = f"({expr})" if expr else "IDENTITY"
 
-        return f"GENERATED{this} AS {expr}{sequence_opts}"
+        return f"GENERATED{this} AS {expr}{sequence_opts}{stored}"
 
     def generatedasrowcolumnconstraint_sql(
         self, expression: exp.GeneratedAsRowColumnConstraint

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5627,6 +5627,9 @@ class Parser(metaclass=_Parser):
 
             self._match_r_paren()
 
+        if self._match_text_seq("STORED"):
+            this.set("stored", True)
+
         return this
 
     def _parse_inline(self) -> exp.InlineLengthColumnConstraint:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5629,6 +5629,8 @@ class Parser(metaclass=_Parser):
 
         if self._match_text_seq("STORED"):
             this.set("stored", True)
+        elif self._match_text_seq("VIRTUAL"):
+            this.set("virtual", True)
 
         return this
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -949,6 +949,11 @@ class TestMySQL(Validator):
                 "postgres": "STRING_AGG(DISTINCT CONCAT(a, b, c), '' ORDER BY d NULLS FIRST)",
             },
         )
+
+        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))")
+        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)")
+        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) VIRTUAL)")
+
         self.validate_identity(
             "CREATE TABLE z (a INT) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET=utf8 COLLATE=utf8_bin COMMENT='x'"
         )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -950,9 +950,15 @@ class TestMySQL(Validator):
             },
         )
 
-        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))")
-        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)")
-        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) VIRTUAL)")
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))"
+        )
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)"
+        )
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) VIRTUAL)"
+        )
 
         self.validate_identity(
             "CREATE TABLE z (a INT) ENGINE=InnoDB AUTO_INCREMENT=1 CHARACTER SET=utf8 COLLATE=utf8_bin COMMENT='x'"

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1034,7 +1034,9 @@ class TestPostgres(Validator):
             "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5 RESTART IDENTITY CASCADE",
         )
 
-        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)")
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)"
+        )
 
         self.validate_all(
             "CREATE TABLE x (a UUID, b BYTEA)",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1034,6 +1034,15 @@ class TestPostgres(Validator):
             "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5 RESTART IDENTITY CASCADE",
         )
 
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))",
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))",
+        )
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)",
+            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)",
+        )
+
         self.validate_all(
             "CREATE TABLE x (a UUID, b BYTEA)",
             write={

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1034,14 +1034,7 @@ class TestPostgres(Validator):
             "TRUNCATE TABLE ONLY t1, t2, ONLY t3, t4, t5 RESTART IDENTITY CASCADE",
         )
 
-        self.validate_identity(
-            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))",
-            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1))",
-        )
-        self.validate_identity(
-            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)",
-            "CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)",
-        )
+        self.validate_identity("CREATE TABLE IF NOT EXISTS example (col_a INT, col_c INT GENERATED ALWAYS AS (col_a + 1) STORED)")
 
         self.validate_all(
             "CREATE TABLE x (a UUID, b BYTEA)",

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -179,9 +179,15 @@ class TestSQLite(Validator):
         self.validate_identity("CREATE TABLE foo (id INTEGER PRIMARY KEY ASC)")
         self.validate_identity("CREATE TEMPORARY TABLE foo (id INTEGER)")
 
-        self.validate_identity("CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2))")
-        self.validate_identity("CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2) STORED)")
-        self.validate_identity("CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2) VIRTUAL)")
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2))"
+        )
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2) STORED)"
+        )
+        self.validate_identity(
+            "CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2) VIRTUAL)"
+        )
 
         self.validate_all(
             """

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -179,6 +179,10 @@ class TestSQLite(Validator):
         self.validate_identity("CREATE TABLE foo (id INTEGER PRIMARY KEY ASC)")
         self.validate_identity("CREATE TEMPORARY TABLE foo (id INTEGER)")
 
+        self.validate_identity("CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2))")
+        self.validate_identity("CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2) STORED)")
+        self.validate_identity("CREATE TABLE IF NOT EXISTS foo (col_a INTEGER, col_c INTEGER GENERATED ALWAYS AS (col_a + 2) VIRTUAL)")
+
         self.validate_all(
             """
             CREATE TABLE "Track"


### PR DESCRIPTION
[Slack discussion](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1733033895230909), issue #4463 

This adds parsing for the `STORED` token in generated columns. _This is my first time contributing here, so don't be shy with pointing out any correction_.

Fixes #4463 

## Examples of syntax

```py
from sqlglot import parse

parse("""
  CREATE TABLE IF NOT EXISTS example (
    col_a INT NOT NULL,
    col_b INT NOT NULL,
    col_c INT GENERATED ALWAYS AS (col_a + col_b) STORED,
    col_d INT GENERATED ALWAYS AS (col_a + col_b) VIRTUAL
  );
""", read='postgres')
```

### TODO

- [x] Test Postgres Stored
- [x] Test MySQL Stored
- [x] Test MySQL Virtual Implicit 
- [x] Test MySQL Virtual
- [ ] Test SQLite Stored
- [ ] Test SQLite Virtual Implicit
- [ ] Test SQLite Virtual

The docs seem to support support for stored columns but when I tried it didn't seem to be available (but I don't really use it that much so I may have done something wrong here). 

## Questions

- [ ] Do I need to do anything to limit this to the postgresql dialect?
  - (I actually don't know if this is valid syntax in other dialects)