### PR TITLE
feat(postgres)!: Add support for ANY_VALUE for versions 16+

### DIFF
--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -908,6 +908,18 @@ FROM json_data, field_ids""",
             },
         )
 
+        # Postgres introduced ANY_VALUE in version 16
+        self.validate_all(
+            "SELECT ANY_VALUE(1) AS col",
+            write={
+                "postgres": "SELECT ANY_VALUE(1) AS col",
+                "postgres, version=16": "SELECT ANY_VALUE(1) AS col",
+                "postgres, version=17.5": "SELECT ANY_VALUE(1) AS col",
+                "postgres, version=15": "SELECT MAX(1) AS col",
+                "postgres, version=13.9": "SELECT MAX(1) AS col",
+            },
+        )
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(
@@ -1436,21 +1448,3 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
                         "clickhouse": "SELECT JSONExtractString(foo, '12')",
                     },
                 )
-
-    def test_any_value(self):
-        self.validate_all(
-            "SELECT ANY_VALUE(1) AS col",
-            write={
-                "postgres, version=15": "SELECT MAX(1) AS col",
-                "postgres, version=13.9": "SELECT MAX(1) AS col",
-            },
-        )
-
-        self.validate_all(
-            "SELECT ANY_VALUE(1) AS col",
-            write={
-                "postgres": "SELECT ANY_VALUE(1) AS col",
-                "postgres, version=16": "SELECT ANY_VALUE(1) AS col",
-                "postgres, version=17.5": "SELECT ANY_VALUE(1) AS col",
-            },
-        )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1436,3 +1436,21 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
                         "clickhouse": "SELECT JSONExtractString(foo, '12')",
                     },
                 )
+
+    def test_any_value(self):
+        self.validate_all(
+            "SELECT ANY_VALUE(1) AS col",
+            write={
+                "postgres, version=15": "SELECT MAX(1) AS col",
+                "postgres, version=13.9": "SELECT MAX(1) AS col",
+            },
+        )
+
+        self.validate_all(
+            "SELECT ANY_VALUE(1) AS col",
+            write={
+                "postgres": "SELECT ANY_VALUE(1) AS col",
+                "postgres, version=16": "SELECT ANY_VALUE(1) AS col",
+                "postgres, version=17.5": "SELECT ANY_VALUE(1) AS col",
+            },
+        )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -778,7 +778,7 @@ class TestPresto(Validator):
                 "hive": "FIRST(x)",
                 "mysql": "ANY_VALUE(x)",
                 "oracle": "ANY_VALUE(x)",
-                "postgres": "MAX(x)",
+                "postgres": "ANY_VALUE(x)",
                 "presto": "ARBITRARY(x)",
                 "redshift": "ANY_VALUE(x)",
                 "snowflake": "ANY_VALUE(x)",


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/4674

Postgres 16 (released 24 Sep 2023) added support for `ANY_VALUE`. As this may be too recent for some Postgres workloads, I thought it'd make for another use case of `Version`, but if we want to simplify we can instead always preserve the roundtrip.


Docs
---------
[PSQL ANY_VALUE](https://www.postgresql.org/docs/16/functions-aggregate.html) | [PSQL Feature Matrix](https://www.postgresql.org/about/featurematrix/)