### PR TITLE
feat(parser)!: support RELY option for PRIMARY KEY, FOREIGN KEY, and UNIQUE constraints

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1933,7 +1933,7 @@ class TransformColumnConstraint(ColumnConstraintKind):
 
 
 class PrimaryKeyColumnConstraint(ColumnConstraintKind):
-    arg_types = {"desc": False}
+    arg_types = {"desc": False, "options": False}
 
 
 class TitleColumnConstraint(ColumnConstraintKind):
@@ -1941,7 +1941,13 @@ class TitleColumnConstraint(ColumnConstraintKind):
 
 
 class UniqueColumnConstraint(ColumnConstraintKind):
-    arg_types = {"this": False, "index_type": False, "on_conflict": False, "nulls": False}
+    arg_types = {
+        "this": False,
+        "index_type": False,
+        "on_conflict": False,
+        "nulls": False,
+        "options": False,
+    }
 
 
 class UppercaseColumnConstraint(ColumnConstraintKind):
@@ -2140,6 +2146,7 @@ class ForeignKey(Expression):
         "reference": False,
         "delete": False,
         "update": False,
+        "options": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1066,7 +1066,9 @@ class Generator(metaclass=_Generator):
         desc = expression.args.get("desc")
         if desc is not None:
             return f"PRIMARY KEY{' DESC' if desc else ' ASC'}"
-        return "PRIMARY KEY"
+        options = self.expressions(expression, key="options", flat=True, sep=" ")
+        options = f" {options}" if options else ""
+        return f"PRIMARY KEY{options}"
 
     def uniquecolumnconstraint_sql(self, expression: exp.UniqueColumnConstraint) -> str:
         this = self.sql(expression, "this")
@@ -1076,7 +1078,9 @@ class Generator(metaclass=_Generator):
         on_conflict = self.sql(expression, "on_conflict")
         on_conflict = f" {on_conflict}" if on_conflict else ""
         nulls_sql = " NULLS NOT DISTINCT" if expression.args.get("nulls") else ""
-        return f"UNIQUE{nulls_sql}{this}{index_type}{on_conflict}"
+        options = self.expressions(expression, key="options", flat=True, sep=" ")
+        options = f" {options}" if options else ""
+        return f"UNIQUE{nulls_sql}{this}{index_type}{on_conflict}{options}"
 
     def createable_sql(self, expression: exp.Create, locations: t.DefaultDict) -> str:
         return self.sql(expression, "this")
@@ -2921,7 +2925,9 @@ class Generator(metaclass=_Generator):
         delete = f" ON DELETE {delete}" if delete else ""
         update = self.sql(expression, "update")
         update = f" ON UPDATE {update}" if update else ""
-        return f"FOREIGN KEY{expressions}{reference}{delete}{update}"
+        options = self.expressions(expression, key="options", flat=True, sep=" ")
+        options = f" {options}" if options else ""
+        return f"FOREIGN KEY{expressions}{reference}{delete}{update}{options}"
 
     def primarykey_sql(self, expression: exp.ForeignKey) -> str:
         expressions = self.expressions(expression, flat=True)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7059,6 +7059,7 @@ class Parser(metaclass=_Parser):
             parse_result = parse_method()
             if parse_result is not None:
                 items.append(parse_result)
+
         return items
 
     def _parse_tokens(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1326,7 +1326,7 @@ class Parser(metaclass=_Parser):
             "BTREE",
             "HASH",
         ),
-        **dict.fromkeys(("DEFERRABLE", "NORELY"), tuple()),
+        **dict.fromkeys(("DEFERRABLE", "NORELY", "RELY"), tuple()),
     }
 
     INSERT_ALTERNATIVES = {"ABORT", "FAIL", "IGNORE", "REPLACE", "ROLLBACK"}
@@ -6015,6 +6015,7 @@ class Parser(metaclass=_Parser):
             this=self._parse_schema(self._parse_unique_key()),
             index_type=self._match(TokenType.USING) and self._advance_any() and self._prev.text,
             on_conflict=self._parse_on_conflict(),
+            options=self._parse_key_constraint_options(),
         )
 
     def _parse_key_constraint_options(self) -> t.List[str]:
@@ -6063,7 +6064,7 @@ class Parser(metaclass=_Parser):
     def _parse_foreign_key(self) -> exp.ForeignKey:
         expressions = self._parse_wrapped_id_vars()
         reference = self._parse_references()
-        options = {}
+        on_options = {}
 
         while self._match(TokenType.ON):
             if not self._match_set((TokenType.DELETE, TokenType.UPDATE)):
@@ -6080,13 +6081,14 @@ class Parser(metaclass=_Parser):
                 self._advance()
                 action = self._prev.text.upper()
 
