### PR TITLE
fix: pushdown_predicates takes care of join marks before the actual push down

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -1,13 +1,15 @@
+import typing as t
+
 from sqlglot import exp
 from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.optimizer.simplify import simplify
-from sqlglot.dialects.dialect import Dialect
+from sqlglot.dialects.dialect import DialectType
 from sqlglot.transforms import eliminate_join_marks as eliminate_jm
 
 
 def pushdown_predicates(
-    expression, dialect: Dialect | None = None, eliminate_join_marks: bool = False
+    expression, dialect: t.Optional[DialectType] = None, eliminate_join_marks: bool = False
 ):
     """
     Rewrite sqlglot AST to pushdown predicates in FROMS and JOINS

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -2,6 +2,7 @@ from sqlglot import exp
 from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.optimizer.simplify import simplify
+from sqlglot.transforms import eliminate_join_marks
 
 
 def pushdown_predicates(expression, dialect=None):
@@ -27,6 +28,7 @@ def pushdown_predicates(expression, dialect=None):
 
         for scope in reversed(list(root.traverse())):
             select = scope.expression
+            select = eliminate_join_marks(select)
             where = select.args.get("where")
             if where:
                 selected_sources = scope.selected_sources

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -2,10 +2,11 @@ from sqlglot import exp
 from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.optimizer.simplify import simplify
-from sqlglot.transforms import eliminate_join_marks
+from sqlglot.sqlglot.dialects.dialect import Dialect
+from sqlglot.transforms import eliminate_join_marks as eliminate_join_marks
 
 
-def pushdown_predicates(expression, dialect=None):
+def pushdown_predicates(expression, dialect: Dialect | None = None):
     """
     Rewrite sqlglot AST to pushdown predicates in FROMS and JOINS
 
@@ -26,9 +27,11 @@ def pushdown_predicates(expression, dialect=None):
     if root:
         scope_ref_count = root.ref_count()
 
+        if dialect and dialect.SUPPORTS_COLUMN_JOIN_MARKS:
+            expression = eliminate_join_marks(expression)
+
         for scope in reversed(list(root.traverse())):
             select = scope.expression
-            select = eliminate_join_marks(select)
             where = select.args.get("where")
             if where:
                 selected_sources = scope.selected_sources

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -1,5 +1,3 @@
-import typing as t
-
 from sqlglot import exp
 from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
@@ -9,7 +7,7 @@ from sqlglot.transforms import eliminate_join_marks as eliminate_jm
 
 
 def pushdown_predicates(
-    expression, dialect: t.Optional[DialectType] = None, eliminate_join_marks: bool = False
+    expression, dialect: DialectType = None, eliminate_join_marks: bool = False
 ):
     """
     Rewrite sqlglot AST to pushdown predicates in FROMS and JOINS
@@ -23,11 +21,11 @@ def pushdown_predicates(
 
     Args:
         expression (sqlglot.Expression): expression to optimize
-        eliminate_join_marks (Optional[bool]): override to eliminate legacy join marks for eligible dialects
+        eliminate_join_marks (Optional[bool]): an override to eliminate legacy join marks
     Returns:
         sqlglot.Expression: optimized expression
     """
-    if dialect and eliminate_join_marks:
+    if eliminate_join_marks:
         expression = eliminate_jm(expression)
 
     root = build_scope(expression)

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -3,10 +3,10 @@ from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.optimizer.simplify import simplify
 from sqlglot.sqlglot.dialects.dialect import Dialect
-from sqlglot.transforms import eliminate_join_marks
+from sqlglot.transforms import eliminate_join_marks as eliminate_jm
 
 
-def pushdown_predicates(expression, dialect: Dialect | None = None):
+def pushdown_predicates(expression, dialect: Dialect | None = None, eliminate_join_marks: bool = False):
     """
     Rewrite sqlglot AST to pushdown predicates in FROMS and JOINS
 
@@ -19,11 +19,12 @@ def pushdown_predicates(expression, dialect: Dialect | None = None):
 
     Args:
         expression (sqlglot.Expression): expression to optimize
+        eliminate_join_marks (Optional[bool]): override to eliminate legacy join marks for eligible dialects
     Returns:
         sqlglot.Expression: optimized expression
     """
