### PR TITLE
feat: initial Druid dialect

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -68,6 +68,7 @@ from sqlglot.dialects.databricks import Databricks
 from sqlglot.dialects.dialect import Dialect, Dialects
 from sqlglot.dialects.doris import Doris
 from sqlglot.dialects.drill import Drill
+from sqlglot.dialects.druid import Druid
 from sqlglot.dialects.duckdb import DuckDB
 from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.materialize import Materialize

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -41,9 +41,7 @@ UNESCAPED_SEQUENCES = {
 }
 
 
-def _annotate_with_type_lambda(
-    data_type: exp.DataType.Type,
-) -> t.Callable[[TypeAnnotator, E], E]:
+def _annotate_with_type_lambda(data_type: exp.DataType.Type) -> t.Callable[[TypeAnnotator, E], E]:
     return lambda self, e: self._annotate_with_type(e, data_type)
 
 
@@ -142,9 +140,7 @@ class _Dialect(type):
 
         base = seq_get(bases, 0)
         base_tokenizer = (getattr(base, "tokenizer_class", Tokenizer),)
-        base_jsonpath_tokenizer = (
-            getattr(base, "jsonpath_tokenizer_class", JSONPathTokenizer),
-        )
+        base_jsonpath_tokenizer = (getattr(base, "jsonpath_tokenizer_class", JSONPathTokenizer),)
         base_parser = (getattr(base, "parser_class", Parser),)
         base_generator = (getattr(base, "generator_class", Generator),)
 
@@ -154,23 +150,17 @@ class _Dialect(type):
         klass.jsonpath_tokenizer_class = klass.__dict__.get(
             "JSONPathTokenizer", type("JSONPathTokenizer", base_jsonpath_tokenizer, {})
         )
-        klass.parser_class = klass.__dict__.get(
-            "Parser", type("Parser", base_parser, {})
-        )
+        klass.parser_class = klass.__dict__.get("Parser", type("Parser", base_parser, {}))
         klass.generator_class = klass.__dict__.get(
             "Generator", type("Generator", base_generator, {})
         )
 
-        klass.QUOTE_START, klass.QUOTE_END = list(
-            klass.tokenizer_class._QUOTES.items()
-        )[0]
+        klass.QUOTE_START, klass.QUOTE_END = list(klass.tokenizer_class._QUOTES.items())[0]
         klass.IDENTIFIER_START, klass.IDENTIFIER_END = list(
             klass.tokenizer_class._IDENTIFIERS.items()
         )[0]
 
-        def get_start_end(
-            token_type: TokenType,
-        ) -> t.Tuple[t.Optional[str], t.Optional[str]]:
+        def get_start_end(token_type: TokenType) -> t.Tuple[t.Optional[str], t.Optional[str]]:
             return next(
                 (
                     (s, e)
@@ -203,9 +193,7 @@ class _Dialect(type):
             klass.generator_class.SUPPORTS_UESCAPE = False
 
         if enum not in ("", "databricks", "hive", "spark", "spark2"):
-            modifier_transforms = (
-                klass.generator_class.AFTER_HAVING_MODIFIER_TRANSFORMS.copy()
-            )
+            modifier_transforms = klass.generator_class.AFTER_HAVING_MODIFIER_TRANSFORMS.copy()
             for modifier in ("cluster", "distribute", "sort"):
                 modifier_transforms.pop(modifier, None)
 
@@ -215,21 +203,15 @@ class _Dialect(type):
             klass.parser_class.ID_VAR_TOKENS = klass.parser_class.ID_VAR_TOKENS | {
                 TokenType.STRAIGHT_JOIN,
             }
-            klass.parser_class.TABLE_ALIAS_TOKENS = (
-                klass.parser_class.TABLE_ALIAS_TOKENS
-                | {
-                    TokenType.STRAIGHT_JOIN,
-                }
-            )
+            klass.parser_class.TABLE_ALIAS_TOKENS = klass.parser_class.TABLE_ALIAS_TOKENS | {
+                TokenType.STRAIGHT_JOIN,
+            }
 
         if not klass.SUPPORTS_SEMI_ANTI_JOIN:
-            klass.parser_class.TABLE_ALIAS_TOKENS = (
-                klass.parser_class.TABLE_ALIAS_TOKENS
-                | {
-                    TokenType.ANTI,
-                    TokenType.SEMI,
-                }
-            )
+            klass.parser_class.TABLE_ALIAS_TOKENS = klass.parser_class.TABLE_ALIAS_TOKENS | {
+                TokenType.ANTI,
+                TokenType.SEMI,
+            }
 
         return klass
 
@@ -680,25 +662,16 @@ class Dialect(metaclass=_Dialect):
             for expr_type in expressions
         },
         exp.Abs: lambda self, e: self._annotate_by_args(e, "this"),
-        exp.Anonymous: lambda self, e: self._annotate_with_type(
-            e, exp.DataType.Type.UNKNOWN
-        ),
+        exp.Anonymous: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.UNKNOWN),
         exp.Array: lambda self, e: self._annotate_by_args(e, "expressions", array=True),
         exp.ArrayAgg: lambda self, e: self._annotate_by_args(e, "this", array=True),
-        exp.ArrayConcat: lambda self, e: self._annotate_by_args(
-            e, "this", "expressions"
-        ),
+        exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),
         exp.Coalesce: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Count: lambda self, e: self._annotate_with_type(
-            e,
-            (
-                exp.DataType.Type.BIGINT
-                if e.args.get("big_int")
-                else exp.DataType.Type.INT
-            ),
+            e, exp.DataType.Type.BIGINT if e.args.get("big_int") else exp.DataType.Type.INT
         ),
         exp.DataType: lambda self, e: self._annotate_with_type(e, e.copy()),
         exp.DateAdd: lambda self, e: self._annotate_timeunit(e),
@@ -718,9 +691,7 @@ class Dialect(metaclass=_Dialect):
         ),
         exp.Greatest: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.If: lambda self, e: self._annotate_by_args(e, "true", "false"),
-        exp.Interval: lambda self, e: self._annotate_with_type(
-            e, exp.DataType.Type.INTERVAL
-        ),
+        exp.Interval: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
         exp.Least: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Literal: lambda self, e: self._annotate_literal(e),
         exp.Map: lambda self, e: self._annotate_map(e),
@@ -729,20 +700,12 @@ class Dialect(metaclass=_Dialect):
         exp.Null: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.NULL),
         exp.Nullif: lambda self, e: self._annotate_by_args(e, "this", "expression"),
         exp.PropertyEQ: lambda self, e: self._annotate_by_args(e, "expression"),
-        exp.Slice: lambda self, e: self._annotate_with_type(
-            e, exp.DataType.Type.UNKNOWN
-        ),
+        exp.Slice: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.UNKNOWN),
         exp.Struct: lambda self, e: self._annotate_struct(e),
