### PR TITLE
feat(optimizer): Fix qualify for SEMI/ANTI joins

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2453,6 +2453,10 @@ class Join(Expression):
     def alias_or_name(self) -> str:
         return self.this.alias_or_name
 
+    @property
+    def is_semi_or_anti_join(self) -> bool:
+        return self.kind in ("SEMI", "ANTI")
+
     def on(
         self,
         *expressions: t.Optional[ExpOrStr],

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -174,7 +174,7 @@ def _expand_using(scope: Scope, resolver: Resolver) -> t.Dict[str, t.Any]:
         ordered.append(join_table)
 
         using = join.args.get("using")
-        if not using:
+        if not using or join.is_semi_or_anti_join:
             continue
 
         join_columns = resolver.get_source_columns(join_table)

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -311,6 +311,12 @@ class Scope:
             result = {}
 
             for name, node in self.references:
+                parent = node.parent
+                if isinstance(parent, exp.Join) and parent.is_semi_or_anti_join:
+                    # The RHS table of SEMI/ANTI joins shouldn't be collected as a
+                    # selected source
+                    continue
+
                 if name in result:
                     raise OptimizeError(f"Alias already used: {name}")
                 if name in self.sources:

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -786,3 +786,24 @@ SELECT X.A AS FOO FROM X AS X GROUP BY X.A = 1;
 # execute: false
 SELECT x.a AS foo FROM x WHERE foo = 1;
 SELECT X.A AS FOO FROM X AS X WHERE X.A = 1;
+
+
+--------------------------------------
+-- SEMI / ANTI Joins
+--------------------------------------
+
+# title: SEMI JOIN table is excluded from the scope
+SELECT * FROM x SEMI JOIN y USING (b);
+SELECT x.a AS a, x.b AS b FROM x AS x SEMI JOIN y AS y USING (b);
+
+# title: ANTI JOIN table is excluded from the scope
+SELECT * FROM x ANTI JOIN y USING (b);
+SELECT x.a AS a, x.b AS b FROM x AS x ANTI JOIN y AS y USING (b);
+
+# title: SEMI + normal joins reinclude the table on scope
+SELECT * FROM x SEMI JOIN y USING (b) JOIN y USING (b);
+SELECT x.a AS a, COALESCE(x.b, y_2.b) AS b, y_2.c AS c FROM x AS x SEMI JOIN y AS y USING (b) JOIN y AS y_2 ON x.b = y_2.b;
+
+# title: ANTI + normal joins reinclude the table on scope
+SELECT * FROM x ANTI JOIN y USING (b) JOIN y USING (b);
+SELECT x.a AS a, COALESCE(x.b, y_2.b) AS b, y_2.c AS c FROM x AS x ANTI JOIN y AS y USING (b) JOIN y AS y_2 ON x.b = y_2.b;


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/3557

The RHS table of an SEMI/ANTI join shouldn't be collected as a selected source (in contrast to normal joins) since it's only used for the filtering process under the hood.

Note that as a side-effect of this, the `_expand_using` rule for SEMI/ANTI joins is turned off since we'd now fail to resolve the RHS related columns if they're expanded.

PS: I believe a different solution would be to run `transforms.py::eliminate_semi_and_anti_joins` before the optimizer

