### PR TITLE
Fix(parser): avoid bubbling up Dot comment

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5600,7 +5600,7 @@ class Parser(metaclass=_Parser):
             else:
                 this = self.expression(exp.Dot, this=this, expression=field)
 
-            if field and field.comments:
+            if field and field.comments and isinstance(this, exp.Column):
                 t.cast(exp.Expression, this).add_comments(field.pop_comments())
 
             this = self._parse_bracket(this)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1009,3 +1009,8 @@ class TestParser(unittest.TestCase):
         ast = parse_one(sql)
         assert not any(isinstance(n, exp.Column) for n in ast.walk())
         assert len(list(ast.find_all(exp.Dot))) == 7
+
+    def test_dot_comment(self):
+        sql = 'a.b."c"."d"."E" /* sqlglot.meta case_sensitive */'
+        ast = parse_one(sql)
+        self.assertEqual(ast.expression.comments, [" sqlglot.meta case_sensitive "])


### PR DESCRIPTION
Addresses the issue discussed in this Slack thread: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1750873457473389. TL;DR, comment is moved outside of the `Identifier` node but it carries additional semantics so it's incorrect.