### PR TITLE
feat(parser)!: annotate type of ARRAY_FIRST, ARRAY_LAST

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -761,6 +761,8 @@ class Dialect(metaclass=_Dialect):
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.ArrayConcatAgg: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ArrayToString: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TEXT),
+        exp.ArrayFirst: lambda self, e: self._annotate_by_array_element(e),
+        exp.ArrayLast: lambda self, e: self._annotate_by_array_element(e),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5569,6 +5569,14 @@ class ArrayFilter(Func):
     _sql_names = ["FILTER", "ARRAY_FILTER"]
 
 
+class ArrayFirst(Func):
+    pass
+
+
+class ArrayLast(Func):
+    pass
+
+
 class ArrayToString(Func):
     arg_types = {"this": True, "expression": True, "null": False}
     _sql_names = ["ARRAY_TO_STRING", "ARRAY_JOIN"]

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -631,3 +631,15 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
         else:
             self._set_type(expression, exp.DataType.Type.INT)
         return expression
+
+    def _annotate_by_array_element(self, expression: exp.Expression) -> exp.Expression:
+        self._annotate_args(expression)
+
+        array_arg = expression.this
+        if array_arg.type.is_type(exp.DataType.Type.ARRAY):
+            element_type = seq_get(array_arg.type.expressions, 0)
+            self._set_type(expression, element_type)
+        else:
+            self._set_type(expression, exp.DataType.Type.UNKNOWN)
+
+        return expression

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1745,6 +1745,9 @@ WHERE
             },
         )
 
+        self.validate_identity("ARRAY_FIRST(['a', 'b'])")
+        self.validate_identity("ARRAY_LAST(['a', 'b'])")
+
     def test_errors(self):
         with self.assertRaises(ParseError):
             self.parse_one("SELECT * FROM a - b.c.d2")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -461,7 +461,7 @@ STRING;
 
 # dialect: bigquery
 ARRAY_CONCAT(['a'], ['b']);
-ARRAY<VARCHAR>;
+ARRAY<STRING>;
 
 # dialect: bigquery
 ARRAY_CONCAT_AGG(tbl.array_col);
@@ -470,6 +470,22 @@ ARRAY<STRING>;
 # dialect: bigquery
 ARRAY_TO_STRING(['a'], ['b'], ',');
 STRING;
+
+# dialect: bigquery
+ARRAY_FIRST(['a', 'b']);
+STRING;
+
+# dialect: bigquery
+ARRAY_LAST(['a', 'b']);
+STRING;
+
+# dialect: bigquery
+ARRAY_FIRST([1, 1.5]);
+DOUBLE;
+
+# dialect: bigquery
+ARRAY_LAST([1, 1.5]);
+DOUBLE;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
This PR, adds support for the annotation of `ARRAY_FIRST`, `ARRAY_LAST`.

**DOCS**
[BigQuery ARRAY_FIRST](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_first)
[BigQuery ARRAY_LAST](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#array_last)