### PR TITLE
fix(snowflake)!: support TO_CHAR to duckdb STRFTIME

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1858,7 +1858,7 @@ def groupconcat_sql(
     return self.sql(listagg)
 
 
-def build_timetostr_or_tochar(args: t.List) -> exp.TimeToStr | exp.ToChar:
+def build_timetostr_or_tochar(args: t.List, dialect: Dialect) -> exp.TimeToStr | exp.ToChar:
     this = seq_get(args, 0)
 
     if this and not this.type:
@@ -1866,6 +1866,7 @@ def build_timetostr_or_tochar(args: t.List) -> exp.TimeToStr | exp.ToChar:
 
         annotate_types(this)
         if this.is_type(*exp.DataType.TEMPORAL_TYPES):
-            return build_formatted_time(exp.TimeToStr, "oracle", default=True)(args)
+            dialect_name = dialect.__class__.__name__.lower()
+            return build_formatted_time(exp.TimeToStr, dialect_name, default=True)(args)
 
     return exp.ToChar.from_arg_list(args)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1856,3 +1856,16 @@ def groupconcat_sql(
             listagg.set("expressions", [f"{args}{self.sql(expression=expression.this)}"])
 
     return self.sql(listagg)
+
+
+def build_timetostr_or_tochar(args: t.List) -> exp.TimeToStr | exp.ToChar:
+    this = seq_get(args, 0)
+
+    if this and not this.type:
+        from sqlglot.optimizer.annotate_types import annotate_types
+
+        annotate_types(this)
+        if this.is_type(*exp.DataType.TEMPORAL_TYPES):
+            return build_formatted_time(exp.TimeToStr, "oracle", default=True)(args)
+
+    return exp.ToChar.from_arg_list(args)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -6,6 +6,7 @@ from sqlglot import exp, generator, jsonpath, parser, tokens, transforms
 from sqlglot.dialects.dialect import (
     Dialect,
     NormalizationStrategy,
+    build_timetostr_or_tochar,
     binary_from_function,
     build_default_decimal_type,
     build_timestamp_from_parts,
@@ -463,6 +464,7 @@ class Snowflake(Dialect):
             "TRY_TO_TIMESTAMP": _build_datetime(
                 "TRY_TO_TIMESTAMP", exp.DataType.Type.TIMESTAMP, safe=True
             ),
+            "TO_CHAR": build_timetostr_or_tochar,
             "TO_DATE": _build_datetime("TO_DATE", exp.DataType.Type.DATE),
             "TO_NUMBER": lambda args: exp.ToNumber(
                 this=seq_get(args, 0),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -588,6 +588,16 @@ class TestSnowflake(Validator):
                 "teradata": "TO_CHAR(x, y)",
             },
         )
+        self.validate_identity(
+            "TO_CHAR(foo::DATE, 'yyyy')", "TO_CHAR(CAST(CAST(foo AS DATE) AS TIMESTAMP), 'yyyy')"
+        )
+        self.validate_all(
+            "TO_CHAR(foo::TIMESTAMP, 'YYYY-MM')",
+            write={
+                "snowflake": "TO_CHAR(CAST(foo AS TIMESTAMP), 'yyyy-mm')",
+                "duckdb": "STRFTIME(CAST(foo AS TIMESTAMP), '%Y-%m')",
+            },
+        )
         self.validate_all(
             "SQUARE(x)",
             write={


### PR DESCRIPTION
Fixes #4857

Add support for the transpilation of `TO_CHAR` of snowflake to duckdb's `STRFTIME`.

**DOCS**
[Snowflake TO_CHAR](https://docs.snowflake.com/en/sql-reference/functions/to_char) | [DuckDB STRFTIME](https://duckdb.org/docs/stable/sql/functions/dateformat.html)