### PR TITLE
fix(athena): always generate string literal from FileFormatProperty

### DIFF
--- a/sqlglot/dialects/athena.py
+++ b/sqlglot/dialects/athena.py
@@ -71,6 +71,13 @@ def _partitioned_by_property_sql(self: Athena.Generator, e: exp.PartitionedByPro
     return f"{prop_name}={self.sql(e, 'this')}"
 
 
+def _file_format_property_sql(self: Athena.Generator, e: exp.FileFormatProperty) -> str:
+    this = e.args.get("this")
+    if not this:
+        return "format=''"
+    return f"format={exp.Literal.string(this.name)}"
+
+
 class Athena(Trino):
     """
     Over the years, it looks like AWS has taken various execution engines, bolted on AWS-specific modifications and then
@@ -148,7 +155,7 @@ class Athena(Trino):
 
         TRANSFORMS = {
             **Trino.Generator.TRANSFORMS,
-            exp.FileFormatProperty: lambda self, e: f"format={self.sql(e, 'this')}",
+            exp.FileFormatProperty: _file_format_property_sql,
             exp.PartitionedByProperty: _partitioned_by_property_sql,
             exp.LocationProperty: _location_property_sql,
         }

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Optional
 
 from sqlglot import (
     Dialect,
@@ -16,7 +17,7 @@ from sqlglot.parser import logger as parser_logger
 
 
 class Validator(unittest.TestCase):
-    dialect = None
+    dialect: Optional[str] = None
 
     def parse_one(self, sql, **kwargs):
         return parse_one(sql, read=self.dialect, **kwargs)


### PR DESCRIPTION
As described in https://github.com/tobymao/sqlglot/discussions/5124, Athena requires the WITH(format='parquet') to use a string literal on the right hand side of the the format=