### PR TITLE
fix(tsql)!: Preserve roundtrips of DATETIME/DATETIME2

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -885,6 +885,7 @@ class ClickHouse(Dialect):
             exp.DataType.Type.DATE32: "Date32",
             exp.DataType.Type.DATETIME: "DateTime",
             exp.DataType.Type.DATETIME2: "DateTime",
+            exp.DataType.Type.SMALLDATETIME: "DateTime",
             exp.DataType.Type.DATETIME64: "DateTime64",
             exp.DataType.Type.DECIMAL: "Decimal",
             exp.DataType.Type.DECIMAL32: "Decimal32",

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -884,6 +884,7 @@ class ClickHouse(Dialect):
             exp.DataType.Type.BIGINT: "Int64",
             exp.DataType.Type.DATE32: "Date32",
             exp.DataType.Type.DATETIME: "DateTime",
+            exp.DataType.Type.DATETIME2: "DateTime",
             exp.DataType.Type.DATETIME64: "DateTime64",
             exp.DataType.Type.DECIMAL: "Decimal",
             exp.DataType.Type.DECIMAL32: "Decimal32",

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -787,6 +787,7 @@ class MySQL(Dialect):
 
         TIMESTAMP_TYPE_MAPPING = {
             exp.DataType.Type.DATETIME2: "DATETIME",
+            exp.DataType.Type.SMALLDATETIME: "DATETIME",
             exp.DataType.Type.TIMESTAMP: "DATETIME",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
             exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP",

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -786,6 +786,7 @@ class MySQL(Dialect):
         }
 
         TIMESTAMP_TYPE_MAPPING = {
+            exp.DataType.Type.DATETIME2: "DATETIME",
             exp.DataType.Type.TIMESTAMP: "DATETIME",
             exp.DataType.Type.TIMESTAMPTZ: "TIMESTAMP",
             exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP",

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -111,7 +111,7 @@ def _build_formatted_time(
         assert len(args) == 2
 
         return exp_class(
-            this=exp.cast(args[1], exp.DataType.Type.DATETIME),
+            this=exp.cast(args[1], exp.DataType.Type.DATETIME2),
             format=exp.Literal.string(
                 format_time(
                     args[0].name.lower(),
@@ -492,7 +492,7 @@ class TSQL(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "CLUSTERED INDEX": TokenType.INDEX,
-            "DATETIME2": TokenType.DATETIME,
+            "DATETIME2": TokenType.DATETIME2,
             "DATETIMEOFFSET": TokenType.TIMESTAMPTZ,
             "DECLARE": TokenType.DECLARE,
             "EXEC": TokenType.COMMAND,
@@ -507,7 +507,7 @@ class TSQL(Dialect):
             "PROC": TokenType.PROCEDURE,
             "REAL": TokenType.FLOAT,
             "ROWVERSION": TokenType.ROWVERSION,
-            "SMALLDATETIME": TokenType.DATETIME,
+            "SMALLDATETIME": TokenType.DATETIME2,
             "SMALLMONEY": TokenType.SMALLMONEY,
             "SQL_VARIANT": TokenType.VARIANT,
             "SYSTEM_USER": TokenType.CURRENT_USER,
@@ -873,8 +873,8 @@ class TSQL(Dialect):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.BOOLEAN: "BIT",
+            exp.DataType.Type.DATETIME2: "DATETIME2",
             exp.DataType.Type.DECIMAL: "NUMERIC",
-            exp.DataType.Type.DATETIME: "DATETIME2",
             exp.DataType.Type.DOUBLE: "FLOAT",
             exp.DataType.Type.INT: "INTEGER",
             exp.DataType.Type.ROWVERSION: "ROWVERSION",

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -507,7 +507,7 @@ class TSQL(Dialect):
             "PROC": TokenType.PROCEDURE,
             "REAL": TokenType.FLOAT,
             "ROWVERSION": TokenType.ROWVERSION,
-            "SMALLDATETIME": TokenType.DATETIME2,
+            "SMALLDATETIME": TokenType.SMALLDATETIME,
             "SMALLMONEY": TokenType.SMALLMONEY,
             "SQL_VARIANT": TokenType.VARIANT,
             "SYSTEM_USER": TokenType.CURRENT_USER,
@@ -881,6 +881,7 @@ class TSQL(Dialect):
             exp.DataType.Type.TEXT: "VARCHAR(MAX)",
             exp.DataType.Type.TIMESTAMP: "DATETIME2",
             exp.DataType.Type.TIMESTAMPTZ: "DATETIMEOFFSET",
+            exp.DataType.Type.SMALLDATETIME: "SMALLDATETIME",
             exp.DataType.Type.UTINYINT: "TINYINT",
             exp.DataType.Type.VARIANT: "SQL_VARIANT",
         }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4347,6 +4347,7 @@ class DataType(Expression):
         DATEMULTIRANGE = auto()
         DATERANGE = auto()
         DATETIME = auto()
+        DATETIME2 = auto()
         DATETIME64 = auto()
         DECIMAL = auto()
         DECIMAL32 = auto()
@@ -4529,6 +4530,7 @@ class DataType(Expression):
         Type.DATE,
         Type.DATE32,
         Type.DATETIME,
+        Type.DATETIME2,
         Type.DATETIME64,
         Type.TIME,
         Type.TIMESTAMP,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4407,6 +4407,7 @@ class DataType(Expression):
         ROWVERSION = auto()
         SERIAL = auto()
         SET = auto()
+        SMALLDATETIME = auto()
         SMALLINT = auto()
         SMALLMONEY = auto()
         SMALLSERIAL = auto()
@@ -4532,6 +4533,7 @@ class DataType(Expression):
         Type.DATETIME,
         Type.DATETIME2,
         Type.DATETIME64,
+        Type.SMALLDATETIME,
         Type.TIME,
         Type.TIMESTAMP,
         Type.TIMESTAMPNTZ,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -453,6 +453,7 @@ class Generator(metaclass=_Generator):
     ARRAY_SIZE_DIM_REQUIRED: t.Optional[bool] = None
 
     TYPE_MAPPING = {
+        exp.DataType.Type.DATETIME2: "TIMESTAMP",
         exp.DataType.Type.NCHAR: "CHAR",
         exp.DataType.Type.NVARCHAR: "VARCHAR",
         exp.DataType.Type.MEDIUMTEXT: "TEXT",
@@ -4056,7 +4057,7 @@ class Generator(metaclass=_Generator):
 
             if to.this == exp.DataType.Type.DATE:
                 transformed = exp.StrToDate(this=value, format=fmt)
-            elif to.this == exp.DataType.Type.DATETIME:
+            elif to.this in (exp.DataType.Type.DATETIME, exp.DataType.Type.DATETIME2):
                 transformed = exp.StrToTime(this=value, format=fmt)
             elif to.this in self.PARAMETERIZABLE_TEXT_TYPES:
                 transformed = cast(this=exp.TimeToStr(this=value, format=fmt), to=to, safe=safe)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -464,6 +464,7 @@ class Generator(metaclass=_Generator):
         exp.DataType.Type.TINYBLOB: "BLOB",
         exp.DataType.Type.INET: "INET",
         exp.DataType.Type.ROWVERSION: "VARBINARY",
+        exp.DataType.Type.SMALLDATETIME: "TIMESTAMP",
     }
 
     TIME_PART_SINGULARS = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -334,6 +334,7 @@ class Parser(metaclass=_Parser):
         TokenType.DATETIME,
         TokenType.DATETIME2,
         TokenType.DATETIME64,
+        TokenType.SMALLDATETIME,
         TokenType.DATE,
         TokenType.DATE32,
         TokenType.INT4RANGE,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -332,6 +332,7 @@ class Parser(metaclass=_Parser):
         TokenType.TIMESTAMPLTZ,
         TokenType.TIMESTAMPNTZ,
         TokenType.DATETIME,
+        TokenType.DATETIME2,
         TokenType.DATETIME64,
         TokenType.DATE,
         TokenType.DATE32,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -157,6 +157,7 @@ class TokenType(AutoName):
     TIMESTAMP_MS = auto()
     TIMESTAMP_NS = auto()
     DATETIME = auto()
+    DATETIME2 = auto()
     DATETIME64 = auto()
     DATE = auto()
     DATE32 = auto()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -159,6 +159,7 @@ class TokenType(AutoName):
     DATETIME = auto()
     DATETIME2 = auto()
     DATETIME64 = auto()
+    SMALLDATETIME = auto()
     DATE = auto()
     DATE32 = auto()
     INT4RANGE = auto()

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -516,26 +516,6 @@ class TestTSQL(Validator):
         self.validate_identity("CAST(x AS BIT)")
 
         self.validate_all(
-            "CAST(x AS DATETIME2)",
-            read={
-                "": "CAST(x AS DATETIME2)",
-            },
-            write={
-                "mysql": "CAST(x AS DATETIME)",
-                "tsql": "CAST(x AS DATETIME2)",
-            },
-        )
-        self.validate_all(
-            "CAST(x AS DATETIME)",
-            read={
-                "": "CAST(x AS DATETIME)",
-            },
-            write={
-                "mysql": "CAST(x AS DATETIME)",
-                "tsql": "CAST(x AS DATETIME)",
-            },
-        )
-        self.validate_all(
             "CAST(x AS DATETIME2(6))",
             write={
                 "hive": "CAST(x AS TIMESTAMP)",
@@ -551,6 +531,19 @@ class TestTSQL(Validator):
                 "hive": "CAST(x AS BINARY)",
             },
         )
+
+        for temporal_type in ("SMALLDATETIME", "DATETIME", "DATETIME2"):
+            self.validate_all(
+                f"CAST(x AS {temporal_type})",
+                read={
+                    "": f"CAST(x AS {temporal_type})",
+                },
+                write={
+                    "mysql": "CAST(x AS DATETIME)",
+                    "duckdb": "CAST(x AS TIMESTAMP)",
+                    "tsql": f"CAST(x AS {temporal_type})",
+                },
+            )
 
     def test_types_ints(self):
         self.validate_all(
@@ -757,14 +750,6 @@ class TestTSQL(Validator):
             write={
                 "spark": "CAST(x AS TIMESTAMP)",
                 "tsql": "CAST(x AS DATETIMEOFFSET)",
-            },
-        )
-
-        self.validate_all(
-            "CAST(x as SMALLDATETIME)",
-            write={
-                "spark": "CAST(x AS TIMESTAMP)",
-                "tsql": "CAST(x AS DATETIME2)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -518,11 +518,21 @@ class TestTSQL(Validator):
         self.validate_all(
             "CAST(x AS DATETIME2)",
             read={
-                "": "CAST(x AS DATETIME)",
+                "": "CAST(x AS DATETIME2)",
             },
             write={
                 "mysql": "CAST(x AS DATETIME)",
                 "tsql": "CAST(x AS DATETIME2)",
+            },
+        )
+        self.validate_all(
+            "CAST(x AS DATETIME)",
+            read={
+                "": "CAST(x AS DATETIME)",
+            },
+            write={
+                "mysql": "CAST(x AS DATETIME)",
+                "tsql": "CAST(x AS DATETIME)",
             },
         )
         self.validate_all(
@@ -1094,7 +1104,7 @@ WHERE
 
         expected_sqls = [
             "CREATE PROCEDURE [TRANSF].[SP_Merge_Sales_Real] @Loadid INTEGER, @NumberOfRows INTEGER WITH EXECUTE AS OWNER, SCHEMABINDING, NATIVE_COMPILATION AS BEGIN SET XACT_ABORT ON",
-            "DECLARE @DWH_DateCreated AS DATETIME2 = CONVERT(DATETIME2, GETDATE(), 104)",
+            "DECLARE @DWH_DateCreated AS DATETIME = CONVERT(DATETIME, GETDATE(), 104)",
             "DECLARE @DWH_DateModified AS DATETIME2 = CONVERT(DATETIME2, GETDATE(), 104)",
             "DECLARE @DWH_IdUserCreated AS INTEGER = SUSER_ID(CURRENT_USER())",
             "DECLARE @DWH_IdUserModified AS INTEGER = SUSER_ID(CURRENT_USER())",
@@ -1438,7 +1448,7 @@ WHERE
             "CONVERT(DATETIME, x, 121)",
             write={
                 "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
-                "tsql": "CONVERT(DATETIME2, x, 121)",
+                "tsql": "CONVERT(DATETIME, x, 121)",
             },
         )
         self.validate_all(
@@ -1899,7 +1909,7 @@ WHERE
   *
 FROM OPENJSON(@json) WITH (
     Number VARCHAR(200) '$.Order.Number',
-    Date DATETIME2 '$.Order.Date',
+    Date DATETIME '$.Order.Date',
     Customer VARCHAR(200) '$.AccountNumber',
     Quantity INTEGER '$.Item.Quantity',
     [Order] NVARCHAR(MAX) AS JSON


### PR DESCRIPTION
[Public Slack context](https://tobiko-data.slack.com/archives/C044BRE5W4S/p1733610657252759)

This PR introduces `Type.DATETIME2` with the intention of preserving T-SQL's roundtrips of `DATETIME` and `DATETIME2` respectively.

According to the docs, `DATETIME2` is an extension to `DATETIME` supporting higher precision, date range etc. However, it's not 100% backwards compatible so transforming `"DATETIME" -> Type.DATETIME2` is not always safe.


Docs
--------
[T-SQL DATETIME](https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime-transact-sql?view=sql-server-ver16) | [T-SQL DATETIME2](https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-ver16) | [S/O DATETIME VS DATETIME2](https://stackoverflow.com/questions/1334143/datetime2-vs-datetime-in-sql-server)