### PR TITLE
Feat: Support exp.PartitionedByProperty for parse_into()

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -800,6 +800,7 @@ class Parser(metaclass=_Parser):
         exp.Order: lambda self: self._parse_order(),
         exp.Ordered: lambda self: self._parse_ordered(),
         exp.Properties: lambda self: self._parse_properties(),
+        exp.PartitionedByProperty: lambda self: self._parse_partitioned_by(),
         exp.Qualify: lambda self: self._parse_qualify(),
         exp.Returning: lambda self: self._parse_returning(),
         exp.Select: lambda self: self._parse_select(),


### PR DESCRIPTION
Currently, SQLGLot throws an exception if you try something like:

```
>>> parse_one('(a, b)', into=exp.PartitionedByProperty)
TypeError: No parser registered for <class 'sqlglot.expressions.PartitionedByProperty'>
```

This PR allows it to work:
```
>>> parse_one('(a, b)', into=exp.PartitionedByProperty)
PartitionedByProperty(
  this=Schema(
    expressions=[
      Identifier(this=a, quoted=False),
      Identifier(this=b, quoted=False)]))
```

The use-case is to be able to correctly roundtrip partition expressions like `exp.PartitionedByBucket` from JSON where `exp.PartitionedByProperty` may be stored as a Python list of string representations of the AST nodes (eg in SQLMesh state)