### PR TITLE
Support setting visibility on `ALTER COLUMN`.

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1703,6 +1703,7 @@ class AlterColumn(Expression):
         "drop": False,
         "comment": False,
         "allow_null": False,
+        "visible": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3292,6 +3292,10 @@ class Generator(metaclass=_Generator):
         if comment:
             return f"ALTER COLUMN {this} COMMENT {comment}"
 
+        visible = expression.args.get("visible")
+        if visible:
+            return f"ALTER COLUMN {this} SET {visible}"
+
         allow_null = expression.args.get("allow_null")
         drop = expression.args.get("drop")
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7114,6 +7114,12 @@ class Parser(metaclass=_Parser):
                 this=column,
                 allow_null=False,
             )
+
+        if self._match_text_seq("SET", "VISIBLE"):
+            return self.expression(exp.AlterColumn, this=column, visible="VISIBLE")
+        if self._match_text_seq("SET", "INVISIBLE"):
+            return self.expression(exp.AlterColumn, this=column, visible="INVISIBLE")
+
         self._match_text_seq("SET", "DATA")
         self._match_text_seq("TYPE")
         return self.expression(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -152,6 +152,8 @@ class TestMySQL(Validator):
         )
         self.validate_identity("ALTER TABLE t ALTER INDEX i INVISIBLE")
         self.validate_identity("ALTER TABLE t ALTER INDEX i VISIBLE")
+        self.validate_identity("ALTER TABLE t ALTER COLUMN c SET INVISIBLE")
+        self.validate_identity("ALTER TABLE t ALTER COLUMN c SET VISIBLE")
 
     def test_identity(self):
         self.validate_identity("SELECT HIGH_PRIORITY STRAIGHT_JOIN SQL_CALC_FOUND_ROWS * FROM t")


### PR DESCRIPTION
MySQL 8.0 introduced the [ability to hide and unhide columns]. Columns can be hidden in a `CREATE TABLE` statement (currently unimplemented in `sqlglot`) and can be subsequently changed with an `ALTER TABLE` syntax: `ALTER COLUMN x SET {VISIBLE|INVISIBLE}`.

This commit adds support for column hiding through the `ALTER TABLE` syntax. However, it does so in a MySQL-specific way. Other RDBMSs have similar support for column hiding, but implement it slightly differently:

* Oracle uses `MODIFY x INVISIBLE`
* DB2 uses `ALTER x t IMPLICITLY HIDDEN`
* SQLServer uses `ALTER x ADD HIDDEN`

As there is no other dialect in `sqlglot` that implements invisibility, and because the parser currently maintains other dialect-specific implementations, I wasn't sure if the amount of effort to refactor the parser to be dialect-agnostic was worthwhile for this specific change (I couldn't find a similar pattern).  If you disagree, I would be willing to attempt the refactor, though, I would appreciate some suggestions on how it could be done, as it was not immediately apparent.  

[ability to hide and unhide columns]: https://dev.mysql.com/doc/refman/8.4/en/alter-table.html