### PR TITLE
feat(parser): PIVOT/UNPIVOT pipe syntax

### DIFF
--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -359,3 +359,22 @@ WHERE
   a_x1 > 0""",
                     pretty=True,
                 )
+
+    def test_pivot_unpivot(self):
+        self.validate_identity(
+            "FROM x |> PIVOT(SUM(x1) FOR quarter IN ('foo1', 'foo2'))",
+            "WITH __tmp1 AS (SELECT * FROM x PIVOT(SUM(x1) FOR quarter IN ('foo1', 'foo2'))) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "FROM x |> JOIN y on x.id = y.id |> PIVOT(SUM(x1) FOR quarter IN ('foo1', 'foo2'))",
+            "WITH __tmp1 AS (SELECT * FROM x PIVOT(SUM(x1) FOR quarter IN ('foo1', 'foo2')) JOIN y ON x.id = y.id) SELECT * FROM __tmp1",
+        )
+
+        self.validate_identity(
+            "FROM x |> UNPIVOT(col FOR item IN (foo1, foo2))",
+            "WITH __tmp1 AS (SELECT * FROM x UNPIVOT(col FOR item IN (foo1, foo2))) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "FROM x |> JOIN y on x.id = y.id |> UNPIVOT(col FOR item IN (foo1, foo2))",
+            "WITH __tmp1 AS (SELECT * FROM x UNPIVOT(col FOR item IN (foo1, foo2)) JOIN y ON x.id = y.id) SELECT * FROM __tmp1",
+        )


### PR DESCRIPTION
This PR adds support for the `PIVOT/UNPIVOT` pipe syntax. 

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |    ✅      |
| `WHERE (replacing QUALIFY)`           |   ✅        |
| `EXTEND`           |          |
| `SET`              |          |
| `RENAME`           |          |
| `DROP`             |         |
| `AS`               |           |
| `LIMIT`        |    ✅       |
| `AGGREGATE WITH GROUP/ORDER BY`       |   ✅        |
| `ORDER BY` | ✅  |
| `UNION`               |      ✅      |
| `INTERSECT`               |   ✅         |
| `EXCEPT`               |       ✅     |
| `JOIN`           |      ✅       |
| `CALL`               |           |
| `TABLESAMPLE`      |           |
| `PIVOT`            |       ✅     |
| `UNPIVOT`          |      ✅      |