### PR TITLE
Feat: make to_table more lenient

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -31,6 +31,7 @@ from sqlglot.helper import (
     ensure_collection,
     ensure_list,
     seq_get,
+    split_num_words,
     subclasses,
     to_bool,
 )
@@ -7962,7 +7963,15 @@ def to_table(
     if isinstance(sql_path, Table):
         return maybe_copy(sql_path, copy=copy)
 
-    table = maybe_parse(sql_path, into=Table, dialect=dialect)
+    try:
+        table = maybe_parse(sql_path, into=Table, dialect=dialect)
+    except ParseError:
+        catalog, db, this = split_num_words(sql_path, ".", 3)
+
+        if not this:
+            raise
+
+        table = table_(this, db=db, catalog=catalog)
 
     for k, v in kwargs.items():
         table.set(k, v)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -990,14 +990,19 @@ FROM foo""",
         self.assertEqual(table_only.name, "table_name")
         self.assertIsNone(table_only.args.get("db"))
         self.assertIsNone(table_only.args.get("catalog"))
+
         db_and_table = exp.to_table("db.table_name")
         self.assertEqual(db_and_table.name, "table_name")
         self.assertEqual(db_and_table.args.get("db"), exp.to_identifier("db"))
         self.assertIsNone(db_and_table.args.get("catalog"))
+
         catalog_db_and_table = exp.to_table("catalog.db.table_name")
         self.assertEqual(catalog_db_and_table.name, "table_name")
         self.assertEqual(catalog_db_and_table.args.get("db"), exp.to_identifier("db"))
         self.assertEqual(catalog_db_and_table.args.get("catalog"), exp.to_identifier("catalog"))
+
+        table_only_unsafe_identifier = exp.to_table("3e")
+        self.assertEqual(table_only_unsafe_identifier.sql(), '"3e"')
 
     def test_to_column(self):
         column_only = exp.to_column("column_name")


### PR DESCRIPTION
This PR allows `exp.to_table` to construct `Table` instances even if the identifiers in the SQL path are unsafe, i.e., they are unquoted when they should be.

https://github.com/TobikoData/sqlmesh/issues/4426