### PR TITLE
feat(exasol): added edit_distance built in function to exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from sqlglot import exp, generator, parser
 from sqlglot.dialects.dialect import Dialect, rename_func, binary_from_function
 from sqlglot.helper import seq_get
+from sqlglot.generator import unsupported_args
 
 
 class Exasol(Dialect):
@@ -15,6 +16,7 @@ class Exasol(Dialect):
             "BIT_LSHIFT": binary_from_function(exp.BitwiseLeftShift),
             "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
             "EVERY": lambda args: exp.All(this=seq_get(args, 0)),
+            "EDIT_DISTANCE": exp.Levenshtein.from_arg_list,
         }
 
     class Generator(generator.Generator):
@@ -54,6 +56,8 @@ class Exasol(Dialect):
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/every.htm
+            exp.All: rename_func("EVERY"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_and.htm
             exp.BitwiseAnd: rename_func("BIT_AND"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_or.htm
@@ -66,8 +70,10 @@ class Exasol(Dialect):
             exp.BitwiseRightShift: rename_func("BIT_RSHIFT"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_xor.htm
             exp.BitwiseXor: rename_func("BIT_XOR"),
-            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/every.htm
-            exp.All: rename_func("EVERY"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/edit_distance.htm#EDIT_DISTANCE
+            exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
+                rename_func("EDIT_DISTANCE")
+            ),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm
             exp.Mod: rename_func("MOD"),
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -181,3 +181,24 @@ class TestExasol(Validator):
                 "duckdb": "SELECT department, ALL (age >= 30) AS EVERY FROM employee_table GROUP BY department",
             },
         )
+
+    def test_stringFunctions(self):
+        self.validate_all(
+            "EDIT_DISTANCE(col1, col2)",
+            read={
+                "exasol": "EDIT_DISTANCE(col1, col2)",
+                "bigquery": "EDIT_DISTANCE(col1, col2)",
+                "clickhouse": "editDistance(col1, col2)",
+                "drill": "LEVENSHTEIN_DISTANCE(col1, col2)",
+                "duckdb": "LEVENSHTEIN(col1, col2)",
+                "hive": "LEVENSHTEIN(col1, col2)",
+            },
+            write={
+                "exasol": "EDIT_DISTANCE(col1, col2)",
+                "bigquery": "EDIT_DISTANCE(col1, col2)",
+                "clickhouse": "editDistance(col1, col2)",
+                "drill": "LEVENSHTEIN_DISTANCE(col1, col2)",
+                "duckdb": "LEVENSHTEIN(col1, col2)",
+                "hive": "LEVENSHTEIN(col1, col2)",
+            },
+        )


### PR DESCRIPTION
This involves adding [EDIT_DISTANCE](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/edit_distance.htm) built -in function to exasol dialect in sqlglot.