### PR TITLE
Fix(optimizer)!: do not coerce parameterized types

### DIFF
--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -315,3 +315,10 @@ STRING;
 # dialect: bigquery
 STRING(timestamp_expr, timezone);
 STRING;
+
+--------------------------------------
+-- Snowflake
+--------------------------------------
+
+LEAST(x::DECIMAL(18, 2));
+DECIMAL(18, 2);


### PR DESCRIPTION
Fixes #4792

Decided to avoid any coercions when type parameters are present, to avoid dealing with:

- Are we dealing with something like `VARCHAR(MAX)`, where the parameter is a `Var`?
- Are there two parameters in the source type? if so, do we require that the target type (a) also has two parameters and (b) all of them are numbers and both parameters in source are smaller than their counterparts in target? E.g., do we only coerce in cases like `DECIMAL(18, 2) -> DECIMAL(20, 3)`? Is this coercion correct across different dialects? Etc.
