### PR TITLE
Fix(clickhouse)!: respect type nullability when casting in strtodate_sql

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1098,7 +1098,7 @@ class ClickHouse(Dialect):
             if not isinstance(expression.parent, exp.Cast):
                 # StrToDate returns DATEs in other dialects (eg. postgres), so
                 # this branch aims to improve the transpilation to clickhouse
-                return self.cast_sql(exp.cast(expression, 'DATE'))
+                return self.cast_sql(exp.cast(expression, "DATE"))
 
             return strtodate_sql
 

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1098,7 +1098,7 @@ class ClickHouse(Dialect):
             if not isinstance(expression.parent, exp.Cast):
                 # StrToDate returns DATEs in other dialects (eg. postgres), so
                 # this branch aims to improve the transpilation to clickhouse
-                return f"CAST({strtodate_sql} AS DATE)"
+                return self.cast_sql(exp.cast(expression, 'DATE'))
 
             return strtodate_sql
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -187,6 +187,13 @@ class TestClickhouse(Validator):
         )
 
         self.validate_all(
+            "SELECT CAST(STR_TO_DATE(SUBSTRING(a.eta, 1, 10), '%Y-%m-%d') AS Nullable(DATE))",
+            read={
+                "clickhouse": "SELECT CAST(STR_TO_DATE(SUBSTRING(a.eta, 1, 10), '%Y-%m-%d') AS Nullable(DATE))",
+                "oracle": "SELECT to_date(substr(a.eta, 1,10), 'YYYY-MM-DD')",
+            },
+        )
+        self.validate_all(
             "CHAR(67) || CHAR(65) || CHAR(84)",
             read={
                 "clickhouse": "CHAR(67) || CHAR(65) || CHAR(84)",
@@ -208,13 +215,13 @@ class TestClickhouse(Validator):
             },
         )
         self.validate_all(
-            "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS DATE)",
+            "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS Nullable(DATE))",
             read={
-                "clickhouse": "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS DATE)",
+                "clickhouse": "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS Nullable(DATE))",
                 "postgres": "SELECT TO_DATE('05 12 2000', 'DD MM YYYY')",
             },
             write={
-                "clickhouse": "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS DATE)",
+                "clickhouse": "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS Nullable(DATE))",
                 "postgres": "SELECT CAST(CAST(TO_DATE('05 12 2000', 'DD MM YYYY') AS TIMESTAMP) AS DATE)",
             },
         )


### PR DESCRIPTION
When transpiling from e.g. oracle `select to_date(substr(nullable_column, 1,10), 'YYYY-MM-DD')` to clickhouse the following 
 `SELECT CAST(STR_TO_DATE(SUBSTRING(nullable_column, 1, 10), '%Y-%m-%d') AS DATE)` which fails `Cannot convert NULL value to non-Nullable type: while executing`.

By this PR we ask sqlglot to use already existing cast method which respects data types nullity while transpiling.