### PR TITLE
Feat!: Cleaner IS_ASCII for TSQL

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1269,4 +1269,4 @@ class TSQL(Dialect):
             )
 
         def isascii_sql(self, expression: exp.IsAscii) -> str:
-            return f"(PATINDEX('%[^' + CHAR(0x00) + '-' + CHAR(0x7f) + ']%' COLLATE Latin1_General_BIN, {self.sql(expression.this)}) = 0)"
+            return f"(PATINDEX(CONVERT(VARCHAR(MAX), 0x255b5e002d7f5d25) COLLATE Latin1_General_BIN, {self.sql(expression.this)}) = 0)"

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -528,7 +528,7 @@ class TestDialect(Validator):
                 "sqlite": "SELECT (NOT x GLOB CAST(x'2a5b5e012d7f5d2a' AS TEXT))",
                 "mysql": "SELECT REGEXP_LIKE(x, '^[[:ascii:]]*$')",
                 "postgres": "SELECT (x ~ '^[[:ascii:]]*$')",
-                "tsql": "SELECT (PATINDEX('%[^' + CHAR(0x00) + '-' + CHAR(0x7f) + ']%' COLLATE Latin1_General_BIN, x) = 0)",
+                "tsql": "SELECT (PATINDEX(CONVERT(VARCHAR(MAX), 0x255b5e002d7f5d25) COLLATE Latin1_General_BIN, x) = 0)",
                 "oracle": "SELECT NVL(REGEXP_LIKE(x, '^[' || CHR(1) || '-' || CHR(127) || ']*$'), TRUE)",
             },
         )


### PR DESCRIPTION
I found a cleaner way to implement `IS_ASCII` for TSQL. It is basically the same as the SQLite trick. See #4557