### PR TITLE
fix(optimizer): Merge subqueries when inner has subquery name conflict with outer

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -237,12 +237,12 @@ def _rename_inner_sources(outer_scope: Scope, inner_scope: Scope, alias: str) ->
         source, _ = inner_scope.selected_sources[conflict]
         new_alias = exp.to_identifier(new_name)
 
-        if isinstance(source, exp.Subquery):
-            source.set("alias", exp.TableAlias(this=new_alias))
-        elif isinstance(source, exp.Table) and source.alias:
+        if isinstance(source, exp.Table) and source.alias:
             source.set("alias", new_alias)
         elif isinstance(source, exp.Table):
             source.replace(exp.alias_(source, new_alias))
+        elif isinstance(source.parent, exp.Subquery):
+            source.parent.set("alias", exp.TableAlias(this=new_alias))
 
         for column in inner_scope.source_columns(conflict):
             column.set("table", exp.to_identifier(new_name))

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -481,3 +481,21 @@ FROM (
   LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id
 ) AS ITBL;
 WITH tbl AS (SELECT 1 AS id) SELECT OTBL.id AS id FROM tbl AS OTBL LEFT OUTER JOIN tbl AS ITBL_2 ON OTBL.id = ITBL_2.id LEFT OUTER JOIN tbl AS ITBL_3 ON OTBL.id = ITBL_3.id LEFT OUTER JOIN tbl AS ITBL ON OTBL.id = ITBL.id;
+
+# title: Inner query contains subquery with an alias that conflicts with outer query
+WITH i AS (
+  SELECT
+    a
+  FROM (
+    SELECT 1 a
+  ) AS conflict
+), j AS (
+  SELECT 1 AS a
+)
+SELECT
+  i.a,
+  conflict.a
+FROM i
+LEFT JOIN j AS conflict
+  ON i.a = conflict.a;
+WITH j AS (SELECT 1 AS a) SELECT conflict_2.a AS a, conflict.a AS a FROM (SELECT 1 AS a) AS conflict_2 LEFT JOIN j AS conflict ON conflict_2.a = conflict.a;


### PR DESCRIPTION
The current check is broken (selected_sources returns the inner Select instance, not the Subquery instance), but this code doesn't usually get exercised because `eliminate_subqueries` runs first.

But I don't know yet know how I'll install this change... without 3.7 support, we might need to fork 😓 