### PR TITLE
fix(fabric): Type mismatches and precision error

### DIFF
--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from sqlglot import exp
 from sqlglot.dialects.dialect import NormalizationStrategy
 from sqlglot.dialects.tsql import TSQL
+from sqlglot.tokens import TokenType
 
 
 class Fabric(TSQL):
@@ -28,29 +29,42 @@ class Fabric(TSQL):
     # Fabric is case-sensitive unlike T-SQL which is case-insensitive
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_SENSITIVE
 
+    class Tokenizer(TSQL.Tokenizer):
+        # Override T-SQL tokenizer to handle TIMESTAMP differently
+        # In T-SQL, TIMESTAMP is a synonym for ROWVERSION, but in Fabric we want it to be a datetime type
+        # Also add UTINYINT keyword mapping since T-SQL doesn't have it
+        KEYWORDS = {
+            **TSQL.Tokenizer.KEYWORDS,
+            "TIMESTAMP": TokenType.TIMESTAMP,  # Override T-SQL's mapping of TIMESTAMP to ROWVERSION
+            "UTINYINT": TokenType.UTINYINT,  # Add UTINYINT keyword that T-SQL is missing
+        }
+
     class Generator(TSQL.Generator):
         # Fabric-specific type mappings - override T-SQL types that aren't supported
         # Reference: https://learn.microsoft.com/en-us/fabric/data-warehouse/data-types
         TYPE_MAPPING = {
-            **TSQL.Generator.TYPE_MAPPING,
-            # Fabric doesn't support these types, map to alternatives
-            exp.DataType.Type.MONEY: "DECIMAL",
-            exp.DataType.Type.SMALLMONEY: "DECIMAL",
+            exp.DataType.Type.BOOLEAN: "BIT",
             exp.DataType.Type.DATETIME: "DATETIME2(6)",
-            exp.DataType.Type.SMALLDATETIME: "DATETIME2(6)",
+            exp.DataType.Type.DECIMAL: "DECIMAL",
+            exp.DataType.Type.DOUBLE: "FLOAT",
+            exp.DataType.Type.IMAGE: "VARBINARY",
+            exp.DataType.Type.INT: "INT",
+            exp.DataType.Type.JSON: "VARCHAR",
+            exp.DataType.Type.MONEY: "DECIMAL",
             exp.DataType.Type.NCHAR: "CHAR",
             exp.DataType.Type.NVARCHAR: "VARCHAR",
+            exp.DataType.Type.ROWVERSION: "ROWVERSION",
+            exp.DataType.Type.SMALLDATETIME: "DATETIME2(6)",
+            exp.DataType.Type.SMALLMONEY: "DECIMAL",
             exp.DataType.Type.TEXT: "VARCHAR(MAX)",
-            exp.DataType.Type.IMAGE: "VARBINARY",
+            exp.DataType.Type.TIMESTAMP: "DATETIME2(6)",
+            exp.DataType.Type.TIMESTAMPNTZ: "DATETIME2(6)",
+            exp.DataType.Type.TIMESTAMPTZ: "DATETIMEOFFSET(6)",
             exp.DataType.Type.TINYINT: "SMALLINT",
-            exp.DataType.Type.UTINYINT: "SMALLINT",  # T-SQL parses TINYINT as UTINYINT
-            exp.DataType.Type.JSON: "VARCHAR",
+            exp.DataType.Type.UTINYINT: "SMALLINT",
+            exp.DataType.Type.UUID: "VARBINARY(MAX)",
+            exp.DataType.Type.VARIANT: "SQL_VARIANT",
             exp.DataType.Type.XML: "VARCHAR",
-            exp.DataType.Type.UUID: "VARBINARY(MAX)",  # UNIQUEIDENTIFIER has limitations in Fabric
-            # Override T-SQL mappings that use different names in Fabric
-            exp.DataType.Type.DECIMAL: "DECIMAL",  # T-SQL uses NUMERIC
-            exp.DataType.Type.DOUBLE: "FLOAT",
-            exp.DataType.Type.INT: "INT",  # T-SQL uses INTEGER
         }
 
         def datatype_sql(self, expression: exp.DataType) -> str:
