### PR TITLE
Feat!: add support for coalesce semantics in DPipe concatenation

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1155,6 +1155,12 @@ class ClickHouse(Dialect):
 
             return prefix + self.func("has", arr.this.unnest(), this)
 
+        def dpipe_sql(self, expression: exp.DPipe) -> str:
+            for e in expression.flatten():
+                if not isinstance(e, exp.Literal):
+                    e.replace(exp.func("coalesce", e, exp.Literal.string("")))
+            return super().dpipe_sql(expression)
+
         def eq_sql(self, expression: exp.EQ) -> str:
             return self._any_to_has(expression, super().eq_sql)
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -5,6 +5,18 @@ from tests.dialects.test_dialect import Validator
 class TestOracle(Validator):
     dialect = "oracle"
 
+    def test_string_concat(self):
+        self.validate_identity("SELECT CONCAT('abcde', 2, NULL, 22)")
+
+        self.validate_all(
+            "a || b",
+            write={
+                "": "a || b",
+                "clickhouse": "COALESCE(a, '') || COALESCE(b, '')",
+                "oracle": "a || b",
+            },
+        )
+
     def test_oracle(self):
         self.validate_identity("1 /* /* */")
         self.validate_all(


### PR DESCRIPTION
In oracle 

```
select null || 'Hello'
```
returns `Hello`

In ClickHouse it should produce same result, but default DPipe will cause Null instead.

By this PR we replace DPIle with concat(coalesce=True) which makes the trick.

Also, I apply concat(coalesce=True) only to non-Literal expression to make final sql less verbose. 