### PR TITLE
fix(Snowflake): Enhance parity for FILE_FORMAT & CREDENTIALS in CREATE STAGE

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -903,8 +903,17 @@ class Snowflake(Dialect):
 
         def _parse_file_format_property(self) -> exp.FileFormatProperty:
             self._match(TokenType.EQ)
+            if self._match(TokenType.L_PAREN, advance=False):
+                return self.expression(
+                    exp.FileFormatProperty, expressions=self._parse_wrapped_options()
+                )
+            # note: although not specified in the docs, Snowflake does accept a string/identifier for FILE_FORMAT
+            format_name = self._parse_string() or self._parse_table_parts()
+            if not isinstance(format_name, exp.Literal):
+                format_name = exp.Literal(this=str(format_name), is_string=True)
             return self.expression(
-                exp.FileFormatProperty, expressions=self._parse_wrapped_options()
+                exp.FileFormatProperty,
+                expressions=[exp.Property(this=exp.Var(this="FORMAT_NAME"), value=format_name)],
             )
 
     class Tokenizer(tokens.Tokenizer):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -905,14 +905,13 @@ class Snowflake(Dialect):
         def _parse_file_format_property(self) -> exp.FileFormatProperty:
             self._match(TokenType.EQ)
             if self._match(TokenType.L_PAREN, advance=False):
-                return self.expression(
-                    exp.FileFormatProperty, expressions=self._parse_wrapped_options()
-                )
-            # note: although not specified in the docs, Snowflake does accept a string/identifier for FILE_FORMAT
-            format_name = self._parse_string() or self._parse_table_parts()
+                expressions = self._parse_wrapped_options()
+            else:
+                expressions = [self._parse_format_name()]
+
             return self.expression(
                 exp.FileFormatProperty,
-                expressions=[exp.Property(this=exp.Var(this="FORMAT_NAME"), value=format_name)],
+                expressions=expressions,
             )
 
         def _parse_credentials_property(self) -> exp.CredentialsProperty:

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1357,7 +1357,3 @@ class Snowflake(Dialect):
             if offset and not limit:
                 expression.limit(exp.Null(), copy=False)
             return super().select_sql(expression)
-
-        def credentialsproperty_sql(self, expression: exp.CredentialsProperty) -> str:
-            credentials = self.expressions(expression, "expressions", sep=" ")
-            return f"CREDENTIALS=({credentials})"

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2789,6 +2789,10 @@ class FileFormatProperty(Property):
     arg_types = {"this": False, "expressions": False}
 
 
+class CredentialsProperty(Property):
+    arg_types = {"expressions": True}
+
+
 class FreespaceProperty(Property):
     arg_types = {"this": True, "percent": False}
 
@@ -3134,6 +3138,7 @@ class Properties(Expression):
         "CLUSTERED_BY": ClusteredByProperty,
         "COLLATE": CollateProperty,
         "COMMENT": SchemaCommentProperty,
+        "CREDENTIALS": CredentialsProperty,
         "DEFINER": DefinerProperty,
         "DISTKEY": DistKeyProperty,
         "DISTRIBUTED_BY": DistributedByProperty,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4896,3 +4896,7 @@ class Generator(metaclass=_Generator):
         this = self.sql(expression, "this")
         target = self.sql(expression, "target")
         return f"PUT {this} {target}{props_sql}"
+
+    def credentialsproperty_sql(self, expression: exp.CredentialsProperty) -> str:
+        credentials = self.expressions(expression, "expressions", sep=" ")
+        return f"CREDENTIALS=({credentials})"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -132,6 +132,8 @@ class Generator(metaclass=_Generator):
         exp.CommentColumnConstraint: lambda self, e: f"COMMENT {self.sql(e, 'this')}",
         exp.ConnectByRoot: lambda self, e: f"CONNECT_BY_ROOT {self.sql(e, 'this')}",
         exp.CopyGrantsProperty: lambda *_: "COPY GRANTS",
+        exp.CredentialsProperty: lambda self,
+        e: f"CREDENTIALS=({self.expressions(e, 'expressions', sep=' ')})",
         exp.DateFormatColumnConstraint: lambda self, e: f"FORMAT {self.sql(e, 'this')}",
         exp.DefaultColumnConstraint: lambda self, e: f"DEFAULT {self.sql(e, 'this')}",
         exp.DynamicProperty: lambda *_: "DYNAMIC",
@@ -4896,7 +4898,3 @@ class Generator(metaclass=_Generator):
         this = self.sql(expression, "this")
         target = self.sql(expression, "target")
         return f"PUT {this} {target}{props_sql}"
-
-    def credentialsproperty_sql(self, expression: exp.CredentialsProperty) -> str:
-        credentials = self.expressions(expression, "expressions", sep=" ")
-        return f"CREDENTIALS=({credentials})"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7969,14 +7969,14 @@ class Parser(metaclass=_Parser):
         while self._curr and not self._match(TokenType.R_PAREN):
             if self._match_text_seq("FORMAT_NAME", "="):
                 # The FORMAT_NAME can be set to an identifier for Snowflake and T-SQL
