### PR TITLE
LOGICAL_AND and LOGICAL_OR for MySQL

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -732,6 +732,8 @@ class MySQL(Dialect):
             exp.ILike: no_ilike_sql,
             exp.JSONExtractScalar: arrow_json_extract_sql,
             exp.Length: rename_func("CHAR_LENGTH"),
+            exp.LogicalOr: rename_func("MAX"),
+            exp.LogicalAnd: rename_func("MIN"),
             exp.Max: max_or_greatest,
             exp.Min: min_or_least,
             exp.Month: _remove_ts_or_ds_to_date(),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -495,6 +495,7 @@ class TestSnowflake(Validator):
                 "snowflake": "SELECT BOOLAND_AGG(c1), BOOLAND_AGG(c2) FROM test",
                 "spark": "SELECT BOOL_AND(c1), BOOL_AND(c2) FROM test",
                 "sqlite": "SELECT MIN(c1), MIN(c2) FROM test",
+                "mysql": "SELECT MIN(c1), MIN(c2) FROM test",
             },
         )
         for suffix in (


### PR DESCRIPTION
Added support for `LOGICAL_AND` and `LOGICAL_OR` in MySQL. The latest MySQL version supports `BIT_AND` and `BIT_OR`, but `MIN` and `MAX` also work and have wider support. The `MIN` and `MAX` trick is already used by SQLite.

For `BIT_OR`/`BIT_AND` see [this](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html#function_bit-and).