### PR TITLE
feat(clickhouse): support `GLOBAL NOT IN`

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -479,8 +479,7 @@ class ClickHouse(Dialect):
 
         RANGE_PARSERS = {
             **parser.Parser.RANGE_PARSERS,
-            TokenType.GLOBAL: lambda self, this: self._match(TokenType.IN)
-            and self._parse_in(this, is_global=True),
+            TokenType.GLOBAL: lambda self, this: self._parse_global_in(this),
         }
 
         # The PLACEHOLDER entry is popped because 1) it doesn't affect Clickhouse (it corresponds to
@@ -632,6 +631,14 @@ class ClickHouse(Dialect):
         def _parse_in(self, this: t.Optional[exp.Expression], is_global: bool = False) -> exp.In:
             this = super()._parse_in(this)
             this.set("is_global", is_global)
+            return this
+
+        def _parse_global_in(self, this: t.Optional[exp.Expression]) -> exp.Not | exp.In:
+            is_negated = self._match(TokenType.NOT)
+            this = self._match(TokenType.IN) and self._parse_in(this, is_global=True)
+            if is_negated:
+                return self.expression(exp.Not, this=this)
+
             return this
 
         def _parse_table(
@@ -1290,3 +1297,18 @@ class ClickHouse(Dialect):
                 is_sql = self.wrap(is_sql)
 
             return is_sql
+
+        def in_sql(self, expression: exp.In) -> str:
+            in_sql = super().in_sql(expression)
+
+            if isinstance(expression.parent, exp.Not) and expression.args.get("is_global"):
+                in_sql = in_sql.replace("GLOBAL IN", "GLOBAL NOT IN", 1)
+
+            return in_sql
+
+        def not_sql(self, expression: exp.Not) -> str:
+            if isinstance(expression.this, exp.In) and expression.this.args.get("is_global"):
+                # let `GLOBAL IN` child interpose `NOT`
+                return self.sql(expression, "this")
+
+            return super().not_sql(expression)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -87,6 +87,7 @@ class TestClickhouse(Validator):
         self.validate_identity("SELECT exponentialTimeDecayedAvg(60)(a, b)")
         self.validate_identity("levenshteinDistance(col1, col2)", "editDistance(col1, col2)")
         self.validate_identity("SELECT * FROM foo WHERE x GLOBAL IN (SELECT * FROM bar)")
+        self.validate_identity("SELECT * FROM foo WHERE x GLOBAL NOT IN (SELECT * FROM bar)")
         self.validate_identity("POSITION(haystack, needle)")
         self.validate_identity("POSITION(haystack, needle, position)")
         self.validate_identity("CAST(x AS DATETIME)", "CAST(x AS DateTime)")


### PR DESCRIPTION
Clickhouse has `GLOBAL NOT IN` variant https://clickhouse.com/docs/sql-reference/operators/in. Superset 4.1 is conservatively refusing a `GLOBAL NOT IN` query as not-read-only.

I parsed the keyword into a new `exp.In` flag `is_negated`, but I'm not sure if a richer datatype for `is_global` make sense.

Hope this helps.