### PR TITLE
Add tokens and corresponding tests to Oracle dialect

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -94,18 +94,29 @@ class Oracle(Dialect):
         KEYWORDS = {
             **tokens.Tokenizer.KEYWORDS,
             "(+)": TokenType.JOIN_MARKER,
+            "ANYDATA": TokenType.TEXT,
+            "ANYDATASET": TokenType.TEXT,
+            "ANYTYPE": TokenType.TEXT,
             "BINARY_DOUBLE": TokenType.DOUBLE,
             "BINARY_FLOAT": TokenType.FLOAT,
             "BULK COLLECT INTO": TokenType.BULK_COLLECT_INTO,
             "COLUMNS": TokenType.COLUMN,
+            "LONG": TokenType.INT,
             "MATCH_RECOGNIZE": TokenType.MATCH_RECOGNIZE,
             "MINUS": TokenType.EXCEPT,
+            "NCLOB": TokenType.TEXT,
             "NVARCHAR2": TokenType.NVARCHAR,
             "ORDER SIBLINGS BY": TokenType.ORDER_SIBLINGS_BY,
+            "ROWID": TokenType.TEXT,
             "SAMPLE": TokenType.TABLE_SAMPLE,
+            "SDO_GEOMETRY": TokenType.TEXT,
+            "SDO_TOPO_GEOMETRY": TokenType.TEXT,
+            "SDO_GEORASTER": TokenType.TEXT,
             "START": TokenType.BEGIN,
             "TOP": TokenType.TOP,
+            "UROWID": TokenType.TEXT,
             "VARCHAR2": TokenType.VARCHAR,
+            "XMLTYPE": TokenType.TEXT
         }
 
     class Parser(parser.Parser):

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -116,7 +116,7 @@ class Oracle(Dialect):
             "TOP": TokenType.TOP,
             "UROWID": TokenType.TEXT,
             "VARCHAR2": TokenType.VARCHAR,
-            "XMLTYPE": TokenType.TEXT
+            "XMLTYPE": TokenType.TEXT,
         }
 
     class Parser(parser.Parser):

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -701,3 +701,69 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
         self.validate_identity(
             "ANALYZE TABLE tbl VALIDATE STRUCTURE CASCADE COMPLETE OFFLINE INTO db.tbl"
         )
+        self.validate_all(
+            "x::LONG",
+            write={
+                "": "CAST(x AS INT)",
+            },
+        )
+        self.validate_all(
+            "x::NCLOB",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::ROWID",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::ROWID",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::ANYTYPE",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::ANYDATA",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::ANYDATASET",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::SDO_GEOMETRY",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::SDO_GEORASTER",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::SDO_TOPO_GEOMETRY",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )
+        self.validate_all(
+            "x::XMLTYPE",
+            write={
+                "": "CAST(x AS TEXT)",
+            },
+        )


### PR DESCRIPTION
Oracle supports a number of custom datatypes not yet covered by the current codebase.
This PR adds tokens some of these datatypes and corresponding unit tests.