### PR TITLE
feat(parser): annotate type of ARRAY_CONCAT_AGG

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -759,6 +759,7 @@ class Dialect(metaclass=_Dialect):
         exp.Array: lambda self, e: self._annotate_by_args(e, "expressions", array=True),
         exp.ArrayAgg: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
+        exp.ArrayConcatAgg: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -463,6 +463,10 @@ STRING;
 ARRAY_CONCAT(['a'], ['b']);
 ARRAY<VARCHAR>;
 
+# dialect: bigquery
+ARRAY_CONCAT_AGG(tbl.array_col);
+ARRAY<STRING>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -907,6 +907,7 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
                 "bigint_col": "BIGINT",
                 "bool_col": "BOOLEAN",
                 "interval_col": "INTERVAL",
+                "array_col": "ARRAY<STRING>",
             }
         }
 


### PR DESCRIPTION
This PR adds type annotation of `ARRAY_CONCAT_AGG` function of BigQuery.

[BigQuery ARRAY_CONCAT_AGG](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#array_concat_agg)