### PR TITLE
feat(snowflake): Transpile DataType.BIGDECIMAL to DOUBLE

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1132,6 +1132,7 @@ class Snowflake(Dialect):
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.NESTED: "OBJECT",
             exp.DataType.Type.STRUCT: "OBJECT",
+            exp.DataType.Type.BIGDECIMAL: "DOUBLE",
         }
 
         TOKEN_MAPPING = {

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1061,6 +1061,16 @@ class TestSnowflake(Validator):
                 dialect="snowflake",
             )
 
+        self.validate_all(
+            "SELECT CAST(1 AS DOUBLE), CAST(1 AS DOUBLE)",
+            read={
+                "bigquery": "SELECT CAST(1 AS BIGDECIMAL), CAST(1 AS BIGNUMERIC)",
+            },
+            write={
+                "snowflake": "SELECT CAST(1 AS DOUBLE), CAST(1 AS DOUBLE)",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
This is a best-effort transpilation as BigQuery's `BIGDECIMAL` has P=77, S=38 while Snowflake's `NUMBER` can't exceed P=38, S=37.


Docs
--------
[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#decimal_types) | [Snowflake](https://docs.snowflake.com/en/sql-reference/data-types-numeric)