### PR TITLE
feat(postgres): Support generated columns

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -476,6 +476,20 @@ class Postgres(Dialect):
                 and self.dialect.to_json_path(self._parse_bitwise()),
             )
 
+        def _parse_generated_as_identity(
+            self,
+        ) -> (
+            exp.GeneratedAsIdentityColumnConstraint
+            | exp.ComputedColumnConstraint
+            | exp.GeneratedAsRowColumnConstraint
+        ):
+            this = super()._parse_generated_as_identity()
+
+            if self._match_texts(("STORED")):
+                this = self.expression(exp.ComputedColumnConstraint, this=this.expression)
+
+            return this
+
     class Generator(generator.Generator):
         SINGLE_STRING_INTERVAL = True
         RENAME_TABLE_WITH_DB = False
@@ -691,3 +705,6 @@ class Postgres(Dialect):
                 if isinstance(seq_get(exprs, 0), exp.Select)
                 else f"{self.normalize_func('ARRAY')}[{self.expressions(expression, flat=True)}]"
             )
+
+        def computedcolumnconstraint_sql(self, expression: exp.ComputedColumnConstraint) -> str:
+            return f"GENERATED ALWAYS AS ({self.sql(expression, 'this')}) STORED"

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -485,7 +485,7 @@ class Postgres(Dialect):
         ):
             this = super()._parse_generated_as_identity()
 
-            if self._match_texts(("STORED")):
+            if self._match_text_seq("STORED"):
                 this = self.expression(exp.ComputedColumnConstraint, this=this.expression)
 
             return this

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1047,6 +1047,7 @@ class TestPostgres(Validator):
         self.validate_identity("CREATE TABLE tbl (col INT UNIQUE NULLS NOT DISTINCT DEFAULT 9.99)")
         self.validate_identity("CREATE TABLE tbl (col UUID UNIQUE DEFAULT GEN_RANDOM_UUID())")
         self.validate_identity("CREATE TABLE tbl (col UUID, UNIQUE NULLS NOT DISTINCT (col))")
+        self.validate_identity("CREATE TABLE tbl (col_a INT GENERATED ALWAYS AS (1 + 2) STORED)")
 
         self.validate_identity("CREATE INDEX CONCURRENTLY ix_table_id ON tbl USING btree(id)")
         self.validate_identity(


### PR DESCRIPTION
Fixes #4463

Postgres supports the following column constraints for `CREATE TABLE` DDLs:

```
where column_constraint is:

[ CONSTRAINT constraint_name ]
{ 
  ...
  GENERATED ALWAYS AS ( generation_expr ) STORED |
  GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY [ ( sequence_options ) ] |
  ...
}
```

The former defines a _generated_ column while the latter an _identity_ one. 

This PR overrides `parser.py::_parse_generated_as_identity()` which will transform the produced `exp.GeneratedAsIdentityColumnConstraint` into an `exp.ComputedColumnConstraint()`, as is already happening on `spark.py`.


> [!WARNING]  
> Something that stands out as bad naming/design is the fact that `exp.GeneratedAsIdentityColumnConstraint` should concern only **IDENTITY** columns, but overtime it has grown to parse different variants of the `GENERATED` syntax even if semantically they're not equivalent. 
>
> This leads to the "hacky" solution of having to transform it to `exp.ComputedColumnConstraint` _after_ it has been parsed, as is happening in the PR. Should we make an effort to deduplicate the two? 


Docs
--------
[PSQL CREATE TABLE](https://www.postgresql.org/docs/current/sql-createtable.html) | [PSQL GENERATED columns](https://www.postgresql.org/docs/current/ddl-generated-columns.html) | [PSQL IDENTITY columns](https://www.postgresql.org/docs/current/ddl-identity-columns.html)