### PR TITLE
fix(databricks): Preserve colon operators in TRY_CAST

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -334,7 +334,9 @@ class Spark2(Hive):
 
         def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
             arg = expression.this
-            is_json_extract = isinstance(arg, (exp.JSONExtract, exp.JSONExtractScalar))
+            is_json_extract = isinstance(
+                arg, (exp.JSONExtract, exp.JSONExtractScalar)
+            ) and not arg.args.get("variant_extract")
 
             # We can't use a non-nested type (eg. STRING) as a schema
             if expression.to.args.get("nested") and (is_parse_json(arg) or is_json_extract):

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -165,6 +165,8 @@ class TestDatabricks(Validator):
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):
         self.validate_identity("SELECT c1:price, c1:price.foo, c1:price.bar[1]")
+        self.validate_identity("SELECT TRY_CAST(c1:price AS ARRAY<VARIANT>)")
+        self.validate_identity("""SELECT TRY_CAST(c1:["foo bar"]["baz qux"] AS ARRAY<VARIANT>)""")
         self.validate_identity(
             """SELECT c1:item[1].price FROM VALUES ('{ "item": [ { "model" : "basic", "price" : 6.12 }, { "model" : "medium", "price" : 9.24 } ] }') AS T(c1)"""
         )


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5027

The colon operator returns a `VARIANT` type:

```SQL
databricks> WITH tbl as (SELECT parse_json('{"owner":"amy"}') as col) 
            SELECT typeof(col:['owner']) FROM tbl;
VARIANT
```

But `FROM_JSON(json_str, schema)` accepts only JSON strings:

```SQL
databricks> WITH tbl as (SELECT parse_json('{"owner":"amy"}') as col) 
            SELECT FROM_JSON(col:owner, 'VARIANT') FROM tbl;

[DATATYPE_MISMATCH.UNEXPECTED_INPUT_TYPE] Cannot resolve "from_json(variant_get(col, $.owner))" due to data type mismatch: 
The first parameter requires the "STRING" type, however "variant_get(col, $.owner)" has the type "VARIANT"
```


