### PR TITLE
fix(postgres): Revert exp.StrPos generation, fix str_position_sql edge case

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -32,6 +32,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     trim_sql,
     ts_or_ds_add_cast,
+    str_position_sql,
 )
 from sqlglot.helper import is_int, seq_get
 from sqlglot.parser import binary_range_parser
@@ -583,8 +584,7 @@ class Postgres(Dialect):
                 ]
             ),
             exp.SHA2: sha256_sql,
-            exp.StrPosition: lambda self,
-            e: f"POSITION({self.sql(e, 'substr')} IN {self.sql(e, 'this')})",
+            exp.StrPosition: str_position_sql,
             exp.StrToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
             exp.StructExtract: struct_extract_sql,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1686,7 +1686,7 @@ class TestDialect(Validator):
             write={
                 "drill": "STRPOS(haystack, needle)",
                 "duckdb": "STRPOS(haystack, needle)",
-                "postgres": "POSITION(needle IN haystack)",
+                "postgres": "STRPOS(haystack, needle)",
                 "presto": "STRPOS(haystack, needle)",
                 "spark": "LOCATE(needle, haystack)",
                 "clickhouse": "position(haystack, needle)",
@@ -1699,7 +1699,7 @@ class TestDialect(Validator):
             write={
                 "drill": "STRPOS(haystack, needle)",
                 "duckdb": "STRPOS(haystack, needle)",
-                "postgres": "POSITION(needle IN haystack)",
+                "postgres": "STRPOS(haystack, needle)",
                 "presto": "STRPOS(haystack, needle)",
                 "bigquery": "STRPOS(haystack, needle)",
                 "spark": "LOCATE(needle, haystack)",
@@ -1711,8 +1711,9 @@ class TestDialect(Validator):
         self.validate_all(
             "POSITION(needle, haystack, pos)",
             write={
-                "drill": "STRPOS(SUBSTR(haystack, pos), needle) + pos - 1",
-                "presto": "STRPOS(SUBSTR(haystack, pos), needle) + pos - 1",
+                "drill": "`IF`(STRPOS(SUBSTR(haystack, pos), needle) = 0, 0, STRPOS(SUBSTR(haystack, pos), needle) + pos - 1)",
+                "presto": "IF(STRPOS(SUBSTR(haystack, pos), needle) = 0, 0, STRPOS(SUBSTR(haystack, pos), needle) + pos - 1)",
+                "postgres": "CASE WHEN STRPOS(SUBSTR(haystack, pos), needle) = 0 THEN 0 ELSE STRPOS(SUBSTR(haystack, pos), needle) + pos - 1 END",
                 "spark": "LOCATE(needle, haystack, pos)",
                 "clickhouse": "position(haystack, needle, pos)",
                 "snowflake": "POSITION(needle, haystack, pos)",

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -588,8 +588,8 @@ class TestHive(Validator):
         self.validate_all(
             "LOCATE('a', x, 3)",
             write={
-                "duckdb": "STRPOS(SUBSTR(x, 3), 'a') + 3 - 1",
-                "presto": "STRPOS(SUBSTR(x, 3), 'a') + 3 - 1",
+                "duckdb": "CASE WHEN STRPOS(SUBSTR(x, 3), 'a') = 0 THEN 0 ELSE STRPOS(SUBSTR(x, 3), 'a') + 3 - 1 END",
+                "presto": "IF(STRPOS(SUBSTR(x, 3), 'a') = 0, 0, STRPOS(SUBSTR(x, 3), 'a') + 3 - 1)",
                 "hive": "LOCATE('a', x, 3)",
                 "spark": "LOCATE('a', x, 3)",
             },


### PR DESCRIPTION
This PR reverts https://github.com/tobymao/sqlglot/pull/4577 as Postgres's `exp.StrPos` generation does not take into account the `position` arg anymore (regression).

Also, the position offset logic is fixed; If a match is not found the return value should be 0, so `position_offset` should be added conditionally e.g:

```SQL
-- Example query on a dialect that supports 'pos' when match is not found
spark-sql (default)> SELECT LOCATE('a', 'abc', 2);
locate(a, abc, 2)
0

-- Incorrect transpilation (before this PR): Match hasn't been found but position offset is applied
postgres> SELECT STRPOS(SUBSTR('abc', 2), 'a') + 2 - 1;
 ?column?
----------
        1
(1 row)

-- Correct transpilation (after this PR): Match is not found, position offset is not applied
postgres> SELECT CASE WHEN STRPOS(SUBSTR('abc', 2), 'a') = 0 THEN 0 ELSE STRPOS(SUBSTR('abc', 2), 'a') + 2 - 1 END;
 case
------
    0
(1 row)
```


Docs
---------
[Postgres](https://www.postgresql.org/docs/9.1/functions-string.html) | [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/position) | [DuckDB](https://duckdb.org/docs/sql/functions/char.html#strposstring-search_string) | [Presto/Trino](https://prestodb.io/docs/current/functions/string.html#strpos-string-substring-bigint) | [Spark/DB](https://docs.databricks.com/en/sql/language-manual/functions/locate.html) 