### PR TITLE
fix(optimizer)!: Do not remove parens on bracketed expressions

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -749,7 +749,7 @@ def simplify_parens(expression):
 
     if (
         not isinstance(this, exp.Select)
-        and not isinstance(parent, exp.SubqueryPredicate)
+        and not isinstance(parent, (exp.SubqueryPredicate, exp.Bracket))
         and (
             not isinstance(parent, (exp.Condition, exp.Binary))
             or isinstance(parent, exp.Paren)

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -363,6 +363,9 @@ x * (1 - y);
 ANY(t.value);
 ANY(t.value);
 
+SELECT (ARRAY_AGG(foo))[1];
+SELECT (ARRAY_AGG(foo))[1];
+
 --------------------------------------
 -- Literals
 --------------------------------------


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/3672

Afaict it's only Postgres that cannot parse inline bracketed expressions such as the following:


- Before this PR
```Python3
>>> simplify(parse_one("SELECT (ARRAY_AGG(name))[1]")).sql()
'SELECT ARRAY_AGG(name)[1]'
```
```SQL
postgres> WITH sample_data AS (SELECT 'foo' AS name) SELECT ARRAY_AGG(name)[1] FROM sample_data;
ERROR:  syntax error at or near "["
LINE 1: ...a AS (SELECT 'foo' AS name) SELECT ARRAY_AGG(name)[1] FROM s...
```

- After
```Python3
>>> simplify(parse_one("SELECT (ARRAY_AGG(name))[1]")).sql()
'SELECT (ARRAY_AGG(name))[1]'
```
```SQL
postgres> WITH sample_data AS (SELECT 'foo' AS name) SELECT (ARRAY_AGG(name))[1] FROM sample_data;
 array_agg
-----------
 foo
(1 row)
```

