### PR TITLE
feat(dialects): add Fabric dialect with custom SQL generation and tests

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -74,6 +74,7 @@ DIALECTS = [
     "Druid",
     "DuckDB",
     "Dune",
+    "Fabric",
     "Hive",
     "Materialize",
     "MySQL",

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -77,6 +77,7 @@ class Dialects(str, Enum):
     DRUID = "druid"
     DUCKDB = "duckdb"
     DUNE = "dune"
+    FABRIC = "fabric"
     HIVE = "hive"
     MATERIALIZE = "materialize"
     MYSQL = "mysql"

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+
+from sqlglot import exp
+from sqlglot.dialects.tsql import TSQL
+
+
+class Fabric(TSQL):
+    """
+    Microsoft Fabric dialect that inherits from T-SQL but uses uppercase
+    INFORMATION_SCHEMA references as required by Fabric.
+    """
+
+    class Generator(TSQL.Generator):
+        def create_sql(self, expression: exp.Create) -> str:
+            kind = expression.kind
+            exists = expression.args.pop("exists", None)
+
+            like_property = expression.find(exp.LikeProperty)
+            if like_property:
+                ctas_expression = like_property.this
+            else:
+                ctas_expression = expression.expression
+
+            if kind == "VIEW":
+                expression.this.set("catalog", None)
+                with_ = expression.args.get("with")
+                if ctas_expression and with_:
+                    # We've already preprocessed the Create expression to bubble up any nested CTEs,
+                    # but CREATE VIEW actually requires the WITH clause to come after it so we need
+                    # to amend the AST by moving the CTEs to the CREATE VIEW statement's query.
+                    ctas_expression.set("with", with_.pop())
+
+            table = expression.find(exp.Table)
+
+            # Convert CTAS statement to SELECT .. INTO ..
+            if kind == "TABLE" and ctas_expression:
+                if isinstance(ctas_expression, exp.UNWRAPPED_QUERIES):
+                    ctas_expression = ctas_expression.subquery()
+
+                properties = expression.args.get("properties") or exp.Properties()
+                is_temp = any(isinstance(p, exp.TemporaryProperty) for p in properties.expressions)
+
+                select_into = exp.select("*").from_(exp.alias_(ctas_expression, "temp", table=True))
+                select_into.set("into", exp.Into(this=table, temporary=is_temp))
+
+                if like_property:
+                    select_into.limit(0, copy=False)
+
+                sql = self.sql(select_into)
+            else:
+                sql = super(TSQL.Generator, self).create_sql(expression)
+
+            if exists:
+                identifier = self.sql(exp.Literal.string(exp.table_name(table) if table else ""))
+                sql_with_ctes = self.prepend_ctes(expression, sql)
+                sql_literal = self.sql(exp.Literal.string(sql_with_ctes))
+                if kind == "SCHEMA":
+                    return f"""IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = {identifier}) EXEC({sql_literal})"""
+                elif kind == "TABLE":
+                    assert table
+                    where = exp.and_(
+                        exp.column("TABLE_NAME").eq(table.name),
+                        exp.column("TABLE_SCHEMA").eq(table.db) if table.db else None,
+                        exp.column("TABLE_CATALOG").eq(table.catalog) if table.catalog else None,
+                    )
+                    return f"""IF NOT EXISTS (SELECT * FROM INFORMATION_SCHEMA.TABLES WHERE {where}) EXEC({sql_literal})"""
+                elif kind == "INDEX":
+                    index = self.sql(exp.Literal.string(expression.this.text("this")))
+                    return f"""IF NOT EXISTS (SELECT * FROM sys.indexes WHERE object_id = object_id({identifier}) AND name = {index}) EXEC({sql_literal})"""
+            elif expression.args.get("replace"):
+                sql = sql.replace("CREATE OR REPLACE ", "CREATE OR ALTER ", 1)
+
+            return self.prepend_ctes(expression, sql)

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -1,17 +1,74 @@
 from __future__ import annotations
 
-
 from sqlglot import exp
 from sqlglot.dialects.tsql import TSQL
 
 
 class Fabric(TSQL):
     """
-    Microsoft Fabric dialect that inherits from T-SQL but uses uppercase
-    INFORMATION_SCHEMA references as required by Fabric.
+    Microsoft Fabric dialect that inherits from T-SQL.
+
+    Key differences from T-SQL:
+    - Uses uppercase INFORMATION_SCHEMA references in conditional DDL
+    - Only supports a subset of T-SQL data types (maps unsupported types to alternatives)
+    - DATETIME2 and TIME precision limited to 6 digits maximum
+    - VARCHAR(MAX) and VARBINARY(MAX) are supported (in preview)
+
+    Data type mappings for unsupported types:
+    - MONEY/SMALLMONEY -> DECIMAL
+    - DATETIME/SMALLDATETIME -> DATETIME2
+    - NCHAR/NVARCHAR -> CHAR/VARCHAR (no Unicode support in Parquet)
+    - TEXT -> VARCHAR
+    - IMAGE -> VARBINARY
+    - TINYINT -> SMALLINT
+    - JSON/XML -> VARCHAR
     """
 
     class Generator(TSQL.Generator):
+        # Fabric-specific type mappings - override T-SQL types that aren't supported
+        # Reference: https://learn.microsoft.com/en-us/fabric/data-warehouse/data-types
+        TYPE_MAPPING = {
+            **TSQL.Generator.TYPE_MAPPING,
+            # Fabric doesn't support these types, map to alternatives
+            exp.DataType.Type.MONEY: "DECIMAL",
+            exp.DataType.Type.SMALLMONEY: "DECIMAL",
+            exp.DataType.Type.DATETIME: "DATETIME2",
+            exp.DataType.Type.SMALLDATETIME: "DATETIME2",
+            exp.DataType.Type.TIMESTAMPTZ: "DATETIME2",
+            exp.DataType.Type.NCHAR: "CHAR",
+            exp.DataType.Type.NVARCHAR: "VARCHAR",
+            exp.DataType.Type.TEXT: "VARCHAR",
+            exp.DataType.Type.IMAGE: "VARBINARY",
+            exp.DataType.Type.TINYINT: "SMALLINT",
+            exp.DataType.Type.UTINYINT: "SMALLINT",  # T-SQL parses TINYINT as UTINYINT
+            exp.DataType.Type.JSON: "VARCHAR",
+            exp.DataType.Type.XML: "VARCHAR",
+            # Override T-SQL mappings that use different names in Fabric
+            exp.DataType.Type.DECIMAL: "DECIMAL",  # T-SQL uses NUMERIC
+            exp.DataType.Type.DOUBLE: "FLOAT",
+        }
+
+        def datatype_sql(self, expression: exp.DataType) -> str:
+            # Handle precision limits for DATETIME2 and TIME in Fabric (max 6 digits)
+            if expression.is_type(exp.DataType.Type.DATETIME2, exp.DataType.Type.TIME):
+                expressions = expression.expressions
+                if expressions:
+                    # Handle both Literal and DataTypeParam
+                    param = expressions[0]
+                    if isinstance(param, exp.DataTypeParam):
+                        param = param.this
+
+                    if isinstance(param, exp.Literal):
+                        prec_value = int(param.this)
+                        if prec_value > 6:
+                            # Create new expression with capped precision
+                            new_param = exp.DataTypeParam(this=exp.Literal.number("6"))
+                            expression = exp.DataType.build(
+                                expression.this, expressions=[new_param]
+                            )
+
+            return super().datatype_sql(expression)
+
         def create_sql(self, expression: exp.Create) -> str:
             kind = expression.kind
             exists = expression.args.pop("exists", None)

--- a/tests/test_fabric.py
+++ b/tests/test_fabric.py
@@ -1,0 +1,50 @@
+import unittest
+from sqlglot import transpile
+from sqlglot.dialects.fabric import Fabric
+
+
+class TestFabric(unittest.TestCase):
+    def test_fabric_create_schema_with_exists(self):
+        """Test that Fabric dialect uses uppercase INFORMATION_SCHEMA.SCHEMATA"""
+        sql = "CREATE SCHEMA IF NOT EXISTS test_schema"
+        result = transpile(sql, read="fabric", write="fabric")[0]
+
+        # Should use uppercase INFORMATION_SCHEMA.SCHEMATA and SCHEMA_NAME
+        self.assertIn("INFORMATION_SCHEMA.SCHEMATA", result)
+        self.assertIn("SCHEMA_NAME", result)
+        self.assertNotIn("information_schema.schemata", result)
+        self.assertNotIn("schema_name", result)
+
+    def test_fabric_create_table_with_exists(self):
+        """Test that Fabric dialect uses uppercase INFORMATION_SCHEMA.TABLES"""
+        sql = "CREATE TABLE IF NOT EXISTS test_table (id INT)"
+        result = transpile(sql, read="fabric", write="fabric")[0]
+
+        # Should use uppercase INFORMATION_SCHEMA.TABLES and column names
+        self.assertIn("INFORMATION_SCHEMA.TABLES", result)
+        self.assertIn("TABLE_NAME", result)
+        self.assertNotIn("information_schema.tables", result)
+        self.assertNotIn("table_name", result)
+
+    def test_fabric_inherits_from_tsql(self):
+        """Test that Fabric dialect inherits T-SQL functionality"""
+        # Test a T-SQL specific feature like TOP
+        sql = "SELECT TOP 10 * FROM users"
+        result = transpile(sql, read="fabric", write="fabric")[0]
+
+        # Should maintain T-SQL syntax
+        self.assertIn("SELECT TOP 10", result)
+
+    def test_fabric_dialect_instance(self):
+        """Test that Fabric dialect is properly instantiated"""
+        dialect = Fabric()
+        self.assertIsInstance(dialect, Fabric)
+        self.assertTrue(hasattr(dialect, "Generator"))
+
+        # Should have the custom Generator that overrides create_sql
+        generator = dialect.Generator()
+        self.assertTrue(hasattr(generator, "create_sql"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fabric.py
+++ b/tests/test_fabric.py
@@ -45,6 +45,124 @@ class TestFabric(unittest.TestCase):
         generator = dialect.Generator()
         self.assertTrue(hasattr(generator, "create_sql"))
 
+    def test_fabric_data_type_mappings(self):
+        """Test that Fabric maps unsupported data types to supported alternatives"""
+        test_cases = [
+            # money -> decimal
+            ("CREATE TABLE test (price MONEY)", "DECIMAL"),
+            ("CREATE TABLE test (price SMALLMONEY)", "DECIMAL"),
+            # datetime -> datetime2
+            ("CREATE TABLE test (created DATETIME)", "DATETIME2"),
+            ("CREATE TABLE test (created SMALLDATETIME)", "DATETIME2"),
+            # unicode types -> non-unicode equivalents
+            ("CREATE TABLE test (name NCHAR(10))", "CHAR(10)"),
+            ("CREATE TABLE test (name NVARCHAR(50))", "VARCHAR(50)"),
+            # text types -> varchar
+            ("CREATE TABLE test (content TEXT)", "VARCHAR"),
+            # binary types
+            ("CREATE TABLE test (image_data IMAGE)", "VARBINARY"),
+            # integer types - NOTE: T-SQL parses TINYINT as UTINYINT
+            ("CREATE TABLE test (tiny_val TINYINT)", "SMALLINT"),
+            # json -> varchar
+            ("CREATE TABLE test (data JSON)", "VARCHAR"),
+            # xml -> varchar
+            ("CREATE TABLE test (xml_data XML)", "VARCHAR"),
+        ]
+
+        for input_sql, expected_type in test_cases:
+            with self.subTest(input_sql=input_sql):
+                # Read as T-SQL, write as Fabric to get type conversions
+                result = transpile(input_sql, read="tsql", write="fabric")[0]
+                self.assertIn(expected_type, result.upper())
+
+    def test_fabric_datetime2_precision_limit(self):
+        """Test that Fabric limits DATETIME2 and TIME precision to 6 digits"""
+        test_cases = [
+            ("CREATE TABLE test (ts DATETIME2(7))", "DATETIME2(6)"),
+            ("CREATE TABLE test (ts TIME(7))", "TIME(6)"),
+            ("CREATE TABLE test (ts DATETIME2(9))", "DATETIME2(6)"),
+            ("CREATE TABLE test (ts TIME(3))", "TIME(3)"),  # Should remain unchanged
+        ]
+
+        for input_sql, expected in test_cases:
+            with self.subTest(input_sql=input_sql):
+                # Read as T-SQL, write as Fabric to get precision limiting
+                result = transpile(input_sql, read="tsql", write="fabric")[0]
+                self.assertIn(expected, result)
+
+    def test_fabric_varchar_max_support(self):
+        """Test that Fabric supports VARCHAR(MAX) and VARBINARY(MAX) (in preview)"""
+        test_cases = [
+            "CREATE TABLE test (large_text VARCHAR(MAX))",
+            "CREATE TABLE test (large_binary VARBINARY(MAX))",
+        ]
+
+        for input_sql in test_cases:
+            with self.subTest(input_sql=input_sql):
+                result = transpile(input_sql, read="fabric", write="fabric")[0]
+                # Should preserve MAX keyword
+                self.assertIn("MAX", result)
+
+    def test_fabric_supported_data_types(self):
+        """Test that Fabric properly handles all supported data types"""
+        # Note: These are the T-SQL representations that should work in Fabric
+        supported_types = [
+            "BIT",
+            "SMALLINT",
+            "INT",
+            "BIGINT",
+            "DECIMAL",  # Will be generated as DECIMAL (not NUMERIC)
+            "FLOAT",
+            "REAL",
+            "DATE",
+            "TIME",
+            "DATETIME2",
+            "CHAR",
+            "VARCHAR",
+            "VARBINARY",
+            "UNIQUEIDENTIFIER",
+        ]
+
+        for data_type in supported_types:
+            with self.subTest(data_type=data_type):
+                sql = f"CREATE TABLE test (col {data_type})"
+                # Read as T-SQL, write as Fabric
+                result = transpile(sql, read="tsql", write="fabric")[0]
+                # Should transpile without error and preserve supported types
+                self.assertTrue(len(result) > 0)  # Just check it doesn't fail
+
+    def test_fabric_uniqueidentifier_handling(self):
+        """Test that UNIQUEIDENTIFIER is supported but has special behavior"""
+        sql = "CREATE TABLE test (id UNIQUEIDENTIFIER)"
+        result = transpile(sql, read="fabric", write="fabric")[0]
+
+        # Should preserve UNIQUEIDENTIFIER
+        self.assertIn("UNIQUEIDENTIFIER", result)
+
+    def test_fabric_unsupported_type_combinations(self):
+        """Test combinations of unsupported types in complex scenarios"""
+        sql = """
+        CREATE TABLE test_table (
+            id INT,
+            old_date DATETIME,
+            unicode_name NVARCHAR(100),
+            money_field MONEY,
+            tiny_num TINYINT,
+            json_data JSON,
+            xml_content XML
+        )
+        """
+
+        # Read as T-SQL, write as Fabric to get type conversions
+        result = transpile(sql, read="tsql", write="fabric")[0]
+
+        # Check that all unsupported types are converted
+        self.assertIn("DATETIME2", result)  # DATETIME -> DATETIME2
+        self.assertIn("VARCHAR(100)", result)  # NVARCHAR -> VARCHAR
+        self.assertIn("DECIMAL", result)  # MONEY -> DECIMAL
+        self.assertIn("SMALLINT", result)  # TINYINT -> SMALLINT (via UTINYINT)
+        # JSON and XML should both become VARCHAR
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This pull request introduces support for a new SQL dialect, Microsoft Fabric, by extending the existing T-SQL dialect. Key changes include adding the `Fabric` dialect, implementing a custom SQL generator for Fabric-specific syntax, and adding unit tests to validate the new functionality.

### Addition of the Fabric Dialect:

* **`sqlglot/dialects/__init__.py` and `sqlglot/dialects/dialect.py`:** Added `Fabric` to the list of supported dialects and its corresponding enum. [[1]](diffhunk://#diff-3645b7632cb445f83188b8af62dad4ba7bc3fd52c0f25287513c4c5f8da5b665R77) [[2]](diffhunk://#diff-fbb39ad01c051fb9448d4194537b53f8ff1861201921bfef2ef541757365a197R80)
* **`sqlglot/dialects/fabric.py`:** Introduced the `Fabric` class, inheriting from `TSQL`. This includes a custom `Generator` that overrides the `create_sql` method to handle Fabric-specific requirements, such as uppercase `INFORMATION_SCHEMA` references and `CREATE OR ALTER` syntax.

### Unit Tests for Fabric Dialect:

* **`tests/test_fabric.py`:** Added unit tests to verify the functionality of the `Fabric` dialect. Tests include checking uppercase `INFORMATION_SCHEMA` usage, inheritance from T-SQL, and the proper instantiation of the `Fabric` dialect and its custom generator.