### PR TITLE
Refactor!: remove `this` from Coalesce in favor of `expressions`

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -745,7 +745,7 @@ class Dialect(metaclass=_Dialect):
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),
-        exp.Coalesce: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
+        exp.Coalesce: lambda self, e: self._annotate_by_args(e, "expressions"),
         exp.Count: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.BIGINT if e.args.get("big_int") else exp.DataType.Type.INT
         ),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5664,7 +5664,7 @@ class Ceil(Func):
 
 
 class Coalesce(Func):
-    arg_types = {"this": True, "expressions": False, "is_nvl": False}
+    arg_types = {"expressions": False, "is_nvl": False}
     is_var_len_args = True
     _sql_names = ["COALESCE", "IFNULL", "NVL"]
 

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -244,7 +244,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
                     return exp.null()
                 return node
 
-            alias = exp.Coalesce(this=alias, expressions=[value.this.transform(remove_aggs)])
+            alias = exp.Coalesce(expressions=[alias, value.this.transform(remove_aggs)])
 
         select.parent.replace(alias)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -151,7 +151,7 @@ def build_trim(args: t.List, is_left: bool = True):
 
 
 def build_coalesce(args: t.List, is_nvl: t.Optional[bool] = None) -> exp.Coalesce:
-    return exp.Coalesce(this=seq_get(args, 0), expressions=args[1:], is_nvl=is_nvl)
+    return exp.Coalesce(expressions=args, is_nvl=is_nvl)
 
 
 def build_locate_strposition(args: t.List):
@@ -4935,9 +4935,7 @@ class Parser(metaclass=_Parser):
                     safe=not self.dialect.STRICT_STRING_CONCAT,
                 )
             elif self._match(TokenType.DQMARK):
-                this = self.expression(
-                    exp.Coalesce, this=this, expressions=ensure_list(self._parse_term())
-                )
+                this = self.expression(exp.Coalesce, expressions=[this, self._parse_term()])
             elif self._match_pair(TokenType.LT, TokenType.LT):
                 this = self.expression(
                     exp.BitwiseLeftShift, this=this, expression=self._parse_term()


### PR DESCRIPTION
This is a refactor I've been meaning to do. The current representation of `Coalesce` is weird– for some reason we store the first argument in `this` and the rest of them in `expressions`, even though it's always a variable-length argument function as far as I can tell.