### PR TITLE
fix(parser)!: CTEs instead of subqueries for pipe syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel, ParseError, concat_messages, merge_errors
-from sqlglot.helper import apply_index_offset, ensure_list, seq_get, find_new_name
+from sqlglot.helper import apply_index_offset, ensure_list, seq_get
 from sqlglot.time import format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
 from sqlglot.trie import TrieResult, in_trie, new_trie
@@ -8310,7 +8310,7 @@ class Parser(metaclass=_Parser):
     def _build_pipe_cte(self, query: exp.Query, expressions: t.List[exp.Expression]) -> exp.Query:
         if query.selects:
             self._pipe_cte_counter += 1
-            new_cte = find_new_name(base=f"_pipe_cte_{self._pipe_cte_counter}", taken=[])
+            new_cte = f"_pipe_cte_{self._pipe_cte_counter}"
             ctes = (
                 query.args.pop("with", None)
                 if isinstance(query, exp.Select)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1127,127 +1127,6 @@ class Parser(metaclass=_Parser):
         "TRUNCATE": lambda self: self._parse_partitioned_by_bucket_or_truncate(),
     }
 
-    def _new_cte_name(self):
-        self._pipe_cte_counter += 1
-        return find_new_name(base=f"_pipe_cte_{self._pipe_cte_counter}", taken=[])
-
-    def _build_pipe_cte(self, query: exp.Query, expressions: t.List[exp.Expression]) -> exp.Query:
-        if query.selects:
-            new_cte = self._new_cte_name()
-            ctes = (
-                query.args.pop("with", None)
-                if isinstance(query, exp.Select)
-                else query.this.args.pop("with", None)
-            )
-            new_select = exp.select(*expressions, copy=False).from_(new_cte, copy=False)
-            if ctes:
-                new_select.set("with", ctes)
-
-            return new_select.with_(new_cte, as_=query, copy=False)
-
-        return query.select(*expressions, copy=False)
-
-    def _parse_pipe_syntax_select(self, query: exp.Query) -> exp.Query:
-        select = self._parse_select()
-        if isinstance(select, exp.Select):
-            return self._build_pipe_cte(query, select.expressions)
-
-        return query
-
-    def _parse_pipe_syntax_where(self, query: exp.Query) -> exp.Query:
-        where = self._parse_where()
-        return query.where(where, copy=False)
-
-    def _parse_pipe_syntax_limit(self, query: exp.Query) -> exp.Query:
-        limit = self._parse_limit()
-        offset = self._parse_offset()
-        if limit:
-            curr_limit = query.args.get("limit", limit)
-            if curr_limit.expression.to_py() >= limit.expression.to_py():
-                query.limit(limit, copy=False)
-        if offset:
-            curr_offset = query.args.get("offset")
-            curr_offset = curr_offset.expression.to_py() if curr_offset else 0
-            query.offset(exp.Literal.number(curr_offset + offset.expression.to_py()), copy=False)
-        return query
-
-    def _parse_pipe_syntax_aggregate_fields(self) -> t.Optional[exp.Expression]:
-        this = self._parse_assignment()
-        if self._match_text_seq("GROUP", "AND", advance=False):
-            return this
-
-        this = self._parse_alias(this)
-
-        if self._match_set((TokenType.ASC, TokenType.DESC), advance=False):
-            return self._parse_ordered(lambda: this)
-
-        return this
-
-    def _parse_pipe_syntax_aggregate_group_order_by(
-        self, query: exp.Query, group_by_exists: bool = True
-    ) -> exp.Query:
-        expr = self._parse_csv(self._parse_pipe_syntax_aggregate_fields)
-        aggregates_or_groups, orders = [], []
-        for element in expr:
-            if isinstance(element, exp.Ordered):
-                this = element.this
-                if isinstance(this, exp.Alias):
-                    element.set("this", this.args["alias"])
-                orders.append(element)
-            else:
-                this = element
-            aggregates_or_groups.append(this)
-
-        if group_by_exists and isinstance(query, exp.Select):
-            query = query.select(*aggregates_or_groups, copy=False).group_by(
-                *[element.args.get("alias", element) for element in aggregates_or_groups],
-                copy=False,
-            )
-        else:
-            query = query.select(*aggregates_or_groups, append=False, copy=False)
-
-        if orders:
-            return query.order_by(*orders, append=False, copy=False)
-
-        return query
-
-    def _parse_pipe_syntax_aggregate(self, query: exp.Query) -> exp.Query:
-        self._match_text_seq("AGGREGATE")
-        query = self._parse_pipe_syntax_aggregate_group_order_by(query, group_by_exists=False)
-
-        if self._match(TokenType.GROUP_BY) or (
-            self._match_text_seq("GROUP", "AND") and self._match(TokenType.ORDER_BY)
-        ):
-            return self._parse_pipe_syntax_aggregate_group_order_by(query)
-
-        return query
-
-    def _parse_pipe_syntax_set_operator(
-        self, query: t.Optional[exp.Query]
-    ) -> t.Optional[exp.Query]:
-        first_setop = self.parse_set_operation(this=query)
-
-        if not first_setop or not query:
-            return None
-
-        if not query.selects:
-            query = query.select("*", copy=False)
-
-        this = first_setop.this.pop()
-        distinct = first_setop.args.pop("distinct")
-        setops = [first_setop.expression.pop(), *self._parse_expressions()]
-
-        if isinstance(first_setop, exp.Union):
-            query = query.union(*setops, distinct=distinct, copy=False, **first_setop.args)
-        elif isinstance(first_setop, exp.Except):
-            query = query.except_(*setops, distinct=distinct, copy=False, **first_setop.args)
-        else:
-            query = query.intersect(*setops, distinct=distinct, copy=False, **first_setop.args)
-
-        return self._build_pipe_cte(
-            query, [element.args.get("alias", element) for element in this.expressions]
-        )
-
     def _parse_partitioned_by_bucket_or_truncate(self) -> exp.Expression:
         klass = (
             exp.PartitionedByBucket
@@ -7272,26 +7151,6 @@ class Parser(metaclass=_Parser):
 
         return this
 
-    def _parse_pipe_syntax_query(self, query: exp.Query) -> t.Optional[exp.Query]:
-        while self._match(TokenType.PIPE_GT):
-            start = self._curr
-            parser = self.PIPE_SYNTAX_TRANSFORM_PARSERS.get(self._curr.text.upper())
-            if not parser:
-                set_op_query = self._parse_pipe_syntax_set_operator(query)
-                if not set_op_query:
-                    self._retreat(start)
-                    self.raise_error(f"Unsupported pipe syntax operator: '{start.text.upper()}'.")
-                    break
-
-                query = set_op_query
-            else:
-                query = parser(self, query)
-
-        if query and not query.selects:
-            return query.select("*", copy=False)
-
-        return query
-
     def _parse_wrapped_id_vars(self, optional: bool = False) -> t.List[exp.Expression]:
         return self._parse_wrapped_csv(self._parse_id_var, optional=optional)
 
@@ -8447,3 +8306,141 @@ class Parser(metaclass=_Parser):
         expression = self.expression(exp.Identifier, this=token.text, **kwargs)
         expression.update_positions(token)
         return expression
+
+    def _build_pipe_cte(self, query: exp.Query, expressions: t.List[exp.Expression]) -> exp.Query:
+        if query.selects:
+            self._pipe_cte_counter += 1
+            new_cte = find_new_name(base=f"_pipe_cte_{self._pipe_cte_counter}", taken=[])
+            ctes = (
+                query.args.pop("with", None)
+                if isinstance(query, exp.Select)
+                else query.this.args.pop("with", None)
+            )
+            new_select = exp.select(*expressions, copy=False).from_(new_cte, copy=False)
+            if ctes:
+                new_select.set("with", ctes)
+
+            return new_select.with_(new_cte, as_=query, copy=False)
+
+        return query.select(*expressions, copy=False)
+
+    def _parse_pipe_syntax_select(self, query: exp.Query) -> exp.Query:
+        select = self._parse_select()
+        if isinstance(select, exp.Select):
+            return self._build_pipe_cte(query, select.expressions)
+
+        return query
+
+    def _parse_pipe_syntax_where(self, query: exp.Query) -> exp.Query:
+        where = self._parse_where()
+        return query.where(where, copy=False)
+
+    def _parse_pipe_syntax_limit(self, query: exp.Query) -> exp.Query:
+        limit = self._parse_limit()
+        offset = self._parse_offset()
+        if limit:
+            curr_limit = query.args.get("limit", limit)
+            if curr_limit.expression.to_py() >= limit.expression.to_py():
+                query.limit(limit, copy=False)
+        if offset:
+            curr_offset = query.args.get("offset")
+            curr_offset = curr_offset.expression.to_py() if curr_offset else 0
+            query.offset(exp.Literal.number(curr_offset + offset.expression.to_py()), copy=False)
+        return query
+
+    def _parse_pipe_syntax_aggregate_fields(self) -> t.Optional[exp.Expression]:
+        this = self._parse_assignment()
+        if self._match_text_seq("GROUP", "AND", advance=False):
+            return this
+
+        this = self._parse_alias(this)
+
+        if self._match_set((TokenType.ASC, TokenType.DESC), advance=False):
+            return self._parse_ordered(lambda: this)
+
+        return this
+
+    def _parse_pipe_syntax_aggregate_group_order_by(
+        self, query: exp.Query, group_by_exists: bool = True
+    ) -> exp.Query:
+        expr = self._parse_csv(self._parse_pipe_syntax_aggregate_fields)
+        aggregates_or_groups, orders = [], []
+        for element in expr:
+            if isinstance(element, exp.Ordered):
+                this = element.this
+                if isinstance(this, exp.Alias):
+                    element.set("this", this.args["alias"])
+                orders.append(element)
+            else:
+                this = element
+            aggregates_or_groups.append(this)
+
+        if group_by_exists and isinstance(query, exp.Select):
+            query = query.select(*aggregates_or_groups, copy=False).group_by(
+                *[projection.args.get("alias", projection) for projection in aggregates_or_groups],
+                copy=False,
+            )
+        else:
+            query = query.select(*aggregates_or_groups, append=False, copy=False)
+
+        if orders:
+            return query.order_by(*orders, append=False, copy=False)
+
+        return query
+
+    def _parse_pipe_syntax_aggregate(self, query: exp.Query) -> exp.Query:
+        self._match_text_seq("AGGREGATE")
+        query = self._parse_pipe_syntax_aggregate_group_order_by(query, group_by_exists=False)
+
+        if self._match(TokenType.GROUP_BY) or (
+            self._match_text_seq("GROUP", "AND") and self._match(TokenType.ORDER_BY)
+        ):
+            return self._parse_pipe_syntax_aggregate_group_order_by(query)
+
+        return query
+
+    def _parse_pipe_syntax_set_operator(
+        self, query: t.Optional[exp.Query]
+    ) -> t.Optional[exp.Query]:
+        first_setop = self.parse_set_operation(this=query)
+
+        if not first_setop or not query:
+            return None
+
+        if not query.selects:
+            query.select("*", copy=False)
+
+        this = first_setop.this.pop()
+        distinct = first_setop.args.pop("distinct")
+        setops = [first_setop.expression.pop(), *self._parse_expressions()]
+
+        if isinstance(first_setop, exp.Union):
+            query = query.union(*setops, distinct=distinct, copy=False, **first_setop.args)
+        elif isinstance(first_setop, exp.Except):
+            query = query.except_(*setops, distinct=distinct, copy=False, **first_setop.args)
+        else:
+            query = query.intersect(*setops, distinct=distinct, copy=False, **first_setop.args)
+
+        return self._build_pipe_cte(
+            query, [projection.args.get("alias", projection) for projection in this.expressions]
+        )
+
+    def _parse_pipe_syntax_query(self, query: exp.Query) -> t.Optional[exp.Query]:
+        while self._match(TokenType.PIPE_GT):
+            start = self._curr
+            parser = self.PIPE_SYNTAX_TRANSFORM_PARSERS.get(self._curr.text.upper())
+            if not parser:
+                set_op_query = self._parse_pipe_syntax_set_operator(query)
+                if not set_op_query:
+                    self._retreat(start)
+                    self.raise_error(f"Unsupported pipe syntax operator: '{start.text.upper()}'.")
+                    break
+
+                query = set_op_query
+            else:
+                query = parser(self, query)
+
+        if query and not query.selects:
+            return query.select("*", copy=False)
+
+        return query

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3518,7 +3518,7 @@ FROM subquery2""",
         )
         self.validate_identity(
             "FROM x |> SELECT x1 + 1 as x1_a, x2 - 1 as x2_a |> WHERE x1_a > 1 |> SELECT x2_a",
-            "WITH _pipe_cte_1 AS (SELECT x1 + 1 AS x1_a, x2 - 1 AS x2_a FROM x WHERE x1_a > 1) SELECT x2_a FROM _pipe_cte_1",
+            "WITH __tmp1 AS (SELECT x1 + 1 AS x1_a, x2 - 1 AS x2_a FROM x WHERE x1_a > 1) SELECT x2_a FROM __tmp1",
         )
         self.validate_identity(
             "FROM x |> WHERE x1 > 0 OR x2 > 0 |> WHERE x3 > 1 AND x4 > 1 |> SELECT x1, x4",
@@ -3530,7 +3530,7 @@ FROM subquery2""",
         )
         self.validate_identity(
             "FROM x |> WHERE x1 > 1 AND x2 > 2 |> SELECT x1 as gt1, x2 as gt2 |> SELECT gt1 * 2 + gt2 * 2 AS gt2_2",
-            "WITH _pipe_cte_1 AS (SELECT x1 AS gt1, x2 AS gt2 FROM x WHERE x1 > 1 AND x2 > 2) SELECT gt1 * 2 + gt2 * 2 AS gt2_2 FROM _pipe_cte_1",
+            "WITH __tmp1 AS (SELECT x1 AS gt1, x2 AS gt2 FROM x WHERE x1 > 1 AND x2 > 2) SELECT gt1 * 2 + gt2 * 2 AS gt2_2 FROM __tmp1",
         )
         self.validate_identity("FROM x |> ORDER BY x1", "SELECT * FROM x ORDER BY x1")
         self.validate_identity(
@@ -3577,7 +3577,7 @@ FROM subquery2""",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1) AS s_x1 |> SELECT s_x1",
-            "WITH _pipe_cte_1 AS (SELECT SUM(x1) AS s_x1 FROM x) SELECT s_x1 FROM _pipe_cte_1",
+            "WITH __tmp1 AS (SELECT SUM(x1) AS s_x1 FROM x) SELECT s_x1 FROM __tmp1",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3) GROUP BY x4, x5",
@@ -3589,7 +3589,7 @@ FROM subquery2""",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1) as s_x1 GROUP BY x1 |> SELECT s_x1, x1 as ss_x1",
-            "WITH _pipe_cte_1 AS (SELECT SUM(x1) AS s_x1, x1 FROM x GROUP BY x1) SELECT s_x1, x1 AS ss_x1 FROM _pipe_cte_1",
+            "WITH __tmp1 AS (SELECT SUM(x1) AS s_x1, x1 FROM x GROUP BY x1) SELECT s_x1, x1 AS ss_x1 FROM __tmp1",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1) GROUP", "SELECT SUM(x1) AS GROUP FROM x"
@@ -3612,7 +3612,7 @@ FROM subquery2""",
                 f"Testing pipe syntax AGGREGATE with GROUP AND ORDER BY for order option: {order_option}"
             ):
                 self.validate_all(
-                    f"WITH _pipe_cte_1 AS (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM x GROUP BY g_x1 ORDER BY g_x1 {order_option}) SELECT g_x1, x_s FROM _pipe_cte_1",
+                    f"WITH __tmp1 AS (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM x GROUP BY g_x1 ORDER BY g_x1 {order_option}) SELECT g_x1, x_s FROM __tmp1",
                     read={
                         "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s GROUP AND ORDER BY x1 AS g_x1 {order_option} |> SELECT g_x1, x_s",
                     },
@@ -3628,7 +3628,7 @@ FROM subquery2""",
                     self.validate_all(
                         f"FROM x|> {op_operator} (SELECT y1 FROM y), (SELECT z1 FROM z)",
                         write={
-                            "bigquery": f"WITH _pipe_cte_1 AS (SELECT * FROM x {op_operator} (SELECT y1 FROM y) {op_operator} (SELECT z1 FROM z)) SELECT * FROM _pipe_cte_1",
+                            "bigquery": f"WITH __tmp1 AS (SELECT * FROM x {op_operator} (SELECT y1 FROM y) {op_operator} (SELECT z1 FROM z)) SELECT * FROM __tmp1",
                         },
                     )
 
