### PR TITLE
fix(tsql, postgres)!: Improve UUID support

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -144,7 +144,7 @@ class Spark(Spark2):
             **Spark2.Generator.TYPE_MAPPING,
             exp.DataType.Type.MONEY: "DECIMAL(15, 4)",
             exp.DataType.Type.SMALLMONEY: "DECIMAL(6, 4)",
-            exp.DataType.Type.UNIQUEIDENTIFIER: "STRING",
+            exp.DataType.Type.UUID: "STRING",
             exp.DataType.Type.TIMESTAMPLTZ: "TIMESTAMP_LTZ",
             exp.DataType.Type.TIMESTAMPNTZ: "TIMESTAMP_NTZ",
         }

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -525,7 +525,7 @@ class TSQL(Dialect):
             "TOP": TokenType.TOP,
             "TIMESTAMP": TokenType.ROWVERSION,
             "TINYINT": TokenType.UTINYINT,
-            "UNIQUEIDENTIFIER": TokenType.UNIQUEIDENTIFIER,
+            "UNIQUEIDENTIFIER": TokenType.UUID,
             "UPDATE STATISTICS": TokenType.COMMAND,
             "XML": TokenType.XML,
         }
@@ -919,6 +919,7 @@ class TSQL(Dialect):
             exp.DataType.Type.SMALLDATETIME: "SMALLDATETIME",
             exp.DataType.Type.UTINYINT: "TINYINT",
             exp.DataType.Type.VARIANT: "SQL_VARIANT",
+            exp.DataType.Type.UUID: "UNIQUEIDENTIFIER",
         }
 
         TYPE_MAPPING.pop(exp.DataType.Type.NCHAR)
@@ -974,6 +975,7 @@ class TSQL(Dialect):
             exp.TsOrDsAdd: date_delta_sql("DATEADD", cast=True),
             exp.TsOrDsDiff: date_delta_sql("DATEDIFF"),
             exp.TimestampTrunc: lambda self, e: self.func("DATETRUNC", e.unit, e.this),
+            exp.Uuid: lambda *_: "NEWID()",
             exp.DateFromParts: rename_func("DATEFROMPARTS"),
         }
 

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -579,6 +579,7 @@ class TSQL(Dialect):
             "JSON_VALUE": parser.build_extract_json_with_path(exp.JSONExtractScalar),
             "LEN": _build_with_arg_as_text(exp.Length),
             "LEFT": _build_with_arg_as_text(exp.Left),
+            "NEWID": exp.Uuid.from_arg_list,
             "RIGHT": _build_with_arg_as_text(exp.Right),
             "PARSENAME": _build_parsename,
             "REPLICATE": exp.Repeat.from_arg_list,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6748,7 +6748,7 @@ class UnixSeconds(Func):
 
 
 class Uuid(Func):
-    _sql_names = ["UUID", "GEN_RANDOM_UUID", "GENERATE_UUID", "NEWID", "UUID_STRING"]
+    _sql_names = ["UUID", "GEN_RANDOM_UUID", "GENERATE_UUID", "UUID_STRING"]
 
     arg_types = {"this": False, "name": False}
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4476,7 +4476,6 @@ class DataType(Expression):
         UMEDIUMINT = auto()
         UDECIMAL = auto()
         UNION = auto()
-        UNIQUEIDENTIFIER = auto()
         UNKNOWN = auto()  # Sentinel value, useful for type annotation
         USERDEFINED = "USER-DEFINED"
         USMALLINT = auto()
@@ -6749,7 +6748,7 @@ class UnixSeconds(Func):
 
 
 class Uuid(Func):
-    _sql_names = ["UUID", "GEN_RANDOM_UUID", "GENERATE_UUID", "UUID_STRING"]
+    _sql_names = ["UUID", "GEN_RANDOM_UUID", "GENERATE_UUID", "NEWID", "UUID_STRING"]
 
     arg_types = {"this": False, "name": False}
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -387,7 +387,6 @@ class Parser(metaclass=_Parser):
         TokenType.BIGSERIAL,
         TokenType.XML,
         TokenType.YEAR,
-        TokenType.UNIQUEIDENTIFIER,
         TokenType.USERDEFINED,
         TokenType.MONEY,
         TokenType.SMALLMONEY,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -192,7 +192,6 @@ class TokenType(AutoName):
     BIGSERIAL = auto()
     XML = auto()
     YEAR = auto()
-    UNIQUEIDENTIFIER = auto()
     USERDEFINED = auto()
     MONEY = auto()
     SMALLMONEY = auto()

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3184,6 +3184,7 @@ FROM subquery2""",
                 "postgres": "GEN_RANDOM_UUID()",
                 "bigquery": "GENERATE_UUID()",
                 "snowflake": "UUID_STRING()",
+                "tsql": "NEWID()",
             },
             write={
                 "hive": "UUID()",
@@ -3197,6 +3198,7 @@ FROM subquery2""",
                 "postgres": "GEN_RANDOM_UUID()",
                 "bigquery": "GENERATE_UUID()",
                 "snowflake": "UUID_STRING()",
+                "tsql": "NEWID()",
             },
         )
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1088,7 +1088,8 @@ class TestPostgres(Validator):
                 "duckdb": "CREATE TABLE x (a UUID, b BLOB)",
                 "presto": "CREATE TABLE x (a UUID, b VARBINARY)",
                 "hive": "CREATE TABLE x (a UUID, b BINARY)",
-                "spark": "CREATE TABLE x (a UUID, b BINARY)",
+                "spark": "CREATE TABLE x (a STRING, b BINARY)",
+                "tsql": "CREATE TABLE x (a UNIQUEIDENTIFIER, b VARBINARY)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -929,6 +929,15 @@ class TestTSQL(Validator):
             },
         )
         self.validate_all(
+            "CREATE TABLE x (a UNIQUEIDENTIFIER, b VARBINARY)",
+            write={
+                "duckdb": "CREATE TABLE x (a UUID, b BLOB)",
+                "presto": "CREATE TABLE x (a UUID, b VARBINARY)",
+                "spark": "CREATE TABLE x (a STRING, b BINARY)",
+                "postgres": "CREATE TABLE x (a UUID, b BYTEA)",
+            },
+        )
+        self.validate_all(
             "SELECT * INTO foo.bar.baz FROM (SELECT * FROM a.b.c) AS temp",
             read={
                 "": "CREATE TABLE foo.bar.baz AS SELECT * FROM a.b.c",


### PR DESCRIPTION
This PR addresses some UUID support issues with T-SQL and Postgres. A small example of what I wanted to get working:

Input: sqlglot.transpile('create table x (i uniqueidentifier not null default(newid()))', read='tsql', write='postgres')
Output: ['CREATE TABLE x (i UNIQUEIDENTIFIER NOT NULL DEFAULT (NEWID()))']
Expected: ['CREATE TABLE x (i uuid NOT NULL DEFAULT (gen_random_uuid()))']

- Removed unnecessary UNIQUEIDENTIFER token (standardized on UUID)
- Added NEWID() support to T-SQL
- Cleaned up Spark UUID support, which I noticed was also broken. (I think Hive might be, too, but I don't know for a fact so I didn't touch that one.)
