### PR TITLE
Fix(optimizer)!: parse unqualified names in DISTINCT ON (...) as identifiers

### DIFF
--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -90,6 +90,14 @@ SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY a, b;
 SELECT DISTINCT a AS c, b AS d FROM x ORDER BY 1;
 SELECT DISTINCT x.a AS c, x.b AS d FROM x AS x ORDER BY c;
 
+# execute: false
+SELECT DISTINCT ON (x, t.y) * FROM t;
+SELECT DISTINCT ON (x, t.y) * FROM t AS t;
+
+# execute: false
+SELECT DISTINCT ON (new_col) t1.col1 AS new_col FROM table1 AS t1;
+SELECT DISTINCT ON (new_col) t1.col1 AS new_col FROM table1 AS t1;
+
 SELECT 2 FROM x GROUP BY 1;
 SELECT 2 AS "2" FROM x AS x GROUP BY 1;
 


### PR DESCRIPTION
Fixes #4791

This is the example I used to conclude that aliases take precedence over table columns:

```
D WITH t AS (SELECT 1 AS x, 'a' AS y UNION ALL SELECT 1 AS x, 'b' AS y) SELECT DISTINCT ON (x) x::varchar || y AS x, y AS y FROM t;
┌─────────┬─────────┐
│    x    │    y    │
│ varchar │ varchar │
├─────────┼─────────┤
│ 1b      │ b       │
│ 1a      │ a       │
└─────────┴─────────┘
```

The behavior is consistent across Postgres, DuckDB and ClickHouse. I tested many of the remaining dialects (*) but they don't seem to support `DISTINCT ON (...)`, so this shouldn't affect them.

(*) BigQuery, Databricks, MySQL, Oracle, Redshift, Snowflake, Spark, Trino, T-SQL