### PR TITLE
Fix(snowflake): ensure a standalone GET() expression can be parsed

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -863,8 +863,14 @@ class Snowflake(Dialect):
                 properties=self._parse_properties(),
             )
 
-        def _parse_get(self) -> exp.Get | exp.Command:
+        def _parse_get(self) -> t.Optional[exp.Expression]:
             start = self._prev
+
+            # If we detect GET( then we need to parse a function, not a statement
+            if self._match(TokenType.L_PAREN):
+                self._retreat(self._index - 2)
+                return self._parse_expression()
+
             target = self._parse_location_path()
 
             # Parse as command if unquoted file path

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -22,6 +22,7 @@ class TestSnowflake(Validator):
         expr.selects[0].assert_is(exp.AggFunc)
         self.assertEqual(expr.sql(dialect="snowflake"), "SELECT APPROX_TOP_K(C4, 3, 5) FROM t")
 
+        self.validate_identity("GET(a, b)")
         self.validate_identity("INSERT INTO test VALUES (x'48FAF43B0AFCEF9B63EE3A93EE2AC2')")
         self.validate_identity("SELECT STAR(tbl, exclude := [foo])")
         self.validate_identity("SELECT CAST([1, 2, 3] AS VECTOR(FLOAT, 3))")
@@ -106,6 +107,10 @@ class TestSnowflake(Validator):
         )
         self.validate_identity(
             """SELECT TO_TIMESTAMP('2025-01-16T14:45:30.123+0500', 'yyyy-mm-DD"T"hh24:mi:ss.ff3TZHTZM')"""
+        )
+        self.validate_identity(
+            "GET(value, 'foo')::VARCHAR",
+            "CAST(GET(value, 'foo') AS VARCHAR)",
         )
         self.validate_identity(
             "SELECT 1 put",


### PR DESCRIPTION
SQLGlot fails to parse `GET(a, b)` in the main branch today due to https://github.com/tobymao/sqlglot/pull/5019.