@@ -3646,13 +3646,13 @@ FROM subquery2""",
                             self.validate_all(
                                 f"FROM x|> SELECT x1, x2 FROM x |> {op_prefix} {op_operator} {suffix_operator} (SELECT y1, y2 FROM y), (SELECT z1, z2 FROM z)",
                                 write={
-                                    "bigquery": f"WITH _pipe_cte_1 AS (SELECT x1, x2 FROM x {op_prefix} {op_operator} BY NAME (SELECT y1, y2 FROM y) {op_prefix} {op_operator} BY NAME (SELECT z1, z2 FROM z)) SELECT x1, x2 FROM _pipe_cte_1",
+                                    "bigquery": f"WITH __tmp1 AS (SELECT x1, x2 FROM x {op_prefix} {op_operator} BY NAME (SELECT y1, y2 FROM y) {op_prefix} {op_operator} BY NAME (SELECT z1, z2 FROM z)) SELECT x1, x2 FROM __tmp1",
                                 },
                             )
 
             self.validate_identity(
                 "FROM d.x |> SELECT x.x1 |> UNION (SELECT 2 AS a1) |> SELECT x1 |> UNION (SELECT 3 as a2) |> SELECT x1 |> WHERE x1 > 100",
-                """WITH _pipe_cte_1 AS (
+                """WITH __tmp1 AS (
   SELECT
     x.x1
   FROM d.x
@@ -3661,27 +3661,27 @@ FROM subquery2""",
     SELECT
       2 AS a1
   )
