### PR TITLE
feat(fabric): Add precision cap to temporal data types

### DIFF
--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -40,7 +40,7 @@ class Fabric(TSQL):
             exp.DataType.Type.SMALLDATETIME: "DATETIME2(6)",
             exp.DataType.Type.NCHAR: "CHAR",
             exp.DataType.Type.NVARCHAR: "VARCHAR",
-            exp.DataType.Type.TEXT: "VARCHAR",
+            exp.DataType.Type.TEXT: "VARCHAR(MAX)",
             exp.DataType.Type.IMAGE: "VARBINARY",
             exp.DataType.Type.TINYINT: "SMALLINT",
             exp.DataType.Type.UTINYINT: "SMALLINT",  # T-SQL parses TINYINT as UTINYINT

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -72,7 +72,7 @@ class Fabric(TSQL):
                 if precision is None:
                     # No precision specified, default to 6
                     target_precision = 6
-                elif isinstance(precision, exp.DataTypeParam) and precision.this.is_int:
+                elif precision.this.is_int:
                     # Cap precision at 6
                     current_precision = precision.this.to_py()
                     target_precision = min(current_precision, 6)

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -66,9 +66,7 @@ class Fabric(TSQL):
                 exp.DataType.Type.TIMESTAMPTZ,  # DATETIMEOFFSET in Fabric
             ):
                 # Get the current precision (first expression if it exists)
-                precision = None
-                if expression.expressions:
-                    precision = expression.expressions[0]
+                precision = expression.find(exp.DataTypeParam)
 
                 # Determine the target precision
                 if precision is None:

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -82,7 +82,7 @@ class Fabric(TSQL):
                 # Create a new expression with the target precision
                 new_expression = exp.DataType(
                     this=expression.this,
-                    expressions=[exp.DataTypeParam(this=exp.Literal.number(str(target_precision)))],
+                    expressions=[exp.DataTypeParam(this=exp.Literal.number(target_precision))],
                 )
 
                 return super().datatype_sql(new_expression)

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -78,9 +78,6 @@ class Fabric(TSQL):
                     # Cap precision at 6
                     current_precision = int(precision.this.this)
                     target_precision = min(current_precision, 6)
