### PR TITLE
feat(starrocks): Support parsing "NONE" as security option

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2241,7 +2241,7 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_security(self) -> t.Optional[exp.SecurityProperty]:
-        if self._match_texts(("DEFINER", "INVOKER")):
+        if self._match_texts(("NONE", "DEFINER", "INVOKER")):
             security_specifier = self._prev.text.upper()
             return self.expression(exp.SecurityProperty, this=security_specifier)
         return None

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -38,6 +38,9 @@ class TestStarrocks(Validator):
         self.validate_identity(
             "CREATE TABLE foo (col1 LARGEINT) DISTRIBUTED BY HASH (col1) BUCKETS 1"
         )
+        self.validate_identity(
+            "CREATE VIEW foo (foo_col1) SECURITY NONE AS SELECT bar_col1 FROM bar"
+        )
 
     def test_identity(self):
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")


### PR DESCRIPTION
StarRocks security option for CREATE VIEW can contain "NONE" as a value

[Create View Documentation](https://docs.starrocks.io/docs/sql-reference/sql-statements/View/CREATE_VIEW/#parameters)