### PR TITLE
Fix(Trino): Prevent first_value and last_value from being converted

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -272,12 +272,17 @@ class Presto(Dialect):
             "ELEMENT_AT": lambda args: exp.Bracket(
                 this=seq_get(args, 0), expressions=[seq_get(args, 1)], offset=1, safe=True
             ),
+            "FIRST_VALUE": exp.FirstValue.from_arg_list,
             "FROM_HEX": exp.Unhex.from_arg_list,
             "FROM_UNIXTIME": _build_from_unixtime,
             "FROM_UTF8": lambda args: exp.Decode(
                 this=seq_get(args, 0), replace=seq_get(args, 1), charset=exp.Literal.string("utf-8")
             ),
+            "LAST_VALUE": exp.LastValue.from_arg_list,
+            "LAG": exp.Lag.from_arg_list,
+            "LEAD": exp.Lead.from_arg_list,
             "LEVENSHTEIN_DISTANCE": exp.Levenshtein.from_arg_list,
+            "NTH_VALUE": exp.NthValue.from_arg_list,
             "NOW": exp.CurrentTimestamp.from_arg_list,
             "REGEXP_EXTRACT": build_regexp_extract(exp.RegexpExtract),
             "REGEXP_EXTRACT_ALL": build_regexp_extract(exp.RegexpExtractAll),
@@ -392,7 +397,6 @@ class Presto(Dialect):
             exp.Encode: lambda self, e: encode_decode_sql(self, e, "TO_UTF8"),
             exp.FileFormatProperty: lambda self, e: f"FORMAT='{e.name.upper()}'",
             exp.First: _first_last_sql,
-            exp.FirstValue: _first_last_sql,
             exp.FromTimeZone: lambda self,
             e: f"WITH_TIMEZONE({self.sql(e, 'this')}, {self.sql(e, 'zone')}) AT TIME ZONE 'UTC'",
             exp.GenerateSeries: sequence_sql,
@@ -403,7 +407,6 @@ class Presto(Dialect):
             exp.Initcap: _initcap_sql,
             exp.JSONExtract: lambda self, e: self.jsonextract_sql(e),
             exp.Last: _first_last_sql,
-            exp.LastValue: _first_last_sql,
             exp.LastDay: lambda self, e: self.func("LAST_DAY_OF_MONTH", e.this),
             exp.Lateral: explode_to_unnest_sql,
             exp.Left: left_to_substring_sql,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -272,17 +272,12 @@ class Presto(Dialect):
             "ELEMENT_AT": lambda args: exp.Bracket(
                 this=seq_get(args, 0), expressions=[seq_get(args, 1)], offset=1, safe=True
             ),
-            "FIRST_VALUE": exp.FirstValue.from_arg_list,
             "FROM_HEX": exp.Unhex.from_arg_list,
             "FROM_UNIXTIME": _build_from_unixtime,
             "FROM_UTF8": lambda args: exp.Decode(
                 this=seq_get(args, 0), replace=seq_get(args, 1), charset=exp.Literal.string("utf-8")
             ),
-            "LAST_VALUE": exp.LastValue.from_arg_list,
-            "LAG": exp.Lag.from_arg_list,
-            "LEAD": exp.Lead.from_arg_list,
             "LEVENSHTEIN_DISTANCE": exp.Levenshtein.from_arg_list,
-            "NTH_VALUE": exp.NthValue.from_arg_list,
             "NOW": exp.CurrentTimestamp.from_arg_list,
             "REGEXP_EXTRACT": build_regexp_extract(exp.RegexpExtract),
             "REGEXP_EXTRACT_ALL": build_regexp_extract(exp.RegexpExtractAll),

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1083,6 +1083,9 @@ class TestPresto(Validator):
                 "snowflake": "CURRENT_USER()",
             },
         )
+        self.validate_identity(
+            "SELECT id, FIRST_VALUE(is_deleted) OVER (PARTITION BY id) AS first_is_deleted, NTH_VALUE(is_deleted, 2) OVER (PARTITION BY id) AS nth_is_deleted, LAST_VALUE(is_deleted) OVER (PARTITION BY id) AS last_is_deleted FROM my_table"
+        )
 
     def test_encode_decode(self):
         self.validate_identity("FROM_UTF8(x, y)")


### PR DESCRIPTION
Fixes #4660 