### PR TITLE
Feat: Add support for REVERSE

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6455,6 +6455,10 @@ class Repeat(Func):
     arg_types = {"this": True, "times": True}
 
 
+class Reverse(Func):
+    pass
+
+
 # https://learn.microsoft.com/en-us/sql/t-sql/functions/round-transact-sql?view=sql-server-ver16
 # tsql third argument function == trunctaion if not 0
 class Round(Func):


### PR DESCRIPTION
`REVERSE(x)` reverses the string. Aside from SQLite, I am not aware of any engine that does not support it.

[Oracle](https://psoug.org/definition/reverse.htm)
[MySQL](https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#function_reverse)
[Postgres](https://neon.tech/postgresql/postgresql-string-functions/postgresql-reverse)
[TSQL](https://learn.microsoft.com/en-us/sql/t-sql/functions/reverse-transact-sql?view=sql-server-ver16)