### PR TITLE
Refactor!!: bundle multiple WHEN [NOT] MATCHED into a exp.WhenSequence

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1547,7 +1547,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
     if alias:
         targets.add(normalize(alias.this))
 
-    for when in expression.args["when_sequence"].expressions:
+    for when in expression.args["whens"].expressions:
         # only remove the target names from the THEN clause
         # theyre still valid in the <condition> part of WHEN MATCHED / WHEN NOT MATCHED
         # ref: https://github.com/TobikoData/sqlmesh/issues/2934

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1547,7 +1547,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
     if alias:
         targets.add(normalize(alias.this))
 
-    for when in expression.expressions:
+    for when in expression.args["when_sequence"].expressions:
         # only remove the target names from the THEN clause
         # theyre still valid in the <condition> part of WHEN MATCHED / WHEN NOT MATCHED
         # ref: https://github.com/TobikoData/sqlmesh/issues/2934

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6678,7 +6678,7 @@ class Merge(DML):
         "this": True,
         "using": True,
         "on": True,
-        "when_sequence": True,
+        "whens": True,
         "with": False,
         "returning": False,
     }
@@ -6688,7 +6688,7 @@ class When(Expression):
     arg_types = {"matched": True, "source": False, "condition": False, "then": True}
 
 
-class WhenSequence(Expression):
+class Whens(Expression):
     """Wraps around one or more WHEN [NOT] MATCHED [...] clauses."""
 
     arg_types = {"expressions": True}
@@ -7354,16 +7354,14 @@ def merge(
     expressions = []
     for when_expr in when_exprs:
         expressions.extend(
-            maybe_parse(
-                when_expr, dialect=dialect, copy=copy, into=WhenSequence, **opts
-            ).expressions
+            maybe_parse(when_expr, dialect=dialect, copy=copy, into=Whens, **opts).expressions
         )
 
     merge = Merge(
         this=maybe_parse(into, dialect=dialect, copy=copy, **opts),
         using=maybe_parse(using, dialect=dialect, copy=copy, **opts),
         on=maybe_parse(on, dialect=dialect, copy=copy, **opts),
-        when_sequence=WhenSequence(expressions=expressions),
+        whens=Whens(expressions=expressions),
     )
     if returning:
         merge = merge.returning(returning, dialect=dialect, copy=False, **opts)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3694,6 +3694,9 @@ class Generator(metaclass=_Generator):
             then = self.sql(then_expression)
         return f"WHEN {matched}{source}{condition} THEN {then}"
 
+    def whensequence_sql(self, expression: exp.WhenSequence) -> str:
+        return self.expressions(expression, sep=" ", indent=False)
+
     def merge_sql(self, expression: exp.Merge) -> str:
         table = expression.this
         table_alias = ""
@@ -3706,16 +3709,17 @@ class Generator(metaclass=_Generator):
         this = self.sql(table)
         using = f"USING {self.sql(expression, 'using')}"
         on = f"ON {self.sql(expression, 'on')}"
-        expressions = self.expressions(expression, sep=" ", indent=False)
+        when_sequence = self.sql(expression, "when_sequence")
+
         returning = self.sql(expression, "returning")
         if returning:
-            expressions = f"{expressions}{returning}"
+            when_sequence = f"{when_sequence}{returning}"
 
         sep = self.sep()
 
         return self.prepend_ctes(
             expression,
-            f"MERGE INTO {this}{table_alias}{sep}{using}{sep}{on}{sep}{expressions}",
+            f"MERGE INTO {this}{table_alias}{sep}{using}{sep}{on}{sep}{when_sequence}",
         )
 
     @unsupported_args("format")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3694,7 +3694,7 @@ class Generator(metaclass=_Generator):
             then = self.sql(then_expression)
         return f"WHEN {matched}{source}{condition} THEN {then}"
 
-    def whensequence_sql(self, expression: exp.WhenSequence) -> str:
+    def whens_sql(self, expression: exp.Whens) -> str:
         return self.expressions(expression, sep=" ", indent=False)
 
     def merge_sql(self, expression: exp.Merge) -> str:
@@ -3709,17 +3709,17 @@ class Generator(metaclass=_Generator):
         this = self.sql(table)
         using = f"USING {self.sql(expression, 'using')}"
         on = f"ON {self.sql(expression, 'on')}"
-        when_sequence = self.sql(expression, "when_sequence")
+        whens = self.sql(expression, "whens")
 
         returning = self.sql(expression, "returning")
         if returning:
-            when_sequence = f"{when_sequence}{returning}"
+            whens = f"{whens}{returning}"
 
         sep = self.sep()
 
         return self.prepend_ctes(
             expression,
-            f"MERGE INTO {this}{table_alias}{sep}{using}{sep}{on}{sep}{when_sequence}",
+            f"MERGE INTO {this}{table_alias}{sep}{using}{sep}{on}{sep}{whens}",
         )
 
     @unsupported_args("format")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -776,7 +776,7 @@ class Parser(metaclass=_Parser):
         exp.Table: lambda self: self._parse_table_parts(),
         exp.TableAlias: lambda self: self._parse_table_alias(),
         exp.Tuple: lambda self: self._parse_value(),
-        exp.WhenSequence: lambda self: self._parse_when_matched(),
+        exp.Whens: lambda self: self._parse_when_matched(),
         exp.Where: lambda self: self._parse_where(),
         exp.Window: lambda self: self._parse_named_window(),
         exp.With: lambda self: self._parse_with(),
@@ -7008,11 +7008,11 @@ class Parser(metaclass=_Parser):
             this=target,
             using=using,
             on=on,
-            when_sequence=self._parse_when_matched(),
+            whens=self._parse_when_matched(),
             returning=self._parse_returning(),
         )
 
