### PR TITLE
feat(parser): DROP pipe syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -935,6 +935,7 @@ class Parser(metaclass=_Parser):
         "AS": lambda self, query: self._build_pipe_cte(
             query, [exp.Star()], self._parse_table_alias()
         ),
+        "DROP": lambda self, query: self._parse_pipe_syntax_drop(query),
         "EXTEND": lambda self, query: self._parse_pipe_syntax_extend(query),
         "LIMIT": lambda self, query: self._parse_pipe_syntax_limit(query),
         "ORDER BY": lambda self, query: query.order_by(
@@ -8478,6 +8479,14 @@ class Parser(metaclass=_Parser):
         self._match_text_seq("EXTEND")
         query.select(*[exp.Star(), *self._parse_expressions()], append=False, copy=False)
         return self._build_pipe_cte(query, [exp.Star()])
+
+    def _parse_pipe_syntax_drop(self, query: exp.Select) -> exp.Select:
+        self._match_text_seq("DROP")
+
+        star = exp.Star()
+        star.set("except", self._parse_csv(self._parse_assignment))
+
+        return query.select(star, append=False, copy=False)
 
     def _parse_pipe_syntax_query(self, query: exp.Select) -> t.Optional[exp.Select]:
         while self._match(TokenType.PIPE_GT):

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -391,3 +391,21 @@ WHERE
             "FROM (SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2) |> EXTEND SUM(item2) OVER() AS item2_sum",
             "WITH __tmp1 AS (SELECT *, SUM(item2) OVER () AS item2_sum FROM (SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2)) SELECT * FROM __tmp1",
         )
+
+    def test_drop(self):
+        self.validate_identity(
+            "FROM x |> DROP x1, x2",
+            "SELECT * EXCEPT (x1, x2) FROM x",
+        )
+        self.validate_identity(
+            "FROM x |> SELECT x.x1, x.x2, x.x3 |> DROP x1, x2 |> WHERE x3 > 0",
+            "WITH __tmp1 AS (SELECT x.x1, x.x2, x.x3 FROM x) SELECT * EXCEPT (x1, x2) FROM __tmp1 WHERE x3 > 0",
+        )
+        self.validate_identity(
+            "FROM x |> SELECT x.x1, x.x2, x.x3 |> DROP x1, x2 |> WHERE x3 > 0",
+            "WITH __tmp1 AS (SELECT x.x1, x.x2, x.x3 FROM x) SELECT * EXCEPT (x1, x2) FROM __tmp1 WHERE x3 > 0",
+        )
+        self.validate_identity(
+            "FROM (SELECT 1 AS x, 2 AS y) AS t |> DROP x |> SELECT t.x AS original_x, y",
+            "WITH __tmp1 AS (SELECT t.x AS original_x, y FROM (SELECT 1 AS x, 2 AS y) AS t) SELECT * FROM __tmp1",
+        )


### PR DESCRIPTION
This PR adds support for the `DROP` pipe syntax. 

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |    ✅      |
| `WHERE (replacing QUALIFY)`           |   ✅        |
| `EXTEND`           |      ✅      |
| `SET`              |          |
| `RENAME`           |          |
| `DROP`             |   ✅        |
| `AS`               |    ✅       |
| `LIMIT`        |    ✅       |
| `AGGREGATE WITH GROUP/ORDER BY`       |   ✅        |
| `ORDER BY` | ✅  |
| `UNION`               |      ✅      |
| `INTERSECT`               |   ✅         |
| `EXCEPT`               |       ✅     |
| `JOIN`           |      ✅       |
| `CALL`               |           |
| `TABLESAMPLE`      |           |
| `PIVOT`            |       ✅     |
| `UNPIVOT`          |      ✅      |