### PR TITLE
fix(clickhouse): Support optional timezone argument in date_diff()

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -22,7 +22,6 @@ from sqlglot.dialects.dialect import (
     unit_to_var,
     trim_sql,
 )
-from sqlglot.expressions import DateDiff
 from sqlglot.generator import Generator
 from sqlglot.helper import is_int, seq_get
 from sqlglot.tokens import Token, TokenType
@@ -94,34 +93,17 @@ def _build_str_to_date(args: t.List) -> exp.Cast | exp.Anonymous:
     return exp.cast(strtodate, exp.DataType.build(exp.DataType.Type.DATETIME))
 
 
-def _build_clickhouse_date_diff(args: t.List) -> exp.DateDiff:
-    # The date_diff function in ClickHouse includes an optional fourth positional argument for
-    # timezone which is not present in most other dialects.
-    unit_based = len(args) >= 3
-    has_timezone = len(args) == 4
-
-    this = args[2] if unit_based else seq_get(args, 0)
-
-    unit = None
-    if unit_based:
-        unit = args[0]
-    timezone = None
-    if has_timezone:
-        timezone = args[-1]
-    return DateDiff(this=this, expression=seq_get(args, 1), unit=unit, timezone=timezone)
-
-
 def _datetime_delta_sql(name: str) -> t.Callable[[Generator, DATEΤΙΜΕ_DELTA], str]:
     def _delta_sql(self: Generator, expression: DATEΤΙΜΕ_DELTA) -> str:
         if not expression.unit:
             return rename_func(name)(self, expression)
 
-        extra_args = []
-        if isinstance(expression, exp.DateDiff):
-            extra_args = [expression.timezone]
-
         return self.func(
-            name, unit_to_var(expression), expression.expression, expression.this, *extra_args
+            name,
+            unit_to_var(expression),
+            expression.expression,
+            expression.this,
+            expression.args.get("zone"),
         )
 
     return _delta_sql
@@ -320,8 +302,8 @@ class ClickHouse(Dialect):
             "COUNTIF": _build_count_if,
             "DATE_ADD": build_date_delta(exp.DateAdd, default_unit=None),
             "DATEADD": build_date_delta(exp.DateAdd, default_unit=None),
-            "DATE_DIFF": _build_clickhouse_date_diff,
-            "DATEDIFF": _build_clickhouse_date_diff,
+            "DATE_DIFF": build_date_delta(exp.DateDiff, default_unit=None, supports_timezone=True),
+            "DATEDIFF": build_date_delta(exp.DateDiff, default_unit=None, supports_timezone=True),
             "DATE_FORMAT": _build_date_format,
             "DATE_SUB": build_date_delta(exp.DateSub, default_unit=None),
             "DATESUB": build_date_delta(exp.DateSub, default_unit=None),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1250,7 +1250,7 @@ def build_date_delta(
             unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
         expression = exp_class(this=this, expression=seq_get(args, 1), unit=unit)
         if supports_timezone and has_timezone:
-            expression.args["zone"] = args[-1]
+            expression.set("zone", args[-1])
         return expression
 
     return _builder

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1238,15 +1238,20 @@ def build_date_delta(
     exp_class: t.Type[E],
     unit_mapping: t.Optional[t.Dict[str, str]] = None,
     default_unit: t.Optional[str] = "DAY",
+    supports_timezone: bool = False,
 ) -> t.Callable[[t.List], E]:
     def _builder(args: t.List) -> E:
-        unit_based = len(args) == 3
+        unit_based = len(args) >= 3
+        has_timezone = len(args) == 4
         this = args[2] if unit_based else seq_get(args, 0)
         unit = None
         if unit_based or default_unit:
             unit = args[0] if unit_based else exp.Literal.string(default_unit)
             unit = exp.var(unit_mapping.get(unit.name.lower(), unit.name)) if unit_mapping else unit
-        return exp_class(this=this, expression=seq_get(args, 1), unit=unit)
+        expression = exp_class(this=this, expression=seq_get(args, 1), unit=unit)
+        if supports_timezone and has_timezone:
+            expression.args["zone"] = args[-1]
+        return expression
 
     return _builder
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5752,11 +5752,7 @@ class DateSub(Func, IntervalOp):
 
 class DateDiff(Func, TimeUnit):
     _sql_names = ["DATEDIFF", "DATE_DIFF"]
-    arg_types = {"this": True, "expression": True, "unit": False, "timezone": False}
-
-    @property
-    def timezone(self) -> t.Optional[Literal]:
-        return self.args.get("timezone")
+    arg_types = {"this": True, "expression": True, "unit": False, "zone": False}
 
 
 class DateTrunc(Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5752,7 +5752,11 @@ class DateSub(Func, IntervalOp):
 
 class DateDiff(Func, TimeUnit):
     _sql_names = ["DATEDIFF", "DATE_DIFF"]
-    arg_types = {"this": True, "expression": True, "unit": False}
+    arg_types = {"this": True, "expression": True, "unit": False, "timezone": False}
+
+    @property
+    def timezone(self) -> t.Optional[Literal]:
+        return self.args.get("timezone")
 
 
 class DateTrunc(Func):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1220,6 +1220,15 @@ LIFETIME(MIN 0 MAX 0)""",
                         f"SELECT {func_alias}(SECOND, 1, bar)",
                         f"SELECT {func_name}(SECOND, 1, bar)",
                     )
+        # 4-arg functions of type <func>(unit, value, date, timezone)
+        for func in (("DATE_DIFF", "DATEDIFF"),):
+            func_name = func[0]
+            for func_alias in func:
+                with self.subTest(f"Test 4-arg date-time function {func_alias}"):
+                    self.validate_identity(
+                        f"SELECT {func_alias}(SECOND, 1, bar, 'UTC')",
+                        f"SELECT {func_name}(SECOND, 1, bar, 'UTC')",
+                    )
 
     def test_convert(self):
         self.assertEqual(


### PR DESCRIPTION
Unlike many other dialects, ClickHouse's dateDiff function supports an optional fourth argument for specifying a timezone.  This PR updates the DateDiff AST node to support this optional argument and updates the logic in the ClickHouse dialect to populate it.

The existing helper for constructing a DateDiff was a bit hard to extend, so I've included a new ClickHouse-specific implementation which can handle the optional fourth argument.

https://clickhouse.com/docs/sql-reference/functions/date-time-functions#date_diff