### PR TITLE
Fix!: load dialects lazily

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -61,6 +61,8 @@ dialect implementations in order to understand how their various components can 
 ----
 """
 
+import importlib
+
 DIALECTS = [
     "Athena",
     "BigQuery",
@@ -106,8 +108,6 @@ __all__ = list(MODULE_BY_ATTRIBUTE)
 def __getattr__(name):
     module_name = MODULE_BY_ATTRIBUTE.get(name)
     if module_name:
-        import importlib
-
         module = importlib.import_module(f"sqlglot.dialects.{module_name}")
         return getattr(module, name)
 

--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -61,31 +61,54 @@ dialect implementations in order to understand how their various components can 
 ----
 """
 
-from sqlglot.dialects.athena import Athena
-from sqlglot.dialects.bigquery import BigQuery
-from sqlglot.dialects.clickhouse import ClickHouse
-from sqlglot.dialects.databricks import Databricks
-from sqlglot.dialects.dialect import Dialect, Dialects
-from sqlglot.dialects.doris import Doris
-from sqlglot.dialects.drill import Drill
-from sqlglot.dialects.druid import Druid
-from sqlglot.dialects.duckdb import DuckDB
-from sqlglot.dialects.dune import Dune
-from sqlglot.dialects.hive import Hive
-from sqlglot.dialects.materialize import Materialize
-from sqlglot.dialects.mysql import MySQL
-from sqlglot.dialects.oracle import Oracle
-from sqlglot.dialects.postgres import Postgres
-from sqlglot.dialects.presto import Presto
-from sqlglot.dialects.prql import PRQL
-from sqlglot.dialects.redshift import Redshift
-from sqlglot.dialects.risingwave import RisingWave
-from sqlglot.dialects.snowflake import Snowflake
-from sqlglot.dialects.spark import Spark
-from sqlglot.dialects.spark2 import Spark2
-from sqlglot.dialects.sqlite import SQLite
-from sqlglot.dialects.starrocks import StarRocks
-from sqlglot.dialects.tableau import Tableau
-from sqlglot.dialects.teradata import Teradata
-from sqlglot.dialects.trino import Trino
-from sqlglot.dialects.tsql import TSQL
+DIALECTS = [
+    "Athena",
+    "BigQuery",
+    "ClickHouse",
+    "Databricks",
+    "Doris",
+    "Drill",
+    "Druid",
+    "DuckDB",
+    "Dune",
+    "Hive",
+    "Materialize",
+    "MySQL",
+    "Oracle",
+    "Postgres",
+    "Presto",
+    "PRQL",
+    "Redshift",
+    "RisingWave",
+    "Snowflake",
+    "Spark",
+    "Spark2",
+    "SQLite",
+    "StarRocks",
+    "Tableau",
+    "Teradata",
+    "Trino",
+    "TSQL",
+]
+
+MODULE_BY_DIALECT = {name: name.lower() for name in DIALECTS}
+DIALECT_MODULE_NAMES = MODULE_BY_DIALECT.values()
+
+MODULE_BY_ATTRIBUTE = {
+    **MODULE_BY_DIALECT,
+    "Dialect": "dialect",
+    "Dialects": "dialect",
+}
+
+__all__ = list(MODULE_BY_ATTRIBUTE)
+
+
+def __getattr__(name):
+    module_name = MODULE_BY_ATTRIBUTE.get(name)
+    if module_name:
+        import importlib
+
+        module = importlib.import_module(f"sqlglot.dialects.{module_name}")
+        return getattr(module, name)
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import importlib
 import logging
 import typing as t
 from enum import Enum, auto
 from functools import reduce
 
 from sqlglot import exp
+from sqlglot.dialects import DIALECT_MODULE_NAMES
 from sqlglot.errors import ParseError
 from sqlglot.generator import Generator, unsupported_args
 from sqlglot.helper import AutoName, flatten, is_int, seq_get, subclasses, to_bool
@@ -119,8 +121,6 @@ class _Dialect(type):
 
     def __getattr__(cls, name):
         if name == "classes":
-            from sqlglot.dialects import DIALECT_MODULE_NAMES
-
             # We want `<DialectSubclass>.classes` to return *all* available dialects
             if len(DIALECT_MODULE_NAMES) != len(cls._classes):
                 for key in DIALECT_MODULE_NAMES:
@@ -133,9 +133,6 @@ class _Dialect(type):
     @classmethod
     def _try_load(cls, key: str | Dialects) -> None:
         try:
-            import importlib
-            from sqlglot.dialects import DIALECT_MODULE_NAMES
-
             if isinstance(key, Dialects):
                 key = key.value
 
