### PR TITLE
Feat(oracle): add support for CAST(... DEFAULT <value> ON CONVERSION FAILURE)

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5518,6 +5518,7 @@ class Cast(Func):
         "format": False,
         "safe": False,
         "action": False,
+        "default": False,
     }
 
     @property

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3182,7 +3182,9 @@ class Generator(metaclass=_Generator):
         to_sql = f" {to_sql}" if to_sql else ""
         action = self.sql(expression, "action")
         action = f" {action}" if action else ""
-        return f"{safe_prefix or ''}CAST({self.sql(expression, 'this')} AS{to_sql}{format_sql}{action})"
+        default = self.sql(expression, "default")
+        default = f" DEFAULT {default} ON CONVERSION ERROR" if default else ""
+        return f"{safe_prefix or ''}CAST({self.sql(expression, 'this')} AS{to_sql}{default}{format_sql}{action})"
 
     def currentdate_sql(self, expression: exp.CurrentDate) -> str:
         zone = self.sql(expression, "this")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6122,7 +6122,12 @@ class Parser(metaclass=_Parser):
         fmt = None
         to = self._parse_types()
 
-        if self._match(TokenType.FORMAT):
+        default = self._match(TokenType.DEFAULT)
+        if default:
+            default = self._parse_bitwise()
+            self._match_text_seq("ON", "CONVERSION", "ERROR")
+
+        if self._match_set((TokenType.FORMAT, TokenType.COMMA)):
             fmt_string = self._parse_string()
             fmt = self._parse_at_time_zone(fmt_string)
 
@@ -6160,6 +6165,7 @@ class Parser(metaclass=_Parser):
             format=fmt,
             safe=safe,
             action=self._parse_var_from_options(self.CAST_ACTIONS, raise_unmatched=False),
+            default=default,
         )
 
     def _parse_string_agg(self) -> exp.GroupConcat:
@@ -6263,7 +6269,7 @@ class Parser(metaclass=_Parser):
         namespaces = []
 
         while True:
-            if self._match_text_seq("DEFAULT"):
+            if self._match(TokenType.DEFAULT):
                 uri = self._parse_string()
             else:
                 uri = self._parse_alias(self._parse_string())

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -16,6 +16,7 @@ class TestOracle(Validator):
         )
         self.parse_one("ALTER TABLE tbl_name DROP FOREIGN KEY fk_symbol").assert_is(exp.Alter)
 
+        self.validate_identity("CAST(value AS NUMBER DEFAULT 0 ON CONVERSION ERROR)")
         self.validate_identity("SYSDATE")
         self.validate_identity("CREATE GLOBAL TEMPORARY TABLE t AS SELECT * FROM orders")
         self.validate_identity("CREATE PRIVATE TEMPORARY TABLE t AS SELECT * FROM orders")
@@ -78,6 +79,10 @@ class TestOracle(Validator):
         )
         self.validate_identity(
             "SELECT MIN(column_name) KEEP (DENSE_RANK FIRST ORDER BY column_name DESC) FROM table_name"
+        )
+        self.validate_identity(
+            "SELECT CAST('January 15, 1989, 11:00 A.M.' AS DATE DEFAULT NULL ON CONVERSION ERROR, 'Month dd, YYYY, HH:MI A.M.') FROM DUAL",
+            "SELECT TO_DATE('January 15, 1989, 11:00 A.M.', 'Month dd, YYYY, HH12:MI P.M.') FROM DUAL",
         )
         self.validate_identity(
             "SELECT TRUNC(SYSDATE)",


### PR DESCRIPTION
Fixes #4682

This only covers the `CAST` example, left the second one out for now, @jaredschwartz-ofs feel free to tackle it in a follow up if you need it.