### PR TITLE
feat(exasol): add bitwiseOr function to exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -8,6 +8,7 @@ class Exasol(Dialect):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "BIT_AND": binary_from_function(exp.BitwiseAnd),
+            "BIT_OR": binary_from_function(exp.BitwiseOr),
         }
 
     class Generator(generator.Generator):
@@ -49,6 +50,8 @@ class Exasol(Dialect):
             **generator.Generator.TRANSFORMS,
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_and.htm
             exp.BitwiseAnd: rename_func("BIT_AND"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_or.htm
+            exp.BitwiseOr: rename_func("BIT_OR"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm
             exp.Mod: rename_func("MOD"),
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -86,3 +86,19 @@ class TestExasol(Validator):
                 "spark": "SELECT x & 1",
             },
         )
+        self.validate_all(
+            "SELECT BIT_OR(x, 1)",
+            read={
+                "exasol": "SELECT BIT_OR(x, 1)",
+                "duckdb": "SELECT x | 1",
+                "presto": "SELECT BITWISE_OR(x, 1)",
+                "spark": "SELECT x | 1",
+            },
+            write={
+                "exasol": "SELECT BIT_OR(x, 1)",
+                "duckdb": "SELECT x | 1",
+                "hive": "SELECT x | 1",
+                "presto": "SELECT BITWISE_OR(x, 1)",
+                "spark": "SELECT x | 1",
+            },
+        )


### PR DESCRIPTION
This involves adding [BIT_OR](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_or.htm) built -in function to exasol dialect in sqlglot.