### PR TITLE
fix(duckdb): Allow escape strings similar to Postgres

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -297,6 +297,7 @@ class DuckDB(Dialect):
         return super().to_json_path(path)
 
     class Tokenizer(tokens.Tokenizer):
+        BYTE_STRINGS = [("e'", "'"), ("E'", "'")]
         HEREDOC_STRINGS = ["$"]
 
         HEREDOC_TAG_IS_IDENTIFIER = True

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -899,6 +899,16 @@ class TestDuckDB(Validator):
             "NOT a ILIKE b",
         )
 
+        self.validate_all(
+            "SELECT e'Hello\nworld'",
+            read={
+                "duckdb": "SELECT E'Hello\nworld'",
+            },
+            write={
+                "duckdb": "SELECT e'Hello\nworld'",
+            },
+        )
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
Fixes #4496

This PR adds support for DuckDB's escape strings `E'...'` / `e'...'`, which is a Postgres-borrowed concept.

Docs
------
[DuckDB](https://duckdb.org/docs/sql/data_types/literal_types.html#escape-string-literals) | [Postgres](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE)