### PR TITLE
STRPOS to POSITION for Postgres

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -27,7 +27,6 @@ from sqlglot.dialects.dialect import (
     build_timestamp_trunc,
     rename_func,
     sha256_sql,
-    str_position_sql,
     struct_extract_sql,
     timestamptrunc_sql,
     timestrtotime_sql,
@@ -583,7 +582,6 @@ class Postgres(Dialect):
                 ]
             ),
             exp.SHA2: sha256_sql,
-            exp.StrPosition: str_position_sql,
             exp.StrToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
             exp.StructExtract: struct_extract_sql,
@@ -721,3 +719,7 @@ class Postgres(Dialect):
 
         def isascii_sql(self, expression: exp.IsAscii) -> str:
             return f"({self.sql(expression.this)} ~ '^[[:ascii:]]*$')"
+
+        def strposition_sql(self, expression: exp.StrPosition):
+            substr = expression.args.get("substr")
+            return f"POSITION({self.sql(substr)} in {self.sql(expression.this)})"

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1686,7 +1686,7 @@ class TestDialect(Validator):
             write={
                 "drill": "STRPOS(haystack, needle)",
                 "duckdb": "STRPOS(haystack, needle)",
-                "postgres": "STRPOS(haystack, needle)",
+                "postgres": "POSITION(needle in haystack)",
                 "presto": "STRPOS(haystack, needle)",
                 "spark": "LOCATE(needle, haystack)",
                 "clickhouse": "position(haystack, needle)",
@@ -1699,7 +1699,7 @@ class TestDialect(Validator):
             write={
                 "drill": "STRPOS(haystack, needle)",
                 "duckdb": "STRPOS(haystack, needle)",
-                "postgres": "STRPOS(haystack, needle)",
+                "postgres": "POSITION(needle in haystack)",
                 "presto": "STRPOS(haystack, needle)",
                 "bigquery": "STRPOS(haystack, needle)",
                 "spark": "LOCATE(needle, haystack)",


### PR DESCRIPTION
`STRPOS` works well for Postgres and the [documentation](https://www.postgresql.org/docs/9.1/functions-string.html) states that "[it is the] same as position(substring in string), but note the reversed argument order", but in reality, `POSITION(substring in string)` is more robust as it works with binary strings as well.

```sql
select strpos(decode('DEADBEEF', 'hex'), decode('BE', 'hex'));
# ERROR:  function strpos(bytea, bytea) does not exist

select position(decode('BE', 'hex') in decode('DEADBEEF', 'hex'));
#  position 
# ----------
#         3
```