### PR TITLE
feat(sqlite): implement RESPECT/IGNORE NULLS in first_value()

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -307,3 +307,12 @@ class SQLite(Dialect):
         @unsupported_args("this")
         def currentschema_sql(self, expression: exp.CurrentSchema) -> str:
             return "'main'"
+
+        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
+            self.unsupported(
+                "SQLite does not support IGNORE NULLS in window functions."
+            )
+
+        def respectnulls_sql(self, expression: exp.RespectNulls) -> str:
+            # simply compile the inner expression
+            return self.sql(expression.this)

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -1,3 +1,4 @@
+from sqlglot.errors import UnsupportedError
 from tests.dialects.test_dialect import Validator
 
 from sqlglot.helper import logger as helper_logger
@@ -173,6 +174,25 @@ class TestSQLite(Validator):
             "CREATE TABLE foo (bar LONGVARCHAR)",
             write={"sqlite": "CREATE TABLE foo (bar TEXT)"},
         )
+
+    def test_respectnulls(self):
+        self.validate_all(
+            "SELECT FIRST_VALUE(val) OVER (PARTITION BY gb ORDER BY ob)",
+            read={
+                "duckdb": "SELECT FIRST_VALUE(val RESPECT NULLS) OVER (PARTITION BY gb ORDER BY ob IGNORE NULLS)",
+            },
+            write={
+                "duckdb": "SELECT FIRST_VALUE(val RESPECT NULLS) OVER (PARTITION BY gb ORDER BY ob IGNORE NULLS)",
+            },
+        )
+    def test_ignorenulls(self):
+        with self.assertRaises(UnsupportedError):
+            self.validate_all(
+                "SELECT FIRST_VALUE(val) OVER (PARTITION BY gb ORDER BY ob IGNORE NULLS)",
+                read={
+                    "sqlite": "SELECT FIRST_VALUE(va IGNORE NULLS) OVER (PARTITION BY gb ORDER BY ob)",
+                },
+            )
 
     def test_warnings(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
If handed the duckdb/postgres/etc SQL of `SELECT FIRST_VALUE(val RESPECT NULLS) OVER ....` then we should just strip out the `RESPECT NULLS` part. If handed `IGNORE NULLS`, we should error, because sqlite doesn't support this, it always considers nulls.

This isn't a working PR I'm sure. Consider it more of a bug that I'm filing, and giving a slight head start in fixing it. I'll be curious to see what changes need to happen to actualy make this work.