### PR TITLE
fix(postgres)!: Preserve quoting for user defined types

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -512,6 +512,18 @@ class Postgres(Dialect):
 
             return this
 
+        def _parse_user_defined_type(
+            self, identifier: exp.Identifier
+        ) -> t.Optional[exp.Expression]:
+            udt_type: exp.Identifier | exp.Dot = identifier
+
+            while self._match(TokenType.DOT):
+                part = self._parse_id_var()
+                if part:
+                    udt_type = exp.Dot(this=udt_type, expression=part)
+
+            return exp.DataType.build(udt_type, udt=True)
+
     class Generator(generator.Generator):
         SINGLE_STRING_INTERVAL = True
         RENAME_TABLE_WITH_DB = False

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4753,6 +4753,8 @@ class DataType(Expression):
                 if udt:
                     return DataType(this=DataType.Type.USERDEFINED, kind=dtype, **kwargs)
                 raise
+        elif isinstance(dtype, (Identifier, Dot)) and udt:
+            return DataType(this=DataType.Type.USERDEFINED, kind=dtype, **kwargs)
         elif isinstance(dtype, DataType.Type):
             data_type_exp = DataType(this=dtype)
         elif isinstance(dtype, DataType):
@@ -4792,9 +4794,6 @@ class DataType(Expression):
             if matches:
                 return True
         return False
-
-
-DATA_TYPE = t.Union[str, DataType, DataType.Type]
 
 
 # https://www.postgresql.org/docs/15/datatype-pseudo.html
@@ -5028,6 +5027,9 @@ class Dot(Binary):
 
         parts.reverse()
         return parts
+
+
+DATA_TYPE = t.Union[str, Identifier, Dot, DataType, DataType.Type]
 
 
 class DPipe(Binary):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5121,6 +5121,14 @@ class Parser(metaclass=_Parser):
             exp.DataTypeParam, this=this, expression=self._parse_var(any_token=True)
         )
 
+    def _parse_user_defined_type(self, identifier: exp.Identifier) -> t.Optional[exp.Expression]:
+        type_name = identifier.name
+
+        while self._match(TokenType.DOT):
+            type_name = f"{type_name}.{self._advance_any() and self._prev.text}"
+
+        return exp.DataType.build(type_name, udt=True)
+
     def _parse_types(
         self, check_func: bool = False, schema: bool = False, allow_identifiers: bool = True
     ) -> t.Optional[exp.Expression]:
@@ -5142,12 +5150,7 @@ class Parser(metaclass=_Parser):
                 if tokens[0].token_type in self.TYPE_TOKENS:
                     self._prev = tokens[0]
                 elif self.dialect.SUPPORTS_USER_DEFINED_TYPES:
-                    type_name = identifier.name
-
-                    while self._match(TokenType.DOT):
-                        type_name = f"{type_name}.{self._advance_any() and self._prev.text}"
-
-                    this = exp.DataType.build(type_name, udt=True)
+                    this = self._parse_user_defined_type(identifier)
                 else:
                     self._retreat(self._index - 1)
                     return None

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1449,3 +1449,14 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
                         "clickhouse": "SELECT JSONExtractString(foo, '12')",
                     },
                 )
+
+    def test_udt(self):
+        def _validate_udt(sql: str):
+            self.validate_identity(sql).to.assert_is(exp.DataType)
+
+        _validate_udt("CAST(5 AS MyType)")
+        _validate_udt('CAST(5 AS "MyType")')
+        _validate_udt("CAST(5 AS MySchema.MyType)")
+        _validate_udt('CAST(5 AS "MySchema"."MyType")')
+        _validate_udt('CAST(5 AS MySchema."MyType")')
+        _validate_udt('CAST(5 AS "MyCatalog"."MySchema"."MyType")')


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5212

I went ahead and fixed this for Postgres only; It seems to be one of the few dialects that supports user defined types and the identifier resolution is respected:

```SQL
postgres> CREATE TYPE "fOo";
CREATE TYPE

postgres> SELECT CAST(1 AS foo);
ERROR:  type "foo" does not exist
LINE 1: SELECT CAST(1 AS foo);
                         ^
postgres> SELECT CAST(1 AS "fOo");
ERROR:  type "fOo" is only a shell
LINE 1: SELECT CAST(1 AS "fOo");
```

DuckDB also supports UDTs but quoting doesn't seem to make a difference: 

```sql
duckdb> CREATE TYPE "fOo" AS INTEGER;

duckdb>  SELECT CAST (1 AS foo);
┌────────────────┐
│ CAST(1 AS foo) │
│     int32      │
├────────────────┤
│       1        │
└────────────────┘

duckdb>  SELECT CAST (1 AS "Foo");
┌────────────────┐
│ CAST(1 AS Foo) │
│     int32      │
├────────────────┤
│       1        │
└────────────────┘
```

Lastly, T-SQL also allows UDTs, but the approach of this PR wouldn't work because T-SQL also supports such statements (notice the builtin quoted type)

```SQL
CREATE TABLE [mytable]([email] [varchar](255) NOT NULL)
```

Which would be transpiled as the identifier `"VARCHAR"` to other dialects.