-    def _parse_when_matched(self) -> exp.WhenSequence:
+    def _parse_when_matched(self) -> exp.Whens:
         whens = []
 
         while self._match(TokenType.WHEN):
@@ -7061,7 +7061,7 @@ class Parser(metaclass=_Parser):
                     then=then,
                 )
             )
-        return self.expression(exp.WhenSequence, expressions=whens)
+        return self.expression(exp.Whens, expressions=whens)
 
     def _parse_show(self) -> t.Optional[exp.Expression]:
         parser = self._find_parser(self.SHOW_PARSERS, self.SHOW_TRIE)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -776,7 +776,7 @@ class Parser(metaclass=_Parser):
         exp.Table: lambda self: self._parse_table_parts(),
         exp.TableAlias: lambda self: self._parse_table_alias(),
         exp.Tuple: lambda self: self._parse_value(),
-        exp.When: lambda self: seq_get(self._parse_when_matched(), 0),
+        exp.WhenSequence: lambda self: self._parse_when_matched(),
         exp.Where: lambda self: self._parse_where(),
         exp.Window: lambda self: self._parse_named_window(),
         exp.With: lambda self: self._parse_with(),
@@ -7008,11 +7008,11 @@ class Parser(metaclass=_Parser):
             this=target,
             using=using,
             on=on,
-            expressions=self._parse_when_matched(),
+            when_sequence=self._parse_when_matched(),
             returning=self._parse_returning(),
         )
 
-    def _parse_when_matched(self) -> t.List[exp.When]:
+    def _parse_when_matched(self) -> exp.WhenSequence:
         whens = []
 
         while self._match(TokenType.WHEN):
@@ -7061,7 +7061,7 @@ class Parser(metaclass=_Parser):
                     then=then,
                 )
             )
-        return whens
+        return self.expression(exp.WhenSequence, expressions=whens)
 
     def _parse_show(self) -> t.Optional[exp.Expression]:
         parser = self._find_parser(self.SHOW_PARSERS, self.SHOW_TRIE)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -27,9 +27,9 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(
             parse_one(
                 "WHEN MATCHED THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary)",
-                into=exp.When,
+                into=exp.WhenSequence,
             ),
-            exp.When,
+            exp.WhenSequence,
         )
 
         with self.assertRaises(ParseError) as ctx:

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -27,9 +27,9 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(
             parse_one(
                 "WHEN MATCHED THEN UPDATE SET target.salary = COALESCE(source.salary, target.salary)",
-                into=exp.WhenSequence,
+                into=exp.Whens,
             ),
-            exp.WhenSequence,
+            exp.Whens,
         )
 
         with self.assertRaises(ParseError) as ctx:


### PR DESCRIPTION
The motivation behind this PR is to make parsing multiple `WHEN [NOT] MATCHED` clauses easier. This is related to a SQLMesh refactor I'm currently working on.