### PR TITLE
fix(parser): Do not parse set ops if input expr is None

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4725,7 +4725,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_set_operations(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
-        while True:
+        while this:
             setop = self.parse_set_operation(this)
             if not setop:
                 break

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -298,6 +298,7 @@ class TestDuckDB(Validator):
         self.validate_identity("SUMMARIZE tbl").assert_is(exp.Summarize)
         self.validate_identity("SUMMARIZE SELECT * FROM tbl").assert_is(exp.Summarize)
         self.validate_identity("CREATE TABLE tbl_summary AS SELECT * FROM (SUMMARIZE tbl)")
+        self.validate_identity("SELECT STAR(tbl, exclude := [foo])")
         self.validate_identity("UNION_VALUE(k1 := 1)").find(exp.PropertyEQ).this.assert_is(
             exp.Identifier
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -22,7 +22,7 @@ class TestSnowflake(Validator):
         self.assertEqual(expr.sql(dialect="snowflake"), "SELECT APPROX_TOP_K(C4, 3, 5) FROM t")
 
         self.validate_identity("INSERT INTO test VALUES (x'48FAF43B0AFCEF9B63EE3A93EE2AC2')")
-        self.validate_identity("exclude := [foo]")
+        self.validate_identity("SELECT STAR(tbl, exclude := [foo])")
         self.validate_identity("SELECT CAST([1, 2, 3] AS VECTOR(FLOAT, 3))")
         self.validate_identity("SELECT CONNECT_BY_ROOT test AS test_column_alias")
         self.validate_identity("SELECT number").selects[0].assert_is(exp.Column)


### PR DESCRIPTION
https://github.com/tobymao/sqlglot/pull/4959 introduced a silent regression in which `parse_set_operations` wouldn't check if `this` exists prior to attempting to parse a set op.

