### PR TITLE
feat(executor): support conversion from table to pylist

### DIFF
--- a/sqlglot/executor/table.py
+++ b/sqlglot/executor/table.py
@@ -32,6 +32,9 @@ class Table:
     def pop(self):
         self.rows.pop()
 
+    def to_pylist(self):
+        return [dict(zip(self.columns, row)) for row in self.rows]
+
     @property
     def width(self):
         return len(self.columns)


### PR DESCRIPTION
Add support for converting a `sqlglot.executor.table.Table` to a list of rows/dictionaries (`list[dict]`).

This would make it easier to compare execution results with expected results:
```python
from sqlglot.executor import execute

query = "SELECT avg(price) AS average_price FROM items"
tables = {
    "items": [
        {"id": 1, "price": 1.0},
        {"id": 2, "price": 2.0},
    ]
}

result = execute(query, tables=tables).to_pylist()
expected_result = [{"average_price": 1.5}]
assert result == expected_result
```

The method name "to_pylist" is taken from PyArrow.