### PR TITLE
Fix(athena): Correctly handle PartitionByProperty when it contains Iceberg transforms

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -599,7 +599,6 @@ class Hive(Dialect):
             exp.UnixToTime: _unix_to_time_sql,
             exp.UnixToTimeStr: rename_func("FROM_UNIXTIME"),
             exp.Unnest: rename_func("EXPLODE"),
-            exp.PartitionedByProperty: lambda self, e: f"PARTITIONED BY {self.sql(e, 'this')}",
             exp.NumberToStr: rename_func("FORMAT_NUMBER"),
             exp.National: lambda self, e: self.national_sql(e, prefix=""),
             exp.ClusteredColumnConstraint: lambda self,
@@ -741,3 +740,6 @@ class Hive(Dialect):
                 this = this.this
 
             return self.func("DATE_FORMAT", this, self.format_time(expression))
+
+        def partitionedbyproperty_sql(self, expression: exp.PartitionedByProperty) -> str:
+            return f"PARTITIONED BY {self.sql(expression, 'this')}"

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -57,8 +57,14 @@ def _no_sort_array(self: Presto.Generator, expression: exp.SortArray) -> str:
 
 def _schema_sql(self: Presto.Generator, expression: exp.Schema) -> str:
     if isinstance(expression.parent, exp.PartitionedByProperty):
-        columns = ", ".join(f"'{c.name}'" for c in expression.expressions)
-        return f"ARRAY[{columns}]"
+        column_literals = []
+        for c in expression.expressions:
+            if isinstance(c, exp.Func):
+                column_literals.append(self.sql(c))
+            else:
+                column_literals.append(self.sql(c, "this"))
+
+        return self.sql(exp.Array(expressions=[exp.Literal.string(c) for c in column_literals]))
 
     if expression.parent:
         for schema in expression.parent.find_all(exp.Schema):

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -56,7 +56,7 @@ class TestSpark(Validator):
             "CREATE TABLE x USING ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
             write={
                 "duckdb": "CREATE TABLE x",
-                "presto": "CREATE TABLE x WITH (FORMAT='ICEBERG', PARTITIONED_BY=ARRAY['MONTHS'])",
+                "presto": "CREATE TABLE x WITH (FORMAT='ICEBERG', PARTITIONED_BY=ARRAY['MONTHS(y)'])",
                 "hive": "CREATE TABLE x STORED AS ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
                 "spark": "CREATE TABLE x USING ICEBERG PARTITIONED BY (MONTHS(y)) LOCATION 's3://z'",
             },

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -93,6 +93,16 @@ class TestTrino(Validator):
             "CREATE TABLE foo.bar WITH (LOCATION='s3://bucket/foo/bar') AS SELECT 1"
         )
 
+        # Hive connector syntax (partitioned_by)
+        self.validate_identity(
+            "CREATE TABLE foo (a VARCHAR, b INTEGER, c DATE) WITH (PARTITIONED_BY=ARRAY['a', 'b'])"
+        )
+
+        # Iceberg connector syntax (partitioning, can contain Iceberg transform expressions)
+        self.validate_identity(
+            "CREATE TABLE foo (a VARCHAR, b INTEGER, c DATE) WITH (PARTITIONING=ARRAY['a', 'bucket(4, b)', 'month(c)'])",
+        )
+
     def test_analyze(self):
         self.validate_identity("ANALYZE tbl")
         self.validate_identity("ANALYZE tbl WITH (prop1=val1, prop2=val2)")


### PR DESCRIPTION
This addresses part of SQLMesh issue: https://github.com/TobikoData/sqlmesh/issues/4090

Given the following:
```
>>> prop = exp.PartitionedByProperty(this=exp.Schema(expressions=[exp.func("bucket", 4, exp.column("foo"))]))
```

Prior to this PR, when generating against Athena's Trino engine, the value would be truncated:
```
>>> prop.sql(dialect="athena")
"partitioned_by=ARRAY['bucket']" #should be `partitioned_by=ARRAY['bucket(4, foo)']`
```

The same value works correctly in Hive mode:
```
>>> prop.sql(dialect="hive")
'PARTITIONED BY (BUCKET(4, foo))'
```

However, simply fixing the truncation is not enough. The arguments are swapped when running in Hive mode vs Trino Mode. The argument order is documented in the AWS docs [here for Hive](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg-creating-tables.html#querying-iceberg-partitioning) and [here for Trino](https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html#ctas-table-properties).

This PR does the following:
 - Fix the truncation in the **Presto** generator (which is a superclass of Athena's Trino generator). Presto and Trino both support the Iceberg partition transform syntax and the current truncation is a bug for them as well.
 - Reorder the arguments for the `bucket` and `truncate` Iceberg transforms to be correct for whatever Athena generator is being used (Hive or Trino)