-                prop = self.expression(
-                    exp.Property, this=exp.var("FORMAT_NAME"), value=self._parse_table_parts()
-                )
+                format_name = self._parse_string() or self._parse_table_parts()
+                prop = self.expression(exp.Property, this=exp.var("FORMAT_NAME"), value=format_name)
                 opts.append(prop)
             else:
                 parsed_prop = self._parse_property()
                 if parsed_prop is None:
                     self.raise_error("Unable to parse option")
+                    break
                 opts.append(parsed_prop)
 
             self._match(TokenType.COMMA)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7974,10 +7974,10 @@ class Parser(metaclass=_Parser):
                 )
                 opts.append(prop)
             else:
-                prop = self._parse_property()
-                if prop is None:
+                parsed_prop = self._parse_property()
+                if parsed_prop is None:
                     self.raise_error("Unable to parse option")
-                opts.append(prop)
+                opts.append(parsed_prop)
 
             self._match(TokenType.COMMA)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7966,19 +7966,19 @@ class Parser(metaclass=_Parser):
         self._match(TokenType.L_PAREN)
 
         opts: t.List[t.Optional[exp.Expression]] = []
+        option: exp.Expression | None
         while self._curr and not self._match(TokenType.R_PAREN):
             if self._match_text_seq("FORMAT_NAME", "="):
                 # The FORMAT_NAME can be set to an identifier for Snowflake and T-SQL
-                prop = self._parse_format_name()
-                opts.append(prop)
+                option = self._parse_format_name()
             else:
-                parsed_prop = self._parse_property()
-                if parsed_prop is None:
-                    self.raise_error("Unable to parse option")
-                    break
-                opts.append(parsed_prop)
+                option = self._parse_property()
 
-            self._match(TokenType.COMMA)
+            if option is None:
+                self.raise_error("Unable to parse option")
+                break
+
+            opts.append(option)
 
         return opts
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7974,7 +7974,10 @@ class Parser(metaclass=_Parser):
                 )
                 opts.append(prop)
             else:
-                opts.append(self._parse_property())
+                prop = self._parse_property()
+                if prop is None:
+                    self.raise_error("Unable to parse option")
+                opts.append(prop)
 
             self._match(TokenType.COMMA)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7969,8 +7969,7 @@ class Parser(metaclass=_Parser):
         while self._curr and not self._match(TokenType.R_PAREN):
             if self._match_text_seq("FORMAT_NAME", "="):
                 # The FORMAT_NAME can be set to an identifier for Snowflake and T-SQL
-                format_name = self._parse_string() or self._parse_table_parts()
-                prop = self.expression(exp.Property, this=exp.var("FORMAT_NAME"), value=format_name)
+                prop = self._parse_format_name()
                 opts.append(prop)
             else:
                 parsed_prop = self._parse_property()
@@ -8169,4 +8168,13 @@ class Parser(metaclass=_Parser):
                 "from": self._match_text_seq("FROM") and self._parse_bitwise(),
                 "for": self._match_text_seq("FOR") and self._parse_bitwise(),
             },
