### PR TITLE
feat(parser): ORDER BY with pipe syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -933,6 +933,7 @@ class Parser(metaclass=_Parser):
     PIPE_SYNTAX_TRANSFORM_PARSERS = {
         "SELECT": lambda self, query: self._parse_pipe_syntax_select(query),
         "WHERE": lambda self, query: self._parse_pipe_syntax_where(query),
+        "ORDER BY": lambda self, query: query.order_by(self._parse_order(), copy=False),
     }
 
     PROPERTY_PARSERS: t.Dict[str, t.Callable] = {

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3481,3 +3481,24 @@ FROM subquery2""",
             "FROM x |> WHERE x1 > 1 AND x2 > 2 |> SELECT x1 as gt1, x2 as gt2 |> SELECT gt1 * 2 + gt2 * 2 AS gt2_2",
             "SELECT gt1 * 2 + gt2 * 2 AS gt2_2 FROM (SELECT x1 AS gt1, x2 AS gt2 FROM (SELECT * FROM x WHERE x1 > 1 AND x2 > 2))",
         )
+        self.validate_identity("FROM x |> ORDER BY x1", "SELECT * FROM x ORDER BY x1")
+        self.validate_identity(
+            "FROM x |> ORDER BY x1 |> ORDER BY x2", "SELECT * FROM x ORDER BY x1, x2"
+        )
+        self.validate_identity(
+            "FROM x |> ORDER BY x1 |> WHERE x1 > 0 OR x1 != 1 |> ORDER BY x2 |> WHERE x2 > 0 AND x2 != 1 |> SELECT x1, x2",
+            "SELECT x1, x2 FROM (SELECT * FROM x WHERE (x1 > 0 OR x1 <> 1) AND (x2 > 0 AND x2 <> 1) ORDER BY x1, x2)",
+        )
+        self.validate_identity(
+            "FROM x |> ORDER BY x1 |> WHERE x1 > 0 |> SELECT x1",
+            "SELECT x1 FROM (SELECT * FROM x WHERE x1 > 0 ORDER BY x1)",
+        )
+        self.validate_identity(
+            "FROM x |> WHERE x1 > 0 |> SELECT x1 |> ORDER BY x1",
+            "SELECT x1 FROM (SELECT * FROM x WHERE x1 > 0) ORDER BY x1",
+        )
+
+        self.validate_identity(
+            "FROM x |> SELECT x1, x2, x3 |> ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
+            "SELECT x1, x2, x3 FROM (SELECT * FROM x) ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
+        )


### PR DESCRIPTION
**DOCS**
[ORDER BY pipe syntax](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#order_by_pipe_operator)

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |         |
| `WHERE (replacing QUALIFY)`           |          |
| `EXTEND`           |          |
| `SET`              |          |
| `RENAME`           |          |
| `DROP`             |         |
| `AS`               |           |
| `LIMIT`        |          |
| `AGGREGATE`        |          |
| `ORDER BY` | ✅  |
| `UNION`               |           |
| `INTERSECT`               |           |
| `EXCEPT`               |           |
| `JOIN`           |           |
| `CALL`               |           |
| `TABLESAMPLE`      |           |
| `PIVOT`            |           |
| `UNPIVOT`          |           |