### PR TITLE
Fix(athena): Correctly handle CTAS queries that contain Unions

### DIFF
--- a/sqlglot/dialects/athena.py
+++ b/sqlglot/dialects/athena.py
@@ -15,7 +15,7 @@ def _generate_as_hive(expression: exp.Expression) -> bool:
             if properties and properties.find(exp.ExternalProperty):
                 return True  # CREATE EXTERNAL TABLE is Hive
 
-            if not isinstance(expression.expression, exp.Select):
+            if not isinstance(expression.expression, exp.Query):
                 return True  # any CREATE TABLE other than CREATE TABLE AS SELECT is Hive
         else:
             return expression.kind != "VIEW"  # CREATE VIEW is never Hive but CREATE SCHEMA etc is

--- a/tests/dialects/test_athena.py
+++ b/tests/dialects/test_athena.py
@@ -154,6 +154,12 @@ class TestAthena(Validator):
             write_sql='CREATE TABLE "foo" AS WITH "foo" AS (SELECT "a", "b" FROM "bar") SELECT * FROM "foo"',
         )
 
+        # CTAS with Union should still hit the Trino engine and not Hive
+        self.validate_identity(
+            'CREATE TABLE `foo` AS WITH `foo` AS (SELECT "a", `b` FROM "bar") SELECT * FROM "foo" UNION SELECT * FROM "foo"',
+            write_sql='CREATE TABLE "foo" AS WITH "foo" AS (SELECT "a", "b" FROM "bar") SELECT * FROM "foo" UNION SELECT * FROM "foo"',
+        )
+
         self.validate_identity("DESCRIBE foo.bar", write_sql="DESCRIBE `foo`.`bar`", identify=True)
 
     def test_dml_quoting(self):


### PR DESCRIPTION
Prior to this, if a CTAS query contained a Union, eg:

```
CREATE TABLE foo AS
 SELECT * FROM a
 UNION
 SELECT * FROM b
```

Then it would be incorrectly quoted as Hive / backticks and not Trino / quotes

This PR loosens the "should this be Trino?" check to use the `exp.Query` base class instead of just `exp.Select`, so `exp.Union` is now detected correctly.

This addresses https://github.com/TobikoData/sqlmesh/issues/4091

