### PR TITLE
Fix(presto)!: cast constructed timestamp literal to zone-aware type if needed

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -315,6 +315,7 @@ class Presto(Dialect):
 
     class Parser(parser.Parser):
         VALUES_FOLLOWED_BY_PAREN = False
+        LITERAL_TYPE_CONSTRUCTOR_IS_CAST = False
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
@@ -601,6 +602,14 @@ class Presto(Dialect):
             "where",
             "with",
         }
+
+        def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
+            if expression.args.get("constructor"):
+                this = self.sql(expression, "this")
+                dtype = self.sql(expression, "to")
+                return f"{dtype} {this}"
+
+            return super().cast_sql(expression, safe_prefix=safe_prefix)
 
         def jsonformat_sql(self, expression: exp.JSONFormat) -> str:
             this = expression.this

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -315,7 +315,7 @@ class Presto(Dialect):
 
     class Parser(parser.Parser):
         VALUES_FOLLOWED_BY_PAREN = False
-        LITERAL_TYPE_CONSTRUCTOR_IS_CAST = False
+        ZONE_AWARE_TIMESTAMP_CONSTRUCTOR = True
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
@@ -602,14 +602,6 @@ class Presto(Dialect):
             "where",
             "with",
         }
-
-        def cast_sql(self, expression: exp.Cast, safe_prefix: t.Optional[str] = None) -> str:
-            if expression.args.get("constructor"):
-                this = self.sql(expression, "this")
-                dtype = self.sql(expression, "to")
-                return f"{dtype} {this}"
-
-            return super().cast_sql(expression, safe_prefix=safe_prefix)
 
         def jsonformat_sql(self, expression: exp.JSONFormat) -> str:
             this = expression.this

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5685,7 +5685,6 @@ class Cast(Func):
         "safe": False,
         "action": False,
         "default": False,
-        "constructor": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5685,6 +5685,7 @@ class Cast(Func):
         "safe": False,
         "action": False,
         "default": False,
+        "constructor": False,
     }
 
     @property

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1522,6 +1522,10 @@ class Parser(metaclass=_Parser):
     # as BigQuery, where all joins have the same precedence.
     JOINS_HAVE_EQUAL_PRECEDENCE = False
 
