### PR TITLE
feat(parser)!: annotate type of ARRAY_TO_STRING

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -760,6 +760,7 @@ class Dialect(metaclass=_Dialect):
         exp.ArrayAgg: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.ArrayConcatAgg: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.ArrayToString:lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TEXT),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -760,7 +760,7 @@ class Dialect(metaclass=_Dialect):
         exp.ArrayAgg: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.ArrayConcatAgg: lambda self, e: self._annotate_by_args(e, "this"),
-        exp.ArrayToString:lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TEXT),
+        exp.ArrayToString: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TEXT),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -467,6 +467,10 @@ ARRAY<VARCHAR>;
 ARRAY_CONCAT_AGG(tbl.array_col);
 ARRAY<STRING>;
 
+# dialect: bigquery
+ARRAY_TO_STRING(['a'], ['b'], ',');
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `ARRAY_TO_STRING` function.

This annotation expands to the dialects that use `ARRAY_JOIN`. 

**DOCS**
[BigQuery ARRAY_TO_STRING](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_to_string)