### PR TITLE
fix(duckdb)!: parse at sign as ABS function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -439,6 +439,7 @@ class DuckDB(Dialect):
         NO_PAREN_FUNCTION_PARSERS = {
             **parser.Parser.NO_PAREN_FUNCTION_PARSERS,
             "MAP": lambda self: self._parse_map(),
+            "@": lambda self: exp.Abs(this=self._parse_bitwise()),
         }
 
         TABLE_ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS - {

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1569,3 +1569,29 @@ class TestDuckDB(Validator):
             """,
             "SELECT l_returnflag, l_linestatus, SUM(l_quantity) AS sum_qty, SUM(l_extendedprice) AS sum_base_price, SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price, SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge, AVG(l_quantity) AS avg_qty, AVG(l_extendedprice) AS avg_price, AVG(l_discount) AS avg_disc, COUNT(*) AS count_order",
         )
+
+    def test_at_sign_to_abs(self):
+        self.validate_identity(
+            "SELECT @col FROM t",
+            "SELECT ABS(col) FROM t",
+        )
+        self.validate_identity(
+            "SELECT @col + 1 FROM t",
+            "SELECT ABS(col + 1) FROM t",
+        )
+        self.validate_identity(
+            "SELECT (@col) + 1 FROM t",
+            "SELECT (ABS(col)) + 1 FROM t",
+        )
+        self.validate_identity(
+            "SELECT @(-1)",
+            "SELECT ABS((-1))",
+        )
+        self.validate_identity(
+            "SELECT @(-1) + 1",
+            "SELECT ABS((-1) + 1)",
+        )
+        self.validate_identity(
+            "SELECT (@-1) + 1",
+            "SELECT (ABS(-1)) + 1",
+        )


### PR DESCRIPTION
Fixes #4912 

This PR adds support for the usage of `@` as an `abs` function. 

The usage of `@`, seems to contain a precedence issue (the current parsing logic works based on this in order to avoid any divergence). The docs of DuckDB mention that `@` is an alias of `abs`. 
In the bellow example, this seems to be false: 
```
D select @(-1) -20;
┌──────────────┐
│ @((-1 - 20)) │
│    int32     │
├──────────────┤
│      21      │
└──────────────┘

D select abs(-1) -20;
┌────────────────┐
│ (abs(-1) - 20) │
│     int32      │
├────────────────┤
│      -19       │
└────────────────┘
```