+    # Whether the semantics of <type> <literal> are equivalent to CAST(<literal> AS <type).
+    # In Presto, TIMESTAMP ts is not the same as CAST(ts AS TIMESTAMP) if time zone is included.
+    LITERAL_TYPE_CONSTRUCTOR_IS_CAST = True
+
     __slots__ = (
         "error_level",
         "error_message_context",
@@ -5132,7 +5136,12 @@ class Parser(metaclass=_Parser):
                 if parser:
                     return parser(self, this, data_type)
 
-                return self.expression(exp.Cast, this=this, to=data_type)
+                return self.expression(
+                    exp.Cast,
+                    this=this,
+                    to=data_type,
+                    constructor=not self.LITERAL_TYPE_CONSTRUCTOR_IS_CAST,
+                )
 
             # The expressions arg gets set by the parser when we have something like DECIMAL(38, 0)
             # in the input SQL. In that case, we'll produce these tokens: DECIMAL ( 38 , 0 )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -7,18 +7,21 @@ class TestPresto(Validator):
     dialect = "presto"
 
     def test_cast(self):
-        self.validate_identity("TIMESTAMP '2025-06-20 11:22:29 Europe/Prague'")
         self.validate_identity("DEALLOCATE PREPARE my_query", check_command_warning=True)
         self.validate_identity("DESCRIBE INPUT x", check_command_warning=True)
         self.validate_identity("DESCRIBE OUTPUT x", check_command_warning=True)
-        self.validate_identity(
-            "RESET SESSION hive.optimized_reader_enabled", check_command_warning=True
-        )
         self.validate_identity("SELECT * FROM x qualify", "SELECT * FROM x AS qualify")
         self.validate_identity("CAST(x AS IPADDRESS)")
         self.validate_identity("CAST(x AS IPPREFIX)")
         self.validate_identity("CAST(TDIGEST_AGG(1) AS TDIGEST)")
         self.validate_identity("CAST(x AS HYPERLOGLOG)")
+        self.validate_identity(
+            "RESET SESSION hive.optimized_reader_enabled", check_command_warning=True
+        )
+        self.validate_identity(
+            "TIMESTAMP '2025-06-20 11:22:29 Europe/Prague'",
+            "CAST('2025-06-20 11:22:29 Europe/Prague' AS TIMESTAMP WITH TIME ZONE)",
+        )
 
         self.validate_all(
             "CAST(x AS BOOLEAN)",
@@ -376,7 +379,7 @@ class TestPresto(Validator):
             "DAY_OF_MONTH(timestamp '2012-08-08 01:00:00')",
             write={
                 "spark": "DAYOFMONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_MONTH(TIMESTAMP '2012-08-08 01:00:00')",
+                "presto": "DAY_OF_MONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
                 "duckdb": "DAYOFMONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
@@ -385,7 +388,7 @@ class TestPresto(Validator):
             "DAY_OF_YEAR(timestamp '2012-08-08 01:00:00')",
             write={
                 "spark": "DAYOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_YEAR(TIMESTAMP '2012-08-08 01:00:00')",
+                "presto": "DAY_OF_YEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
                 "duckdb": "DAYOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
@@ -394,7 +397,7 @@ class TestPresto(Validator):
             "WEEK_OF_YEAR(timestamp '2012-08-08 01:00:00')",
             write={
                 "spark": "WEEKOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "presto": "WEEK_OF_YEAR(TIMESTAMP '2012-08-08 01:00:00')",
+                "presto": "WEEK_OF_YEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
                 "duckdb": "WEEKOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -7,6 +7,7 @@ class TestPresto(Validator):
     dialect = "presto"
 
     def test_cast(self):
+        self.validate_identity("TIMESTAMP '2025-06-20 11:22:29 Europe/Prague'")
         self.validate_identity("DEALLOCATE PREPARE my_query", check_command_warning=True)
         self.validate_identity("DESCRIBE INPUT x", check_command_warning=True)
         self.validate_identity("DESCRIBE OUTPUT x", check_command_warning=True)
@@ -375,7 +376,7 @@ class TestPresto(Validator):
             "DAY_OF_MONTH(timestamp '2012-08-08 01:00:00')",
             write={
                 "spark": "DAYOFMONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_MONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "DAY_OF_MONTH(TIMESTAMP '2012-08-08 01:00:00')",
                 "duckdb": "DAYOFMONTH(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
@@ -384,7 +385,7 @@ class TestPresto(Validator):
             "DAY_OF_YEAR(timestamp '2012-08-08 01:00:00')",
             write={
                 "spark": "DAYOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "presto": "DAY_OF_YEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "DAY_OF_YEAR(TIMESTAMP '2012-08-08 01:00:00')",
                 "duckdb": "DAYOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )
@@ -393,7 +394,7 @@ class TestPresto(Validator):
             "WEEK_OF_YEAR(timestamp '2012-08-08 01:00:00')",
             write={
                 "spark": "WEEKOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
-                "presto": "WEEK_OF_YEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
+                "presto": "WEEK_OF_YEAR(TIMESTAMP '2012-08-08 01:00:00')",
                 "duckdb": "WEEKOFYEAR(CAST('2012-08-08 01:00:00' AS TIMESTAMP))",
             },
         )

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -5,6 +5,7 @@ class TestTrino(Validator):
     dialect = "trino"
 
     def test_trino(self):
+        self.validate_identity("TIMESTAMP '2025-06-20 11:22:29 Europe/Prague'")
         self.validate_identity("JSON_QUERY(m.properties, 'lax $.area' OMIT QUOTES NULL ON ERROR)")
         self.validate_identity("JSON_EXTRACT(content, json_path)")
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -5,7 +5,6 @@ class TestTrino(Validator):
     dialect = "trino"
 
     def test_trino(self):
-        self.validate_identity("TIMESTAMP '2025-06-20 11:22:29 Europe/Prague'")
         self.validate_identity("JSON_QUERY(m.properties, 'lax $.area' OMIT QUOTES NULL ON ERROR)")
         self.validate_identity("JSON_EXTRACT(content, json_path)")
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")
@@ -19,6 +18,22 @@ class TestTrino(Validator):
         )
         self.validate_identity(
             "JSON_QUERY(content, 'strict $.HY.*' WITH UNCONDITIONAL WRAPPER KEEP QUOTES)"
+        )
+        self.validate_identity(
+            "SELECT TIMESTAMP '2012-10-31 01:00 -2'",
+            "SELECT CAST('2012-10-31 01:00 -2' AS TIMESTAMP WITH TIME ZONE)",
+        )
+        self.validate_identity(
+            "SELECT TIMESTAMP '2012-10-31 01:00 +2'",
+            "SELECT CAST('2012-10-31 01:00 +2' AS TIMESTAMP WITH TIME ZONE)",
+        )
+
+        self.validate_all(
+            "SELECT TIMESTAMP '2012-10-31 01:00:00 +02:00'",
+            write={
+                "duckdb": "SELECT CAST('2012-10-31 01:00:00 +02:00' AS TIMESTAMPTZ)",
+                "trino": "SELECT CAST('2012-10-31 01:00:00 +02:00' AS TIMESTAMP WITH TIME ZONE)",
+            },
         )
 
     def test_listagg(self):


### PR DESCRIPTION
Fixes #5252
