### PR TITLE
fix(tsql): support default values on definitons and the OUTPUT/OUT/READ_ONLY syntax

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -736,8 +736,10 @@ class TSQL(Dialect):
             convert.set("strict", strict)
             return convert
 
-        def _parse_column_def(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
-            this = super()._parse_column_def(this)
+        def _parse_column_def(
+            self, this: t.Optional[exp.Expression], as_use_declare: bool = False
+        ) -> t.Optional[exp.Expression]:
+            this = super()._parse_column_def(this=this, as_use_declare=as_use_declare)
             if not this:
                 return None
             if self._match(TokenType.EQ):

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -598,7 +598,7 @@ class TSQL(Dialect):
             ("ENCRYPTION", "RECOMPILE", "SCHEMABINDING", "NATIVE_COMPILATION", "EXECUTE"), tuple()
         )
 
-        COLUMN_DEFINTION_OUTPUTS = {"OUT", "OUTPUT", "READ_ONLY"}
+        COLUMN_DEFINITION_MODES = {"OUT", "OUTPUT", "READ_ONLY"}
 
         RETURNS_TABLE_TOKENS = parser.Parser.ID_VAR_TOKENS - {
             TokenType.TABLE,
@@ -746,7 +746,7 @@ class TSQL(Dialect):
                 return None
             if self._match(TokenType.EQ):
                 this.set("default", self._parse_disjunction())
-            if self._match_texts(self.COLUMN_DEFINTION_OUTPUTS):
+            if self._match_texts(self.COLUMN_DEFINITION_MODES):
                 this.set("output", self._prev.text)
             return this
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -598,6 +598,8 @@ class TSQL(Dialect):
             ("ENCRYPTION", "RECOMPILE", "SCHEMABINDING", "NATIVE_COMPILATION", "EXECUTE"), tuple()
         )
 
+        COLUMN_DEFINTION_OUTPUTS = {"OUT", "OUTPUT", "READ_ONLY"}
+
         RETURNS_TABLE_TOKENS = parser.Parser.ID_VAR_TOKENS - {
             TokenType.TABLE,
             *parser.Parser.TYPE_TOKENS,
@@ -743,8 +745,8 @@ class TSQL(Dialect):
             if not this:
                 return None
             if self._match(TokenType.EQ):
-                this.set("default", self._parse_expression())
-            if self._match_texts(("OUT", "OUTPUT", "READ_ONLY")):
+                this.set("default", self._parse_disjunction())
+            if self._match_texts(self.COLUMN_DEFINTION_OUTPUTS):
                 this.set("output", self._prev.text)
             return this
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -739,9 +739,9 @@ class TSQL(Dialect):
             return convert
 
         def _parse_column_def(
-            self, this: t.Optional[exp.Expression], as_use_declare: bool = False
+            self, this: t.Optional[exp.Expression], computed_column: bool = True
         ) -> t.Optional[exp.Expression]:
-            this = super()._parse_column_def(this=this, as_use_declare=as_use_declare)
+            this = super()._parse_column_def(this=this, computed_column=computed_column)
             if not this:
                 return None
             if self._match(TokenType.EQ):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1675,6 +1675,8 @@ class ColumnDef(Expression):
         "constraints": False,
         "exists": False,
         "position": False,
+        "default": False,
+        "output": False,
     }
 
     @property

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5551,7 +5551,7 @@ class Parser(metaclass=_Parser):
         return self._parse_statement()
 
     def _parse_function_parameter(self) -> t.Optional[exp.Expression]:
