### PR TITLE
fix(hive)!: support STRUCT(*) and MAP(*)

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -446,7 +446,7 @@ class Hive(Dialect):
             return self.expression(exp.Parameter, this=this, expression=expression)
 
         def _to_prop_eq(self, expression: exp.Expression, index: int) -> exp.Expression:
-            if isinstance(expression, exp.Star):
+            if expression.is_star:
                 return expression
 
             if isinstance(expression, exp.Column):

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -446,6 +446,9 @@ class Hive(Dialect):
             return self.expression(exp.Parameter, this=this, expression=expression)
 
         def _to_prop_eq(self, expression: exp.Expression, index: int) -> exp.Expression:
+            if isinstance(expression, exp.Star):
+                return expression
+
             if isinstance(expression, exp.Column):
                 key = expression.this
             else:
@@ -577,6 +580,7 @@ class Hive(Dialect):
             exp.StrToTime: _str_to_time_sql,
             exp.StrToUnix: _str_to_unix_sql,
             exp.StructExtract: struct_extract_sql,
+            exp.StarMap: rename_func("MAP"),
             exp.Table: transforms.preprocess([transforms.unnest_generate_series]),
             exp.TimeStrToDate: rename_func("TO_DATE"),
             exp.TimeStrToTime: timestrtotime_sql,

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -810,6 +810,21 @@ class TestHive(Validator):
 
         self.validate_identity("SELECT 1_2")
 
+        self.validate_all(
+            "SELECT MAP(*), STRUCT(*) FROM t",
+            read={
+                "hive": "SELECT MAP(*), STRUCT(*) FROM t",
+                "spark2": "SELECT MAP(*), STRUCT(*) FROM t",
+                "spark": "SELECT MAP(*), STRUCT(*) FROM t",
+                "databricks": "SELECT MAP(*), STRUCT(*) FROM t",
+            },
+            write={
+                "spark2": "SELECT MAP(*), STRUCT(*) FROM t",
+                "spark": "SELECT MAP(*), STRUCT(*) FROM t",
+                "databricks": "SELECT MAP(*), STRUCT(*) FROM t",
+            },
+        )
+
     def test_escapes(self) -> None:
         self.validate_identity("'\n'", "'\\n'")
         self.validate_identity("'\\n'")


### PR DESCRIPTION
Fixes #4871

This PR adds support for `STRUCT(*)` and `MAP(*)` for hive, spark, spark2, databricks dialects. 