### PR TITLE
fix: Add MAX_BY & MIN_BY to FUNCTION_PARSER

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2578,3 +2578,11 @@ SINGLE = TRUE""",
         self.assertEqual(expr.find(exp.Placeholder), exp.Placeholder(this="1"))
         self.validate_identity("SELECT :1, :2")
         self.validate_identity("SELECT :1 + :2")
+
+    def test_max_by_min_by(self):
+        max_by = self.validate_identity("MAX_BY(DISTINCT selected_col, filtered_col)")
+        min_by = self.validate_identity("MIN_BY(DISTINCT selected_col, filtered_col)")
+
+        for node in (max_by, min_by):
+            self.assertEqual(len(node.this.expressions), 1)
+            self.assertIsInstance(node.expression, exp.Column)

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -889,3 +889,5 @@ CAST(x AS INT128)
 CAST(x AS UINT128)
 CAST(x AS UINT256)
 SELECT export
+SELECT ARG_MAX(DISTINCT selected_col, filtered_col) FROM table
+SELECT ARG_MIN(DISTINCT selected_col, filtered_col) FROM table


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5020

Currently, the query of the issue yields a parse error because `DISTINCT` defaults to parsing all of the arguments as it's own CSV list in `parser.py::_parse_lambda`. 

Note: From my testing, the dialects that support `DISTINCT` such as Snowflake or CH only allow it for the first argument:

```SQL
snowflake> WITH t AS (SELECT 1 AS col, 2 AS bar) SELECT MAX_BY(DISTINCT col, bar, 2) FROM t;
[1]

snowflake> WITH t AS (SELECT 1 AS col, 2 AS bar) SELECT MAX_BY(col, DISTINCT bar, 2) FROM t;
Syntax error: unexpected 'DISTINCT'. (line 1)
```
