### PR TITLE
fix(snowflake): add support for HEX_DECODE_BINARY

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -666,6 +666,7 @@ class DuckDB(Dialect):
                 exp.cast(e.expression, exp.DataType.Type.TIMESTAMP),
                 exp.cast(e.this, exp.DataType.Type.TIMESTAMP),
             ),
+            exp.Unhex: rename_func("FROM_HEX"),
             exp.UnixToStr: lambda self, e: self.func(
                 "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)
             ),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -666,7 +666,6 @@ class DuckDB(Dialect):
                 exp.cast(e.expression, exp.DataType.Type.TIMESTAMP),
                 exp.cast(e.this, exp.DataType.Type.TIMESTAMP),
             ),
-            exp.Unhex: rename_func("FROM_HEX"),
             exp.UnixToStr: lambda self, e: self.func(
                 "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)
             ),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -431,6 +431,7 @@ class Snowflake(Dialect):
                 this=seq_get(args, 0), expression=seq_get(args, 1), max_dist=seq_get(args, 2)
             ),
             "FLATTEN": exp.Explode.from_arg_list,
+            "FROM_HEX_BINARY": exp.Unhex.from_arg_list,
             "GET_PATH": lambda args, dialect: exp.JSONExtract(
                 this=seq_get(args, 0), expression=dialect.to_json_path(seq_get(args, 1))
             ),
@@ -1030,6 +1031,7 @@ class Snowflake(Dialect):
             exp.TsOrDsToTime: lambda self, e: self.func(
                 "TRY_TO_TIME" if e.args.get("safe") else "TO_TIME", e.this, self.format_time(e)
             ),
+            exp.Unhex: rename_func("FROM_HEX_BINARY"),
             exp.UnixToTime: rename_func("TO_TIMESTAMP"),
             exp.Uuid: rename_func("UUID_STRING"),
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -431,7 +431,7 @@ class Snowflake(Dialect):
                 this=seq_get(args, 0), expression=seq_get(args, 1), max_dist=seq_get(args, 2)
             ),
             "FLATTEN": exp.Explode.from_arg_list,
-            "FROM_HEX_BINARY": exp.Unhex.from_arg_list,
+            "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
             "GET_PATH": lambda args, dialect: exp.JSONExtract(
                 this=seq_get(args, 0), expression=dialect.to_json_path(seq_get(args, 1))
             ),
@@ -1031,7 +1031,7 @@ class Snowflake(Dialect):
             exp.TsOrDsToTime: lambda self, e: self.func(
                 "TRY_TO_TIME" if e.args.get("safe") else "TO_TIME", e.this, self.format_time(e)
             ),
-            exp.Unhex: rename_func("FROM_HEX_BINARY"),
+            exp.Unhex: rename_func("HEX_DECODE_BINARY"),
             exp.UnixToTime: rename_func("TO_TIMESTAMP"),
             exp.Uuid: rename_func("UUID_STRING"),
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -431,10 +431,10 @@ class Snowflake(Dialect):
                 this=seq_get(args, 0), expression=seq_get(args, 1), max_dist=seq_get(args, 2)
             ),
             "FLATTEN": exp.Explode.from_arg_list,
-            "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
             "GET_PATH": lambda args, dialect: exp.JSONExtract(
                 this=seq_get(args, 0), expression=dialect.to_json_path(seq_get(args, 1))
             ),
+            "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
             "IFF": exp.If.from_arg_list,
             "LAST_DAY": lambda args: exp.LastDay(
                 this=seq_get(args, 0), unit=map_date_part(seq_get(args, 1))

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -998,6 +998,15 @@ class TestSnowflake(Validator):
 
         self.validate_identity("CREATE TABLE t (id INT PRIMARY KEY AUTOINCREMENT)")
 
+        self.validate_all(
+            "SELECT FROM_HEX_BINARY('65')",
+            write={
+                "bigquery": "SELECT FROM_HEX('65')",
+                "duckdb": "SELECT FROM_HEX('65')",
+                "snowflake": "SELECT FROM_HEX_BINARY('65')",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -999,11 +999,11 @@ class TestSnowflake(Validator):
         self.validate_identity("CREATE TABLE t (id INT PRIMARY KEY AUTOINCREMENT)")
 
         self.validate_all(
-            "SELECT FROM_HEX_BINARY('65')",
+            "SELECT HEX_DECODE_BINARY('65')",
             write={
                 "bigquery": "SELECT FROM_HEX('65')",
                 "duckdb": "SELECT FROM_HEX('65')",
-                "snowflake": "SELECT FROM_HEX_BINARY('65')",
+                "snowflake": "SELECT HEX_DECODE_BINARY('65')",
             },
         )
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1002,7 +1002,7 @@ class TestSnowflake(Validator):
             "SELECT HEX_DECODE_BINARY('65')",
             write={
                 "bigquery": "SELECT FROM_HEX('65')",
-                "duckdb": "SELECT FROM_HEX('65')",
+                "duckdb": "SELECT UNHEX('65')",
                 "snowflake": "SELECT HEX_DECODE_BINARY('65')",
             },
         )


### PR DESCRIPTION
The [HEX_DECODE_BINARY](https://docs.snowflake.com/en/sql-reference/functions/hex_decode_binary) function is equivalent to the `Unhex` function that is already supported by sqlglot. To support it, we just had to add the map in snowflake and add the transform in duckdb.

Partially solves #4852, we still need to add support for `HEX_DECODE_STRING`.

Testing:
Duckdb ([playground](https://codapi.org/embed/?sandbox=duckdb&code=data%3A%3Bbase64%2CK07NSU0uUeBKK8rPjc9IrdBQNzNV19RRKKksSM1P00AV1tThSklNzk9JxRCHqccuranDVZqHaTiSGMJkZEEA))

<img width="1506" alt="Screenshot 2025-03-07 at 6 40 35 PM" src="https://github.com/user-attachments/assets/0b7b36ae-5f4b-4010-84fb-1c544cd988db" />

Bigquery
(Note that Bigquery outputs binary data (bytes) in base64)
<img width="758" alt="Screenshot 2025-03-07 at 6 23 06 PM" src="https://github.com/user-attachments/assets/e096d009-54d1-4713-aeaf-e81dd84bbacf" />

Snowflake
(Note that Snowflake outputs binary data in hex format)
<img width="1175" alt="Screenshot 2025-03-07 at 6 34 53 PM" src="https://github.com/user-attachments/assets/b04997f9-a104-48e5-8ffb-c2022093e9f1" />

