### PR TITLE
fix(snowflake): generate LIMIT when OFFSET exists #4575

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1229,10 +1229,5 @@ class Snowflake(Dialect):
             limit = expression.args.get("limit")
             offset = expression.args.get("offset")
             if offset and not limit:
-                expression.set(
-                    "limit",
-                    exp.Limit(
-                        expression=exp.Null(),
-                    ),
-                )
+                expression.limit(exp.Null(), copy=False)
             return super().select_sql(expression)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1224,3 +1224,15 @@ class Snowflake(Dialect):
                 self.unsupported("DateSub cannot be transpiled if the subtracted count is unknown")
 
             return date_delta_sql("DATEADD")(self, expression)
+
+        def select_sql(self, expression: exp.Select) -> str:
+            limit = expression.args.get("limit")
+            offset = expression.args.get("offset")
+            if offset and not limit:
+                expression.set(
+                    "limit",
+                    exp.Limit(
+                        expression=exp.Null(),
+                    ),
+                )
+            return super().select_sql(expression)

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2360,3 +2360,11 @@ SINGLE = TRUE""",
         self.assertEqual(ast.sql("snowflake"), query)
         self.assertEqual(len(list(ast.find_all(exp.Column))), 1)
         self.assertEqual(window.this.sql("snowflake"), "db.schema.FUNC(a)")
+
+    def test_offset_without_limit(self):
+        self.validate_all(
+            "SELECT 1 ORDER BY 1 OFFSET 0",
+            write={
+                "snowflake": "SELECT 1 ORDER BY 1 LIMIT NULL OFFSET 0",
+            },
+        )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2363,8 +2363,8 @@ SINGLE = TRUE""",
 
     def test_offset_without_limit(self):
         self.validate_all(
-            "SELECT 1 ORDER BY 1 OFFSET 0",
-            write={
-                "snowflake": "SELECT 1 ORDER BY 1 LIMIT NULL OFFSET 0",
+            "SELECT 1 ORDER BY 1 LIMIT NULL OFFSET 0",
+            read={
+                "trino": "SELECT 1 ORDER BY 1 OFFSET 0",
             },
         )


### PR DESCRIPTION
Fixes snowflake problem #4575 

This PR allows the generation of snowflake queries when the `OFFSET` is present in the input dialect without a `LIMIT`.

Based on the snowflake's doc, an `OFFSET` must always match with a `LIMIT`. Based on the discussion [here](https://snowflake.discourse.group/t/how-do-i-use-offset-without-limit/5342), a `LIMIT NULL` can be inserted into the query in order to be parsed correctly. 

Example:
```
>>> sqlglot.transpile("SELECT 1 ORDER BY 1 OFFSET 0", read="trino", write="snowflake")
['SELECT 1 ORDER BY 1 LIMIT NULL OFFSET 0']
```

**Docs**
[Snowflake LIMIT](https://docs.snowflake.com/en/sql-reference/constructs/limit#postgresql-syntax)