### PR TITLE
Fix(optimizer): compare the whole type to determine if a cast can be removed

### DIFF
--- a/sqlglot/optimizer/canonicalize.py
+++ b/sqlglot/optimizer/canonicalize.py
@@ -93,15 +93,18 @@ def remove_redundant_casts(expression: exp.Expression) -> exp.Expression:
     if (
         isinstance(expression, exp.Cast)
         and expression.this.type
-        and expression.to.this == expression.this.type.this
+        and expression.to == expression.this.type
     ):
         return expression.this
+
     if (
         isinstance(expression, (exp.Date, exp.TsOrDsToDate))
         and expression.this.type
         and expression.this.type.this == exp.DataType.Type.DATE
+        and not expression.this.type.expressions
     ):
         return expression.this
+
     return expression
 
 

--- a/tests/fixtures/optimizer/canonicalize.sql
+++ b/tests/fixtures/optimizer/canonicalize.sql
@@ -124,6 +124,12 @@ SELECT CAST(CAST(`t`.`some_col` AS DATE) AS DATETIME) < CAST(CAST(`t`.`other_col
 --------------------------------------
 -- Remove redundant casts
 --------------------------------------
+CAST(CAST("foo" AS DECIMAL(4, 2)) AS DECIMAL(8, 4)) AS "x";
+CAST(CAST("foo" AS DECIMAL(4, 2)) AS DECIMAL(8, 4)) AS "x";
+
+CAST(CAST("foo" AS DECIMAL(4, 2)) AS DECIMAL(4, 2)) AS "x";
+CAST("foo" AS DECIMAL(4, 2)) AS "x";
+
 CAST(CAST('2023-01-01' AS DATE) AS DATE);
 CAST('2023-01-01' AS DATE);
 


### PR DESCRIPTION
Fixes #4977

- Compare the inferred expression's type with that of the `CAST` _structurally_
- Do not simplify `exp.Date` or `exp.TsOrDsToDate` if the inferred expression's type is "complex"