### PR TITLE
Chore!: Introduce pyproject.toml and switch to packaging via build

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Create a virtual environment
       run: |
         python -m venv .venv

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -29,8 +29,4 @@ jobs:
     - name: Run checks (linter, code style, tests)
       run: |
         source ./.venv/bin/activate
-        if [[ ${{ matrix.python-version }} == "3.7" ]]; then
-          make test test-rs
-        else
-          make check
-        fi
+        make check

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -55,13 +55,13 @@ jobs:
     - uses: actions/setup-python@v5
       if: matrix.os == 'windows'
       with:
-        python-version: '3.7'
+        python-version: '3.8'
         architecture: ${{ matrix.python-architecture || 'x64' }}
     - name: Build wheels
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        args: --release --out dist --interpreter 3.7 3.8 3.9 3.10 3.11 3.12 3.13
+        args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12 3.13
         sccache: 'true'
         manylinux: auto
         working-directory: ./sqlglotrs

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -122,7 +122,7 @@ jobs:
         python -m venv .venv
         source ./.venv/bin/activate
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build twine
         make install-dev
     - name: Build and publish
       env:
@@ -130,7 +130,7 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
       run: |
         source ./.venv/bin/activate
-        python setup.py sdist bdist_wheel
+        python -m build
         twine upload dist/*
     - name: Update API docs
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,7 @@ celerybeat.pid
 .venv
 env/
 venv/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "An easily customizable SQL parser and transpiler"
 readme = "README.md"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
 license = { file = "LICENSE" }
-requires-python = ">= 3.7"
+requires-python = ">= 3.8"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,41 @@
+[project]
+name = "sqlglot"
+dynamic = ["version", "optional-dependencies"]
+description = "An easily customizable SQL parser and transpiler"
+readme = "README.md"
+authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
+license = { file = "LICENSE" }
+requires-python = ">= 3.7"
+classifiers=[
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: SQL",
+    "Programming Language :: Python :: 3 :: Only",
+]
+
+[project.urls]
+Homepage = "https://sqlglot.com/"
+Documentation = "https://sqlglot.com/sqlglot.html"
+Repository = "https://github.com/tobymao/sqlglot"
+Issues = "https://github.com/tobymao/sqlglot/issues"
+
+[build-system]
+requires = ["setuptools >= 61.0", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+include-package-data = false
+
+[tool.setuptools_scm]
+version_file = "sqlglot/_version.py"
+fallback_version = "0.0.0"
+local_scheme = "no-local-version"
+
+[tool.setuptools.packages.find]
+include=["sqlglot", "sqlglot.*"]
+
+[tool.setuptools.package-data]
+"*" = ["py.typed"]

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import find_packages, setup
+from setuptools import setup
 
 
 def sqlglotrs_version():
@@ -9,24 +9,11 @@ def sqlglotrs_version():
     raise ValueError("Could not find version in Cargo.toml")
 
 
+# Everything is defined in pyproject.toml except the extras because for the [rs] extra we need to dynamically
+# read the sqlglotrs version. [dev] has to be specified here as well because you cant specify some extras groups
+# dynamically and others statically, it has to be either all dynamic or all static
+# ref: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata
 setup(
-    name="sqlglot",
-    description="An easily customizable SQL parser and transpiler",
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/tobymao/sqlglot",
-    author="Toby Mao",
-    author_email="toby.mao@gmail.com",
-    license="MIT",
-    packages=find_packages(include=["sqlglot", "sqlglot.*"]),
-    package_data={"sqlglot": ["py.typed"]},
-    use_scm_version={
-        "write_to": "sqlglot/_version.py",
-        "fallback_version": "0.0.0",
-        "local_scheme": "no-local-version",
-    },
-    setup_requires=["setuptools_scm"],
-    python_requires=">=3.7",
     extras_require={
         "dev": [
             "duckdb>=0.6",
@@ -45,13 +32,4 @@ setup(
         ],
         "rs": [f"sqlglotrs=={sqlglotrs_version()}"],
     },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: SQL",
-        "Programming Language :: Python :: 3 :: Only",
-    ],
 )

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -410,8 +410,7 @@ class Expression(metaclass=_Expression):
 
     def iter_expressions(self, reverse: bool = False) -> t.Iterator[Expression]:
         """Yields the key and expression for all arguments, exploding list args."""
-        # remove tuple when python 3.7 is deprecated
-        for vs in reversed(tuple(self.args.values())) if reverse else self.args.values():  # type: ignore
+        for vs in reversed(self.args.values()) if reverse else self.args.values():  # type: ignore
             if type(vs) is list:
                 for v in reversed(vs) if reverse else vs:  # type: ignore
                     if hasattr(v, "parent"):

--- a/sqlglotrs/pyproject.toml
+++ b/sqlglotrs/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "sqlglotrs"
 description = "An easily customizable SQL parser and transpiler"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
This moves the bulk of the `setup.py` declarations to `pyproject.toml` and builds packages using `python -m build` instead of invoking setuptools directly.

Note that this just affects Python sqlglot, sqlglot-rs already uses `pyproject.toml` and has a build process based on maturin.

I checked that the wheel and sdist files produced by `python -m build` contained the same files as before, in particular the `py.typed` marker and a correct `extras` declaration for `[rs]` with the version parsed from Cargo.toml