### PR TITLE
fix(optimizer): annotate DPipe with VARCHAR

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -708,6 +708,7 @@ class Dialect(metaclass=_Dialect):
             exp.Concat,
             exp.ConcatWs,
             exp.DateToDateStr,
+            exp.DPipe,
             exp.GroupConcat,
             exp.Initcap,
             exp.Lower,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -37,6 +37,12 @@ ARRAY<DOUBLE>;
 SORT_ARRAY(ARRAY(tbl.bigint_col));
 ARRAY<BIGINT>;
 
+tbl.bigint || tbl.str_col;
+VARCHAR;
+
+tbl.str_col || tbl.bigint;
+VARCHAR;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
Fixes annotation for the `exp.DPipe` (`||`). 
For example when the input is `int || varchar` the output type must be `varchar` and not the default `binary coersion` type which is `int`.