### PR TITLE
fix: Add additional allowed tokens for parsing aggregate functions in DDL

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5003,7 +5003,7 @@ class Parser(metaclass=_Parser):
                 expressions = self._parse_csv(self._parse_equality)
             elif is_aggregate:
                 func_or_ident = self._parse_function(anonymous=True) or self._parse_id_var(
-                    any_token=False, tokens=(TokenType.VAR,)
+                    any_token=False, tokens=(TokenType.VAR, TokenType.ANY)
                 )
                 if not func_or_ident or not self._match(TokenType.COMMA):
                     return None


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4723 by adding an additional allowed token when parsing column definitions with an aggregate function type. Note that while the specific issue manifests itself for the `clickhouse` dialect, the issue could potentially apply to any dialect supporting aggregate functions which support using a keyword function like `any` in the column type.