### PR TITLE
Fix(optimizer): column qualify not applying in an order by inside within group when it also the alias

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -292,8 +292,7 @@ class Scope:
                     or (
                         isinstance(ancestor, exp.Order)
                         and (
-                            isinstance(ancestor.parent, exp.Window)
-                            or isinstance(ancestor.parent, exp.WithinGroup)
+                            isinstance(ancestor.parent, (exp.Window, exp.WithinGroup))
                             or column.name not in named_selects
                         )
                     )

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -293,6 +293,7 @@ class Scope:
                         isinstance(ancestor, exp.Order)
                         and (
                             isinstance(ancestor.parent, exp.Window)
+                            or isinstance(ancestor.parent, exp.WithinGroup)
                             or column.name not in named_selects
                         )
                     )


### PR DESCRIPTION
example test code
```
query = """
    SELECT group_name, GROUP_CONCAT(name, ', ') WITHIN GROUP (ORDER BY sub_group_name NULLS LAST) AS sub_group_name
    FROM department 
    GROUP BY group_name
"""

parsed_query = parse_one(query)
qualified_query = qualify(parsed_query, schema={"department": {"group_name": "string", "sub_group_name": "string", "name": "string"}})

print(qualified_query.sql(pretty=True))
```

current output
```
SELECT
  "department"."group_name" AS "group_name",
  GROUP_CONCAT("department"."name", ', ') WITHIN GROUP (ORDER BY
    "sub_group_name" NULLS LAST) AS "sub_group_name"
FROM "department" AS "department"
GROUP BY
  "department"."group_name"
```

after fix 
```
SELECT
  "department"."group_name" AS "group_name",
  GROUP_CONCAT("department"."name", ', ') WITHIN GROUP (ORDER BY
    "department"."sub_group_name" NULLS LAST) AS "sub_group_name"
FROM "department" AS "department"
GROUP BY
  "department"."group_name"
```