### PR TITLE
Fix(trino): Dont quote identifiers in string literals for the partitioned_by property

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -57,29 +57,13 @@ def _no_sort_array(self: Presto.Generator, expression: exp.SortArray) -> str:
 
 def _schema_sql(self: Presto.Generator, expression: exp.Schema) -> str:
     if isinstance(expression.parent, exp.PartitionedByProperty):
-
-        def _force_unquoted(node: exp.Expression):
-            if isinstance(node, exp.Identifier) and node.quoted:
-                node.set("quoted", False)
-            return node
-
         # Any columns in the ARRAY[] string literals should not be quoted
-        # When identify=False on the generator, identifiers are not force-quoted, but any exp.Identifier nodes with `quoted=True` are still quoted
-        # so to ensure exp.Identifier nodes are never quoted under any circumstances, we need to:
-        # - set `identify=False` on the generator
-        # - set `quoted=False` on any exp.Identifier objects
-        orig_identify = self.identify
-        self.identify = False
-        expressions = expression.transform(_force_unquoted)
+        expression.transform(lambda n: n.name if isinstance(n, exp.Identifier) else n, copy=False)
 
-        try:
-            partition_exprs = [
-                self.sql(c) if isinstance(c, (exp.Func, exp.Property)) else self.sql(c, "this")
-                for c in expressions
-            ]
-        finally:
-            self.identify = orig_identify
-
+        partition_exprs = [
+            self.sql(c) if isinstance(c, (exp.Func, exp.Property)) else self.sql(c, "this")
+            for c in expression.expressions
+        ]
         return self.sql(exp.Array(expressions=[exp.Literal.string(c) for c in partition_exprs]))
 
     if expression.parent:

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -97,10 +97,18 @@ class TestTrino(Validator):
         self.validate_identity(
             "CREATE TABLE foo (a VARCHAR, b INTEGER, c DATE) WITH (PARTITIONED_BY=ARRAY['a', 'b'])"
         )
+        self.validate_identity(
+            'CREATE TABLE "foo" ("a" VARCHAR, "b" INTEGER, "c" DATE) WITH (PARTITIONED_BY=ARRAY[\'a\', \'b\'])',
+            identify=True,
+        )
 
         # Iceberg connector syntax (partitioning, can contain Iceberg transform expressions)
         self.validate_identity(
             "CREATE TABLE foo (a VARCHAR, b INTEGER, c DATE) WITH (PARTITIONING=ARRAY['a', 'bucket(4, b)', 'month(c)'])",
+        )
+        self.validate_identity(
+            'CREATE TABLE "foo" ("a" VARCHAR, "b" INTEGER, "c" DATE) WITH (PARTITIONING=ARRAY[\'a\', \'bucket(4, b)\', \'month(c)\'])',
+            identify=True,
         )
 
     def test_analyze(self):


### PR DESCRIPTION
Prior to this PR, `CREATE TABLE` expressions containing  for Athena/Trino were generated like so when `identify=True` was set (or an `exp.Identifier` node had `quoted=True` set):
```
create table "test_table" (id integer, ds varchar) with (partitioning=array['"ds"'])
```

This is valid for Athena and Trino/Iceberg, but not Trino/Hive. Trino/Hive would throw the following error:
```
Query failed: Partition columns ["ds"] not present in schema
```

This PR ensures that identifiers in partitioning expression string literals are never quoted