### PR TITLE
fix(postgres): Fix arrow extraction for string keys representing numbers

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1651,7 +1651,7 @@ def build_json_extract_path(
                 return expr_type.from_arg_list(args)
 
             text = arg.name
-            if is_int(text):
+            if is_int(text) and (not arrow_req_json_type or not arg.is_string):
                 index = int(text)
                 segments.append(
                     exp.JSONPathSubscript(this=index if zero_based_indexing else index - 1)


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4840

Before this PR, SQLGlot would parse the following query as a JSON path subscript:

```Python3
>>> ast = sqlglot.parse_one("SELECT foo ->> '1'", dialect="postgres")
>>> ast
Select(
  expressions=[
    JSONExtractScalar(
      this=Column(
        this=Identifier(this=foo, quoted=False)),
      expression=JSONPath(
        expressions=[
          JSONPathRoot(),
          JSONPathSubscript(this=1)]),
      only_json_types=True)])
>>> ast.sql("postgres")
'SELECT foo ->> 1'
```

Note that this alters the semantics since `'1'` was a string (key) roundtripped into an integer:

```SQL
postgres> WITH tbl AS (SELECT '{"1":"b"}'::jsonb as col) SELECT col ->> '1' FROM tbl;
 ?column?
----------
 b


postgres> WITH tbl AS (SELECT '{"1":"b"}'::jsonb as col) SELECT col ->> 1 FROM tbl;
 ?column?
----------


```

However, in the following scenarios it actually is a subscript:

```SQL
# Arrow operator with a literal integer
postgres> select CAST('[1,2,3]' AS JSON) ->> 1;
 ?column?
----------
 2


# Function-based extraction with literal string as the subscript index
postgres> SELECT JSON_EXTRACT_PATH_TEXT('{"farm": ["a", "b", "c"]}', 'farm', '0');
 json_extract_path_text
------------------------
 a

```

<br />


This PR fixes `dialect.py::build_json_extract_path` such that the RHS will be parsed in:
- A `JSONPathSubscript`, if it's a literal int following an arrow op **or** a literal string in the function repr
- A `JSONPathKey`, if it's a literal string following an arrow op

Docs
--------
[Postgres JSON Functions](https://www.postgresql.org/docs/9.3/functions-json.html)