### PR TITLE
fix(duckdb)!: Remove extra MAP bracket and ARRAY wrap

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -112,6 +112,8 @@ class Version(int):
             parts.extend(["0"] * (3 - len(parts)))
             v = int("".join([p.zfill(3) for p in parts]))
         else:
+            # No version defined means we should support the latest engine semantics, so
+            # the comparison to any specific version should yield that latest is greater
             v = sys.maxsize
 
         return super(Version, cls).__new__(cls, v)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib
 import logging
 import typing as t
+import sys
+
 from enum import Enum, auto
 from functools import reduce
 
@@ -101,6 +103,18 @@ class NormalizationStrategy(str, AutoName):
 
     CASE_INSENSITIVE = auto()
     """Always case-insensitive, regardless of quotes."""
+
+
+class Version(int):
+    def __new__(cls, version_str: t.Optional[str], *args, **kwargs):
+        if version_str:
+            parts = version_str.split(".")
+            parts.extend(["0"] * (3 - len(parts)))
+            v = int("".join([p.zfill(3) for p in parts]))
+        else:
+            v = sys.maxsize
+
+        return super(Version, cls).__new__(cls, v)
 
 
 class _Dialect(type):
@@ -1001,6 +1015,10 @@ class Dialect(metaclass=_Dialect):
 
     def generator(self, **opts) -> Generator:
         return self.generator_class(dialect=self, **opts)
+
+    @property
+    def version(self) -> Version:
+        return Version(self.settings.get("version", None))
 
 
 DialectType = t.Union[str, Dialect, t.Type[Dialect], None]

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -466,15 +466,6 @@ class DuckDB(Dialect):
 
             return sample
 
-        def _parse_bracket(
-            self, this: t.Optional[exp.Expression] = None
-        ) -> t.Optional[exp.Expression]:
-            bracket = super()._parse_bracket(this)
-            if isinstance(bracket, exp.Bracket):
-                bracket.set("returns_list_for_maps", True)
-
-            return bracket
-
         def _parse_map(self) -> exp.ToMap | exp.Map:
             if self._match(TokenType.L_BRACE, advance=False):
                 return self.expression(exp.ToMap, this=self._parse_bracket())
@@ -893,24 +884,6 @@ class DuckDB(Dialect):
                 return rename_func("RANGE")(self, expression)
 
             return self.function_fallback_sql(expression)
-
-        def bracket_sql(self, expression: exp.Bracket) -> str:
-            this = expression.this
-            if isinstance(this, exp.Array):
-                this.replace(exp.paren(this))
-
-            bracket = super().bracket_sql(expression)
-
-            if not expression.args.get("returns_list_for_maps"):
-                if not this.type:
-                    from sqlglot.optimizer.annotate_types import annotate_types
-
-                    this = annotate_types(this)
-
-                if this.is_type(exp.DataType.Type.MAP):
-                    bracket = f"({bracket})[1]"
-
-            return bracket
 
         def withingroup_sql(self, expression: exp.WithinGroup) -> str:
             expression_sql = self.sql(expression, "expression")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5087,6 +5087,7 @@ class Bracket(Condition):
         "expressions": True,
         "offset": False,
         "safe": False,
+        "returns_list_for_maps": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5087,7 +5087,6 @@ class Bracket(Condition):
         "expressions": True,
         "offset": False,
         "safe": False,
-        "returns_list_for_maps": False,
     }
 
     @property

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -168,6 +168,18 @@ class TestDialect(Validator):
         self.assertFalse(snowflake_class in {"bigquery", "redshift"})
         self.assertFalse(snowflake_object in {"bigquery", "redshift"})
 
