### PR TITLE
fix!: hive, spark2, spark, databricks type coercion for IF and COALESCE functions

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from copy import deepcopy
+from collections import defaultdict
+
 from sqlglot import exp, transforms, jsonpath
 from sqlglot.dialects.dialect import (
     date_delta_sql,
@@ -9,6 +12,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.spark import Spark
 from sqlglot.tokens import TokenType
+from sqlglot.optimizer.annotate_types import TypeAnnotator
 
 
 def _jsonextract_sql(
@@ -23,12 +27,12 @@ class Databricks(Spark):
     SAFE_DIVISION = False
     COPY_PARAMS_ARE_CSV = False
 
-    TEXT_COERCES_TO = {key: set() for key in exp.DataType.TEXT_TYPES}
+    COERCES_TO = defaultdict(set, deepcopy(TypeAnnotator.COERCES_TO))
     for text_type in exp.DataType.TEXT_TYPES:
-        TEXT_COERCES_TO[text_type] |= {*exp.DataType.SIGNED_INTEGER_TYPES}
-        TEXT_COERCES_TO[text_type] |= {*exp.DataType.TEMPORAL_TYPES}
-        TEXT_COERCES_TO[text_type] |= {*exp.DataType.FLOAT_TYPES}
-        TEXT_COERCES_TO[text_type] |= {
+        COERCES_TO[text_type] |= {
+            *exp.DataType.INTEGER_TYPES,
+            *exp.DataType.TEMPORAL_TYPES,
+            *exp.DataType.TEMPORAL_TYPES,
             exp.DataType.Type.BINARY,
             exp.DataType.Type.BOOLEAN,
             exp.DataType.Type.DOUBLE,

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from sqlglot import exp, transforms, jsonpath
 from sqlglot.dialects.dialect import (
     date_delta_sql,
@@ -23,6 +22,18 @@ def _jsonextract_sql(
 class Databricks(Spark):
     SAFE_DIVISION = False
     COPY_PARAMS_ARE_CSV = False
+
+    TEXT_COERCES_TO = {key: set() for key in exp.DataType.TEXT_TYPES}
+    for text_type in exp.DataType.TEXT_TYPES:
+        TEXT_COERCES_TO[text_type] |= {*exp.DataType.SIGNED_INTEGER_TYPES}
+        TEXT_COERCES_TO[text_type] |= {*exp.DataType.TEMPORAL_TYPES}
+        TEXT_COERCES_TO[text_type] |= {*exp.DataType.FLOAT_TYPES}
+        TEXT_COERCES_TO[text_type] |= {
+            exp.DataType.Type.BINARY,
+            exp.DataType.Type.BOOLEAN,
+            exp.DataType.Type.DOUBLE,
+            exp.DataType.Type.INTERVAL,
+        }
 
     class JSONPathTokenizer(jsonpath.JSONPathTokenizer):
         IDENTIFIERS = ["`", '"']

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -30,12 +30,10 @@ class Databricks(Spark):
     COERCES_TO = defaultdict(set, deepcopy(TypeAnnotator.COERCES_TO))
     for text_type in exp.DataType.TEXT_TYPES:
         COERCES_TO[text_type] |= {
-            *exp.DataType.INTEGER_TYPES,
+            *exp.DataType.NUMERIC_TYPES,
             *exp.DataType.TEMPORAL_TYPES,
-            *exp.DataType.FLOAT_TYPES,
             exp.DataType.Type.BINARY,
             exp.DataType.Type.BOOLEAN,
-            exp.DataType.Type.DECIMAL,
             exp.DataType.Type.INTERVAL,
         }
 

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import deepcopy
 from collections import defaultdict
 
 from sqlglot import exp, transforms, jsonpath

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -26,7 +26,7 @@ class Databricks(Spark):
     SAFE_DIVISION = False
     COPY_PARAMS_ARE_CSV = False
 
-    COERCES_TO = defaultdict(set, deepcopy(TypeAnnotator.COERCES_TO))
+    COERCES_TO = defaultdict(set, TypeAnnotator.COERCES_TO.copy())
     for text_type in exp.DataType.TEXT_TYPES:
         COERCES_TO[text_type] |= {
             *exp.DataType.NUMERIC_TYPES,

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -32,10 +32,10 @@ class Databricks(Spark):
         COERCES_TO[text_type] |= {
             *exp.DataType.INTEGER_TYPES,
             *exp.DataType.TEMPORAL_TYPES,
-            *exp.DataType.TEMPORAL_TYPES,
+            *exp.DataType.FLOAT_TYPES,
             exp.DataType.Type.BINARY,
             exp.DataType.Type.BOOLEAN,
-            exp.DataType.Type.DOUBLE,
+            exp.DataType.Type.DECIMAL,
             exp.DataType.Type.INTERVAL,
         }
 

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -789,6 +789,9 @@ class Dialect(metaclass=_Dialect):
         exp.VarMap: lambda self, e: self._annotate_map(e),
     }
 
+    # Specifies what types a text type can be coerced into based on the dialect
+    TEXT_COERCES_TO: t.Dict[exp.DataType.Type, t.Set[exp.DataType.Type]] = {}
+
     @classmethod
     def get_or_raise(cls, dialect: DialectType) -> Dialect:
         """

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -789,8 +789,8 @@ class Dialect(metaclass=_Dialect):
         exp.VarMap: lambda self, e: self._annotate_map(e),
     }
 
-    # Specifies what types a text type can be coerced into based on the dialect
-    TEXT_COERCES_TO: t.Dict[exp.DataType.Type, t.Set[exp.DataType.Type]] = {}
+    # Specifies what types a given type can be coerced into
+    COERCES_TO: t.Dict[exp.DataType.Type, t.Set[exp.DataType.Type]] = {}
 
     @classmethod
     def get_or_raise(cls, dialect: DialectType) -> Dialect:

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -223,10 +223,8 @@ class Hive(Dialect):
     # Support only the non-ANSI mode (default for Hive, Spark2, Spark)
     COERCES_TO = defaultdict(set, deepcopy(TypeAnnotator.COERCES_TO))
     for target_type in {
-        *exp.DataType.INTEGER_TYPES,
+        *exp.DataType.NUMERIC_TYPES,
         *exp.DataType.TEMPORAL_TYPES,
-        *exp.DataType.FLOAT_TYPES,
-        exp.DataType.Type.DECIMAL,
         exp.DataType.Type.INTERVAL,
     }:
         COERCES_TO[target_type] |= exp.DataType.TEXT_TYPES

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -226,7 +226,7 @@ class Hive(Dialect):
         *exp.DataType.INTEGER_TYPES,
         *exp.DataType.TEMPORAL_TYPES,
         *exp.DataType.FLOAT_TYPES,
-        exp.DataType.Type.DOUBLE,
+        exp.DataType.Type.DECIMAL,
         exp.DataType.Type.INTERVAL,
     }:
         COERCES_TO[target_type] |= exp.DataType.TEXT_TYPES

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -221,7 +221,7 @@ class Hive(Dialect):
     }
 
     # Support only the non-ANSI mode (default for Hive, Spark2, Spark)
-    COERCES_TO = defaultdict(set, deepcopy(TypeAnnotator.COERCES_TO))
+    COERCES_TO = defaultdict(set, TypeAnnotator.COERCES_TO.copy())
     for target_type in {
         *exp.DataType.NUMERIC_TYPES,
         *exp.DataType.TEMPORAL_TYPES,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import typing as t
 from functools import partial
-from copy import deepcopy
 from collections import defaultdict
 
 from sqlglot import exp, generator, parser, tokens, transforms

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -160,25 +160,7 @@ class Spark2(Hive):
         exp.Pad: lambda self, e: _annotate_by_similar_args(
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         ),
-        exp.If: lambda self, e: self._annotate_by_args(
-            e, "true", "false", promote=True, coerce_text=True
-        ),
-        exp.Coalesce: lambda self, e: self._annotate_by_args(
-            e, "this", "expressions", promote=True, coerce_text=True
-        ),
     }
-
-    TEXT_COERCES_TO = {}
-    for target_type in {
-        *exp.DataType.SIGNED_INTEGER_TYPES,
-        *exp.DataType.TEMPORAL_TYPES,
-        *exp.DataType.FLOAT_TYPES,
-        exp.DataType.Type.BINARY,
-        exp.DataType.Type.BOOLEAN,
-        exp.DataType.Type.DOUBLE,
-        exp.DataType.Type.INTERVAL,
-    }:
-        TEXT_COERCES_TO.setdefault(target_type, set()).update(exp.DataType.TEXT_TYPES)
 
     class Tokenizer(Hive.Tokenizer):
         HEX_STRINGS = [("X'", "'"), ("x'", "'")]

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -25,7 +25,7 @@ from sqlglot.transforms import (
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
-    from sqlglot.optimizer.annotate_types import TypeAnnotator
+from sqlglot.optimizer.annotate_types import TypeAnnotator
 
 
 def _map_sql(self: Spark2.Generator, expression: exp.Map) -> str:
@@ -160,7 +160,25 @@ class Spark2(Hive):
         exp.Pad: lambda self, e: _annotate_by_similar_args(
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         ),
+        exp.If: lambda self, e: self._annotate_by_args(
+            e, "true", "false", promote=True, coerce_text=True
+        ),
+        exp.Coalesce: lambda self, e: self._annotate_by_args(
+            e, "this", "expressions", promote=True, coerce_text=True
+        ),
     }
+
+    TEXT_COERCES_TO = {}
+    for target_type in {
+        *exp.DataType.SIGNED_INTEGER_TYPES,
+        *exp.DataType.TEMPORAL_TYPES,
+        *exp.DataType.FLOAT_TYPES,
+        exp.DataType.Type.BINARY,
+        exp.DataType.Type.BOOLEAN,
+        exp.DataType.Type.DOUBLE,
+        exp.DataType.Type.INTERVAL,
+    }:
+        TEXT_COERCES_TO.setdefault(target_type, set()).update(exp.DataType.TEXT_TYPES)
 
     class Tokenizer(Hive.Tokenizer):
         HEX_STRINGS = [("X'", "'"), ("x'", "'")]

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -25,7 +25,7 @@ from sqlglot.transforms import (
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
-from sqlglot.optimizer.annotate_types import TypeAnnotator
+    from sqlglot.optimizer.annotate_types import TypeAnnotator
 
 
 def _map_sql(self: Spark2.Generator, expression: exp.Map) -> str:

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -182,7 +182,6 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         annotators: t.Optional[AnnotatorsType] = None,
         coerces_to: t.Optional[t.Dict[exp.DataType.Type, t.Set[exp.DataType.Type]]] = None,
         binary_coercions: t.Optional[BinaryCoercions] = None,
-        dialect: t.Optional[DialectType] = None,
     ) -> None:
         self.schema = schema
         self.annotators = annotators or Dialect.get_or_raise(schema.dialect).ANNOTATORS

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -343,12 +343,9 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         if type2_value in self.coerces_to.get(type1_value, {}):
             return type2_value
 
-        if coerce_text:
-            return (
-                type2_value
-                if type2_value in self.text_coerces_to.get(type1_value, {})
-                else type1_value
-            )
+        if coerce_text and type2_value in self.text_coerces_to.get(type1_value, {}):
+            return type2_value
+
         return type1_value
 
     def _annotate_binary(self, expression: B) -> B:

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -100,6 +100,125 @@ STRING;
 RPAD(tbl.str_col, 1, tbl.str_col);
 STRING;
 
+# dialect: spark2, spark, databricks
+IF(cond, tbl.double_col, tbl.bigint_col);
+DOUBLE;
+
+# dialect: spark2, spark, databricks
+IF(cond, tbl.bigint_col, tbl.double_col);
+DOUBLE;
+
+# dialect: spark2, spark
+IF(cond, tbl.double_col, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark
+IF(cond, tbl.str_col, tbl.double_col);
+STRING;
+
+# dialect: databricks
+IF(cond, tbl.str_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+IF(cond, tbl.double_col, tbl.str_col);
+DOUBLE;
+
+# dialect: spark2, spark
+IF(cond, tbl.date_col, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark
+IF(cond, tbl.str_col, tbl.date_col);
+STRING;
+
+# dialect: databricks
+IF(cond, tbl.date_col, tbl.str_col);
+DATE;
+
+# dialect: databricks
+IF(cond, tbl.str_col, tbl.date_col);
+DATE;
+
+# dialect: spark2, spark, databricks
+IF(cond, tbl.date_col, tbl.timestamp_col);
+TIMESTAMP;
+
+# dialect: spark2, spark, databricks
+IF(cond, tbl.timestamp_col, tbl.date_col);
+TIMESTAMP;
+
+# dialect: spark2, spark, databricks
+IF(cond, NULL, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+IF(cond, tbl.str_col, NULL);
+STRING;
+
+# dialect: spark2, spark
+COALESCE(tbl.str_col, tbl.date_col, tbl.bigint_col);
+STRING;
+
+# dialect: spark2, spark
+COALESCE(tbl.date_col, tbl.str_col, tbl.bigint_col);
+STRING;
+
+# dialect: spark2, spark
+COALESCE(tbl.date_col, tbl.bigint_col, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark
+COALESCE(tbl.str_col, tbl.date_col, tbl.bigint_col);
+STRING;
+
+# dialect: spark2, spark
+COALESCE(tbl.date_col, tbl.str_col, tbl.bigint_col);
+STRING;
+
+# dialect: spark2, spark
+COALESCE(tbl.date_col, NULL, tbl.bigint_col, tbl.str_col);
+STRING;
+
+# dialect: databricks
+COALESCE(tbl.str_col, tbl.bigint_col);
+BIGINT;
+
+# dialect: databricks
+COALESCE(tbl.bigint_col, tbl.str_col);
+BIGINT;
+
+# dialect: databricks
+COALESCE(tbl.str_col, NULL, tbl.bigint_col);
+BIGINT;
+
+# dialect: databricks
+COALESCE(tbl.bigint_col, NULL, tbl.str_col);
+BIGINT;
+
+# dialect: spark2, spark
+COALESCE(tbl.bool_col, tbl.str_col);
+STRING;
+
+# dialect: databricks
+COALESCE(tbl.bool_col, tbl.str_col);
+BOOLEAN;
+
+# dialect: spark2, spark
+COALESCE(tbl.interval_col, tbl.str_col);
+STRING;
+
+# dialect: databricks
+COALESCE(tbl.interval_col, tbl.str_col);
+INTERVAL;
+
+# dialect: spark2, spark
+COALESCE(tbl.bin_col, tbl.str_col);
+STRING;
+
+# dialect: databricks
+COALESCE(tbl.bin_col, tbl.str_col);
+BINARY;
 
 --------------------------------------
 -- BigQuery

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -100,19 +100,19 @@ STRING;
 RPAD(tbl.str_col, 1, tbl.str_col);
 STRING;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 IF(cond, tbl.double_col, tbl.bigint_col);
 DOUBLE;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 IF(cond, tbl.bigint_col, tbl.double_col);
 DOUBLE;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 IF(cond, tbl.double_col, tbl.str_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 IF(cond, tbl.str_col, tbl.double_col);
 STRING;
 
@@ -124,11 +124,11 @@ DOUBLE;
 IF(cond, tbl.double_col, tbl.str_col);
 DOUBLE;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 IF(cond, tbl.date_col, tbl.str_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 IF(cond, tbl.str_col, tbl.date_col);
 STRING;
 
@@ -140,43 +140,43 @@ DATE;
 IF(cond, tbl.str_col, tbl.date_col);
 DATE;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 IF(cond, tbl.date_col, tbl.timestamp_col);
 TIMESTAMP;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 IF(cond, tbl.timestamp_col, tbl.date_col);
 TIMESTAMP;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 IF(cond, NULL, tbl.str_col);
 STRING;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 IF(cond, tbl.str_col, NULL);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.str_col, tbl.date_col, tbl.bigint_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.date_col, tbl.str_col, tbl.bigint_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.date_col, tbl.bigint_col, tbl.str_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.str_col, tbl.date_col, tbl.bigint_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.date_col, tbl.str_col, tbl.bigint_col);
 STRING;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.date_col, NULL, tbl.bigint_col, tbl.str_col);
 STRING;
 
@@ -196,25 +196,17 @@ BIGINT;
 COALESCE(tbl.bigint_col, NULL, tbl.str_col);
 BIGINT;
 
-# dialect: spark2, spark
-COALESCE(tbl.bool_col, tbl.str_col);
-STRING;
-
 # dialect: databricks
 COALESCE(tbl.bool_col, tbl.str_col);
 BOOLEAN;
 
-# dialect: spark2, spark
+# dialect: hive, spark2, spark
 COALESCE(tbl.interval_col, tbl.str_col);
 STRING;
 
 # dialect: databricks
 COALESCE(tbl.interval_col, tbl.str_col);
 INTERVAL;
-
-# dialect: spark2, spark
-COALESCE(tbl.bin_col, tbl.str_col);
-STRING;
 
 # dialect: databricks
 COALESCE(tbl.bin_col, tbl.str_col);

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -891,7 +891,17 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
 
     def test_annotate_funcs(self):
         test_schema = {
-            "tbl": {"bin_col": "BINARY", "str_col": "STRING", "bignum_col": "BIGNUMERIC"}
+            "tbl": {
+                "bin_col": "BINARY",
+                "str_col": "STRING",
+                "bignum_col": "BIGNUMERIC",
+                "date_col": "DATE",
+                "timestamp_col": "TIMESTAMP",
+                "double_col": "DOUBLE",
+                "bigint_col": "BIGINT",
+                "bool_col": "BOOLEAN",
+                "interval_col": "INTERVAL",
+            }
         }
 
         for i, (meta, sql, expected) in enumerate(


### PR DESCRIPTION
Fixes #5067 

This PR fixes type coercion issues in the IF and COALESCE functions for Hive, Spark2, Spark, and Databricks.
For Hive, Spark 2 and Spark, we maintain the default non-ANSI behavior.
For Databricks, we follow the default ANSI-compliant behavior.

**DOCS**
[Hive Type precedence](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27838462#LanguageManualTypes-AllowedImplicitConversions)
[Databricks Type precedence graph](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-datatype-rules#type-precedence-graph)