### PR TITLE
Add a query provider to the expand function, enabling lazy loading of queries during AST transformations.

### DIFF
--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -282,9 +282,7 @@ class TestExpressions(unittest.TestCase):
     def test_expand_with_lazy_source_provider(self):
         class DynamicSourceProvider:
             def __init__(self, dialect: str = "spark"):
-                self._sources = {
-                    normalize_table_name("`a-b`.`c`",dialect): "select 1"
-                }
+                self._sources = {normalize_table_name("`a-b`.`c`", dialect): "select 1"}
 
             def get(self, name: str) -> t.Optional[Query]:
                 query_sql = self._sources.get(name)
@@ -294,17 +292,14 @@ class TestExpressions(unittest.TestCase):
 
         dynamic_source_provider = DynamicSourceProvider()
 
-        get_source = lambda name: dynamic_source_provider.get(name)
-
         self.assertEqual(
-                exp.expand(
-                    parse_one('select * from "a-b"."C" AS a'),
-                    get_source,
-                    dialect="spark",
-                ).sql(),
-                "SELECT * FROM (SELECT 1) AS a /* source: a-b.c */",
-            )
-
+            exp.expand(
+                parse_one('select * from "a-b"."C" AS a'),
+                lambda name: dynamic_source_provider.get(name),
+                dialect="spark",
+            ).sql(),
+            "SELECT * FROM (SELECT 1) AS a /* source: a-b.c */",
+        )
 
     def test_replace_placeholders(self):
         self.assertEqual(


### PR DESCRIPTION
## PR Description

This PR introduces lazy query resolution to the exp.expand function, significantly enhancing its efficiency and flexibility. Previously, expanding a query required a complete dictionary of all possible source queries upfront, which could be inefficient for large datasets with thousands of views. This approach necessitated either prior knowledge of all referenced tables or a costly recursive traversal to gather them, leading to unnecessary parsing overhead when only a subset of queries needed expansion.

---
### With this update:

Queries can now be resolved on demand, eliminating the need for pre-parsing all queries and improving performance.

A new abstract class, QueryProvider, has been added to define a standardized interface for retrieving queries by name.

A default implementation ensures backward compatibility with existing functionality.

This enhancement optimizes query expansion workflows, particularly for large-scale datasets, by reducing unnecessary computations and improving scalability.