### PR TITLE
fix(snowflake): generate SELECT for UNNEST without JOIN or FROM

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1102,6 +1102,15 @@ class TestSnowflake(Validator):
                 "snowflake": r"SELECT FIRST_VALUE(TABLE1.COLUMN1) IGNORE NULLS OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1"
             },
         )
+        self.validate_all(
+            "SELECT * FROM foo WHERE 'str' IN (SELECT value FROM TABLE(FLATTEN(INPUT => vals)) AS _u(seq, key, path, index, value, this))",
+            read={
+                "bigquery": "SELECT * FROM foo WHERE 'str' IN UNNEST(vals)",
+            },
+            write={
+                "snowflake": "SELECT * FROM foo WHERE 'str' IN (SELECT value FROM TABLE(FLATTEN(INPUT => vals)) AS _u(seq, key, path, index, value, this))",
+            },
+        )
 
     def test_staged_files(self):
         # Ensure we don't treat staged file paths as identifiers (i.e. they're not normalized)


### PR DESCRIPTION
This PR fixes the following issue: 
```
BigQuery:
SELECT * FROM foo WHERE 'str' IN UNNEST(vals)

Snowflake (generated):
SELECT * FROM foo WHERE 'str' IN (SELECT TABLE(FLATTEN(INPUT => vals)) AS _u(seq, key, path, index, value, this))
```
In this above example, we have to add a `SELECT value FROM` for the unnested expression. 

After the fix:
```
BigQuery:
SELECT * FROM foo WHERE 'str' IN UNNEST(vals)

Snowflake (generated):
SELECT * FROM foo WHERE 'str' IN (SELECT value FROM TABLE(FLATTEN(INPUT => vals)) AS _u(seq, key, path, index, value, this))
 ```