### PR TITLE
fix(trino): Add more JSON_QUERY options

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -26,6 +26,8 @@ class Trino(Presto):
             **dict.fromkeys(
                 ("WITH", "WITHOUT"),
                 (
+                    ("WRAPPER"),
+                    ("ARRAY", "WRAPPER"),
                     ("CONDITIONAL", "WRAPPER"),
                     ("CONDITIONAL", "ARRAY", "WRAPPED"),
                     ("UNCONDITIONAL", "WRAPPER"),

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -7,6 +7,8 @@ class TestTrino(Validator):
     def test_trino(self):
         self.validate_identity("JSON_EXTRACT(content, json_path)")
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
+        self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH WRAPPER)")
+        self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH ARRAY WRAPPER)")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER)")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITHOUT CONDITIONAL WRAPPER)")
         self.validate_identity("JSON_QUERY(description, 'strict $.comment' KEEP QUOTES)")


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4672

The `CONDITIONAL` / `UNCONDITIONAL` keywords are optional, so this PR adds the missing `[ARRAY] WRAPPER` options for `WITH` / `WITHOUT`:

```
JSON_QUERY(
    json_input [ FORMAT JSON [ ENCODING { UTF8 | UTF16 | UTF32 } ] ],
    json_path
    [ PASSING json_argument [, ...] ]
    [ RETURNING type [ FORMAT JSON [ ENCODING { UTF8 | UTF16 | UTF32 } ] ] ]
    [ WITHOUT [ ARRAY ] WRAPPER |
      WITH [ { CONDITIONAL | UNCONDITIONAL } ] [ ARRAY ] WRAPPER ]
    [ { KEEP | OMIT } QUOTES [ ON SCALAR STRING ] ]
    [ { ERROR | NULL | EMPTY ARRAY | EMPTY OBJECT } ON EMPTY ]
    [ { ERROR | NULL | EMPTY ARRAY | EMPTY OBJECT } ON ERROR ]
    )
```

Docs
-------
[Trino JSON_QUERY](https://trino.io/docs/current/functions/json.html#json-query)