### PR TITLE
feat(exasol): added BIT_LSHIFT built in function to exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -12,6 +12,7 @@ class Exasol(Dialect):
             "BIT_OR": binary_from_function(exp.BitwiseOr),
             "BIT_XOR": binary_from_function(exp.BitwiseXor),
             "BIT_NOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
+            "BIT_LSHIFT": binary_from_function(exp.BitwiseLeftShift),
         }
 
     class Generator(generator.Generator):
@@ -57,6 +58,8 @@ class Exasol(Dialect):
             exp.BitwiseOr: rename_func("BIT_OR"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_not.htm
             exp.BitwiseNot: rename_func("BIT_NOT"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_lshift.htm
+            exp.BitwiseLeftShift: rename_func("BIT_LSHIFT"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_xor.htm
             exp.BitwiseXor: rename_func("BIT_XOR"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -137,3 +137,19 @@ class TestExasol(Validator):
                 "spark": "SELECT ~x",
             },
         )
+        self.validate_all(
+            "SELECT BIT_LSHIFT(x, 1)",
+            read={
+                "exasol": "SELECT BIT_LSHIFT(x, 1)",
+                "spark": "SELECT SHIFTLEFT(x, 1)",
+                "duckdb": "SELECT x << 1",
+                "hive": "SELECT x << 1",
+            },
+            write={
+                "exasol": "SELECT BIT_LSHIFT(x, 1)",
+                "duckdb": "SELECT x << 1",
+                "presto": "SELECT BITWISE_ARITHMETIC_SHIFT_LEFT(x, 1)",
+                "hive": "SELECT x << 1",
+                "spark": "SELECT SHIFTLEFT(x, 1)",
+            },
+        )


### PR DESCRIPTION
This involves adding [BIT_LSHIFT](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_lshift.htm) built -in function to exasol dialect in sqlglot.