### PR TITLE
fix(duckdb): Fix INTERVAL roundtrip of DATE_ADD

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -76,7 +76,10 @@ def _date_delta_sql(self: DuckDB.Generator, expression: DATETIME_DELTA) -> str:
 
     this = exp.cast(this, to_type) if to_type else this
 
-    return f"{self.sql(this)} {op} {self.sql(exp.Interval(this=expression.expression, unit=unit))}"
+    expr = expression.expression
+    interval = expr if isinstance(expr, exp.Interval) else exp.Interval(this=expr, unit=unit)
+
+    return f"{self.sql(this)} {op} {self.sql(interval)}"
 
 
 # BigQuery -> DuckDB conversion for the DATE function

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -910,6 +910,10 @@ class TestDuckDB(Validator):
                 "postgres": "SELECT 'ThOmAs' ~* 'thomas'",
             },
         )
+        self.validate_identity(
+            "SELECT DATE_ADD(CAST('2020-01-01' AS DATE), INTERVAL 1 DAY)",
+            "SELECT CAST('2020-01-01' AS DATE) + INTERVAL '1' DAY",
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4728

DuckDB's `_date_delta_sql` would preemptively construct an `INTERVAL` for the RHS, but that is not needed for roundtrips where the `expression.expression` is already one.

After this PR:
```SQL
D SELECT DATE_ADD(CAST('2020-01-01' AS DATE), INTERVAL 1 DAY);
┌──────────────────────────────────────────────────────────────────────────────────────────┐
│ date_add(CAST('2020-01-01' AS DATE), to_days(CAST(trunc(CAST(1 AS DOUBLE)) AS INTEGER))) │
│                                        timestamp                                         │
├──────────────────────────────────────────────────────────────────────────────────────────┤
│ 2020-01-02 00:00:00                                                                      │
└──────────────────────────────────────────────────────────────────────────────────────────┘


D SELECT CAST('2020-01-01' AS DATE) + INTERVAL '1' DAY;
┌─────────────────────────────────────────────────────────────────────────────────────┐
│ (CAST('2020-01-01' AS DATE) + to_days(CAST(trunc(CAST('1' AS DOUBLE)) AS INTEGER))) │
│                                      timestamp                                      │
├─────────────────────────────────────────────────────────────────────────────────────┤
│ 2020-01-02 00:00:00                                                                 │
└─────────────────────────────────────────────────────────────────────────────────────┘

```