### PR TITLE
fix(snowflake)!: Fix CREATE EXTERNAL TABLE properties

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -516,6 +516,7 @@ class Snowflake(Dialect):
 
         PROPERTY_PARSERS = {
             **parser.Parser.PROPERTY_PARSERS,
+            "FILE_FORMAT": lambda self: self._parse_file_format_property(),
             "LOCATION": lambda self: self._parse_location_property(),
             "TAG": lambda self: self._parse_tag(),
             "USING": lambda self: self._match_text_seq("TEMPLATE")
@@ -898,6 +899,12 @@ class Snowflake(Dialect):
             # outoflineFK, explicitly names the columns
             return super()._parse_foreign_key()
 
+        def _parse_file_format_property(self) -> exp.FileFormatProperty:
+            self._match(TokenType.EQ)
+            return self.expression(
+                exp.FileFormatProperty, expressions=self._parse_wrapped_options()
+            )
+
     class Tokenizer(tokens.Tokenizer):
         STRING_ESCAPES = ["\\", "'"]
         HEX_STRINGS = [("x'", "'"), ("X'", "'")]
@@ -992,6 +999,8 @@ class Snowflake(Dialect):
             exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.Explode: rename_func("FLATTEN"),
             exp.Extract: rename_func("DATE_PART"),
+            exp.FileFormatProperty: lambda self,
+            e: f"FILE_FORMAT=({self.expressions(e, 'expressions', sep=' ')})",
             exp.FromTimeZone: lambda self, e: self.func(
                 "CONVERT_TIMEZONE", e.args.get("zone"), "'UTC'", e.this
             ),
@@ -1007,6 +1016,10 @@ class Snowflake(Dialect):
             exp.JSONObject: lambda self, e: self.func("OBJECT_CONSTRUCT_KEEP_NULL", *e.expressions),
             exp.JSONPathRoot: lambda *_: "",
             exp.JSONValueArray: _json_extract_value_array_sql,
+            exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost")(
+                rename_func("EDITDISTANCE")
+            ),
+            exp.LocationProperty: lambda self, e: f"LOCATION={self.sql(e, 'this')}",
             exp.LogicalAnd: rename_func("BOOLAND_AGG"),
             exp.LogicalOr: rename_func("BOOLOR_AGG"),
             exp.Map: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
@@ -1070,9 +1083,6 @@ class Snowflake(Dialect):
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
             exp.WeekOfYear: rename_func("WEEKOFYEAR"),
             exp.Xor: rename_func("BOOLXOR"),
-            exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost")(
-                rename_func("EDITDISTANCE")
-            ),
         }
 
         SUPPORTED_JSON_PATH_PARTS = {
@@ -1093,6 +1103,8 @@ class Snowflake(Dialect):
 
         PROPERTIES_LOCATION = {
             **generator.Generator.PROPERTIES_LOCATION,
+            exp.PartitionedByProperty: exp.Properties.Location.POST_SCHEMA,
+            exp.LocationProperty: exp.Properties.Location.POST_WITH,
             exp.SetProperty: exp.Properties.Location.UNSUPPORTED,
             exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
         }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2785,7 +2785,7 @@ class FallbackProperty(Property):
 
 
 class FileFormatProperty(Property):
-    arg_types = {"this": True}
+    arg_types = {"this": False, "expressions": False}
 
 
 class FreespaceProperty(Property):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1500,9 +1500,6 @@ class TestSnowflake(Validator):
             "CREATE TABLE orders_clone_restore CLONE orders BEFORE (STATEMENT => '8e5d0ca9-005e-44e6-b858-a8f5b37c5726')"
         )
         self.validate_identity(
-            "CREATE TABLE a (x DATE, y BIGINT) PARTITION BY (x) integration='q' auto_refresh=TRUE file_format=(type = parquet)"
-        )
-        self.validate_identity(
             "CREATE SCHEMA mytestschema_clone_restore CLONE testschema BEFORE (TIMESTAMP => TO_TIMESTAMP(40 * 365 * 86400))"
         )
         self.validate_identity(
@@ -1544,8 +1541,8 @@ class TestSnowflake(Validator):
   partition by (col1,col2,col3)
   location=@s2/logs/
   partition_type = user_specified
-  file_format = (type = parquet)""",
-            "CREATE EXTERNAL TABLE et2 (col1 DATE AS (CAST(GET_PATH(PARSE_JSON(metadata$external_table_partition), 'COL1') AS DATE)), col2 VARCHAR AS (CAST(GET_PATH(PARSE_JSON(metadata$external_table_partition), 'COL2') AS VARCHAR)), col3 DECIMAL(38, 0) AS (CAST(GET_PATH(PARSE_JSON(metadata$external_table_partition), 'COL3') AS DECIMAL(38, 0)))) LOCATION @s2/logs/ PARTITION BY (col1, col2, col3) partition_type=user_specified file_format=(type = parquet)",
+  file_format = (type = parquet compression = gzip binary_as_text = false)""",
+            "CREATE EXTERNAL TABLE et2 (col1 DATE AS (CAST(GET_PATH(PARSE_JSON(metadata$external_table_partition), 'COL1') AS DATE)), col2 VARCHAR AS (CAST(GET_PATH(PARSE_JSON(metadata$external_table_partition), 'COL2') AS VARCHAR)), col3 DECIMAL(38, 0) AS (CAST(GET_PATH(PARSE_JSON(metadata$external_table_partition), 'COL3') AS DECIMAL(38, 0)))) PARTITION BY (col1, col2, col3) LOCATION=@s2/logs/ partition_type=user_specified FILE_FORMAT=(type=parquet compression=gzip binary_as_text=FALSE)",
         )
 
         self.validate_all(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/4945

This PR solves the following issues:
- The `FILE_FORMAT` property should be parsed with `parse_wrapped_options()` (originally from `COPY INTO`)
- The `LOCATION` property should be generated with a `=` 
- The `LOCATION` property should come after the `PARTITIONED BY`
- The removed test case is incorrect: Missing `EXTERNAL` specifier & `LOCATION` property

The normal `CREATE TABLE` does not support these properties, so they should be exclusive to `EXTERNAL` tables.

Docs
-------
[Snowflake CREATE EXTERNAL TABLE](https://docs.snowflake.com/en/sql-reference/sql/create-external-table) |  [Snowflake CREATE TABLE](https://docs.snowflake.com/en/sql-reference/sql/create-table)