### PR TITLE
Fix(parser)!: treat NEXT as a func keyword, parse NEXT VALUE FOR in tsql, oracle

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -128,6 +128,7 @@ class Oracle(Dialect):
 
         NO_PAREN_FUNCTION_PARSERS = {
             **parser.Parser.NO_PAREN_FUNCTION_PARSERS,
+            "NEXT": lambda self: self._parse_next_value_for(),
             "SYSDATE": lambda self: self.expression(exp.CurrentTimestamp, sysdate=True),
         }
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -597,6 +597,11 @@ class TSQL(Dialect):
             ),
         }
 
+        NO_PAREN_FUNCTION_PARSERS = {
+            **parser.Parser.NO_PAREN_FUNCTION_PARSERS,
+            "NEXT": lambda self: self._parse_next_value_for(),
+        }
+
         # The DCOLON (::) operator serves as a scope resolution (exp.ScopeResolution) operator in T-SQL
         COLUMN_OPERATORS = {
             **parser.Parser.COLUMN_OPERATORS,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -586,6 +586,7 @@ class Parser(metaclass=_Parser):
         TokenType.INSERT,
         TokenType.LIKE,
         TokenType.MERGE,
+        TokenType.NEXT,
         TokenType.OFFSET,
         TokenType.PRIMARY_KEY,
         TokenType.RANGE,
@@ -1107,7 +1108,6 @@ class Parser(metaclass=_Parser):
             exp.ConnectByRoot, this=self._parse_column()
         ),
         "IF": lambda self: self._parse_if(),
-        "NEXT": lambda self: self._parse_next_value_for(),
     }
 
     INVALID_FUNC_NAME_TOKENS = {

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1203,7 +1203,8 @@ MATCH_RECOGNIZE (
   DEFINE
     B AS totalprice < PREV(totalprice),
     C AS totalprice > PREV(totalprice) AND totalprice <= A.totalprice,
-    D AS totalprice > PREV(totalprice)
+    D AS totalprice > PREV(totalprice),
+    E AS MAX(foo) >= NEXT(bar)
 )""",
             pretty=True,
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -2075,3 +2075,18 @@ FROM OPENJSON(@json) WITH (
                 "tsql": UnsupportedError,
             },
         )
+
+    def test_next_value_for(self):
+        self.validate_identity(
+            "SELECT NEXT VALUE FOR db.schema.sequence_name OVER (ORDER BY foo), col"
+        )
+        self.validate_all(
+            "SELECT NEXT VALUE FOR db.schema.sequence_name",
+            read={
+                "oracle": "SELECT NEXT VALUE FOR db.schema.sequence_name",
+                "tsql": "SELECT NEXT VALUE FOR db.schema.sequence_name",
+            },
+            write={
+                "oracle": "SELECT NEXT VALUE FOR db.schema.sequence_name",
+            },
+        )

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -830,8 +830,6 @@ JSON_OBJECT('x': 1 RETURNING VARCHAR(100))
 JSON_OBJECT('x': 1 RETURNING VARBINARY FORMAT JSON ENCODING UTF8)
 PRIOR AS x
 SELECT if.x
-SELECT NEXT VALUE FOR db.schema.sequence_name
-SELECT NEXT VALUE FOR db.schema.sequence_name OVER (ORDER BY foo), col
 SELECT PERCENTILE_CONT(x, 0.5) OVER ()
 WITH my_cte AS (SELECT 'a' AS desc) SELECT desc AS description FROM my_cte
 WITH my_cte AS (SELECT 'a' AS asc) SELECT asc AS description FROM my_cte


### PR DESCRIPTION
Fixes #4466