### PR TITLE
feat(parser): AGGREGATE with GROUP AND ORDER BY pipe syntax

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -525,6 +525,16 @@ class BigQuery(Dialect):
         LOG_DEFAULTS_TO_LN = True
         SUPPORTS_IMPLICIT_UNNEST = True
 
+        # BigQuery does not allow ASC/DESC to be used as an identifier
+        ID_VAR_TOKENS = parser.Parser.ID_VAR_TOKENS - {TokenType.ASC, TokenType.DESC}
+        ALIAS_TOKENS = parser.Parser.ALIAS_TOKENS - {TokenType.ASC, TokenType.DESC}
+        TABLE_ALIAS_TOKENS = parser.Parser.TABLE_ALIAS_TOKENS - {TokenType.ASC, TokenType.DESC}
+        COMMENT_TABLE_ALIAS_TOKENS = parser.Parser.COMMENT_TABLE_ALIAS_TOKENS - {
+            TokenType.ASC,
+            TokenType.DESC,
+        }
+        UPDATE_ALIAS_TOKENS = parser.Parser.UPDATE_ALIAS_TOKENS - {TokenType.ASC, TokenType.DESC}
+
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "CONTAINS_SUBSTR": _build_contains_substring,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1194,7 +1194,9 @@ class Parser(metaclass=_Parser):
         self._match_text_seq("AGGREGATE")
         query = self._parse_pipe_syntax_aggregate_group_order_by(query, group_by_exists=False)
 
-        if self._match(TokenType.GROUP_BY) or self._match_text_seq("GROUP", "AND", "ORDER BY"):
+        if self._match(TokenType.GROUP_BY) or (
+            self._match_text_seq("GROUP", "AND") and self._match(TokenType.ORDER_BY)
+        ):
             return self._parse_pipe_syntax_aggregate_group_order_by(query)
 
         return query

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1157,8 +1157,8 @@ class Parser(metaclass=_Parser):
         return this
 
     def _parse_pipe_syntax_aggregate_group_order_by(
-        self, query: exp.Select, group_by_exists: bool = True
-    ) -> exp.Select:
+        self, query: exp.Query, group_by_exists: bool = True
+    ) -> exp.Query:
         expr = self._parse_csv(self._parse_pipe_syntax_aggregate_fields)
         aggregates_or_groups, orders = [], []
         for element in expr:
@@ -1176,7 +1176,7 @@ class Parser(metaclass=_Parser):
             else:
                 aggregates_or_groups.append(element)
 
-        if group_by_exists:
+        if group_by_exists and isinstance(query, exp.Select):
             query = query.select(*aggregates_or_groups, copy=False).group_by(
                 *[element.alias_or_name for element in aggregates_or_groups], copy=False
             )
@@ -1190,7 +1190,7 @@ class Parser(metaclass=_Parser):
 
         return query
 
-    def _parse_pipe_syntax_aggregate(self, query: exp.Select) -> exp.Query:
+    def _parse_pipe_syntax_aggregate(self, query: exp.Query) -> exp.Query:
         self._match_text_seq("AGGREGATE")
         query = self._parse_pipe_syntax_aggregate_group_order_by(query, group_by_exists=False)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1173,10 +1173,7 @@ class Parser(metaclass=_Parser):
 
         if group_by_exists and isinstance(query, exp.Select):
             query = query.select(*aggregates_or_groups, copy=False).group_by(
-                *[
-                    element.args["alias"] if isinstance(element, exp.Alias) else element
-                    for element in aggregates_or_groups
-                ],
+                *[element.args.get("alias", element) for element in aggregates_or_groups],
                 copy=False,
             )
         else:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1146,7 +1146,9 @@ class Parser(metaclass=_Parser):
 
     def _parse_pipe_syntax_aggregate_fields(self) -> t.Optional[exp.Expression]:
         this = self._parse_assignment()
-        if self._match_text_seq("GROUP", advance=False):
+        if self._match(TokenType.GROUP_BY, advance=False) or self._match_text_seq(
+            "GROUP", "AND", advance=False
+        ):
             return this
 
         this = self._parse_alias(this)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1146,9 +1146,7 @@ class Parser(metaclass=_Parser):
 
     def _parse_pipe_syntax_aggregate_fields(self) -> t.Optional[exp.Expression]:
         this = self._parse_assignment()
-        if self._match(TokenType.GROUP_BY, advance=False) or self._match_text_seq(
-            "GROUP", "AND", advance=False
-        ):
+        if self._match_text_seq("GROUP", "AND", advance=False):
             return this
 
         this = self._parse_alias(this)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1144,7 +1144,7 @@ class Parser(metaclass=_Parser):
             query.offset(offset, copy=False)
         return query
 
-    def _parse_pipe_syntax_order(self) -> t.Optional[exp.Expression]:
+    def _parse_pipe_syntax_aggregate_fields(self) -> t.Optional[exp.Expression]:
         this = self._parse_assignment()
         if self._match_text_seq("GROUP", advance=False):
             return this
@@ -1159,7 +1159,7 @@ class Parser(metaclass=_Parser):
     def _parse_pipe_syntax_aggregate_group_order_by(
         self, query: exp.Select, group_by_exists: bool = True
     ) -> exp.Select:
