### PR TITLE
fix(optimizer.merge_subqueries): consider original table names as take

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -227,7 +227,11 @@ def _rename_inner_sources(outer_scope: Scope, inner_scope: Scope, alias: str) ->
     """
     inner_taken = set(inner_scope.selected_sources)
 
-    outer_taken = set(outer_scope.selected_sources) | set(node.name for node, _ in outer_scope.selected_sources.values() if isinstance(node, exp.Table))
+    outer_taken = set(outer_scope.selected_sources) | set(
+        node.name
+        for node, _ in outer_scope.selected_sources.values()
+        if isinstance(node, exp.Table)
+    )
 
     conflicts = outer_taken.intersection(inner_taken)
     conflicts -= {alias}

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -226,7 +226,9 @@ def _rename_inner_sources(outer_scope: Scope, inner_scope: Scope, alias: str) ->
     Renames any sources in the inner query that conflict with names in the outer query.
     """
     inner_taken = set(inner_scope.selected_sources)
-    outer_taken = set(outer_scope.selected_sources)
+
+    outer_taken = set(outer_scope.selected_sources) | set(node.name for node, _ in outer_scope.selected_sources.values() if isinstance(node, exp.Table))
+
     conflicts = outer_taken.intersection(inner_taken)
     conflicts -= {alias}
 

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -95,7 +95,7 @@ SELECT x.a AS a, x.b AS b FROM x AS x;
 
 # title: CTE with conflicting table name
 # execute: false
-WITH CTE AS (SELECT a, b FROM x LEFT JOIN y as z on x.a <= z.b) SELECT a, b FROM CTE LEFT JOIN z as y;
+WITH cte_t AS (SELECT a, b FROM x LEFT JOIN y as z on x.a <= z.b) SELECT a, b FROM cte_t LEFT JOIN z as y;
 SELECT x.a AS a, b AS b FROM x AS x LEFT JOIN y AS z_2 ON x.a <= z_2.b LEFT JOIN z AS y;
 
 # title: Nested CTE

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -93,6 +93,11 @@ SELECT x.a AS a, x.b AS b FROM main.x AS x;
 WITH y AS (SELECT a, b FROM x) SELECT a, b FROM y AS z;
 SELECT x.a AS a, x.b AS b FROM x AS x;
 
+# title: CTE with conflicting table name
+# execute: false
+WITH CTE AS (SELECT a, b FROM x LEFT JOIN y as z on x.a <= z.b) SELECT a, b FROM CTE LEFT JOIN z as y;
+SELECT x.a AS a, b AS b FROM x AS x LEFT JOIN y AS z_2 ON x.a <= z_2.b LEFT JOIN z AS y;
+
 # title: Nested CTE
 WITH x2 AS (SELECT a FROM main.x), x3 AS (SELECT a FROM x2) SELECT a FROM x3;
 SELECT x.a AS a FROM main.x AS x;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -94,9 +94,8 @@ WITH y AS (SELECT a, b FROM x) SELECT a, b FROM y AS z;
 SELECT x.a AS a, x.b AS b FROM x AS x;
 
 # title: CTE with conflicting table name
-# execute: false
-WITH cte_t AS (SELECT a, b FROM x LEFT JOIN y as z on x.a <= z.b) SELECT a, b FROM cte_t LEFT JOIN z as y;
-SELECT x.a AS a, b AS b FROM x AS x LEFT JOIN y AS z_2 ON x.a <= z_2.b LEFT JOIN z AS y;
+WITH cte_t AS (SELECT a, x.b FROM x LEFT JOIN y as z on x.a <= z.b) SELECT cte_t.a, y.c FROM cte_t LEFT JOIN z as y on cte_t.a = y.c;
+SELECT x.a AS a, y.c AS c FROM x AS x LEFT JOIN y AS z_2 ON x.a <= z_2.b LEFT JOIN z AS y ON x.a = y.c;
 
 # title: Nested CTE
 WITH x2 AS (SELECT a FROM main.x), x3 AS (SELECT a FROM x2) SELECT a FROM x3;


### PR DESCRIPTION
In merge_subqueries, we do not consider the original table names in the outer_scope as taken, which may cause some issue in the below conner case

`WITH cte_t AS (SELECT a, x.b FROM x LEFT JOIN y as z on x.a <= z.b) SELECT cte_t.a, y.c FROM cte_t LEFT JOIN z as y on cte_t.a = y.c` where the optimizer does not think `z` is taken in the outer_scope. When we _merge_joins, we will add `JOIN y AS z` to the outer_scope, which actually changed the meaning of z.

Without the fix, the above query will have `SELECT x.a AS a, y.c AS c FROM x AS x LEFT JOIN y AS z ON x.a <= z.b LEFT JOIN z AS y ON x.a = y.c` as the output of merge_subqueries, which seems wrong.