### PR TITLE
fix: DuckDB should use count_if_to_sum transformation.

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -14,6 +14,7 @@ from sqlglot.dialects.dialect import (
     binary_from_function,
     bool_xor_sql,
     build_default_decimal_type,
+    count_if_to_sum,
     date_trunc_to_time,
     datestrtodate_sql,
     no_datetime_sql,
@@ -555,6 +556,11 @@ class DuckDB(Dialect):
             exp.ArraySum: rename_func("LIST_SUM"),
             exp.BitwiseXor: rename_func("XOR"),
             exp.CommentColumnConstraint: no_comment_column_constraint_sql,
+            # DuckDB COUNT_IF was only fixed to work as an aggregate function fully in
+            #  1.2.0, but it does not function correctly in previous versions.
+            # (https://github.com/duckdb/duckdb/pull/15061). This works for prior
+            # versions and 1.2.0+ 
+            exp.CountIf: count_if_to_sum,
             exp.CurrentDate: lambda *_: "CURRENT_DATE",
             exp.CurrentTime: lambda *_: "CURRENT_TIME",
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -789,7 +789,7 @@ class TestDuckDB(Validator):
         self.validate_all(
             "SELECT COUNT_IF(x)",
             write={
-                "duckdb": "SELECT COUNT_IF(x)",
+                "duckdb": "SUM(CASE WHEN x THEN 1 ELSE 0 END)",
                 "bigquery": "SELECT COUNTIF(x)",
             },
         )


### PR DESCRIPTION
DuckDB COUNT_IF was only fixed to work as an aggregate function fully in 1.2.0 (via  https://github.com/duckdb/duckdb/pull/15061), but it does not function correctly in previous versions, since it was raising a error 'Catalog Error: count_if is not an aggregate function`( https://github.com/duckdb/duckdb-web/issues/3294)

With this PR,  COUNT_IF are translated to code that  works for both prior versions and 1.2.0+ 