### PR TITLE
fix: expand util - align normalization behaviour with lazy and non-lazy source providers.

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8519,9 +8519,7 @@ def expand(
     Returns:
         The transformed expression.
     """
-    normalized_sources = {
-        normalize_table_name(k, dialect=dialect): v for k, v in sources.items()
-    }
+    normalized_sources = {normalize_table_name(k, dialect=dialect): v for k, v in sources.items()}
     # Create a query provider based on the sources parameter
 
     def _expand(node: Expression):

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -277,7 +277,6 @@ class TestExpressions(unittest.TestCase):
             "SELECT * FROM (SELECT 1) AS a /* source: a-b.c */",
         )
 
-
     def test_expand_with_lazy_source_provider(self):
         self.assertEqual(
             exp.expand(
@@ -287,7 +286,6 @@ class TestExpressions(unittest.TestCase):
             ).sql(),
             "SELECT * FROM (SELECT 1) AS a /* source: a-b.c */",
         )
-
 
     def test_replace_placeholders(self):
         self.assertEqual(

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,11 +1,9 @@
-import sys
 import datetime
 import math
-import typing as t
+import sys
 import unittest
 
 from sqlglot import ParseError, alias, exp, parse_one
-from sqlglot.expressions import Query, normalize_table_name
 
 
 class TestExpressions(unittest.TestCase):
@@ -279,27 +277,17 @@ class TestExpressions(unittest.TestCase):
             "SELECT * FROM (SELECT 1) AS a /* source: a-b.c */",
         )
 
+
     def test_expand_with_lazy_source_provider(self):
-        class DynamicSourceProvider:
-            def __init__(self, dialect: str = "spark"):
-                self._sources = {normalize_table_name("`a-b`.`c`", dialect): "select 1"}
-
-            def get(self, name: str) -> t.Optional[Query]:
-                query_sql = self._sources.get(name)
-
-                if query_sql:
-                    return parse_one(query_sql)
-
-        dynamic_source_provider = DynamicSourceProvider()
-
         self.assertEqual(
             exp.expand(
                 parse_one('select * from "a-b"."C" AS a'),
-                lambda name: dynamic_source_provider.get(name),
+                {"`a-b`.c": lambda: parse_one("select 1", dialect="spark")},
                 dialect="spark",
             ).sql(),
             "SELECT * FROM (SELECT 1) AS a /* source: a-b.c */",
         )
+
 
     def test_replace_placeholders(self):
         self.assertEqual(
@@ -862,6 +850,7 @@ class TestExpressions(unittest.TestCase):
 
     def test_convert(self):
         from collections import namedtuple
+
         import pytz
 
         PointTuple = namedtuple("Point", ["x", "y"])


### PR DESCRIPTION
This is a fix to the nice new feature added in [#4872 ](https://github.com/tobymao/sqlglot/pull/4872).

The issue is that in the way it is implemented, there was an inconsistency if passing sources a `Callable` or a string.

For strings, normalization happens by the `expand` function. For callables, it doesn't. So for example the following calls would have different results.

It's expected for the same name to be resolved to the same query, so normalization should be consistent regardless of lazy parsing.

I changed the implementation a bit so that it is back to only accepting a dict, but values are allowed to be callables with no arguments. This makes the handling of lazy and non-lazy `Query` objects almost identical.

running this:
```Python
expand(parse_one("""select * from "a-b"."C" AS a""", read="spark"), sources={'`a-b`.c': parse_one("select 1")}, dialect="spark").sql()
```

returns:
`'SELECT * FROM (SELECT 1) AS a /* source: a-b.c */'`

But running this:
```Python
def resolve(name: str):
    if name == "`a-b`.c":
        return parse_one("select 1")
    return None

expand(parse_one("""select * from "a-b"."C" AS a""", read="spark"), sources=resolve, dialect="spark").sql()
```

returns:
`'SELECT * FROM "a-b"."C" AS a'`


In this PR usage for lazy is more similar to non lazy. Instead of this:
```Python
def resolve(name: str):
    if name == "`a-b`.c":
        return parse_one("select 1")
    if n == "other-table":
        return parse_one("select 2")
    return None

expand(parse_one("""select * from "a-b"."C" AS a""", read="spark"), sources=resolve, dialect="spark").sql()
```

The interface will be this, which I think is very similar to the non-lazy version (though this part is optional, let me know if you prefer I retained the previous API. Consistent normalization is more important):

```Python
sources = {
    "`a-b`.c": lambda: parse_one("select 1"),
    "other-table": lambda: parse_one("select 2")
}

expand(parse_one("""select * from "a-b"."C" AS a""", read="spark"), sources=sources, dialect="spark").sql()
```




