### PR TITLE
Feat(databricks): add support for the VOID type

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -27,6 +27,12 @@ class Databricks(Spark):
     class JSONPathTokenizer(jsonpath.JSONPathTokenizer):
         IDENTIFIERS = ["`", '"']
 
+    class Tokenizer(Spark.Tokenizer):
+        KEYWORDS = {
+            **Spark.Tokenizer.KEYWORDS,
+            "VOID": TokenType.VOID,
+        }
+
     class Parser(Spark.Parser):
         LOG_DEFAULTS_TO_LN = True
         STRICT_CAST = True
@@ -82,6 +88,11 @@ class Databricks(Spark):
         }
 
         TRANSFORMS.pop(exp.TryCast)
+
+        TYPE_MAPPING = {
+            **Spark.Generator.TYPE_MAPPING,
+            exp.DataType.Type.NULL: "VOID",
+        }
 
         def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
             constraint = expression.find(exp.GeneratedAsIdentityColumnConstraint)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -397,6 +397,7 @@ class Parser(metaclass=_Parser):
         TokenType.IMAGE,
         TokenType.VARIANT,
         TokenType.VECTOR,
+        TokenType.VOID,
         TokenType.OBJECT,
         TokenType.OBJECT_IDENTIFIER,
         TokenType.INET,
@@ -5238,6 +5239,8 @@ class Parser(metaclass=_Parser):
                 this = self.expression(exp.DataType, this=self.expression(exp.Interval, unit=unit))
             else:
                 this = self.expression(exp.DataType, this=exp.DataType.Type.INTERVAL)
+        elif type_token == TokenType.VOID:
+            this = exp.DataType(this=exp.DataType.Type.NULL)
 
         if maybe_func and check_func:
             index2 = self._index

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -222,6 +222,7 @@ class TokenType(AutoName):
     UNKNOWN = auto()
     VECTOR = auto()
     DYNAMIC = auto()
+    VOID = auto()
 
     # keywords
     ALIAS = auto()

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -7,6 +7,12 @@ class TestDatabricks(Validator):
     dialect = "databricks"
 
     def test_databricks(self):
+        null_type = exp.DataType.build("VOID", dialect="databricks")
+        self.assertEqual(null_type.sql(), "NULL")
+        self.assertEqual(null_type.sql("databricks"), "VOID")
+
+        self.validate_identity("SELECT CAST(NULL AS VOID)")
+        self.validate_identity("SELECT void FROM t")
         self.validate_identity("SELECT * FROM stream")
         self.validate_identity("SELECT t.current_time FROM t")
         self.validate_identity("ALTER TABLE labels ADD COLUMN label_score FLOAT")


### PR DESCRIPTION
Reference: https://docs.databricks.com/aws/en/sql/language-manual/data-types/null-type

This also works, FYI:

```sql
-- returns a single row with a column void
with t as (select 1 as void) select void from t
```