### PR TITLE
Starrocks dialect support for array_agg,array_intersect,sd_distance and sd_point

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -16,6 +16,26 @@ from sqlglot.dialects.mysql import MySQL
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 
+def st_distance_sphere(self, expression: exp.StDistance) -> str:
+    """
+    Converts ST_Distance(point1, point2) to StarRocks format:
+    ST_Distance_Sphere(ST_X(point1), ST_Y(point1), ST_X(point2), ST_Y(point2))
+    """
+    point1 = expression.this
+    point2 = expression.expression
+    
+    if not point1 or not point2:
+        raise ValueError("ST_Distance requires two point arguments")
+    
+    # Generate the four coordinate expressions for StarRocks format
+    point1_x = f"ST_X({self.sql(point1)})"
+    point1_y = f"ST_Y({self.sql(point1)})"
+    point2_x = f"ST_X({self.sql(point2)})"
+    point2_y = f"ST_Y({self.sql(point2)})"
+    
+    # Return in StarRocks ST_Distance_Sphere format with proper formatting
+    return f"ST_Distance_Sphere({point1_x}, {point1_y}, {point2_x}, {point2_y})"
+
 
 class StarRocks(MySQL):
     STRICT_JSON_PATH_SYNTAX = False
@@ -103,7 +123,7 @@ class StarRocks(MySQL):
                     partition_expressions=partition_expressions,
                     create_expressions=create_expressions,
                 )
-            return super()._parse_partitioned_by()
+            return super()._parse_partitioned_by()      
 
     class Generator(MySQL.Generator):
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
@@ -133,6 +153,10 @@ class StarRocks(MySQL):
             **MySQL.Generator.TRANSFORMS,
             exp.Array: inline_array_sql,
             exp.ArrayToString: rename_func("ARRAY_JOIN"),
