### PR TITLE
Fix: ignore/respect nulls generation edge case

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4287,7 +4287,8 @@ class Generator(metaclass=_Generator):
             agg_func = expression.find(exp.AggFunc)
 
             if agg_func:
-                return self.sql(agg_func)[:-1] + f" {text})"
+                agg_func_sql = self.sql(agg_func, comment=False)[:-1] + f" {text})"
+                return self.maybe_comment(agg_func_sql, comments=agg_func.comments)
 
         return f"{self.sql(expression, 'this')} {text}"
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -178,6 +178,10 @@ class TestBigQuery(Validator):
             "CREATE OR REPLACE VIEW test (tenant_id OPTIONS (description='Test description on table creation')) AS SELECT 1 AS tenant_id, 1 AS customer_id",
         )
         self.validate_identity(
+            "--c\nARRAY_AGG(v IGNORE NULLS)",
+            "ARRAY_AGG(v IGNORE NULLS) /* c */",
+        )
+        self.validate_identity(
             'SELECT r"\\t"',
             "SELECT '\\\\t'",
         )


### PR DESCRIPTION
Fixes the following bug:

```python
>>> import sqlglot
>>> print(sqlglot.transpile("--c\narray_agg(v ignore nulls)", "bigquery")[0])
array_agg(v) /* c * IGNORE NULLS)
```