### PR TITLE
fix: orphan node(s) in eliminate_join_marks

### DIFF
--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sqlglot import parse_one
+from sqlglot import parse_one, expressions as exp
 from sqlglot.transforms import (
     eliminate_distinct_on,
     eliminate_join_marks,
@@ -256,3 +256,11 @@ class TestTransforms(unittest.TestCase):
                 f"SELECT table1.id, table2.cloumn1, table3.id FROM table1 LEFT JOIN table2 ON table1.id = table2.id LEFT JOIN (SELECT tableInner1.id FROM tableInner1 LEFT JOIN tableInner2 ON tableInner1.id = tableInner2.id) {alias}table3 ON table1.id = table3.id",
                 dialect,
             )
+
+            # if multiple conditions, we check that after transformations the tree remains consistent
+            s = "select a.id from a, b where a.id = b.id (+) AND b.d (+) = const"
+            tree = parse_one(s, dialect=dialect)
+            assert ([type(t.parent.parent) for t in tree.find_all(exp.Table)]) == [
+                exp.Select,
+                exp.Select,
+            ]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -260,7 +260,7 @@ class TestTransforms(unittest.TestCase):
             # if multiple conditions, we check that after transformations the tree remains consistent
             s = "select a.id from a, b where a.id = b.id (+) AND b.d (+) = const"
             tree = parse_one(s, dialect=dialect)
-            assert ([type(t.parent.parent) for t in tree.find_all(exp.Table)]) == [
+            assert ([type(t.parent_select) for t in tree.find_all(exp.Table)]) == [
                 exp.Select,
                 exp.Select,
             ]


### PR DESCRIPTION
Currently there is a problem if a join with join marks has multiple conditions because a new join is created every time, there is a column with a join mark. This reset the parent of the joined table and the link is lost which breaks the tree consistency down

Example:

```
s = "select a.id from a, b where a.id = b.id (+) and b.d (+) = const"

tree = parse_one(s, dialect="oracle")
print("before", [type(t.parent_select) for t in tree.find_all(exp.Table)])
eliminate_join_marks(tree)
print("after", [type(t.parent_select) for t in tree.find_all(exp.Table)])
```

outputs

```
before [<class 'sqlglot.expressions.Select'>, <class 'sqlglot.expressions.Select'>]
after [<class 'sqlglot.expressions.Select'>, <class 'NoneType'>]
```

against expected 

```
before [<class 'sqlglot.expressions.Select'>, <class 'sqlglot.expressions.Select'>]
after [<class 'sqlglot.expressions.Select'>, <class 'sqlglot.expressions.Select'>]
```

This fix makes sure that a Join is created only once, if it is new.

Testing: added a unit test (not sure if it helps much)