### PR TITLE
Fix(redshift): generate proper syntax for column type alteration

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -158,6 +158,7 @@ class Redshift(Postgres):
         SUPPORTS_CONVERT_TIMEZONE = True
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
         SUPPORTS_MEDIAN = True
+        ALTER_SET_TYPE = "TYPE"
 
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -451,6 +451,9 @@ class Generator(metaclass=_Generator):
     # The function name of the exp.ArraySize expression
     ARRAY_SIZE_NAME: str = "ARRAY_LENGTH"
 
+    # The syntax to use when altering the type of a column
+    ALTER_SET_TYPE = "SET DATA TYPE"
+
     # Whether exp.ArraySize should generate the dimension arg too (valid for Postgres & DuckDB)
     # None -> Doesn't support it at all
     # False (DuckDB) -> Has backwards-compatible support, but preferably generated without
@@ -3252,7 +3255,7 @@ class Generator(metaclass=_Generator):
             collate = f" COLLATE {collate}" if collate else ""
             using = self.sql(expression, "using")
             using = f" USING {using}" if using else ""
-            return f"ALTER COLUMN {this} SET DATA TYPE {dtype}{collate}{using}"
+            return f"ALTER COLUMN {this} {self.ALTER_SET_TYPE} {dtype}{collate}{using}"
 
         default = self.sql(expression, "default")
         if default:

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -320,6 +320,7 @@ class TestRedshift(Validator):
         )
 
     def test_identity(self):
+        self.validate_identity("ALTER TABLE table_name ALTER COLUMN bla TYPE VARCHAR")
         self.validate_identity("SELECT CAST(value AS FLOAT(8))")
         self.validate_identity("1 div", "1 AS div")
         self.validate_identity("LISTAGG(DISTINCT foo, ', ')")


### PR DESCRIPTION
Reference: https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html