### PR TITLE
fix(bigquery): Do not generate NULL ordering on Windows

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2131,6 +2131,16 @@ OPTIONS (
                 },
             )
 
+            self.validate_all(
+                f"SELECT SUM(f1) OVER (ORDER BY f2 {sort_order}) FROM t",
+                read={
+                    "": f"SELECT SUM(f1) OVER (ORDER BY f2 {sort_order} {null_order}) FROM t",
+                },
+                write={
+                    "bigquery": f"SELECT SUM(f1) OVER (ORDER BY f2 {sort_order}) FROM t",
+                },
+            )
+
     def test_json_extract(self):
         self.validate_all(
             """SELECT JSON_QUERY('{"class": {"students": []}}', '$.class')""",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -79,7 +79,7 @@ class TestDuckDB(Validator):
         self.validate_all(
             "SELECT SUM(X) OVER (ORDER BY x)",
             write={
-                "bigquery": "SELECT SUM(X) OVER (ORDER BY x NULLS LAST)",
+                "bigquery": "SELECT SUM(X) OVER (ORDER BY x)",
                 "duckdb": "SELECT SUM(X) OVER (ORDER BY x)",
                 "mysql": "SELECT SUM(X) OVER (ORDER BY CASE WHEN x IS NULL THEN 1 ELSE 0 END, x)",
             },


### PR DESCRIPTION
Fixes #4478

https://github.com/tobymao/sqlglot/pull/4172 disallowed NULL ordering from being generated in aggregation functions; This PR extends this to also include windows of aggfuncs:

```
bq> WITH t1 AS (SELECT 1 AS f1, 2 AS f2) SELECT SUM(f1) OVER (ORDER BY f1 NULLS LAST) from t1;

NULLS LAST not supported with ascending sort order in RANGE clauses of analytic functions.
```

The previous fix was not complete as in the case of windows, the `exp.Ordered` is on the same level as `exp.AggFunc`:

```
    Window(
      this=Sum(
        this=Column(
          this=Identifier(this=f1, quoted=False))),
      order=Order(
        expressions=[
          Ordered(
            this=Column(
              this=Identifier(this=f2, quoted=False)),
            desc=False,
            nulls_first=False)]),
      over=OVER)],
```