### PR TITLE
feat(tsql): add support for DATETRUNC #4531

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -370,6 +370,17 @@ def _timestrtotime_sql(self: TSQL.Generator, expression: exp.TimeStrToTime):
     return sql
 
 
+def _parse_datetrunc(args: t.List) -> exp.TimestampTrunc:
+    unit = seq_get(args, 0)
+    this = seq_get(args, 1)
+
+    # Every date - time type in tsql resoves to DATETIME2
+    if isinstance(this, exp.Expression) and this.is_string:
+        this = exp.TimeStrToTime(this=args[1])
+
+    return exp.TimestampTrunc(unit=unit, this=this)
+
+
 class TSQL(Dialect):
     SUPPORTS_SEMI_ANTI_JOIN = False
     LOG_BASE_FIRST = False
@@ -570,6 +581,7 @@ class TSQL(Dialect):
             "SUSER_SNAME": exp.CurrentUser.from_arg_list,
             "SYSTEM_USER": exp.CurrentUser.from_arg_list,
             "TIMEFROMPARTS": _build_timefromparts,
+            "DATETRUNC": _parse_datetrunc,
         }
 
         JOIN_HINTS = {"LOOP", "HASH", "MERGE", "REMOTE"}

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -2090,3 +2090,19 @@ FROM OPENJSON(@json) WITH (
                 "oracle": "SELECT NEXT VALUE FOR db.schema.sequence_name",
             },
         )
+
+    def test_datetrunc(self):
+        self.validate_all(
+            "SELECT DATETRUNC(month, '2021-12-08 11:30:15.1234567')",
+            write={
+                "duckdb": "SELECT DATE_TRUNC('MONTH', CAST('2021-12-08 11:30:15.1234567' AS TIMESTAMP))"
+            },
+        )
+        self.validate_all(
+            "SELECT DATETRUNC(year, DATEFROMPARTS(2010, 12, 31))",
+            write={"duckdb": "SELECT DATE_TRUNC('YEAR', MAKE_DATE(2010, 12, 31))"},
+        )
+        self.validate_all(
+            "SELECT DATETRUNC(year, CAST('2021-12-08' AS date))",
+            write={"duckdb": "SELECT DATE_TRUNC('YEAR', CAST('2021-12-08' AS DATE))"},
+        )


### PR DESCRIPTION
Fixes [https://github.com/tobymao/sqlglot/issues/4531](https://github.com/tobymao/sqlglot/issues/4531)

This PR adds support for the `DATETRUNC` function of `T-SQL`.

In cases, where the `date` parameter is a `string literal`, a casting is applied to produce a `DATETIME2` expression.
Based on `T-SQL`, all `string literals` should resolve into `DATETIME2`.
Dialects like `duckdb` do not support the direct `string literals` as dates, thus the casting is mandatory.  

**Docs**
[T-SQL DATETRUNC](https://learn.microsoft.com/en-us/sql/t-sql/functions/datetrunc-transact-sql?view=sql-server-ver16)