### PR TITLE
feat(fabric): implement UnixToTime transformation to DATEADD syntax

### DIFF
--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -50,3 +50,11 @@ class TestFabric(Validator):
         self.validate_identity("CAST(x AS TIME(9))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(9))", "CAST(x AS DATETIME2(6))")
         self.validate_identity("CAST(x AS DATETIMEOFFSET(9))", "CAST(x AS DATETIMEOFFSET(6))")
+
+    def test_unix_to_time(self):
+        """Test UnixToTime transformation to DATEADD with microseconds"""
+
+        self.validate_identity(
+            "UNIX_TO_TIME(column)",
+            "DATEADD(MICROSECONDS, CAST(ROUND(column * 1e6, 0) AS BIGINT), CAST('1970-01-01' AS DATETIME2(6)))",
+        )


### PR DESCRIPTION
This pull request introduces enhancements to the `Fabric` dialect in `sqlglot`, focusing on adding support for Unix timestamp transformations, improving precision handling, and expanding test coverage. The most important changes include implementing a transformation for `UnixToTime`, capping precision for certain data types, and adding tests for the new functionality.

### Enhancements to the `Fabric` dialect:

* **Unix timestamp transformation**: Added a `_unix_to_time_sql` method to transform `UnixToTime` expressions into the Fabric-specific `DATEADD` syntax, which converts Unix timestamps into datetime values with microsecond precision.
* **Precision handling**: Updated `datatype_sql` to cap precision at 6 for certain data types and added a fallback to default precision of 6 for non-integer precision values.

### Test coverage improvements:

* **New test for Unix timestamp transformation**: Added a `test_unix_to_time` method to validate the transformation of `UNIX_TO_TIME(column)` into the correct `DATEADD` syntax.…nd add corresponding test