### PR TITLE
fix(sqlite): correct json key value pair separator

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -140,6 +140,7 @@ class SQLite(Dialect):
         SUPPORTS_TO_NUMBER = False
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
         SUPPORTS_MEDIAN = False
+        JSON_KEY_VALUE_PAIR_SEP = ","
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -108,6 +108,9 @@ class TestSQLite(Validator):
             "SELECT * FROM station WHERE city IS NOT ''",
             "SELECT * FROM station WHERE NOT city IS ''",
         )
+        self.validate_identity(
+            "SELECT JSON_OBJECT('col1', 1, 'col2', '1')"
+        )
 
     def test_strftime(self):
         self.validate_identity("SELECT STRFTIME('%Y/%m/%d', 'now')")

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -108,9 +108,7 @@ class TestSQLite(Validator):
             "SELECT * FROM station WHERE city IS NOT ''",
             "SELECT * FROM station WHERE NOT city IS ''",
         )
-        self.validate_identity(
-            "SELECT JSON_OBJECT('col1', 1, 'col2', '1')"
-        )
+        self.validate_identity("SELECT JSON_OBJECT('col1', 1, 'col2', '1')")
 
     def test_strftime(self):
         self.validate_identity("SELECT STRFTIME('%Y/%m/%d', 'now')")


### PR DESCRIPTION
Fixes #4770 

Replacing the separator of `JSON_OBJECT` from `":"` to `","`

**DOCS**
[SQLite JSON_OBJECT](https://www.sqlite.org/json1.html#jobj)