### PR TITLE
fix(duckdb): support parentheses with FROM-First syntax #4561

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3068,9 +3068,14 @@ class Parser(metaclass=_Parser):
                     is_unpivot=self._prev.token_type == TokenType.UNPIVOT
                 )
             elif self._match(TokenType.FROM):
-                this = exp.select("*").from_(
-                    t.cast(exp.From, self._parse_from(skip_from_token=True))
-                )
+                from_ = self._parse_from(skip_from_token=True)
+                # Support parentheses for duckdb FROM-first syntax
+                select = self._parse_select()
+                if select:
+                    select.set("from", from_)
+                    this = select
+                else:
+                    this = exp.select("*").from_(t.cast(exp.From, from_))
             else:
                 this = (
                     self._parse_table()

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1434,3 +1434,23 @@ class TestDuckDB(Validator):
         self.validate_identity(
             "SELECT * FROM (UNPIVOT monthly_sales ON COLUMNS(* EXCLUDE (empid, dept)) INTO NAME month VALUE sales) AS unpivot_alias"
         )
+
+    def test_from_first_with_parentheses(self):
+        self.validate_all(
+            "CREATE TABLE t1 AS (FROM t2 SELECT foo1, foo2)",
+            write={
+                "duckdb": "CREATE TABLE t1 AS (SELECT foo1, foo2 FROM t2)",
+            },
+        )
+        self.validate_all(
+            "FROM (FROM t1 SELECT foo1, foo2)",
+            write={
+                "duckdb": "SELECT * FROM (SELECT foo1, foo2 FROM t1)",
+            },
+        )
+        self.validate_all(
+            "WITH t1 AS (FROM (FROM t2 SELECT foo1, foo2)) FROM t1",
+            write={
+                "duckdb": "WITH t1 AS (SELECT * FROM (SELECT foo1, foo2 FROM t2)) SELECT * FROM t1",
+            },
+        )


### PR DESCRIPTION
Fixes #4561

In the previous implementation, an error was thrown every time the `FROM-First` syntax was used with parentheses.
For example: 
```
CREATE TABLE table1 AS (FROM table2 SELECT foo1, foo2)
```
In the above example, an error `sqlglot.errors.ParseError: Expecting )` was thrown because the parsing of the `SELECT`  was missing. 

After the fix: 
```
>>> sqlglot.transpile("FROM (FROM table1 SELECT foo1, foo2)", read="duckdb", write="duckdb")
['SELECT * FROM (SELECT foo1, foo2 FROM table1)']
```

**Docs**
[DuckDB From-First](https://duckdb.org/docs/sql/query_syntax/from#from-first-syntax)