### PR TITLE
fix(sqlite): transpile double quoted PRIMARY KEY

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -44,9 +44,7 @@ def _transform_create(expression: exp.Expression) -> exp.Expression:
                 primary_key = e
 
         if primary_key and len(primary_key.expressions) == 1:
-            expr = primary_key.expressions[0]
-            name = expr.this.name if isinstance(expr, exp.Ordered) else expr.name
-            column = defs[name]
+            column = defs[primary_key.expressions[0].name]
             column.append(
                 "constraints", exp.ColumnConstraint(kind=exp.PrimaryKeyColumnConstraint())
             )

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -44,7 +44,9 @@ def _transform_create(expression: exp.Expression) -> exp.Expression:
                 primary_key = e
 
         if primary_key and len(primary_key.expressions) == 1:
-            column = defs[primary_key.expressions[0].name]
+            expr = primary_key.expressions[0]
+            name = expr.this.name if isinstance(expr, exp.Ordered) else expr.name
+            column = defs[name]
             column.append(
                 "constraints", exp.ColumnConstraint(kind=exp.PrimaryKeyColumnConstraint())
             )

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2660,6 +2660,10 @@ class Sort(Order):
 class Ordered(Expression):
     arg_types = {"this": True, "desc": False, "nulls_first": True, "with_fill": False}
 
+    @property
+    def name(self) -> str:
+        return self.this.name
+
 
 class Property(Expression):
     arg_types = {"this": True, "value": True}

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -110,7 +110,8 @@ class TestSQLite(Validator):
         )
         self.validate_identity("SELECT JSON_OBJECT('col1', 1, 'col2', '1')")
         self.validate_identity(
-            'CREATE TABLE "foo t" ("foo t id" TEXT NOT NULL PRIMARY KEY ("foo t id"))'
+            'CREATE TABLE "foo t" ("foo t id" TEXT NOT NULL, PRIMARY KEY ("foo t id"))',
+            'CREATE TABLE "foo t" ("foo t id" TEXT NOT NULL PRIMARY KEY)',
         )
 
     def test_strftime(self):

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -109,6 +109,9 @@ class TestSQLite(Validator):
             "SELECT * FROM station WHERE NOT city IS ''",
         )
         self.validate_identity("SELECT JSON_OBJECT('col1', 1, 'col2', '1')")
+        self.validate_identity(
+            'CREATE TABLE "foo t" ("foo t id" TEXT NOT NULL PRIMARY KEY ("foo t id"))'
+        )
 
     def test_strftime(self):
         self.validate_identity("SELECT STRFTIME('%Y/%m/%d', 'now')")


### PR DESCRIPTION
Fixes #4938

**DOCS**
[SQLite double quotes identifier](https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted)