### PR TITLE
fix(snowflake)!: Allow parsing of TO_TIME & TRY_TO_TIME

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6654,7 +6654,7 @@ class TsOrDsToDatetime(Func):
 
 
 class TsOrDsToTime(Func):
-    pass
+    arg_types = {"this": True, "format": False, "safe": False}
 
 
 class TsOrDsToTimestamp(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3934,6 +3934,16 @@ class Generator(metaclass=_Generator):
 
     def tsordstotime_sql(self, expression: exp.TsOrDsToTime) -> str:
         this = expression.this
+        time_format = self.format_time(expression)
+
+        if time_format:
+            return self.sql(
+                exp.cast(
+                    exp.StrToTime(this=this, format=expression.args["format"]),
+                    exp.DataType.Type.TIME,
+                )
+            )
+
         if isinstance(this, exp.TsOrDsToTime) or this.is_type(exp.DataType.Type.TIME):
             return self.sql(this)
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4625

This PR adds support for Snowflake's `TO_TIME` & `TRY_TO_TIME` by mimicking the implementation of `TO_DATE`:
- The expression `exp.TsOrDsToTime` is chosen & enhanced with `format` and `safe` args
- Snowflake's `_build_datetime` can now handle `Type.TIME` kind (proxy for `TO_TIME`)
- The base generator of `exp.TsOrDsToTime` is extended to also account for `format` on other dialects, allowing transpilation of `TO_TIME( <string_expr> [, <format> ])`

After this PR, the following transpilations are enabled:

- Single argument:
```Python3
snowflake> SELECT TO_TIME(CONVERT_TIMEZONE('UTC', 'US/Pacific', '2024-08-06 09:10:00.000')) AS pst_time
PST_TIME
02:10:00

duckdb> SELECT CAST(CAST('2024-08-06 09:10:00.000' AS TIMESTAMP) AT TIME ZONE 'UTC' AT TIME ZONE 'US/Pacific' AS TIME) AS pst_time;
┌──────────┐
│ pst_time │
│   time   │
├──────────┤
│ 02:10:00 │
└──────────┘
```

- Two arguments:
```Python3
snowflake> SELECT TO_TIME('11.15.00', 'HH24.MI.SS') AS TIME;
TIME
11:15:00

duckdb> SELECT CAST(STRPTIME('11.15.00', '%H.%M.%S') AS TIME);
┌────────────────────────────────────────────────┐
│ CAST(strptime('11.15.00', '%H.%M.%S') AS TIME) │
│                      time                      │
├────────────────────────────────────────────────┤
│ 11:15:00                                       │
└────────────────────────────────────────────────┘
```

Docs
-------
[TO_TIME](https://docs.snowflake.com/en/sql-reference/functions/to_time) | [TRY_TO_TIME](https://docs.snowflake.com/en/sql-reference/functions/try_to_time)