### PR TITLE
feat(snowflake): add support for GET statements

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -859,21 +859,17 @@ class Snowflake(Dialect):
             )
 
         def _parse_get(self) -> exp.Get | exp.Command:
-            base = self._prev
-
-            if self._curr.token_type not in (TokenType.STRING, TokenType.PARAMETER):
-                return self._parse_as_command(base)
-
-            source = self._parse_location_path()
+            start = self._prev
+            target = self._parse_location_path()
 
             # Parse as command if unquoted file path
             if self._curr.token_type == TokenType.URI_START:
-                return self._parse_as_command(base)
+                return self._parse_as_command(start)
 
             return self.expression(
                 exp.Get,
-                source=source,
                 this=self._parse_string(),
+                target=target,
                 properties=self._parse_properties(),
             )
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -512,6 +512,7 @@ class Snowflake(Dialect):
 
         STATEMENT_PARSERS = {
             **parser.Parser.STATEMENT_PARSERS,
+            TokenType.GET: lambda self: self._parse_get(),
             TokenType.PUT: lambda self: self._parse_put(),
             TokenType.SHOW: lambda self: self._parse_show(),
         }
@@ -857,6 +858,25 @@ class Snowflake(Dialect):
                 properties=self._parse_properties(),
             )
 
+        def _parse_get(self) -> exp.Get | exp.Command:
+            base = self._prev
+
+            if self._curr.token_type not in (TokenType.STRING, TokenType.PARAMETER):
+                return self._parse_as_command(base)
+
+            source = self._parse_location_path()
+
+            # Parse as command if unquoted file path
+            if self._curr.token_type == TokenType.URI_START:
+                return self._parse_as_command(base)
+
+            return self.expression(
+                exp.Get,
+                source=source,
+                this=self._parse_string(),
+                properties=self._parse_properties(),
+            )
+
         def _parse_location_property(self) -> exp.LocationProperty:
             self._match(TokenType.EQ)
             return self.expression(exp.LocationProperty, this=self._parse_location_path())
@@ -937,6 +957,7 @@ class Snowflake(Dialect):
             "CHARACTER VARYING": TokenType.VARCHAR,
             "EXCLUDE": TokenType.EXCEPT,
             "FILE FORMAT": TokenType.FILE_FORMAT,
+            "GET": TokenType.GET,
             "ILIKE ANY": TokenType.ILIKE_ANY,
             "LIKE ANY": TokenType.LIKE_ANY,
             "MATCH_CONDITION": TokenType.MATCH_CONDITION,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3309,7 +3309,7 @@ class Put(Expression):
 
 # https://docs.snowflake.com/en/sql-reference/sql/get
 class Get(Expression):
-    arg_types = {"source": True, "this": True, "properties": False}
+    arg_types = {"this": True, "target": True, "properties": False}
 
 
 class Table(Expression):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3307,6 +3307,11 @@ class Put(Expression):
     arg_types = {"this": True, "target": True, "properties": False}
 
 
