### PR TITLE
fix(duckdb): Parse SHA256

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -379,6 +379,7 @@ class DuckDB(Dialect):
             "DECODE": lambda args: exp.Decode(
                 this=seq_get(args, 0), charset=exp.Literal.string("utf-8")
             ),
+            "EDITDIST3": exp.Levenshtein.from_arg_list,
             "ENCODE": lambda args: exp.Encode(
                 this=seq_get(args, 0), charset=exp.Literal.string("utf-8")
             ),
@@ -386,6 +387,7 @@ class DuckDB(Dialect):
             "EPOCH_MS": lambda args: exp.UnixToTime(
                 this=seq_get(args, 0), scale=exp.UnixToTime.MILLIS
             ),
+            "GENERATE_SERIES": _build_generate_series(),
             "JSON": exp.ParseJSON.from_arg_list,
             "JSON_EXTRACT_PATH": parser.build_extract_json_with_path(exp.JSONExtract),
             "JSON_EXTRACT_STRING": parser.build_extract_json_with_path(exp.JSONExtractScalar),
@@ -397,6 +399,7 @@ class DuckDB(Dialect):
             "MAKE_TIMESTAMP": _build_make_timestamp,
             "QUANTILE_CONT": exp.PercentileCont.from_arg_list,
             "QUANTILE_DISC": exp.PercentileDisc.from_arg_list,
+            "RANGE": _build_generate_series(end_exclusive=True),
             "REGEXP_EXTRACT": build_regexp_extract(exp.RegexpExtract),
             "REGEXP_EXTRACT_ALL": build_regexp_extract(exp.RegexpExtractAll),
             "REGEXP_MATCHES": exp.RegexpLike.from_arg_list,
@@ -406,6 +409,7 @@ class DuckDB(Dialect):
                 replacement=seq_get(args, 2),
                 modifiers=seq_get(args, 3),
             ),
+            "SHA256": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(256)),
             "STRFTIME": build_formatted_time(exp.TimeToStr, "duckdb"),
             "STRING_SPLIT": exp.Split.from_arg_list,
             "STRING_SPLIT_REGEX": exp.RegexpSplit.from_arg_list,
@@ -418,9 +422,6 @@ class DuckDB(Dialect):
             "TO_TIMESTAMP": exp.UnixToTime.from_arg_list,
             "UNNEST": exp.Explode.from_arg_list,
             "XOR": binary_from_function(exp.BitwiseXor),
-            "GENERATE_SERIES": _build_generate_series(),
-            "RANGE": _build_generate_series(end_exclusive=True),
-            "EDITDIST3": exp.Levenshtein.from_arg_list,
         }
 
         FUNCTIONS.pop("DATE_SUB")

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -865,6 +865,7 @@ LANGUAGE js AS
                 "presto": "SHA256(x)",
                 "trino": "SHA256(x)",
                 "postgres": "SHA256(x)",
+                "duckdb": "SHA256(x)",
             },
             write={
                 "bigquery": "SHA256(x)",
@@ -875,6 +876,7 @@ LANGUAGE js AS
                 "redshift": "SHA2(x, 256)",
                 "trino": "SHA256(x)",
                 "duckdb": "SHA256(x)",
+                "snowflake": "SHA2(x, 256)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4815

The diffs besides `SHA256` are to ab-sort the dict. After this PR:

```python3
>>> sqlglot.parse_one("SHA256(x)", dialect="duckdb").sql("snowflake")
'SHA2(x, 256)'
```


Docs
----------
[DuckDB](https://duckdb.org/docs/stable/sql/functions/utility.html#sha256value) |  [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/sha2#syntax)