### PR TITLE
fix(athena): avoid escaping backslashes when generating athena `SELECT` statements

### DIFF
--- a/sqlglot/dialects/athena.py
+++ b/sqlglot/dialects/athena.py
@@ -165,3 +165,6 @@ class Athena(Trino):
                 return self._hive_generator.generate(expression, copy)
 
             return super().generate(expression, copy)
+
+
+del Athena.UNESCAPED_SEQUENCES["\\\\"], Athena.ESCAPED_SEQUENCES["\\"]

--- a/tests/dialects/test_athena.py
+++ b/tests/dialects/test_athena.py
@@ -36,6 +36,7 @@ class TestAthena(Validator):
             write_sql='/* leading comment */ SELECT * FROM "foo"',
             identify=True,
         )
+        self.validate_identity(r"SELECT '\d+'")
 
     def test_ddl(self):
         # Hive-like, https://docs.aws.amazon.com/athena/latest/ug/create-table.html


### PR DESCRIPTION
Closes #5267.