### PR TITLE
fix: Pin ubuntu to 22.04 for Python 3.7

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]


### PR DESCRIPTION
The regression in the CI seems to be due to `ubuntu-latest` i.e Ubuntu 24.04 no longer supporting Python 3.7

https://github.com/actions/setup-python/issues/962