### PR TITLE
Fix(redshift)!: turn off multi-arg coalesce simplification

### DIFF
--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -843,6 +843,10 @@ x;
 COALESCE(x, 1) = 2;
 NOT x IS NULL AND x = 2;
 
+# dialect: redshift
+COALESCE(x, 1) = 2;
+COALESCE(x, 1) = 2;
+
 2 = COALESCE(x, 1);
 NOT x IS NULL AND x = 2;
 


### PR DESCRIPTION
Motivated by the following behavior in Redshift. Turning `COALESCE(x, 1) = 2` into `NOT x IS NULL AND x = 2` can lead to different results.

![image](https://github.com/user-attachments/assets/6384aeaf-4631-40f8-aa19-bea89e156b01)
