### PR TITLE
feat(parser): FK REFERENCES without specifying column

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6088,7 +6088,11 @@ class Parser(metaclass=_Parser):
         return self.expression(exp.Reference, this=this, expressions=expressions, options=options)
 
     def _parse_foreign_key(self) -> exp.ForeignKey:
-        expressions = self._parse_wrapped_id_vars()
+        expressions = (
+            self._parse_wrapped_id_vars()
+            if not self._match(TokenType.REFERENCES, advance=False)
+            else None
+        )
         reference = self._parse_references()
         on_options = {}
 

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -162,21 +162,10 @@ class TestDatabricks(Validator):
             },
         )
 
-        self.validate_identity(
-            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2)"
-        )
-
-        self.validate_identity(
-            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2 (foo))"
-        )
-
-        self.validate_identity(
-            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2 MATCH FULL)"
-        )
-
-        self.validate_identity(
-            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2 NOT ENFORCED)"
-        )
+        for option in ("", " (foo)", " MATCH FULL", " NOT ENFORCED"):
+            self.validate_identity(
+                f"CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2{option})"
+            )
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -162,6 +162,10 @@ class TestDatabricks(Validator):
             },
         )
 
+        self.validate_identity(
+            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2)"
+        )
+
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):
         self.validate_identity("SELECT c1:price, c1:price.foo, c1:price.bar[1]")

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -166,6 +166,18 @@ class TestDatabricks(Validator):
             "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2)"
         )
 
+        self.validate_identity(
+            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2 (foo))"
+        )
+
+        self.validate_identity(
+            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2 MATCH FULL)"
+        )
+
+        self.validate_identity(
+            "CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2 NOT ENFORCED)"
+        )
+
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):
         self.validate_identity("SELECT c1:price, c1:price.foo, c1:price.bar[1]")

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -163,9 +163,10 @@ class TestDatabricks(Validator):
         )
 
         for option in ("", " (foo)", " MATCH FULL", " NOT ENFORCED"):
-            self.validate_identity(
-                f"CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2{option})"
-            )
+            with self.subTest(f"Databricks foreign key REFERENCES option: {option}."):
+                self.validate_identity(
+                    f"CREATE TABLE t1 (foo BIGINT NOT NULL CONSTRAINT foo_c FOREIGN KEY REFERENCES t2{option})"
+                )
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):


### PR DESCRIPTION
Fixes #5057

**DOCS**
[Databricks FK](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-create-table-constraint#syntax)