### PR TITLE
Feat: allow tables to be preserved in replace_table

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -8,7 +8,7 @@ from functools import reduce
 from sqlglot import exp
 from sqlglot.errors import ParseError
 from sqlglot.generator import Generator, unsupported_args
-from sqlglot.helper import AutoName, flatten, is_int, seq_get, subclasses
+from sqlglot.helper import AutoName, flatten, is_int, seq_get, subclasses, to_bool
 from sqlglot.jsonpath import JSONPathTokenizer, parse as parse_json_path
 from sqlglot.parser import Parser
 from sqlglot.time import TIMEZONES, format_time, subsecond_precision
@@ -770,14 +770,7 @@ class Dialect(metaclass=_Dialect):
                     elif len(pair) == 2:
                         value = pair[1].strip()
 
-                        # Coerce the value to boolean if it matches to the truthy/falsy values below
-                        value_lower = value.lower()
-                        if value_lower in ("true", "1"):
-                            value = True
-                        elif value_lower in ("false", "0"):
-                            value = False
-
-                    kwargs[key] = value
+                    kwargs[key] = to_bool(value)
 
             except ValueError:
                 raise ValueError(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8231,7 +8231,7 @@ def replace_tables(
     mapping = {normalize_table_name(k, dialect=dialect): v for k, v in mapping.items()}
 
     def _replace_tables(node: Expression) -> Expression:
-        if isinstance(node, Table):
+        if isinstance(node, Table) and not node.meta.get("preserve_reference"):
             original = normalize_table_name(node, dialect=dialect)
             new_name = mapping.get(original)
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -31,6 +31,7 @@ from sqlglot.helper import (
     ensure_list,
     seq_get,
     subclasses,
+    to_bool,
 )
 from sqlglot.tokens import Token, TokenError
 
@@ -312,7 +313,7 @@ class Expression(metaclass=_Expression):
                     for kv in "".join(meta).split(","):
                         k, *v = kv.split("=")
                         value = v[0].strip() if v else True
-                        self.meta[k.strip()] = value
+                        self.meta[k.strip()] = to_bool(value)
 
                 if not prepend:
                     self.comments.append(comment)
@@ -8231,7 +8232,7 @@ def replace_tables(
     mapping = {normalize_table_name(k, dialect=dialect): v for k, v in mapping.items()}
 
     def _replace_tables(node: Expression) -> Expression:
-        if isinstance(node, Table) and not node.meta.get("preserve_reference"):
+        if isinstance(node, Table) and node.meta.get("replace") is not False:
             original = normalize_table_name(node, dialect=dialect)
             new_name = mapping.get(original)
 

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -456,6 +456,20 @@ def first(it: t.Iterable[T]) -> T:
     return next(i for i in it)
 
 
+def to_bool(value: t.Optional[str | bool]) -> t.Optional[str | bool]:
+    if isinstance(value, bool) or value is None:
+        return value
+
+    # Coerce the value to boolean if it matches to the truthy/falsy values below
+    value_lower = value.lower()
+    if value_lower in ("true", "1"):
+        return True
+    elif value_lower in ("false", "0"):
+        return False
+
+    return value
+
+
 def merge_ranges(ranges: t.List[t.Tuple[A, A]]) -> t.List[t.Tuple[A, A]]:
     """
     Merges a sequence of ranges, represented as tuples (low, high) whose values

--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -464,7 +464,7 @@ def to_bool(value: t.Optional[str | bool]) -> t.Optional[str | bool]:
     value_lower = value.lower()
     if value_lower in ("true", "1"):
         return True
-    elif value_lower in ("false", "0"):
+    if value_lower in ("false", "0"):
         return False
 
     return value

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -258,6 +258,14 @@ class TestExpressions(unittest.TestCase):
             'SELECT * FROM "my-project"."example"."table" /* example.table */',
         )
 
+        self.assertEqual(
+            exp.replace_tables(
+                parse_one("select * from example.table /* sqlglot.meta preserve_reference */"),
+                {"example.table": "a.b"},
+            ).sql(),
+            "SELECT * FROM example.table /* sqlglot.meta preserve_reference */",
+        )
+
     def test_expand(self):
         self.assertEqual(
             exp.expand(

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -260,10 +260,10 @@ class TestExpressions(unittest.TestCase):
 
         self.assertEqual(
             exp.replace_tables(
-                parse_one("select * from example.table /* sqlglot.meta preserve_reference */"),
+                parse_one("select * from example.table /* sqlglot.meta replace=false */"),
                 {"example.table": "a.b"},
             ).sql(),
-            "SELECT * FROM example.table /* sqlglot.meta preserve_reference */",
+            "SELECT * FROM example.table /* sqlglot.meta replace=false */",
         )
 
     def test_expand(self):
@@ -1176,7 +1176,7 @@ FROM foo""",
 
     def test_set_meta(self):
         query = parse_one("SELECT * FROM foo /* sqlglot.meta x = 1, y = a, z */")
-        self.assertEqual(query.find(exp.Table).meta, {"x": "1", "y": "a", "z": True})
+        self.assertEqual(query.find(exp.Table).meta, {"x": True, "y": "a", "z": True})
         self.assertEqual(query.sql(), "SELECT * FROM foo /* sqlglot.meta x = 1, y = a, z */")
 
     def test_assert_is(self):


### PR DESCRIPTION
This will allow SQLMesh users to control which table references will be resolved to the db objects in the physical layer.