-        exp.Sum: lambda self, e: self._annotate_by_args(
-            e, "this", "expressions", promote=True
-        ),
+        exp.Sum: lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True),
         exp.Timestamp: lambda self, e: self._annotate_with_type(
             e,
-            (
-                exp.DataType.Type.TIMESTAMPTZ
-                if e.args.get("with_tz")
-                else exp.DataType.Type.TIMESTAMP
-            ),
+            exp.DataType.Type.TIMESTAMPTZ if e.args.get("with_tz") else exp.DataType.Type.TIMESTAMP,
         ),
         exp.ToMap: lambda self, e: self._annotate_to_map(e),
         exp.TryCast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
@@ -808,9 +771,7 @@ class Dialect(metaclass=_Dialect):
             if not result:
                 from difflib import get_close_matches
 
-                similar = (
-                    seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0) or ""
-                )
+                similar = seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0) or ""
                 if similar:
                     similar = f" Did you mean {similar}?"
 
@@ -832,9 +793,7 @@ class Dialect(metaclass=_Dialect):
             )
 
         if expression and expression.is_string:
-            return exp.Literal.string(
-                format_time(expression.this, cls.TIME_MAPPING, cls.TIME_TRIE)
-            )
+            return exp.Literal.string(format_time(expression.this, cls.TIME_MAPPING, cls.TIME_TRIE))
 
         return expression
 
@@ -844,9 +803,7 @@ class Dialect(metaclass=_Dialect):
         if normalization_strategy is None:
             self.normalization_strategy = self.NORMALIZATION_STRATEGY
         else:
-            self.normalization_strategy = NormalizationStrategy(
-                normalization_strategy.upper()
-            )
+            self.normalization_strategy = NormalizationStrategy(normalization_strategy.upper())
 
         self.settings = kwargs
 
