### PR TITLE
Chore: temporarily disable sqlglotrs benchmarking

### DIFF
--- a/.github/workflows/rust-bench.yml
+++ b/.github/workflows/rust-bench.yml
@@ -1,7 +1,7 @@
 on: [pull_request]
 name: benchmark pull requests
 jobs:
-  runBenchmark:
+  run-benchmark:
     name: run benchmark
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/rust-bench.yml
+++ b/.github/workflows/rust-bench.yml
@@ -10,3 +10,4 @@ jobs:
         with:
           branchName: ${{ github.base_ref }}
           cwd: "sqlglotrs"
+          additional_flags: "--lib"

--- a/.github/workflows/rust-bench.yml
+++ b/.github/workflows/rust-bench.yml
@@ -4,10 +4,10 @@ jobs:
   run-benchmark:
     name: run benchmark
     runs-on: ubuntu-latest
+    if: ${{ false }}  # Uncomment this when the workflow is fixed (currently fails in PRs)
     steps:
       - uses: actions/checkout@v4
       - uses: boa-dev/criterion-compare-action@v3
         with:
           branchName: ${{ github.base_ref }}
           cwd: "sqlglotrs"
-          additional_flags: "--lib"

--- a/sqlglotrs/Cargo.toml
+++ b/sqlglotrs/Cargo.toml
@@ -6,7 +6,6 @@ license = "MIT"
 
 [lib]
 name = "sqlglotrs"
-bench = false
 crate-type = ["cdylib", "rlib"]
 
 [[bench]]

--- a/sqlglotrs/Cargo.toml
+++ b/sqlglotrs/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT"
 
 [lib]
 name = "sqlglotrs"
+bench = false
 crate-type = ["cdylib", "rlib"]
 
 [[bench]]


### PR DESCRIPTION
The CI is currently broken for PRs, I'm temporarily disabling the job so we can take our time to debug this without producing noise.