### PR TITLE
feat(exasol): implemented BIT_AND function with test

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
-from sqlglot import exp, generator
-from sqlglot.dialects.dialect import Dialect
+from sqlglot import exp, generator, parser
+from sqlglot.dialects.dialect import Dialect, rename_func, binary_from_function
 
 
 class Exasol(Dialect):
+    class Parser(parser.Parser):
+        FUNCTIONS = {
+            **parser.Parser.FUNCTIONS,
+            "BIT_AND": binary_from_function(exp.BitwiseAnd),
+        }
+
     class Generator(generator.Generator):
         # https://docs.exasol.com/db/latest/sql_references/data_types/datatypedetails.htm#StringDataType
         STRING_TYPE_MAPPING = {
@@ -38,3 +44,11 @@ class Exasol(Dialect):
                 return "TIMESTAMP WITH LOCAL TIME ZONE"
 
             return super().datatype_sql(expression)
+
+        TRANSFORMS = {
+            **generator.Generator.TRANSFORMS,
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_and.htm
+            exp.BitwiseAnd: rename_func("BIT_AND"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm
+            exp.Mod: rename_func("MOD"),
+        }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -57,3 +57,32 @@ class TestExasol(Validator):
             "CAST(x AS TIMESTAMP(3) WITH LOCAL TIME ZONE)",
             "CAST(x AS TIMESTAMP WITH LOCAL TIME ZONE)",
         )
+
+    def test_mod(self):
+        self.validate_all(
+            "SELECT MOD(x, 10)",
+            read={"exasol": "SELECT MOD(x, 10)"},
+            write={
+                "teradata": "SELECT x MOD 10",
+                "mysql": "SELECT x % 10",
+                "exasol": "SELECT MOD(x, 10)",
+            },
+        )
+
+    def test_bits(self):
+        self.validate_all(
+            "SELECT BIT_AND(x, 1)",
+            read={
+                "exasol": "SELECT BIT_AND(x, 1)",
+                "duckdb": "SELECT x & 1",
+                "presto": "SELECT BITWISE_AND(x, 1)",
+                "spark": "SELECT x & 1",
+            },
+            write={
+                "exasol": "SELECT BIT_AND(x, 1)",
+                "duckdb": "SELECT x & 1",
+                "hive": "SELECT x & 1",
+                "presto": "SELECT BITWISE_AND(x, 1)",
+                "spark": "SELECT x & 1",
+            },
+        )


### PR DESCRIPTION
This involves adding [BIT_AND](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_and.html) built -in function to exasol dialect in sqlglot.