-        expr = self._parse_csv(self._parse_pipe_syntax_order)
+        expr = self._parse_csv(self._parse_pipe_syntax_aggregate_fields)
         aggregates_or_groups, orders = [], []
         for element in expr:
             if isinstance(element, exp.Ordered):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3567,8 +3567,8 @@ FROM subquery2""",
                 f"Testing pipe syntax AGGREGATE with GROUP AND ORDER BY for order option: {order_option}"
             ):
                 self.validate_all(
-                    f"SELECT g_x1 FROM (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM (SELECT * FROM x) GROUP BY g_x1 ORDER BY g_x1 {order_option})",
+                    f"SELECT g_x1, x_s FROM (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM (SELECT * FROM x) GROUP BY g_x1 ORDER BY g_x1 {order_option})",
                     read={
-                        "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s GROUP AND ORDER BY x1 AS g_x1 {order_option} |> SELECT g_x1",
+                        "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s GROUP AND ORDER BY x1 AS g_x1 {order_option} |> SELECT g_x1, x_s",
                     },
                 )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3548,6 +3548,9 @@ FROM subquery2""",
             "FROM x |> AGGREGATE SUM(x1) as s_x1 GROUP BY x1 |> SELECT s_x1, x1 as ss_x1",
             "SELECT s_x1, x1 AS ss_x1 FROM (SELECT SUM(x1) AS s_x1, x1 FROM (SELECT * FROM x) GROUP BY x1)",
         )
+        self.validate_identity(
+            "FROM x |> AGGREGATE SUM(x1) GROUP", "SELECT SUM(x1) AS GROUP FROM (SELECT * FROM x)"
+        )
 
         for order_option in ("ASC", "DESC", "ASC NULLS LAST", "DESC NULLS FIRST"):
             with self.subTest(f"Testing pipe syntax AGGREGATE for order option: {order_option}"):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3528,3 +3528,47 @@ FROM subquery2""",
                     f"FROM x |> SELECT x1, x2 |> WHERE x1 > 0 |> WHERE x2 > 0  |> ORDER BY x1, x2 |> {option}",
                     f"SELECT x1, x2 FROM (SELECT * FROM x) WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2 {option}",
                 )
+        self.validate_identity(
+            "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3)",
+            "SELECT SUM(x1), MAX(x2), MIN(x3) FROM (SELECT * FROM x)",
+        )
+        self.validate_identity(
+            "FROM x |> AGGREGATE SUM(x1) AS s_x1 |> SELECT s_x1",
+            "SELECT s_x1 FROM (SELECT SUM(x1) AS s_x1 FROM (SELECT * FROM x))",
+        )
+        self.validate_identity(
+            "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3) GROUP BY x4, x5",
+            "SELECT SUM(x1), MAX(x2), MIN(x3), x4, x5 FROM (SELECT * FROM x) GROUP BY x4, x5",
+        )
+        self.validate_identity(
+            "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3) GROUP BY x4 AS a_x4, x5 AS a_x5",
+            "SELECT SUM(x1), MAX(x2), MIN(x3), x4 AS a_x4, x5 AS a_x5 FROM (SELECT * FROM x) GROUP BY a_x4, a_x5",
+        )
+        self.validate_identity(
+            "FROM x |> AGGREGATE SUM(x1) as s_x1 GROUP BY x1 |> SELECT s_x1, x1 as ss_x1",
+            "SELECT s_x1, x1 AS ss_x1 FROM (SELECT SUM(x1) AS s_x1, x1 FROM (SELECT * FROM x) GROUP BY x1)",
+        )
+
+        for order_option in ("ASC", "DESC", "ASC NULLS LAST", "DESC NULLS FIRST"):
+            with self.subTest(f"Testing pipe syntax AGGREGATE for order option: {order_option}"):
+                self.validate_all(
+                    f"SELECT SUM(x1) AS x_s FROM (SELECT * FROM x) ORDER BY x_s {order_option}",
+                    read={
+                        "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s {order_option}",
+                    },
+                )
+                self.validate_all(
+                    f"SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM (SELECT * FROM x) GROUP BY g_x1 ORDER BY x_s {order_option}",
+                    read={
+                        "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s {order_option} GROUP BY x1 AS g_x1",
+                    },
+                )
+            with self.subTest(
+                f"Testing pipe syntax AGGREGATE with GROUP AND ORDER BY for order option: {order_option}"
+            ):
+                self.validate_all(
+                    f"SELECT g_x1 FROM (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM (SELECT * FROM x) GROUP BY g_x1 ORDER BY g_x1 {order_option})",
+                    read={
+                        "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s GROUP AND ORDER BY x1 AS g_x1 {order_option} |> SELECT g_x1",
+                    },
+                )


### PR DESCRIPTION
Add support for the `AGGREGATE` pipe syntax.

In the case of BigQuery the `ASC` and `DESC` have been removed from the `ID_VAR_TOKENS` because they can't be used as identifiers. Moreover, in BigQuery pipe syntax when we find `ASC` or `DESC` it means that the query needs an `ORDE BY`.

**DOCS**
[BigQuery AGGREGATE Syntax](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#aggregate_pipe_operator)
[Databricks AGGREGATE Syntax](en/sql/language-manual/sql-ref-syntax-qry-select-pipeop)

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |         |
| `WHERE (replacing QUALIFY)`           |          |
| `EXTEND`           |          |
| `SET`              |          |
| `RENAME`           |          |
| `DROP`             |         |
| `AS`               |           |
| `LIMIT/OFFSET`        |    ✅       |
| `AGGREGATE WITH GROUP/ORDER BY`       |   ✅        |
| `ORDER BY` | ✅  |
| `UNION`               |           |
| `INTERSECT`               |           |
| `EXCEPT`               |           |
| `JOIN`           |           |
| `CALL`               |           |
| `TABLESAMPLE`      |           |
| `PIVOT`            |           |
| `UNPIVOT`          |           |