### PR TITLE
fix(tsql)!: separate ISNULL from COALESCE

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -578,7 +578,7 @@ class TSQL(Dialect):
             "FORMAT": _build_format,
             "GETDATE": exp.CurrentTimestamp.from_arg_list,
             "HASHBYTES": _build_hashbytes,
-            "ISNULL": build_coalesce,
+            "ISNULL": lambda args: build_coalesce(args=args, is_null=True),
             "JSON_QUERY": _build_json_query,
             "JSON_VALUE": parser.build_extract_json_with_path(exp.JSONExtractScalar),
             "LEN": _build_with_arg_as_text(exp.Length),
@@ -1351,3 +1351,7 @@ class TSQL(Dialect):
             output = self.sql(expression, "output")
             output = f" {output}" if output else ""
             return f"{this}{default}{output}"
+
+        def coalesce_sql(self, expression: exp.Coalesce) -> str:
+            func_name = "ISNULL" if expression.args.get("is_null") else "COALESCE"
+            return rename_func(func_name)(self, expression)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5720,7 +5720,7 @@ class Ceil(Func):
 
 
 class Coalesce(Func):
-    arg_types = {"this": True, "expressions": False, "is_nvl": False}
+    arg_types = {"this": True, "expressions": False, "is_nvl": False, "is_null": False}
     is_var_len_args = True
     _sql_names = ["COALESCE", "IFNULL", "NVL"]
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -150,8 +150,10 @@ def build_trim(args: t.List, is_left: bool = True):
     )
 
 
-def build_coalesce(args: t.List, is_nvl: t.Optional[bool] = None) -> exp.Coalesce:
-    return exp.Coalesce(this=seq_get(args, 0), expressions=args[1:], is_nvl=is_nvl)
+def build_coalesce(
+    args: t.List, is_nvl: t.Optional[bool] = None, is_null: t.Optional[bool] = None
+) -> exp.Coalesce:
+    return exp.Coalesce(this=seq_get(args, 0), expressions=args[1:], is_nvl=is_nvl, is_null=is_null)
 
 
 def build_locate_strposition(args: t.List):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1318,6 +1318,7 @@ WHERE
         )
 
     def test_isnull(self):
+        self.validate_identity("ISNULL(x, y)")
         self.validate_all("ISNULL(x, y)", write={"spark": "COALESCE(x, y)"})
 
     def test_json(self):


### PR DESCRIPTION
This PR fixes the issue of treating `ISNULL` as `COALESCE` in T-SQL.
This assumption is wrong because these two functions have different semantics.

**DOCS**
[T-SQL COALESCE vs ISNULL](https://learn.microsoft.com/en-us/sql/t-sql/language-elements/coalesce-transact-sql?view=sql-server-ver16#compare-coalesce-and-isnull)