### PR TITLE
Fix(tokenizer-rs): use is_whitespace in token scan loop

### DIFF
--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -142,7 +142,7 @@ impl<'a> TokenizerState<'a> {
                 break;
             }
 
-            if !self.settings.white_space.contains_key(&self.current_char) {
+            if !self.current_char.is_whitespace() {
                 if self.current_char.is_ascii_digit() {
                     self.scan_number()?;
                 } else if let Some(identifier_end) =

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -23,6 +23,11 @@ class TestTranspile(unittest.TestCase):
 
     def test_weird_chars(self):
         self.assertEqual(transpile("0Êß")[0], "0 AS Êß")
+        self.assertEqual(
+            # Ideographic space after SELECT (\u3000)
+            transpile("SELECT　* FROM t WHERE c = 1")[0],
+            "SELECT * FROM t WHERE c = 1",
+        )
 
     def test_alias(self):
         self.assertEqual(transpile("SELECT SUM(y) KEEP")[0], "SELECT SUM(y) AS KEEP")


### PR DESCRIPTION
Fixes #4748