### PR TITLE
Fix DuckDB IN literal list

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp, generator, parser, tokens, transforms
-from sqlglot.expressions import DATA_TYPE
+from sqlglot.expressions import DATA_TYPE, Array, Literal
 from sqlglot.dialects.dialect import (
     Dialect,
     JSON_EXTRACT_TYPE,
@@ -962,8 +962,15 @@ class DuckDB(Dialect):
                 in_sql = self.sql(field)
             else:
                 in_sql = f"{self.expressions(expression, flat=True)}"
+                should_add_parens = True
+
                 exprs = expression.args.get("expressions")
-                if not exprs or len(exprs) > 1:
+                if exprs and len(exprs) == 1:
+                    expr = exprs[0]
+                    if isinstance(expr, Array):
+                        should_add_parens = False
+
+                if should_add_parens:
                     in_sql = f"({in_sql})"
 
             return f"{self.sql(expression, 'this')}{is_global} IN {in_sql}"

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -948,6 +948,23 @@ class DuckDB(Dialect):
 
             return super().tablesample_sql(expression, tablesample_keyword=tablesample_keyword)
 
+        def in_sql(self, expression: exp.In) -> str:
+            query = expression.args.get("query")
+            unnest = expression.args.get("unnest")
+            field = expression.args.get("field")
+            is_global = " GLOBAL" if expression.args.get("is_global") else ""
+
+            if query:
+                in_sql = self.sql(query)
+            elif unnest:
+                in_sql = self.in_unnest_op(unnest)
+            elif field:
+                in_sql = self.sql(field)
+            else:
+                in_sql = f"{self.expressions(expression, flat=True)}"
+
+            return f"{self.sql(expression, 'this')}{is_global} IN {in_sql}"
+
         def interval_sql(self, expression: exp.Interval) -> str:
             multiplier: t.Optional[int] = None
             unit = expression.text("unit").lower()

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -962,6 +962,9 @@ class DuckDB(Dialect):
                 in_sql = self.sql(field)
             else:
                 in_sql = f"{self.expressions(expression, flat=True)}"
+                exprs = expression.args.get("expressions")
+                if not exprs or len(exprs) > 1:
+                    in_sql = f"({in_sql})"
 
             return f"{self.sql(expression, 'this')}{is_global} IN {in_sql}"
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -879,9 +879,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
                 continue
 
             predicate = column.find_ancestor(exp.Predicate, exp.Select)
-            assert isinstance(
-                predicate, exp.Binary
-            ), "Columns can only be marked with (+) when involved in a binary operation"
+            assert isinstance(predicate, exp.Binary), (
+                "Columns can only be marked with (+) when involved in a binary operation"
+            )
 
             predicate_parent = predicate.parent
             join_predicate = predicate.pop()
@@ -893,9 +893,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
                 c for c in join_predicate.right.find_all(exp.Column) if c.args.get("join_mark")
             ]
 
-            assert not (
-                left_columns and right_columns
-            ), "The (+) marker cannot appear in both sides of a binary predicate"
+            assert not (left_columns and right_columns), (
+                "The (+) marker cannot appear in both sides of a binary predicate"
+            )
 
             marked_column_tables = set()
             for col in left_columns or right_columns:
@@ -905,9 +905,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
                 col.set("join_mark", False)
                 marked_column_tables.add(table)
 
-            assert (
-                len(marked_column_tables) == 1
-            ), "Columns of only a single table can be marked with (+) in a given binary predicate"
+            assert len(marked_column_tables) == 1, (
+                "Columns of only a single table can be marked with (+) in a given binary predicate"
+            )
 
             # Add predicate if join already copied, or add join if it is new
             join_this = old_joins.get(col.table, query_from).this
@@ -928,9 +928,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
 
         if query_from.alias_or_name in new_joins:
             only_old_joins = old_joins.keys() - new_joins.keys()
-            assert (
-                len(only_old_joins) >= 1
-            ), "Cannot determine which table to use in the new FROM clause"
+            assert len(only_old_joins) >= 1, (
+                "Cannot determine which table to use in the new FROM clause"
+            )
 
             new_from_name = list(only_old_joins)[0]
             query.set("from", exp.From(this=old_joins[new_from_name].this))

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1580,6 +1580,9 @@ class TestDuckDB(Validator):
             "SELECT l_returnflag, l_linestatus, SUM(l_quantity) AS sum_qty, SUM(l_extendedprice) AS sum_base_price, SUM(l_extendedprice * (1 - l_discount)) AS sum_disc_price, SUM(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge, AVG(l_quantity) AS avg_qty, AVG(l_extendedprice) AS avg_price, AVG(l_discount) AS avg_disc, COUNT(*) AS count_order",
         )
 
+        # Literal lists should not be surrounded with parens in IN expressions
+        self.assertEqual(exp.column("a").isin(["a"]).sql(dialect="duckdb"), "a IN ['a']")
+
     def test_at_sign_to_abs(self):
         self.validate_identity(
             "SELECT @col FROM t",


### PR DESCRIPTION
In DuckDB `a IN (['a'])` will throw an error as it interprets `(['a'])` as casting `'a'` to a LIST. Instead, for IN, we should generate `a IN ['a']`.