### PR TITLE
Fix(duckdb): enable support for user-defined types

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -272,7 +272,7 @@ def _json_extract_value_array_sql(
 
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
-    SUPPORTS_USER_DEFINED_TYPES = False
+    SUPPORTS_USER_DEFINED_TYPES = True
     SAFE_DIVISION = True
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -256,6 +256,7 @@ class TestDuckDB(Validator):
             parse_one("a // b", read="duckdb").assert_is(exp.IntDiv).sql(dialect="duckdb"), "a // b"
         )
 
+        self.validate_identity("CAST(x AS FOO)")
         self.validate_identity("SELECT UNNEST([1, 2])").selects[0].assert_is(exp.UDTF)
         self.validate_identity("'red' IN flags").args["field"].assert_is(exp.Column)
         self.validate_identity("'red' IN tbl.flags")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -610,7 +610,7 @@ FROM tbl1""",
         self.validate("CAST(x AS INT)::BOOLEAN", "CAST(CAST(x AS INT) AS BOOLEAN)")
 
         with self.assertRaises(ParseError):
-            transpile("x::z", read="duckdb")
+            transpile("x::z", read="clickhouse")
 
     def test_not_range(self):
         self.validate("a NOT LIKE b", "NOT a LIKE b")


### PR DESCRIPTION
DuckDB [supports user-defined types](https://duckdb.org/docs/sql/statements/create_type.html):

```
D create type foo as integer;
D select x::foo from (select 1 x) t;
┌────────────────┐
│ CAST(x AS foo) │
│     int32      │
├────────────────┤
│              1 │
└────────────────┘
```

This was probably added after we added support for them in SQLGlot.