### PR TITLE
feat(generator): unsupported warning for T-SQL query option

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2581,6 +2581,7 @@ class Generator(metaclass=_Generator):
         return f" {options}" if options else ""
 
     def queryoption_sql(self, expression: exp.QueryOption) -> str:
+        self.unsupported("Unsupported query option.")
         return ""
 
     def offset_limit_modifiers(

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -559,6 +559,14 @@ class TestTSQL(Validator):
             with self.assertRaises(ParseError, msg=f"When running '{query}'"):
                 self.parse_one(query)
 
+        self.validate_all(
+            "SELECT col FROM t OPTION(LABEL = 'foo')",
+            write={
+                "tsql": "SELECT col FROM t OPTION(LABEL = 'foo')",
+                "databricks": UnsupportedError,
+            },
+        )
+
     def test_types(self):
         self.validate_identity("CAST(x AS XML)")
         self.validate_identity("CAST(x AS UNIQUEIDENTIFIER)")


### PR DESCRIPTION
Added a warning for the `QueryOption` expression, which is mainly used for the T-SQL transpilation.

**DOCS**
[T-SQL Option Sytnaxt](https://learn.microsoft.com/en-us/sql/t-sql/queries/option-clause-transact-sql?view=sql-server-ver16)


