### PR TITLE
fix(duckdb): Transpile exp.RegexpILike

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -608,6 +608,9 @@ class DuckDB(Dialect):
                 e.args.get("modifiers"),
             ),
             exp.RegexpLike: rename_func("REGEXP_MATCHES"),
+            exp.RegexpILike: lambda self, e: self.func(
+                "REGEXP_MATCHES", e.this, e.expression, exp.Literal.string("i")
+            ),
             exp.RegexpSplit: rename_func("STR_SPLIT_REGEX"),
             exp.Return: lambda self, e: self.sql(e, "this"),
             exp.ReturnsProperty: lambda self, e: "TABLE" if isinstance(e.this, exp.Schema) else "",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -903,6 +903,13 @@ class TestDuckDB(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT REGEXP_MATCHES('ThOmAs', 'thomas', 'i')",
+            read={
+                "postgres": "SELECT 'ThOmAs' ~* 'thomas'",
+            },
+        )
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4639

DuckDB does not implement Postgres's `~*` operator:

```SQL
postgres> SELECT 'ThOmAs' ~* 'thomas';
 ?column?
----------
 t
(1 row)

duckdb> SELECT 'ThOmAs' ~* 'thomas';
Catalog Error: Scalar Function with name ~* does not exist!
Did you mean "~"?
LINE 1: SELECT 'ThOmAs' ~* 'thomas';
```

The next best solution as described in the issue is `REGEXP_MATCHES` with the `'i'` flag to account for the case-insensitive matching:

```SQL
duckdb>  SELECT REGEXP_MATCHES('ThOmAs', 'thomas', 'i');
┌─────────────────────────────────────────┐
│ regexp_matches('ThOmAs', 'thomas', 'i') │
│                 boolean                 │
├─────────────────────────────────────────┤
│ true                                    │
└─────────────────────────────────────────┘

duckdb>  SELECT REGEXP_MATCHES('ThOmAs', 'thomas');
┌────────────────────────────────────┐
│ regexp_matches('ThOmAs', 'thomas') │
│              boolean               │
├────────────────────────────────────┤
│ false                              │
└────────────────────────────────────┘
```

Docs
-------
[Postgres](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-TABLE) | [DuckDB](https://duckdb.org/docs/sql/functions/regular_expressions.html#options-for-regular-expression-functions)