### PR TITLE
fix(clickhouse): Generate bracket notation for exp.VarMap

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -164,8 +164,8 @@ def _map_sql(self: ClickHouse.Generator, expression: exp.Map | exp.VarMap) -> st
     if not (expression.parent and expression.parent.arg_key == "settings"):
         return _lower_func(var_map_sql(self, expression))
 
-    keys = expression.args["keys"]
-    values = expression.args["values"]
+    keys = expression.args.get("keys")
+    values = expression.args.get("values")
 
     if not isinstance(keys, exp.Array) or not isinstance(values, exp.Array):
         self.unsupported("Cannot convert array columns into map.")

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -160,6 +160,26 @@ def _timestrtotime_sql(self: ClickHouse.Generator, expression: exp.TimeStrToTime
     return self.sql(exp.cast(ts, datatype, dialect=self.dialect))
 
 
+def _map_sql(self: ClickHouse.Generator, expression: exp.Map | exp.VarMap) -> str:
+    if not (expression.parent and expression.parent.arg_key == "settings"):
+        return _lower_func(var_map_sql(self, expression))
+
+    keys = expression.args["keys"]
+    values = expression.args["values"]
+
+    if not isinstance(keys, exp.Array) or not isinstance(values, exp.Array):
+        self.unsupported("Cannot convert array columns into map.")
+        return ""
+
+    args = []
+    for key, value in zip(keys.expressions, values.expressions):
+        args.append(f"{self.sql(key)}: {self.sql(value)}")
+
+    csv_args = ", ".join(args)
+
+    return f"{{{csv_args}}}"
+
+
 class ClickHouse(Dialect):
     NORMALIZE_FUNCTIONS: bool | str = False
     NULL_ORDERING = "nulls_are_last"
@@ -989,7 +1009,7 @@ class ClickHouse(Dialect):
             exp.JSONPathKey: json_path_key_only_name,
             exp.JSONPathRoot: lambda *_: "",
             exp.Length: length_or_char_length_sql,
-            exp.Map: lambda self, e: _lower_func(var_map_sql(self, e)),
+            exp.Map: _map_sql,
             exp.Median: rename_func("median"),
             exp.Nullif: rename_func("nullIf"),
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
@@ -1011,7 +1031,7 @@ class ClickHouse(Dialect):
             exp.TimeStrToTime: _timestrtotime_sql,
             exp.TimestampAdd: _datetime_delta_sql("TIMESTAMP_ADD"),
             exp.TimestampSub: _datetime_delta_sql("TIMESTAMP_SUB"),
-            exp.VarMap: lambda self, e: _lower_func(var_map_sql(self, e)),
+            exp.VarMap: _map_sql,
             exp.Xor: lambda self, e: self.func("xor", e.this, e.expression, *e.expressions),
             exp.MD5Digest: rename_func("MD5"),
             exp.MD5: lambda self, e: self.func("LOWER", self.func("HEX", self.func("MD5", e.this))),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1119,8 +1119,8 @@ def struct_extract_sql(self: Generator, expression: exp.StructExtract) -> str:
 def var_map_sql(
     self: Generator, expression: exp.Map | exp.VarMap, map_func_name: str = "MAP"
 ) -> str:
-    keys = expression.args["keys"]
-    values = expression.args["values"]
+    keys = expression.args.get("keys")
+    values = expression.args.get("values")
 
     if not isinstance(keys, exp.Array) or not isinstance(values, exp.Array):
         self.unsupported("Cannot convert array columns into map.")

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -551,6 +551,9 @@ class TestClickhouse(Validator):
 
         self.validate_identity("SELECT 1_2_3_4_5", "SELECT 12345")
         self.validate_identity("SELECT 1_b", "SELECT 1_b")
+        self.validate_identity(
+            "SELECT COUNT(1) FROM table SETTINGS additional_table_filters = {'a': 'b', 'c': 'd'}"
+        )
 
     def test_clickhouse_values(self):
         values = exp.select("*").from_(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4662

As shown in the issue, the function-based representation doesn't work under `SETTINGS`:

```SQL

:) WITH table AS (SELECT 1) SELECT COUNT(1) FROM table SETTINGS additional_table_filters = map('table', 'tenant_id = 123');

Syntax error: failed at position 120 (end of query):

Expected one of: token, OpeningRoundBracket, FILTER, RESPECT NULLS, IGNORE NULLS, OVER, literal or map, literal, NULL, NULL, number, Bool, TRUE, FALSE, string literal, OpeningCurlyBrace
```

But the bracket notation does:

```
:) WITH table AS (SELECT 1) SELECT COUNT(1) FROM table SETTINGS additional_table_filters = {'table': 'tenant_id = 123'};

   ┌─COUNT(1)─┐
1. │        1 │
   └──────────┘
```


<br/>
<br/>

This PR applies a bandaid solution for this issue in which `MAP(...)` is maintained _except_ the `SETTINGS` case, in which we revert back to the bracket notation.


Docs
-------
[Clickhouse MAP](https://clickhouse.com/docs/en/sql-reference/data-types/map)