### PR TITLE
Fix!: exp.Merge condition for Trino/Postgres

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1578,7 +1578,11 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
             then.transform(
                 lambda node: (
                     exp.column(node.this)
-                    if isinstance(node, exp.Column) and normalize(node.args.get("table")) in targets
+                    if (
+                        isinstance(node, exp.Column)
+                        and normalize(node.args.get("table")) in targets
+                        and not isinstance(node.parent, exp.Func)
+                    )
                     else node
                 ),
                 copy=False,

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1584,9 +1584,9 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
                     ):
                         equal_lhs.replace(exp.column(equal_lhs.this))
             if isinstance(then, exp.Insert):
-                column_list = then.args.get("this")
-                if column_list is not None:
-                    for column in column_list.find_all(exp.Column):
+                column_list = then.this
+                if isinstance(column_list, exp.Tuple):
+                    for column in column_list.expressions:
                         if normalize(column.args.get("table")) in targets:
                             column.replace(exp.column(column.this))
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2336,6 +2336,17 @@ SELECT
             },
         )
 
+        # needs to preserve the target alias in then WHEN condition and function but not in the THEN clause
+        self.validate_all(
+            """MERGE INTO foo AS target USING (SELECT a, b FROM tbl) AS src ON src.a = target.a
+            WHEN MATCHED THEN UPDATE SET target.b = COALESCE(src.b, target.b)
+            WHEN NOT MATCHED THEN INSERT (target.a, target.b) VALUES (src.a, src.b)""",
+            write={
+                "trino": """MERGE INTO foo AS target USING (SELECT a, b FROM tbl) AS src ON src.a = target.a WHEN MATCHED THEN UPDATE SET b = COALESCE(src.b, target.b) WHEN NOT MATCHED THEN INSERT (a, b) VALUES (src.a, src.b)""",
+                "postgres": """MERGE INTO foo AS target USING (SELECT a, b FROM tbl) AS src ON src.a = target.a WHEN MATCHED THEN UPDATE SET b = COALESCE(src.b, target.b) WHEN NOT MATCHED THEN INSERT (a, b) VALUES (src.a, src.b)""",
+            },
+        )
+
     def test_substring(self):
         self.validate_all(
             "SUBSTR('123456', 2, 3)",


### PR DESCRIPTION
Fixes #4595

Further building upon https://github.com/tobymao/sqlglot/pull/3940 there was a gap whereby the UPDATE part of a MERGE query needed to be fully qualified if it's used within a function.
The specific example we had was when we were concatenating arrays but I've substituted for a coalesce in the unit test.