### PR TITLE
fix(tsql): Transpile standalone exp.Fetch LIMIT

### DIFF
--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -300,6 +300,14 @@ class TestOracle(Validator):
             "SELECT /*+ ORDERED */ * /* test */ FROM tbl",
         )
 
+        self.validate_all(
+            "SELECT * FROM t FETCH FIRST 10 ROWS ONLY",
+            write={
+                "oracle": "SELECT * FROM t FETCH FIRST 10 ROWS ONLY",
+                "tsql": "SELECT * FROM t ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
+            },
+        )
+
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4665

Dialects like Oracle can `FETCH` directly from a result set:

```SQL
oracle>  WITH t AS (SELECT 1 AS col UNION SELECT 2 AS col UNION SELECT 3 as col) 
SELECT * FROM t FETCH FIRST 2 ROWS ONLY;

col
1
2
```

<br/>

T-SQL has the concept of OFFSET-FETCH which are defined under an ORDER BY clause. Thus, a possible transpilation is the following:

```SQL
tsql> WITH t AS (SELECT 1 AS col UNION SELECT 2 AS col UNION SELECT 3 AS col) 
SELECT * FROM t AS ROWS ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 2 ROWS ONLY

col
1
2
```


Docs
--------
[T-SQL OFFSET-FETCH](https://www.sqlservertutorial.net/sql-server-basics/sql-server-offset-fetch/) | [Oracle FETCH](https://www.oracletutorial.com/oracle-basics/oracle-fetch/)