@@ -937,22 +894,16 @@ class Dialect(metaclass=_Dialect):
             identify: If set to `False`, the quotes will only be added if the identifier is deemed
                 "unsafe", with respect to its characters and this dialect's normalization strategy.
         """
-        if isinstance(expression, exp.Identifier) and not isinstance(
-            expression.parent, exp.Func
-        ):
+        if isinstance(expression, exp.Identifier) and not isinstance(expression.parent, exp.Func):
             name = expression.this
             expression.set(
                 "quoted",
-                identify
-                or self.case_sensitive(name)
-                or not exp.SAFE_IDENTIFIER_RE.match(name),
+                identify or self.case_sensitive(name) or not exp.SAFE_IDENTIFIER_RE.match(name),
             )
 
         return expression
 
-    def to_json_path(
-        self, path: t.Optional[exp.Expression]
-    ) -> t.Optional[exp.Expression]:
+    def to_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
         if isinstance(path, exp.Literal):
             path_text = path.name
             if path.is_number:
@@ -1028,16 +979,10 @@ def if_sql(
 
 def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
     this = expression.this
-    if (
-        self.JSON_TYPE_REQUIRED_FOR_EXTRACTION
-        and isinstance(this, exp.Literal)
-        and this.is_string
-    ):
+    if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
         this.replace(exp.cast(this, exp.DataType.Type.JSON))
 
-    return self.binary(
-        expression, "->" if isinstance(expression, exp.JSONExtract) else "->>"
-    )
+    return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
 
 
 def inline_array_sql(self: Generator, expression: exp.Array) -> str:
@@ -1054,8 +999,7 @@ def inline_array_unless_query(self: Generator, expression: exp.Array) -> str:
 def no_ilike_sql(self: Generator, expression: exp.ILike) -> str:
     return self.like_sql(
         exp.Like(
-            this=exp.Lower(this=expression.this),
-            expression=exp.Lower(this=expression.expression),
+            this=exp.Lower(this=expression.this), expression=exp.Lower(this=expression.expression)
         )
     )
 
@@ -1129,7 +1073,9 @@ def str_position_sql(
 
 
 def struct_extract_sql(self: Generator, expression: exp.StructExtract) -> str:
-    return f"{self.sql(expression, 'this')}.{self.sql(exp.to_identifier(expression.expression.name))}"
+    return (
+        f"{self.sql(expression, 'this')}.{self.sql(exp.to_identifier(expression.expression.name))}"
+    )
 
 
 def var_map_sql(
@@ -1169,9 +1115,7 @@ def build_formatted_time(
             this=seq_get(args, 0),
             format=Dialect[dialect].format_time(
                 seq_get(args, 1)
-                or (
-                    Dialect[dialect].TIME_FORMAT if default is True else default or None
-                )
+                or (Dialect[dialect].TIME_FORMAT if default is True else default or None)
             ),
         )
 
@@ -1181,19 +1125,13 @@ def build_formatted_time(
 def time_format(
     dialect: DialectType = None,
 ) -> t.Callable[[Generator, exp.UnixToStr | exp.StrToUnix], t.Optional[str]]:
-    def _time_format(
-        self: Generator, expression: exp.UnixToStr | exp.StrToUnix
-    ) -> t.Optional[str]:
+    def _time_format(self: Generator, expression: exp.UnixToStr | exp.StrToUnix) -> t.Optional[str]:
         """
         Returns the time format for a given expression, unless it's equivalent
         to the default time format of the dialect of interest.
         """
         time_format = self.format_time(expression)
-        return (
-            time_format
-            if time_format != Dialect.get_or_raise(dialect).TIME_FORMAT
-            else None
-        )
+        return time_format if time_format != Dialect.get_or_raise(dialect).TIME_FORMAT else None
 
     return _time_format
 
@@ -1209,11 +1147,7 @@ def build_date_delta(
         unit = None
         if unit_based or default_unit:
             unit = args[0] if unit_based else exp.Literal.string(default_unit)
-            unit = (
-                exp.var(unit_mapping.get(unit.name.lower(), unit.name))
-                if unit_mapping
-                else unit
-            )
+            unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
         return exp_class(this=this, expression=seq_get(args, 1), unit=unit)
 
     return _builder
@@ -1231,9 +1165,7 @@ def build_date_delta_with_interval(
         if not isinstance(interval, exp.Interval):
             raise ParseError(f"INTERVAL expression expected but got '{interval}'")
 
-        return expression_class(
-            this=args[0], expression=interval.this, unit=unit_to_str(interval)
-        )
+        return expression_class(this=args[0], expression=interval.this, unit=unit_to_str(interval))
 
     return _builder
 
@@ -1252,17 +1184,13 @@ def date_add_interval_sql(
 ) -> t.Callable[[Generator, exp.Expression], str]:
     def func(self: Generator, expression: exp.Expression) -> str:
         this = self.sql(expression, "this")
-        interval = exp.Interval(
-            this=expression.expression, unit=unit_to_var(expression)
-        )
+        interval = exp.Interval(this=expression.expression, unit=unit_to_var(expression))
         return f"{data_type}_{kind}({this}, {self.sql(interval)})"
 
     return func
 
 
-def timestamptrunc_sql(
-    zone: bool = False,
-) -> t.Callable[[Generator, exp.TimestampTrunc], str]:
+def timestamptrunc_sql(zone: bool = False) -> t.Callable[[Generator, exp.TimestampTrunc], str]:
     def _timestamptrunc_sql(self: Generator, expression: exp.TimestampTrunc) -> str:
         args = [unit_to_str(expression), expression.this]
         if zone:
@@ -1293,8 +1221,7 @@ def no_time_sql(self: Generator, expression: exp.Time) -> str:
     # Transpile BQ's TIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIME)
     this = exp.cast(expression.this, exp.DataType.Type.TIMESTAMPTZ)
     expr = exp.cast(
-        exp.AtTimeZone(this=this, zone=expression.args.get("zone")),
-        exp.DataType.Type.TIME,
+        exp.AtTimeZone(this=this, zone=expression.args.get("zone")), exp.DataType.Type.TIME
     )
     return self.sql(expr)
 
@@ -1306,17 +1233,13 @@ def no_datetime_sql(self: Generator, expression: exp.Datetime) -> str:
     if expr.name.lower() in TIMEZONES:
         # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIMESTAMP)
         this = exp.cast(this, exp.DataType.Type.TIMESTAMPTZ)
-        this = exp.cast(
-            exp.AtTimeZone(this=this, zone=expr), exp.DataType.Type.TIMESTAMP
-        )
+        this = exp.cast(exp.AtTimeZone(this=this, zone=expr), exp.DataType.Type.TIMESTAMP)
         return self.sql(this)
 
     this = exp.cast(this, exp.DataType.Type.DATE)
     expr = exp.cast(expr, exp.DataType.Type.TIME)
 
-    return self.sql(
-        exp.cast(exp.Add(this=this, expression=expr), exp.DataType.Type.TIMESTAMP)
-    )
+    return self.sql(exp.cast(exp.Add(this=this, expression=expr), exp.DataType.Type.TIMESTAMP))
 
 
 def locate_to_strposition(args: t.List) -> exp.Expression:
@@ -1327,19 +1250,14 @@ def locate_to_strposition(args: t.List) -> exp.Expression:
 
 def strposition_to_locate_sql(self: Generator, expression: exp.StrPosition) -> str:
     return self.func(
-        "LOCATE",
-        expression.args.get("substr"),
-        expression.this,
-        expression.args.get("position"),
+        "LOCATE", expression.args.get("substr"), expression.this, expression.args.get("position")
     )
 
 
 def left_to_substring_sql(self: Generator, expression: exp.Left) -> str:
     return self.sql(
         exp.Substring(
-            this=expression.this,
-            start=exp.Literal.number(1),
-            length=expression.expression,
+            this=expression.this, start=exp.Literal.number(1), length=expression.expression
         )
     )
 
@@ -1348,8 +1266,7 @@ def right_to_substring_sql(self: Generator, expression: exp.Left) -> str:
     return self.sql(
         exp.Substring(
             this=expression.this,
-            start=exp.Length(this=expression.this)
-            - exp.paren(expression.expression - 1),
+            start=exp.Length(this=expression.this) - exp.paren(expression.expression - 1),
         )
     )
 
@@ -1369,8 +1286,7 @@ def timestrtotime_sql(
         precision = subsecond_precision(expression.this.name)
         if precision > 0:
             datatype = exp.DataType.build(
-                datatype.this,
-                expressions=[exp.DataTypeParam(this=exp.Literal.number(precision))],
+                datatype.this, expressions=[exp.DataTypeParam(this=exp.Literal.number(precision))]
             )
 
     return self.sql(exp.cast(expression.this, datatype, dialect=self.dialect))
@@ -1388,9 +1304,7 @@ def encode_decode_sql(
     if charset and charset.name.lower() != "utf-8":
         self.unsupported(f"Expected utf-8 character set, got {charset}.")
 
-    return self.func(
-        name, expression.this, expression.args.get("replace") if replace else None
-    )
+    return self.func(name, expression.this, expression.args.get("replace") if replace else None)
 
 
 def min_or_least(self: Generator, expression: exp.Min) -> str:
@@ -1435,18 +1349,14 @@ def str_to_time_sql(self: Generator, expression: exp.Expression) -> str:
 
 
 def concat_to_dpipe_sql(self: Generator, expression: exp.Concat) -> str:
-    return self.sql(
-        reduce(lambda x, y: exp.DPipe(this=x, expression=y), expression.expressions)
-    )
+    return self.sql(reduce(lambda x, y: exp.DPipe(this=x, expression=y), expression.expressions))
 
 
 def concat_ws_to_dpipe_sql(self: Generator, expression: exp.ConcatWs) -> str:
     delim, *rest_args = expression.expressions
     return self.sql(
         reduce(
-            lambda x, y: exp.DPipe(
-                this=x, expression=exp.DPipe(this=delim, expression=y)
-            ),
+            lambda x, y: exp.DPipe(this=x, expression=exp.DPipe(this=delim, expression=y)),
             rest_args,
         )
     )
@@ -1466,16 +1376,11 @@ def regexp_extract_sql(self: Generator, expression: exp.RegexpExtract) -> str:
 @unsupported_args("position", "occurrence", "modifiers")
 def regexp_replace_sql(self: Generator, expression: exp.RegexpReplace) -> str:
     return self.func(
-        "REGEXP_REPLACE",
-        expression.this,
-        expression.expression,
-        expression.args["replacement"],
+        "REGEXP_REPLACE", expression.this, expression.expression, expression.args["replacement"]
     )
 
 
-def pivot_column_names(
-    aggregations: t.List[exp.Expression], dialect: DialectType
-) -> t.List[str]:
+def pivot_column_names(aggregations: t.List[exp.Expression], dialect: DialectType) -> t.List[str]:
     names = []
     for agg in aggregations:
         if isinstance(agg, exp.Alias):
@@ -1494,9 +1399,7 @@ def pivot_column_names(
                     else node
                 )
             )
-            names.append(
-                agg_all_unquoted.sql(dialect=dialect, normalize_functions="lower")
-            )
+            names.append(agg_all_unquoted.sql(dialect=dialect, normalize_functions="lower"))
 
     return names
 
@@ -1538,13 +1441,9 @@ def generatedasidentitycolumnconstraint_sql(
     return f"IDENTITY({start}, {increment})"
 
 
-def arg_max_or_min_no_count(
-    name: str,
-) -> t.Callable[[Generator, exp.ArgMax | exp.ArgMin], str]:
+def arg_max_or_min_no_count(name: str) -> t.Callable[[Generator, exp.ArgMax | exp.ArgMin], str]:
     @unsupported_args("count")
-    def _arg_max_or_min_sql(
-        self: Generator, expression: exp.ArgMax | exp.ArgMin
-    ) -> str:
+    def _arg_max_or_min_sql(self: Generator, expression: exp.ArgMax | exp.ArgMin) -> str:
         return self.func(name, expression.this, expression.expression)
 
     return _arg_max_or_min_sql
@@ -1563,9 +1462,7 @@ def ts_or_ds_add_cast(expression: exp.TsOrDsAdd) -> exp.TsOrDsAdd:
     return expression
 
 
-def date_delta_sql(
-    name: str, cast: bool = False
-) -> t.Callable[[Generator, DATE_ADD_OR_DIFF], str]:
+def date_delta_sql(name: str, cast: bool = False) -> t.Callable[[Generator, DATE_ADD_OR_DIFF], str]:
     def _delta_sql(self: Generator, expression: DATE_ADD_OR_DIFF) -> str:
         if cast and isinstance(expression, exp.TsOrDsAdd):
             expression = ts_or_ds_add_cast(expression)
@@ -1580,9 +1477,7 @@ def date_delta_sql(
     return _delta_sql
 
 
-def unit_to_str(
-    expression: exp.Expression, default: str = "DAY"
-) -> t.Optional[exp.Expression]:
+def unit_to_str(expression: exp.Expression, default: str = "DAY") -> t.Optional[exp.Expression]:
     unit = expression.args.get("unit")
 
     if isinstance(unit, exp.Placeholder):
@@ -1592,9 +1487,7 @@ def unit_to_str(
     return exp.Literal.string(default) if default else None
 
 
-def unit_to_var(
-    expression: exp.Expression, default: str = "DAY"
-) -> t.Optional[exp.Expression]:
+def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[exp.Expression]:
     unit = expression.args.get("unit")
 
     if isinstance(unit, (exp.Var, exp.Placeholder)):
@@ -1616,9 +1509,7 @@ def map_date_part(
 
 def map_date_part(part, dialect: DialectType = Dialect):
     mapped = (
-        Dialect.get_or_raise(dialect).DATE_PART_MAPPING.get(part.name.upper())
-        if part
-        else None
+        Dialect.get_or_raise(dialect).DATE_PART_MAPPING.get(part.name.upper()) if part else None
     )
     return exp.var(mapped) if mapped else part
 
@@ -1636,9 +1527,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
     alias = expression.this.args.get("alias")
 
     def normalize(identifier: t.Optional[exp.Identifier]) -> t.Optional[str]:
-        return (
-            self.dialect.normalize_identifier(identifier).name if identifier else None
-        )
+        return self.dialect.normalize_identifier(identifier).name if identifier else None
 
     targets = {normalize(expression.this.this)}
 
@@ -1654,8 +1543,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
             then.transform(
                 lambda node: (
                     exp.column(node.this)
-                    if isinstance(node, exp.Column)
-                    and normalize(node.args.get("table")) in targets
+                    if isinstance(node, exp.Column) and normalize(node.args.get("table")) in targets
                     else node
                 ),
                 copy=False,
@@ -1665,9 +1553,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
 
 
 def build_json_extract_path(
-    expr_type: t.Type[F],
-    zero_based_indexing: bool = True,
-    arrow_req_json_type: bool = False,
+    expr_type: t.Type[F], zero_based_indexing: bool = True, arrow_req_json_type: bool = False
 ) -> t.Callable[[t.List], F]:
     def _builder(args: t.List) -> F:
         segments: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
@@ -1680,9 +1566,7 @@ def build_json_extract_path(
             if is_int(text):
                 index = int(text)
                 segments.append(
-                    exp.JSONPathSubscript(
-                        this=index if zero_based_indexing else index - 1
-                    )
+                    exp.JSONPathSubscript(this=index if zero_based_indexing else index - 1)
                 )
             else:
                 segments.append(exp.JSONPathKey(this=text))
@@ -1748,9 +1632,7 @@ def filter_array_using_unnest(self: Generator, expression: exp.ArrayFilter) -> s
         return ""
 
     unnest = exp.Unnest(expressions=[expression.this])
-    filtered = (
-        exp.select(alias).from_(exp.alias_(unnest, None, table=[alias])).where(cond)
-    )
+    filtered = exp.select(alias).from_(exp.alias_(unnest, None, table=[alias])).where(cond)
     return self.sql(exp.Array(expressions=[filtered]))
 
 
@@ -1789,9 +1671,7 @@ def sha256_sql(self: Generator, expression: exp.SHA2) -> str:
     return self.func(f"SHA{expression.text('length') or '256'}", expression.this)
 
 
-def sequence_sql(
-    self: Generator, expression: exp.GenerateSeries | exp.GenerateDateArray
-) -> str:
+def sequence_sql(self: Generator, expression: exp.GenerateSeries | exp.GenerateDateArray) -> str:
     start = expression.args.get("start")
     end = expression.args.get("end")
     step = expression.args.get("step")
@@ -1816,6 +1696,5 @@ def build_regexp_extract(args: t.List, dialect: Dialect) -> exp.RegexpExtract:
     return exp.RegexpExtract(
         this=seq_get(args, 0),
         expression=seq_get(args, 1),
-        group=seq_get(args, 2)
-        or exp.Literal.number(dialect.REGEXP_EXTRACT_DEFAULT_GROUP),
+        group=seq_get(args, 2) or exp.Literal.number(dialect.REGEXP_EXTRACT_DEFAULT_GROUP),
     )

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -41,7 +41,9 @@ UNESCAPED_SEQUENCES = {
 }
 
 
-def _annotate_with_type_lambda(data_type: exp.DataType.Type) -> t.Callable[[TypeAnnotator, E], E]:
+def _annotate_with_type_lambda(
+    data_type: exp.DataType.Type,
+) -> t.Callable[[TypeAnnotator, E], E]:
     return lambda self, e: self._annotate_with_type(e, data_type)
 
 
@@ -56,6 +58,7 @@ class Dialects(str, Enum):
     DATABRICKS = "databricks"
     DORIS = "doris"
     DRILL = "drill"
+    DRUID = "druid"
     DUCKDB = "duckdb"
     HIVE = "hive"
     MATERIALIZE = "materialize"
@@ -139,7 +142,9 @@ class _Dialect(type):
 
         base = seq_get(bases, 0)
         base_tokenizer = (getattr(base, "tokenizer_class", Tokenizer),)
-        base_jsonpath_tokenizer = (getattr(base, "jsonpath_tokenizer_class", JSONPathTokenizer),)
+        base_jsonpath_tokenizer = (
+            getattr(base, "jsonpath_tokenizer_class", JSONPathTokenizer),
+        )
         base_parser = (getattr(base, "parser_class", Parser),)
         base_generator = (getattr(base, "generator_class", Generator),)
 
@@ -149,17 +154,23 @@ class _Dialect(type):
         klass.jsonpath_tokenizer_class = klass.__dict__.get(
             "JSONPathTokenizer", type("JSONPathTokenizer", base_jsonpath_tokenizer, {})
         )
-        klass.parser_class = klass.__dict__.get("Parser", type("Parser", base_parser, {}))
+        klass.parser_class = klass.__dict__.get(
+            "Parser", type("Parser", base_parser, {})
+        )
         klass.generator_class = klass.__dict__.get(
             "Generator", type("Generator", base_generator, {})
         )
 
-        klass.QUOTE_START, klass.QUOTE_END = list(klass.tokenizer_class._QUOTES.items())[0]
+        klass.QUOTE_START, klass.QUOTE_END = list(
+            klass.tokenizer_class._QUOTES.items()
+        )[0]
         klass.IDENTIFIER_START, klass.IDENTIFIER_END = list(
             klass.tokenizer_class._IDENTIFIERS.items()
         )[0]
 
-        def get_start_end(token_type: TokenType) -> t.Tuple[t.Optional[str], t.Optional[str]]:
+        def get_start_end(
+            token_type: TokenType,
+        ) -> t.Tuple[t.Optional[str], t.Optional[str]]:
             return next(
                 (
                     (s, e)
@@ -192,7 +203,9 @@ class _Dialect(type):
             klass.generator_class.SUPPORTS_UESCAPE = False
 
         if enum not in ("", "databricks", "hive", "spark", "spark2"):
-            modifier_transforms = klass.generator_class.AFTER_HAVING_MODIFIER_TRANSFORMS.copy()
+            modifier_transforms = (
+                klass.generator_class.AFTER_HAVING_MODIFIER_TRANSFORMS.copy()
+            )
             for modifier in ("cluster", "distribute", "sort"):
                 modifier_transforms.pop(modifier, None)
 
@@ -202,15 +215,21 @@ class _Dialect(type):
             klass.parser_class.ID_VAR_TOKENS = klass.parser_class.ID_VAR_TOKENS | {
                 TokenType.STRAIGHT_JOIN,
             }
-            klass.parser_class.TABLE_ALIAS_TOKENS = klass.parser_class.TABLE_ALIAS_TOKENS | {
-                TokenType.STRAIGHT_JOIN,
-            }
+            klass.parser_class.TABLE_ALIAS_TOKENS = (
+                klass.parser_class.TABLE_ALIAS_TOKENS
+                | {
+                    TokenType.STRAIGHT_JOIN,
+                }
+            )
 
         if not klass.SUPPORTS_SEMI_ANTI_JOIN:
-            klass.parser_class.TABLE_ALIAS_TOKENS = klass.parser_class.TABLE_ALIAS_TOKENS | {
-                TokenType.ANTI,
-                TokenType.SEMI,
-            }
+            klass.parser_class.TABLE_ALIAS_TOKENS = (
+                klass.parser_class.TABLE_ALIAS_TOKENS
+                | {
+                    TokenType.ANTI,
+                    TokenType.SEMI,
+                }
+            )
 
         return klass
 
@@ -661,16 +680,25 @@ class Dialect(metaclass=_Dialect):
             for expr_type in expressions
         },
         exp.Abs: lambda self, e: self._annotate_by_args(e, "this"),
-        exp.Anonymous: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.UNKNOWN),
+        exp.Anonymous: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.UNKNOWN
+        ),
         exp.Array: lambda self, e: self._annotate_by_args(e, "expressions", array=True),
         exp.ArrayAgg: lambda self, e: self._annotate_by_args(e, "this", array=True),
-        exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
+        exp.ArrayConcat: lambda self, e: self._annotate_by_args(
+            e, "this", "expressions"
+        ),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),
         exp.Coalesce: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Count: lambda self, e: self._annotate_with_type(
-            e, exp.DataType.Type.BIGINT if e.args.get("big_int") else exp.DataType.Type.INT
+            e,
+            (
+                exp.DataType.Type.BIGINT
+                if e.args.get("big_int")
+                else exp.DataType.Type.INT
+            ),
         ),
         exp.DataType: lambda self, e: self._annotate_with_type(e, e.copy()),
         exp.DateAdd: lambda self, e: self._annotate_timeunit(e),
@@ -690,7 +718,9 @@ class Dialect(metaclass=_Dialect):
         ),
         exp.Greatest: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.If: lambda self, e: self._annotate_by_args(e, "true", "false"),
-        exp.Interval: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
+        exp.Interval: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.INTERVAL
+        ),
         exp.Least: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Literal: lambda self, e: self._annotate_literal(e),
         exp.Map: lambda self, e: self._annotate_map(e),
@@ -699,12 +729,20 @@ class Dialect(metaclass=_Dialect):
         exp.Null: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.NULL),
         exp.Nullif: lambda self, e: self._annotate_by_args(e, "this", "expression"),
         exp.PropertyEQ: lambda self, e: self._annotate_by_args(e, "expression"),
-        exp.Slice: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.UNKNOWN),
+        exp.Slice: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.UNKNOWN
+        ),
         exp.Struct: lambda self, e: self._annotate_struct(e),
-        exp.Sum: lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True),
+        exp.Sum: lambda self, e: self._annotate_by_args(
+            e, "this", "expressions", promote=True
+        ),
         exp.Timestamp: lambda self, e: self._annotate_with_type(
             e,
-            exp.DataType.Type.TIMESTAMPTZ if e.args.get("with_tz") else exp.DataType.Type.TIMESTAMP,
+            (
+                exp.DataType.Type.TIMESTAMPTZ
+                if e.args.get("with_tz")
+                else exp.DataType.Type.TIMESTAMP
+            ),
         ),
         exp.ToMap: lambda self, e: self._annotate_to_map(e),
         exp.TryCast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
@@ -770,7 +808,9 @@ class Dialect(metaclass=_Dialect):
             if not result:
                 from difflib import get_close_matches
 
-                similar = seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0) or ""
+                similar = (
+                    seq_get(get_close_matches(dialect_name, cls.classes, n=1), 0) or ""
+                )
                 if similar:
                     similar = f" Did you mean {similar}?"
 
@@ -792,7 +832,9 @@ class Dialect(metaclass=_Dialect):
             )
 
         if expression and expression.is_string:
-            return exp.Literal.string(format_time(expression.this, cls.TIME_MAPPING, cls.TIME_TRIE))
+            return exp.Literal.string(
+                format_time(expression.this, cls.TIME_MAPPING, cls.TIME_TRIE)
+            )
 
         return expression
 
@@ -802,7 +844,9 @@ class Dialect(metaclass=_Dialect):
         if normalization_strategy is None:
             self.normalization_strategy = self.NORMALIZATION_STRATEGY
         else:
-            self.normalization_strategy = NormalizationStrategy(normalization_strategy.upper())
+            self.normalization_strategy = NormalizationStrategy(
+                normalization_strategy.upper()
+            )
 
         self.settings = kwargs
 
@@ -893,16 +937,22 @@ class Dialect(metaclass=_Dialect):
             identify: If set to `False`, the quotes will only be added if the identifier is deemed
                 "unsafe", with respect to its characters and this dialect's normalization strategy.
         """
