### PR TITLE
Support MySQL's `ALTER INDEX`.

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1706,6 +1706,14 @@ class AlterColumn(Expression):
     }
 
 
+# https://dev.mysql.com/doc/refman/8.0/en/invisible-indexes.html
+class AlterIndex(Expression):
+    arg_types = {
+        "this": True,
+        "visible": True,
+    }
+
+
 # https://docs.aws.amazon.com/redshift/latest/dg/r_ALTER_TABLE.html
 class AlterDistStyle(Expression):
     pass

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3296,6 +3296,14 @@ class Generator(metaclass=_Generator):
 
         return f"ALTER COLUMN {this} DROP DEFAULT"
 
+    def alterindex_sql(self, expression: exp.AlterIndex) -> str:
+        this = self.sql(expression, "this")
+
+        visible = expression.args.get("visible")
+        visible_sql = "VISIBLE" if visible else "INVISIBLE"
+
+        return f"ALTER INDEX {this} {visible_sql}"
+
     def alterdiststyle_sql(self, expression: exp.AlterDistStyle) -> str:
         this = self.sql(expression, "this")
         if not isinstance(expression.this, exp.Var):

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -150,6 +150,8 @@ class TestMySQL(Validator):
                 "sqlite": "CREATE TABLE x (id INTEGER NOT NULL AUTOINCREMENT PRIMARY KEY)",
             },
         )
+        self.validate_identity("ALTER TABLE t ALTER INDEX i INVISIBLE")
+        self.validate_identity("ALTER TABLE t ALTER INDEX i VISIBLE")
 
     def test_identity(self):
         self.validate_identity("SELECT HIGH_PRIORITY STRAIGHT_JOIN SQL_CALC_FOUND_ROWS * FROM t")


### PR DESCRIPTION
MySQL 8.0 and above [support altering an existing index](https://dev.mysql.com/doc/refman/8.0/en/alter-table.html), `x`, using the syntax, `ALTER TABLE x ALTER INDEX {VISIBLE | INVISIBLE}`. This allows for the index to become either invisible _or_ visible. No other index changes are permitted. This commit adds support for such syntax.

As I am still learning how this codebase works, I have done my best to put the implementations into the correct places. I also wasn't positive if this should leverage `IndexOptionConstraints`; however, I decided not to use this parser, as the full set of options is _not_ supported  by MySQL's `ALTER INDEX`. Please provide feedback if I have chosen a suboptimal implementation.
