### PR TITLE
Feat(optimizer): add support for Spark's TRANSFORM clause

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -5,7 +5,7 @@ import typing as t
 from collections import defaultdict
 
 from sqlglot import expressions as exp
-from sqlglot.helper import find_new_name
+from sqlglot.helper import find_new_name, seq_get
 from sqlglot.optimizer.scope import Scope, traverse_scope
 
 if t.TYPE_CHECKING:
@@ -217,6 +217,7 @@ def _mergeable(
         and not _is_a_window_expression_in_unmergable_operation()
         and not _is_recursive()
         and not (inner_select.args.get("order") and outer_scope.is_union)
+        and not isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform)
     )
 
 

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -1455,3 +1455,38 @@ LEFT JOIN "_u_1" AS "_u_1"
   ON "_u_1"."tagname" = "event"."tagname"
 WHERE
   "event"."priority" = 'High' AND NOT "_u_1"."tagname" IS NULL;
+
+# title: SELECT TRANSFORM ... Spark clause when schema is provided
+# execute: false
+# dialect: spark
+WITH a AS (SELECT 'v' AS x) SELECT * FROM (SELECT TRANSFORM(x) USING 'cat' AS (y STRING) FROM a);
+WITH `a` AS (
+  SELECT
+    'v' AS `x`
+), `_q_0` AS (
+  SELECT
+    TRANSFORM(`a`.`x`) USING 'cat' AS (
+      `y` STRING
+    )
+  FROM `a` AS `a`
+)
+SELECT
+  `_q_0`.`y` AS `y`
+FROM `_q_0` AS `_q_0`;
+
+# title: SELECT TRANSFORM ... Spark clause when schema is not provided
+# execute: false
+# dialect: spark
+WITH a AS (SELECT 'v' AS x) SELECT * FROM (SELECT TRANSFORM(x) USING 'cat'  FROM a);
+WITH `a` AS (
+  SELECT
+    'v' AS `x`
+), `_q_0` AS (
+  SELECT
+    TRANSFORM(`a`.`x`) USING 'cat'
+  FROM `a` AS `a`
+)
+SELECT
+  `_q_0`.`key` AS `key`,
+  `_q_0`.`value` AS `value`
+FROM `_q_0` AS `_q_0`;


### PR DESCRIPTION
Fixes #4991

Reference: https://spark.apache.org/docs/3.5.1/sql-ref-syntax-qry-select-transform.html