### PR TITLE
fix(trino): support QUOTES option for JSON_QUERY #4623

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -39,9 +39,10 @@ class Trino(Presto):
             if self._match_text_seq("KEEP", "QUOTES") or self._match_text_seq("OMIT", "QUOTES"):
                 option = self._tokens[self._index - 2].text.upper()
 
-            scalar = "ON SCALAR STRING" if self._match_text_seq("ON", "SCALAR", "STRING") else None
-
             if option:
+                scalar = (
+                    "ON SCALAR STRING" if self._match_text_seq("ON", "SCALAR", "STRING") else None
+                )
                 return self.expression(
                     exp.JSONExtractQuote,
                     option=option,

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -40,18 +40,11 @@ class Trino(Presto):
             ):
                 return None
 
-            option = self._tokens[self._index - 2].text.upper()
-
-            if option:
-                scalar = (
-                    "ON SCALAR STRING" if self._match_text_seq("ON", "SCALAR", "STRING") else None
-                )
-                return self.expression(
-                    exp.JSONExtractQuote,
-                    option=option,
-                    scalar=scalar,
-                )
-            return None
+            return self.expression(
+                exp.JSONExtractQuote,
+                option=self._tokens[self._index - 2].text.upper(),
+                scalar=self._match_text_seq("ON", "SCALAR", "STRING"),
+            )
 
         def _parse_json_query(self) -> exp.JSONExtract:
             return self.expression(

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -35,9 +35,12 @@ class Trino(Presto):
         }
 
         def _parse_json_query_quote(self) -> t.Optional[exp.JSONExtractQuote]:
-            option = None
-            if self._match_text_seq("KEEP", "QUOTES") or self._match_text_seq("OMIT", "QUOTES"):
-                option = self._tokens[self._index - 2].text.upper()
+            if not (
+                self._match_text_seq("KEEP", "QUOTES") or self._match_text_seq("OMIT", "QUOTES")
+            ):
+                return None
+
+            option = self._tokens[self._index - 2].text.upper()
 
             if option:
                 scalar = (
@@ -77,11 +80,6 @@ class Trino(Presto):
             exp.JSONPathRoot,
             exp.JSONPathSubscript,
         }
-
-        def jsonextractquote_sql(self, expression: exp.JSONExtractQuote) -> str:
-            scalar = expression.args.get("scalar")
-            scalar = f" {scalar}" if scalar else ""
-            return f"{expression.args.get('option')} QUOTES" + scalar
 
         def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
             if not expression.args.get("json_query"):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6156,6 +6156,7 @@ class JSONExtract(Binary, Func):
         "variant_extract": False,
         "json_query": False,
         "option": False,
+        "quote": False,
     }
     _sql_names = ["JSON_EXTRACT"]
     is_var_len_args = True
@@ -6163,6 +6164,14 @@ class JSONExtract(Binary, Func):
     @property
     def output_name(self) -> str:
         return self.expression.output_name if not self.expressions else ""
+
+
+# https://trino.io/docs/current/functions/json.html#json-query
+class JSONExtractQuote(Expression):
+    arg_types = {
+        "option": True,
+        "scalar": False,
+    }
 
 
 class JSONExtractArray(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4422,8 +4422,8 @@ class Generator(metaclass=_Generator):
         return f"{empty}{error}{null}"
 
     def jsonextractquote_sql(self, expression: exp.JSONExtractQuote) -> str:
-        scalar = " ON SCALAR STRING" if self.sql(expression, "scalar") else ""
-        return f"{expression.args.get('option')} QUOTES{scalar}"
+        scalar = " ON SCALAR STRING" if expression.args.get("scalar") else ""
+        return f"{self.sql(expression,'option')} QUOTES{scalar}"
 
     def jsonexists_sql(self, expression: exp.JSONExists) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4420,7 +4420,11 @@ class Generator(metaclass=_Generator):
         null = self.sql(expression, "null")
 
         return f"{empty}{error}{null}"
-
+    
+    def jsonextractquote_sql(self, expression: exp.JSONExtractQuote) -> str:
+            scalar = " ON SCALAR STRING" if self.sql(expression, "scalar") else ""
+            return f"{expression.args.get('option')} QUOTES{scalar}"
+    
     def jsonexists_sql(self, expression: exp.JSONExists) -> str:
         this = self.sql(expression, "this")
         path = self.sql(expression, "path")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4423,7 +4423,7 @@ class Generator(metaclass=_Generator):
 
     def jsonextractquote_sql(self, expression: exp.JSONExtractQuote) -> str:
         scalar = " ON SCALAR STRING" if expression.args.get("scalar") else ""
-        return f"{self.sql(expression,'option')} QUOTES{scalar}"
+        return f"{self.sql(expression, 'option')} QUOTES{scalar}"
 
     def jsonexists_sql(self, expression: exp.JSONExists) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4420,11 +4420,11 @@ class Generator(metaclass=_Generator):
         null = self.sql(expression, "null")
 
         return f"{empty}{error}{null}"
-    
+
     def jsonextractquote_sql(self, expression: exp.JSONExtractQuote) -> str:
-            scalar = " ON SCALAR STRING" if self.sql(expression, "scalar") else ""
-            return f"{expression.args.get('option')} QUOTES{scalar}"
-    
+        scalar = " ON SCALAR STRING" if self.sql(expression, "scalar") else ""
+        return f"{expression.args.get('option')} QUOTES{scalar}"
+
     def jsonexists_sql(self, expression: exp.JSONExists) -> str:
         this = self.sql(expression, "this")
         path = self.sql(expression, "path")

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -9,6 +9,10 @@ class TestTrino(Validator):
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER)")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT CONDITIONAL WRAPPER)")
+        self.validate_identity("JSON_QUERY(description, 'strict $.comment' KEEP QUOTES)")
+        self.validate_identity(
+            "JSON_QUERY(description, 'strict $.comment' OMIT QUOTES ON SCALAR STRING)"
+        )
 
     def test_listagg(self):
         self.validate_identity(

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -13,6 +13,9 @@ class TestTrino(Validator):
         self.validate_identity(
             "JSON_QUERY(description, 'strict $.comment' OMIT QUOTES ON SCALAR STRING)"
         )
+        self.validate_identity(
+            "JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER KEEP QUOTES)"
+        )
 
     def test_listagg(self):
         self.validate_identity(


### PR DESCRIPTION
Fixes #4623

This PR adds support for the QUOTES option of the JSON_QUERY.

Example:
```
parse_one("JSON_QUERY(description, 'strict $.comment' OMIT QUOTES ON SCALAR STRING)", dialect="trino")
JSONExtract(
  this=Column(
    this=Identifier(this=description, quoted=False)),
  expression=Literal(this=strict $.comment, is_string=True),
  json_query=True,
  quote=JSONExtractQuote(option=OMIT, scalar=True))
```

**DOCS**
[Trino QUOTES option](https://trino.io/docs/current/functions/json.html#json-query)