### PR TITLE
Feat: add support for Chr in tsql and sqlite

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -1236,7 +1236,8 @@ class MySQL(Dialect):
         def chr_sql(self, expression: exp.Chr) -> str:
             this = self.expressions(sqls=[expression.this] + expression.expressions)
             charset = expression.args.get("charset")
-            return f"CHAR({this} USING {charset})" if charset else f"CHAR({this})"
+            using = f" USING {self.sql(charset)}" if charset else ""
+            return f"CHAR({this}{using})"
 
         def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
             unit = expression.args.get("unit")

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -1236,8 +1236,8 @@ class MySQL(Dialect):
         def chr_sql(self, expression: exp.Chr) -> str:
             this = self.expressions(sqls=[expression.this] + expression.expressions)
             charset = expression.args.get("charset")
-            using = f" USING {self.sql(charset)}" if charset else ""
-            return f"CHAR({this}{using})"
+            charset = self.sql(charset) if charset else "utf8mb4"
+            return f"CHAR({this} USING {charset})"
 
         def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
             unit = expression.args.get("unit")

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -1236,8 +1236,7 @@ class MySQL(Dialect):
         def chr_sql(self, expression: exp.Chr) -> str:
             this = self.expressions(sqls=[expression.this] + expression.expressions)
             charset = expression.args.get("charset")
-            charset = self.sql(charset) if charset else "utf8mb4"
-            return f"CHAR({this} USING {charset})"
+            return f"CHAR({this} USING {charset})" if charset else f"CHAR({this})"
 
         def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
             unit = expression.args.get("unit")

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -172,6 +172,7 @@ class SQLite(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: any_value_to_max_sql,
+            exp.Chr: rename_func("CHAR"),
             exp.Concat: concat_to_dpipe_sql,
             exp.CountIf: count_if_to_sum,
             exp.Create: transforms.preprocess([_transform_create]),

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -905,6 +905,7 @@ class TSQL(Dialect):
             exp.AnyValue: any_value_to_max_sql,
             exp.ArrayToString: rename_func("STRING_AGG"),
             exp.AutoIncrementColumnConstraint: lambda *_: "IDENTITY",
+            exp.Chr: rename_func("CHAR"),
             exp.DateAdd: date_delta_sql("DATEADD"),
             exp.DateDiff: date_delta_sql("DATEDIFF"),
             exp.CTE: transforms.preprocess([qualify_derived_table_outputs]),

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -263,7 +263,7 @@ class TestMySQL(Validator):
         )
         self.validate_identity("INTERVAL '1' YEAR")
         self.validate_identity("DATE_ADD(x, INTERVAL '1' YEAR)")
-        self.validate_identity("CHAR(77, 77.3, '77.3' USING latin1)")
+        self.validate_identity("CHAR(77, 77.3, '77.3' USING utf8mb4)")
         self.validate_identity("SELECT * FROM t1 PARTITION(p0)")
         self.validate_identity("SELECT @var1 := 1, @var2")
         self.validate_identity("SELECT @var1, @var2 := @var1")
@@ -328,7 +328,7 @@ class TestMySQL(Validator):
         self.validate_all(
             "CHAR(10)",
             write={
-                "mysql": "CHAR(10 USING utf8mb4)",
+                "mysql": "CHAR(10)",
                 "presto": "CHR(10)",
                 "sqlite": "CHAR(10)",
                 "tsql": "CHAR(10)",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -263,6 +263,8 @@ class TestMySQL(Validator):
         )
         self.validate_identity("INTERVAL '1' YEAR")
         self.validate_identity("DATE_ADD(x, INTERVAL '1' YEAR)")
+        self.validate_identity("CHAR(0)")
+        self.validate_identity("CHAR(77, 121, 83, 81, '76')")
         self.validate_identity("CHAR(77, 77.3, '77.3' USING utf8mb4)")
         self.validate_identity("SELECT * FROM t1 PARTITION(p0)")
         self.validate_identity("SELECT @var1 := 1, @var2")

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -263,9 +263,7 @@ class TestMySQL(Validator):
         )
         self.validate_identity("INTERVAL '1' YEAR")
         self.validate_identity("DATE_ADD(x, INTERVAL '1' YEAR)")
-        self.validate_identity("CHAR(0)")
-        self.validate_identity("CHAR(77, 121, 83, 81, '76')")
-        self.validate_identity("CHAR(77, 77.3, '77.3' USING utf8mb4)")
+        self.validate_identity("CHAR(77, 77.3, '77.3' USING latin1)")
         self.validate_identity("SELECT * FROM t1 PARTITION(p0)")
         self.validate_identity("SELECT @var1 := 1, @var2")
         self.validate_identity("SELECT @var1, @var2 := @var1")
@@ -330,8 +328,10 @@ class TestMySQL(Validator):
         self.validate_all(
             "CHAR(10)",
             write={
-                "mysql": "CHAR(10)",
+                "mysql": "CHAR(10 USING utf8mb4)",
                 "presto": "CHR(10)",
+                "sqlite": "CHAR(10)",
+                "tsql": "CHAR(10)",
             },
         )
 


### PR DESCRIPTION
I renamed `exp.Chr` for SQLite, TSQL, and added default encoding for MySQL.


```
SELECT CHAR(10) # sqlite
SELECT CHR(10) # postgres
SELECT CHAR(10 USING utf8mb4) # mysql
```
See [SQLite docs](https://www.sqlite.org/lang_corefunc.html#char) and [TSQL docs](https://learn.microsoft.com/en-us/sql/t-sql/functions/char-transact-sql?view=sql-server-ver16).

The encoding is necessary since MySQL 8.0.19 (see [this](https://stackoverflow.com/questions/65614116/in-mysql-char-function-works-weird)).