### PR TITLE
Fix(optimizer): do not qualify ctes that are pivoted

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -97,12 +97,16 @@ def qualify_tables(
                     source.alias
                 )
 
-                _qualify(source)
+                if pivots:
+                    if not pivots[0].alias:
+                        pivot_alias = next_alias_name()
+                        pivots[0].set("alias", exp.TableAlias(this=exp.to_identifier(pivot_alias)))
 
-                if pivots and not pivots[0].alias:
-                    pivots[0].set(
-                        "alias", exp.TableAlias(this=exp.to_identifier(next_alias_name()))
-                    )
+                    # This case corresponds to a pivoted CTE, we don't want to qualify that
+                    if isinstance(scope.sources.get(source.alias_or_name), Scope):
+                        continue
+
+                _qualify(source)
 
                 if infer_csv_schemas and schema and isinstance(source.this, exp.ReadCSV):
                     with csv_reader(source.this) as reader:

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -218,6 +218,28 @@ class TestOptimizer(unittest.TestCase):
     def test_qualify_tables(self):
         self.assertEqual(
             optimizer.qualify_tables.qualify_tables(
+                parse_one(
+                    "WITH cte AS (SELECT * FROM t) SELECT * FROM cte PIVOT(SUM(c) FOR v IN ('x', 'y'))"
+                ),
+                db="db",
+                catalog="catalog",
+            ).sql(),
+            "WITH cte AS (SELECT * FROM catalog.db.t AS t) SELECT * FROM cte AS cte PIVOT(SUM(c) FOR v IN ('x', 'y')) AS _q_0",
+        )
+
+        self.assertEqual(
+            optimizer.qualify_tables.qualify_tables(
+                parse_one(
+                    "WITH cte AS (SELECT * FROM t) SELECT * FROM cte PIVOT(SUM(c) FOR v IN ('x', 'y')) AS pivot_alias"
+                ),
+                db="db",
+                catalog="catalog",
+            ).sql(),
+            "WITH cte AS (SELECT * FROM catalog.db.t AS t) SELECT * FROM cte AS cte PIVOT(SUM(c) FOR v IN ('x', 'y')) AS pivot_alias",
+        )
+
+        self.assertEqual(
+            optimizer.qualify_tables.qualify_tables(
                 parse_one("select a from b"), catalog="catalog"
             ).sql(),
             "SELECT a FROM b AS b",


### PR DESCRIPTION
Addresses the issue reported in https://github.com/tobymao/sqlglot/pull/4767, cc @zeta9044.

The problem here is that pivoted tables show up as scope "sources", where the source itself is a `Table`, [regardless](https://github.com/tobymao/sqlglot/blob/main/sqlglot/optimizer/scope.py#L722) of the pivoted table being a CTE (unpivoted CTE references are stored as `Scope` sources). This leads `qualify_tables` to qualify CTE references as well.

Simple script to reproduce:

```python
sql = """
INSERT INTO sales_summary
WITH sales_by_quarter AS (
    SELECT * FROM t
)
SELECT *
FROM sales_by_quarter
PIVOT(
    SUM(total_amount)
    FOR quarter IN ('Q1', 'Q2', 'Q3', 'Q4')
)
ORDER BY product_name;
"""

from sqlglot import parse_one
from sqlglot.optimizer.qualify import qualify
from sqlglot.optimizer.scope import traverse_scope

expr = parse_one(sql)
print(qualify(expr, db="foo", catalog="bar").sql(pretty=True))
```