### PR TITLE
fix(Snowflake): quote identifiers in stage references

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -874,7 +874,12 @@ class Snowflake(Dialect):
             ):
                 parts.append(self._advance_any(ignore_reserved=True))
 
-            return exp.var("".join(part.text for part in parts if part))
+            part_texts = (
+                f'"{part.text}"' if part.token_type == TokenType.IDENTIFIER else part.text
+                for part in parts
+                if part
+            )
+            return exp.var("".join(part_texts))
 
         def _parse_lambda_arg(self) -> t.Optional[exp.Expression]:
             this = super()._parse_lambda_arg()

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1064,7 +1064,11 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT * FROM '@mystage'")
         self.validate_identity("SELECT * FROM @namespace.mystage/path/to/file.json.gz")
         self.validate_identity("SELECT * FROM @namespace.%table_name/path/to/file.json.gz")
+        self.validate_identity('SELECT * FROM @"mystage"')
+        self.validate_identity('SELECT * FROM @"myschema"."mystage"/file.gz')
+        self.validate_identity('SELECT * FROM @"my_DB"."schEMA1".mystage/file.gz')
         self.validate_identity("SELECT * FROM '@external/location' (FILE_FORMAT => 'path.to.csv')")
+        self.validate_identity('PUT \'file:///dir/tmp.csv\' @"my_DB"."schEMA1"."MYstage"')
         self.validate_identity("PUT file:///dir/tmp.csv @%table", check_command_warning=True)
         self.validate_identity("SELECT * FROM (SELECT a FROM @foo)")
         self.validate_identity(


### PR DESCRIPTION
Snowflake distinguishes between quoted/unquoted identifiers in stage names:
* `@mySTAGE` -> gets canonicalized to uppercase name, i.e., references a stage named `"MYSTAGE"`
* `@"mySTAGE"` -> preserves the name in this verbatim casing, i.e., references a stage named `"mySTAGE"`

The same also applies for fully qualified stage references, e.g., `@"myDB"."mySCHEMA"."mySTAGE"` would preserve the casing of the database/schema/stage names.

This PR slightly adjusts the logic, and extends the existing parsing tests in `test_staged_files(..)` to cover these edge cases.