### PR TITLE
feat(clickhouse): Support parsing CTAS with alias

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1999,7 +1999,7 @@ class Parser(metaclass=_Parser):
             # exp.Properties.Location.POST_SCHEMA and POST_WITH
             extend_props(self._parse_properties())
 
-            self._match(TokenType.ALIAS)
+            has_alias = self._match(TokenType.ALIAS)
             if not self._match_set(self.DDL_SELECT_TOKENS, advance=False):
                 # exp.Properties.Location.POST_ALIAS
                 extend_props(self._parse_properties())
@@ -2009,6 +2009,11 @@ class Parser(metaclass=_Parser):
                 extend_props(self._parse_properties())
             else:
                 expression = self._parse_ddl_select()
+                # Some dialects also support using a table as an alias instead of a SELECT.
+                # Here we fallback to this as an alternative.
+                if not expression and has_alias:
+                    if self._match_set({TokenType.VAR}, advance=False):
+                        expression = self._parse_table_parts()
 
             if create_token.token_type == TokenType.TABLE:
                 # exp.Properties.Location.POST_EXPRESSION

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2012,7 +2012,7 @@ class Parser(metaclass=_Parser):
                 # Some dialects also support using a table as an alias instead of a SELECT.
                 # Here we fallback to this as an alternative.
                 if not expression and has_alias:
-                    if self._match_set({TokenType.VAR}, advance=False):
+                    if self._match(TokenType.VAR, advance=False):
                         expression = self._parse_table_parts()
 
             if create_token.token_type == TokenType.TABLE:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -770,11 +770,9 @@ ORDER BY (
         ctas_alias = "CREATE TABLE my_db.my_table AS another_db.another_table"
 
         expected = exp.Create(
-            this=exp.Table(this=exp.Identifier(this="my_table"), db=exp.Identifier(this="my_db")),
+            this=exp.to_table("my_db.my_table"),
             kind="TABLE",
-            expression=exp.Table(
-                this=exp.Identifier(this="another_table"), db=exp.Identifier(this="another_db")
-            ),
+            expression=exp.to_table("another_db.another_table"),
         )
         self.assertEqual(self.parse_one(ctas_alias), expected)
         self.validate_identity(ctas_alias)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -766,6 +766,19 @@ ORDER BY (
             pretty=True,
         )
 
+    def test_create_table_as_alias(self):
+        ctas_alias = "CREATE TABLE my_db.my_table AS another_db.another_table"
+
+        expected = exp.Create(
+            this=exp.Table(this=exp.Identifier(this="my_table"), db=exp.Identifier(this="my_db")),
+            kind="TABLE",
+            expression=exp.Table(
+                this=exp.Identifier(this="another_table"), db=exp.Identifier(this="another_db")
+            ),
+        )
+        self.assertEqual(self.parse_one(ctas_alias), expected)
+        self.validate_identity(ctas_alias)
+
     def test_ddl(self):
         db_table_expr = exp.Table(this=None, db=exp.to_identifier("foo"), catalog=None)
         create_with_cluster = exp.Create(


### PR DESCRIPTION
This PR adds support for ClickHouse's special variant of `CREATE TABLE AS` which allows you to specify another table to create your table from as opposed to using a `SELECT` statement. 

I don't know of any other dialects which support this, but I still added the implementation in `sqlglot.parser` since I did not see an easy way to customize just this part of the parser in the `sqlglot.dialects.clickhouse`.

https://clickhouse.com/docs/sql-reference/statements/create/table#with-a-schema-similar-to-other-table