### PR TITLE
Fix(duckdb): Generate correct DETACH syntax if IF EXISTS is set

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1164,3 +1164,12 @@ class DuckDB(Dialect):
         def autoincrementcolumnconstraint_sql(self, _) -> str:
             self.unsupported("The AUTOINCREMENT column constraint is not supported by DuckDB")
             return ""
+
+        def detach_sql(self, expression: exp.Detach) -> str:
+            this = self.sql(expression, "this")
+            # the DATABASE keyword is required if IF EXISTS is set
+            # without it, DuckDB throws an error: Parser Error: syntax error at or near "exists" (Line Number: 1)
+            # ref: https://duckdb.org/docs/stable/sql/statements/attach.html#detach-syntax
+            exists_sql = " DATABASE IF EXISTS" if expression.args.get("exists") else ""
+
+            return f"DETACH{exists_sql} {this}"

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1494,7 +1494,11 @@ class TestDuckDB(Validator):
 
         # DETACH
         self.validate_identity("DETACH new_database")
-        self.validate_identity("DETACH IF EXISTS file")
+
+        # when 'if exists' is set, the syntax is DETACH DATABASE, not DETACH
+        # ref: https://duckdb.org/docs/stable/sql/statements/attach.html#detach-syntax
+        self.validate_identity("DETACH IF EXISTS file", "DETACH DATABASE IF EXISTS file")
+        self.validate_identity("DETACH DATABASE IF EXISTS file", "DETACH DATABASE IF EXISTS file")
 
         self.validate_identity("DETACH DATABASE db", "DETACH db")
 


### PR DESCRIPTION
Prior to this PR:
```
>>> parse_one("DETACH DATABASE IF EXISTS foo", dialect="duckdb").sql(dialect="duckdb")
'DETACH IF EXISTS foo'
```

This is invalid syntax, at least as of DuckDB 1.3.0. Unlike `ATTACH`, when `IF EXISTS` is used for `DETACH`, it has to be `DETACH DATABASE` or the following error gets thrown:
```
Parser Error: syntax error at or near "exists" (Line Number: 1)
```

This is in line with the [DuckDB documentation
](https://duckdb.org/docs/stable/sql/statements/attach.html#detach-syntax)

Note that `DETACH foo` works as expected, the error is only thrown if `IF EXISTS` is added