### PR TITLE
Fix token col attribute when there is leading whitespace after newline

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -1109,7 +1109,7 @@ class Tokenizer(metaclass=_Tokenizer):
         if self.WHITE_SPACE.get(self._char) is TokenType.BREAK:
             # Ensures we don't count an extra line if we get a \r\n line break sequence
             if not (self._char == "\r" and self._peek == "\n"):
-                self._col = 1
+                self._col = i
                 self._line += 1
         else:
             self._col += i

--- a/sqlglotrs/src/tokenizer.rs
+++ b/sqlglotrs/src/tokenizer.rs
@@ -173,7 +173,7 @@ impl<'a> TokenizerState<'a> {
         if Some(&self.token_types.break_) == self.settings.white_space.get(&self.current_char) {
             // Ensures we don't count an extra line if we get a \r\n line break sequence.
             if !(self.current_char == '\r' && self.peek_char == '\n') {
-                self.column = 1;
+                self.column = i as usize;
                 self.line += 1;
             }
         } else {

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -67,9 +67,19 @@ x"""
         tokens = Tokenizer().tokenize("SELECT\r\n  1,\r\n  2")
 
         self.assertEqual(tokens[0].line, 1)
+        self.assertEqual(tokens[0].col, 6)
         self.assertEqual(tokens[1].line, 2)
+        self.assertEqual(tokens[1].col, 3)
         self.assertEqual(tokens[2].line, 2)
+        self.assertEqual(tokens[2].col, 4)
         self.assertEqual(tokens[3].line, 3)
+        self.assertEqual(tokens[3].col, 3)
+
+        tokens = Tokenizer().tokenize("  SELECT\n    100")
+        self.assertEqual(tokens[0].line, 1)
+        self.assertEqual(tokens[0].col, 8)
+        self.assertEqual(tokens[1].line, 2)
+        self.assertEqual(tokens[1].col, 7)
 
     def test_crlf(self):
         tokens = Tokenizer().tokenize("SELECT a\r\nFROM b")


### PR DESCRIPTION
Addresses #5091, by initializing the self._col value to `i` instead of `1` after a newline, which will correctly account for any leading whitespace which is accumulated in the _scan method. 