### PR TITLE
Fix(trino): Correctly handle exp.LocationProperty

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -57,11 +57,17 @@ class Trino(Presto):
             )
 
     class Generator(Presto.Generator):
+        PROPERTIES_LOCATION = {
+            **Presto.Generator.PROPERTIES_LOCATION,
+            exp.LocationProperty: exp.Properties.Location.POST_WITH,
+        }
+
         TRANSFORMS = {
             **Presto.Generator.TRANSFORMS,
             exp.ArraySum: lambda self,
             e: f"REDUCE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.ArrayUniqueAgg: lambda self, e: f"ARRAY_AGG(DISTINCT {self.sql(e, 'this')})",
+            exp.LocationProperty: lambda self, e: self.property_sql(e),
             exp.Merge: merge_without_target_sql,
             exp.TimeStrToTime: lambda self, e: timestrtotime_sql(self, e, include_precision=True),
             exp.Trim: trim_sql,

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -85,6 +85,10 @@ class TestTrino(Validator):
         self.validate_identity(
             "ALTER VIEW people SET AUTHORIZATION alice", check_command_warning=True
         )
+        self.validate_identity("CREATE SCHEMA foo WITH (LOCATION='s3://bucket/foo')")
+        self.validate_identity(
+            "CREATE TABLE foo.bar WITH (LOCATION='s3://bucket/foo/bar') AS SELECT 1"
+        )
 
     def test_analyze(self):
         self.validate_identity("ANALYZE tbl")


### PR DESCRIPTION
Prior to this change, `exp.LocationProperty` was parsed correctly but stripped entirely when generating SQL.

The reason for this is that the Trino dialect extends the Presto dialect and it was marked as `exp.Properties.Location.UNSUPPORTED` in the Presto dialect.

However, it is supported in Trino, in both [schemas](https://trino.io/docs/current/sql/create-schema.html#examples) and tables.

I've updated it to be `exp.Properties.Location.POST_WITH` and also treat it as a normal property instead of a naked property because it needs to be generated as `key=value` and not `key value`.

Before:
```
>>> parse_one("CREATE SCHEMA foo WITH (location = 's3://bucket')", dialect="trino").sql(dialect="trino")
Unsupported property locationproperty
'CREATE SCHEMA foo'
```

After:
```
>>> parse_one("CREATE SCHEMA foo WITH (location = 's3://bucket')", dialect="trino").sql(dialect="trino")
"CREATE SCHEMA foo WITH (LOCATION='s3://bucket')"
```

It's a similar story for `CREATE TABLE`. Before:
```
>>> parse_one("CREATE TABLE foo (id INT) WITH (location = 's3://bucket')", dialect="trino").sql(dialect="trino")
Unsupported property locationproperty
'CREATE TABLE foo (id INTEGER)'
```

After:
```
>>> parse_one("CREATE TABLE foo (id INT) WITH (location = 's3://bucket')", dialect="trino").sql(dialect="trino")
"CREATE TABLE foo (id INTEGER) WITH (LOCATION='s3://bucket')"
```

It's only worked by accident so far in SQLMesh because if `location` is specified as part of `physical_properties` on a model, it's created as an `exp.Property` instead of an `exp.LocationProperty` and there is no issue with `exp.Property`.