### PR TITLE
Fix(scope)!: include bigquery unnest aliases in selected sources

### DIFF
--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -871,6 +871,10 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         sql = "UPDATE tbl1 SET col = 0"
         self.assertEqual(len(traverse_scope(parse_one(sql))), 0)
 
+        sql = "SELECT * FROM t LEFT JOIN UNNEST(a) AS a1 LEFT JOIN UNNEST(a1.a) AS a2"
+        scope = build_scope(parse_one(sql, read="bigquery"))
+        self.assertEqual(set(scope.selected_sources), {"t", "a1", "a2"})
+
     @patch("sqlglot.optimizer.scope.logger")
     def test_scope_warning(self, logger):
         self.assertEqual(len(traverse_scope(parse_one("WITH q AS (@y) SELECT * FROM q"))), 1)


### PR DESCRIPTION
This addresses the issue reported in this Slack thread: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1750862162339109. This should only impact users that have queries with `UNNEST` sources and who build scopes without first calling `qualify_tables` or `qualify` on the ASTs.

This example reproduces the error:

```python
from sqlglot import parse_one
from sqlglot.optimizer.scope import build_scope

query = """
SELECT
    ID
    , release
    FROM table
    LEFT JOIN UNNEST(environments) AS env
    LEFT JOIN UNNEST(env.deploySteps) AS release
"""

parsed = parse_one(query, dialect="bigquery")
scope = build_scope(parsed)

print(scope.selected_sources)
```