### PR TITLE
fix(hive): Simplify DATE_FORMAT roundtrip

### DIFF
--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -336,8 +336,8 @@ class TestHive(Validator):
                 "bigquery": "FORMAT_DATE('%Y-%m-%d %H:%M:%S', CAST('2020-01-01' AS DATETIME))",
                 "duckdb": "STRFTIME(CAST('2020-01-01' AS TIMESTAMP), '%Y-%m-%d %H:%M:%S')",
                 "presto": "DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP), '%Y-%m-%d %T')",
-                "hive": "DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss')",
-                "spark": "DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss')",
+                "hive": "DATE_FORMAT('2020-01-01', 'yyyy-MM-dd HH:mm:ss')",
+                "spark": "DATE_FORMAT('2020-01-01', 'yyyy-MM-dd HH:mm:ss')",
             },
         )
         self.validate_all(
@@ -758,7 +758,7 @@ class TestHive(Validator):
         self.validate_all(
             "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(b, 'yyyy'), GROUPING SETS ((a, DATE_FORMAT(b, 'yyyy')), a)",
             write={
-                "hive": "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(CAST(b AS TIMESTAMP), 'yyyy'), GROUPING SETS ((a, DATE_FORMAT(CAST(b AS TIMESTAMP), 'yyyy')), a)",
+                "hive": "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(b, 'yyyy'), GROUPING SETS ((a, DATE_FORMAT(b, 'yyyy')), a)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -342,7 +342,7 @@ TBLPROPERTIES (
             "SELECT DATE_FORMAT(DATE '2020-01-01', 'EEEE') AS weekday",
             write={
                 "presto": "SELECT DATE_FORMAT(CAST(CAST('2020-01-01' AS DATE) AS TIMESTAMP), '%W') AS weekday",
-                "spark": "SELECT DATE_FORMAT(CAST(CAST('2020-01-01' AS DATE) AS TIMESTAMP), 'EEEE') AS weekday",
+                "spark": "SELECT DATE_FORMAT(CAST('2020-01-01' AS DATE), 'EEEE') AS weekday",
             },
         )
         self.validate_all(


### PR DESCRIPTION
To facilitate Hive -> Presto [transpilation](https://github.com/tobymao/sqlglot/issues/831#issuecomment-1363629299) of `DATE_FORMAT`, https://github.com/tobymao/sqlglot/commit/0f9216647179aa28292984a9c25b53e9677cce1c casted the 1st arg into a `TIMESTAMP` by wrapping it in `exp.TimeStrToTime`. 

However, this is not required for Hive's roundtrip since it can process all date/time types, e.g:

- Spark 2:
```SQL
spark2> spark.sql("SELECT DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS cast, 
                          DATE_FORMAT('2020-01-01', 'yyyy-MM-dd HH:mm:ss') AS no_cast").show();

+-------------------+-------------------+
|               cast|            no_cast|
+-------------------+-------------------+
|2020-01-01 00:00:00|2020-01-01 00:00:00|
+-------------------+-------------------+
```

- Spark 3
```SQL
spark3> SELECT DATE_FORMAT(CAST('2020-01-01 00:00:00' AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS cast,  
               DATE_FORMAT('2020-01-01 00:00:00', 'yyyy-MM-dd HH:mm:ss') AS no_cast;
cast                    no_cast
2020-01-01 00:00:00     2020-01-01 00:00:00



spark3> SELECT DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP), 'EEEE') AS cast, 
               DATE_FORMAT('2020-01-01', 'EEEE') AS nocast;

cast            nocast
Wednesday       Wednesday
```

Docs
--------
[Spark3 DATE_FORMAT](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.date_format.html) | [Databricks DATE_FORMAT](https://docs.databricks.com/en/sql/language-manual/functions/date_format.html) | [Presto DATE_FORMAT](https://prestodb.io/docs/current/functions/datetime.html#date_format-timestamp-format-varchar)

 