### PR TITLE
chore: Refactor colon placeholder parsing 

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -401,6 +401,8 @@ class Snowflake(Dialect):
         TABLE_ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS | {TokenType.WINDOW}
         TABLE_ALIAS_TOKENS.discard(TokenType.MATCH_CONDITION)
 
+        COLON_PLACEHOLDER_TOKENS = ID_VAR_TOKENS | {TokenType.NUMBER}
+
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "APPROX_PERCENTILE": exp.ApproxQuantile.from_arg_list,
@@ -512,15 +514,6 @@ class Snowflake(Dialect):
             **parser.Parser.STATEMENT_PARSERS,
             TokenType.PUT: lambda self: self._parse_put(),
             TokenType.SHOW: lambda self: self._parse_show(),
-        }
-
-        PLACEHOLDER_PARSERS = {
-            **parser.Parser.PLACEHOLDER_PARSERS,
-            TokenType.COLON: lambda self: (
-                self.expression(exp.Placeholder, this=self._prev.text)
-                if self._match_set(self.ID_VAR_TOKENS) or self._match(TokenType.NUMBER)
-                else None
-            ),
         }
 
         PROPERTY_PARSERS = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -580,6 +580,8 @@ class Parser(metaclass=_Parser):
 
     ALIAS_TOKENS = ID_VAR_TOKENS
 
+    COLON_PLACEHOLDER_TOKENS = ID_VAR_TOKENS
+
     ARRAY_CONSTRUCTORS = {
         "ARRAY": exp.Array,
         "LIST": exp.List,
@@ -902,7 +904,7 @@ class Parser(metaclass=_Parser):
         TokenType.PARAMETER: lambda self: self._parse_parameter(),
         TokenType.COLON: lambda self: (
             self.expression(exp.Placeholder, this=self._prev.text)
-            if self._match_set(self.ID_VAR_TOKENS)
+            if self._match_set(self.COLON_PLACEHOLDER_TOKENS)
             else None
         ),
     }


### PR DESCRIPTION
Follow up of https://github.com/tobymao/sqlglot/pull/5008

Since the difference between `PLACEHOLDER_PARSERS` is only the following token set, we can spare overriding the entire dict and instead create & override a new set for `TokenType.COLON`.

cc: @hovaesco 