### PR TITLE
array_agg_transpilation_fix

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -133,6 +133,7 @@ class StarRocks(MySQL):
             **MySQL.Generator.TRANSFORMS,
             exp.Array: inline_array_sql,
             exp.ArrayToString: rename_func("ARRAY_JOIN"),
+            exp.ArrayAgg: rename_func("ARRAY_AGG"),
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.DateDiff: lambda self, e: self.func(
                 "DATE_DIFF", unit_to_str(e), e.this, e.expression

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -9,6 +9,7 @@ class TestStarrocks(Validator):
         self.validate_identity("SELECT ARRAY_JOIN([1, 3, 5, NULL], '_', 'NULL')")
         self.validate_identity("SELECT ARRAY_JOIN([1, 3, 5, NULL], '_')")
         self.validate_identity("ALTER TABLE a SWAP WITH b")
+        self.validate_identity("SELECT ARRAY_AGG(a) FROM x")
 
     def test_ddl(self):
         ddl_sqls = [


### PR DESCRIPTION
This is regarding the issue https://github.com/tobymao/sqlglot/issues/5122 .

As suggested, multiple PRs were to be created. Accordingly, this PR has been raised.

read="snowflake",
write="starrocks",
Array_agg is getting transpiled as group_concat in starrocks which is not ideal transpilation


# Issue re-production step:
```
!pip install sqlglot
import sqlglot

original_sql = """
select array_agg(x) as array_agg 
from my_sample_table;
"""

transpiled_sql = sqlglot.transpile(
    original_sql,
    read="snowflake",
    write='starrocks',
    pretty=True
)[0]

print("Transpiled as", transpiled_sql)
```

### Output from Sqlglot:
```
Transpiled as SELECT
  GROUP_CONCAT(x) AS array_agg
FROM my_sample_table
```
### Expected Output:

```
Transpiled as SELECT
  ARRAY_AGG(x) AS array_agg
FROM my_sample_table
```

### Supporting Documentation:

https://docs.snowflake.com/en/sql-reference/functions/array_agg
https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/array_agg/