-    if dialect and dialect.SUPPORTS_COLUMN_JOIN_MARKS:
-        expression = eliminate_join_marks(expression)
+    if dialect and dialect.SUPPORTS_COLUMN_JOIN_MARKS and eliminate_join_marks:
+        expression = eliminate_jm(expression)
 
     root = build_scope(expression)
 

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -3,7 +3,7 @@ from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.optimizer.simplify import simplify
 from sqlglot.sqlglot.dialects.dialect import Dialect
-from sqlglot.transforms import eliminate_join_marks as eliminate_join_marks
+from sqlglot.transforms import eliminate_join_marks
 
 
 def pushdown_predicates(expression, dialect: Dialect | None = None):
@@ -22,13 +22,13 @@ def pushdown_predicates(expression, dialect: Dialect | None = None):
     Returns:
         sqlglot.Expression: optimized expression
     """
+    if dialect and dialect.SUPPORTS_COLUMN_JOIN_MARKS:
+        expression = eliminate_join_marks(expression)
+
     root = build_scope(expression)
 
     if root:
         scope_ref_count = root.ref_count()
-
-        if dialect and dialect.SUPPORTS_COLUMN_JOIN_MARKS:
-            expression = eliminate_join_marks(expression)
 
         for scope in reversed(list(root.traverse())):
             select = scope.expression

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -2,11 +2,13 @@ from sqlglot import exp
 from sqlglot.optimizer.normalize import normalized
 from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.optimizer.simplify import simplify
-from sqlglot.sqlglot.dialects.dialect import Dialect
+from sqlglot.dialects.dialect import Dialect
 from sqlglot.transforms import eliminate_join_marks as eliminate_jm
 
 
-def pushdown_predicates(expression, dialect: Dialect | None = None, eliminate_join_marks: bool = False):
+def pushdown_predicates(
+    expression, dialect: Dialect | None = None, eliminate_join_marks: bool = False
+):
     """
     Rewrite sqlglot AST to pushdown predicates in FROMS and JOINS
 
