### PR TITLE
feat(teradata)!: support translate with error

### DIFF
--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -162,7 +162,7 @@ class Teradata(Dialect):
             # https://docs.teradata.com/r/SQL-Functions-Operators-Expressions-and-Predicates/June-2017/Data-Type-Conversions/TRYCAST
             "TRYCAST": parser.Parser.FUNCTION_PARSERS["TRY_CAST"],
             "RANGE_N": lambda self: self._parse_rangen(),
-            "TRANSLATE": lambda self: self._parse_translate(self.STRICT_CAST),
+            "TRANSLATE": lambda self: self._parse_translate(),
         }
 
         FUNCTIONS = {
@@ -175,7 +175,7 @@ class Teradata(Dialect):
             TokenType.DSTAR: exp.Pow,
         }
 
-        def _parse_translate(self, strict: bool) -> exp.Expression:
+        def _parse_translate(self) -> exp.Expression:
             this = self._parse_assignment()
             self._match(TokenType.USING)
             self._match_texts(self.CHARSET_TRANSLATORS)

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -182,7 +182,11 @@ class Teradata(Dialect):
                 self.raise_error("Expected USING in TRANSLATE")
 
             if self._match_texts(self.CHARSET_TRANSLATORS):
-                charset_split = self._prev.text.split("_TO_")
+                charset = self._prev.text.upper()
+                if self._match_text_seq("WITH", "ERROR"):
+                    return self.expression(exp.TranslateCharacters, this=this, expression=charset)
+
+                charset_split = charset.split("_TO_")
                 to = self.expression(exp.CharacterSet, this=charset_split[1])
             else:
                 self.raise_error("Expected a character set translator after USING in TRANSLATE")

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -175,7 +175,7 @@ class Teradata(Dialect):
             TokenType.DSTAR: exp.Pow,
         }
 
-        def _parse_translate(self) -> exp.Expression:
+        def _parse_translate(self) -> exp.TranslateCharacters:
             this = self._parse_assignment()
             self._match(TokenType.USING)
             self._match_texts(self.CHARSET_TRANSLATORS)

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -177,16 +177,13 @@ class Teradata(Dialect):
 
         def _parse_translate(self, strict: bool) -> exp.Expression:
             this = self._parse_assignment()
-
             self._match(TokenType.USING)
-
             self._match_texts(self.CHARSET_TRANSLATORS)
-            charset = self._prev.text.upper()
 
             return self.expression(
                 exp.TranslateCharacters,
                 this=this,
-                expression=charset,
+                expression=self._prev.text.upper(),
                 with_error=self._match_text_seq("WITH", "ERROR"),
             )
 

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -178,20 +178,17 @@ class Teradata(Dialect):
         def _parse_translate(self, strict: bool) -> exp.Expression:
             this = self._parse_assignment()
 
-            if not self._match(TokenType.USING):
-                self.raise_error("Expected USING in TRANSLATE")
+            self._match(TokenType.USING)
 
-            if self._match_texts(self.CHARSET_TRANSLATORS):
-                charset = self._prev.text.upper()
-                if self._match_text_seq("WITH", "ERROR"):
-                    return self.expression(exp.TranslateCharacters, this=this, expression=charset)
+            self._match_texts(self.CHARSET_TRANSLATORS)
+            charset = self._prev.text.upper()
 
-                charset_split = charset.split("_TO_")
-                to = self.expression(exp.CharacterSet, this=charset_split[1])
-            else:
-                self.raise_error("Expected a character set translator after USING in TRANSLATE")
-
-            return self.expression(exp.Cast if strict else exp.TryCast, this=this, to=to)
+            return self.expression(
+                exp.TranslateCharacters,
+                this=this,
+                expression=charset,
+                with_error=self._match_text_seq("WITH", "ERROR"),
+            )
 
         # FROM before SET in Teradata UPDATE syntax
         # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/Teradata-VantageTM-SQL-Data-Manipulation-Language-17.20/Statement-Syntax/UPDATE/UPDATE-Syntax-Basic-Form-FROM-Clause

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5700,7 +5700,7 @@ class CastToStrType(Func):
 
 # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Functions-Expressions-and-Predicates/String-Operators-and-Functions/TRANSLATE/TRANSLATE-Function-Syntax
 class TranslateCharacters(Expression):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": True, "with_error": False}
 
 
 class Collate(Binary, Func):

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5698,6 +5698,11 @@ class CastToStrType(Func):
     arg_types = {"this": True, "to": True}
 
 
+# https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Functions-Expressions-and-Predicates/String-Operators-and-Functions/TRANSLATE/TRANSLATE-Function-Syntax
+class TranslateCharacters(Expression):
+    arg_types = {"this": True, "expression": True}
+
+
 class Collate(Binary, Func):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4925,3 +4925,8 @@ class Generator(metaclass=_Generator):
             return f"PUT {this} {target}{props_sql}"
         else:
             return f"GET {target} {this}{props_sql}"
+
+    def translatecharacters_sql(self, expression: exp.TranslateCharacters):
+        this = self.sql(expression, "this")
+        expr = self.sql(expression, "expression")
+        return f"TRANSLATE({this} USING {expr} WITH ERROR)"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4929,4 +4929,5 @@ class Generator(metaclass=_Generator):
     def translatecharacters_sql(self, expression: exp.TranslateCharacters):
         this = self.sql(expression, "this")
         expr = self.sql(expression, "expression")
-        return f"TRANSLATE({this} USING {expr} WITH ERROR)"
+        with_error = " WITH ERROR" if expression.args.get("with_error") else ""
+        return f"TRANSLATE({this} USING {expr}{with_error})"

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -48,6 +48,7 @@ class TestTeradata(Validator):
             },
         )
         self.validate_identity("CAST(x AS CHAR CHARACTER SET UNICODE)")
+        self.validate_identity("TRANSLATE(x USING LATIN_TO_UNICODE WITH ERROR)")
 
     def test_update(self):
         self.validate_all(

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -41,13 +41,7 @@ class TestTeradata(Validator):
         ).assert_is(exp.Command)
 
     def test_translate(self):
-        self.validate_all(
-            "TRANSLATE(x USING LATIN_TO_UNICODE)",
-            write={
-                "teradata": "CAST(x AS CHAR CHARACTER SET UNICODE)",
-            },
-        )
-        self.validate_identity("CAST(x AS CHAR CHARACTER SET UNICODE)")
+        self.validate_identity("TRANSLATE(x USING LATIN_TO_UNICODE)")
         self.validate_identity("TRANSLATE(x USING LATIN_TO_UNICODE WITH ERROR)")
 
     def test_update(self):


### PR DESCRIPTION
Finsihes [PR 5049](https://github.com/tobymao/sqlglot/pull/5049)

In general, the `TRANSLATE` is expressed as a `CAST`.
In the case of the `WITH ERROR` a new expression is added in order to represent this special case on the AST.

**DOCS**
[Teradata Translate](https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/SQL-Functions-Expressions-and-Predicates/String-Operators-and-Functions/TRANSLATE/TRANSLATE-Function-Syntax)