### PR TITLE
feat(postgres): Support Postgres XMLTABLE syntax #4553

### DIFF
--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1309,3 +1309,8 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
         self.validate_identity(
             "SELECT XMLELEMENT(NAME foo, XMLATTRIBUTES('xyz' AS bar), XMLELEMENT(NAME abc), XMLCOMMENT('test'), XMLELEMENT(NAME xyz))"
         )
+
+    def test_xmltable(self):
+        self.validate_identity(
+            "SELECT id, name FROM XMLTABLE('/root/user' PASSING xml_data COLUMNS id INT PATH '@id', name TEXT PATH 'name/text()') AS t"
+        )


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4553

Reference: https://www.postgresql.org/docs/current/functions-xml.html#FUNCTIONS-XML-PROCESSING-XMLTABLE

Very similar to the Oracle implementation in https://github.com/tobymao/sqlglot/pull/1159, except the the by_ref functionality is not implemented because Postgres does not support this (yet).