### PR TITLE
feat(parser): start with SELECT and nested pipe syntax

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -691,6 +691,8 @@ class ClickHouse(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            consume_pipe: bool = False,
+            wrap_pipe: bool = False,
         ) -> t.Optional[exp.Expression]:
             this = super()._parse_table(
                 schema=schema,

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -508,6 +508,8 @@ class DuckDB(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            consume_pipe: bool = False,
+            wrap_pipe: bool = False,
         ) -> t.Optional[exp.Expression]:
             # DuckDB supports prefix aliases, e.g. FROM foo: bar
             if self._next and self._next.token_type == TokenType.COLON:

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -189,11 +189,17 @@ class PRQL(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            consume_pipe: bool = False,
+            wrap_pipe: bool = False,
         ) -> t.Optional[exp.Expression]:
             return self._parse_table_parts()
 
         def _parse_from(
-            self, joins: bool = False, skip_from_token: bool = False
+            self,
+            joins: bool = False,
+            skip_from_token: bool = False,
+            consume_pipe: bool = False,
+            wrap_pipe: bool = False,
         ) -> t.Optional[exp.From]:
             if not skip_from_token and not self._match(TokenType.FROM):
                 return None

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -90,6 +90,8 @@ class Redshift(Postgres):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            consume_pipe: bool = False,
+            wrap_pipe: bool = False,
         ) -> t.Optional[exp.Expression]:
             # Redshift supports UNPIVOTing SUPER objects, e.g. `UNPIVOT foo.obj[0] AS val AT attr`
             unpivot = self._match(TokenType.UNPIVOT)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -799,6 +799,8 @@ class Snowflake(Dialect):
             parse_bracket: bool = False,
             is_db_reference: bool = False,
             parse_partition: bool = False,
+            consume_pipe: bool = False,
+            wrap_pipe: bool = False,
         ) -> t.Optional[exp.Expression]:
             table = super()._parse_table(
                 schema=schema,

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -35,6 +35,30 @@ class TestPipeSyntax(Validator):
             "FROM x |> WHERE x1 > 1 AND x2 > 2 |> SELECT x1 as gt1, x2 as gt2 |> SELECT gt1 * 2 + gt2 * 2 AS gt2_2",
             "WITH __tmp1 AS (SELECT x1 AS gt1, x2 AS gt2 FROM x WHERE x1 > 1 AND x2 > 2), __tmp2 AS (SELECT gt1 * 2 + gt2 * 2 AS gt2_2 FROM __tmp1) SELECT * FROM __tmp2",
         )
+        self.validate_identity(
+            "SELECT 1 AS y, 2 AS x |> SELECT x, y",
+            "WITH __tmp1 AS (SELECT x, y FROM (SELECT 1 AS y, 2 AS x)) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "SELECT x1, x2, x3 FROM x |> AS a_x |> WHERE a_x.x1 > 0",
+            "WITH a_x AS (SELECT x1, x2, x3 FROM x) SELECT * FROM a_x WHERE a_x.x1 > 0",
+        )
+        self.validate_identity(
+            "SELECT x,y FROM (SELECT 1 as x, 2 as y) |> SELECT x, y",
+            "WITH __tmp1 AS (SELECT x, y FROM (SELECT 1 AS x, 2 AS y)) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2 |> EXTEND SUM(item2) OVER() AS item2_sum",
+            "WITH __tmp1 AS (SELECT *, SUM(item2) OVER () AS item2_sum FROM (SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2)) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "SELECT x, x1 FROM (FROM (SELECT 1 as x, 2 as x1) |> AGGREGATE SUM(x1) as xx GROUP BY x,x1) |> SELECT x",
+            "WITH __tmp2 AS (SELECT x FROM (SELECT * FROM (WITH __tmp1 AS (SELECT SUM(x1) AS xx, x, x1 FROM (SELECT 1 AS x, 2 AS x1) GROUP BY x, x1) SELECT * FROM __tmp1))) SELECT * FROM __tmp2",
+        )
+        self.validate_identity(
+            "FROM (SELECT 1 as x1) AS x |> SELECT x.x1 |> UNION ALL (FROM (SELECT 1 AS c) |> SELECT c) |> SELECT x1",
+            "SELECT * FROM (WITH __tmp1 AS (SELECT x.x1 FROM (SELECT 1 AS x1) AS x), __tmp3 AS (SELECT * FROM __tmp1), __tmp4 AS (SELECT * FROM __tmp3 UNION ALL SELECT * FROM (WITH __tmp2 AS (SELECT c FROM (SELECT 1 AS c)) SELECT * FROM __tmp2)), __tmp5 AS (SELECT x1 FROM __tmp4) SELECT * FROM __tmp5)"
+        )
 
     def test_order_by(self):
         self.validate_identity("FROM x |> ORDER BY x1", "SELECT * FROM x ORDER BY x1")
