### PR TITLE
fix(duckdb): support postgres JSON/JSONB_OBJECT_AGG to duckdb JSON_GROUP_OBJECT

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -662,6 +662,8 @@ class DuckDB(Dialect):
             exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
                 rename_func("LEVENSHTEIN")
             ),
+            exp.JSONObjectAgg: rename_func("JSON_GROUP_OBJECT"),
+            exp.JSONBObjectAgg: rename_func("JSON_GROUP_OBJECT"),
         }
 
         SUPPORTED_JSON_PATH_PARTS = {

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -393,6 +393,10 @@ class Postgres(Dialect):
             "SHA384": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(384)),
             "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
             "LEVENSHTEIN_LESS_EQUAL": _build_levenshtein_less_equal,
+            "JSON_OBJECT_AGG": lambda args: exp.JSONObjectAgg(
+                expressions=[seq_get(args, 0), seq_get(args, 1)]
+            ),
+            "JSONB_OBJECT_AGG": exp.JSONBObjectAgg.from_arg_list,
         }
 
         NO_PAREN_FUNCTIONS = {
@@ -617,6 +621,8 @@ class Postgres(Dialect):
             exp.Unicode: rename_func("ASCII"),
             exp.UnixToTime: _unix_to_time_sql,
             exp.Levenshtein: _levenshtein_sql,
+            exp.JSONObjectAgg: rename_func("JSON_OBJECT_AGG"),
+            exp.JSONBObjectAgg: rename_func("JSONB_OBJECT_AGG"),
         }
 
         TRANSFORMS.pop(exp.CommentColumnConstraint)

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -393,9 +393,7 @@ class Postgres(Dialect):
             "SHA384": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(384)),
             "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
             "LEVENSHTEIN_LESS_EQUAL": _build_levenshtein_less_equal,
-            "JSON_OBJECT_AGG": lambda args: exp.JSONObjectAgg(
-                expressions=[seq_get(args, 0), seq_get(args, 1)]
-            ),
+            "JSON_OBJECT_AGG": lambda args: exp.JSONObjectAgg(expressions=args),
             "JSONB_OBJECT_AGG": exp.JSONBObjectAgg.from_arg_list,
         }
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6070,10 +6070,7 @@ class JSONObjectAgg(AggFunc):
 
 # https://www.postgresql.org/docs/9.5/functions-aggregate.html
 class JSONBObjectAgg(AggFunc):
-    arg_types = {
-        "key": True,
-        "value": True,
-    }
+    arg_types = {"this": True, "expression": True}
 
 
 # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_ARRAY.html

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6068,6 +6068,14 @@ class JSONObjectAgg(AggFunc):
     }
 
 
+# https://www.postgresql.org/docs/9.5/functions-aggregate.html
+class JSONBObjectAgg(AggFunc):
+    arg_types = {
+        "key": True,
+        "value": True,
+    }
+
+
 # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_ARRAY.html
 class JSONArray(Func):
     arg_types = {

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -910,26 +910,6 @@ class TestDuckDB(Validator):
             },
         )
 
-        self.validate_all(
-            "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
-            read={
-                "postgres": "SELECT JSON_OBJECT_AGG(k, v) FROM t",
-            },
-            write={
-                "duckdb": "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
-            },
-        )
-
-        self.validate_all(
-            "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
-            read={
-                "postgres": "SELECT JSONB_OBJECT_AGG(k, v) FROM t",
-            },
-            write={
-                "duckdb": "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
-            },
-        )
-
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -910,6 +910,26 @@ class TestDuckDB(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
+            read={
+                "postgres": "SELECT JSON_OBJECT_AGG(k, v) FROM t",
+            },
+            write={
+                "duckdb": "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
+            },
+        )
+
+        self.validate_all(
+            "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
+            read={
+                "postgres": "SELECT JSONB_OBJECT_AGG(k, v) FROM t",
+            },
+            write={
+                "duckdb": "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
+            },
+        )
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -838,8 +838,21 @@ class TestPostgres(Validator):
             "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY a) FILTER(WHERE CAST(b AS BOOLEAN)) AS mean_value FROM (VALUES (0, 't')) AS fake_data(a, b)"
         )
 
-        self.validate_identity("SELECT JSON_OBJECT_AGG(k, v) FROM t")
-        self.validate_identity("SELECT JSONB_OBJECT_AGG(k, v) FROM t")
+        self.validate_all(
+            "SELECT JSON_OBJECT_AGG(k, v) FROM t",
+            write={
+                "postgres": "SELECT JSON_OBJECT_AGG(k, v) FROM t",
+                "duckdb": "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
+            },
+        )
+
+        self.validate_all(
+            "SELECT JSONB_OBJECT_AGG(k, v) FROM t",
+            write={
+                "postgres": "SELECT JSONB_OBJECT_AGG(k, v) FROM t",
+                "duckdb": "SELECT JSON_GROUP_OBJECT(k, v) FROM t",
+            },
+        )
 
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -838,6 +838,9 @@ class TestPostgres(Validator):
             "SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY a) FILTER(WHERE CAST(b AS BOOLEAN)) AS mean_value FROM (VALUES (0, 't')) AS fake_data(a, b)"
         )
 
+        self.validate_identity("SELECT JSON_OBJECT_AGG(k, v) FROM t")
+        self.validate_identity("SELECT JSONB_OBJECT_AGG(k, v) FROM t")
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(


### PR DESCRIPTION
Fixes #4667

`duckdb` only supports the `JSON_GROUP_OBJECT` aggregate function (`JSONB` isn't supported), thus for both 
`JSON/JSONB_OBJECT_AGG` cases the mapping is the `JSON_GROUP_OBJECT` function.

Moreover, the roundtrip for the postgres `JSON/JSONB_OBJECT_AGG` is preserved.

**DOCS**
[DuckDB JSON_GROUP_OBJECT](https://duckdb.org/docs/data/json/json_functions#json-aggregate-functions) | [Postgres  JSON/JSONB_OBJECT_AGG ](https://www.postgresql.org/docs/9.5/functions-aggregate.html)