### PR TITLE
fix(tsql): support PRIMARY KEY constraint with DESC, ASC #4610

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5902,7 +5902,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_primary_key_part(self) -> t.Optional[exp.Expression]:
-        return self._parse_field()
+        return self._parse_ordered() or self._parse_field()
 
     def _parse_period_for_system_time(self) -> t.Optional[exp.PeriodForSystemTimeConstraint]:
         if not self._match(TokenType.TIMESTAMP_SNAPSHOT):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -436,6 +436,13 @@ class TestTSQL(Validator):
             "'a' + 'b'",
         )
 
+        self.validate_identity(
+            "CREATE TABLE db.t1 (a INTEGER, b VARCHAR(50), CONSTRAINT c PRIMARY KEY (a DESC))",
+        )
+        self.validate_identity(
+            "CREATE TABLE db.t1 (a INTEGER, b INTEGER, CONSTRAINT c PRIMARY KEY (a DESC, b))"
+        )
+
     def test_option(self):
         possible_options = [
             "HASH GROUP",


### PR DESCRIPTION
Fixes #4610

This PR adds support for using `DESC or ASC` in the `PRIMARY KEY` constraint definition.

Example:
`
CREATE TABLE db.t1 (a INTEGER, b VARCHAR(50), CONSTRAINT c PRIMARY KEY (a DESC))
`

**DOCS**
[T-SQL Constraints](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver16#constraint)