### PR TITLE
fix(tsql)!: support TOP with PERCENT and WITH TIES

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2357,8 +2357,7 @@ class Fetch(Expression):
     arg_types = {
         "direction": False,
         "count": False,
-        "percent": False,
-        "with_ties": False,
+        "limit_options": False,
     }
 
 
@@ -2400,7 +2399,21 @@ class Lambda(Expression):
 
 
 class Limit(Expression):
-    arg_types = {"this": False, "expression": True, "offset": False, "expressions": False}
+    arg_types = {
+        "this": False,
+        "expression": True,
+        "offset": False,
+        "limit_options": False,
+        "expressions": False,
+    }
+
+
+class LimitOptions(Expression):
+    arg_types = {
+        "percent": False,
+        "rows": False,
+        "with_ties": False,
+    }
 
 
 class Literal(Condition):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4469,10 +4469,8 @@ class Parser(metaclass=_Parser):
     def _parse_limit_options(self) -> exp.LimitOptions:
         percent = self._match(TokenType.PERCENT)
         rows = self._match_set((TokenType.ROW, TokenType.ROWS))
-        only = self._match_text_seq("ONLY")
+        self._match_text_seq("ONLY")
         with_ties = self._match_text_seq("WITH", "TIES")
-        if only and with_ties:
-            self.raise_error("Cannot specify both ONLY and WITH TIES in FETCH clause")
         return self.expression(exp.LimitOptions, percent=percent, rows=rows, with_ties=with_ties)
 
     def _parse_limit(
@@ -4483,7 +4481,6 @@ class Parser(metaclass=_Parser):
     ) -> t.Optional[exp.Expression]:
         if skip_limit_token or self._match(TokenType.TOP if top else TokenType.LIMIT):
             comments = self._prev_comments
-            limit_options = None
             if top:
                 limit_paren = self._match(TokenType.L_PAREN)
                 expression = self._parse_term() if limit_paren else self._parse_number()
@@ -4493,6 +4490,7 @@ class Parser(metaclass=_Parser):
 
                 limit_options = self._parse_limit_options()
             else:
+                limit_options = None
                 expression = self._parse_term()
 
             if self._match(TokenType.COMMA):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4466,6 +4466,15 @@ class Parser(metaclass=_Parser):
             exp.Ordered, this=this, desc=desc, nulls_first=nulls_first, with_fill=with_fill
         )
 
+    def _parse_limit_options(self) -> exp.LimitOptions:
+        percent = self._match(TokenType.PERCENT)
+        rows = self._match_set((TokenType.ROW, TokenType.ROWS))
+        only = self._match_text_seq("ONLY")
+        with_ties = self._match_text_seq("WITH", "TIES")
+        if only and with_ties:
+            self.raise_error("Cannot specify both ONLY and WITH TIES in FETCH clause")
+        return self.expression(exp.LimitOptions, percent=percent, rows=rows, with_ties=with_ties)
+
     def _parse_limit(
         self,
         this: t.Optional[exp.Expression] = None,
@@ -4474,12 +4483,15 @@ class Parser(metaclass=_Parser):
     ) -> t.Optional[exp.Expression]:
         if skip_limit_token or self._match(TokenType.TOP if top else TokenType.LIMIT):
             comments = self._prev_comments
+            limit_options = None
             if top:
                 limit_paren = self._match(TokenType.L_PAREN)
                 expression = self._parse_term() if limit_paren else self._parse_number()
 
                 if limit_paren:
                     self._match_r_paren()
+
+                limit_options = self._parse_limit_options()
             else:
                 expression = self._parse_term()
 
@@ -4495,6 +4507,7 @@ class Parser(metaclass=_Parser):
                 expression=expression,
                 offset=offset,
                 comments=comments,
+                limit_options=limit_options,
                 expressions=self._parse_limit_by(),
             )
 
@@ -4505,22 +4518,12 @@ class Parser(metaclass=_Parser):
             direction = self._prev.text.upper() if direction else "FIRST"
 
             count = self._parse_field(tokens=self.FETCH_TOKENS)
-            percent = self._match(TokenType.PERCENT)
-
-            self._match_set((TokenType.ROW, TokenType.ROWS))
-
-            only = self._match_text_seq("ONLY")
-            with_ties = self._match_text_seq("WITH", "TIES")
-
-            if only and with_ties:
-                self.raise_error("Cannot specify both ONLY and WITH TIES in FETCH clause")
 
             return self.expression(
                 exp.Fetch,
                 direction=direction,
                 count=count,
-                percent=percent,
-                with_ties=with_ties,
+                limit_options=self._parse_limit_options(),
             )
 
         return this

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1705,6 +1705,8 @@ WHERE
                 "spark": "SELECT * FROM A LIMIT 3",
             },
         )
+        self.validate_identity("SELECT TOP 10 PERCENT")
+        self.validate_identity("SELECT TOP 10 PERCENT WITH TIES")
 
     def test_format(self):
         self.validate_identity("SELECT FORMAT(foo, 'dddd', 'de-CH')")


### PR DESCRIPTION
Fixes #4793

This PR adds support for using `PERCENT` and `WITH TIES` alongside the `TOP` command in T-SQL. 

Moreover, the base parsing method `limit` and the base generator method `fetch` have been refactored.

**DOCS**
[T-SQL TOP PERCENT/WITH TIES](https://learn.microsoft.com/en-us/sql/t-sql/queries/top-transact-sql?view=sql-server-ver16#syntax)