### PR TITLE
feat(Snowflake): enhance support for CASE expressions in BEGIN..END blocks

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -934,8 +934,24 @@ class Snowflake(Dialect):
                     break
                 statements.append(stmt)
                 self._match(TokenType.SEMICOLON)
-            self._match(TokenType.END)
+                self._match(TokenType.END)
             return self.expression(exp.BeginEndBlock, expressions=statements)
+
+        def _parse_case(self) -> t.Optional[exp.Expression]:
+            expr = super()._parse_case()
+            if not expr:
+                return None
+
+            # determine whether this is a conditional CASE expression, or a CASE scripting block
+            # TODO the list of types below may need to be extended over time
+            statement_types = (exp.Select, exp.Return, exp.DML)
+            expressions = [e.args["true"] for e in expr.args["ifs"]] + [expr.args.get("default")]
+            is_case_block = any(isinstance(e, statement_types) for e in expressions)
+
+            if not is_case_block:
+                return expr
+
+            return self.expression(exp.CaseScriptingBlock, **expr.args)
 
     class Tokenizer(tokens.Tokenizer):
         STRING_ESCAPES = ["\\", "'"]
@@ -1380,3 +1396,6 @@ class Snowflake(Dialect):
         def beginendblock_sql(self, expression: exp.BeginEndBlock) -> str:
             expressions = self.expressions(expression, "expressions", sep="; ")
             return f"BEGIN {expressions}; END"
+
+        def casescriptingblock_sql(self, expression: exp.CaseScriptingBlock) -> str:
+            return self._case_sql(expression, delimiter=";", end="END CASE")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6960,6 +6960,10 @@ class Semicolon(Expression):
     arg_types = {}
 
 
+class BeginEndBlock(Expression):
+    arg_types = {"expressions": True}
+
+
 def _norm_arg(arg):
     return arg.lower() if type(arg) is str else arg
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5607,6 +5607,11 @@ class Case(Func):
         return instance
 
 
