### PR TITLE
fix(tsql)!: Fix parsing of ADD CONSTRAINT

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7362,8 +7362,9 @@ class Parser(metaclass=_Parser):
 
             return None
 
-        if not self.dialect.ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN or self._match_text_seq(
-            "COLUMNS"
+        if not self._match_set(self.ADD_CONSTRAINT_TOKENS, advance=False) and (
+            not self.dialect.ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN
+            or self._match_text_seq("COLUMNS")
         ):
             schema = self._parse_schema()
 


### PR DESCRIPTION
Fixes https://github.com/TobikoData/sqlmesh/issues/4813

The roundtrip is preserved in both cases but the AST was incorrect ([Internal discussion](https://tobikodata.slack.com/archives/C040V7ZP9NH/p1750877167847629))

- Before:

```Python
>>> sqlglot.parse_one("ALTER TABLE tbl ADD CONSTRAINT cnstr PRIMARY KEY CLUSTERED (ID)", "tsql")
Alter(
  this=Table(
    this=Identifier(this=tbl, quoted=False)),
  kind=TABLE,
  actions=[
    ColumnDef(
      this=Identifier(this=CONSTRAINT, quoted=False),
      kind=DataType(this=Type.USERDEFINED, kind=cnstr),
      constraints=[
        ColumnConstraint(
          kind=PrimaryKeyColumnConstraint(
            )),
        ColumnConstraint(
          kind=ClusteredColumnConstraint(
            this=[
              Ordered(
                this=Column(
                  this=Identifier(this=ID, quoted=False)),
                nulls_first=True)]))])])
```

<br />


- After
```Python3
>>> sqlglot.parse_one("ALTER TABLE tbl ADD CONSTRAINT cnstr PRIMARY KEY CLUSTERED (ID)", "tsql")
Alter(
  this=Table(
    this=Identifier(this=tbl, quoted=False)),
  kind=TABLE,
  actions=[
    AddConstraint(
      expressions=[
        Constraint(
          this=Identifier(this=cnstr, quoted=False),
          expressions=[
            PrimaryKeyColumnConstraint(
              ),
            ClusteredColumnConstraint(
              this=[
                Ordered(
                  this=Column(
                    this=Identifier(this=ID, quoted=False)),
                  nulls_first=True)])])])])

```


Docs
------------
[T-SQL ALTER](https://learn.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql?view=sql-server-ver17) 