### PR TITLE
feat(snowflake): parse SHOW FILE FORMATS

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -549,6 +549,7 @@ class Snowflake(Dialect):
             "COLUMNS": _show_parser("COLUMNS"),
             "USERS": _show_parser("USERS"),
             "TERSE USERS": _show_parser("USERS"),
+            "FILE FORMATS": _show_parser("FILE FORMATS"),
             "FUNCTIONS": _show_parser("FUNCTIONS"),
             "PROCEDURES": _show_parser("PROCEDURES"),
             "WAREHOUSES": _show_parser("WAREHOUSES"),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2092,6 +2092,15 @@ MATCH_RECOGNIZE (
         self.assertEqual(ast.this, "DATABASES")
         self.assertEqual(ast.args.get("scope_kind"), "ACCOUNT")
 
+    def test_show_file_formats(self):
+        self.validate_identity("SHOW FILE FORMATS")
+        self.validate_identity("SHOW FILE FORMATS LIKE 'foo' IN DATABASE db1")
+        self.validate_identity("SHOW FILE FORMATS LIKE 'foo' IN SCHEMA db1.schema1")
+
+        ast = parse_one("SHOW FILE FORMATS IN ACCOUNT", read="snowflake")
+        self.assertEqual(ast.this, "FILE FORMATS")
+        self.assertEqual(ast.args.get("scope_kind"), "ACCOUNT")
+
     def test_show_functions(self):
         self.validate_identity("SHOW FUNCTIONS")
         self.validate_identity("SHOW FUNCTIONS LIKE 'foo' IN CLASS bla")


### PR DESCRIPTION
return exp.Show instead of exp.Command

see https://docs.snowflake.com/en/sql-reference/sql/show-file-formats