### PR TITLE
fix(postgres)!: Parse empty bracketed ARRAY with cast

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5118,7 +5118,12 @@ class Parser(metaclass=_Parser):
         while self._curr:
             datatype_token = self._prev.token_type
             matched_l_bracket = self._match(TokenType.L_BRACKET)
-            if not matched_l_bracket and not matched_array:
+
+            if (not matched_l_bracket and not matched_array) or (
+                datatype_token == TokenType.ARRAY and self._match(TokenType.R_BRACKET)
+            ):
+                # Postgres allows casting empty arrays such as ARRAY[]::INT[],
+                # not to be confused with the fixed size array parsing
                 break
 
             matched_array = False

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -146,10 +146,6 @@ class TestPostgres(Validator):
             "SELECT ARRAY[1, 2] @> ARRAY[1, 2, 3]",
         )
         self.validate_identity(
-            "SELECT ARRAY[]::INT[] AS foo",
-            "SELECT CAST(ARRAY[] AS INT[]) AS foo",
-        )
-        self.validate_identity(
             "SELECT DATE_PART('isodow'::varchar(6), current_date)",
             "SELECT EXTRACT(CAST('isodow' AS VARCHAR(6)) FROM CURRENT_DATE)",
         )
@@ -350,6 +346,13 @@ class TestPostgres(Validator):
             "CAST(x AS BIGINT)",
         )
 
+        self.validate_all(
+            "SELECT ARRAY[]::INT[] AS foo",
+            write={
+                "postgres": "SELECT CAST(ARRAY[] AS INT[]) AS foo",
+                "duckdb": "SELECT CAST([] AS INT[]) AS foo",
+            },
+        )
         self.validate_all(
             "STRING_TO_ARRAY('xx~^~yy~^~zz', '~^~', 'yy')",
             read={


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4674

- AST before:
```Python3
>>> ast = sqlglot.parse_one("SELECT ARRAY[]::INT[]", dialect="postgres")
>>> ast
Select(
  expressions=[
    Cast(
      this=DataType(
        this=Type.ARRAY,
        expressions=[
          DataType(this=Type.ARRAY, nested=True)],
        nested=True),
      to=DataType(
        this=Type.ARRAY,
        expressions=[
          DataType(this=Type.INT, nested=False)],
        nested=True))])
```
<br/>

- AST after
```Python3
>>> ast = sqlglot.parse_one("SELECT ARRAY[]::INT[]", dialect="postgres")
>>> ast
Select(
  expressions=[
    Cast(
      this=Array(
        ),
      to=DataType(
        this=Type.ARRAY,
        expressions=[
          DataType(this=Type.INT, nested=False)],
        nested=True))])
```

<br/>


Note how before, the `ARRAY[]` would be confused into nesting itself even though on Postgres it's a 1-D array:
```SQL
psql> SELECT ARRAY[1]::INT[];
 array
-------
 {1}
(1 row)
```