### PR TITLE
Feat(trino): add support for ON ... ERROR/NULL syntax for JSON_QUERY

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -401,7 +401,6 @@ class Presto(Dialect):
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.Initcap: _initcap_sql,
-            exp.JSONExtract: lambda self, e: self.jsonextract_sql(e),
             exp.Last: _first_last_sql,
             exp.LastDay: lambda self, e: self.func("LAST_DAY_OF_MONTH", e.this),
             exp.Lateral: explode_to_unnest_sql,

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -53,6 +53,7 @@ class Trino(Presto):
                 option=self._parse_var_from_options(self.JSON_QUERY_OPTIONS, raise_unmatched=False),
                 json_query=True,
                 quote=self._parse_json_query_quote(),
+                on_condition=self._parse_on_condition(),
             )
 
     class Generator(Presto.Generator):
@@ -70,7 +71,6 @@ class Trino(Presto):
             exp.Merge: merge_without_target_sql,
             exp.TimeStrToTime: lambda self, e: timestrtotime_sql(self, e, include_precision=True),
             exp.Trim: trim_sql,
-            exp.JSONExtract: lambda self, e: self.jsonextract_sql(e),
         }
 
         SUPPORTED_JSON_PATH_PARTS = {
@@ -90,7 +90,14 @@ class Trino(Presto):
             quote = self.sql(expression, "quote")
             quote = f" {quote}" if quote else ""
 
-            return self.func("JSON_QUERY", expression.this, json_path + option + quote)
+            on_condition = self.sql(expression, "on_condition")
+            on_condition = f" {on_condition}" if on_condition else ""
+
+            return self.func(
+                "JSON_QUERY",
+                expression.this,
+                json_path + option + quote + on_condition,
+            )
 
         def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
             this = expression.this

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6211,6 +6211,7 @@ class JSONExtract(Binary, Func):
         "json_query": False,
         "option": False,
         "quote": False,
+        "on_condition": False,
     }
     _sql_names = ["JSON_EXTRACT"]
     is_var_len_args = True

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -5,6 +5,7 @@ class TestTrino(Validator):
     dialect = "trino"
 
     def test_trino(self):
+        self.validate_identity("JSON_QUERY(m.properties, 'lax $.area' OMIT QUOTES NULL ON ERROR)")
         self.validate_identity("JSON_EXTRACT(content, json_path)")
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
         self.validate_identity("JSON_QUERY(content, 'strict $.HY.*' WITH WRAPPER)")


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/3905

This doesn't cover the full syntax spec yet, just the `... ON {EMPTY|ERROR}` clause.

Reference: https://trino.io/docs/current/functions/json.html#json-query