### PR TITLE
feat(hive)!: Transpile exp.PosExplode pos column alias

### DIFF
--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1564,7 +1564,9 @@ class TestDialect(Validator):
             "SELECT a FROM x CROSS JOIN UNNEST(y) WITH ORDINALITY AS t (a)",
             write={
                 "presto": "SELECT a FROM x CROSS JOIN UNNEST(y) WITH ORDINALITY AS t(a)",
-                "spark": "SELECT a FROM x LATERAL VIEW POSEXPLODE(y) t AS a",
+                "spark2": "SELECT a FROM x LATERAL VIEW POSEXPLODE(y) t AS a, pos",
+                "spark": "SELECT a FROM x LATERAL VIEW POSEXPLODE(y) t AS a, pos",
+                "databricks": "SELECT a FROM x LATERAL VIEW POSEXPLODE(y) t AS a, pos",
             },
         )
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5271

- Without offset alias:

```SQL
bigquery> WITH tbl AS (SELECT 1 AS col) SELECT * FROM tbl CROSS JOIN UNNEST([3, 2, 1]) AS ref WITH OFFSET
col	ref	offset
1	3	0
1	2	1
1	1	2


spark-sql (default)> WITH tbl AS (SELECT 1 AS col) SELECT * FROM tbl LATERAL VIEW POSEXPLODE(ARRAY(3, 2, 1)) AS offset, ref;
col     offset  ref
1       0       3
1       1       2
1       2       1
```

- With offset alias
```SQL
bigquery> WITH tbl AS (SELECT 1 AS col) SELECT * FROM tbl CROSS JOIN UNNEST([3, 2, 1]) AS ref WITH OFFSET AS pos
col	ref	pos
1	3	0
1	2	1
1	1	2


spark-sql (default)> WITH tbl AS (SELECT 1 AS col) SELECT * FROM tbl LATERAL VIEW POSEXPLODE(ARRAY(3, 2, 1)) AS pos, ref;
col     offset  pos
1       0       3
1       1       2
1       2       1
```


Docs
---------
[BigQuery](https://cloud.google.com/bigquery/docs/arrays) | [Spark / DBX](https://docs.databricks.com/aws/en/sql/language-manual/functions/posexplode)