### PR TITLE
fix(tsql): Retain limit clause in subquery expression.

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1095,7 +1095,14 @@ class TSQL(Dialect):
                     # we replace here because otherwise TOP would be generated in select_sql
                     limit.replace(exp.Fetch(direction="FIRST", count=limit.expression))
 
-            return super().select_sql(expression)
+            expr = super().select_sql(expression)
+
+            if limit and expression.args.get("limit") is None:
+                # To prevent a limit clause being dropped from the expression
+                # Causing subsequent `select_sql` calls on same expression to lack this
+                expression.set("limit", limit)
+
+            return expr
 
         def convert_sql(self, expression: exp.Convert) -> str:
             name = "TRY_CONVERT" if expression.args.get("safe") else "CONVERT"

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1856,11 +1856,9 @@ WHERE
                 "spark": "SELECT * FROM A LIMIT 3",
             },
         )
-        self.validate_all(
+        self.validate_identity(
             "CREATE TABLE schema.table AS SELECT a, id FROM (SELECT a, (SELECT id FROM tb ORDER BY t DESC LIMIT 1) as id FROM tbl) AS _subquery",
-            write={
-                "tsql": "SELECT * INTO schema.table FROM (SELECT a AS a, id AS id FROM (SELECT a AS a, (SELECT TOP 1 id FROM tb ORDER BY t DESC) AS id FROM tbl) AS _subquery) AS temp"
-            },
+            "SELECT * INTO schema.table FROM (SELECT a AS a, id AS id FROM (SELECT a AS a, (SELECT TOP 1 id FROM tb ORDER BY t DESC) AS id FROM tbl) AS _subquery) AS temp",
         )
         self.validate_identity("SELECT TOP 10 PERCENT")
         self.validate_identity("SELECT TOP 10 PERCENT WITH TIES")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1856,6 +1856,12 @@ WHERE
                 "spark": "SELECT * FROM A LIMIT 3",
             },
         )
+        self.validate_all(
+            "CREATE TABLE schema.table AS SELECT a, id FROM (SELECT a, (SELECT id FROM tb ORDER BY t DESC LIMIT 1) as id FROM tbl) AS _subquery",
+            write={
+                "tsql": "SELECT * INTO schema.table FROM (SELECT a AS a, id AS id FROM (SELECT a AS a, (SELECT TOP 1 id FROM tb ORDER BY t DESC) AS id FROM tbl) AS _subquery) AS temp"
+            },
+        )
         self.validate_identity("SELECT TOP 10 PERCENT")
         self.validate_identity("SELECT TOP 10 PERCENT WITH TIES")
 


### PR DESCRIPTION
Fixes issue: https://github.com/TobikoData/sqlmesh/issues/4649 

Subqueries are parsed twice (at least for tsql) by `select_sql`, which causes subqueries using `LIMIT` or `TOP` to drop these on the second run, when converting CTAS statement to `SELECT .. INTO ..`. 

The subquery expression object suffers a side-effect in `Generator.select_sql` method where any `limit` expression is popped from the expression and propagated within the method as a string component. 

This simple fix reinjects the original `limit` expression to any query that HAD a `limit` expression prior to `select_sql`, but lacks it afterward.