### PR TITLE
Feat(sqlglotrs): match the Python implementation of __repr__ for tokens

### DIFF
--- a/sqlglotrs/src/token.rs
+++ b/sqlglotrs/src/token.rs
@@ -1,7 +1,7 @@
 use crate::settings::TokenType;
 use pyo3::prelude::*;
 use pyo3::types::{PyList, PyString};
-use pyo3::{pyclass, Py, PyObject, Python};
+use pyo3::{pyclass, pymethods, Py, PyObject, Python};
 
 #[derive(Debug)]
 #[pyclass]
@@ -55,5 +55,27 @@ impl Token {
                 }
             }
         });
+    }
+}
+
+#[pymethods]
+impl Token {
+    fn __repr__(&self, py: Python) -> PyResult<String> {
+        let text = self.text.bind(py).to_str()?;
+        let comments = self.comments.bind(py);
+        let token_type_str = self.token_type_py.bind(py).str()?;
+        let comments_repr = comments.repr()?;
+        let comments_str = comments_repr.to_str()?;
+
+        Ok(format!(
+            "<Token token_type: {}, text: {}, line: {}, col: {}, start: {}, end: {}, comments: {}>",
+            token_type_str,
+            text,
+            self.line,
+            self.col,
+            self.start,
+            self.end,
+            comments_str
+        ))
     }
 }

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -201,3 +201,10 @@ x"""
         self.assertEqual(len(partial_tokens), 1)
         self.assertEqual(partial_tokens[0].token_type, TokenType.VAR)
         self.assertEqual(partial_tokens[0].text, "foo")
+
+    def test_token_repr(self):
+        # Ensures both the Python and the Rust tokenizer produce a human-friendly representation
+        self.assertEqual(
+            repr(Tokenizer().tokenize("foo")),
+            "[<Token token_type: TokenType.VAR, text: foo, line: 1, col: 3, start: 0, end: 2, comments: []>]",
+        )


### PR DESCRIPTION
Behavior in main today, using the Rust tokenizer:

```python
>>> import sqlglot
>>> sqlglot.tokenize("foo")
[<builtins.Token object at 0x105d7adf0>]
```

Behavior in this PR:

```python
>>> import sqlglot
>>> sqlglot.tokenize("foo")
[<Token token_type: TokenType.VAR, text: foo, line: 1, col: 3, start: 0, end: 2, comments: []>]
```

Behavior in both main and this PR when using the Python tokenizer:

```python
>>> import sqlglot
>>> sqlglot.tokenize("foo")
[<Token token_type: TokenType.VAR, text: foo, line: 1, col: 3, start: 0, end: 2, comments: []>]
```
