### PR TITLE
feat(fabric): implement type mappings for unsupported Fabric types

### DIFF
--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 
+from sqlglot import exp
 from sqlglot.dialects.dialect import NormalizationStrategy
 from sqlglot.dialects.tsql import TSQL
 
@@ -27,3 +28,29 @@ class Fabric(TSQL):
 
     # Fabric is case-sensitive unlike T-SQL which is case-insensitive
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_SENSITIVE
+
+    class Generator(TSQL.Generator):
+        # Fabric-specific type mappings - override T-SQL types that aren't supported
+        # Reference: https://learn.microsoft.com/en-us/fabric/data-warehouse/data-types
+        TYPE_MAPPING = {
+            **TSQL.Generator.TYPE_MAPPING,
+            # Fabric doesn't support these types, map to alternatives
+            exp.DataType.Type.MONEY: "DECIMAL",
+            exp.DataType.Type.SMALLMONEY: "DECIMAL",
+            exp.DataType.Type.DATETIME: "DATETIME2",
+            exp.DataType.Type.SMALLDATETIME: "DATETIME2",
+            exp.DataType.Type.TIMESTAMPTZ: "DATETIME2",
+            exp.DataType.Type.NCHAR: "CHAR",
+            exp.DataType.Type.NVARCHAR: "VARCHAR",
+            exp.DataType.Type.TEXT: "VARCHAR",
+            exp.DataType.Type.IMAGE: "VARBINARY",
+            exp.DataType.Type.TINYINT: "SMALLINT",
+            exp.DataType.Type.UTINYINT: "SMALLINT",  # T-SQL parses TINYINT as UTINYINT
+            exp.DataType.Type.JSON: "VARCHAR",
+            exp.DataType.Type.XML: "VARCHAR",
+            exp.DataType.Type.UUID: "VARBINARY(MAX)",  # UNIQUEIDENTIFIER has limitations in Fabric
+            # Override T-SQL mappings that use different names in Fabric
+            exp.DataType.Type.DECIMAL: "DECIMAL",  # T-SQL uses NUMERIC
+            exp.DataType.Type.DOUBLE: "FLOAT",
+            exp.DataType.Type.INT: "INT",  # T-SQL uses INTEGER
+        }

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -1,0 +1,27 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestFabric(Validator):
+    dialect = "fabric"
+
+    def test_type_mappings(self):
+        """Test unsupported types are correctly mapped to their alternatives"""
+        self.validate_all("CAST(x AS TINYINT)", write={"fabric": "CAST(x AS SMALLINT)"})
+        self.validate_all("CAST(x AS DATETIME)", write={"fabric": "CAST(x AS DATETIME2)"})
+        self.validate_all("CAST(x AS SMALLDATETIME)", write={"fabric": "CAST(x AS DATETIME2)"})
+        self.validate_all("CAST(x AS NCHAR)", write={"fabric": "CAST(x AS CHAR)"})
+        self.validate_all("CAST(x AS NVARCHAR)", write={"fabric": "CAST(x AS VARCHAR)"})
+        self.validate_all("CAST(x AS TEXT)", write={"fabric": "CAST(x AS VARCHAR)"})
+        self.validate_all("CAST(x AS IMAGE)", write={"fabric": "CAST(x AS VARBINARY)"})
+        self.validate_all("CAST(x AS MONEY)", write={"fabric": "CAST(x AS DECIMAL)"})
+        self.validate_all("CAST(x AS SMALLMONEY)", write={"fabric": "CAST(x AS DECIMAL)"})
+        self.validate_all("CAST(x AS JSON)", write={"fabric": "CAST(x AS VARCHAR)"})
+        self.validate_all("CAST(x AS XML)", write={"fabric": "CAST(x AS VARCHAR)"})
+        self.validate_all(
+            "CAST(x AS UNIQUEIDENTIFIER)", write={"fabric": "CAST(x AS VARBINARY(MAX))"}
+        )
+        self.validate_all("CAST(x AS TIMESTAMPTZ)", write={"fabric": "CAST(x AS DATETIME2)"})
+        self.validate_all("CAST(x AS DOUBLE)", write={"fabric": "CAST(x AS FLOAT)"})
+        # Test T-SQL override mappings
+        self.validate_all("CAST(x AS DECIMAL)", write={"fabric": "CAST(x AS DECIMAL)"})
+        self.validate_all("CAST(x AS INT)", write={"fabric": "CAST(x AS INT)"})


### PR DESCRIPTION
This pull request introduces support for the Fabric SQL dialect by adding a new `Generator` class with Fabric-specific type mappings and corresponding tests to ensure the mappings are correctly applied. The most important changes include defining type mappings for unsupported or differently named types in Fabric and adding comprehensive tests for these mappings.

### Fabric SQL Dialect Enhancements:

* **Type Mapping for Unsupported/Differently Named Types**:
  - Added a `Generator` class within the `Fabric` dialect to override T-SQL types that are unsupported or have different names in Fabric. Examples include mapping `MONEY` and `SMALLMONEY` to `DECIMAL`, `DATETIME` and `SMALLDATETIME` to `DATETIME2`, and `TINYINT` to `SMALLINT`.

### Testing:

* **Validation of Type Mappings**:
  - Added a new test class `TestFabric` to validate that unsupported types are correctly mapped to their Fabric alternatives. For example, `CAST(x AS TINYINT)` is validated to write as `CAST(x AS SMALLINT)` in Fabric.