### PR TITLE
Fix(planner): ensure aggregate variable is bound

### DIFF
--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -201,11 +201,13 @@ class Step:
 
             aggregate.add_dependency(step)
             step = aggregate
+        else:
+            aggregate = None
 
         order = expression.args.get("order")
 
         if order:
-            if isinstance(step, Aggregate):
+            if aggregate and isinstance(step, Aggregate):
                 for i, ordered in enumerate(order.expressions):
                     if extract_agg_operands(exp.alias_(ordered.this, f"_o_{i}", quoted=True)):
                         ordered.this.replace(exp.column(f"_o_{i}", step.name, quoted=True))


### PR DESCRIPTION
Fixes #4525

Planner looks to be working correctly with this change, without any optimizations needed:

```python
>>> import sqlglot
>>> import sqlglot.planner
>>>
>>> r = 'select suma from (select sum(a) as suma from table1) order by suma'
>>> parsed = sqlglot.parse_one(r, dialect='snowflake')
>>> p = sqlglot.planner.Plan(parsed)
>>> p
Plan
----
- Sort: (4385150576)
    Context:
      Key:
        - suma NULLS LAST
    Projections:
      - suma
    Dependencies:
    - Aggregate: (4382705472)
      Context:
        Aggregations:
          - SUM(a) AS suma
      Projections:
        - "table1"."suma"
      Dependencies:
      - Scan: table1 (4364384592)
        Context:
          Source: table1
        Projections:
```