### PR TITLE
feat(postgres): Support generation of exp.CountIf

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -738,3 +738,8 @@ class Postgres(Dialect):
         @unsupported_args("this")
         def currentschema_sql(self, expression: exp.CurrentSchema) -> str:
             return "CURRENT_SCHEMA"
+
+        def countif_sql(self, expression: exp.CountIf) -> str:
+            cond = expression.this
+            filter = exp.Filter(this=exp.Count(this=exp.Star()), expression=exp.Where(this=cond))
+            return self.sql(filter)

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -33,6 +33,7 @@ from sqlglot.dialects.dialect import (
     trim_sql,
     ts_or_ds_add_cast,
     strposition_sql,
+    count_if_to_sum,
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import is_int, seq_get
@@ -621,6 +622,7 @@ class Postgres(Dialect):
             exp.Levenshtein: _levenshtein_sql,
             exp.JSONObjectAgg: rename_func("JSON_OBJECT_AGG"),
             exp.JSONBObjectAgg: rename_func("JSONB_OBJECT_AGG"),
+            exp.CountIf: count_if_to_sum,
         }
 
         TRANSFORMS.pop(exp.CommentColumnConstraint)
@@ -738,8 +740,3 @@ class Postgres(Dialect):
         @unsupported_args("this")
         def currentschema_sql(self, expression: exp.CurrentSchema) -> str:
             return "CURRENT_SCHEMA"
-
-        def countif_sql(self, expression: exp.CountIf) -> str:
-            cond = expression.this
-            filter = exp.Filter(this=exp.Count(this=exp.Star()), expression=exp.Where(this=cond))
-            return self.sql(filter)

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2633,6 +2633,7 @@ SELECT
                 "snowflake": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
                 "sqlite": "SELECT SUM(IIF(col % 2 = 0, 1, 0)) FROM foo",
                 "tsql": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
+                "postgres": "SELECT COUNT(*) FILTER(WHERE col % 2 = 0) FROM foo",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2633,7 +2633,8 @@ SELECT
                 "snowflake": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
                 "sqlite": "SELECT SUM(IIF(col % 2 = 0, 1, 0)) FROM foo",
                 "tsql": "SELECT COUNT_IF(col % 2 = 0) FROM foo",
-                "postgres": "SELECT COUNT(*) FILTER(WHERE col % 2 = 0) FROM foo",
+                "postgres": "SELECT SUM(CASE WHEN col % 2 = 0 THEN 1 ELSE 0 END) FROM foo",
+                "redshift": "SELECT SUM(CASE WHEN col % 2 = 0 THEN 1 ELSE 0 END) FROM foo",
             },
         )
         self.validate_all(


### PR DESCRIPTION
This PR transpiles the `COUNT_IF` function found in BQ, Snowflake etc into Postgres:

- Used as aggregate
```SQL
bigquery> SELECT COUNTIF(x<0) AS num_negative, COUNTIF(x>0) AS num_positive
FROM UNNEST([5, -2, 3, 6, -10, -7, 4, 0]) AS x;

num_negative	num_positive
3	        4

postgres> SELECT SUM(CASE WHEN x < 0 THEN 1 ELSE 0 END) AS num_negative, SUM(CASE WHEN x > 0 THEN 1 ELSE 0 END) AS num_positive 
FROM UNNEST(ARRAY[5, -2, 3, 6, -10, -7, 4, 0]) AS _t0(x);

 num_negative | num_positive
--------------+--------------
            3 |            4
```

<br />

- Used as window
```SQL
bigquery> SELECT
   x,
   COUNTIF(x<0) OVER (ORDER BY ABS(x) ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS num_negative FROM UNNEST([5, -2, 3, 6, -10, NULL, -7, 4, 0]) AS x;

x	num_negative
	0
0	1
-2	1
3	1
4	0
5	0
6	1
-7	2
-10	2

postgres> SELECT 
 x, 
 SUM(CASE WHEN x < 0 THEN 1 ELSE 0 END) OVER (ORDER BY ABS(x) NULLS FIRST ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS num_negative 
 FROM UNNEST(ARRAY[5, -2, 3, 6, -10, NULL, -7, 4, 0]) AS _t0(x);
  x  | num_negative
-----+--------------
     |            0
   0 |            1
  -2 |            1
   3 |            1
   4 |            0
   5 |            0
   6 |            1
  -7 |            2
 -10 |            2
```

Docs
------
[Postgres Aggregate Functions](https://www.postgresql.org/docs/current/sql-expressions.html#SYNTAX-AGGREGATES) | [Postgres COUNT FILTER](https://stackoverflow.com/a/29022738) | [BQ COUNTIF](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#countif)