### PR TITLE
fix(sqlite): Add REPLACE to command tokens

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -99,6 +99,8 @@ class SQLite(Dialect):
         KEYWORDS = tokens.Tokenizer.KEYWORDS.copy()
         KEYWORDS.pop("/*+")
 
+        COMMANDS = {*tokens.Tokenizer.COMMANDS, TokenType.REPLACE}
+
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -113,6 +113,7 @@ class TestSQLite(Validator):
             'CREATE TABLE "foo t" ("foo t id" TEXT NOT NULL, PRIMARY KEY ("foo t id"))',
             'CREATE TABLE "foo t" ("foo t id" TEXT NOT NULL PRIMARY KEY)',
         )
+        self.validate_identity("REPLACE INTO foo (x, y) VALUES (1, 2)", check_command_warning=True)
 
     def test_strftime(self):
         self.validate_identity("SELECT STRFTIME('%Y/%m/%d', 'now')")


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5187

From a quick pass I did not find a dialect other than MySQL and SQLite that supports the `REPLACE` statement.

We already had MySQL command support [here](https://github.com/tobymao/sqlglot/pull/3425/files).


Docs
-----------
[SQLite REPLACE](https://www.sqlite.org/lang_replace.html) | [REPLACE examples](https://www.sqlitetutorial.net/sqlite-replace-statement/)