### PR TITLE
Fix(mysql)!: preserve TIMESTAMP on roundtrip

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -211,6 +211,7 @@ class MySQL(Dialect):
             "START": TokenType.BEGIN,
             "SIGNED": TokenType.BIGINT,
             "SIGNED INTEGER": TokenType.BIGINT,
+            "TIMESTAMP": TokenType.TIMESTAMPTZ,
             "UNLOCK TABLES": TokenType.COMMAND,
             "UNSIGNED": TokenType.UBIGINT,
             "UNSIGNED INTEGER": TokenType.UBIGINT,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -111,7 +111,7 @@ class TestMySQL(Validator):
         )
         self.validate_identity(
             "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMPTZ, ts_ltz TIMESTAMPLTZ)",
-            "CREATE TABLE test (ts DATETIME, ts_tz TIMESTAMP, ts_ltz TIMESTAMP)",
+            "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMP, ts_ltz TIMESTAMP)",
         )
         self.validate_identity(
             "ALTER TABLE test_table ALTER COLUMN test_column SET DATA TYPE LONGTEXT",
@@ -298,7 +298,7 @@ class TestMySQL(Validator):
         )
         self.validate_identity(
             "CAST(x AS TIMESTAMP)",
-            "CAST(x AS DATETIME)",
+            "TIMESTAMP(x)",
         )
         self.validate_identity(
             "CAST(x AS TIMESTAMPTZ)",


### PR DESCRIPTION
Fixes #5127

Today, we convert `TIMESTAMP` into `DATETIME` for MySQL. This is incorrect, as demonstrated below:

```
mysql> CREATE TABLE foo (ts TIMESTAMP, dt DATETIME);
Query OK, 0 rows affected (0.028 sec)

mysql> INSERT INTO foo (ts, dt) VALUES ('2025-05-30 12:00:00', '2025-05-30 12:00:00');
Query OK, 1 row affected (0.005 sec)

mysql> SELECT * FROM foo WHERE ts = '2025-05-30 12:00:00';
+---------------------+---------------------+
| ts                  | dt                  |
+---------------------+---------------------+
| 2025-05-30 12:00:00 | 2025-05-30 12:00:00 |
+---------------------+---------------------+
1 row in set (0.001 sec)

mysql> SELECT * FROM foo WHERE dt = '2025-05-30 12:00:00';
+---------------------+---------------------+
| ts                  | dt                  |
+---------------------+---------------------+
| 2025-05-30 12:00:00 | 2025-05-30 12:00:00 |
+---------------------+---------------------+
1 row in set (0.001 sec)

mysql> SET time_zone = '-05:00';
Query OK, 0 rows affected (0.001 sec)

mysql> SELECT * FROM foo WHERE ts = '2025-05-30 12:00:00';
Empty set (0.001 sec)

mysql> SELECT * FROM foo WHERE dt = '2025-05-30 12:00:00';
+---------------------+---------------------+
| ts                  | dt                  |
+---------------------+---------------------+
| 2025-05-30 04:00:00 | 2025-05-30 12:00:00 |
+---------------------+---------------------+
1 row in set (0.000 sec)
```

By transpiling `TIMESTAMP` into `DATETIME`, it incorrectly changes the semantics. Specifically, with this transformation, the 2nd-to-last query would return 1 row if we used SQLGlot's transformed DDL, because we'd essentially be running the last query (`ts` and `dt` would be both `DATETIME` values).