### PR TITLE
feat(parser): LIMIT/OFFSET pipe syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -934,6 +934,8 @@ class Parser(metaclass=_Parser):
         "SELECT": lambda self, query: self._parse_pipe_syntax_select(query),
         "WHERE": lambda self, query: self._parse_pipe_syntax_where(query),
         "ORDER BY": lambda self, query: query.order_by(self._parse_order(), copy=False),
+        "LIMIT": lambda self, query: self._parse_pipe_syntax_limit(query),
+        "OFFSET": lambda self, query: query.offset(self._parse_offset(), copy=False),
     }
 
     PROPERTY_PARSERS: t.Dict[str, t.Callable] = {
@@ -1131,6 +1133,15 @@ class Parser(metaclass=_Parser):
     def _parse_pipe_syntax_where(self, query: exp.Query) -> exp.Query:
         where = self._parse_where()
         return query.where(where, copy=False)
+
+    def _parse_pipe_syntax_limit(self, query: exp.Query) -> exp.Query:
+        limit = self._parse_limit()
+        offset = self._parse_offset()
+        if limit:
+            query.limit(limit, copy=False)
+        if offset:
+            query.offset(offset, copy=False)
+        return query
 
     def _parse_partitioned_by_bucket_or_truncate(self) -> exp.Expression:
         klass = (

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3497,8 +3497,19 @@ FROM subquery2""",
             "FROM x |> WHERE x1 > 0 |> SELECT x1 |> ORDER BY x1",
             "SELECT x1 FROM (SELECT * FROM x WHERE x1 > 0) ORDER BY x1",
         )
-
         self.validate_identity(
             "FROM x |> SELECT x1, x2, x3 |> ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
             "SELECT x1, x2, x3 FROM (SELECT * FROM x) ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
         )
+        for option in ("LIMIT 1", "OFFSET 2", "LIMIT 1 OFFSET 2"):
+            with self.subTest(f"Testing pipe syntax LIMIT and OFFSET option: {option}"):
+                self.validate_identity(f"FROM x |> {option}", f"SELECT * FROM x {option}")
+                self.validate_identity(f"FROM x |> {option}", f"SELECT * FROM x {option}")
+                self.validate_identity(
+                    f"FROM x |> {option} |> SELECT x1, x2 |> WHERE x1 > 0 |> WHERE x2 > 0  |> ORDER BY x1, x2 ",
+                    f"SELECT x1, x2 FROM (SELECT * FROM x {option}) WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2",
+                )
+                self.validate_identity(
+                    f"FROM x |> SELECT x1, x2 |> WHERE x1 > 0 |> WHERE x2 > 0  |> ORDER BY x1, x2 |> {option}",
+                    f"SELECT x1, x2 FROM (SELECT * FROM x) WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2 {option}",
+                )


### PR DESCRIPTION
BigQuery only allows `OFFSET` with prefix a `LIMIT`. 
Databricks supports `OFFSET` without `LIMIT`.

**DOCS**
[BigQuery LIMIT pipe syntax](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#limit_pipe_operator)
[Databricks LIMIT/OFFSET pipe syntax](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-qry-select-pipeop#syntax)

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |         |
| `WHERE (replacing QUALIFY)`           |          |
| `EXTEND`           |          |
| `SET`              |          |
| `RENAME`           |          |
| `DROP`             |         |
| `AS`               |           |
| `LIMIT/OFFSET`        |    ✅       |
| `AGGREGATE`        |          |
| `ORDER BY` | ✅  |
| `UNION`               |           |
| `INTERSECT`               |           |
| `EXCEPT`               |           |
| `JOIN`           |           |
| `CALL`               |           |
| `TABLESAMPLE`      |           |
| `PIVOT`            |           |
| `UNPIVOT`          |           |