### PR TITLE
Feat!(snowflake): improve transpilation of TO_TIMESTAMP* variants

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -44,7 +44,7 @@ def _build_datetime(
         scale_or_fmt = seq_get(args, 1)
 
         int_value = value is not None and is_int(value.name)
-        int_scale_or_fmt = scale_or_fmt is not None and is_int(scale_or_fmt.name)
+        int_scale_or_fmt = scale_or_fmt is not None and scale_or_fmt.is_int
 
         if isinstance(value, exp.Literal) or (value and scale_or_fmt):
             # Converts calls like `TO_TIME('01:02:03')` into casts

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -124,6 +124,7 @@ WHERE
         self.validate_identity(
             "SELECT * FROM DATA AS DATA_L ASOF JOIN DATA AS DATA_R MATCH_CONDITION (DATA_L.VAL > DATA_R.VAL) ON DATA_L.ID = DATA_R.ID"
         )
+        self.validate_identity("TO_TIMESTAMP(col, fmt)")
         self.validate_identity(
             "CAST(x AS GEOGRAPHY)",
             "TO_GEOGRAPHY(x)",
@@ -668,6 +669,15 @@ WHERE
             write={
                 "bigquery": "SELECT a FROM test AS t QUALIFY ROW_NUMBER() OVER (PARTITION BY a ORDER BY Z NULLS LAST) = 1",
                 "snowflake": "SELECT a FROM test AS t QUALIFY ROW_NUMBER() OVER (PARTITION BY a ORDER BY Z) = 1",
+            },
+        )
+        self.validate_all(
+            "SELECT TO_TIMESTAMP(col, 'DD-MM-YYYY HH12:MI:SS') FROM t",
+            write={
+                "bigquery": "SELECT PARSE_TIMESTAMP('%d-%m-%Y %I:%M:%S', col) FROM t",
+                "duckdb": "SELECT STRPTIME(col, '%d-%m-%Y %I:%M:%S') FROM t",
+                "snowflake": "SELECT TO_TIMESTAMP(col, 'DD-mm-yyyy hh12:mi:ss') FROM t",
+                "spark": "SELECT TO_TIMESTAMP(col, 'dd-MM-yyyy hh:mm:ss') FROM t",
             },
         )
         self.validate_all(


### PR DESCRIPTION
I realized that Snowflake requires a constant for the 2nd argument of `TO_TIMESTAMP*` when it detects that the used variant is `timestampFunction ( <numeric_expr> [ , <scale> ] )` ([docs](https://docs.snowflake.com/en/sql-reference/functions/to_timestamp)), so we can leverage this constraint to improve the transpilation.

<img width="932" alt="Screenshot 2024-12-04 at 12 35 23 PM" src="https://github.com/user-attachments/assets/0b3412ea-44f3-4e2d-87d2-f825a19ba14f">