+# https://docs.snowflake.com/en/sql-reference/sql/get
+class Get(Expression):
+    arg_types = {"source": True, "this": True, "properties": False}
+
+
 class Table(Expression):
     arg_types = {
         "this": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4904,16 +4904,18 @@ class Generator(metaclass=_Generator):
         return ""
 
     def put_sql(self, expression: exp.Put) -> str:
-        props_sql = self._format_props(expression.args.get("properties"))
-        this = self.sql(expression, "this")
-        target = self.sql(expression, "target")
-        return f"PUT {this} {target}{props_sql}"
+        return self._get_put_sql(expression)
 
     def get_sql(self, expression: exp.Get) -> str:
-        props_sql = self._format_props(expression.args.get("properties"))
-        this = self.sql(expression, "this")
-        source = self.sql(expression, "source")
-        return f"GET {source} {this}{props_sql}"
+        return self._get_put_sql(expression)
 
-    def _format_props(self, props: exp.Properties | None) -> str:
-        return self.properties(props, prefix=" ", sep=" ", wrapped=False) if props else ""
+    def _get_put_sql(self, expression: exp.Put | exp.Get) -> str:
+        props = expression.args.get("properties")
+        props_sql = self.properties(props, prefix=" ", sep=" ", wrapped=False) if props else ""
+        this = self.sql(expression, "this")
+        target = self.sql(expression, "target")
+
+        if isinstance(expression, exp.Put):
+            return f"PUT {this} {target}{props_sql}"
+        else:
+            return f"GET {target} {this}{props_sql}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -146,6 +146,7 @@ class Generator(metaclass=_Generator):
         exp.Except: lambda self, e: self.set_operations(e),
         exp.ExternalProperty: lambda *_: "EXTERNAL",
         exp.Floor: lambda self, e: self.ceil_floor(e),
+        exp.Get: lambda self, e: self.get_put_sql(e),
         exp.GlobalProperty: lambda *_: "GLOBAL",
         exp.HeapProperty: lambda *_: "HEAP",
         exp.IcebergProperty: lambda *_: "ICEBERG",
@@ -175,6 +176,7 @@ class Generator(metaclass=_Generator):
         exp.PivotAny: lambda self, e: f"ANY{self.sql(e, 'this')}",
         exp.ProjectionPolicyColumnConstraint: lambda self,
         e: f"PROJECTION POLICY {self.sql(e, 'this')}",
+        exp.Put: lambda self, e: self.get_put_sql(e),
         exp.RemoteWithConnectionModelProperty: lambda self,
         e: f"REMOTE WITH CONNECTION {self.sql(e, 'this')}",
         exp.ReturnsProperty: lambda self, e: (
@@ -4903,13 +4905,10 @@ class Generator(metaclass=_Generator):
         self.unsupported("Unsupported SHOW statement")
         return ""
 
-    def put_sql(self, expression: exp.Put) -> str:
-        return self._get_put_sql(expression)
-
-    def get_sql(self, expression: exp.Get) -> str:
-        return self._get_put_sql(expression)
-
-    def _get_put_sql(self, expression: exp.Put | exp.Get) -> str:
+    def get_put_sql(self, expression: exp.Put | exp.Get) -> str:
+        # Snowflake GET/PUT statements:
+        #   PUT <file> <internalStage> <properties>
+        #   GET <internalStage> <file> <properties>
         props = expression.args.get("properties")
         props_sql = self.properties(props, prefix=" ", sep=" ", wrapped=False) if props else ""
         this = self.sql(expression, "this")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4915,5 +4915,5 @@ class Generator(metaclass=_Generator):
         source = self.sql(expression, "source")
         return f"GET {source} {this}{props_sql}"
 
-    def _format_props(self, props) -> str:
+    def _format_props(self, props: exp.Properties | None) -> str:
         return self.properties(props, prefix=" ", sep=" ", wrapped=False) if props else ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4904,8 +4904,16 @@ class Generator(metaclass=_Generator):
         return ""
 
     def put_sql(self, expression: exp.Put) -> str:
-        props = expression.args.get("properties")
-        props_sql = self.properties(props, prefix=" ", sep=" ", wrapped=False) if props else ""
+        props_sql = self._format_props(expression.args.get("properties"))
         this = self.sql(expression, "this")
         target = self.sql(expression, "target")
         return f"PUT {this} {target}{props_sql}"
+
+    def get_sql(self, expression: exp.Get) -> str:
+        props_sql = self._format_props(expression.args.get("properties"))
+        this = self.sql(expression, "this")
+        source = self.sql(expression, "source")
+        return f"GET {source} {this}{props_sql}"
+
+    def _format_props(self, props) -> str:
+        return self.properties(props, prefix=" ", sep=" ", wrapped=False) if props else ""

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -512,6 +512,7 @@ class Parser(metaclass=_Parser):
         TokenType.FINAL,
         TokenType.FORMAT,
         TokenType.FULL,
+        TokenType.GET,
         TokenType.IDENTIFIER,
         TokenType.IS,
         TokenType.ISNULL,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -290,6 +290,7 @@ class TokenType(AutoName):
     FROM = auto()
     FULL = auto()
     FUNCTION = auto()
+    GET = auto()
     GLOB = auto()
     GLOBAL = auto()
     GRANT = auto()

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -111,6 +111,10 @@ class TestSnowflake(Validator):
             "SELECT 1 AS put",
         )
         self.validate_identity(
+            "SELECT 1 get",
+            "SELECT 1 AS get",
+        )
+        self.validate_identity(
             "WITH t (SELECT 1 AS c) SELECT c FROM t",
             "WITH t AS (SELECT 1 AS c) SELECT c FROM t",
         )
@@ -2472,20 +2476,20 @@ SINGLE = TRUE""",
         # GET with file path and stage ref containing spaces (wrapped in single quotes)
         ast = parse_one("GET '@s1/my folder' 'file://my file.txt'", read="snowflake")
         self.assertIsInstance(ast, exp.Get)
-        self.assertEqual(ast.args["source"], exp.Var(this="'@s1/my folder'"))
+        self.assertEqual(ast.args["target"], exp.Var(this="'@s1/my folder'"))
         self.assertEqual(ast.this, exp.Literal(this="file://my file.txt", is_string=True))
         self.assertEqual(ast.sql("snowflake"), "GET '@s1/my folder' 'file://my file.txt'")
 
         # expression with additional properties
         ast = parse_one("GET @stage1/folder 'file:///tmp/my.txt' PARALLEL = 1", read="snowflake")
         self.assertIsInstance(ast, exp.Get)
-        self.assertEqual(ast.args["source"], exp.Var(this="@stage1/folder"))
+        self.assertEqual(ast.args["target"], exp.Var(this="@stage1/folder"))
         self.assertEqual(ast.this, exp.Literal(this="file:///tmp/my.txt", is_string=True))
         properties = ast.args.get("properties")
         props_dict = {prop.this.this: prop.args["value"].this for prop in properties.expressions}
         self.assertEqual(props_dict, {"PARALLEL": "1"})
 
-        # # the unquoted URI variant is not fully supported yet
+        # the unquoted URI variant is not fully supported yet
         self.validate_identity("GET @%table file:///dir/tmp.csv", check_command_warning=True)
         self.validate_identity(
             "GET @s1/test file:///dir/tmp.csv PARALLEL=1",


### PR DESCRIPTION
## Motivation

Hi folks, following up on https://github.com/tobymao/sqlglot/issues/4813 in order to add support for `GET` statements in snowflake dialect similarly to the way `PUT` statements are being handled.

## Changes

- Add a `GET` expression and TokenType
- Extend Snowflake Parser with `_parse_get` which parses `GET` statements to `exp.Get`, except for the case of unquoted file path (treated as `exp.Command`)
- Tests to cover the functionality of get parsing

Thank you for the support 🙌 