### PR TITLE
fix(tsql): transpile snowflake TIMESTAMP_NTZ to DATETIME2

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -891,6 +891,7 @@ class TSQL(Dialect):
             exp.DataType.Type.ROWVERSION: "ROWVERSION",
             exp.DataType.Type.TEXT: "VARCHAR(MAX)",
             exp.DataType.Type.TIMESTAMP: "DATETIME2",
+            exp.DataType.Type.TIMESTAMPNTZ: "DATETIME2",
             exp.DataType.Type.TIMESTAMPTZ: "DATETIMEOFFSET",
             exp.DataType.Type.SMALLDATETIME: "SMALLDATETIME",
             exp.DataType.Type.UTINYINT: "TINYINT",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -753,6 +753,15 @@ class TestTSQL(Validator):
             },
         )
 
+        # percision of TIMESTAMP_NTZ 0 to 9 (same as TIMESTAMP)
+        # percision of DATETIME2 0 to 7
+        self.validate_all(
+            "CREATE TABLE t (col1 TIMESTAMP_NTZ(2))",
+            write={
+                "tsql": "CREATE TABLE t (col1 DATETIME2(2))",
+            },
+        )
+
     def test_types_bin(self):
         self.validate_all(
             "CAST(x as BIT)",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -762,6 +762,7 @@ class TestTSQL(Validator):
                 "tsql": "CREATE TABLE t (col1 DATETIME2(2))",
             },
         )
+
     def test_types_bin(self):
         self.validate_all(
             "CAST(x as BIT)",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -753,15 +753,15 @@ class TestTSQL(Validator):
             },
         )
 
-        # percision of TIMESTAMP_NTZ 0 to 9 (same as TIMESTAMP)
-        # percision of DATETIME2 0 to 7
         self.validate_all(
-            "CREATE TABLE t (col1 TIMESTAMP_NTZ(2))",
+            "CREATE TABLE t (col1 DATETIME2(2))",
+            read={
+                "snowflake": "CREATE TABLE t (col1 TIMESTAMP_NTZ(2))",
+            },
             write={
                 "tsql": "CREATE TABLE t (col1 DATETIME2(2))",
             },
         )
-
     def test_types_bin(self):
         self.validate_all(
             "CAST(x as BIT)",


### PR DESCRIPTION
Fixes [here](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1736263004411849)

This PR fixes the transpilation of the `TIMESTAMP_NTZ` to `DATETIME2`. 
Based on the snowflake's docs: `TIMESTAMP_NTZ is the default for TIMESTAMP`.

**Note** : the precision of `snowflake's TIMESTAMP_NTZ` is `0 to 9`, and the precision of `tsql's DATETIME2` is `0 to 7`. 

**Docs**
[Snowflake TIMESTAMP_NTZ](https://docs.snowflake.com/en/sql-reference/data-types-datetime#label-datatypes-timestamp-variations) | [T-SQL datetime2](https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetime2-transact-sql?view=sql-server-ver16)