### PR TITLE
Fix(clickhouse)!: add generate_series table column alias

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -649,6 +649,13 @@ class ClickHouse(Dialect):
                 is_db_reference=is_db_reference,
             )
 
+            if isinstance(this, exp.Table):
+                inner = this.this
+                alias = this.args.get("alias")
+
+                if isinstance(inner, exp.GenerateSeries) and alias and not alias.columns:
+                    alias.set("columns", [exp.to_identifier("generate_series")])
+
             if self._match(TokenType.FINAL):
                 this = self.expression(exp.Final, this=this)
 
@@ -902,7 +909,6 @@ class ClickHouse(Dialect):
         TABLE_HINTS = False
         GROUPINGS_SEP = ""
         SET_OP_MODIFIERS = False
-        SUPPORTS_TABLE_ALIAS_COLUMNS = False
         VALUES_AS_TABLE = False
         ARRAY_SIZE_NAME = "LENGTH"
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -159,6 +159,13 @@ class TestClickhouse(Validator):
             "CREATE TABLE t (foo String CODEC(LZ4HC(9), ZSTD, DELTA), size String ALIAS formatReadableSize(size_bytes), INDEX idx1 a TYPE bloom_filter(0.001) GRANULARITY 1, INDEX idx2 a TYPE set(100) GRANULARITY 2, INDEX idx3 a TYPE minmax GRANULARITY 3)"
         )
         self.validate_identity(
+            "SELECT generate_series FROM generate_series(0, 10) AS g(x)",
+        )
+        self.validate_identity(
+            "SELECT generate_series FROM generate_series(0, 10) AS g",
+            "SELECT generate_series FROM generate_series(0, 10) AS g(generate_series)",
+        )
+        self.validate_identity(
             "INSERT INTO tab VALUES ({'key1': 1, 'key2': 10}), ({'key1': 2, 'key2': 20}), ({'key1': 3, 'key2': 30})",
             "INSERT INTO tab VALUES (map('key1', 1, 'key2', 10)), (map('key1', 2, 'key2', 20)), (map('key1', 3, 'key2', 30))",
         )
@@ -226,9 +233,9 @@ class TestClickhouse(Validator):
             },
         )
         self.validate_all(
-            "SELECT a, b FROM (SELECT * FROM x) AS t",
+            "SELECT a, b FROM (SELECT * FROM x) AS t(a, b)",
             read={
-                "clickhouse": "SELECT a, b FROM (SELECT * FROM x) AS t",
+                "clickhouse": "SELECT a, b FROM (SELECT * FROM x) AS t(a, b)",
                 "duckdb": "SELECT a, b FROM (SELECT * FROM x) AS t(a, b)",
             },
         )

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -259,6 +259,11 @@ WITH T1 AS (SELECT 1 AS C1, 1 AS C2, 'Y' AS TOP_PARENT_INDICATOR, 1 AS ID FROM D
 SELECT * FROM ROWS FROM (GENERATE_SERIES(1, 3), GENERATE_SERIES(10, 12)) AS t(a, b);
 SELECT t.a AS a, t.b AS b FROM ROWS FROM (GENERATE_SERIES(1, 3), GENERATE_SERIES(10, 12)) AS t(a, b);
 
+# execute: false
+# dialect: clickhouse
+SELECT generate_series FROM generate_series(0, 10) AS g;
+SELECT g.generate_series AS generate_series FROM generate_series(0, 10) AS g(generate_series);
+
 --------------------------------------
 -- Derived tables
 --------------------------------------


### PR DESCRIPTION
Fixes #4740

cc @cpcloud ClickHouse now supports table aliases with column names, relevant past ticket [here](https://github.com/tobymao/sqlglot/issues/3726).