### PR TITLE
Fix(optimizer)!: infer timestamp function types as TIMESTAMPTZ for bigquery

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -51,7 +51,7 @@ UNESCAPED_SEQUENCES = {
 }
 
 
-def _annotate_with_type_lambda(data_type: exp.DataType.Type) -> t.Callable[[TypeAnnotator, E], E]:
+def annotate_with_type_lambda(data_type: exp.DataType.Type) -> t.Callable[[TypeAnnotator, E], E]:
     return lambda self, e: self._annotate_with_type(e, data_type)
 
 
@@ -683,15 +683,15 @@ class Dialect(metaclass=_Dialect):
             exp.ParseJSON,
         },
         exp.DataType.Type.TIME: {
+            exp.CurrentTime,
             exp.Time,
+            exp.TimeAdd,
+            exp.TimeSub,
         },
         exp.DataType.Type.TIMESTAMP: {
-            exp.CurrentTime,
             exp.CurrentTimestamp,
             exp.StrToTime,
-            exp.TimeAdd,
             exp.TimeStrToTime,
-            exp.TimeSub,
             exp.TimestampAdd,
             exp.TimestampSub,
             exp.UnixToTime,
@@ -733,7 +733,7 @@ class Dialect(metaclass=_Dialect):
             for expr_type in subclasses(exp.__name__, exp.Binary)
         },
         **{
-            expr_type: _annotate_with_type_lambda(data_type)
+            expr_type: annotate_with_type_lambda(data_type)
             for data_type, expressions in TYPE_TO_EXPRESSIONS.items()
             for expr_type in expressions
         },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -19,6 +19,15 @@ INT;
 LEAST(1, 2.5, 3);
 DOUBLE;
 
+CURRENT_TIME();
+TIME;
+
+TIME_ADD(CAST('09:05:03' AS TIME), INTERVAL 2 HOUR);
+TIME;
+
+TIME_SUB(CAST('09:05:03' AS TIME), INTERVAL 2 HOUR);
+TIME;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
SQLGlot currently infers a `TIMESTAMP` type for functions like `CURRENT_TIMESTAMP` in BigQuery, which is problematic because this type is mapped to `DATETIME` to facilitate transpilation.

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.annotate_types import annotate_types
>>>
>>> annotate_types(parse_one("SELECT CURRENT_TIMESTAMP()", "bigquery"), dialect="bigquery").selects[0].type
DataType(this=Type.TIMESTAMP)
>>> annotate_types(parse_one("SELECT CURRENT_TIMESTAMP()", "bigquery"), dialect="bigquery").selects[0].type.sql("bigquery")
'DATETIME'
```

This PR changes the type inference logic so that we annotate the functions with `TIMESTAMPTZ` instead.