### PR TITLE
fix(snowflake): Transpile ISOWEEK to WEEKISO

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -372,6 +372,11 @@ class Snowflake(Dialect):
         "ff6": "%f",
     }
 
+    DATE_PART_MAPPING = {
+        **Dialect.DATE_PART_MAPPING,
+        "ISOWEEK": "WEEKISO",
+    }
+
     def quote_identifier(self, expression: E, identify: bool = True) -> E:
         # This disables quoting DUAL in SELECT ... FROM DUAL, because Snowflake treats an
         # unquoted DUAL keyword in a special way and does not map it to a user-defined table
@@ -1033,7 +1038,9 @@ class Snowflake(Dialect):
             exp.DayOfWeekIso: rename_func("DAYOFWEEKISO"),
             exp.DayOfYear: rename_func("DAYOFYEAR"),
             exp.Explode: rename_func("FLATTEN"),
-            exp.Extract: rename_func("DATE_PART"),
+            exp.Extract: lambda self, e: self.func(
+                "DATE_PART", map_date_part(e.this, self.dialect), e.expression
+            ),
             exp.FileFormatProperty: lambda self,
             e: f"FILE_FORMAT=({self.expressions(e, 'expressions', sep=' ')})",
             exp.FromTimeZone: lambda self, e: self.func(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1071,6 +1071,14 @@ class TestSnowflake(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT DATE_PART(WEEKISO, CAST('2013-12-25' AS DATE))",
+            read={
+                "bigquery": "SELECT EXTRACT(ISOWEEK FROM CAST('2013-12-25' AS DATE))",
+                "snowflake": "SELECT DATE_PART(WEEKISO, CAST('2013-12-25' AS DATE))",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
- Before:
```Python3
>>> parse_one("SELECT EXTRACT(ISOWEEK FROM DATE '2013-12-25') AS the_day", "bigquery").sql("snowflake")
"SELECT DATE_PART(ISOWEEK, CAST('2013-12-25' AS DATE)) AS the_day

bigquery> SELECT EXTRACT(ISOWEEK FROM DATE '2013-12-25') AS the_day
52


snowflake> SELECT DATE_PART(ISOWEEK, CAST('2013-12-25' AS DATE)) AS the_day;
Error: invalid value [ISOWEEK] for parameter 'DATE_PART date/time part'
```

<br />

- After 
```Python3
>>> parse_one("SELECT EXTRACT(ISOWEEK FROM DATE '2013-12-25') AS the_day", "bigquery").sql("snowflake")
"SELECT DATE_PART(WEEKISO, CAST('2013-12-25' AS DATE)) AS the_day"

snowflake> SELECT DATE_PART(WEEKISO, CAST('2013-12-25' AS DATE)) AS the_day;
52
```

Docs
------
[BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#extract) | [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/date_part)