### PR TITLE
fix(bigquery)!: ARRAY_CONCAT type annotation

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -444,6 +444,7 @@ class BigQuery(Dialect):
                 exp.Substring,
             )
         },
+        exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Concat: _annotate_concat,
         exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Split: lambda self, e: self._annotate_by_args(e, "this", array=True),

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -329,6 +329,7 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                 ],
                 nested=True,
             )
+
             if not any(
                 cd.kind.is_type(exp.DataType.Type.UNKNOWN)
                 for cd in struct_type.expressions

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -459,6 +459,10 @@ STRING;
 STRING(timestamp_expr, timezone);
 STRING;
 
+# dialect: bigquery
+ARRAY_CONCAT(['a'], ['b']);
+ARRAY<VARCHAR>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR fixes the type annotation of `ARRAY_CONCAT`

Following examples (`qualify` -> `annotate_types`)

Before the fix:
```
SELECT ARRAY_CONCAT(['a'], ['b'])

Select(
  expressions=[
    Alias(
      this=ArrayConcat(
        this=Array(
          expressions=[
            Literal(this='a', is_string=True, _type=DataType(this=Type.VARCHAR))],
          _type=DataType(
            this=Type.ARRAY,
            expressions=[
              DataType(this=Type.VARCHAR)],
            nested=True)),
        expressions=[
          Array(
            expressions=[
              Literal(this='b', is_string=True, _type=DataType(this=Type.VARCHAR))],
            _type=DataType(
              this=Type.ARRAY,
              expressions=[
                DataType(this=Type.VARCHAR)],
              nested=True))],
        _type=DataType(this=Type.VARCHAR)),
      alias=Identifier(this='_col_0', quoted=True, _type=DataType(this=Type.UNKNOWN)),
      _type=DataType(this=Type.VARCHAR))],
  _type=DataType(
    this=Type.STRUCT,
    expressions=[
      ColumnDef(
        this=Identifier(this=_col_0, quoted=False),
        kind=DataType(this=Type.VARCHAR))],
    nested=True)
```

After the fix:
```
SELECT ARRAY_CONCAT(['a'], ['b'])

Select(
  expressions=[
    Alias(
      this=ArrayConcat(
        this=Array(
          expressions=[
            Literal(this='a', is_string=True, _type=DataType(this=Type.VARCHAR))],
          _type=DataType(
            this=Type.ARRAY,
            expressions=[
              DataType(this=Type.VARCHAR)],
            nested=True)),
        expressions=[
          Array(
            expressions=[
              Literal(this='b', is_string=True, _type=DataType(this=Type.VARCHAR))],
            _type=DataType(
              this=Type.ARRAY,
              expressions=[
                DataType(this=Type.VARCHAR)],
              nested=True))],
        _type=DataType(
          this=Type.ARRAY,
          expressions=[
            DataType(this=Type.VARCHAR)],
          nested=True)),
      alias=Identifier(this='_col_0', quoted=True, _type=DataType(this=Type.UNKNOWN)),
      _type=DataType(
        this=Type.ARRAY,
        expressions=[
          DataType(this=Type.VARCHAR)],
        nested=True))],
  _type=DataType(
    this=Type.STRUCT,
    expressions=[
      ColumnDef(
        this=Identifier(this=_col_0, quoted=False),
        kind=DataType(
          this=Type.ARRAY,
          expressions=[
            DataType(this=Type.VARCHAR)],
          nested=True))],
    nested=True))
```

**DOCS**
[BigQuery ARRAY_CONCAT](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_concat)