### PR TITLE
Fix(postgres): generate float if the type has precision

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -687,6 +687,14 @@ class Postgres(Dialect):
                     values = self.expressions(expression, key="values", flat=True)
                     return f"{self.expressions(expression, flat=True)}[{values}]"
                 return "ARRAY"
+
+            if (
+                expression.is_type(exp.DataType.Type.DOUBLE, exp.DataType.Type.FLOAT)
+                and expression.expressions
+            ):
+                # Postgres doesn't support precision for REAL and DOUBLE PRECISION types
+                return f"FLOAT({self.expressions(expression, flat=True)})"
+
             return super().datatype_sql(expression)
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -320,6 +320,7 @@ class TestRedshift(Validator):
         )
 
     def test_identity(self):
+        self.validate_identity("SELECT CAST(value AS FLOAT(8))")
         self.validate_identity("1 div", "1 AS div")
         self.validate_identity("LISTAGG(DISTINCT foo, ', ')")
         self.validate_identity("CREATE MATERIALIZED VIEW orders AUTO REFRESH YES AS SELECT 1")


### PR DESCRIPTION
Postgres doesn't support specifying a precision for the `REAL` and `DOUBLE PRECISION` types:

```
georgesittas=# select 1::real(4);
ERROR:  syntax error at or near "("
LINE 1: select 1::real(4);
                      ^
georgesittas=# select 1::double precision(4);
ERROR:  syntax error at or near "("
LINE 1: select 1::double precision(4);
                                  ^
georgesittas=# select 1::real;
 float4
--------
      1
(1 row)

georgesittas=# select 1::double precision;
 float8
--------
      1
(1 row)
```

OTOH, according to its [docs](https://www.postgresql.org/docs/current/datatype-numeric.html), it does support a `FLOAT(p)` type, so we use that instead to (1) roundtrip and (2) facilitate transpilation from other dialects to Postgres:

> PostgreSQL also supports the SQL-standard notations float and float(p) for specifying inexact numeric types. Here, p specifies the minimum acceptable precision in binary digits. PostgreSQL accepts float(1) to float(24) as selecting the real type, while float(25) to float(53) select double precision. Values of p outside the allowed range draw an error. float with no precision specified is taken to mean double precision.

Fixes #4508