### PR TITLE
fix(databricks)!: Preserve PARSE_JSON()

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -61,6 +61,7 @@ class Databricks(Spark):
         COPY_PARAMS_EQ_REQUIRED = True
         JSON_PATH_SINGLE_QUOTE_ESCAPE = False
         QUOTE_JSON_PATH = False
+        PARSE_JSON_NAME = "PARSE_JSON"
 
         TRANSFORMS = {
             **Spark.Generator.TRANSFORMS,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -469,7 +469,7 @@ class Hive(Dialect):
         JSON_PATH_SINGLE_QUOTE_ESCAPE = True
         SUPPORTS_TO_NUMBER = False
         WITH_PROPERTIES_PREFIX = "TBLPROPERTIES"
-        PARSE_JSON_NAME = None
+        PARSE_JSON_NAME: t.Optional[str] = None
         PAD_FILL_PATTERN_IS_REQUIRED = True
         SUPPORTS_MEDIAN = False
         ARRAY_SIZE_NAME = "SIZE"

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -50,6 +50,7 @@ class TestDatabricks(Validator):
         self.validate_identity(
             "COPY INTO target FROM `s3://link` FILEFORMAT = AVRO VALIDATE = ALL FILES = ('file1', 'file2') FORMAT_OPTIONS ('opt1'='true', 'opt2'='test') COPY_OPTIONS ('mergeSchema'='true')"
         )
+        self.validate_identity("SELECT PARSE_JSON('{}')")
         self.validate_identity(
             "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(foo, 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t",
             "SELECT DATE_FORMAT(CAST(FROM_UTC_TIMESTAMP(CAST(foo AS TIMESTAMP), 'America/Los_Angeles') AS TIMESTAMP), 'yyyy-MM-dd HH:mm:ss') AS foo FROM t",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -394,7 +394,7 @@ class TestSnowflake(Validator):
             """SELECT PARSE_JSON('{"fruit":"banana"}'):fruit""",
             write={
                 "bigquery": """SELECT JSON_EXTRACT(PARSE_JSON('{"fruit":"banana"}'), '$.fruit')""",
-                "databricks": """SELECT '{"fruit":"banana"}':fruit""",
+                "databricks": """SELECT PARSE_JSON('{"fruit":"banana"}'):fruit""",
                 "duckdb": """SELECT JSON('{"fruit":"banana"}') -> '$.fruit'""",
                 "mysql": """SELECT JSON_EXTRACT('{"fruit":"banana"}', '$.fruit')""",
                 "presto": """SELECT JSON_EXTRACT(JSON_PARSE('{"fruit":"banana"}'), '$.fruit')""",


### PR DESCRIPTION
The difference being that `PARSE_JSON(foo)` yields `VARIANT` but `foo` is a `STRING`:

```SQL
SELECT 
 typeof(PARSE_JSON('{"fruit":"banana"}')) AS col1, 
 typeof('{"fruit":"banana"}') AS col2;

col1	col2
variant	string
```

```SQL
SELECT 
 typeof(PARSE_JSON('{"fruit":"banana"}'):fruit) AS col1, 
 typeof('{"fruit":"banana"}':fruit) AS col2;

col1	col2
variant	string
```