### PR TITLE
Feat(duckdb): add support for GROUP clause in standard PIVOT syntax

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2045,6 +2045,8 @@ class Generator(metaclass=_Generator):
         expressions = self.expressions(expression, flat=True)
         direction = "UNPIVOT" if expression.unpivot else "PIVOT"
 
+        group = self.sql(expression, "group")
+
         if expression.this:
             this = self.sql(expression, "this")
             if not expressions:
@@ -2055,7 +2057,6 @@ class Generator(metaclass=_Generator):
             into = f"{self.seg('INTO')} {into}" if into else ""
             using = self.expressions(expression, key="using", flat=True)
             using = f"{self.seg('USING')} {using}" if using else ""
-            group = self.sql(expression, "group")
             return f"{direction} {this}{on}{into}{using}{group}"
 
         alias = self.sql(expression, "alias")
@@ -2071,7 +2072,7 @@ class Generator(metaclass=_Generator):
 
         default_on_null = self.sql(expression, "default_on_null")
         default_on_null = f" DEFAULT ON NULL ({default_on_null})" if default_on_null else ""
-        return f"{self.seg(direction)}{nulls}({expressions} FOR {field}{default_on_null}){alias}"
+        return f"{self.seg(direction)}{nulls}({expressions} FOR {field}{default_on_null}{group}){alias}"
 
     def version_sql(self, expression: exp.Version) -> str:
         this = f"FOR {expression.name}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4182,7 +4182,7 @@ class Parser(metaclass=_Parser):
             into=into,
         )
 
-    def _parse_pivot_in(self) -> exp.In | exp.PivotAny:
+    def _parse_pivot_in(self) -> exp.In:
         def _parse_aliased_expression() -> t.Optional[exp.Expression]:
             this = self._parse_select_or_expression()
 
@@ -4247,6 +4247,8 @@ class Parser(metaclass=_Parser):
             self._parse_bitwise
         )
 
+        group = self._parse_group()
+
         self._match_r_paren()
 
         pivot = self.expression(
@@ -4256,6 +4258,7 @@ class Parser(metaclass=_Parser):
             unpivot=unpivot,
             include_nulls=include_nulls,
             default_on_null=default_on_null,
+            group=group,
         )
 
         if not self._match_set((TokenType.PIVOT, TokenType.UNPIVOT), advance=False):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -401,6 +401,9 @@ class TestDuckDB(Validator):
             "SELECT * FROM (PIVOT Cities ON Year USING SUM(Population) GROUP BY Country) AS pivot_alias"
         )
         self.validate_identity(
+            "SELECT * FROM cities PIVOT(SUM(population) FOR year IN (2000, 2010, 2020) GROUP BY country)"
+        )
+        self.validate_identity(
             # QUALIFY comes after WINDOW
             "SELECT schema_name, function_name, ROW_NUMBER() OVER my_window AS function_rank FROM DUCKDB_FUNCTIONS() WINDOW my_window AS (PARTITION BY schema_name ORDER BY function_name) QUALIFY ROW_NUMBER() OVER my_window < 3"
         )


### PR DESCRIPTION
Addresses the first item in #4944