### PR TITLE
Feat: allow explicit aliasing in if(...) expressions

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6164,7 +6164,9 @@ class Parser(metaclass=_Parser):
 
     def _parse_if(self) -> t.Optional[exp.Expression]:
         if self._match(TokenType.L_PAREN):
-            args = self._parse_csv(self._parse_assignment)
+            args = self._parse_csv(
+                lambda: self._parse_alias(self._parse_assignment(), explicit=True)
+            )
             this = self.validate_expression(exp.If.from_arg_list(args), args)
             self._match_r_paren()
         else:

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -245,6 +245,7 @@ TBLPROPERTIES (
             "REFRESH TABLE t",
         )
 
+        self.validate_identity("IF(cond, foo AS bar, bla AS baz)")
         self.validate_identity("any_value(col, true)", "ANY_VALUE(col) IGNORE NULLS")
         self.validate_identity("first(col, true)", "FIRST(col) IGNORE NULLS")
         self.validate_identity("first_value(col, true)", "FIRST_VALUE(col) IGNORE NULLS")


### PR DESCRIPTION
Small lift to support things like `@IF(cond, <expression> as column)` in SQLMesh. SQLGlot does not parse this today and SQLMesh fails to parse things like `SELECT @IF(cond, a AS b) FROM t`, because it falls back to its [statement parser logic](https://github.com/TobikoData/sqlmesh/blob/8db57008b53cdde59c12fa3298c910cff2440c4d/sqlmesh/core/dialect.py#L520-L543) and expects an `)` after the `true` arg:

```sqlglot.errors.ParseError: Expecting ). Line 1, Col: 18.
  select @IF(cond, a as b) from t
                   ~
```

Context: https://tobiko-data.slack.com/archives/C044BRE5W4S/p1744207056323959