### PR TITLE
clickhouse: fix unparseable `AggregateFunction(count)`

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5048,14 +5048,19 @@ class Parser(metaclass=_Parser):
                 func_or_ident = self._parse_function(anonymous=True) or self._parse_id_var(
                     any_token=False, tokens=(TokenType.VAR, TokenType.ANY)
                 )
-                if not func_or_ident or not self._match(TokenType.COMMA):
+                if not func_or_ident:
                     return None
-                expressions = self._parse_csv(
-                    lambda: self._parse_types(
-                        check_func=check_func, schema=schema, allow_identifiers=allow_identifiers
+                expressions = [func_or_ident]
+                if self._match(TokenType.COMMA):
+                    expressions.extend(
+                        self._parse_csv(
+                            lambda: self._parse_types(
+                                check_func=check_func,
+                                schema=schema,
+                                allow_identifiers=allow_identifiers,
+                            )
+                        )
                     )
-                )
-                expressions.insert(0, func_or_ident)
             else:
                 expressions = self._parse_csv(self._parse_type_size)
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1116,13 +1116,15 @@ LIFETIME(MIN 0 MAX 0)""",
             CREATE TABLE t (
                 a AggregateFunction(quantiles(0.5, 0.9), UInt64),
                 b AggregateFunction(quantiles, UInt64),
-                c SimpleAggregateFunction(sum, Float64)
+                c SimpleAggregateFunction(sum, Float64),
+                d AggregateFunction(count)
             )""",
             write={
                 "clickhouse": """CREATE TABLE t (
   a AggregateFunction(quantiles(0.5, 0.9), UInt64),
   b AggregateFunction(quantiles, UInt64),
-  c SimpleAggregateFunction(sum, Float64)
+  c SimpleAggregateFunction(sum, Float64),
+  d AggregateFunction(count)
 )"""
             },
             pretty=True,


### PR DESCRIPTION
count is the only agg function that may not have argument at all