### PR TITLE
fix(tsql): generate correct DateFromParts naming #4558

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -948,6 +948,7 @@ class TSQL(Dialect):
             exp.TsOrDsAdd: date_delta_sql("DATEADD", cast=True),
             exp.TsOrDsDiff: date_delta_sql("DATEDIFF"),
             exp.TimestampTrunc: lambda self, e: self.func("DATETRUNC", e.unit, e.this),
+            exp.DateFromParts: rename_func("DATEFROMPARTS"),
         }
 
         TRANSFORMS.pop(exp.ReturnsProperty)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1220,7 +1220,10 @@ WHERE
     def test_datefromparts(self):
         self.validate_all(
             "SELECT DATEFROMPARTS('2020', 10, 01)",
-            write={"spark": "SELECT MAKE_DATE('2020', 10, 01)"},
+            write={
+                "spark": "SELECT MAKE_DATE('2020', 10, 01)",
+                "tsql": "SELECT DATEFROMPARTS('2020', 10, 01)",
+            },
         )
 
     def test_datename(self):


### PR DESCRIPTION
Fixes #4558

```
>>> sqlglot.exp.DateFromParts(year="2012", month="4", day="21").sql(dialect="tsql")`
'DATEFROMPARTS(2012, 4, 21)'
```

**Docs**
[T-SQL DATEFROMPARTS](https://learn.microsoft.com/en-us/sql/t-sql/functions/datefromparts-transact-sql?view=sql-server-ver16)