### PR TITLE
StrPosition fixed for Oracle

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -9,6 +9,7 @@ from sqlglot.dialects.dialect import (
     build_formatted_time,
     no_ilike_sql,
     rename_func,
+    str_position_sql,
     to_number_with_nls_param,
     trim_sql,
 )
@@ -317,6 +318,9 @@ class Oracle(Dialect):
                     transforms.eliminate_distinct_on,
                     transforms.eliminate_qualify,
                 ]
+            ),
+            exp.StrPosition: lambda self, e: str_position_sql(
+                self, e, str_position_func_name="INSTR"
             ),
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
             exp.StrToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -45,6 +45,7 @@ class TestOracle(Validator):
         self.validate_identity("SELECT COUNT(*) * 10 FROM orders SAMPLE (10) SEED (1)")
         self.validate_identity("SELECT * FROM V$SESSION")
         self.validate_identity("SELECT TO_DATE('January 15, 1989, 11:00 A.M.')")
+        self.validate_identity("SELECT INSTR(haystack, needle)")
         self.validate_identity(
             "SELECT * FROM test UNPIVOT INCLUDE NULLS (value FOR Description IN (col AS 'PREFIX ' || CHR(38) || ' SUFFIX'))"
         )


### PR DESCRIPTION
Oracle does not support `STR_POSITION`, the correct function is `INSTR`.

See the [docs](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/INSTR.html).