### PR TITLE
feat(exasol): added `EVERY` built in function

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -14,6 +14,7 @@ class Exasol(Dialect):
             "BIT_NOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
             "BIT_LSHIFT": binary_from_function(exp.BitwiseLeftShift),
             "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
+            "EVERY": lambda args: exp.All(this=seq_get(args, 0)),
         }
 
     class Generator(generator.Generator):

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -171,6 +171,13 @@ class TestExasol(Validator):
         )
 
     def test_aggregateFunctions(self):
-        self.validate_identity(
-            "SELECT department, EVERY(age >= 30) AS EVERY FROM employee_table GROUP BY department"
+        self.validate_all(
+            "SELECT department, EVERY(age >= 30) AS EVERY FROM employee_table GROUP BY department",
+            read={
+                "exasol": "SELECT department, EVERY(age >= 30) AS EVERY FROM employee_table GROUP BY department",
+            },
+            write={
+                "exasol": "SELECT department, EVERY(age >= 30) AS EVERY FROM employee_table GROUP BY department",
+                "duckdb": "SELECT department, ALL (age >= 30) AS EVERY FROM employee_table GROUP BY department",
+            },
         )


### PR DESCRIPTION
This involves adding [EVERY](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/every.htm) built -in function to exasol dialect in sqlglot.