### PR TITLE
feat(duckdb): Transpile Spark's `exp.PosExplode`

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1207,6 +1207,6 @@ class DuckDB(Dialect):
 
             if isinstance(parent, exp.From) or (parent and isinstance(parent.parent, exp.From)):
                 # SELECT * FROM POSEXPLODE(col) -> SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(...), UNNEST(...))
-                return f"(SELECT {posexplode_sql})"
+                return self.sql(exp.Subquery(this=exp.Select(expressions=[posexplode_sql])))
 
             return posexplode_sql

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -926,9 +926,10 @@ TBLPROPERTIES (
             },
         )
         self.validate_all(
-            "SELECT POSEXPLODE(x)",
+            "SELECT POSEXPLODE(ARRAY('a'))",
             write={
-                "duckdb": "SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS pos, UNNEST(x) AS col",
+                "duckdb": "SELECT GENERATE_SUBSCRIPTS(['a'], 1) - 1 AS pos, UNNEST(['a']) AS col",
+                "spark": "SELECT POSEXPLODE(ARRAY('a'))",
             },
         )
         self.validate_all(
@@ -936,18 +937,21 @@ TBLPROPERTIES (
             write={
                 "presto": "SELECT IF(_u.pos = _u_2.a, _u_2.b) AS b, IF(_u.pos = _u_2.a, _u_2.a) AS a FROM UNNEST(SEQUENCE(1, GREATEST(CARDINALITY(x)))) AS _u(pos) CROSS JOIN UNNEST(x) WITH ORDINALITY AS _u_2(b, a) WHERE _u.pos = _u_2.a OR (_u.pos > CARDINALITY(x) AND _u_2.a = CARDINALITY(x))",
                 "duckdb": "SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS a, UNNEST(x) AS b",
+                "spark": "SELECT POSEXPLODE(x) AS (a, b)",
             },
         )
         self.validate_all(
-            "SELECT * FROM POSEXPLODE(x)",
+            "SELECT * FROM POSEXPLODE(ARRAY('a'))",
             write={
-                "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS pos, UNNEST(x) AS col)",
+                "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(['a'], 1) - 1 AS pos, UNNEST(['a']) AS col)",
+                "spark": "SELECT * FROM POSEXPLODE(ARRAY('a'))",
             },
         )
         self.validate_all(
-            "SELECT * FROM POSEXPLODE(x) AS (a, b)",
+            "SELECT * FROM POSEXPLODE(ARRAY('a')) AS (a, b)",
             write={
-                "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS a, UNNEST(x) AS b)",
+                "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(['a'], 1) - 1 AS a, UNNEST(['a']) AS b)",
+                "spark": "SELECT * FROM POSEXPLODE(ARRAY('a')) AS _t0(a, b)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -926,9 +926,28 @@ TBLPROPERTIES (
             },
         )
         self.validate_all(
+            "SELECT POSEXPLODE(x)",
+            write={
+                "duckdb": "SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS pos, UNNEST(x) AS col",
+            },
+        )
+        self.validate_all(
             "SELECT POSEXPLODE(x) AS (a, b)",
             write={
                 "presto": "SELECT IF(_u.pos = _u_2.a, _u_2.b) AS b, IF(_u.pos = _u_2.a, _u_2.a) AS a FROM UNNEST(SEQUENCE(1, GREATEST(CARDINALITY(x)))) AS _u(pos) CROSS JOIN UNNEST(x) WITH ORDINALITY AS _u_2(b, a) WHERE _u.pos = _u_2.a OR (_u.pos > CARDINALITY(x) AND _u_2.a = CARDINALITY(x))",
+                "duckdb": "SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS a, UNNEST(x) AS b",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM POSEXPLODE(x)",
+            write={
+                "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS pos, UNNEST(x) AS col)",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM POSEXPLODE(x) AS (a, b)",
+            write={
+                "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(x, 1) - 1 AS a, UNNEST(x) AS b)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5309

- Spark:

```SQL
spark-sql (default)> SELECT POSEXPLODE(ARRAY('a','b','c'));
pos     col
0       a
1       b
2       c

spark-sql (default)> SELECT POSEXPLODE(ARRAY('a','b','c')) AS (mypos, myval);
mypos   myval
0       a
1       b
2       c

spark-sql (default)> SELECT * FROM POSEXPLODE(ARRAY('a','b','c'));
pos     col
0       a
1       b
2       c

spark-sql (default)> SELECT * FROM POSEXPLODE(ARRAY('a','b','c')) AS (mypos, myval);
mypos   myval
0       a
1       b
2       c
```

<br />


- DuckDB
```SQL
D SELECT GENERATE_SUBSCRIPTS(['a', 'b', 'c'], 1) - 1 AS pos, UNNEST(['a', 'b', 'c']) AS col;
┌───────┬─────────┐
│  pos  │   col   │
│ int64 │ varchar │
├───────┼─────────┤
│     0 │ a       │
│     1 │ b       │
│     2 │ c       │
└───────┴─────────┘


D SELECT GENERATE_SUBSCRIPTS(['a', 'b', 'c'], 1) - 1 AS mypos, UNNEST(['a', 'b', 'c']) AS myval;
┌───────┬─────────┐
│ mypos │  myval  │
│ int64 │ varchar │
├───────┼─────────┤
│     0 │ a       │
│     1 │ b       │
│     2 │ c       │
└───────┴─────────┘


D SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(['a', 'b', 'c'], 1) - 1 AS pos, UNNEST(['a', 'b', 'c']) AS col);
┌───────┬─────────┐
│  pos  │   col   │
│ int64 │ varchar │
├───────┼─────────┤
│     0 │ a       │
│     1 │ b       │
│     2 │ c       │
└───────┴─────────┘


D SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(['a', 'b', 'c'], 1) - 1 AS mypos, UNNEST(['a', 'b', 'c']) AS myval);
┌───────┬─────────┐
│ mypos │  myval  │
│ int64 │ varchar │
├───────┼─────────┤
│     0 │ a       │
│     1 │ b       │
│     2 │ c       │
└───────┴─────────┘

```