### PR TITLE
Add support for qualified column names in Teradata dialect.

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -689,6 +689,7 @@ class ClickHouse(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            qualified_schema_col: bool = False,
         ) -> t.Optional[exp.Expression]:
             this = super()._parse_table(
                 schema=schema,

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -502,6 +502,7 @@ class DuckDB(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            qualified_schema_col: bool = False,
         ) -> t.Optional[exp.Expression]:
             # DuckDB supports prefix aliases, e.g. FROM foo: bar
             if self._next and self._next.token_type == TokenType.COLON:

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -189,6 +189,7 @@ class PRQL(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            qualified_schema_col: bool = False,
         ) -> t.Optional[exp.Expression]:
             return self._parse_table_parts()
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -90,6 +90,7 @@ class Redshift(Postgres):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            qualified_schema_col: bool = False,
         ) -> t.Optional[exp.Expression]:
             # Redshift supports UNPIVOTing SUPER objects, e.g. `UNPIVOT foo.obj[0] AS val AT attr`
             unpivot = self._match(TokenType.UNPIVOT)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -765,6 +765,7 @@ class Snowflake(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            qualified_schema_col: bool = False,
         ) -> t.Optional[exp.Expression]:
             table = super()._parse_table(
                 schema=schema,

--- a/sqlglot/dialects/teradata.py
+++ b/sqlglot/dialects/teradata.py
@@ -244,7 +244,8 @@ class Teradata(Dialect):
                 stored=self._match_text_seq("STORED") and self._parse_stored(),
                 by_name=self._match_text_seq("BY", "NAME"),
                 exists=self._parse_exists(),
-                where=self._match_pair(TokenType.REPLACE, TokenType.WHERE) and self._parse_assignment(),
+                where=self._match_pair(TokenType.REPLACE, TokenType.WHERE)
+                and self._parse_assignment(),
                 partition=self._match(TokenType.PARTITION_BY) and self._parse_partitioned_by(),
                 settings=self._match_text_seq("SETTINGS") and self._parse_settings_property(),
                 expression=self._parse_derived_table_values() or self._parse_ddl_select(),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5816,9 +5816,9 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_schema(
-            self,
-            this: t.Optional[exp.Expression] = None,
-            qualified_schema_col: bool = False,
+        self,
+        this: t.Optional[exp.Expression] = None,
+        qualified_schema_col: bool = False,
     ) -> t.Optional[exp.Expression]:
         index = self._index
         if not self._match(TokenType.L_PAREN):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5829,7 +5829,9 @@ class Parser(metaclass=_Parser):
         if self._match_set(self.SELECT_START_TOKENS):
             self._retreat(index)
             return this
-        args = self._parse_csv(lambda: self._parse_constraint() or self._parse_field_def(qualified_schema_col))
+        args = self._parse_csv(
+            lambda: self._parse_constraint() or self._parse_field_def(qualified_schema_col)
+        )
         self._match_r_paren()
         return self.expression(exp.Schema, this=this, expressions=args)
 

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -172,7 +172,9 @@ class TestTeradata(Validator):
     def test_insert_fully_qualified_col(self):
         self.validate_all(
             "INS INTO x (y.b, y.c) SELECT * FROM tbl_y AS y JOIN tbl_z AS z ON y.a = z.a",
-            write={"teradata": "INSERT INTO x (b, c) SELECT * FROM tbl_y AS y JOIN tbl_z AS z ON y.a = z.a"}
+            write={
+                "teradata": "INSERT INTO x (b, c) SELECT * FROM tbl_y AS y JOIN tbl_z AS z ON y.a = z.a"
+            },
         )
 
     def test_mod(self):

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -169,6 +169,12 @@ class TestTeradata(Validator):
             "INS INTO x SELECT * FROM y", write={"teradata": "INSERT INTO x SELECT * FROM y"}
         )
 
+    def test_insert_fully_qualified_col(self):
+        self.validate_all(
+            "INS INTO x (y.b, y.c) SELECT * FROM tbl_y AS y JOIN tbl_z AS z ON y.a = z.a",
+            write={"teradata": "INSERT INTO x (b, c) SELECT * FROM tbl_y AS y JOIN tbl_z AS z ON y.a = z.a"}
+        )
+
     def test_mod(self):
         self.validate_all("a MOD b", write={"teradata": "a MOD b", "mysql": "a % b"})
 


### PR DESCRIPTION
Hello! We are facing a parsing issue in Teradata when a qualified column is used in an INSERT INTO table's schema. For instance this is valid in Teradata:

```
INSERT INTO x (y.b, y.c) SELECT * FROM tbl_y AS y JOIN tbl_z AS z ON y.a = z.a"
````
The documentation does not state this explicitly, but I double checked by running this query in Teradata Studio:
<img width="431" alt="image" src="https://github.com/user-attachments/assets/dccef821-5bd2-4f80-a5e1-780046602d16" />

I'm submitting this PR with a proposed fix for this issue, which is a little bit tricky because it involves overriding the `_parse_insert` for the Teradata dialect and then introducing a new argument which will be added to the base parser class, which is not ideal. I did my best to remove any non-Teradata functionality from the override and confirmed all tests are passing.