### PR TITLE
feat: Introduce meta comment to parse known functions as exp.Anonymous

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -59,6 +59,7 @@ class _Expression(type):
 
 
 SQLGLOT_META = "sqlglot.meta"
+SQLGLOT_ANONYMOUS = "sqlglot.anonymous"
 TABLE_PARTS = ("this", "db", "catalog")
 COLUMN_PARTS = ("this", "table", "db", "catalog")
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5366,8 +5366,7 @@ class Parser(metaclass=_Parser):
                 # If the meta comment "/* sqlglot.meta anonymous */" is following the function
                 # call we'll construct it as exp.Anonymous, even if it's "known"
                 for comment in post_func_comments:
-                    lower = comment.lower()
-                    if exp.SQLGLOT_META in lower and "anonymous" in lower:
+                    if exp.SQLGLOT_META in comment and "anonymous" in comment:
                         known_function = False
                         break
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5361,6 +5361,15 @@ class Parser(metaclass=_Parser):
             alias = not known_function or upper in self.FUNCTIONS_WITH_ALIASED_ARGS
             args = self._parse_csv(lambda: self._parse_lambda(alias=alias))
 
+            post_func_comments = self._curr and self._curr.comments
+            if known_function and post_func_comments:
+                anonymous_meta = (exp.SQLGLOT_META, "anonymous")
+                # If the meta comment "/* sqlglot.meta anonymous */" is following the function
+                # call we'll construct it as exp.Anonymous, even if it's "known"
+                for comment in post_func_comments:
+                    if all(meta in comment.lower() for meta in anonymous_meta):
+                        known_function = False
+
             if alias and known_function:
                 args = self._kv_to_prop_eq(args)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5363,12 +5363,13 @@ class Parser(metaclass=_Parser):
 
             post_func_comments = self._curr and self._curr.comments
             if known_function and post_func_comments:
-                # If the meta comment "/* sqlglot.meta anonymous */" is following the function
+                # If the user-inputted comment "/* sqlglot.anonymous */" is following the function
                 # call we'll construct it as exp.Anonymous, even if it's "known"
-                for comment in post_func_comments:
-                    if exp.SQLGLOT_META in comment and "anonymous" in comment:
-                        known_function = False
-                        break
+                if any(
+                    comment.lstrip().startswith(exp.SQLGLOT_ANONYMOUS)
+                    for comment in post_func_comments
+                ):
+                    known_function = False
 
             if alias and known_function:
                 args = self._kv_to_prop_eq(args)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5363,12 +5363,13 @@ class Parser(metaclass=_Parser):
 
             post_func_comments = self._curr and self._curr.comments
             if known_function and post_func_comments:
-                anonymous_meta = (exp.SQLGLOT_META, "anonymous")
                 # If the meta comment "/* sqlglot.meta anonymous */" is following the function
                 # call we'll construct it as exp.Anonymous, even if it's "known"
                 for comment in post_func_comments:
-                    if all(meta in comment.lower() for meta in anonymous_meta):
+                    lower = comment.lower()
+                    if exp.SQLGLOT_META in lower and "anonymous" in lower:
                         known_function = False
+                        break
 
             if alias and known_function:
                 args = self._kv_to_prop_eq(args)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -890,8 +890,12 @@ class TestParser(unittest.TestCase):
         self.assertEqual(len(list(ast.find_all(exp.Column))), 1)
 
     def test_udf_meta(self):
-        ast = parse_one("YEAR(a) /* sqlglot.meta anONYMOUs */")
+        ast = parse_one("YEAR(a) /* sqlglot.meta anonymous */")
         self.assertIsInstance(ast, exp.Anonymous)
+
+        # Meta flag is case sensitive
+        ast = parse_one("YEAR(a) /* sqlglot.meta anONYMOUs */")
+        self.assertIsInstance(ast, exp.Year)
 
         # Incomplete or incorrect anonymous meta comments are not registered
         ast = parse_one("YEAR(a) /* sqlglot.meta anon */")

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -890,13 +890,13 @@ class TestParser(unittest.TestCase):
         self.assertEqual(len(list(ast.find_all(exp.Column))), 1)
 
     def test_udf_meta(self):
-        ast = parse_one("YEAR(a) /* sqlglot.meta anonymous */")
+        ast = parse_one("YEAR(a) /* sqlglot.anonymous */")
         self.assertIsInstance(ast, exp.Anonymous)
 
         # Meta flag is case sensitive
-        ast = parse_one("YEAR(a) /* sqlglot.meta anONYMOUs */")
+        ast = parse_one("YEAR(a) /* sqlglot.anONymous */")
         self.assertIsInstance(ast, exp.Year)
 
         # Incomplete or incorrect anonymous meta comments are not registered
-        ast = parse_one("YEAR(a) /* sqlglot.meta anon */")
+        ast = parse_one("YEAR(a) /* sqlglot.anon */")
         self.assertIsInstance(ast, exp.Year)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -888,3 +888,11 @@ class TestParser(unittest.TestCase):
         ast = parse_one("ALTER TABLE tbl DROP COLUMN col")
         self.assertEqual(len(list(ast.find_all(exp.Table))), 1)
         self.assertEqual(len(list(ast.find_all(exp.Column))), 1)
+
+    def test_udf_meta(self):
+        ast = parse_one("YEAR(a) /* sqlglot.meta anONYMOUs */")
+        self.assertIsInstance(ast, exp.Anonymous)
+
+        # Incomplete or incorrect anonymous meta comments are not registered
+        ast = parse_one("YEAR(a) /* sqlglot.meta anon */")
+        self.assertIsInstance(ast, exp.Year)


### PR DESCRIPTION
Fixes #4522

This PR introduces support for the meta comment `/* sqlglot.meta anonymous */` which forces the parser to ignore the known functions during `_parse_function_call`:

- Without meta comment
```Python3
>>> print(repr(parse_one("YEAR(a)")))
Year(
  this=Column(
    this=Identifier(this=a, quoted=False)))
```

- With meta comment
```Python3
>>> print(repr(parse_one("YEAR(a) /* sqlglot.meta anonymous */")))
Anonymous(
  this=YEAR,
  expressions=[
    Column(
      this=Identifier(this=a, quoted=False))],
  _comments=[
    sqlglot.meta anonymous ])

``` 

- With incorrect / incomplete meta comment
```Python3
>>> print(repr(parse_one("YEAR(a) /* sqlglot.meta anon */")))
Year(
  this=Column(
    this=Identifier(this=a, quoted=False)),
  _comments=[
    sqlglot.meta anon ])
```