### PR TITLE
Fix(snowflake): Put COPY GRANTS in the right place for materialized views

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1387,7 +1387,7 @@ class Snowflake(Dialect):
                 # We default CopyGrantsProperty to POST_SCHEMA which means we need to output it POST_NAME if a materialized view is detected
                 # ref: https://docs.snowflake.com/en/sql-reference/sql/create-materialized-view#syntax
                 # ref: https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax
-                post_schema_properties = locations.get(exp.Properties.Location.POST_SCHEMA, [])
+                post_schema_properties = locations[exp.Properties.Location.POST_SCHEMA]
                 post_schema_properties.pop(post_schema_properties.index(copy_grants_property))
 
                 this_name = self.sql(expression.this, "this")

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1376,3 +1376,25 @@ class Snowflake(Dialect):
             if offset and not limit:
                 expression.limit(exp.Null(), copy=False)
             return super().select_sql(expression)
+
+        def createable_sql(self, expression: exp.Create, locations: t.DefaultDict) -> str:
+            kind = self.sql(expression, "kind").upper()
+            is_materialized = expression.find(exp.MaterializedProperty)
+            copy_grants_property = expression.find(exp.CopyGrantsProperty)
+
+            if kind == "VIEW" and is_materialized and copy_grants_property:
+                # For materialized views, COPY GRANTS is located *before* the columns list
+                # This is in contrast to normal views where COPY GRANTS is located *after* the columns list
+                # We default CopyGrantsProperty to POST_SCHEMA which means we need to output it POST_NAME if a materialized view is detected
+                # ref: https://docs.snowflake.com/en/sql-reference/sql/create-materialized-view#syntax
+                # ref: https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax
+                post_schema_properties = locations.get(exp.Properties.Location.POST_SCHEMA, [])
+                post_schema_properties.pop(post_schema_properties.index(copy_grants_property))
+
+                this_name = self.sql(expression.this, "this")
+                copy_grants = self.sql(copy_grants_property)
+                this_schema = self.schema_columns_sql(expression.this)
+
+                return f"{this_name}{self.sep()}{copy_grants}{self.sep()}{this_schema}"
+
+            return super().createable_sql(expression, locations)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1381,7 +1381,7 @@ class Snowflake(Dialect):
             is_materialized = expression.find(exp.MaterializedProperty)
             copy_grants_property = expression.find(exp.CopyGrantsProperty)
 
-            if kind == "VIEW" and is_materialized and copy_grants_property:
+            if expression.kind == "VIEW" and is_materialized and copy_grants_property:
                 # For materialized views, COPY GRANTS is located *before* the columns list
                 # This is in contrast to normal views where COPY GRANTS is located *after* the columns list
                 # We default CopyGrantsProperty to POST_SCHEMA which means we need to output it POST_NAME if a materialized view is detected

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1393,7 +1393,8 @@ class Snowflake(Dialect):
                 this_name = self.sql(expression.this, "this")
                 copy_grants = self.sql(copy_grants_property)
                 this_schema = self.schema_columns_sql(expression.this)
+                this_schema = f"{self.sep()}{this_schema}" if this_schema else ""
 
-                return f"{this_name}{self.sep()}{copy_grants}{self.sep()}{this_schema}"
+                return f"{this_name}{self.sep()}{copy_grants}{this_schema}"
 
             return super().createable_sql(expression, locations)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1378,7 +1378,6 @@ class Snowflake(Dialect):
             return super().select_sql(expression)
 
         def createable_sql(self, expression: exp.Create, locations: t.DefaultDict) -> str:
-            kind = self.sql(expression, "kind").upper()
             is_materialized = expression.find(exp.MaterializedProperty)
             copy_grants_property = expression.find(exp.CopyGrantsProperty)
 


### PR DESCRIPTION
Addresses SQLMesh issue: https://github.com/TobikoData/sqlmesh/issues/4181

Currently, if `exp.CopyGrantsProperty` is present in a `CREATE VIEW` then it is output after the columns list. This is in line with the [Snowflake docs](https://docs.snowflake.com/en/sql-reference/sql/create-view#syntax).

However, for `CREATE MATERIALIZED VIEW`, it [needs to go](https://docs.snowflake.com/en/sql-reference/sql/create-materialized-view#syntax) *before* the columns list or the following error will be thrown:
```
>>> CREATE MATERIALIZED VIEW ERIN_TEST_MV ("ITEM_ID", "NUM_ORDERS") COPY GRANTS AS SELECT ITEM_ID, NUM_ORDERS FROM UPSTREAM_TABLE

SQL compilation error: syntax error line 1 at position 50 unexpected '"ITEM_ID"'.
```