### PR TITLE
Fix(bigquery)!: only coerce time var -like units into strings for date trunc

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5850,8 +5850,6 @@ class DateTrunc(Func):
                 unit_name = TimeUnit.UNABBREVIATED_UNIT_NAME[unit_name]
 
             args["unit"] = Literal.string(unit_name)
-        elif isinstance(unit, Week):
-            unit.set("this", Literal.string(unit.this.name.upper()))
 
         super().__init__(**args)
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -56,6 +56,7 @@ class TestBigQuery(Validator):
         select_with_quoted_udf = self.validate_identity("SELECT `p.d.UdF`(data) FROM `p.d.t`")
         self.assertEqual(select_with_quoted_udf.selects[0].name, "p.d.UdF")
 
+        self.validate_identity("DATE_TRUNC(x, @foo)").unit.assert_is(exp.Parameter)
         self.validate_identity("ARRAY_CONCAT_AGG(x ORDER BY ARRAY_LENGTH(x) LIMIT 2)")
         self.validate_identity("ARRAY_CONCAT_AGG(x LIMIT 2)")
         self.validate_identity("ARRAY_CONCAT_AGG(x ORDER BY ARRAY_LENGTH(x))")


### PR DESCRIPTION
BigQuery preemptively coerces all unit expressions into string literals for `DATE_TRUNC` today:

```python
>>> import sqlglot
>>> sqlglot.parse_one("date_trunc(x, @foo)", "bigquery")
DateTrunc(
  unit=Literal(this='@FOO', is_string=True),
  this=Column(
    this=Identifier(this=x, quoted=False)))
>>> sqlglot.parse_one("date_trunc(x, @foo)", "bigquery").sql("bigquery")
'DATE_TRUNC(x, @FOO)'
```

This messes up the AST and SQLMesh is unable to render macros.