### PR TITLE
feat(mysql): add unsigned double type

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -792,6 +792,7 @@ class MySQL(Dialect):
             exp.DataType.Type.USMALLINT: "SMALLINT",
             exp.DataType.Type.UTINYINT: "TINYINT",
             exp.DataType.Type.UDECIMAL: "DECIMAL",
+            exp.DataType.Type.UDOUBLE: "DOUBLE",
         }
 
         TIMESTAMP_TYPE_MAPPING = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4475,6 +4475,7 @@ class DataType(Expression):
         UINT256 = auto()
         UMEDIUMINT = auto()
         UDECIMAL = auto()
+        UDOUBLE = auto()
         UNION = auto()
         UNKNOWN = auto()  # Sentinel value, useful for type annotation
         USERDEFINED = "USER-DEFINED"
@@ -4558,6 +4559,7 @@ class DataType(Expression):
         Type.MONEY,
         Type.SMALLMONEY,
         Type.UDECIMAL,
+        Type.UDOUBLE,
     }
 
     NUMERIC_TYPES = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -318,6 +318,7 @@ class Parser(metaclass=_Parser):
         TokenType.FIXEDSTRING,
         TokenType.FLOAT,
         TokenType.DOUBLE,
+        TokenType.UDOUBLE,
         TokenType.CHAR,
         TokenType.NCHAR,
         TokenType.VARCHAR,
@@ -418,6 +419,7 @@ class Parser(metaclass=_Parser):
         TokenType.SMALLINT: TokenType.USMALLINT,
         TokenType.TINYINT: TokenType.UTINYINT,
         TokenType.DECIMAL: TokenType.UDECIMAL,
+        TokenType.DOUBLE: TokenType.UDOUBLE,
     }
 
     SUBQUERY_PREDICATES = {

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -123,6 +123,7 @@ class TokenType(AutoName):
     UINT256 = auto()
     FLOAT = auto()
     DOUBLE = auto()
+    UDOUBLE = auto()
     DECIMAL = auto()
     DECIMAL32 = auto()
     DECIMAL64 = auto()

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -14,6 +14,7 @@ class TestMySQL(Validator):
             self.validate_identity(f"CREATE TABLE t (id {t} UNSIGNED)")
             self.validate_identity(f"CREATE TABLE t (id {t}(10) UNSIGNED)")
 
+        self.validate_identity("CREATE TABLE bar (abacate DOUBLE(10, 2) UNSIGNED)")
         self.validate_identity("CREATE TABLE t (id DECIMAL(20, 4) UNSIGNED)")
         self.validate_identity("CREATE TABLE foo (a BIGINT, UNIQUE (b) USING BTREE)")
         self.validate_identity("CREATE TABLE foo (id BIGINT)")


### PR DESCRIPTION
# Objective
This PR adds a `UDOUBLE` type. 

## Explanation
Accordingly [mysql documentation](https://dev.mysql.com/doc/refman/8.0/en/numeric-type-syntax.html) this feature is deprecated but still has support due past versions, turning the column as regular double type.

### Examples
```sql
CREATE TABLE `bar` (`abacate` DOUBLE(10, 2) UNSIGNED NOT NULL);
```

```sql
SELECT COLUMN_NAME, DATA_TYPE FROM information_schema.columns WHERE table_name = 'bar' AND column_name = 'abacate';
```
RESULT:
<img width="277" alt="image" src="https://github.com/user-attachments/assets/9d384a0d-b6a0-4ec3-941f-9cd4241a1f2a" />
