### PR TITLE
Fix(tsql): Change `COLLATE` expression to `Var` for `ALTER TABLE`

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -10,16 +10,16 @@ from sqlglot.dialects.dialect import (
     Dialect,
     NormalizationStrategy,
     any_value_to_max_sql,
+    build_date_delta,
     date_delta_sql,
     datestrtodate_sql,
     generatedasidentitycolumnconstraint_sql,
     max_or_greatest,
     min_or_least,
-    build_date_delta,
     rename_func,
     strposition_sql,
-    trim_sql,
     timestrtotime_sql,
+    trim_sql,
 )
 from sqlglot.helper import seq_get
 from sqlglot.parser import build_coalesce
@@ -889,6 +889,17 @@ class TSQL(Dialect):
                     value = self._parse_bitwise()
 
             return self.expression(exp.DeclareItem, this=var, kind=data_type, default=value)
+
+        def _parse_alter_table_alter(self) -> t.Optional[exp.Expression]:
+            expression = super()._parse_alter_table_alter()
+
+            if expression is not None:
+                collation = expression.args.get("collate")
+                if isinstance(collation, exp.Column) and isinstance(collation.this, exp.Identifier):
+                    identifier = collation.this
+                    collation.set("this", exp.Var(this=identifier.name))
+
+            return expression
 
     class Generator(generator.Generator):
         LIMIT_IS_TOP = True

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1,7 +1,7 @@
 from sqlglot import exp, parse, parse_one
-from tests.dialects.test_dialect import Validator
 from sqlglot.errors import ParseError, UnsupportedError
 from sqlglot.optimizer.annotate_types import annotate_types
+from tests.dialects.test_dialect import Validator
 
 
 class TestTSQL(Validator):
@@ -2242,3 +2242,11 @@ FROM OPENJSON(@json) WITH (
                 "tsql": "SELECT DATETRUNC(YEAR, CAST('foo1' AS DATE))",
             },
         )
+
+    def test_collation_parse(self):
+        self.validate_identity("ALTER TABLE a ALTER COLUMN b CHAR(10) COLLATE abc").assert_is(
+            exp.Alter
+        )
+        self.validate_identity("ALTER TABLE a ALTER COLUMN b CHAR(10) COLLATE abc").args.get(
+            "actions"
+        )[0].args.get("collate").this.assert_is(exp.Var)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -2246,7 +2246,4 @@ FROM OPENJSON(@json) WITH (
     def test_collation_parse(self):
         self.validate_identity("ALTER TABLE a ALTER COLUMN b CHAR(10) COLLATE abc").assert_is(
             exp.Alter
-        )
-        self.validate_identity("ALTER TABLE a ALTER COLUMN b CHAR(10) COLLATE abc").args.get(
-            "actions"
-        )[0].args.get("collate").this.assert_is(exp.Var)
+        ).args.get("actions")[0].get("collate").this.assert_is(exp.Var)


### PR DESCRIPTION
This is to avoid bracketing the `COLLATE` argument when transpiling to tsql in SQLMesh.

Note: This fixes the `COLLATE` transpiling for `ALTER TABLE` commands, but if `COLLATE` is used in table queries, this obviously doesn't address those cases!