### PR TITLE
fix: Pin python 3.13 for sqlglotrs build

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -50,7 +50,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: '3.11'
+        python-version: '3.13'
         architecture: ${{ matrix.python-architecture || 'x64' }}
     - name: Build wheels
       uses: PyO3/maturin-action@v1


### PR DESCRIPTION
The Python 3.13 Windows release does [not work](https://github.com/tobymao/sqlglot/actions/runs/12673518778/job/35320129684) due to a known pyo3 [linker error](https://github.com/PyO3/maturin-action/issues/292).

Pinning the python version was the recommendation [here](https://github.com/PyO3/maturin-action/issues/292#issuecomment-2504729250). If `win32` issues arise, we can also consolidate the `architecture` line.