-                else:
-                    # Non-literal precision, leave as-is
-                    return super().datatype_sql(expression)
 
                 # Create a new expression with the target precision
                 new_expression = exp.DataType(

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -74,11 +74,7 @@ class Fabric(TSQL):
                 if precision is None:
                     # No precision specified, default to 6
                     target_precision = 6
-                elif (
-                    isinstance(precision, exp.DataTypeParam)
-                    and isinstance(precision.this, exp.Literal)
-                    and precision.this.is_int
-                ):
+                elif isinstance(precision, exp.DataTypeParam) and precision.this.is_int:
                     # Cap precision at 6
                     current_precision = int(precision.this.this)
                     target_precision = min(current_precision, 6)

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -74,7 +74,7 @@ class Fabric(TSQL):
                     target_precision = 6
                 elif isinstance(precision, exp.DataTypeParam) and precision.this.is_int:
                     # Cap precision at 6
-                    current_precision = int(precision.this.this)
+                    current_precision = precision.this.to_py()
                     target_precision = min(current_precision, 6)
 
                 # Create a new expression with the target precision

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -11,7 +11,7 @@ class TestFabric(Validator):
         self.validate_all("CAST(x AS SMALLDATETIME)", write={"fabric": "CAST(x AS DATETIME2(6))"})
         self.validate_all("CAST(x AS NCHAR)", write={"fabric": "CAST(x AS CHAR)"})
         self.validate_all("CAST(x AS NVARCHAR)", write={"fabric": "CAST(x AS VARCHAR)"})
-        self.validate_all("CAST(x AS TEXT)", write={"fabric": "CAST(x AS VARCHAR)"})
+        self.validate_all("CAST(x AS TEXT)", write={"fabric": "CAST(x AS VARCHAR(MAX))"})
         self.validate_all("CAST(x AS IMAGE)", write={"fabric": "CAST(x AS VARBINARY)"})
         self.validate_all("CAST(x AS MONEY)", write={"fabric": "CAST(x AS DECIMAL)"})
         self.validate_all("CAST(x AS SMALLMONEY)", write={"fabric": "CAST(x AS DECIMAL)"})

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -7,8 +7,8 @@ class TestFabric(Validator):
     def test_type_mappings(self):
         """Test unsupported types are correctly mapped to their alternatives"""
         self.validate_all("CAST(x AS TINYINT)", write={"fabric": "CAST(x AS SMALLINT)"})
-        self.validate_all("CAST(x AS DATETIME)", write={"fabric": "CAST(x AS DATETIME2)"})
-        self.validate_all("CAST(x AS SMALLDATETIME)", write={"fabric": "CAST(x AS DATETIME2)"})
+        self.validate_all("CAST(x AS DATETIME)", write={"fabric": "CAST(x AS DATETIME2(6))"})
+        self.validate_all("CAST(x AS SMALLDATETIME)", write={"fabric": "CAST(x AS DATETIME2(6))"})
         self.validate_all("CAST(x AS NCHAR)", write={"fabric": "CAST(x AS CHAR)"})
         self.validate_all("CAST(x AS NVARCHAR)", write={"fabric": "CAST(x AS VARCHAR)"})
         self.validate_all("CAST(x AS TEXT)", write={"fabric": "CAST(x AS VARCHAR)"})
@@ -20,8 +20,45 @@ class TestFabric(Validator):
         self.validate_all(
             "CAST(x AS UNIQUEIDENTIFIER)", write={"fabric": "CAST(x AS VARBINARY(MAX))"}
         )
-        self.validate_all("CAST(x AS TIMESTAMPTZ)", write={"fabric": "CAST(x AS DATETIME2)"})
+        self.validate_all(
+            "CAST(x AS TIMESTAMPTZ)", write={"fabric": "CAST(x AS DATETIMEOFFSET(6))"}
+        )
         self.validate_all("CAST(x AS DOUBLE)", write={"fabric": "CAST(x AS FLOAT)"})
         # Test T-SQL override mappings
         self.validate_all("CAST(x AS DECIMAL)", write={"fabric": "CAST(x AS DECIMAL)"})
         self.validate_all("CAST(x AS INT)", write={"fabric": "CAST(x AS INT)"})
+
+    def test_precision_capping(self):
+        """Test that TIME, DATETIME2 & DATETIMEOFFSET precision is capped at 6 digits"""
+        # Default precision should be 6
+        self.validate_all("CAST(x AS TIME)", write={"fabric": "CAST(x AS TIME(6))"})
+        self.validate_all("CAST(x AS DATETIME2)", write={"fabric": "CAST(x AS DATETIME2(6))"})
+        self.validate_all(
+            "CAST(x AS DATETIMEOFFSET)", write={"fabric": "CAST(x AS DATETIMEOFFSET(6))"}
+        )
+
+        # Precision <= 6 should be preserved
+        self.validate_all("CAST(x AS TIME(3))", write={"fabric": "CAST(x AS TIME(3))"})
+        self.validate_all("CAST(x AS DATETIME2(3))", write={"fabric": "CAST(x AS DATETIME2(3))"})
+        self.validate_all(
+            "CAST(x AS DATETIMEOFFSET(3))", write={"fabric": "CAST(x AS DATETIMEOFFSET(3))"}
+        )
+
+        self.validate_all("CAST(x AS TIME(6))", write={"fabric": "CAST(x AS TIME(6))"})
+        self.validate_all("CAST(x AS DATETIME2(6))", write={"fabric": "CAST(x AS DATETIME2(6))"})
+        self.validate_all(
+            "CAST(x AS DATETIMEOFFSET(6))", write={"fabric": "CAST(x AS DATETIMEOFFSET(6))"}
+        )
+
+        # Precision > 6 should be capped at 6
+        self.validate_all("CAST(x AS TIME(7))", write={"fabric": "CAST(x AS TIME(6))"})
+        self.validate_all("CAST(x AS DATETIME2(7))", write={"fabric": "CAST(x AS DATETIME2(6))"})
+        self.validate_all(
+            "CAST(x AS DATETIMEOFFSET(7))", write={"fabric": "CAST(x AS DATETIMEOFFSET(6))"}
+        )
+
+        self.validate_all("CAST(x AS TIME(9))", write={"fabric": "CAST(x AS TIME(6))"})
+        self.validate_all("CAST(x AS DATETIME2(9))", write={"fabric": "CAST(x AS DATETIME2(6))"})
+        self.validate_all(
+            "CAST(x AS DATETIMEOFFSET(9))", write={"fabric": "CAST(x AS DATETIMEOFFSET(6))"}
+        )


### PR DESCRIPTION
This pull request introduces Fabric-specific enhancements to the SQLGlot library, focusing on precision handling. The changes ensure compatibility with Microsoft Fabric's data warehouse by adding precision constraints for temporal data types.

### Fabric dialect enhancements:

* Implemented a custom `datatype_sql` method to cap precision for temporal types (`TIME`, `DATETIME2`, `DATETIMEOFFSET`) at 6 digits, defaulting to 6 when unspecified.

>**NOTE:** Depends on #5249