### PR TITLE
Chore: fix sqlglotrs deployment job

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Upload sdist
       uses: actions/upload-artifact@v4
       with:
-        name: sdist
+        name: wheels-sdist
         path: sqlglotrs/dist
 
   deploy-rs:
@@ -103,7 +103,7 @@ jobs:
         MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
       with:
         command: upload
-        args: --non-interactive --skip-existing *
+        args: --non-interactive --skip-existing wheels-*
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Took another shot at this... The difference was copied from the template printed using the latest `maturin` version using` maturin generate-ci github`.