### PR TITLE
fix(optimizer): Preserve CTE names during table qualification

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -50,8 +50,17 @@ def qualify_tables(
     db = exp.parse_identifier(db, dialect=dialect) if db else None
     catalog = exp.parse_identifier(catalog, dialect=dialect) if catalog else None
 
+    # First collect all CTE names
+    cte_names = set()
+    for scope in traverse_scope(expression):
+        for cte in scope.ctes:
+            cte_names.add(cte.alias)
+
     def _qualify(table: exp.Table) -> None:
         if isinstance(table.this, exp.Identifier):
+            # Skip qualification if table is a CTE reference
+            if table.name in cte_names:
+                return
             if not table.args.get("db"):
                 table.set("db", db)
             if not table.args.get("catalog") and table.args.get("db"):


### PR DESCRIPTION
When qualifying table references in SQL queries, Common Table Expressions (CTEs) should not be qualified with database and catalog names. This change ensures that CTE references remain unqualified while still properly qualifying regular table references.

Previously, the qualify_tables function would incorrectly qualify CTE references as if they were regular tables, resulting in invalid SQL like: `db.schema.cte_name`. Now, it first collects CTE names and skips qualification for any table reference that matches a CTE name.

Example:
Before:
WITH cte AS (SELECT * FROM table)
SELECT * FROM db.schema.cte

After:
WITH cte AS (SELECT * FROM db.schema.table)
SELECT * FROM cte

Changes:
- Collect CTE names at the start of qualify_tables
- Skip qualification for table references that match CTE names
- Maintain qualification for regular table references