+# https://docs.snowflake.com/en/sql-reference/snowflake-scripting/case
+class CaseScriptingBlock(Case):
+    pass
+
+
 class Cast(Func):
     arg_types = {
         "this": True,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2839,19 +2839,22 @@ class Generator(metaclass=_Generator):
         return f"EXISTS{self.wrap(expression)}"
 
     def case_sql(self, expression: exp.Case) -> str:
+        return self._case_sql(expression, delimiter="", end="END")
+
+    def _case_sql(self, expression: exp.Case, delimiter: str, end: str) -> str:
         this = self.sql(expression, "this")
         statements = [f"CASE {this}" if this else "CASE"]
 
         for e in expression.args["ifs"]:
             statements.append(f"WHEN {self.sql(e, 'this')}")
-            statements.append(f"THEN {self.sql(e, 'true')}")
+            statements.append(f"THEN {self.sql(e, 'true')}{delimiter}")
 
         default = self.sql(expression, "default")
 
         if default:
-            statements.append(f"ELSE {default}")
+            statements.append(f"ELSE {default}{delimiter}")
 
-        statements.append("END")
+        statements.append(end)
 
         if self.pretty and self.too_wide(statements):
             return self.indent("\n".join(statements), skip_first=True, skip_last=True)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4735,8 +4735,7 @@ class Parser(metaclass=_Parser):
         return this
 
     def _parse_expression(self) -> t.Optional[exp.Expression]:
-        ass = self._parse_assignment()
-        return self._parse_alias(ass)
+        return self._parse_alias(self._parse_assignment())
 
     def _parse_assignment(self) -> t.Optional[exp.Expression]:
         this = self._parse_disjunction()
@@ -6231,6 +6230,8 @@ class Parser(metaclass=_Parser):
                 default = exp.column("interval")
             else:
                 self.raise_error("Expected END after CASE", self._prev)
+        # note: some dialects allow either "END" or "END CASE" (e.g., Snowflake)
+        self._match(TokenType.CASE)
 
         return self.expression(
             exp.Case, comments=comments, this=expression, ifs=ifs, default=default
@@ -7855,7 +7856,7 @@ class Parser(metaclass=_Parser):
         return None
 
     def _match_set(self, types, advance=True):
-        if not self._curr or self._curr.token_type == TokenType.SEMICOLON:
+        if not self._curr:
             return None
 
         if self._curr.token_type in types:

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -237,6 +237,7 @@ class TokenType(AutoName):
     ATTACH = auto()
     AUTO_INCREMENT = auto()
     BEGIN = auto()
+    BEGIN_BLOCK = auto()
     BETWEEN = auto()
     BULK_COLLECT_INTO = auto()
     CACHE = auto()
@@ -368,6 +369,7 @@ class TokenType(AutoName):
     REFRESH = auto()
     RENAME = auto()
     REPLACE = auto()
+    RETURN = auto()
     RETURNING = auto()
     REFERENCES = auto()
     RIGHT = auto()
@@ -811,6 +813,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "REGEXP": TokenType.RLIKE,
         "RENAME": TokenType.RENAME,
         "REPLACE": TokenType.REPLACE,
+        "RETURN": TokenType.RETURN,
         "RETURNING": TokenType.RETURNING,
         "REFERENCES": TokenType.REFERENCES,
         "RIGHT": TokenType.RIGHT,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2572,3 +2572,8 @@ SINGLE = TRUE""",
             self.validate_identity(
                 f"CREATE TABLE t (col1 INT, col2 INT, col3 INT, PRIMARY KEY (col1) {option}, UNIQUE (col1, col2) {option}, FOREIGN KEY (col3) REFERENCES other_t (id) {option})"
             )
+
+    def test_case_within_begin_block(self):
+        self.validate_identity(
+            "BEGIN CASE ($myvar) WHEN 'foo' THEN select MYFUNC(1); WHEN 'bar' THEN RETURN 2; ELSE RETURN 3; END CASE; END;"
+        )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2575,5 +2575,10 @@ SINGLE = TRUE""",
 
     def test_case_within_begin_block(self):
         self.validate_identity(
-            "BEGIN CASE ($myvar) WHEN 'foo' THEN select MYFUNC(1); WHEN 'bar' THEN RETURN 2; ELSE RETURN 3; END CASE; END;"
+            "BEGIN CASE ($myvar) WHEN 'foo' THEN SELECT MYFUNC(1); WHEN 'bar' THEN RETURN 2; ELSE RETURN 3; END CASE; END"
+        )
+        # same expression, but closing the block with `END` instead of `END CASE`
+        self.validate_identity(
+            "BEGIN CASE ($myvar) WHEN 'foo' THEN SELECT MYFUNC(1); WHEN 'bar' THEN RETURN 2; ELSE RETURN 3; END; END",
+            "BEGIN CASE ($myvar) WHEN 'foo' THEN SELECT MYFUNC(1); WHEN 'bar' THEN RETURN 2; ELSE RETURN 3; END CASE; END",
         )


### PR DESCRIPTION
## Motivation

Snowflake supports two types of `CASE` statements:
* `CASE` for conditional expressions: https://docs.snowflake.com/en/sql-reference/functions/case
* `CASE` for conditional statements in scripting blocks: https://docs.snowflake.com/en/sql-reference/snowflake-scripting/case

Currently we are not able to parse the latter, i.e., `CASE` statements in scripting blocks that are typically encapsulated within `BEGIN ... END` blocks.

For example, the following query is valid in Snowflake, but raises a parsing error against sqlglot:
```
BEGIN 
  CASE ($myvar) 
    WHEN 'foo' THEN SELECT MYFUNC(1); 
    WHEN 'bar' THEN RETURN 2; 
    ELSE RETURN 3; 
  END CASE; 
END
```

One of the challenges when parsing such expressions is the use of semicolons above - the current logic in `Parser._parse(..)` terminates each expression and creates new chunks whenever a semicolons is found (see [here](https://github.com/tobymao/sqlglot/blob/510984f2ddc6ff13b8a8030f698aed9ad0e6f46b/sqlglot/parser.py#L1589)), however, for `CASE` expressions we need to preserve the semicolons, to be able to use `;` as a delimiter for each `WHEN`/`ELSE` clause.

## Changes

* add `BeginEndBlock` model class to represent `BEGIN ... END` code blocks
* add `CaseScriptingBlock` model class to represent `CASE ... END CASE` scripting blocks
* ...