-            options[kind] = action
+            on_options[kind] = action
 
         return self.expression(
             exp.ForeignKey,
             expressions=expressions,
             reference=reference,
-            **options,  # type: ignore
+            options=self._parse_key_constraint_options(),
+            **on_options,  # type: ignore
         )
 
     def _parse_primary_key_part(self) -> t.Optional[exp.Expression]:
@@ -6113,7 +6115,11 @@ class Parser(metaclass=_Parser):
         )
 
         if not in_props and not self._match(TokenType.L_PAREN, advance=False):
-            return self.expression(exp.PrimaryKeyColumnConstraint, desc=desc)
+            return self.expression(
+                exp.PrimaryKeyColumnConstraint,
+                desc=desc,
+                options=self._parse_key_constraint_options(),
+            )
 
         expressions = self._parse_wrapped_csv(
             self._parse_primary_key_part, optional=wrapped_optional
@@ -7053,7 +7059,6 @@ class Parser(metaclass=_Parser):
             parse_result = parse_method()
             if parse_result is not None:
                 items.append(parse_result)
-
         return items
 
     def _parse_tokens(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2563,3 +2563,11 @@ SINGLE = TRUE""",
                     "duckdb": f"SELECT LISTAGG({distinct}col, '|SEPARATOR|' ORDER BY col2) FROM t",
                 },
             )
+
+    def test_rely(self):
+        self.validate_identity(
+            "CREATE TABLE t (col1 INT PRIMARY KEY RELY, col2 INT UNIQUE RELY, col3 INT NOT NULL FOREIGN KEY REFERENCES other_t (id))"
+        )
+        self.validate_identity(
+            "CREATE TABLE t (col1 INT, col2 DATE, col3 VARCHAR, UNIQUE (col1, col2) RELY)"
+        )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2564,10 +2564,11 @@ SINGLE = TRUE""",
                 },
             )
 
-    def test_rely(self):
-        self.validate_identity(
-            "CREATE TABLE t (col1 INT PRIMARY KEY RELY, col2 INT UNIQUE RELY, col3 INT NOT NULL FOREIGN KEY REFERENCES other_t (id) RELY)"
-        )
-        self.validate_identity(
-            "CREATE TABLE t (col1 INT, col2 INT, col3 INT, PRIMARY KEY (col1) RELY, UNIQUE (col1, col2) RELY, FOREIGN KEY (col3) REFERENCES other_t (id) RELY)"
-        )
+    def test_rely_options(self):
+        for option in ("NORELY", "RELY"):
+            self.validate_identity(
+                f"CREATE TABLE t (col1 INT PRIMARY KEY {option}, col2 INT UNIQUE {option}, col3 INT NOT NULL FOREIGN KEY REFERENCES other_t (id) {option})"
+            )
+            self.validate_identity(
+                f"CREATE TABLE t (col1 INT, col2 INT, col3 INT, PRIMARY KEY (col1) {option}, UNIQUE (col1, col2) {option}, FOREIGN KEY (col3) REFERENCES other_t (id) {option})"
+            )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2566,7 +2566,7 @@ SINGLE = TRUE""",
 
     def test_rely(self):
         self.validate_identity(
-            "CREATE TABLE t (col1 INT PRIMARY KEY RELY, col2 INT UNIQUE RELY, col3 INT NOT NULL FOREIGN KEY REFERENCES other_t (id))"
+            "CREATE TABLE t (col1 INT PRIMARY KEY RELY, col2 INT UNIQUE RELY, col3 INT NOT NULL FOREIGN KEY REFERENCES other_t (id) RELY)"
         )
         self.validate_identity(
             "CREATE TABLE t (col1 INT, col2 DATE, col3 VARCHAR, UNIQUE (col1, col2) RELY)"

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2569,5 +2569,5 @@ SINGLE = TRUE""",
             "CREATE TABLE t (col1 INT PRIMARY KEY RELY, col2 INT UNIQUE RELY, col3 INT NOT NULL FOREIGN KEY REFERENCES other_t (id) RELY)"
         )
         self.validate_identity(
-            "CREATE TABLE t (col1 INT, col2 DATE, col3 VARCHAR, UNIQUE (col1, col2) RELY)"
+            "CREATE TABLE t (col1 INT, col2 INT, col3 INT, PRIMARY KEY (col1) RELY, UNIQUE (col1, col2) RELY, FOREIGN KEY (col3) REFERENCES other_t (id) RELY)"
         )


### PR DESCRIPTION
Fixes #4983 

This PR adds parsing support for the `RELY` option in the base parser.
In the future, `KEY_CONSTRAINT_OPTIONS` can have more options to be automatically supported.

**DOCS**
[Snowflake RELY](https://docs.snowflake.com/en/user-guide/join-elimination)