### PR TITLE
Feat: LOGICAL_AND and LOGICAL_OR for Oracle

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -291,6 +291,8 @@ class Oracle(Dialect):
             exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, e.unit),
             exp.Group: transforms.preprocess([transforms.unalias_group]),
             exp.ILike: no_ilike_sql,
+            exp.LogicalOr: rename_func("MAX"),
+            exp.LogicalAnd: rename_func("MIN"),
             exp.Mod: rename_func("MOD"),
             exp.Select: transforms.preprocess(
                 [


### PR DESCRIPTION
Just like SQLite, Oracle does not support `LOGICAL_AND/OR`, but `MIN` and `MAX` work well. I covered the compilation path.