### PR TITLE
fix!: unqualify UNNEST only the left most part of a column

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -309,10 +309,9 @@ def unqualify_unnest(expression: exp.Expression) -> exp.Expression:
         }
         if unnest_aliases:
             for column in expression.find_all(exp.Column):
-                if column.table in unnest_aliases:
-                    column.set("table", None)
-                elif column.db in unnest_aliases:
-                    column.set("db", None)
+                leftmost_part = column.parts[0]
+                if leftmost_part.arg_key != "this" and leftmost_part.this in unnest_aliases:
+                    leftmost_part.pop()
 
     return expression
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1696,13 +1696,13 @@ WHERE
         )
 
         self.validate_all(
-            "SELECT * FROM t1, UNNEST(`t2`.`t3`) AS `col`",
+            "SELECT * FROM t, UNNEST(`t2`.`t3`) AS `col`",
             read={
-                "duckdb": 'SELECT * FROM t1, UNNEST("t1"."t2"."t3") "t1" ("col")',
+                "duckdb": 'SELECT * FROM t, UNNEST("t1"."t2"."t3") "t1" ("col")',
             },
             write={
-                "bigquery": "SELECT * FROM t1, UNNEST(`t2`.`t3`) AS `col`",
-                "redshift": 'SELECT * FROM t1, "t2"."t3" AS "col"',
+                "bigquery": "SELECT * FROM t, UNNEST(`t2`.`t3`) AS `col`",
+                "redshift": 'SELECT * FROM t, "t2"."t3" AS "col"',
             },
         )
 


### PR DESCRIPTION
Fixes #5062

In the previous implementation, `unqualify_unnest` stripped qualifying prefixes from every aliased `UNNEST` expression when the column path matched the `table` or `db` name. This behavior was intended to support dialects like BigQuery and Redshift because the optimizer adds via the `qualify` aliases to the `UNNEST`. 

However, this approach led to incorrect behavior in certain cases. For example:
```
SELECT * FROM t1, UNNEST("t1"."t2"."t3") "t2" ("col")
```
In this query, `unqualify_unnest` would incorrectly remove `"t2"` from the path, resulting in an incorrect SQL output after transpilation (duckb -> bigquery).