@@ -389,52 +413,7 @@ WHERE
         )
         self.validate_identity(
             "FROM (SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2) |> EXTEND SUM(item2) OVER() AS item2_sum",
-            "WITH __tmp1 AS (SELECT *, SUM(item2) OVER () AS item2_sum FROM (SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2)) SELECT * FROM __tmp1",
-        )
-
-    def test_drop(self):
-        self.validate_identity(
-            "FROM x |> DROP x1, x2",
-            "SELECT * EXCEPT (x1, x2) FROM x",
-        )
-        self.validate_identity("FROM x |> DROP x1 |> DROP x2", "SELECT * EXCEPT (x1, x2) FROM x")
-        self.validate_identity(
-            "FROM x |> SELECT x.x1, x.x2, x.x3 |> DROP x1, x2 |> WHERE x3 > 0",
-            "WITH __tmp1 AS (SELECT x.x1, x.x2, x.x3 FROM x) SELECT * EXCEPT (x1, x2) FROM __tmp1 WHERE x3 > 0",
-        )
-        self.validate_identity(
-            "FROM x |> SELECT x.x1, x.x2, x.x3 |> DROP x1, x2 |> WHERE x3 > 0",
-            "WITH __tmp1 AS (SELECT x.x1, x.x2, x.x3 FROM x) SELECT * EXCEPT (x1, x2) FROM __tmp1 WHERE x3 > 0",
-        )
-        self.validate_identity(
-            "FROM (SELECT 1 AS x, 2 AS y) AS t |> DROP x |> SELECT t.x AS original_x, y",
-            "WITH __tmp1 AS (SELECT * EXCEPT (x), t.x AS original_x FROM (SELECT 1 AS x, 2 AS y) AS t), __tmp2 AS (SELECT original_x, y FROM __tmp1) SELECT * FROM __tmp2",
-        )
-
-        self.validate_identity(
-            "FROM x |> PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2')) |> DROP Q1 |> SELECT *",
-            "WITH __tmp1 AS (SELECT * FROM x PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))), __tmp2 AS (SELECT * EXCEPT (Q1) FROM __tmp1), __tmp3 AS (SELECT * FROM __tmp2) SELECT * FROM __tmp3",
-        )
-        self.validate_identity(
-            "FROM x |> DROP x1 |> DROP x2 |> UNION ALL (SELECT 1 AS c)",
-            "WITH __tmp1 AS (SELECT * EXCEPT (x1, x2) FROM x), __tmp2 AS (SELECT * FROM __tmp1 UNION ALL SELECT 1 AS c) SELECT * FROM __tmp2",
-        )
-
-    def test_set(self):
-        self.validate_identity(
-            "FROM x |> SET x1 = 8 * x1", "SELECT * REPLACE (8 * x1 AS x1) FROM x"
-        )
-        self.validate_identity(
-            "FROM x |> SET x1 = 8 * x1 |> SET x2 = 2",
-            "SELECT * REPLACE (8 * x1 AS x1, 2 AS x2) FROM x",
-        )
-        self.validate_identity(
-            "FROM (SELECT 2 AS x, 3 AS y) AS t |> SET x = t.x * t.x, y = 8 |> SELECT t.x AS original_x, x, y",
-            "WITH __tmp1 AS (SELECT * REPLACE (t.x * t.x AS x, 8 AS y), t.x AS original_x FROM (SELECT 2 AS x, 3 AS y) AS t), __tmp2 AS (SELECT original_x, x, y FROM __tmp1) SELECT * FROM __tmp2",
-        )
-        self.validate_identity(
-            "FROM x |> DROP x1 |> DROP x2 |> SET x3 = 2 * x3 |> UNION ALL (SELECT 1 AS c)",
-            "WITH __tmp1 AS (SELECT * EXCEPT (x1, x2) REPLACE (2 * x3 AS x3) FROM x), __tmp2 AS (SELECT * FROM __tmp1 UNION ALL SELECT 1 AS c) SELECT * FROM __tmp2",
+            "SELECT * FROM (WITH __tmp1 AS (SELECT *, SUM(item2) OVER () AS item2_sum FROM (SELECT 'foo1' AS item1, 2 AS item2 UNION ALL SELECT 'foo2' AS item1, 5 AS item2)) SELECT * FROM __tmp1)",
         )
 
     def test_tablesample(self):


### PR DESCRIPTION
This PR removes the support OF `DROP` and `SET` pipe syntax operators.
Adds support for pipe syntax with nesting and also starting the syntax with `SELECT`.

| Operator           | Implemented |
|--------------------|-------------|
| `FROM`             | ✅          |
| `SELECT`           | ✅          |
| `WHERE`           | ✅          |
| `WHERE (replacing HAVING)`           |    ✅      |
| `WHERE (replacing QUALIFY)`           |   ✅        |
| `EXTEND`           |      ✅      |
| `SET`              |           |
| `RENAME`           |          |
| `DROP`             |          |
| `AS`               |    ✅       |
| `LIMIT`        |    ✅       |
| `AGGREGATE WITH GROUP/ORDER BY`       |   ✅        |
| `ORDER BY` | ✅  |
| `UNION`               |      ✅      |
| `INTERSECT`               |   ✅         |
| `EXCEPT`               |       ✅     |
| `JOIN`           |      ✅       |
| `CALL`               |           |
| `TABLESAMPLE`      |   ✅         |
| `PIVOT`            |       ✅     |
| `UNPIVOT`          |      ✅      |