+        )
+
+    def _parse_format_name(self) -> exp.Property:
+        # Note: Although not specified in the docs, Snowflake does accept a string/identifier
+        # for FILE_FORMAT = <format_name>
+        return self.expression(
+            exp.Property,
+            this=exp.var("FORMAT_NAME"),
+            value=self._parse_string() or self._parse_table_parts(),
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1495,6 +1495,10 @@ class TestSnowflake(Validator):
         with self.assertRaises(ParseError):
             self.parse_one("CREATE STAGE stage1 FILE_FORMAT=123", dialect="snowflake")
         self.validate_identity(
+            "CREATE STAGE s1 URL='s3://test-bucket-140f1e26' FILE_FORMAT=(TYPE='JSON') "
+            "CREDENTIALS=(aws_key_id='test' aws_secret_key='test')"
+        )
+        self.validate_identity(
             "CREATE OR REPLACE TAG IF NOT EXISTS cost_center COMMENT='cost_center tag'"
         ).this.assert_is(exp.Identifier)
         self.validate_identity(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1486,17 +1486,24 @@ class TestSnowflake(Validator):
         ).this.assert_is(exp.Table)
         self.validate_identity(
             "CREATE STAGE stage1 FILE_FORMAT='format1'",
-            write_sql="CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='format1')",
-        ).this.assert_is(exp.Table)
+            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='format1')",
+        )
+        self.validate_identity(
+            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=stage1.format1)",
+            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=stage1.format1)",
+        )
+        self.validate_identity(
+            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='stage1.format1')",
+            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='stage1.format1')",
+        )
         self.validate_identity(
             "CREATE STAGE stage1 FILE_FORMAT=schema1.format1",
-            write_sql="CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='schema1.format1')",
-        ).this.assert_is(exp.Table)
+            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=schema1.format1)",
+        )
         with self.assertRaises(ParseError):
             self.parse_one("CREATE STAGE stage1 FILE_FORMAT=123", dialect="snowflake")
         self.validate_identity(
-            "CREATE STAGE s1 URL='s3://test-bucket-140f1e26' FILE_FORMAT=(TYPE='JSON') "
-            "CREDENTIALS=(aws_key_id='test' aws_secret_key='test')"
+            "CREATE STAGE s1 URL='s3://bucket-123' FILE_FORMAT=(TYPE='JSON') CREDENTIALS=(aws_key_id='test' aws_secret_key='test')"
         )
         self.validate_identity(
             "CREATE OR REPLACE TAG IF NOT EXISTS cost_center COMMENT='cost_center tag'"

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1,6 +1,6 @@
 from unittest import mock
 
-from sqlglot import UnsupportedError, exp, parse_one
+from sqlglot import UnsupportedError, exp, parse_one, ParseError
 from sqlglot.optimizer.normalize_identifiers import normalize_identifiers
 from sqlglot.optimizer.qualify_columns import quote_identifiers
 from tests.dialects.test_dialect import Validator
@@ -1484,6 +1484,16 @@ class TestSnowflake(Validator):
         self.validate_identity(
             "CREATE TEMPORARY STAGE stage1 FILE_FORMAT=(TYPE=PARQUET)"
         ).this.assert_is(exp.Table)
+        self.validate_identity(
+            "CREATE STAGE stage1 FILE_FORMAT='format1'",
+            write_sql="CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='format1')",
+        ).this.assert_is(exp.Table)
+        self.validate_identity(
+            "CREATE STAGE stage1 FILE_FORMAT=schema1.format1",
+            write_sql="CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='schema1.format1')",
+        ).this.assert_is(exp.Table)
+        with self.assertRaises(ParseError):
+            self.parse_one("CREATE STAGE stage1 FILE_FORMAT=123", dialect="snowflake")
         self.validate_identity(
             "CREATE OR REPLACE TAG IF NOT EXISTS cost_center COMMENT='cost_center tag'"
         ).this.assert_is(exp.Identifier)

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1488,14 +1488,8 @@ class TestSnowflake(Validator):
             "CREATE STAGE stage1 FILE_FORMAT='format1'",
             "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='format1')",
         )
-        self.validate_identity(
-            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=stage1.format1)",
-            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=stage1.format1)",
-        )
-        self.validate_identity(
-            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='stage1.format1')",
-            "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='stage1.format1')",
-        )
+        self.validate_identity("CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=stage1.format1)")
+        self.validate_identity("CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME='stage1.format1')")
         self.validate_identity(
             "CREATE STAGE stage1 FILE_FORMAT=schema1.format1",
             "CREATE STAGE stage1 FILE_FORMAT=(FORMAT_NAME=schema1.format1)",


### PR DESCRIPTION
## Motivation

With the recent changes in #4947 , we are now able to parse `CREATE STAGE` statements into `exp.Create` (which is awesome! 🎉 ).

We've discovered one small discrepancy related to specifying a `FILE_FORMAT` via a file format name. While this is the canonical syntax [mentioned in the docs](https://docs.snowflake.com/en/sql-reference/sql/create-stage):
```
CREATE STAGE mystage FILE_FORMAT = ( FORMAT_NAME = 'myformat' )
```

... Snowflake also accepts these shorthand syntaxes, specifying the file format name/identifier directly (I've verified that against my Snowflake account):
```
CREATE STAGE mystage FILE_FORMAT = 'myformat'
CREATE STAGE mystage FILE_FORMAT = mystage.myformat
```

---
Note that if you try to parse the expressions above against latest `sqlglot`, we end up in an infinite loop:
```
from sqlglot import parse_one
query = "CREATE STAGE mystage FILE_FORMAT = 'myformat'"
parse_one(query, dialect="snowflake")  # <-- hangs forever (infinite loop)
```

The problem seems to be the following line - here the return value of `self._parse_property()` can be `None` if no property can be parsed, and we then infinitely fill up the `opts` list with `None` values: https://github.com/tobymao/sqlglot/blob/06f4417cdcc30369af5a9f215007667c9635d007/sqlglot/parser.py#L7977

---

Another issue is that the `CREDENTIALS=...` parameter is currently not fully supported for `CREATE STAGE` expressions, which is also addressed in this PR.

## Changes

* Slightly adjust the way we're parsing `FILE_FORMAT` properties in the `_parse_file_format_property(..)` method - also allowing for strings or identifiers (potentially multi-level identifiers, hence `_parse_table_parts(..)` is being used)
* Add support for `CREDENTIALS` property in `CREATE STAGE` expressions
* Add a couple of additional parser test assertions to cover the functionality