### PR TITLE
fix(clickhouse): allow string literal for clickhouse ON CLUSTER clause

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -837,7 +837,7 @@ class ClickHouse(Dialect):
         def _parse_on_property(self) -> t.Optional[exp.Expression]:
             index = self._index
             if self._match_text_seq("CLUSTER"):
-                this = self._parse_id_var()
+                this = self._parse_string() or self._parse_id_var()
                 if this:
                     return self.expression(exp.OnCluster, this=this)
                 else:


### PR DESCRIPTION
First of all, thank you for an amazing library! 🙏 

In ClickHouse, our team uses the `ON CLUSTER` clause with a string macro that is evaluated by the server, like so: `ON CLUSTER '{cluster}'`.

The problem is that queries using the macro string literal:
```
CREATE TABLE foo ON CLUSTER '{cluster}' ...
```
will be parsed and re-generated with a double-quoted identifier
```
CREATE TABLE foo ON CLUSTER "{cluster}" ...
```

This is incorrect because the double-quoted identifier `{cluster}` is not a valid cluster name. The parser should accept the string literal `'{cluster}'`.

In the ClickHouse source, parsing the ON CLUSTER clause uses a function called `parseIdentifierOrStringLiteral`

ON CLUSTER: https://github.com/ClickHouse/ClickHouse/blob/master/src/Parsers/ASTQueryWithOnCluster.cpp#L24

parseIdentifierOrStringLiteral: https://github.com/ClickHouse/ClickHouse/blob/master/src/Parsers/parseIdentifierOrStringLiteral.cpp#L27

The proposed fix is to attempt `_parse_string()` first, then fallback to the existing implementation.

I've copied existing ON CLUSTER test cases and added the equivalent query using string literals.