+    def test_compare_dialect_versions(self):
+        ddb_v1 = Dialect.get_or_raise("duckdb, version=1.0")
+        ddb_v1_2 = Dialect.get_or_raise("duckdb, foo=bar, version=1.0")
+        ddb_v2 = Dialect.get_or_raise("duckdb, version=2.2.4")
+        ddb_latest = Dialect.get_or_raise("duckdb")
+
+        self.assertTrue(ddb_latest.version > ddb_v2.version)
+        self.assertTrue(ddb_v1.version < ddb_v2.version)
+
+        self.assertTrue(ddb_v1.version == ddb_v1_2.version)
+        self.assertTrue(ddb_latest.version == Dialect.get_or_raise("duckdb").version)
+
     def test_cast(self):
         self.validate_all(
             "CAST(a AS TEXT)",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -929,15 +929,15 @@ class TestDuckDB(Validator):
             )
             self.validate_identity(
                 """SELECT LIST_VALUE(1)[i]""",
-                """SELECT ([1])[i]""",
+                """SELECT [1][i]""",
             )
             self.validate_identity(
                 """{'x': LIST_VALUE(1)[i]}""",
-                """{'x': ([1])[i]}""",
+                """{'x': [1][i]}""",
             )
             self.validate_identity(
                 """SELECT LIST_APPLY(RANGE(1, 4), i -> {'f1': LIST_VALUE(1, 2, 3)[i], 'f2': LIST_VALUE(1, 2, 3)[i]})""",
-                """SELECT LIST_APPLY(RANGE(1, 4), i -> {'f1': ([1, 2, 3])[i], 'f2': ([1, 2, 3])[i]})""",
+                """SELECT LIST_APPLY(RANGE(1, 4), i -> {'f1': [1, 2, 3][i], 'f2': [1, 2, 3][i]})""",
             )
 
             self.assertEqual(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -313,6 +313,7 @@ TBLPROPERTIES (
                 "databricks": "SELECT TRY_ELEMENT_AT(ARRAY(1, 2, 3), 2)",
                 "spark": "SELECT TRY_ELEMENT_AT(ARRAY(1, 2, 3), 2)",
                 "duckdb": "SELECT [1, 2, 3][2]",
+                "duckdb, version=1.1.0": "SELECT ([1, 2, 3])[2]",
                 "presto": "SELECT ELEMENT_AT(ARRAY[1, 2, 3], 2)",
             },
         )
@@ -353,6 +354,7 @@ TBLPROPERTIES (
             write={
                 "databricks": "SELECT TRY_ELEMENT_AT(MAP(1, 'a', 2, 'b'), 2)",
                 "duckdb": "SELECT MAP([1, 2], ['a', 'b'])[2]",
+                "duckdb, version=1.1.0": "SELECT (MAP([1, 2], ['a', 'b'])[2])[1]",
                 "spark": "SELECT TRY_ELEMENT_AT(MAP(1, 'a', 2, 'b'), 2)",
             },
         )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -312,7 +312,7 @@ TBLPROPERTIES (
             write={
                 "databricks": "SELECT TRY_ELEMENT_AT(ARRAY(1, 2, 3), 2)",
                 "spark": "SELECT TRY_ELEMENT_AT(ARRAY(1, 2, 3), 2)",
-                "duckdb": "SELECT ([1, 2, 3])[2]",
+                "duckdb": "SELECT [1, 2, 3][2]",
                 "presto": "SELECT ELEMENT_AT(ARRAY[1, 2, 3], 2)",
             },
         )
@@ -352,7 +352,7 @@ TBLPROPERTIES (
             },
             write={
                 "databricks": "SELECT TRY_ELEMENT_AT(MAP(1, 'a', 2, 'b'), 2)",
-                "duckdb": "SELECT (MAP([1, 2], ['a', 'b'])[2])[1]",
+                "duckdb": "SELECT MAP([1, 2], ['a', 'b'])[2]",
                 "spark": "SELECT TRY_ELEMENT_AT(MAP(1, 'a', 2, 'b'), 2)",
             },
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -457,7 +457,7 @@ class TestTSQL(Validator):
             parse_one("SELECT begin", read="tsql")
 
         self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
-        self.validate_identity("DECLARE @v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c')")
+        self.validate_identity("DECLARE @v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c'")
 
         for output in ("OUT", "OUTPUT", "READ_ONLY"):
             self.validate_identity(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4710

This PR solves two legacy issues:

1. `MAP`s do not return `LIST`s anymore but values (1.2 change):
```SQL
spark3> SELECT MAP('key', 'value')['key'] AS col;
col
value

# Transpilation before this PR
duckdb> SELECT (MAP(['key'], ['value'])['key'])[1] AS col;
┌─────────┐
│   col   │
│ varchar │
├─────────┤
│ v       │
└─────────┘

# Transpilation after this PR
duckdb> SELECT MAP(['key'], ['value'])['key'] AS col;
┌─────────┐
│   col   │
│ varchar │
├─────────┤
│ value   │
└─────────┘
```

<br />

2. Inline indexed `LIST`s do not need to be wrapped anymore (this was fixed earlier in the year iirc):
```SQL
spark-sql (default)> SELECT TRY_ELEMENT_AT(ARRAY(1, 2, 3), 2) AS col;
col
2

# Transpilation before this PR
duckdb> SELECT ([1, 2, 3])[2] AS col;
┌───────┐
│  col  │
│ int32 │
├───────┤
│   2   │
└───────┘

# Transpilation after this PR (used to error)
duckdb> SELECT [1, 2, 3][2] AS col;
┌───────┐
│  col  │
│ int32 │
├───────┤
│   2   │
└───────┘
```
3. A silent T-SQL query turning into command due to typo


Docs
--------
[DuckDB 1.2](https://duckdb.org/2025/02/05/announcing-duckdb-120.html#breaking-changes)