@@ -60,29 +74,35 @@ class Fabric(TSQL):
             Fabric limits temporal types (TIME, DATETIME2, DATETIMEOFFSET) to max 6 digits precision.
             When no precision is specified, we default to 6 digits.
             """
+            # First apply the parent type mapping to get the correct base type
+            result = super().datatype_sql(expression)
+
+            # Check if this is a temporal type that needs precision handling
             if expression.is_type(
                 exp.DataType.Type.TIME,
                 exp.DataType.Type.DATETIME2,
-                exp.DataType.Type.TIMESTAMPTZ,  # DATETIMEOFFSET in Fabric
+                exp.DataType.Type.TIMESTAMPTZ,  # Maps to DATETIMEOFFSET in Fabric
+                exp.DataType.Type.TIMESTAMP,  # Maps to DATETIME2 in Fabric
+                exp.DataType.Type.TIMESTAMPNTZ,  # Maps to DATETIME2 in Fabric
+                exp.DataType.Type.DATETIME,  # Maps to DATETIME2 in Fabric
+                exp.DataType.Type.SMALLDATETIME,  # Maps to DATETIME2 in Fabric
             ):
                 # Get the current precision (first expression if it exists)
-                precision = expression.find(exp.DataTypeParam)
+                precision_param = expression.find(exp.DataTypeParam)
+                target_precision = 6  # Default precision
 
-                # Determine the target precision
-                if precision is None:
-                    # No precision specified, default to 6
-                    target_precision = 6
-                elif precision.this.is_int:
+                if precision_param and precision_param.this.is_int:
                     # Cap precision at 6
-                    current_precision = precision.this.to_py()
+                    current_precision = precision_param.this.to_py()
                     target_precision = min(current_precision, 6)
 
-                # Create a new expression with the target precision
-                new_expression = exp.DataType(
-                    this=expression.this,
-                    expressions=[exp.DataTypeParam(this=exp.Literal.number(target_precision))],
-                )
+                # Extract the base type from the result and add precision
+                if "(" in result:
+                    # Type already has parameters, extract just the type name
+                    base_type = result.split("(")[0]
+                else:
+                    base_type = result
 
-                return super().datatype_sql(new_expression)
+                return f"{base_type}({target_precision})"
 
-            return super().datatype_sql(expression)
+            return result

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -6,25 +6,29 @@ class TestFabric(Validator):
     maxDiff = None
 
     def test_type_mappings(self):
-        """Test unsupported types are correctly mapped to their alternatives"""
-        self.validate_identity("CAST(x AS TINYINT)", "CAST(x AS SMALLINT)")
+        """Test that types are correctly mapped to their alternatives"""
+        self.validate_identity("CAST(x AS BOOLEAN)", "CAST(x AS BIT)")
         self.validate_identity("CAST(x AS DATETIME)", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS SMALLDATETIME)", "CAST(x AS DATETIME2(6))")
+        self.validate_identity("CAST(x AS DECIMAL)", "CAST(x AS DECIMAL)")
+        self.validate_identity("CAST(x AS DOUBLE)", "CAST(x AS FLOAT)")
+        self.validate_identity("CAST(x AS IMAGE)", "CAST(x AS VARBINARY)")
+        self.validate_identity("CAST(x AS INT)", "CAST(x AS INT)")
+        self.validate_identity("CAST(x AS JSON)", "CAST(x AS VARCHAR)")
+        self.validate_identity("CAST(x AS MONEY)", "CAST(x AS DECIMAL)")
         self.validate_identity("CAST(x AS NCHAR)", "CAST(x AS CHAR)")
         self.validate_identity("CAST(x AS NVARCHAR)", "CAST(x AS VARCHAR)")
-        self.validate_identity("CAST(x AS TEXT)", "CAST(x AS VARCHAR(MAX))")
-        self.validate_identity("CAST(x AS IMAGE)", "CAST(x AS VARBINARY)")
-        self.validate_identity("CAST(x AS MONEY)", "CAST(x AS DECIMAL)")
+        self.validate_identity("CAST(x AS ROWVERSION)", "CAST(x AS ROWVERSION)")
+        self.validate_identity("CAST(x AS SMALLDATETIME)", "CAST(x AS DATETIME2(6))")
         self.validate_identity("CAST(x AS SMALLMONEY)", "CAST(x AS DECIMAL)")
-        self.validate_identity("CAST(x AS JSON)", "CAST(x AS VARCHAR)")
-        self.validate_identity("CAST(x AS XML)", "CAST(x AS VARCHAR)")
-        self.validate_identity("CAST(x AS UNIQUEIDENTIFIER)", "CAST(x AS VARBINARY(MAX))")
+        self.validate_identity("CAST(x AS TEXT)", "CAST(x AS VARCHAR(MAX))")
+        self.validate_identity("CAST(x AS TIMESTAMP)", "CAST(x AS DATETIME2(6))")
+        self.validate_identity("CAST(x AS TIMESTAMPNTZ)", "CAST(x AS DATETIME2(6))")
         self.validate_identity("CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIMEOFFSET(6))")
-        self.validate_identity("CAST(x AS DOUBLE)", "CAST(x AS FLOAT)")
-
-        # Test T-SQL override mappings
-        self.validate_identity("CAST(x AS DECIMAL)", "CAST(x AS DECIMAL)")
-        self.validate_identity("CAST(x AS INT)", "CAST(x AS INT)")
+        self.validate_identity("CAST(x AS TINYINT)", "CAST(x AS SMALLINT)")
+        self.validate_identity("CAST(x AS UTINYINT)", "CAST(x AS SMALLINT)")
+        self.validate_identity("CAST(x AS UUID)", "CAST(x AS VARBINARY(MAX))")
+        self.validate_identity("CAST(x AS VARIANT)", "CAST(x AS SQL_VARIANT)")
+        self.validate_identity("CAST(x AS XML)", "CAST(x AS VARCHAR)")
 
     def test_precision_capping(self):
         """Test that TIME, DATETIME2 & DATETIMEOFFSET precision is capped at 6 digits"""


### PR DESCRIPTION
Corrects type mappings in the Fabric dialect to align with Fabric's data type support.

- Addresses inconsistencies between T-SQL and Fabric's data type handling.
- Ensures that temporal types (TIME, DATETIME2, DATETIMEOFFSET) precision is capped at 6 digits.
- Adds UTINYINT keyword mapping.