### PR TITLE
feat(parser): SET OPERATORS with pipe syntax

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7366,7 +7366,7 @@ def _apply_set_operation(
     **opts,
 ) -> S:
     return reduce(
-        lambda x, y: set_operation(this=x, expression=y, distinct=distinct),
+        lambda x, y: set_operation(this=x, expression=y, distinct=distinct, **opts),
         (maybe_parse(e, dialect=dialect, copy=copy, **opts) for e in expressions),
     )
 


### PR DESCRIPTION
Add support for the SET OPERATORS = `{UNION, INTERSECT, EXCEPT}` pipe syntax.

**DOCS**
[BigQuery pipe syntax UNION](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#union_pipe_operator)
[BigQuery pipe syntax INTERSECT](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#intersect_pipe_operator)
[BigQuery pipe syntax EXCEPT](https://cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#except_pipe_operator)

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |         |
| `WHERE (replacing QUALIFY)`           |          |
| `EXTEND`           |          |
| `SET`              |          |
| `RENAME`           |          |
| `DROP`             |         |
| `AS`               |           |
| `LIMIT/OFFSET`        |    ✅       |
| `AGGREGATE WITH GROUP/ORDER BY`       |   ✅        |
| `ORDER BY` | ✅  |
| `UNION`               |      ✅      |
| `INTERSECT`               |   ✅         |
| `EXCEPT`               |       ✅     |
| `JOIN`           |           |
| `CALL`               |           |
| `TABLESAMPLE`      |           |
| `PIVOT`            |           |
| `UNPIVOT`          |           |