### PR TITLE
Feat(snowflake): improve transpilation of unnested object lookup

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -336,6 +336,12 @@ def _json_extract_value_array_sql(
 
 def _eliminate_dot_variant_lookup(expression: exp.Expression) -> exp.Expression:
     if isinstance(expression, exp.Select):
+        # This transformation is used to facilitate transpilation of BigQuery `UNNEST` operations
+        # to Snowflake. It should not affect roundtrip because `Unnest` nodes cannot be produced
+        # by Snowflake's parser.
+        #
+        # Additionally, at the time of writing this, BigQuery is the only dialect that produces a
+        # `TableAlias` node that only fills `columns` and not `this`, due to `UNNEST_COLUMN_ONLY`.
         unnest_aliases = set()
         for unnest in find_all_in_scope(expression, exp.Unnest):
             unnest_alias = unnest.args.get("alias")

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -849,12 +849,14 @@ def walk_in_scope(expression, bfs=True, prune=None):
 
         if node is expression:
             continue
+
         if (
             isinstance(node, exp.CTE)
             or (
                 isinstance(node.parent, (exp.From, exp.Join, exp.Subquery))
-                and (_is_derived_table(node) or isinstance(node, exp.UDTF))
+                and _is_derived_table(node)
             )
+            or (isinstance(node.parent, exp.UDTF) and isinstance(node, exp.Query))
             or isinstance(node, exp.UNWRAPPED_QUERIES)
         ):
             crossed_scope_boundary = True


### PR DESCRIPTION
This PR:

- Introduces a new transformation for Snowflake, in order to transpile BigQuery queries with unnests to it
- Modifies the `walk_in_scope` logic to stop considering plain `UDTF`s without `Query` children as scope boundaries

We incorrectly transpile BigQuery queries like the following to Snowflake today:

```python
import sqlglot
print(sqlglot.transpile("select _u.foo from unnest([struct('x' as foo, 'y' AS bar)]) as _u", "bigquery", "snowflake")[0])
# SELECT _u.foo FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('foo', 'x', 'bar', 'y')])) AS _t0(seq, key, path, index, _u, this)
```

The resulting query fails with `Error: invalid identifier '_U.FOO' (line 1)`, because the value `_u` is a `VARIANT`, and so accessing its contents using the dot notation is not allowed. Instead, Snowflake requires that we use either the colon (`x:y`) or the bracket syntax `x['y']` for this reason.

To address this, the new transformation looks for unnests that have a single column alias, and then replaces any columns in scope that are qualified with said alias.

I looked into Snowflake's [docs](https://docs.snowflake.com/en/sql-reference/functions/flatten) for `TABLE(FLATTEN(...))`, and I believe the expected receivers of the lookup operation should be `OBJECT` or `VARIANT` values, for which it is safe to replace the dot syntax with the bracket notation.