@@ -23,7 +25,7 @@ def pushdown_predicates(expression, dialect: Dialect | None = None, eliminate_jo
     Returns:
         sqlglot.Expression: optimized expression
     """
-    if dialect and dialect.SUPPORTS_COLUMN_JOIN_MARKS and eliminate_join_marks:
+    if dialect and eliminate_join_marks:
         expression = eliminate_jm(expression)
 
     root = build_scope(expression)

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -47,5 +47,6 @@ SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b
 
 # title: Correctly treat join marks while pushing predicates down
 # dialect: oracle
+# eliminate_join_marks: True
 SELECT x.a FROM x, (SELECT * FROM y) AS y WHERE x.a = y.a(+) and y.b(+) = 1;
 SELECT x.a FROM x LEFT JOIN (SELECT * FROM y WHERE y.b = 1) y ON x.a = y.a AND TRUE;

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -46,6 +46,6 @@ SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b
 SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b) AS cnt_b FROM x AS x HAVING COUNT(1) > 0 OR (COUNT(x.a) > 0 AND COUNT(x.b) > 0)) AS x WHERE x.cnt > 0 OR (x.cnt_a > 0 AND x.cnt_b > 0);
 
 # title: Correctly treat join marks while pushing predicates down
-# dialect: oracle, redshift
+# dialect: oracle
 SELECT x.a FROM x, (SELECT * FROM y) AS y WHERE x.a = y.a(+) and y.b(+) = 1;
 SELECT x.a FROM x LEFT JOIN (SELECT * FROM y WHERE y.b = 1) y ON x.a = y.a AND TRUE;

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -45,7 +45,7 @@ SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt FROM x AS x HAVING COUNT(1) > 0
 SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b) AS cnt_b FROM x AS x) AS x WHERE (x.cnt_a > 0 AND x.cnt_b > 0) OR x.cnt > 0;
 SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b) AS cnt_b FROM x AS x HAVING COUNT(1) > 0 OR (COUNT(x.a) > 0 AND COUNT(x.b) > 0)) AS x WHERE x.cnt > 0 OR (x.cnt_a > 0 AND x.cnt_b > 0);
 
--- Correctly treat join marks while pushing predicates down
+# title: Correctly treat join marks while pushing predicates down
 # dialect: oracle, redshift
 SELECT x.a FROM x, (SELECT * FROM y) AS y WHERE x.a = y.a(+) and y.b(+) = 1;
 SELECT x.a FROM x LEFT JOIN (SELECT * FROM y WHERE y.b = 1) y ON x.a = y.a AND TRUE;

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -44,3 +44,8 @@ SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt FROM x AS x HAVING COUNT(1) > 0
 -- Pushdown predicate to HAVING (DNF)
 SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b) AS cnt_b FROM x AS x) AS x WHERE (x.cnt_a > 0 AND x.cnt_b > 0) OR x.cnt > 0;
 SELECT x.cnt AS cnt FROM (SELECT COUNT(1) AS cnt, COUNT(x.a) AS cnt_a, COUNT(x.b) AS cnt_b FROM x AS x HAVING COUNT(1) > 0 OR (COUNT(x.a) > 0 AND COUNT(x.b) > 0)) AS x WHERE x.cnt > 0 OR (x.cnt_a > 0 AND x.cnt_b > 0);
+
+-- Correctly treat join marks while pushing predicates down
+# dialect: oracle, redshift
+SELECT x.a FROM x, (SELECT * FROM y) AS y WHERE x.a = y.a(+) and y.b(+) = 1;
+SELECT x.a FROM x LEFT JOIN (SELECT * FROM y WHERE y.b = 1) y ON x.a = y.a AND TRUE;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -145,17 +145,17 @@ class TestOptimizer(unittest.TestCase):
                 if only and title != only:
                     continue
                 dialect = meta.get("dialect")
-                leave_tables_isolated = meta.get("leave_tables_isolated")
-                validate_qualify_columns = meta.get("validate_qualify_columns")
 
                 func_kwargs = {**kwargs}
-                if leave_tables_isolated is not None:
-                    func_kwargs["leave_tables_isolated"] = string_to_bool(leave_tables_isolated)
 
-                if validate_qualify_columns is not None:
-                    func_kwargs["validate_qualify_columns"] = string_to_bool(
-                        validate_qualify_columns
-                    )
+                for bool_param_name in [
+                    "leave_tables_isolated",
+                    "validate_qualify_columns",
+                    "eliminate_join_marks",
+                ]:
+                    value = meta.get(bool_param_name)
+                    if value is not None:
+                        func_kwargs[bool_param_name] = string_to_bool(value)
 
                 if dialect:
                     func_kwargs["dialect"] = dialect

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -144,9 +144,12 @@ class TestOptimizer(unittest.TestCase):
                 title = meta.get("title") or f"{i}, {sql}"
                 if only and title != only:
                     continue
-                dialect = meta.get("dialect")
 
                 func_kwargs = {**kwargs}
+
+                dialect = meta.get("dialect")
+                if dialect:
+                    func_kwargs["dialect"] = dialect
 
                 for bool_param_name in [
                     "leave_tables_isolated",
@@ -156,9 +159,6 @@ class TestOptimizer(unittest.TestCase):
                     value = meta.get(bool_param_name)
                     if value is not None:
                         func_kwargs[bool_param_name] = string_to_bool(value)
-
-                if dialect:
-                    func_kwargs["dialect"] = dialect
 
                 future = pool.submit(parse_and_optimize, func, sql, dialect, **func_kwargs)
                 results[future] = (


### PR DESCRIPTION
This fix makes sure that statements with join marks are converted into their canonical form before pushing down predicates.

Currently pushdown_predicates ignores the join marks syntax and does not convert join marks into joins which breaks the SQL

```
script = "SELECT x.a FROM x, (SELECT * FROM y) AS y WHERE x.a = y.a(+) and y.b(+) = 1"

tree = parse_one(script, dialect="oracle")
pushdown_predicates(tree).sql(pretty=True, dialect="oracle")
```

produces broken code:

```
SELECT
  x.a
FROM x
JOIN (
  SELECT
    *
  FROM y
  WHERE
    y.b (+) = 1
) y
  ON x.a = y.a (+) AND TRUE
WHERE
  TRUE AND TRUE
```

Testing:
- Added a unit test for join marks