-        return self._parse_column_def(self._parse_id_var())
+        return self._parse_column_def(this=self._parse_id_var(), as_use_declare=True)
 
     def _parse_user_defined_function(
         self, kind: t.Optional[TokenType] = None
@@ -5638,10 +5638,15 @@ class Parser(metaclass=_Parser):
     def _parse_field_def(self) -> t.Optional[exp.Expression]:
         return self._parse_column_def(self._parse_field(any_token=True))
 
-    def _parse_column_def(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+    def _parse_column_def(
+        self, this: t.Optional[exp.Expression], as_use_declare: bool = False
+    ) -> t.Optional[exp.Expression]:
         # column defs are not really columns, they're identifiers
         if isinstance(this, exp.Column):
             this = this.this
+
+        if as_use_declare and self._match(TokenType.ALIAS):
+            return self.expression(exp.ColumnDef, this=this, kind=self._parse_types(schema=True))
 
         kind = self._parse_types(schema=True)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5551,7 +5551,7 @@ class Parser(metaclass=_Parser):
         return self._parse_statement()
 
     def _parse_function_parameter(self) -> t.Optional[exp.Expression]:
-        return self._parse_column_def(this=self._parse_id_var(), as_use_declare=True)
+        return self._parse_column_def(this=self._parse_id_var(), computed_column=False)
 
     def _parse_user_defined_function(
         self, kind: t.Optional[TokenType] = None
@@ -5639,14 +5639,14 @@ class Parser(metaclass=_Parser):
         return self._parse_column_def(self._parse_field(any_token=True))
 
     def _parse_column_def(
-        self, this: t.Optional[exp.Expression], as_use_declare: bool = False
+        self, this: t.Optional[exp.Expression], computed_column: bool = True
     ) -> t.Optional[exp.Expression]:
         # column defs are not really columns, they're identifiers
         if isinstance(this, exp.Column):
             this = this.this
 
-        if as_use_declare and self._match(TokenType.ALIAS):
-            return self.expression(exp.ColumnDef, this=this, kind=self._parse_types(schema=True))
+        if not computed_column:
+            self._match(TokenType.ALIAS)
 
         kind = self._parse_types(schema=True)
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -456,6 +456,14 @@ class TestTSQL(Validator):
         with self.assertRaises(ParseError):
             parse_one("SELECT begin", read="tsql")
 
+        self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
+        self.validate_identity("DECLARE @v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')")
+
+        for output in ("OUT", "OUTPUT", "READ_ONLY"):
+            self.validate_identity(
+                f"CREATE PROCEDURE test(@v1 INTEGER {output}, @v2 CHAR(1) {output})"
+            )
+
     def test_option(self):
         possible_options = [
             "HASH GROUP",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -464,11 +464,9 @@ class TestTSQL(Validator):
                 f"CREATE PROCEDURE test(@v1 INTEGER = 1 {output}, @v2 CHAR(1) {output})"
             )
 
-        self.validate_all(
+        self.validate_identity(
+            "CREATE PROCEDURE test(@v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')",
             "CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')",
-            read={
-                "tsql": "CREATE PROCEDURE test(@v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')",
-            },
         )
 
     def test_option(self):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -457,12 +457,20 @@ class TestTSQL(Validator):
             parse_one("SELECT begin", read="tsql")
 
         self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
+        self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
         self.validate_identity("DECLARE @v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')")
 
         for output in ("OUT", "OUTPUT", "READ_ONLY"):
             self.validate_identity(
                 f"CREATE PROCEDURE test(@v1 INTEGER {output}, @v2 CHAR(1) {output})"
             )
+
+        self.validate_all(
+            "CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')",
+            read={
+                "tsql": "CREATE PROCEDURE test(@v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')",
+            },
+        )
 
     def test_option(self):
         possible_options = [

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -457,7 +457,6 @@ class TestTSQL(Validator):
             parse_one("SELECT begin", read="tsql")
 
         self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
-        self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
         self.validate_identity("DECLARE @v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')")
 
         for output in ("OUT", "OUTPUT", "READ_ONLY"):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -462,7 +462,7 @@ class TestTSQL(Validator):
 
         for output in ("OUT", "OUTPUT", "READ_ONLY"):
             self.validate_identity(
-                f"CREATE PROCEDURE test(@v1 INTEGER {output}, @v2 CHAR(1) {output})"
+                f"CREATE PROCEDURE test(@v1 INTEGER = 1 {output}, @v2 CHAR(1) {output})"
             )
 
         self.validate_all(


### PR DESCRIPTION
This PR adds support:

1. For default initialization of both input parameters and declared variables (e.g. `CREATE PROCEDURE test(@input INT = 1`, `DECLARE @var AS INTEGER = 1`) 
2. The `OUTPUT/OUT/READONLY`  keywords, which primarily serve to return scalar values or enforce immutability (e.g. `CREATE PROCEDURE test(@out_var INT OUTPUT)`)

**DOCS**
[T-SQL Stored Procedures Paramaters](https://learn.microsoft.com/en-us/sql/relational-databases/stored-procedures/specify-parameters?view=sql-server-ver16)