### PR TITLE
fix: change posexplode alias order when transpile bigquery unnest with offset

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -356,7 +356,9 @@ def unnest_to_explode(
             offset = unnest.args.get("offset")
             if offset:
                 # For posexplode, offset should come first, then the value column
-                offset_col = offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
+                offset_col = (
+                    offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
+                )
                 columns = [offset_col] + columns
 
             unnest.replace(
@@ -403,7 +405,9 @@ def unnest_to_explode(
                 offset = unnest.args.get("offset")
                 if offset:
                     # For posexplode, offset should come first, then the value column
-                    offset_col = offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
+                    offset_col = (
+                        offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
+                    )
                     alias_cols = [offset_col] + alias_cols
 
                 for e, column in zip(exprs, alias_cols):
@@ -925,9 +929,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
             if not left_join_table:
                 continue
 
-            assert not (
-                len(left_join_table) > 1
-            ), "Cannot combine JOIN predicates from different tables"
+            assert not (len(left_join_table) > 1), (
+                "Cannot combine JOIN predicates from different tables"
+            )
 
             for col in join_cols:
                 col.set("join_mark", False)
@@ -957,9 +961,9 @@ def eliminate_join_marks(expression: exp.Expression) -> exp.Expression:
 
         if query_from.alias_or_name in new_joins:
             only_old_joins = old_joins.keys() - new_joins.keys()
-            assert (
-                len(only_old_joins) >= 1
-            ), "Cannot determine which table to use in the new FROM clause"
+            assert len(only_old_joins) >= 1, (
+                "Cannot determine which table to use in the new FROM clause"
+            )
 
             new_from_name = list(only_old_joins)[0]
             query.set("from", exp.From(this=old_joins[new_from_name].this))

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -355,9 +355,9 @@ def unnest_to_explode(
             columns = alias.columns if alias else []
             offset = unnest.args.get("offset")
             if offset:
-                columns.append(
-                    offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
-                )
+                # For posexplode, offset should come first, then the value column
+                offset_col = offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
+                columns = [offset_col] + columns
 
             unnest.replace(
                 exp.Table(
@@ -402,9 +402,9 @@ def unnest_to_explode(
 
                 offset = unnest.args.get("offset")
                 if offset:
-                    alias_cols.append(
-                        offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
-                    )
+                    # For posexplode, offset should come first, then the value column
+                    offset_col = offset if isinstance(offset, exp.Identifier) else exp.to_identifier("pos")
+                    alias_cols = [offset_col] + alias_cols
 
                 for e, column in zip(exprs, alias_cols):
                     expression.append(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2639,9 +2639,9 @@ OPTIONS (
                 f"SELECT * FROM tbl CROSS JOIN UNNEST(col) AS ref WITH OFFSET {offset}",
                 write={
                     "bigquery": f"SELECT * FROM tbl CROSS JOIN UNNEST(col) AS ref WITH OFFSET AS {alias}",
-                    "hive": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS ref, {alias}",
-                    "spark2": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS ref, {alias}",
-                    "spark": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS ref, {alias}",
-                    "databricks": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS ref, {alias}",
+                    "hive": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS {alias}, ref",
+                    "spark2": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS {alias}, ref",
+                    "spark": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS {alias}, ref",
+                    "databricks": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS {alias}, ref",
                 },
             )


### PR DESCRIPTION
fix: #5274 
related: #5271 

I raised the issue about transpiling bigquery unnest with offset into spark posexplode correctly and #5274 pr resolved that. 
but i found that there is alias ordering problem in transpiled result so i fix it!

original query
```
SELECT * FROM tbl CROSS JOIN UNNEST(col) AS ref WITH OFFSET AS {alias}
```

before:
```
SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS ref, {alias}
```

after:
```
SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS {alias}, ref
```