### PR TITLE
add support for teradata translate with error

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -182,10 +182,13 @@ class Teradata(Dialect):
                 self.raise_error("Expected USING in TRANSLATE")
 
             if self._match_texts(self.CHARSET_TRANSLATORS):
-                charset_split = self._prev.text.split("_TO_")
+                charset_split = self._prev.text.upper().split("_TO_")
                 to = self.expression(exp.CharacterSet, this=charset_split[1])
             else:
                 self.raise_error("Expected a character set translator after USING in TRANSLATE")
+
+            self._match(TokenType.WITH)
+            self._match_texts({"ERROR"})
 
             return self.expression(exp.Cast if strict else exp.TryCast, this=this, to=to)
 

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -49,6 +49,14 @@ class TestTeradata(Validator):
         )
         self.validate_identity("CAST(x AS CHAR CHARACTER SET UNICODE)")
 
+    def test_translate_with_error(self):
+        self.validate_all(
+            "TRANSLATE(x USING LATIN_TO_UNICODE WITH ERROR)",
+            write={
+                "teradata": "CAST(x AS CHAR CHARACTER SET UNICODE)",
+            },
+        )
+
     def test_update(self):
         self.validate_all(
             "UPDATE A FROM schema.tableA AS A, (SELECT col1 FROM schema.tableA GROUP BY col1) AS B SET col2 = '' WHERE A.col1 = B.col1",


### PR DESCRIPTION
According to [these Teradata docs](https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Functions-Expressions-and-Predicates/String-Operators-and-Functions/TRANSLATE), `TRANSLATE` should support `WITH ERROR` at the end. 

This adds this by silently consuming these tokens to avoid parse errors. A unit test is also contributed.

The case issue is also addressed.

