### PR TITLE
fix(snowflake): Properly transpile ARRAY_AGG, IGNORE/RESPECT NULLS

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1154,6 +1154,8 @@ class Snowflake(Dialect):
             exp.VarMap,
         }
 
+        RESPECT_IGNORE_NULLS_UNSUPPORTED_EXPRESSIONS = (exp.ArrayAgg,)
+
         def with_properties(self, properties: exp.Properties) -> str:
             return self.properties(properties, wrapped=False, prefix=self.sep(""), sep=" ")
 
@@ -1414,20 +1416,3 @@ class Snowflake(Dialect):
                 expr_sql = self.sql(exp.WithinGroup(this=expr_sql, expression=order))
 
             return expr_sql
-
-        def _respect_ignore_nulls_sql(self, expression: exp.RespectNulls | exp.IgnoreNulls) -> str:
-            this = expression.this
-            if isinstance(this, exp.ArrayAgg):
-                self.unsupported(
-                    f"RESPECT/IGNORE NULLS is not supported for {this.sql_name()} in Snowflake"
-                )
-                return self.sql(this)
-
-            text = "IGNORE NULLS" if isinstance(expression, exp.IgnoreNulls) else "RESPECT NULLS"
-            return self._embed_ignore_nulls(expression, text)
-
-        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
-            return self._respect_ignore_nulls_sql(expression)
-
-        def respectnulls_sql(self, expression: exp.RespectNulls) -> str:
-            return self._respect_ignore_nulls_sql(expression)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4272,9 +4272,8 @@ class Generator(metaclass=_Generator):
     def _embed_ignore_nulls(self, expression: exp.IgnoreNulls | exp.RespectNulls, text: str) -> str:
         this = expression.this
         if isinstance(this, self.RESPECT_IGNORE_NULLS_UNSUPPORTED_EXPRESSIONS):
-            this_name = this.sql_name() if isinstance(this, exp.Func) else this.__class__
             self.unsupported(
-                f"RESPECT/IGNORE NULLS is not supported for {this_name} in {self.dialect.__class__.__name__}"
+                f"RESPECT/IGNORE NULLS is not supported for {type(this).key} in {self.dialect.__class__.__name__}"
             )
             return self.sql(this)
 


### PR DESCRIPTION
Notes for Snowflake's `ARRAY_AGG`:
- It does not support an inline `ORDER BY`, it must be moved to `WITHIN GROUP (<orderby_clause>)`
- It does not support  `IGNORE NULLS` / `RESPECT NULLS`, the nulls are always excluded. This looks like an exception for some other window functions like `LEAD` or `LAG` which do allow them 

Docs
---------
[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#array_agg) | [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/array_agg)