### PR TITLE
Fix: avoid concealing dialect module exception in _try_load

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -129,16 +129,15 @@ class _Dialect(type):
 
     @classmethod
     def _try_load(cls, key: str | Dialects) -> None:
-        try:
-            if isinstance(key, Dialects):
-                key = key.value
+        if isinstance(key, Dialects):
+            key = key.value
 
-            # This import will lead to a new dialect being loaded, and hence, registered.
-            # We assert that the key is an actual module to avoid blindly importing files.
-            assert key in DIALECT_MODULE_NAMES
+        # This import will lead to a new dialect being loaded, and hence, registered.
+        # We check that the key is an actual sqlglot module to avoid blindly importing
+        # files. Custom user dialects need to be imported at the top-level package, in
+        # order for them to be registered as soon as possible.
+        if key in DIALECT_MODULE_NAMES:
             importlib.import_module(f"sqlglot.dialects.{key}")
-        except Exception:
-            pass
 
     @classmethod
     def __getitem__(cls, key: str) -> t.Type[Dialect]:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -637,7 +637,7 @@ class Expression(metaclass=_Expression):
 
             if not root:
                 root = new_node
-            elif new_node is not node:
+            elif parent and arg_key and new_node is not node:
                 parent.set(arg_key, new_node, index)
 
         assert root

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3176,9 +3176,11 @@ class Parser(metaclass=_Parser):
         last_comments = None
         expressions = []
         while True:
-            expressions.append(self._parse_cte())
-            if last_comments:
-                expressions[-1].add_comments(last_comments)
+            cte = self._parse_cte()
+            if isinstance(cte, exp.CTE):
+                expressions.append(cte)
+                if last_comments:
+                    cte.add_comments(last_comments)
 
             if not self._match(TokenType.COMMA) and not self._match(TokenType.WITH):
                 break


### PR DESCRIPTION
Vaggelis mentioned that as he was iterating locally, he saw an error like `dialect 'postgres' not found. Did you mean 'postgres'?`. This can happen when making changes to dialects themselves that result in an exception at module load time, because the exception is nullified => we fail to register the dialect => sqlglot crashes at runtime.

I refactored the try-except block in order to avoid hiding exceptions. This is consistent with what we do in `dialects/__init__.py` ([source](https://github.com/tobymao/sqlglot/blob/5f9030786f8489e70aee70acabee440ecf23699c/sqlglot/dialects/__init__.py#L111-L112)).