### PR TITLE
Fix(optimizer): ensure there are no shared refs after qualify_tables

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -54,10 +54,10 @@ def qualify_tables(
 
     def _qualify(table: exp.Table) -> None:
         if isinstance(table.this, exp.Identifier):
-            if not table.args.get("db"):
-                table.set("db", db)
-            if not table.args.get("catalog") and table.args.get("db"):
-                table.set("catalog", catalog)
+            if db and not table.args.get("db"):
+                table.set("db", db.copy())
+            if catalog and not table.args.get("catalog") and table.args.get("db"):
+                table.set("catalog", catalog.copy())
 
     if (db or catalog) and not isinstance(expression, exp.Query):
         for node in expression.walk(prune=lambda n: isinstance(n, exp.Query)):
@@ -148,6 +148,7 @@ def qualify_tables(
                 if table_alias:
                     for p in exp.COLUMN_PARTS[1:]:
                         column.set(p, None)
-                    column.set("table", table_alias)
+
+                    column.set("table", table_alias.copy())
 
     return expression

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -176,6 +176,11 @@ class TestOptimizer(unittest.TestCase):
                     expected,
                     actual,
                 )
+                for expression in optimized.walk():
+                    for arg_key, arg in expression.args.items():
+                        if isinstance(arg, exp.Expression):
+                            self.assertEqual(arg_key, arg.arg_key)
+                            self.assertIs(arg.parent, expression)
 
                 if string_to_bool(execute):
                     with self.subTest(f"(execute) {title}"):


### PR DESCRIPTION
There's currently a bug in main where some AST refs are reused in various nodes, leading to corrupted ASTs. I'm not sure what's the severity of this, maybe it's not super important, e.g. if we copy the AST down the line somewhere.

I added a couple of new assertions in `test_optimizer.py::check_file` for some important invariants that need to hold post-optimization. This should catch similar AST mutations in the future. For reference, before fixing the mutations in `qualify_tables.py`, there were about 23 optimizer tests failing (related to that rule).