### PR TITLE
Fix(snowflake)!: only cast strings to timestamp for TO_CHAR (TimeToStr)

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1910,12 +1910,13 @@ def groupconcat_sql(
 
 
 def build_timetostr_or_tochar(args: t.List, dialect: Dialect) -> exp.TimeToStr | exp.ToChar:
-    this = seq_get(args, 0)
+    if len(args) == 2:
+        this = args[0]
+        if not this.type:
+            from sqlglot.optimizer.annotate_types import annotate_types
 
-    if this and not this.type:
-        from sqlglot.optimizer.annotate_types import annotate_types
+            annotate_types(this, dialect=dialect)
 
-        annotate_types(this, dialect=dialect)
         if this.is_type(*exp.DataType.TEMPORAL_TYPES):
             dialect_name = dialect.__class__.__name__.lower()
             return build_formatted_time(exp.TimeToStr, dialect_name, default=True)(args)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1416,7 +1416,7 @@ class Snowflake(Dialect):
 
         def timetostr_sql(self, expression: exp.TimeToStr) -> str:
             this = expression.this
-            if not isinstance(this, exp.TsOrDsToTimestamp):
+            if this.is_string:
                 this = exp.cast(this, exp.DataType.Type.TIMESTAMP)
 
             return self.func("TO_CHAR", this, self.format_time(expression))

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -232,8 +232,8 @@ class TestOracle(Validator):
         self.validate_all(
             "SELECT TO_CHAR(TIMESTAMP '1999-12-01 10:00:00')",
             write={
-                "oracle": "SELECT TO_CHAR(CAST('1999-12-01 10:00:00' AS TIMESTAMP), 'YYYY-MM-DD HH24:MI:SS')",
-                "postgres": "SELECT TO_CHAR(CAST('1999-12-01 10:00:00' AS TIMESTAMP), 'YYYY-MM-DD HH24:MI:SS')",
+                "oracle": "SELECT TO_CHAR(CAST('1999-12-01 10:00:00' AS TIMESTAMP))",
+                "postgres": "SELECT TO_CHAR(CAST('1999-12-01 10:00:00' AS TIMESTAMP))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -80,6 +80,8 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT * REPLACE (CAST(col AS TEXT) AS scol) FROM t")
         self.validate_identity("1 /* /* */")
         self.validate_identity("TO_TIMESTAMP(col, fmt)")
+        self.validate_identity("SELECT TO_CHAR(CAST('12:05:05' AS TIME))")
+        self.validate_identity("SELECT TRIM(COALESCE(TO_CHAR(CAST(c AS TIME)), '')) FROM t")
         self.validate_identity(
             "SELECT * FROM table AT (TIMESTAMP => '2024-07-24') UNPIVOT(a FOR b IN (c)) AS pivot_table"
         )
@@ -641,7 +643,8 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_identity(
-            "TO_CHAR(foo::DATE, 'yyyy')", "TO_CHAR(CAST(CAST(foo AS DATE) AS TIMESTAMP), 'yyyy')"
+            "TO_CHAR(foo::DATE, 'yyyy')",
+            "TO_CHAR(CAST(foo AS DATE), 'yyyy')",
         )
         self.validate_all(
             "TO_CHAR(foo::TIMESTAMP, 'YYYY-MM')",


### PR DESCRIPTION
Fixes #5282

- Only call `build_formatted_time` in `build_timetostr_or_tochar` if a format is actually present. This is done to ensure we don't use a timestamp format by default for `TIME` values, etc:

```python
>>> # Behavior in main today
>>> import sqlglot
>>> sqlglot.transpile("SELECT TO_CHAR(CAST('12:05:05' AS TIME))", "snowflake")
["SELECT TO_CHAR(CAST('12:05:05' AS TIME), 'yyyy-mm-DD hh24:mi:ss')"]
```

- Only cast to `TIMESTAMP` in `timetostr_sql` for Snowflake when the argument is a string. This is more conservative than casting when it's not a `TsOrDsToTimestamp` instance, but imo more correct.

```sql
-- Works
SELECT TO_CHAR(CAST('2020-01-01' AS DATE), 'yyyy-mm-dd')

-- Does not work:
-- Error: too many arguments for function [TO_CHAR('2020-01-01', 'yyyy-mm-dd')] expected 1, got 2 (line 1)
SELECT TO_CHAR('2020-01-01', 'yyyy-mm-dd')
```