### PR TITLE
feat(exasol): added the bit_rshift built in exasol function

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -13,6 +13,7 @@ class Exasol(Dialect):
             "BIT_XOR": binary_from_function(exp.BitwiseXor),
             "BIT_NOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
             "BIT_LSHIFT": binary_from_function(exp.BitwiseLeftShift),
+            "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
         }
 
     class Generator(generator.Generator):
@@ -60,6 +61,8 @@ class Exasol(Dialect):
             exp.BitwiseNot: rename_func("BIT_NOT"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_lshift.htm
             exp.BitwiseLeftShift: rename_func("BIT_LSHIFT"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_rshift.htm
+            exp.BitwiseRightShift: rename_func("BIT_RSHIFT"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_xor.htm
             exp.BitwiseXor: rename_func("BIT_XOR"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -153,3 +153,19 @@ class TestExasol(Validator):
                 "spark": "SELECT SHIFTLEFT(x, 1)",
             },
         )
+        self.validate_all(
+            "SELECT BIT_RSHIFT(x, 1)",
+            read={
+                "exasol": "SELECT BIT_RSHIFT(x, 1)",
+                "spark": "SELECT SHIFTRIGHT(x, 1)",
+                "duckdb": "SELECT x >> 1",
+                "hive": "SELECT x >> 1",
+            },
+            write={
+                "exasol": "SELECT BIT_RSHIFT(x, 1)",
+                "duckdb": "SELECT x >> 1",
+                "presto": "SELECT BITWISE_ARITHMETIC_SHIFT_RIGHT(x, 1)",
+                "hive": "SELECT x >> 1",
+                "spark": "SELECT SHIFTRIGHT(x, 1)",
+            },
+        )


### PR DESCRIPTION
This involves adding [BIT_RSHIFT](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_rshift.htm) built -in function to exasol dialect in sqlglot.