### PR TITLE
fix(tsql): remove BEGIN from identifiers

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -545,6 +545,13 @@ class TSQL(Dialect):
             TokenType.OPTION: lambda self: ("options", self._parse_options()),
         }
 
+        # T-SQL does not allow BEGIN to be used as an identifier
+        ID_VAR_TOKENS = parser.Parser.ID_VAR_TOKENS - {TokenType.BEGIN}
+        ALIAS_TOKENS = parser.Parser.ALIAS_TOKENS - {TokenType.BEGIN}
+        TABLE_ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS - {TokenType.BEGIN}
+        COMMENT_TABLE_ALIAS_TOKENS = parser.Parser.COMMENT_TABLE_ALIAS_TOKENS - {TokenType.BEGIN}
+        UPDATE_ALIAS_TOKENS = parser.Parser.UPDATE_ALIAS_TOKENS - {TokenType.BEGIN}
+
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "CHARINDEX": lambda args: exp.StrPosition(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -558,8 +558,6 @@ class Parser(metaclass=_Parser):
     }
     ID_VAR_TOKENS.remove(TokenType.UNION)
 
-    INTERVAL_VARS = ID_VAR_TOKENS - {TokenType.END}
-
     TABLE_ALIAS_TOKENS = ID_VAR_TOKENS - {
         TokenType.ANTI,
         TokenType.APPLY,

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -453,6 +453,8 @@ class TestTSQL(Validator):
             },
         )
 
+        self.validate_identity("SELECT 'BEGIN'")
+
     def test_option(self):
         possible_options = [
             "HASH GROUP",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -453,7 +453,8 @@ class TestTSQL(Validator):
             },
         )
 
-        self.validate_identity("SELECT 'BEGIN'")
+        with self.assertRaises(ParseError):
+            parse_one("SELECT begin", read="tsql")
 
     def test_option(self):
         possible_options = [


### PR DESCRIPTION
`BEGIN` is a reserved keyword in TSQL, thus it can't be used as an identifier of any purpose.
This PR removes the usage of `BEGIN` for this occasion. 

Moreover, this PR removes the `INTERVAL_VARS` from the base `Parser` class because it isn't needed any more.  

**DOCS**
[T-SQL BEGIN](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/begin-end-transact-sql?view=sql-server-ver16#syntax)