### PR TITLE
feat(exasol): added bit_xor built in exasol function

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -9,6 +9,7 @@ class Exasol(Dialect):
             **parser.Parser.FUNCTIONS,
             "BIT_AND": binary_from_function(exp.BitwiseAnd),
             "BIT_OR": binary_from_function(exp.BitwiseOr),
+            "BIT_XOR": binary_from_function(exp.BitwiseXor),
         }
 
     class Generator(generator.Generator):
@@ -52,6 +53,8 @@ class Exasol(Dialect):
             exp.BitwiseAnd: rename_func("BIT_AND"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_or.htm
             exp.BitwiseOr: rename_func("BIT_OR"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_xor.htm
+            exp.BitwiseXor: rename_func("BIT_XOR"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm
             exp.Mod: rename_func("MOD"),
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -102,3 +102,22 @@ class TestExasol(Validator):
                 "spark": "SELECT x | 1",
             },
         )
+
+        self.validate_all(
+            "SELECT BIT_XOR(x, 1)",
+            read={
+                "": "SELECT x ^ 1",
+                "exasol": "SELECT BIT_XOR(x, 1)",
+                "bigquery": "SELECT x ^ 1",
+                "presto": "SELECT BITWISE_XOR(x, 1)",
+                "postgres": "SELECT x # 1",
+            },
+            write={
+                "": "SELECT x ^ 1",
+                "exasol": "SELECT BIT_XOR(x, 1)",
+                "bigquery": "SELECT x ^ 1",
+                "duckdb": "SELECT XOR(x, 1)",
+                "presto": "SELECT BITWISE_XOR(x, 1)",
+                "postgres": "SELECT x # 1",
+            },
+        )


### PR DESCRIPTION
This involves adding [BIT_XOR](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_xor.htm) built -in function to exasol dialect in sqlglot.