### PR TITLE
feat: Firebolt dialect

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -70,6 +70,7 @@ from sqlglot.dialects.doris import Doris
 from sqlglot.dialects.drill import Drill
 from sqlglot.dialects.druid import Druid
 from sqlglot.dialects.duckdb import DuckDB
+from sqlglot.dialects.firebolt import Firebolt
 from sqlglot.dialects.hive import Hive
 from sqlglot.dialects.materialize import Materialize
 from sqlglot.dialects.mysql import MySQL

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -64,6 +64,7 @@ class Dialects(str, Enum):
     DRILL = "drill"
     DRUID = "druid"
     DUCKDB = "duckdb"
+    FIREBOLT = "firebolt"
     HIVE = "hive"
     MATERIALIZE = "materialize"
     MYSQL = "mysql"

--- a/sqlglot/dialects/firebolt.py
+++ b/sqlglot/dialects/firebolt.py
@@ -1,0 +1,35 @@
+import typing as t
+
+from sqlglot import exp, generator, parser
+from sqlglot.dialects.dialect import Dialect
+from sqlglot.tokens import TokenType
+
+
+class Firebolt(Dialect):
+    class Parser(parser.Parser):
+        UNARY_PARSERS = {
+            **parser.Parser.UNARY_PARSERS,
+            TokenType.NOT: lambda self: self.expression(exp.Not, this=self._parse_unary()),
+        }
+
+        def _negate_range(
+            self, this: t.Optional[exp.Expression] = None
+        ) -> t.Optional[exp.Expression]:
+            if not this:
+                return this
+
+            return self.expression(exp.Not, this=self.expression(exp.Paren, this=this))
+
+    class Generator(generator.Generator):
+        TYPE_MAPPING = {
+            **generator.Generator.TYPE_MAPPING,
+            exp.DataType.Type.VARBINARY: "BYTEA",
+        }
+
+        def not_sql(self, expression: exp.Not) -> str:
+            # Firebolt requires negated to be wrapped in parentheses, since NOT has higher
+            # precedence than IN, IS, BETWEEN, etc.
+            if isinstance(expression.this, exp.In):
+                return f"NOT ({self.sql(expression, 'this')})"
+
+            return super().not_sql(expression)

--- a/tests/dialects/test_firebolt.py
+++ b/tests/dialects/test_firebolt.py
@@ -1,0 +1,28 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestFirebolt(Validator):
+    dialect = "firebolt"
+
+    def test_firebolt(self):
+        # `NOT` has higher precedence than `IN`/equality, negated part should be in parentheses
+        self.validate_all(
+            "SELECT NOT (col IN (1, 2)) FROM tbl",
+            read={
+                "": "SELECT col NOT IN (1, 2) FROM tbl",
+                "firebolt": "SELECT col NOT IN (1, 2) FROM tbl",
+            },
+        )
+        self.validate_all(
+            "SELECT NOT (col IN (1, 2)) FROM tbl",
+            read={"": "SELECT NOT col IN (1, 2) FROM tbl"},
+        )
+        # for equality no parentheses are needed
+        self.validate_all(
+            "SELECT NOT col = 1 FROM tbl",
+            read={"": "SELECT NOT col = 1 FROM tbl"},
+        )
+
+        self.validate_identity("SELECT NOT (col IN (1, 2)) FROM tbl")
+        self.validate_identity("SELECT NOT col IN (TRUE) FROM tbl")
+        self.validate_identity("SELECT (NOT col) IN (TRUE) FROM tbl")


### PR DESCRIPTION
We found a problem when using `sqlglot` in Apache Superset to process (parse, modify the AST, and re-render) Firebolt queries. The problem happens when we run a query with a predicate of `col NOT IN` and it gets translated to `NOT col IN` by the generic parser:

```python
>>> sqlglot.parse_one("SELECT * FROM tbl WHERE i NOT IN (1, 2)").sql()
'SELECT * FROM tbl WHERE NOT i IN (1, 2)'
```

While both queries are semantically equivalent, the first one is valid in Firebolt, while the second is not. This happens because `NOT` has higher precedence than `IN`:

```sql
CREATE TABLE tbl (i INT, b BOOLEAN, t TEXT);
INSERT INTO tbl VALUES (0, FALSE, 'false'), (1, TRUE, 'true');
SELECT * FROM tbl WHERE NOT i IN (1, 2);
```

> firebolt error: - Line 4, Column 25: operator 'not' for input types (integer) not found, try adding explicit casts

This only happens when checking for a range; equality (and other comparisons) works as expected:

```sql
SELECT * FROM tbl WHERE NOT i = 1;   -- this works
```

This PR introduces a custom Firebolt dialect that fixes the problem:

```python
>>> sqlglot.parse_one("SELECT * FROM tbl WHERE i NOT IN (1, 2)").sql("firebolt")
'SELECT * FROM tbl WHERE NOT (i IN (1, 2))'
```