### PR TITLE
Fix!: change comma to cross join when precedence is the same for all join types

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -524,6 +524,7 @@ class BigQuery(Dialect):
         PREFIXED_PIVOT_COLUMNS = True
         LOG_DEFAULTS_TO_LN = True
         SUPPORTS_IMPLICIT_UNNEST = True
+        JOINS_HAVE_EQUAL_PRECEDENCE = True
 
         # BigQuery does not allow ASC/DESC to be used as an identifier
         ID_VAR_TOKENS = parser.Parser.ID_VAR_TOKENS - {TokenType.ASC, TokenType.DESC}

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -297,6 +297,7 @@ class ClickHouse(Dialect):
         MODIFIERS_ATTACHED_TO_SET_OP = False
         INTERVAL_SPANS = False
         OPTIONAL_ALIAS_TOKEN_CTE = False
+        JOINS_HAVE_EQUAL_PRECEDENCE = True
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -305,6 +305,7 @@ class Hive(Dialect):
         LOG_DEFAULTS_TO_LN = True
         STRICT_CAST = False
         VALUES_FOLLOWED_BY_PAREN = False
+        JOINS_HAVE_EQUAL_PRECEDENCE = True
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -102,6 +102,10 @@ class SQLite(Dialect):
         COMMANDS = {*tokens.Tokenizer.COMMANDS, TokenType.REPLACE}
 
     class Parser(parser.Parser):
+        STRING_ALIASES = True
+        ALTER_RENAME_REQUIRES_COLUMN = False
+        JOINS_HAVE_EQUAL_PRECEDENCE = True
+
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "EDITDIST3": exp.Levenshtein.from_arg_list,
@@ -109,9 +113,6 @@ class SQLite(Dialect):
             "DATETIME": lambda args: exp.Anonymous(this="DATETIME", expressions=args),
             "TIME": lambda args: exp.Anonymous(this="TIME", expressions=args),
         }
-
-        STRING_ALIASES = True
-        ALTER_RENAME_REQUIRES_COLUMN = False
 
         def _parse_unique(self) -> exp.UniqueColumnConstraint:
             # Do not consume more tokens if UNIQUE is used as a standalone constraint, e.g:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -111,6 +111,7 @@ class TestClickhouse(Validator):
         self.validate_identity("TRUNCATE DATABASE db ON CLUSTER test_cluster")
         self.validate_identity("TRUNCATE DATABASE db ON CLUSTER '{cluster}'")
         self.validate_identity("EXCHANGE TABLES x.a AND y.b", check_command_warning=True)
+        self.validate_identity("CREATE TABLE test (id UInt8) ENGINE=Null()")
         self.validate_identity(
             "SELECT DATE_BIN(toDateTime('2023-01-01 14:45:00'), INTERVAL '1' MINUTE, toDateTime('2023-01-01 14:35:30'), 'UTC')",
         )
@@ -168,7 +169,6 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "CREATE MATERIALIZED VIEW test_view ON CLUSTER '{cluster}' (id UInt8) ENGINE=AggregatingMergeTree() ORDER BY tuple() AS SELECT * FROM test_data"
         )
-        self.validate_identity("CREATE TABLE test (id UInt8) ENGINE=Null()")
         self.validate_identity(
             "CREATE MATERIALIZED VIEW test_view ON CLUSTER cl1 TO table1 AS SELECT * FROM test_data"
         )
@@ -183,6 +183,10 @@ class TestClickhouse(Validator):
         )
         self.validate_identity(
             "SELECT generate_series FROM generate_series(0, 10) AS g(x)",
+        )
+        self.validate_identity(
+            "SELECT * FROM t1, t2",
+            "SELECT * FROM t1 CROSS JOIN t2",
         )
         self.validate_identity(
             "SELECT and(1, 2)",

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -58,6 +58,10 @@ class TestDatabricks(Validator):
             "COPY INTO target FROM `s3://link` FILEFORMAT = AVRO VALIDATE = ALL FILES = ('file1', 'file2') FORMAT_OPTIONS ('opt1'='true', 'opt2'='test') COPY_OPTIONS ('mergeSchema'='true')"
         )
         self.validate_identity(
+            "SELECT * FROM t1, t2",
+            "SELECT * FROM t1 CROSS JOIN t2",
+        )
+        self.validate_identity(
             "SELECT TIMESTAMP '2025-04-29 18.47.18'::DATE",
             "SELECT CAST(CAST('2025-04-29 18.47.18' AS DATE) AS TIMESTAMP)",
         )

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -492,6 +492,10 @@ class TestHive(Validator):
         self.validate_identity(
             "TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address = 'abc')"
         )
