### PR TITLE
fix!(tsql): support select...into #temp_table syntax

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1176,7 +1176,8 @@ class TSQL(Dialect):
                 properties = expression.args.get("properties")
                 is_temp = any(
                     isinstance(prop, exp.TemporaryProperty)
-                    for prop in (properties.expressions if properties else []))
+                    for prop in (properties.expressions if properties else [])
+                )
 
                 select_into = exp.select("*").from_(exp.alias_(ctas_expression, "temp", table=True))
                 select_into.set("into", exp.Into(this=table, temporary=is_temp))

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -133,13 +133,26 @@ class TestTSQL(Validator):
             },
         )
         self.validate_all(
-            "WITH t(c) AS (SELECT 1) SELECT * INTO TEMP UNLOGGED foo FROM (SELECT c AS c FROM t) AS temp",
+            "WITH t(c) AS (SELECT 1) SELECT * INTO UNLOGGED #foo FROM (SELECT c AS c FROM t) AS temp",
             write={
                 "duckdb": "CREATE TEMPORARY TABLE foo AS WITH t(c) AS (SELECT 1) SELECT * FROM (SELECT c AS c FROM t) AS temp",
                 "postgres": "WITH t(c) AS (SELECT 1) SELECT * INTO TEMPORARY foo FROM (SELECT c AS c FROM t) AS temp",
             },
         )
         self.validate_all(
+            "WITH t(c) AS (SELECT 1) SELECT c INTO #foo FROM t",
+            read={
+                "tsql": "WITH t(c) AS (SELECT 1) SELECT c INTO #foo FROM t",
+                "postgres": "WITH t(c) AS (SELECT 1) SELECT c INTO TEMPORARY foo FROM t",
+            },
+            write={
+                "tsql": "WITH t(c) AS (SELECT 1) SELECT c INTO #foo FROM t",
+                "postgres": "WITH t(c) AS (SELECT 1) SELECT c INTO TEMPORARY foo FROM t",
+                "duckdb": "CREATE TEMPORARY TABLE foo AS WITH t(c) AS (SELECT 1) SELECT c FROM t",
+                "snowflake": "CREATE TEMPORARY TABLE foo AS WITH t(c) AS (SELECT 1) SELECT c FROM t",
+            },
+        )
+        self.validate_all(
             "WITH t(c) AS (SELECT 1) SELECT * INTO UNLOGGED foo FROM (SELECT c AS c FROM t) AS temp",
             write={
                 "duckdb": "CREATE TABLE foo AS WITH t(c) AS (SELECT 1) SELECT * FROM (SELECT c AS c FROM t) AS temp",
@@ -149,6 +162,13 @@ class TestTSQL(Validator):
             "WITH t(c) AS (SELECT 1) SELECT * INTO UNLOGGED foo FROM (SELECT c AS c FROM t) AS temp",
             write={
                 "duckdb": "CREATE TABLE foo AS WITH t(c) AS (SELECT 1) SELECT * FROM (SELECT c AS c FROM t) AS temp",
+            },
+        )
+        self.validate_all(
+            "WITH y AS (SELECT 2 AS c) INSERT INTO #t SELECT * FROM y",
+            write={
+                "duckdb": "WITH y AS (SELECT 2 AS c) INSERT INTO t SELECT * FROM y",
+                "postgres": "WITH y AS (SELECT 2 AS c) INSERT INTO t SELECT * FROM y",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes support for creating temporary tables as select statements in T-SQL. The syntax is the same as selecting into a physical table, except that T-SQL uses a `#` symbol to denote a temp table, and a `##` to denote a global temp table.

This commit will slightly change the AST representation of the query, such that the `Table` expression is marked as `temporary` rather than its `Identifier` expression. This seems to be consistent with other dialects that support `select...into` syntax, e.g. postgres.

Here's a basic example:
```python
>>> sqlglot.parse_one("SELECT 1 INTO #foo", dialect="tsql")

# Before change
Select(
  expressions=[
    Literal(this=1, is_string=False)],
  into=Into(
    this=Table(
      this=Identifier(this=FOO, quoted=False, temporary=True))))

# After change
Select(
  expressions=[
    Literal(this=1, is_string=False)],
  into=Into(
    this=Table(
      this=Identifier(this=foo, quoted=False)),
    temporary=True))
```

This is consistent with Postgres:
```python
>>> sqlglot.parse_one("SELECT 1 INTO TEMPORARY foo", dialect="postgres")

Select(
  expressions=[
    Literal(this=1, is_string=False)],
  into=Into(
    this=Table(
      this=Identifier(this=foo, quoted=False)),
    temporary=True))
```

All tests pass, and new tests were added to ensure functionality remains consistent.  One test was updated to conform with expected T-SQL syntax.

I have a few additional thoughts/notes that I will outline in some targeted reviews in the diff.

Related PRs:
#1688
#1958
#2237
