### PR TITLE
Add numeric parameter support for Snowflake dialect

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -514,6 +514,15 @@ class Snowflake(Dialect):
             TokenType.SHOW: lambda self: self._parse_show(),
         }
 
+        PLACEHOLDER_PARSERS = {
+            **parser.Parser.PLACEHOLDER_PARSERS,
+            TokenType.COLON: lambda self: (
+                self.expression(exp.Placeholder, this=int(self._prev.text))
+                if self._match_set(self.ID_VAR_TOKENS) or self._match(TokenType.NUMBER)
+                else None
+            ),
+        }
+
         PROPERTY_PARSERS = {
             **parser.Parser.PROPERTY_PARSERS,
             "CREDENTIALS": lambda self: self._parse_credentials_property(),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2572,3 +2572,10 @@ SINGLE = TRUE""",
             self.validate_identity(
                 f"CREATE TABLE t (col1 INT, col2 INT, col3 INT, PRIMARY KEY (col1) {option}, UNIQUE (col1, col2) {option}, FOREIGN KEY (col3) REFERENCES other_t (id) {option})"
             )
+
+    def test_parameter(self):
+        expr_placeholder = parse_one("SELECT :1", dialect="snowflake").find(exp.Placeholder)
+        self.assertEqual(expr_placeholder, exp.Placeholder(this=1))
+        self.validate_identity("SELECT :1")
+        self.validate_identity("SELECT :1, :2")
+        self.validate_identity("SELECT :1 + :2")


### PR DESCRIPTION
Add support for numeric parameters in Snowflake dialect, see the relevant Snowflake documentation https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#using-qmark-or-numeric-binding

Example from Snowflake docs:
```py
import snowflake.connector

snowflake.connector.paramstyle='numeric'

con = snowflake.connector.connect(...)

con.cursor().execute(
    "INSERT INTO testtable(col1, col2) "
    "VALUES(:1, :2)", (
        789,
        'test string3'
    ))
```