### PR TITLE
Add flag to allow setting Rust tokenizer per Tokenizer instance

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -986,12 +986,16 @@ class Tokenizer(metaclass=_Tokenizer):
         "_peek",
         "_prev_token_line",
         "_rs_dialect_settings",
+        "use_rs_tokenizer",
     )
 
     def __init__(self, dialect: DialectType = None) -> None:
         from sqlglot.dialects import Dialect
 
         self.dialect = Dialect.get_or_raise(dialect)
+
+        # initialize `use_rs_tokenizer`, and allow it to be overwritten per Tokenizer instance
+        self.use_rs_tokenizer = USE_RS_TOKENIZER
 
         if USE_RS_TOKENIZER:
             self._rs_dialect_settings = RsTokenizerDialectSettings(
@@ -1019,7 +1023,7 @@ class Tokenizer(metaclass=_Tokenizer):
 
     def tokenize(self, sql: str) -> t.List[Token]:
         """Returns a list of tokens corresponding to the SQL string `sql`."""
-        if USE_RS_TOKENIZER:
+        if self.use_rs_tokenizer:
             return self.tokenize_rs(sql)
 
         self.reset()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -976,6 +976,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "size",
         "tokens",
         "dialect",
+        "use_rs_tokenizer",
         "_start",
         "_current",
         "_line",
@@ -986,7 +987,6 @@ class Tokenizer(metaclass=_Tokenizer):
         "_peek",
         "_prev_token_line",
         "_rs_dialect_settings",
-        "use_rs_tokenizer",
     )
 
     def __init__(

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -989,13 +989,15 @@ class Tokenizer(metaclass=_Tokenizer):
         "use_rs_tokenizer",
     )
 
-    def __init__(self, dialect: DialectType = None) -> None:
+    def __init__(
+        self, dialect: DialectType = None, use_rs_tokenizer: bool = USE_RS_TOKENIZER
+    ) -> None:
         from sqlglot.dialects import Dialect
 
         self.dialect = Dialect.get_or_raise(dialect)
 
         # initialize `use_rs_tokenizer`, and allow it to be overwritten per Tokenizer instance
-        self.use_rs_tokenizer = USE_RS_TOKENIZER
+        self.use_rs_tokenizer = use_rs_tokenizer
 
         if USE_RS_TOKENIZER:
             self._rs_dialect_settings = RsTokenizerDialectSettings(


### PR DESCRIPTION
Add flag to allow setting Rust tokenizer per Tokenizer instance.

## Motivation

Currently, it is only possible to enable/disable the Rust tokenizer globally via an environment variable (`USE_RS_TOKENIZER`). It would be great if we had a way to enable/disable the Rust backend per `Tokenizer` instance, i.e., to selectively choose which tokenizer should be used for parsing a particular query.

Why would we want to do this? The Rust tokenizer is faster in most cases, and is compatible with 99.99% of queries, but we've come across a few queries that are not (yet) supported - so it would be great to selectively enable/disable it (to use Rust for the majority of parsing, but use the Python fallback for the 0.01% of queries).

## Solution

This PR proposes a minimally invasive change that adds a new flag `Tokenizer.use_rs_tokenizer` which can be used to enable/disable the Rust tokenizer backend.

## What does this PR enable?

With the changes in this PR, we can selectively enable/disable the Rust tokenizer - for example, using a `REGEX_QUERY_SKIP_RUST_TOKENIZER` regex that analyzes the query beforehand, and then sets the `tokenizer.use_rs_tokenizer = False` flag for certain queries that are not (yet) supported with the Rust backend:
```
    dialect = Dialect.get_or_raise("snowflake")
    tokenizer = dialect.tokenizer

    # determine whether this should skip using the Rust tokenizer (as it can fail for some queries)
    if REGEX_QUERY_SKIP_RUST_TOKENIZER.match(query):
        tokenizer.use_rs_tokenizer = False

    result = dialect.parser().parse(tokenizer.tokenize(query), query)
    ...
```

---

Curious to get your thoughts on this @georgesittas @tobymao - does it make sense from your perspective to enable/disable the Rust backend on a per-query basis..?