+        self.validate_identity(
+            "SELECT * FROM t1, t2",
+            "SELECT * FROM t1 CROSS JOIN t2",
+        )
 
         self.validate_all(
             "SELECT ${hiveconf:some_var}",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -334,7 +334,14 @@ class TestSnowflake(Validator):
         )
 
         self.validate_all(
-            "SELECT _u['foo'], bar, baz FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('foo', 'x', 'bars', ['y', 'z'], 'bazs', ['w'])])) AS _t0(seq, key, path, index, _u, this), TABLE(FLATTEN(INPUT => _u['bars'])) AS _t1(seq, key, path, index, bar, this), TABLE(FLATTEN(INPUT => _u['bazs'])) AS _t2(seq, key, path, index, baz, this)",
+            "SELECT * FROM t1 AS t1 CROSS JOIN t2 AS t2 LEFT JOIN t3 AS t3 ON t1.a = t3.i",
+            read={
+                "bigquery": "SELECT * FROM t1 AS t1, t2 AS t2 LEFT JOIN t3 AS t3 ON t1.a = t3.i",
+                "snowflake": "SELECT * FROM t1 AS t1 CROSS JOIN t2 AS t2 LEFT JOIN t3 AS t3 ON t1.a = t3.i",
+            },
+        )
+        self.validate_all(
+            "SELECT _u['foo'], bar, baz FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('foo', 'x', 'bars', ['y', 'z'], 'bazs', ['w'])])) AS _t0(seq, key, path, index, _u, this) CROSS JOIN TABLE(FLATTEN(INPUT => _u['bars'])) AS _t1(seq, key, path, index, bar, this) CROSS JOIN TABLE(FLATTEN(INPUT => _u['bazs'])) AS _t2(seq, key, path, index, baz, this)",
             read={
                 "bigquery": "SELECT _u.foo, bar, baz FROM UNNEST([struct('x' AS foo, ['y', 'z'] AS bars, ['w'] AS bazs)]) AS _u, UNNEST(_u.bars) AS bar, UNNEST(_u.bazs) AS baz",
             },

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -273,6 +273,10 @@ TBLPROPERTIES (
         self.validate_identity("TRIM(TRAILING 'SL' FROM 'SSparkSQLS')")
         self.validate_identity("SPLIT(str, pattern, lim)")
         self.validate_identity(
+            "SELECT * FROM t1, t2",
+            "SELECT * FROM t1 CROSS JOIN t2",
+        )
+        self.validate_identity(
             "SELECT 1 limit",
             "SELECT 1 AS limit",
         )

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -29,6 +29,10 @@ class TestSQLite(Validator):
             """SELECT item AS "item", some AS "some" FROM data WHERE (item = 'value_1' COLLATE NOCASE) AND (some = 't' COLLATE NOCASE) ORDER BY item ASC LIMIT 1 OFFSET 0"""
         )
         self.validate_identity(
+            "SELECT * FROM t1, t2",
+            "SELECT * FROM t1 CROSS JOIN t2",
+        )
+        self.validate_identity(
             "ALTER TABLE t RENAME a TO b",
             "ALTER TABLE t RENAME COLUMN a TO b",
         )

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -475,7 +475,7 @@ SELECT s.b AS b FROM (SELECT t1.b AS b FROM t1 AS t1 UNION ALL SELECT t2.b AS b 
 # dialect: bigquery
 # execute: false
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct("test" AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.*, tbl2.col.* FROM tbl1, tbl2;
-WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS col1, tbl1.col.col2 AS col2, tbl1.col.lvl1 AS lvl1, tbl2.col.col1 AS col1, tbl2.col.col2 AS col2, tbl2.col.lvl1 AS lvl1 FROM tbl1 AS tbl1, tbl2 AS tbl2;
+WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col), tbl2 AS (SELECT STRUCT(1 AS col1, 2 AS col2, Struct('test' AS col1, Struct(3 AS col2) AS lvl2) AS lvl1) AS col) SELECT tbl1.col.col1 AS col1, tbl1.col.col2 AS col2, tbl1.col.lvl1 AS lvl1, tbl2.col.col1 AS col1, tbl2.col.col2 AS col2, tbl2.col.lvl1 AS lvl1 FROM tbl1 AS tbl1 CROSS JOIN tbl2 AS tbl2;
 
 # dialect: bigquery
 # execute: false
@@ -732,7 +732,7 @@ SELECT t.aa AS aa FROM x AS x, UNNEST(x.a) AS t(aa);
 # dialect: bigquery
 # execute: false
 SELECT aa FROM x, UNNEST(a) AS aa;
-SELECT aa AS aa FROM x AS x, UNNEST(x.a) AS aa;
+SELECT aa AS aa FROM x AS x CROSS JOIN UNNEST(x.a) AS aa;
 
 # dialect: bigquery
 # execute: false
@@ -752,7 +752,7 @@ SELECT x AS x, a AS a, x.a AS a FROM UNNEST([STRUCT(1 AS a)]) AS x CROSS JOIN m 
 # dialect: bigquery
 # execute: false
 WITH cte AS (SELECT [STRUCT(1 AS a)] AS x) select a, x, m.a from cte, UNNEST(x) AS m CROSS JOIN n;
-WITH cte AS (SELECT [STRUCT(1 AS a)] AS x) SELECT a AS a, cte.x AS x, m.a AS a FROM cte AS cte, UNNEST(cte.x) AS m CROSS JOIN n AS n;
+WITH cte AS (SELECT [STRUCT(1 AS a)] AS x) SELECT a AS a, cte.x AS x, m.a AS a FROM cte AS cte CROSS JOIN UNNEST(cte.x) AS m CROSS JOIN n AS n;
 
 # dialect: presto
 SELECT x.a, i.b FROM x CROSS JOIN UNNEST(SPLIT(CAST(b AS VARCHAR), ',')) AS i(b);

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -42,17 +42,17 @@ SELECT 1 FROM c.y.z AS z, z.a;
 # title: bigquery implicit unnest syntax, coordinates.position should be a column, not a table
 # dialect: bigquery
 SELECT results FROM Coordinates, coordinates.position AS results;
-SELECT results FROM c.db.Coordinates AS Coordinates, UNNEST(coordinates.position) AS results;
+SELECT results FROM c.db.Coordinates AS Coordinates CROSS JOIN UNNEST(coordinates.position) AS results;
 
 # title: bigquery implicit unnest syntax, table is already qualified
 # dialect: bigquery
 SELECT results FROM db.coordinates, Coordinates.position AS results;
-SELECT results FROM c.db.coordinates AS coordinates, UNNEST(Coordinates.position) AS results;
+SELECT results FROM c.db.coordinates AS coordinates CROSS JOIN UNNEST(Coordinates.position) AS results;
 
 # title: bigquery schema name clashes with CTE name - this is a join, not an implicit unnest
 # dialect: bigquery
 WITH Coordinates AS (SELECT [1, 2] AS position) SELECT results FROM Coordinates, `Coordinates.position` AS results;
-WITH Coordinates AS (SELECT [1, 2] AS position) SELECT results FROM Coordinates AS Coordinates, `c.Coordinates.position` AS results;
+WITH Coordinates AS (SELECT [1, 2] AS position) SELECT results FROM Coordinates AS Coordinates CROSS JOIN `c.Coordinates.position` AS results;
 
 # title: single cte
 WITH a AS (SELECT 1 FROM z) SELECT 1 FROM a;


### PR DESCRIPTION
In standard SQL, joins that use the JOIN keyword take higher precedence than comma-joins. That is to say, JOIN operators happen before comma operators. This is not the case in some dialects, such as BigQuery, where all joins have the same precedence.

SQLGlot always preserves the JOIN syntax when parsing / transpiling, despite this difference in semantics between SQL dialects. This may occasionally lead to incorrect transpilations, such as in the following example:

```python
import sqlglot

sql = """
WITH
  t1 AS (SELECT 1 AS a),
  t2 AS (SELECT 'a' AS x),
  t3 AS (SELECT 1 AS i)

SELECT
  *
FROM
  t1 AS t1,
  t2 AS t2
  LEFT JOIN t3 AS t3 ON t1.a = t3.i
"""

print(sqlglot.transpile(sql, read="bigquery", write="snowflake", pretty=True)[0])

# WITH t1 AS (
#   SELECT
#     1 AS a
# ), t2 AS (
#   SELECT
#     'a' AS x
# ), t3 AS (
#   SELECT
#     1 AS i
# )
# SELECT
#   *
# FROM t1 AS t1, t2 AS t2
# LEFT JOIN t3 AS t3
#   ON t1.a = t3.i  -- Error: invalid identifier 'T1.A' (line 15)
```

The reason the above transpilation is incorrect, is because Snowflake parses the joins as `t1 CROSS JOIN (t2 LEFT JOIN t3 ON t1.a = t3.i)`, so `t1` is not visible in the right-hand side of the cross join.

This PR fixes this issue by parsing the comma-style joins into explicit CROSS JOINs, for dialects such as BigQuery.

References:
- https://docs.snowflake.com/en/user-guide/querying-joins#introduction
- https://stackoverflow.com/a/31441463
- https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#sequences_of_joins
- https://sqlite.org/lang_select.html#precedence_of_comma_joins_and_cross_join

