### PR TITLE
Fix(tokenizer-rs)!: make hex literal tokenization more robust

### DIFF
--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -575,9 +575,12 @@ impl<'a> TokenizerState<'a> {
     ) -> Result<(), TokenizerError> {
         self.advance(1)?;
         let value = self.extract_value()?[2..].to_string();
-        match u64::from_str_radix(&value, radix) {
-            Ok(_) => self.add(radix_token_type, Some(value)),
-            Err(_) => self.add(self.token_types.identifier, None),
+
+        // Validate if the string consists only of valid hex digits
+        if value.chars().all(|c| c.is_digit(radix)) {
+            self.add(radix_token_type, Some(value))
+        } else {
+            self.add(self.token_types.identifier, None)
         }
     }
 

--- a/tests/dialects/test_dune.py
+++ b/tests/dialects/test_dune.py
@@ -1,3 +1,4 @@
+from sqlglot import exp
 from tests.dialects.test_dialect import Validator
 
 
@@ -8,16 +9,28 @@ class TestDune(Validator):
         self.validate_identity("CAST(x AS INT256)")
         self.validate_identity("CAST(x AS UINT256)")
 
-        self.validate_all(
-            "SELECT 0xdeadbeef",
-            read={
-                "dune": "SELECT X'deadbeef'",
-                "postgres": "SELECT x'deadbeef'",
-                "trino": "SELECT X'deadbeef'",
-            },
-            write={
-                "dune": "SELECT 0xdeadbeef",
-                "postgres": "SELECT x'deadbeef'",
-                "trino": "SELECT x'deadbeef'",
-            },
-        )
+        for hex_literal in (
+            "deadbeef",
+            "deadbeefdead",
+            "deadbeefdeadbeef",
+            "deadbeefdeadbeefde",
+            "deadbeefdeadbeefdead",
+            "deadbeefdeadbeefdeadbeef",
+            "deadbeefdeadbeefdeadbeefdeadbeef",
+        ):
+            with self.subTest(f"Transpiling hex literal {hex_literal}"):
+                self.parse_one(f"0x{hex_literal}").assert_is(exp.HexString)
+
+                self.validate_all(
+                    f"SELECT 0x{hex_literal}",
+                    read={
+                        "dune": f"SELECT X'{hex_literal}'",
+                        "postgres": f"SELECT x'{hex_literal}'",
+                        "trino": f"SELECT X'{hex_literal}'",
+                    },
+                    write={
+                        "dune": f"SELECT 0x{hex_literal}",
+                        "postgres": f"SELECT x'{hex_literal}'",
+                        "trino": f"SELECT x'{hex_literal}'",
+                    },
+                )


### PR DESCRIPTION
This is the current behavior:

```python
>>> import sqlglot
>>>
>>> for hex_literal in (
...     "0xdeadbeef",
...     "0xdeadbeefdead",
...     "0xdeadbeefdeadbeef",
...     "0xdeadbeefdeadbeefde",
...     "0xdeadbeefdeadbeefdead",
...     "0xdeadbeefdeadbeefdeadbeef",
...     "0xdeadbeefdeadbeefdeadbeefdeadbeef",
... ):
...     print(type(sqlglot.parse_one(hex_literal, read="dune")))
...
<class 'sqlglot.expressions.HexString'>
<class 'sqlglot.expressions.HexString'>
<class 'sqlglot.expressions.HexString'>
<class 'sqlglot.expressions.Column'>
<class 'sqlglot.expressions.Column'>
<class 'sqlglot.expressions.Column'>
<class 'sqlglot.expressions.Column'>
```

The reason we get `Column`s starting at `0xdeadbeefdeadbeefde` is because we [rely](https://github.com/tobymao/sqlglot/blob/a9ae2d229640f22134410ca5826c6f19df7ef523/sqlglotrs/src/tokenizer.rs#L578-L581) on `u64::from_str_radix`, which fails to convert something outside of the u64 range, resulting in `IDENTIFIER` tokens.

This fix is closer to the Python [implementation](https://github.com/tobymao/sqlglot/blob/a9ae2d229640f22134410ca5826c6f19df7ef523/sqlglot/tokens.py#L1345-L1353).