### PR TITLE
feat(oracle): add FORCE property

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -153,6 +153,7 @@ class Oracle(Dialect):
             and self.expression(exp.TemporaryProperty, this="GLOBAL"),
             "PRIVATE": lambda self: self._match_text_seq("TEMPORARY")
             and self.expression(exp.TemporaryProperty, this="PRIVATE"),
+            "FORCE": lambda self: self.expression(exp.ForceProperty, this="FORCE"),
         }
 
         QUERY_MODIFIER_PARSERS = {
@@ -319,11 +320,13 @@ class Oracle(Dialect):
             exp.Unicode: lambda self, e: f"ASCII(UNISTR({self.sql(e.this)}))",
             exp.UnixToTime: lambda self,
             e: f"TO_DATE('1970-01-01', 'YYYY-MM-DD') + ({self.sql(e, 'this')} / 86400)",
+            exp.ForceProperty: lambda self, e: self.sql(e, "this"),
         }
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
+            exp.ForceProperty: exp.Properties.Location.POST_CREATE,
         }
 
         def currenttimestamp_sql(self, expression: exp.CurrentTimestamp) -> str:

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -153,7 +153,7 @@ class Oracle(Dialect):
             and self.expression(exp.TemporaryProperty, this="GLOBAL"),
             "PRIVATE": lambda self: self._match_text_seq("TEMPORARY")
             and self.expression(exp.TemporaryProperty, this="PRIVATE"),
-            "FORCE": lambda self: self.expression(exp.ForceProperty, this="FORCE"),
+            "FORCE": lambda self: self.expression(exp.ForceProperty),
         }
 
         QUERY_MODIFIER_PARSERS = {
@@ -320,13 +320,11 @@ class Oracle(Dialect):
             exp.Unicode: lambda self, e: f"ASCII(UNISTR({self.sql(e.this)}))",
             exp.UnixToTime: lambda self,
             e: f"TO_DATE('1970-01-01', 'YYYY-MM-DD') + ({self.sql(e, 'this')} / 86400)",
-            exp.ForceProperty: lambda self, e: self.sql(e, "this"),
         }
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
-            exp.ForceProperty: exp.Properties.Location.POST_CREATE,
         }
 
         def currenttimestamp_sql(self, expression: exp.CurrentTimestamp) -> str:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3094,7 +3094,7 @@ class IncludeProperty(Property):
 
 
 class ForceProperty(Property):
-    arg_types = {"this": True}
+    arg_types = {}
 
 
 class Properties(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3093,6 +3093,10 @@ class IncludeProperty(Property):
     arg_types = {"this": True, "alias": False, "column_def": False}
 
 
+class ForceProperty(Property):
+    arg_types = {"this": True}
+
+
 class Properties(Expression):
     arg_types = {"expressions": True}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -210,6 +210,7 @@ class Generator(metaclass=_Generator):
         exp.WithProcedureOptions: lambda self, e: f"WITH {self.expressions(e, flat=True)}",
         exp.WithSchemaBindingProperty: lambda self, e: f"WITH SCHEMA {self.sql(e, 'this')}",
         exp.WithOperator: lambda self, e: f"{self.sql(e, 'this')} WITH {self.sql(e, 'op')}",
+        exp.ForceProperty: lambda *_: "FORCE",
     }
 
     # Whether null ordering is supported in order by
@@ -600,6 +601,7 @@ class Generator(metaclass=_Generator):
         exp.WithProcedureOptions: exp.Properties.Location.POST_SCHEMA,
         exp.WithSchemaBindingProperty: exp.Properties.Location.POST_SCHEMA,
         exp.WithSystemVersioningProperty: exp.Properties.Location.POST_SCHEMA,
+        exp.ForceProperty: exp.Properties.Location.POST_CREATE,
     }
 
     # Keywords that can't be used as unquoted identifier names

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -319,7 +319,6 @@ class TestOracle(Validator):
                 "tsql": "SELECT * FROM t ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
             },
         )
-        self.validate_identity("SELECT 1 AS FORCE")
         self.validate_identity("CREATE OR REPLACE FORCE VIEW foo1.foo2")
 
     def test_join_marker(self):

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -319,6 +319,8 @@ class TestOracle(Validator):
                 "tsql": "SELECT * FROM t ORDER BY (SELECT NULL) OFFSET 0 ROWS FETCH FIRST 10 ROWS ONLY",
             },
         )
+        self.validate_identity("SELECT 1 AS FORCE")
+        self.validate_identity("CREATE OR REPLACE FORCE VIEW foo1.foo2")
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")


### PR DESCRIPTION
Fixes #4826

Add support for the `FORCE` property, when creating a view in Oracle. 

**DOCS**
[Oracle FORCE](https://docs.oracle.com/cd/B13789_01/server.101/b10759/statements_8004.htm)