### PR TITLE
fix(redshift): handle scale parameter in to_timestamp

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -214,7 +214,7 @@ class Redshift(Postgres):
             exp.TsOrDsAdd: date_delta_sql("DATEADD"),
             exp.TsOrDsDiff: date_delta_sql("DATEDIFF"),
             exp.UnixToTime: lambda self,
-            e: f"(TIMESTAMP 'epoch' + {self.sql(e.this)} * INTERVAL '1 SECOND')",
+            e: self._unix_to_time_sql(e),
         }
 
         # Postgres maps exp.Pivot to no_pivot_sql, but Redshift support pivots
@@ -447,3 +447,11 @@ class Redshift(Postgres):
         def explode_sql(self, expression: exp.Explode) -> str:
             self.unsupported("Unsupported EXPLODE() function")
             return ""
+
+        def _unix_to_time_sql(self, expression: exp.UnixToTime) -> str:
+            scale = expression.args.get("scale")
+
+            if scale not in (None, exp.UnixToTime.SECONDS) and isinstance(scale, exp.Literal) and scale.is_int:
+                return f"(TIMESTAMP 'epoch' + ({self.sql(expression.this)} / POWER(10, {scale.to_py()})) * INTERVAL '1 SECOND')"
+        
+            return f"(TIMESTAMP 'epoch' + {self.sql(expression.this)} * INTERVAL '1 SECOND')"

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -746,6 +746,7 @@ class TestSnowflake(Validator):
                 "bigquery": "SELECT TIMESTAMP_SECONDS(1659981729)",
                 "snowflake": "SELECT TO_TIMESTAMP(1659981729)",
                 "spark": "SELECT CAST(FROM_UNIXTIME(1659981729) AS TIMESTAMP)",
+                "redshift": "SELECT (TIMESTAMP 'epoch' + 1659981729 * INTERVAL '1 SECOND')",
             },
         )
         self.validate_all(
@@ -754,6 +755,7 @@ class TestSnowflake(Validator):
                 "bigquery": "SELECT TIMESTAMP_MILLIS(1659981729000)",
                 "snowflake": "SELECT TO_TIMESTAMP(1659981729000, 3)",
                 "spark": "SELECT TIMESTAMP_MILLIS(1659981729000)",
+                "redshift": "SELECT (TIMESTAMP 'epoch' + (1659981729000 / POWER(10, 3)) * INTERVAL '1 SECOND')",
             },
         )
         self.validate_all(
@@ -762,6 +764,7 @@ class TestSnowflake(Validator):
                 "bigquery": "SELECT TIMESTAMP_SECONDS(CAST(16599817290000 / POWER(10, 4) AS INT64))",
                 "snowflake": "SELECT TO_TIMESTAMP(16599817290000, 4)",
                 "spark": "SELECT TIMESTAMP_SECONDS(16599817290000 / POWER(10, 4))",
+                "redshift": "SELECT (TIMESTAMP 'epoch' + (16599817290000 / POWER(10, 4)) * INTERVAL '1 SECOND')",
             },
         )
         self.validate_all(
@@ -779,6 +782,7 @@ class TestSnowflake(Validator):
                 "presto": "SELECT FROM_UNIXTIME(CAST(1659981729000000000 AS DOUBLE) / POW(10, 9))",
                 "snowflake": "SELECT TO_TIMESTAMP(1659981729000000000, 9)",
                 "spark": "SELECT TIMESTAMP_SECONDS(1659981729000000000 / POWER(10, 9))",
+                "redshift": "SELECT (TIMESTAMP 'epoch' + (1659981729000000000 / POWER(10, 9)) * INTERVAL '1 SECOND')",
             },
         )
         self.validate_all(


### PR DESCRIPTION
PR addressing [this issue](https://github.com/tobymao/sqlglot/issues/5265).

Since Redshift does not have an equivalent to the function `TO_TIMESTAMP`, this PR just extends the existing solution by dividing the unix epoch by the appropriate power of 10.

As an example of the change, the query mentioned in the issue `(SELECT TO_TIMESTAMP(1659981729000, 3))` is now transpiled to `SELECT (TIMESTAMP 'epoch' + (16599817290000 / POWER(10, 4)) * INTERVAL '1 SECOND')`.