### PR TITLE
feat!: add support for `SUBSTRING_INDEX`

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -330,7 +330,6 @@ class ClickHouse(Dialect):
             "MD5": exp.MD5Digest.from_arg_list,
             "SHA256": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(256)),
             "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
-            "SUBSTRING_INDEX": exp.SubstringIndex.from_arg_list,
             "SUBSTRINGINDEX": exp.SubstringIndex.from_arg_list,  # alias for camel-case substringIndex
             "EDITDISTANCE": exp.Levenshtein.from_arg_list,
             "LEVENSHTEINDISTANCE": exp.Levenshtein.from_arg_list,

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1107,9 +1107,6 @@ class ClickHouse(Dialect):
                 supports_position=True,
                 use_ansi_position=False,
             ),
-            exp.SubstringIndex: lambda self, e: self.func(
-                "SUBSTRING_INDEX", e.this, e.args["delimiter"], e.args["count"]
-            ),
             exp.TimeToStr: lambda self, e: self.func(
                 "formatDateTime", e.this, self.format_time(e), e.args.get("zone")
             ),

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -354,7 +354,6 @@ class Hive(Dialect):
                 pair_delim=seq_get(args, 1) or exp.Literal.string(","),
                 key_value_delim=seq_get(args, 2) or exp.Literal.string(":"),
             ),
-            "SUBSTRING_INDEX": exp.SubstringIndex.from_arg_list,
             "TO_DATE": _build_to_date,
             "TO_JSON": exp.JSONFormat.from_arg_list,
             "TRUNC": exp.TimestampTrunc.from_arg_list,

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -325,7 +325,6 @@ class MySQL(Dialect):
             "SCHEMA": exp.CurrentSchema.from_arg_list,
             "DATABASE": exp.CurrentSchema.from_arg_list,
             "STR_TO_DATE": _str_to_date,
-            "SUBSTRING_INDEX": exp.SubstringIndex.from_arg_list,
             "TIMESTAMPDIFF": build_date_delta(exp.TimestampDiff),
             "TO_DAYS": lambda args: exp.paren(
                 exp.DateDiff(


### PR DESCRIPTION
## What & Why

* **New AST node `SubstringIndex`**  
  *inherits from `Func`; doc-string & `arg_types` included.*

* **Parser support** in ClickHouse, Hive, Spark, Spark2, Databricks, MySQL (and alias `SUBSTRINGINDEX` in ClickHouse).  
  Previously the token was parsed as `Anonymous`, so users could not
  transpile `substringIndex` ↔ `SUBSTRING_INDEX` without a manual replace.

* **ClickHouse generator transform**  
  Normalises output to the canonical **`substringIndex`** spelling
  (camel-case, no underscore) instead of the default `SUBSTRINGINDEX`.

* **Tests**  
  * `test_substring_index.py` – parse & round-trip for  
    ClickHouse ↔ Hive, Databricks → MySQL, positive / negative / zero count.

I wanted to transpile `substringIndex` of clickhouse to `SUBSTRING_INDEX` of databricks.

**The change lets me (and everyone) do:**

```python
>>> sql = "SELECT substringIndex('a.b.c.d', '.', 2)"
>>> transpile(sql, read="clickhouse", write="databricks")[0]
"SELECT SUBSTRING_INDEX('a.b.c.d', '.', 2)"