+            exp.ArrayAgg: rename_func("ARRAY_AGG"),
+            exp.ArrayIntersection: rename_func("ARRAY_INTERSECT"),
+            exp.StPoint: rename_func("ST_POINT"),
+            exp.StDistance: st_distance_sphere,
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.DateDiff: lambda self, e: self.func(
                 "DATE_DIFF", unit_to_str(e), e.this, e.expression

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5562,6 +5562,20 @@ class ArrayToString(Func):
     _sql_names = ["ARRAY_TO_STRING", "ARRAY_JOIN"]
 
 
+class ArrayIntersection(Func):
+    arg_types = {"this": True, "expression": True, "null": False}
+    _sql_names = ["ARRAY_INTERSECTION", "ARRAY_INTERSECT"]
+
+
+class StPoint(Func):
+    arg_types = {"this": True, "expression": True, "null": False}
+    _sql_names = ["ST_MAKEPOINT", "ST_POINT"]
+
+
+class StDistance(Func):
+    arg_types = {"this": True, "expression": True}
+    _sql_names = ["ST_DISTANCE","ST_DISTANCE_SPHERE"]
+
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#string
 class String(Func):
     arg_types = {"this": True, "zone": False}

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -9,6 +9,16 @@ class TestStarrocks(Validator):
         self.validate_identity("SELECT ARRAY_JOIN([1, 3, 5, NULL], '_', 'NULL')")
         self.validate_identity("SELECT ARRAY_JOIN([1, 3, 5, NULL], '_')")
         self.validate_identity("ALTER TABLE a SWAP WITH b")
+        self.validate_identity("SELECT ARRAY_INTERSECT([1, 2], [2, 3])")
+        self.validate_identity("SELECT ST_POINT(10, 20)")
+        self.validate_identity("SELECT ARRAY_AGG(a) FROM x")
+        self.validate_all("SELECT ST_DISTANCE_SPHERE(a, b)",
+        write={
+        "starrocks": "SELECT ST_Distance_Sphere(ST_X(a), ST_Y(a), ST_X(b), ST_Y(b))"}
+         )
+
+        
+
 
     def test_ddl(self):
         ddl_sqls = [

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -669,6 +669,12 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("ARRAY_AGG(a)"), exp.ArrayAgg)
         self.assertIsInstance(parse_one("ARRAY_CONTAINS(a, 'a')"), exp.ArrayContains)
         self.assertIsInstance(parse_one("ARRAY_SIZE(a)"), exp.ArraySize)
+        self.assertIsInstance(parse_one("ARRAY_INTERSECTION([1, 2], [2, 3])"), exp.ArrayIntersection)
+        self.assertIsInstance(parse_one("ARRAY_INTERSECT([1, 2], [2, 3])"), exp.ArrayIntersection)
+        self.assertIsInstance(parse_one("ST_MAKEPOINT(10, 20)"), exp.StPoint)
+        self.assertIsInstance(parse_one("ST_POINT(10, 20)"), exp.StPoint)
+        self.assertIsInstance(parse_one("ST_DISTANCE(a, b)"), exp.StDistance)
+        self.assertIsInstance(parse_one("ST_DISTANCE_SPHERE(a, b)"), exp.StDistance)
         self.assertIsInstance(parse_one("AVG(a)"), exp.Avg)
         self.assertIsInstance(parse_one("BEGIN DEFERRED TRANSACTION"), exp.Transaction)
         self.assertIsInstance(parse_one("CEIL(a)"), exp.Ceil)
@@ -1218,3 +1224,33 @@ FROM foo""",
 
     def test_parse_identifier(self):
         self.assertEqual(exp.parse_identifier("a ' b"), exp.to_identifier("a ' b"))
+
+    def test_array_intersection(self):
+        expr = parse_one('ARRAY_INTERSECTION([1, 2], [2, 3])')
+        self.assertIsInstance(expr, exp.ArrayIntersection)
+        self.assertEqual(expr.sql(), 'ARRAY_INTERSECTION(ARRAY(1, 2), ARRAY(2, 3))')
+
+        expr2 = parse_one('ARRAY_INTERSECT([1, 2], [2, 3])')
+        self.assertIsInstance(expr2, exp.ArrayIntersection)
+        self.assertEqual(expr2.sql(), 'ARRAY_INTERSECTION(ARRAY(1, 2), ARRAY(2, 3))')
+
+    def test_st_point(self):
+        expr = parse_one('ST_MAKEPOINT(10, 20)')
+        self.assertIsInstance(expr, exp.StPoint)
+        self.assertEqual(expr.sql(), 'ST_MAKEPOINT(10, 20)')
+
+        expr2 = parse_one('ST_POINT(10, 20)')
+        self.assertIsInstance(expr2, exp.StPoint)
+        self.assertEqual(expr2.sql(), 'ST_MAKEPOINT(10, 20)')
+
+    def test_st_distance(self):
+        expr = parse_one('ST_DISTANCE(a, b)')
+        self.assertIsInstance(expr, exp.StDistance)
+        self.assertEqual(expr.sql(), 'ST_DISTANCE(a, b)')
+
+        expr2 = parse_one('ST_DISTANCE_SPHERE(a, b)')
+        self.assertIsInstance(expr2, exp.StDistance)
+        self.assertEqual(expr2.sql(), 'ST_DISTANCE(a, b)')
+
+
+


### PR DESCRIPTION
This is regarding the issue https://github.com/tobymao/sqlglot/issues/5122 .

read="snowflake",
write="starrocks",
Array_agg is getting transpiled as group_concat in starrocks which is not ideal transpilation
array_intersection,st_makepoint,st_distance is not getting transpiled and hence getting same source query in the target output.

# Issue re-production step:
```python
!pip install sqlglot
import sqlglot

original_sql = """
select array_agg(x) as array_agg ,
array_intersection(["SQL", "storage"], ["mysql", "query", "SQL"], ["SQL"]) AS array_intersect,
st_makepoint(37.5, 45.5) as st_makepoint,
st_distance(st_makepoint(24.7, 56.7), st_makepoint(27.7, 52.7)) AS st_distance
from my_sample_table;
"""

transpiled_sql = sqlglot.transpile(
    original_sql,
    read="snowflake",
    write='starrocks',
    pretty=True
)[0]

print("Transpiled as", transpiled_sql)
```

output from sqlglot:
SELECT
GROUP_CONCAT(x) AS array_agg,
ARRAY_INTERSECTION(["SQL", "storage"], ["mysql", "query", "SQL"], ["SQL"]) AS array_intersect,
ST_MAKEPOINT(37.5, 45.5) AS st_makepoint,
ST_DISTANCE(ST_MAKEPOINT(24.7, 56.7), ST_MAKEPOINT(27.7, 52.7)) AS st_distance
FROM my_sample_table

# expected output:
SELECT
ARRAY_AGG(X) AS ARRAY_AGG,
ARRAY_INTERSECT(["SQL", "storage"], ["mysql", "query", "SQL"], ["SQL"]) AS ARRAY_INTERSECT,
ST_POINT(37.5, 45.5) AS ST_MAKEPOINT,
ST_Distance_Sphere(
ST_X(ST_POINT(24.7, 56.7)),
ST_Y(ST_POINT(24.7, 56.7)),
ST_X(ST_POINT(27.7, 52.7)),
ST_Y(ST_POINT(27.7, 52.7))
) AS ST_DISTANCE
FROM my_sample_table

Supporting Documentation:
https://docs.snowflake.com/en/sql-reference/functions/array_agg
https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/array_agg/
https://docs.snowflake.com/en/sql-reference/functions/array_intersection
https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/array_intersect/
https://docs.snowflake.com/en/sql-reference/functions/st_makepoint
https://docs.starrocks.io/docs/sql-reference/sql-functions/spatial-functions/st_point/
https://docs.snowflake.com/en/sql-reference/functions/st_distance
https://docs.starrocks.io/docs/sql-reference/sql-functions/spatial-functions/st_distance_sphere