-        if isinstance(expression, exp.Identifier) and not isinstance(expression.parent, exp.Func):
+        if isinstance(expression, exp.Identifier) and not isinstance(
+            expression.parent, exp.Func
+        ):
             name = expression.this
             expression.set(
                 "quoted",
-                identify or self.case_sensitive(name) or not exp.SAFE_IDENTIFIER_RE.match(name),
+                identify
+                or self.case_sensitive(name)
+                or not exp.SAFE_IDENTIFIER_RE.match(name),
             )
 
         return expression
 
-    def to_json_path(self, path: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+    def to_json_path(
+        self, path: t.Optional[exp.Expression]
+    ) -> t.Optional[exp.Expression]:
         if isinstance(path, exp.Literal):
             path_text = path.name
             if path.is_number:
@@ -978,10 +1028,16 @@ def if_sql(
 
 def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
     this = expression.this
-    if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
+    if (
+        self.JSON_TYPE_REQUIRED_FOR_EXTRACTION
+        and isinstance(this, exp.Literal)
+        and this.is_string
+    ):
         this.replace(exp.cast(this, exp.DataType.Type.JSON))
 
-    return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
+    return self.binary(
+        expression, "->" if isinstance(expression, exp.JSONExtract) else "->>"
+    )
 
 
 def inline_array_sql(self: Generator, expression: exp.Array) -> str:
@@ -998,7 +1054,8 @@ def inline_array_unless_query(self: Generator, expression: exp.Array) -> str:
 def no_ilike_sql(self: Generator, expression: exp.ILike) -> str:
     return self.like_sql(
         exp.Like(
-            this=exp.Lower(this=expression.this), expression=exp.Lower(this=expression.expression)
+            this=exp.Lower(this=expression.this),
+            expression=exp.Lower(this=expression.expression),
         )
     )
 
@@ -1072,9 +1129,7 @@ def str_position_sql(
 
 
 def struct_extract_sql(self: Generator, expression: exp.StructExtract) -> str:
-    return (
-        f"{self.sql(expression, 'this')}.{self.sql(exp.to_identifier(expression.expression.name))}"
-    )
+    return f"{self.sql(expression, 'this')}.{self.sql(exp.to_identifier(expression.expression.name))}"
 
 
 def var_map_sql(
@@ -1114,7 +1169,9 @@ def build_formatted_time(
             this=seq_get(args, 0),
             format=Dialect[dialect].format_time(
                 seq_get(args, 1)
-                or (Dialect[dialect].TIME_FORMAT if default is True else default or None)
+                or (
+                    Dialect[dialect].TIME_FORMAT if default is True else default or None
+                )
             ),
         )
 
@@ -1124,13 +1181,19 @@ def build_formatted_time(
 def time_format(
     dialect: DialectType = None,
 ) -> t.Callable[[Generator, exp.UnixToStr | exp.StrToUnix], t.Optional[str]]:
-    def _time_format(self: Generator, expression: exp.UnixToStr | exp.StrToUnix) -> t.Optional[str]:
+    def _time_format(
+        self: Generator, expression: exp.UnixToStr | exp.StrToUnix
+    ) -> t.Optional[str]:
         """
         Returns the time format for a given expression, unless it's equivalent
         to the default time format of the dialect of interest.
         """
         time_format = self.format_time(expression)
-        return time_format if time_format != Dialect.get_or_raise(dialect).TIME_FORMAT else None
+        return (
+            time_format
+            if time_format != Dialect.get_or_raise(dialect).TIME_FORMAT
+            else None
+        )
 
     return _time_format
 
@@ -1146,7 +1209,11 @@ def build_date_delta(
         unit = None
         if unit_based or default_unit:
             unit = args[0] if unit_based else exp.Literal.string(default_unit)
-            unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
+            unit = (
+                exp.var(unit_mapping.get(unit.name.lower(), unit.name))
+                if unit_mapping
+                else unit
+            )
         return exp_class(this=this, expression=seq_get(args, 1), unit=unit)
 
     return _builder
@@ -1164,7 +1231,9 @@ def build_date_delta_with_interval(
         if not isinstance(interval, exp.Interval):
             raise ParseError(f"INTERVAL expression expected but got '{interval}'")
 
-        return expression_class(this=args[0], expression=interval.this, unit=unit_to_str(interval))
+        return expression_class(
+            this=args[0], expression=interval.this, unit=unit_to_str(interval)
+        )
 
     return _builder
 
@@ -1183,13 +1252,17 @@ def date_add_interval_sql(
 ) -> t.Callable[[Generator, exp.Expression], str]:
     def func(self: Generator, expression: exp.Expression) -> str:
         this = self.sql(expression, "this")
-        interval = exp.Interval(this=expression.expression, unit=unit_to_var(expression))
+        interval = exp.Interval(
+            this=expression.expression, unit=unit_to_var(expression)
+        )
         return f"{data_type}_{kind}({this}, {self.sql(interval)})"
 
     return func
 
 
-def timestamptrunc_sql(zone: bool = False) -> t.Callable[[Generator, exp.TimestampTrunc], str]:
+def timestamptrunc_sql(
+    zone: bool = False,
+) -> t.Callable[[Generator, exp.TimestampTrunc], str]:
     def _timestamptrunc_sql(self: Generator, expression: exp.TimestampTrunc) -> str:
         args = [unit_to_str(expression), expression.this]
         if zone:
@@ -1220,7 +1293,8 @@ def no_time_sql(self: Generator, expression: exp.Time) -> str:
     # Transpile BQ's TIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIME)
     this = exp.cast(expression.this, exp.DataType.Type.TIMESTAMPTZ)
     expr = exp.cast(
-        exp.AtTimeZone(this=this, zone=expression.args.get("zone")), exp.DataType.Type.TIME
+        exp.AtTimeZone(this=this, zone=expression.args.get("zone")),
+        exp.DataType.Type.TIME,
     )
     return self.sql(expr)
 
@@ -1232,13 +1306,17 @@ def no_datetime_sql(self: Generator, expression: exp.Datetime) -> str:
     if expr.name.lower() in TIMEZONES:
         # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIMESTAMP)
         this = exp.cast(this, exp.DataType.Type.TIMESTAMPTZ)
-        this = exp.cast(exp.AtTimeZone(this=this, zone=expr), exp.DataType.Type.TIMESTAMP)
+        this = exp.cast(
+            exp.AtTimeZone(this=this, zone=expr), exp.DataType.Type.TIMESTAMP
+        )
         return self.sql(this)
 
     this = exp.cast(this, exp.DataType.Type.DATE)
     expr = exp.cast(expr, exp.DataType.Type.TIME)
 
-    return self.sql(exp.cast(exp.Add(this=this, expression=expr), exp.DataType.Type.TIMESTAMP))
+    return self.sql(
+        exp.cast(exp.Add(this=this, expression=expr), exp.DataType.Type.TIMESTAMP)
+    )
 
 
 def locate_to_strposition(args: t.List) -> exp.Expression:
@@ -1249,14 +1327,19 @@ def locate_to_strposition(args: t.List) -> exp.Expression:
 
 def strposition_to_locate_sql(self: Generator, expression: exp.StrPosition) -> str:
     return self.func(
-        "LOCATE", expression.args.get("substr"), expression.this, expression.args.get("position")
+        "LOCATE",
+        expression.args.get("substr"),
+        expression.this,
+        expression.args.get("position"),
     )
 
 
 def left_to_substring_sql(self: Generator, expression: exp.Left) -> str:
     return self.sql(
         exp.Substring(
-            this=expression.this, start=exp.Literal.number(1), length=expression.expression
+            this=expression.this,
+            start=exp.Literal.number(1),
+            length=expression.expression,
         )
     )
 
@@ -1265,7 +1348,8 @@ def right_to_substring_sql(self: Generator, expression: exp.Left) -> str:
     return self.sql(
         exp.Substring(
             this=expression.this,
-            start=exp.Length(this=expression.this) - exp.paren(expression.expression - 1),
+            start=exp.Length(this=expression.this)
+            - exp.paren(expression.expression - 1),
         )
     )
 
@@ -1285,7 +1369,8 @@ def timestrtotime_sql(
         precision = subsecond_precision(expression.this.name)
         if precision > 0:
             datatype = exp.DataType.build(
-                datatype.this, expressions=[exp.DataTypeParam(this=exp.Literal.number(precision))]
+                datatype.this,
+                expressions=[exp.DataTypeParam(this=exp.Literal.number(precision))],
             )
 
     return self.sql(exp.cast(expression.this, datatype, dialect=self.dialect))
@@ -1303,7 +1388,9 @@ def encode_decode_sql(
     if charset and charset.name.lower() != "utf-8":
         self.unsupported(f"Expected utf-8 character set, got {charset}.")
 
-    return self.func(name, expression.this, expression.args.get("replace") if replace else None)
+    return self.func(
+        name, expression.this, expression.args.get("replace") if replace else None
+    )
 
 
 def min_or_least(self: Generator, expression: exp.Min) -> str:
@@ -1348,14 +1435,18 @@ def str_to_time_sql(self: Generator, expression: exp.Expression) -> str:
 
 
 def concat_to_dpipe_sql(self: Generator, expression: exp.Concat) -> str:
-    return self.sql(reduce(lambda x, y: exp.DPipe(this=x, expression=y), expression.expressions))
+    return self.sql(
+        reduce(lambda x, y: exp.DPipe(this=x, expression=y), expression.expressions)
+    )
 
 
 def concat_ws_to_dpipe_sql(self: Generator, expression: exp.ConcatWs) -> str:
     delim, *rest_args = expression.expressions
     return self.sql(
         reduce(
-            lambda x, y: exp.DPipe(this=x, expression=exp.DPipe(this=delim, expression=y)),
+            lambda x, y: exp.DPipe(
+                this=x, expression=exp.DPipe(this=delim, expression=y)
+            ),
             rest_args,
         )
     )
@@ -1375,11 +1466,16 @@ def regexp_extract_sql(self: Generator, expression: exp.RegexpExtract) -> str:
 @unsupported_args("position", "occurrence", "modifiers")
 def regexp_replace_sql(self: Generator, expression: exp.RegexpReplace) -> str:
     return self.func(
-        "REGEXP_REPLACE", expression.this, expression.expression, expression.args["replacement"]
+        "REGEXP_REPLACE",
+        expression.this,
+        expression.expression,
+        expression.args["replacement"],
     )
 
 
-def pivot_column_names(aggregations: t.List[exp.Expression], dialect: DialectType) -> t.List[str]:
+def pivot_column_names(
+    aggregations: t.List[exp.Expression], dialect: DialectType
+) -> t.List[str]:
     names = []
     for agg in aggregations:
         if isinstance(agg, exp.Alias):
@@ -1398,7 +1494,9 @@ def pivot_column_names(aggregations: t.List[exp.Expression], dialect: DialectTyp
                     else node
                 )
             )
-            names.append(agg_all_unquoted.sql(dialect=dialect, normalize_functions="lower"))
+            names.append(
+                agg_all_unquoted.sql(dialect=dialect, normalize_functions="lower")
+            )
 
     return names
 
@@ -1440,9 +1538,13 @@ def generatedasidentitycolumnconstraint_sql(
     return f"IDENTITY({start}, {increment})"
 
 
-def arg_max_or_min_no_count(name: str) -> t.Callable[[Generator, exp.ArgMax | exp.ArgMin], str]:
+def arg_max_or_min_no_count(
+    name: str,
+) -> t.Callable[[Generator, exp.ArgMax | exp.ArgMin], str]:
     @unsupported_args("count")
-    def _arg_max_or_min_sql(self: Generator, expression: exp.ArgMax | exp.ArgMin) -> str:
+    def _arg_max_or_min_sql(
+        self: Generator, expression: exp.ArgMax | exp.ArgMin
+    ) -> str:
         return self.func(name, expression.this, expression.expression)
 
     return _arg_max_or_min_sql
@@ -1461,7 +1563,9 @@ def ts_or_ds_add_cast(expression: exp.TsOrDsAdd) -> exp.TsOrDsAdd:
     return expression
 
 
-def date_delta_sql(name: str, cast: bool = False) -> t.Callable[[Generator, DATE_ADD_OR_DIFF], str]:
+def date_delta_sql(
+    name: str, cast: bool = False
+) -> t.Callable[[Generator, DATE_ADD_OR_DIFF], str]:
     def _delta_sql(self: Generator, expression: DATE_ADD_OR_DIFF) -> str:
         if cast and isinstance(expression, exp.TsOrDsAdd):
             expression = ts_or_ds_add_cast(expression)
@@ -1476,7 +1580,9 @@ def date_delta_sql(name: str, cast: bool = False) -> t.Callable[[Generator, DATE
     return _delta_sql
 
 
-def unit_to_str(expression: exp.Expression, default: str = "DAY") -> t.Optional[exp.Expression]:
+def unit_to_str(
+    expression: exp.Expression, default: str = "DAY"
+) -> t.Optional[exp.Expression]:
     unit = expression.args.get("unit")
 
     if isinstance(unit, exp.Placeholder):
@@ -1486,7 +1592,9 @@ def unit_to_str(expression: exp.Expression, default: str = "DAY") -> t.Optional[
     return exp.Literal.string(default) if default else None
 
 
-def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[exp.Expression]:
+def unit_to_var(
+    expression: exp.Expression, default: str = "DAY"
+) -> t.Optional[exp.Expression]:
     unit = expression.args.get("unit")
 
     if isinstance(unit, (exp.Var, exp.Placeholder)):
@@ -1508,7 +1616,9 @@ def map_date_part(
 
 def map_date_part(part, dialect: DialectType = Dialect):
     mapped = (
-        Dialect.get_or_raise(dialect).DATE_PART_MAPPING.get(part.name.upper()) if part else None
+        Dialect.get_or_raise(dialect).DATE_PART_MAPPING.get(part.name.upper())
+        if part
+        else None
     )
     return exp.var(mapped) if mapped else part
 
@@ -1526,7 +1636,9 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
     alias = expression.this.args.get("alias")
 
     def normalize(identifier: t.Optional[exp.Identifier]) -> t.Optional[str]:
-        return self.dialect.normalize_identifier(identifier).name if identifier else None
+        return (
+            self.dialect.normalize_identifier(identifier).name if identifier else None
+        )
 
     targets = {normalize(expression.this.this)}
 
@@ -1542,7 +1654,8 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
             then.transform(
                 lambda node: (
                     exp.column(node.this)
-                    if isinstance(node, exp.Column) and normalize(node.args.get("table")) in targets
+                    if isinstance(node, exp.Column)
+                    and normalize(node.args.get("table")) in targets
                     else node
                 ),
                 copy=False,
@@ -1552,7 +1665,9 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
 
 
 def build_json_extract_path(
-    expr_type: t.Type[F], zero_based_indexing: bool = True, arrow_req_json_type: bool = False
+    expr_type: t.Type[F],
+    zero_based_indexing: bool = True,
+    arrow_req_json_type: bool = False,
 ) -> t.Callable[[t.List], F]:
     def _builder(args: t.List) -> F:
         segments: t.List[exp.JSONPathPart] = [exp.JSONPathRoot()]
@@ -1565,7 +1680,9 @@ def build_json_extract_path(
             if is_int(text):
                 index = int(text)
                 segments.append(
-                    exp.JSONPathSubscript(this=index if zero_based_indexing else index - 1)
+                    exp.JSONPathSubscript(
+                        this=index if zero_based_indexing else index - 1
+                    )
                 )
             else:
                 segments.append(exp.JSONPathKey(this=text))
@@ -1631,7 +1748,9 @@ def filter_array_using_unnest(self: Generator, expression: exp.ArrayFilter) -> s
         return ""
 
     unnest = exp.Unnest(expressions=[expression.this])
-    filtered = exp.select(alias).from_(exp.alias_(unnest, None, table=[alias])).where(cond)
+    filtered = (
+        exp.select(alias).from_(exp.alias_(unnest, None, table=[alias])).where(cond)
+    )
     return self.sql(exp.Array(expressions=[filtered]))
 
 
@@ -1670,7 +1789,9 @@ def sha256_sql(self: Generator, expression: exp.SHA2) -> str:
     return self.func(f"SHA{expression.text('length') or '256'}", expression.this)
 
 
-def sequence_sql(self: Generator, expression: exp.GenerateSeries | exp.GenerateDateArray) -> str:
+def sequence_sql(
+    self: Generator, expression: exp.GenerateSeries | exp.GenerateDateArray
+) -> str:
     start = expression.args.get("start")
     end = expression.args.get("end")
     step = expression.args.get("step")
@@ -1695,5 +1816,6 @@ def build_regexp_extract(args: t.List, dialect: Dialect) -> exp.RegexpExtract:
     return exp.RegexpExtract(
         this=seq_get(args, 0),
         expression=seq_get(args, 1),
-        group=seq_get(args, 2) or exp.Literal.number(dialect.REGEXP_EXTRACT_DEFAULT_GROUP),
+        group=seq_get(args, 2)
+        or exp.Literal.number(dialect.REGEXP_EXTRACT_DEFAULT_GROUP),
     )

--- a/sqlglot/dialects/druid.py
+++ b/sqlglot/dialects/druid.py
@@ -1,0 +1,107 @@
+from sqlglot import exp, parser
+from sqlglot.dialects.dialect import Dialect
+from sqlglot.generator import Generator
+from sqlglot.tokens import TokenType
+
+
+class TemporalFloor(exp.Func):
+    """
+    Druid-specific FLOOR function with a temporal unit.
+
+    Example: FLOOR(my_date TO DAY)
+    """
+
+    arg_types = {"unit": True, "this": True}
+
+    @property
+    def unit(self) -> exp.Expression:
+        return self.args["unit"]
+
+
+class TemporalCeil(exp.Func):
+    """
+    Druid-specific CEIL function with a temporal unit.
+
+    Example: CEIL(my_date TO DAY)
+    """
+
+    arg_types = {"unit": True, "this": True}
+
+    @property
+    def unit(self) -> exp.Expression:
+        return self.args["unit"]
+
+
+class Druid(Dialect):
+
+    class Parser(parser.Parser):
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+
+            self.FUNCTIONS["FLOOR"] = self._parse_temporal_floor
+            self.FUNCTIONS["CEIL"] = self._parse_temporal_ceil
+
+        def _parse_temporal_floor(self, args, dialect):
+            """
+            Custom handler for FLOOR with 'TO' syntax.
+
+            See https://druid.apache.org/docs/latest/querying/sql-functions#floor-date-and-time.
+            """
+            if len(args) < 1:
+                self.raise_error("FLOOR requires at least one argument")
+
+            this = args[0]
+            unit = None
+
+            # Check for the 'TO' token and handle it
+            if (
+                self._curr
+                and self._curr.token_type == TokenType.VAR
+                and self._curr.text.upper() == "TO"
+            ):
+                self._advance()  # Consume the 'TO' token
+                unit = self._parse_expression()
+                return TemporalFloor(this=this, unit=unit)
+
+            return exp.Floor(this=this)
+
+        def _parse_temporal_ceil(self, args, dialect):
+            """
+            Custom handler for CEIL with 'TO' syntax.
+
+            See https://druid.apache.org/docs/latest/querying/sql-functions#ceil-date-and-time.
+            """
+            if len(args) < 1:
+                self.raise_error("CEIL requires at least one argument")
+
+            this = args[0]
+            unit = None
+
+            # Check for the 'TO' token and handle it
+            if (
+                self._curr
+                and self._curr.token_type == TokenType.VAR
+                and self._curr.text.upper() == "TO"
+            ):
+                self._advance()  # Consume the 'TO' token
+                unit = self._parse_expression()
+                return TemporalCeil(this=this, unit=unit)
+
+            return exp.Ceil(this=this)
+
+    class Generator(Generator):
+        TYPE_MAPPING = {
+            exp.DataType.Type.INT: "LONG",
+            exp.DataType.Type.FLOAT: "FLOAT",
+            exp.DataType.Type.DOUBLE: "DOUBLE",
+            exp.DataType.Type.TEXT: "STRING",
+            exp.DataType.Type.ARRAY: "ARRAY",
+            exp.DataType.Type.COMPLEX: "COMPLEX",
+        }
+
+        TRANSFORMS = {
+            **Generator.TRANSFORMS,
+            TemporalFloor: lambda self, e: f"FLOOR({e.this} TO {e.unit})",
+            TemporalCeil: lambda self, e: f"CEIL({e.this} TO {e.unit})",
+        }

--- a/tests/dialects/test_druid.py
+++ b/tests/dialects/test_druid.py
@@ -1,0 +1,11 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestDruid(Validator):
+    dialect = "druid"
+
+    def test_druid(self):
+        self.validate_identity("SELECT CEIL(__time TO WEEK) FROM t")
+        self.validate_identity("SELECT CEIL(col) FROM t")
+        self.validate_identity("SELECT FLOOR(__time TO WEEK) FROM t")
+        self.validate_identity("SELECT FLOOR(col) FROM t")


### PR DESCRIPTION
We're using `sqlglot` to parse SQL in Apache Superset. The generic dialect has worked fine so far for parsing Druid queries, but we noticed that the [FLOOR (date and time)](https://druid.apache.org/docs/latest/querying/sql-functions#floor-date-and-time) and [CEIL (date and time)](https://druid.apache.org/docs/latest/querying/sql-functions#ceil-date-and-time) functions cannot be parsed:

```python
>>> sqlglot.parse_one("SELECT FLOOR(__time TO WEEK) FROM t")
...
sqlglot.errors.ParseError: Expecting ). Line 1, Col: 22.
  SELECT FLOOR(__time TO WEEK) FROM t
```

This PR introduces an initial dialect for Druid that handles both `FLOOR` and `CEIL` when they are used for time rounding.
