### PR TITLE
feat(snowflake)!: show databases, functions, procedures and warehouses 

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -520,6 +520,8 @@ class Snowflake(Dialect):
         }
 
         SHOW_PARSERS = {
+            "DATABASES": _show_parser("DATABASES"),
+            "TERSE DATABASES": _show_parser("DATABASES"),
             "SCHEMAS": _show_parser("SCHEMAS"),
             "TERSE SCHEMAS": _show_parser("SCHEMAS"),
             "OBJECTS": _show_parser("OBJECTS"),
@@ -539,6 +541,8 @@ class Snowflake(Dialect):
             "COLUMNS": _show_parser("COLUMNS"),
             "USERS": _show_parser("USERS"),
             "TERSE USERS": _show_parser("USERS"),
+            "FUNCTIONS": _show_parser("FUNCTIONS"),
+            "PROCEDURES": _show_parser("PROCEDURES"),
         }
 
         CONSTRAINT_PARSERS = {

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -543,6 +543,7 @@ class Snowflake(Dialect):
             "TERSE USERS": _show_parser("USERS"),
             "FUNCTIONS": _show_parser("FUNCTIONS"),
             "PROCEDURES": _show_parser("PROCEDURES"),
+            "WAREHOUSES": _show_parser("WAREHOUSES"),
         }
 
         CONSTRAINT_PARSERS = {

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2083,6 +2083,11 @@ MATCH_RECOGNIZE (
         self.assertEqual(ast.this, "PROCEDURES")
         self.assertEqual(ast.args.get("scope_kind"), "ACCOUNT")
 
+    def test_show_warehouses(self):
+        self.validate_identity("SHOW WAREHOUSES")
+        ast = parse_one("SHOW WAREHOUSES", read="snowflake")
+        self.assertEqual(ast.this, "WAREHOUSES")
+
     def test_show_schemas(self):
         self.validate_identity(
             "show terse schemas in database db1 starts with 'a' limit 10 from 'b'",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2065,6 +2065,24 @@ MATCH_RECOGNIZE (
         self.validate_identity("SHOW TERSE USERS")
         self.validate_identity("SHOW USERS LIKE '_foo%' STARTS WITH 'bar' LIMIT 5 FROM 'baz'")
 
+    def test_show_databases(self):
+        self.validate_identity("SHOW TERSE DATABASES")
+        ast = parse_one("SHOW DATABASES IN ACCOUNT", read="snowflake")
+        self.assertEqual(ast.this, "DATABASES")
+        self.assertEqual(ast.args.get("scope_kind"), "ACCOUNT")
+
+    def test_show_functions(self):
+        self.validate_identity("SHOW FUNCTIONS")
+        ast = parse_one("SHOW FUNCTIONS IN ACCOUNT", read="snowflake")
+        self.assertEqual(ast.this, "FUNCTIONS")
+        self.assertEqual(ast.args.get("scope_kind"), "ACCOUNT")
+
+    def test_show_procedures(self):
+        self.validate_identity("SHOW PROCEDURES")
+        ast = parse_one("SHOW PROCEDURES IN ACCOUNT", read="snowflake")
+        self.assertEqual(ast.this, "PROCEDURES")
+        self.assertEqual(ast.args.get("scope_kind"), "ACCOUNT")
+
     def test_show_schemas(self):
         self.validate_identity(
             "show terse schemas in database db1 starts with 'a' limit 10 from 'b'",


### PR DESCRIPTION
Parse as expression, rather than command. These are issued by the Snowflake JDBC driver.

Refs:

https://docs.snowflake.com/en/sql-reference/sql/show-databases
https://docs.snowflake.com/en/sql-reference/sql/show-functions
https://docs.snowflake.com/en/sql-reference/sql/show-procedures
https://docs.snowflake.com/en/sql-reference/sql/show-warehouses

NB: `show databases in account` is valid syntax, although its not mentioned above. See the Snowflake JDBC driver's usage [here](https://github.com/snowflakedb/snowflake-jdbc/blob/dcb60b2905ca512c417a90ab08a87305e31e486c/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1648).