### PR TITLE
fix(snowflake): support correct AUTO INCREMENT transpilation

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1005,6 +1005,10 @@ class Snowflake(Dialect):
             exp.DataType.Type.STRUCT: "OBJECT",
         }
 
+        TOKEN_MAPPING = {
+            TokenType.AUTO_INCREMENT: "AUTOINCREMENT",
+        }
+
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,
             exp.SetProperty: exp.Properties.Location.UNSUPPORTED,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -979,6 +979,8 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BIT_SHIFTLEFT(a, 1)", "SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTRIGHT(a, 1)", "SELECT BITSHIFTRIGHT(a, 1)")
 
+        self.validate_identity("CREATE TABLE t (id INT PRIMARY KEY AUTOINCREMENT)")
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
Fixes #4694 

This PR adds support for the AUTO INCREMENT transpilation for `Snowflake`. 
It's similar to the `SQLite`. 

**DOCS**
[Snowflake AUTOINCREMENT](transpilation)