### PR TITLE
fix(oracle)!: to_timestamp without format

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -31,6 +31,13 @@ def _trim_sql(self: Oracle.Generator, expression: exp.Trim) -> str:
     return trim_sql(self, expression)
 
 
+def _build_to_timestamp(args: t.List) -> exp.StrToTime | exp.Anonymous:
+    if len(args) == 1:
+        return exp.Anonymous(this="TO_TIMESTAMP", expressions=args)
+
+    return build_formatted_time(exp.StrToTime, "oracle")(args)
+
+
 class Oracle(Dialect):
     ALIAS_POST_TABLESAMPLE = True
     LOCKING_READS_SUPPORTED = True
@@ -106,7 +113,7 @@ class Oracle(Dialect):
             "NVL": lambda args: build_coalesce(args, is_nvl=True),
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "TO_CHAR": build_timetostr_or_tochar,
-            "TO_TIMESTAMP": build_formatted_time(exp.StrToTime, "oracle"),
+            "TO_TIMESTAMP": _build_to_timestamp,
             "TO_DATE": build_formatted_time(exp.StrToDate, "oracle"),
             "TRUNC": lambda args: exp.DateTrunc(
                 unit=seq_get(args, 1) or exp.Literal.string("DD"),

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -320,6 +320,7 @@ class TestOracle(Validator):
             },
         )
         self.validate_identity("CREATE OR REPLACE FORCE VIEW foo1.foo2")
+        self.validate_identity("TO_TIMESTAMP('foo')")
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")


### PR DESCRIPTION
Fixes #5068 

**DOCS**
[Oracle TO_TIMESTAMP](https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/TO_TIMESTAMP.html)