-), _pipe_cte_2 AS (
+), __tmp2 AS (
   SELECT
     x.x1
-  FROM _pipe_cte_1
-), _pipe_cte_3 AS (
+  FROM __tmp1
+), __tmp3 AS (
   SELECT
     x1
-  FROM _pipe_cte_2
+  FROM __tmp2
   UNION
   (
     SELECT
       3 AS a2
   )
-), _pipe_cte_4 AS (
+), __tmp4 AS (
   SELECT
     x1
-  FROM _pipe_cte_3
+  FROM __tmp3
 )
 SELECT
   x1
-FROM _pipe_cte_4
+FROM __tmp4
 WHERE
   x1 > 100""",
                 pretty=True,
@@ -3689,7 +3689,7 @@ WHERE
 
         self.validate_identity(
             "FROM c.x |> UNION ALL (SELECT 2 AS a1, '2' as a2) |> AGGREGATE AVG(x1) as m_x1 |> SELECT * |> UNION ALL (SELECT y1 FROM c.y) |> SELECT m_x1",
-            """WITH _pipe_cte_1 AS (
+            """WITH __tmp1 AS (
   SELECT
     *
   FROM c.x
@@ -3699,27 +3699,27 @@ WHERE
       2 AS a1,
       '2' AS a2
   )
-), _pipe_cte_2 AS (
+), __tmp2 AS (
   SELECT
     AVG(x1) AS m_x1
-  FROM _pipe_cte_1
-), _pipe_cte_3 AS (
+  FROM __tmp1
+), __tmp3 AS (
   SELECT
     *
-  FROM _pipe_cte_2
+  FROM __tmp2
   UNION ALL
   (
     SELECT
       y1
     FROM c.y
   )
-), _pipe_cte_4 AS (
+), __tmp4 AS (
   SELECT
     *
-  FROM _pipe_cte_3
+  FROM __tmp3
 )
 SELECT
   m_x1
-FROM _pipe_cte_4""",
+FROM __tmp4""",
             pretty=True,
         )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3507,50 +3507,50 @@ FROM subquery2""",
 
     def test_pipe_syntax(self):
         self.validate_identity("FROM x", "SELECT * FROM x")
-        self.validate_identity("FROM x |> SELECT x1, x2", "SELECT x1, x2 FROM (SELECT * FROM x)")
+        self.validate_identity("FROM x |> SELECT x1, x2", "SELECT x1, x2 FROM x")
         self.validate_identity(
             "FROM x |> SELECT x1 as c1, x2 as c2",
-            "SELECT x1 AS c1, x2 AS c2 FROM (SELECT * FROM x)",
+            "SELECT x1 AS c1, x2 AS c2 FROM x",
         )
         self.validate_identity(
             "FROM x |> SELECT x1 + 1 as x1_a, x2 - 1 as x2_a |> WHERE x1_a > 1",
-            "SELECT x1 + 1 AS x1_a, x2 - 1 AS x2_a FROM (SELECT * FROM x) WHERE x1_a > 1",
+            "SELECT x1 + 1 AS x1_a, x2 - 1 AS x2_a FROM x WHERE x1_a > 1",
         )
         self.validate_identity(
             "FROM x |> SELECT x1 + 1 as x1_a, x2 - 1 as x2_a |> WHERE x1_a > 1 |> SELECT x2_a",
-            "SELECT x2_a FROM (SELECT x1 + 1 AS x1_a, x2 - 1 AS x2_a FROM (SELECT * FROM x) WHERE x1_a > 1)",
+            "WITH _pipe_cte_1 AS (SELECT x1 + 1 AS x1_a, x2 - 1 AS x2_a FROM x WHERE x1_a > 1) SELECT x2_a FROM _pipe_cte_1",
         )
         self.validate_identity(
             "FROM x |> WHERE x1 > 0 OR x2 > 0 |> WHERE x3 > 1 AND x4 > 1 |> SELECT x1, x4",
-            "SELECT x1, x4 FROM (SELECT * FROM x WHERE (x1 > 0 OR x2 > 0) AND (x3 > 1 AND x4 > 1))",
+            "SELECT x1, x4 FROM x WHERE (x1 > 0 OR x2 > 0) AND (x3 > 1 AND x4 > 1)",
         )
         self.validate_identity(
             "FROM x |> WHERE x1 > 1 |> WHERE x2 > 2 |> SELECT x1 as gt1, x2 as gt2",
-            "SELECT x1 AS gt1, x2 AS gt2 FROM (SELECT * FROM x WHERE x1 > 1 AND x2 > 2)",
+            "SELECT x1 AS gt1, x2 AS gt2 FROM x WHERE x1 > 1 AND x2 > 2",
         )
         self.validate_identity(
             "FROM x |> WHERE x1 > 1 AND x2 > 2 |> SELECT x1 as gt1, x2 as gt2 |> SELECT gt1 * 2 + gt2 * 2 AS gt2_2",
-            "SELECT gt1 * 2 + gt2 * 2 AS gt2_2 FROM (SELECT x1 AS gt1, x2 AS gt2 FROM (SELECT * FROM x WHERE x1 > 1 AND x2 > 2))",
+            "WITH _pipe_cte_1 AS (SELECT x1 AS gt1, x2 AS gt2 FROM x WHERE x1 > 1 AND x2 > 2) SELECT gt1 * 2 + gt2 * 2 AS gt2_2 FROM _pipe_cte_1",
         )
         self.validate_identity("FROM x |> ORDER BY x1", "SELECT * FROM x ORDER BY x1")
         self.validate_identity(
-            "FROM x |> ORDER BY x1 |> ORDER BY x2", "SELECT * FROM x ORDER BY x1, x2"
+            "FROM x |> ORDER BY x1 |> ORDER BY x2", "SELECT * FROM x ORDER BY x2"
         )
         self.validate_identity(
             "FROM x |> ORDER BY x1 |> WHERE x1 > 0 OR x1 != 1 |> ORDER BY x2 |> WHERE x2 > 0 AND x2 != 1 |> SELECT x1, x2",
-            "SELECT x1, x2 FROM (SELECT * FROM x WHERE (x1 > 0 OR x1 <> 1) AND (x2 > 0 AND x2 <> 1) ORDER BY x1, x2)",
+            "SELECT x1, x2 FROM x WHERE (x1 > 0 OR x1 <> 1) AND (x2 > 0 AND x2 <> 1) ORDER BY x2",
         )
         self.validate_identity(
             "FROM x |> ORDER BY x1 |> WHERE x1 > 0 |> SELECT x1",
-            "SELECT x1 FROM (SELECT * FROM x WHERE x1 > 0 ORDER BY x1)",
+            "SELECT x1 FROM x WHERE x1 > 0 ORDER BY x1",
         )
         self.validate_identity(
             "FROM x |> WHERE x1 > 0 |> SELECT x1 |> ORDER BY x1",
-            "SELECT x1 FROM (SELECT * FROM x WHERE x1 > 0) ORDER BY x1",
+            "SELECT x1 FROM x WHERE x1 > 0 ORDER BY x1",
         )
         self.validate_identity(
             "FROM x |> SELECT x1, x2, x3 |> ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
-            "SELECT x1, x2, x3 FROM (SELECT * FROM x) ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
+            "SELECT x1, x2, x3 FROM x ORDER BY x1 DESC NULLS FIRST, x2 ASC NULLS LAST, x3",
         )
         for option in ("LIMIT 1", "OFFSET 2", "LIMIT 1 OFFSET 2"):
             with self.subTest(f"Testing pipe syntax LIMIT and OFFSET option: {option}"):
@@ -3558,45 +3558,52 @@ FROM subquery2""",
                 self.validate_identity(f"FROM x |> {option}", f"SELECT * FROM x {option}")
                 self.validate_identity(
                     f"FROM x |> {option} |> SELECT x1, x2 |> WHERE x1 > 0 |> WHERE x2 > 0  |> ORDER BY x1, x2 ",
-                    f"SELECT x1, x2 FROM (SELECT * FROM x {option}) WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2",
+                    f"SELECT x1, x2 FROM x WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2 {option}",
                 )
                 self.validate_identity(
                     f"FROM x |> SELECT x1, x2 |> WHERE x1 > 0 |> WHERE x2 > 0  |> ORDER BY x1, x2 |> {option}",
-                    f"SELECT x1, x2 FROM (SELECT * FROM x) WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2 {option}",
+                    f"SELECT x1, x2 FROM x WHERE x1 > 0 AND x2 > 0 ORDER BY x1, x2 {option}",
                 )
         self.validate_identity(
+            "FROM x |> SELECT x1, x2 |> LIMIT 2 |> LIMIT 4", "SELECT x1, x2 FROM x LIMIT 2"
+        )
+        self.validate_identity(
+            "FROM x |> SELECT x1, x2 |> LIMIT 2 OFFSET 2 |> LIMIT 4 OFFSET 2",
+            "SELECT x1, x2 FROM x LIMIT 2 OFFSET 4",
+        )
+        self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3)",
-            "SELECT SUM(x1), MAX(x2), MIN(x3) FROM (SELECT * FROM x)",
+            "SELECT SUM(x1), MAX(x2), MIN(x3) FROM x",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1) AS s_x1 |> SELECT s_x1",
-            "SELECT s_x1 FROM (SELECT SUM(x1) AS s_x1 FROM (SELECT * FROM x))",
+            "WITH _pipe_cte_1 AS (SELECT SUM(x1) AS s_x1 FROM x) SELECT s_x1 FROM _pipe_cte_1",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3) GROUP BY x4, x5",
-            "SELECT SUM(x1), MAX(x2), MIN(x3), x4, x5 FROM (SELECT * FROM x) GROUP BY x4, x5",
+            "SELECT SUM(x1), MAX(x2), MIN(x3), x4, x5 FROM x GROUP BY x4, x5",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1), MAX(x2), MIN(x3) GROUP BY x4 AS a_x4, x5 AS a_x5",
-            "SELECT SUM(x1), MAX(x2), MIN(x3), x4 AS a_x4, x5 AS a_x5 FROM (SELECT * FROM x) GROUP BY a_x4, a_x5",
+            "SELECT SUM(x1), MAX(x2), MIN(x3), x4 AS a_x4, x5 AS a_x5 FROM x GROUP BY a_x4, a_x5",
         )
         self.validate_identity(
             "FROM x |> AGGREGATE SUM(x1) as s_x1 GROUP BY x1 |> SELECT s_x1, x1 as ss_x1",
-            "SELECT s_x1, x1 AS ss_x1 FROM (SELECT SUM(x1) AS s_x1, x1 FROM (SELECT * FROM x) GROUP BY x1)",
+            "WITH _pipe_cte_1 AS (SELECT SUM(x1) AS s_x1, x1 FROM x GROUP BY x1) SELECT s_x1, x1 AS ss_x1 FROM _pipe_cte_1",
         )
         self.validate_identity(
-            "FROM x |> AGGREGATE SUM(x1) GROUP", "SELECT SUM(x1) AS GROUP FROM (SELECT * FROM x)"
+            "FROM x |> AGGREGATE SUM(x1) GROUP", "SELECT SUM(x1) AS GROUP FROM x"
         )
         for order_option in ("ASC", "DESC", "ASC NULLS LAST", "DESC NULLS FIRST"):
             with self.subTest(f"Testing pipe syntax AGGREGATE for order option: {order_option}"):
                 self.validate_all(
-                    f"SELECT SUM(x1) AS x_s FROM (SELECT * FROM x) ORDER BY x_s {order_option}",
+                    f"SELECT SUM(x1) AS x_s FROM x ORDER BY x_s {order_option}",
                     read={
                         "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s {order_option}",
                     },
                 )
                 self.validate_all(
-                    f"SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM (SELECT * FROM x) GROUP BY g_x1 ORDER BY x_s {order_option}",
+                    f"SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM x GROUP BY g_x1 ORDER BY x_s {order_option}",
                     read={
                         "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s {order_option} GROUP BY x1 AS g_x1",
                     },
@@ -3605,7 +3612,7 @@ FROM subquery2""",
                 f"Testing pipe syntax AGGREGATE with GROUP AND ORDER BY for order option: {order_option}"
             ):
                 self.validate_all(
-                    f"SELECT g_x1, x_s FROM (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM (SELECT * FROM x) GROUP BY g_x1 ORDER BY g_x1 {order_option})",
+                    f"WITH _pipe_cte_1 AS (SELECT SUM(x1) AS x_s, x1 AS g_x1 FROM x GROUP BY g_x1 ORDER BY g_x1 {order_option}) SELECT g_x1, x_s FROM _pipe_cte_1",
                     read={
                         "bigquery": f"FROM x |> AGGREGATE SUM(x1) AS x_s GROUP AND ORDER BY x1 AS g_x1 {order_option} |> SELECT g_x1, x_s",
                     },
@@ -3621,7 +3628,7 @@ FROM subquery2""",
                     self.validate_all(
                         f"FROM x|> {op_operator} (SELECT y1 FROM y), (SELECT z1 FROM z)",
                         write={
-                            "bigquery": f"SELECT * FROM x {op_operator} (SELECT y1 FROM y) {op_operator} (SELECT z1 FROM z)",
+                            "bigquery": f"WITH _pipe_cte_1 AS (SELECT * FROM x {op_operator} (SELECT y1 FROM y) {op_operator} (SELECT z1 FROM z)) SELECT * FROM _pipe_cte_1",
                         },
                     )
 
@@ -3639,6 +3646,80 @@ FROM subquery2""",
                             self.validate_all(
                                 f"FROM x|> SELECT x1, x2 FROM x |> {op_prefix} {op_operator} {suffix_operator} (SELECT y1, y2 FROM y), (SELECT z1, z2 FROM z)",
                                 write={
-                                    "bigquery": f"SELECT x1, x2 FROM (SELECT * FROM x) {op_prefix} {op_operator} BY NAME (SELECT y1, y2 FROM y) {op_prefix} {op_operator} BY NAME (SELECT z1, z2 FROM z)",
+                                    "bigquery": f"WITH _pipe_cte_1 AS (SELECT x1, x2 FROM x {op_prefix} {op_operator} BY NAME (SELECT y1, y2 FROM y) {op_prefix} {op_operator} BY NAME (SELECT z1, z2 FROM z)) SELECT x1, x2 FROM _pipe_cte_1",
                                 },
                             )
+
+            self.validate_identity(
+                "FROM d.x |> SELECT x.x1 |> UNION (SELECT 2 AS a1) |> SELECT x1 |> UNION (SELECT 3 as a2) |> SELECT x1 |> WHERE x1 > 100",
+                """WITH _pipe_cte_1 AS (
+  SELECT
+    x.x1
+  FROM d.x
+  UNION
+  (
+    SELECT
+      2 AS a1
+  )
+), _pipe_cte_2 AS (
+  SELECT
+    x.x1
+  FROM _pipe_cte_1
+), _pipe_cte_3 AS (
+  SELECT
+    x1
+  FROM _pipe_cte_2
+  UNION
+  (
+    SELECT
+      3 AS a2
+  )
+), _pipe_cte_4 AS (
+  SELECT
+    x1
+  FROM _pipe_cte_3
+)
+SELECT
+  x1
+FROM _pipe_cte_4
+WHERE
+  x1 > 100""",
+                pretty=True,
+            )
+
+        self.validate_identity(
+            "FROM c.x |> UNION ALL (SELECT 2 AS a1, '2' as a2) |> AGGREGATE AVG(x1) as m_x1 |> SELECT * |> UNION ALL (SELECT y1 FROM c.y) |> SELECT m_x1",
+            """WITH _pipe_cte_1 AS (
+  SELECT
+    *
+  FROM c.x
+  UNION ALL
+  (
+    SELECT
+      2 AS a1,
+      '2' AS a2
+  )
+), _pipe_cte_2 AS (
+  SELECT
+    AVG(x1) AS m_x1
+  FROM _pipe_cte_1
+), _pipe_cte_3 AS (
+  SELECT
+    *
+  FROM _pipe_cte_2
+  UNION ALL
+  (
+    SELECT
+      y1
+    FROM c.y
+  )
+), _pipe_cte_4 AS (
+  SELECT
+    *
+  FROM _pipe_cte_3
+)
+SELECT
+  m_x1
+FROM _pipe_cte_4""",
+            pretty=True,
+        )


### PR DESCRIPTION
This PR refactors the whole implementation of the pipe syntax and substitutes the subquery logic to CTEs. 
This makes the generated SQL more readable and also solves issues with the scoping of the query columns.

A problem with the previous implementation can be spotted in the following example:
```
Input:
FROM c.x |> SELECT x.col1, x.col2

Output:
SELECT x.col1, x.col2 FROM (SELECT * FROM c.x)
```
The subquery "shadows" the scope. 