@@ -827,7 +824,6 @@ class Dialect(metaclass=_Dialect):
             result = cls.get(dialect_name.strip())
             if not result:
                 from difflib import get_close_matches
-                from sqlglot.dialects import DIALECT_MODULE_NAMES
 
                 close_matches = get_close_matches(dialect_name, list(DIALECT_MODULE_NAMES), n=1)
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -119,16 +119,13 @@ class _Dialect(type):
     def __hash__(cls) -> int:
         return hash(cls.__name__.lower())
 
-    def __getattr__(cls, name):
-        if name == "classes":
-            # We want `<DialectSubclass>.classes` to return *all* available dialects
-            if len(DIALECT_MODULE_NAMES) != len(cls._classes):
-                for key in DIALECT_MODULE_NAMES:
-                    cls._try_load(key)
+    @property
+    def classes(cls):
+        if len(DIALECT_MODULE_NAMES) != len(cls._classes):
+            for key in DIALECT_MODULE_NAMES:
+                cls._try_load(key)
 
-            return cls._classes
-
-        return super().__getattr__(name)
+        return cls._classes
 
     @classmethod
     def _try_load(cls, key: str | Dialects) -> None:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -83,11 +83,20 @@ class TestDialect(Validator):
     maxDiff = None
 
     def test_enum(self):
+        dialect_by_key = Dialect.classes
         for dialect in Dialects:
             self.assertIsNotNone(Dialect[dialect])
             self.assertIsNotNone(Dialect.get(dialect))
             self.assertIsNotNone(Dialect.get_or_raise(dialect))
             self.assertIsNotNone(Dialect[dialect.value])
+            self.assertIn(dialect, dialect_by_key)
+
+    def test_lazy_load(self):
+        import subprocess
+
+        code = "import sqlglot; assert len(sqlglot.Dialect._classes) == 1; print('Success')"
+        result = subprocess.run(["python", "-c", code], capture_output=True, text=True)
+        assert "Success" in result.stdout
 
     def test_get_or_raise(self):
         self.assertIsInstance(Dialect.get_or_raise(Hive), Hive)


### PR DESCRIPTION
### Overview

When sqlglot is imported for the first time, all dialects are eagerly imported. The time needed for this is small, but not necessarily insignificant. This PR makes the dialect loading & registering lazy.

<details>
<summary> Benchmark results for <b>make check</b> & import time (BEFORE) </summary>

```
(.venv) ➜  sqlglot git:(main) make check
pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
SQLGLOTRS_TOKENIZER=0 python -m unittest
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 777 tests in 74.419s

OK
RUST_BACKTRACE=1 python -m unittest
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 777 tests in 80.686s

OK
```

```python
>>> import timeit
>>> import numpy as np
>>>
>>>
>>> def import_sqlglot():
...     import sqlglot
...
>>>
>>> print(np.mean(timeit.repeat(import_sqlglot, number=1)))
0.03040810823440552
```

</details>

<details>
<summary> Benchmark results for <b>make check</b> & import time (AFTER) </summary>

```
(.venv) ➜  sqlglot git:(main) ✗ make check
pre-commit run --all-files
ruff.....................................................................Passed
ruff-format..............................................................Passed
mypy.....................................................................Passed
SQLGLOTRS_TOKENIZER=0 python -m unittest
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 777 tests in 76.272s

OK
RUST_BACKTRACE=1 python -m unittest
.........................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 777 tests in 77.444s

OK
```

```python
>>> import timeit
>>> import numpy as np
>>>
>>>
>>> def import_sqlglot():
...     import sqlglot
...
>>>
>>> print(np.mean(timeit.repeat(import_sqlglot, number=1)))
0.008051850087940692
```

</details>

**TL;DR**: importing sqlglot for the first time seems to be ~4 times faster given this refactor.

### Notes

- Users could previously import a dialect class from `sqlglot.dialects`. This is still possible, only now it's done lazily. For this reason, I believe the changes in `sqlglot/dialects/__init__.py` are backwards-compatible.
- The changes in `_Dialect.get` and `_Dialect.__getitem__` should also be backwards-compatible, because if the given key does not exist in the registry, we simply try to load the class first before looking it up again.
- Until now, `Dialect.classes` would return a dict with **ALL** dialects. In order to preserve this behavior, I've renamed `classes` to `_classes` and overrode `_Dialect.__getattr__` in order to load all dialects on-demand, if needed. Basically, `_classes` now represents what's been loaded until now.
- For custom user dialects the situation is the same as before: they still need to import them in modules they're referenced, or, alternatively, at the top-level package so that they're registered as early as possible. Then, lookups should just work because they'll exist in `_classes`.