### PR TITLE
Refactor(athena)!: route statements to hive/trino depending on their type

### DIFF
--- a/sqlglot/dialects/athena.py
+++ b/sqlglot/dialects/athena.py
@@ -2,46 +2,218 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp
-from sqlglot.dialects.trino import Trino
-from sqlglot.dialects.hive import Hive
-from sqlglot.tokens import TokenType
+from sqlglot import exp, generator, parser, tokens
+from sqlglot.dialects import Dialect, Hive, Trino
+from sqlglot.tokens import TokenType, Token
+
+
+class Athena(Dialect):
+    """
+    Over the years, it looks like AWS has taken various execution engines, bolted on AWS-specific
+    modifications and then built the Athena service around them.
+
+    Thus, Athena is not simply hosted Trino, it's more like a router that routes SQL queries to an
+    execution engine depending on the query type.
+
+    As at 2024-09-10, assuming your Athena workgroup is configured to use "Athena engine version 3",
+    the following engines exist:
+
+    Hive:
+     - Accepts mostly the same syntax as Hadoop / Hive
+     - Uses backticks to quote identifiers
+     - Has a distinctive DDL syntax (around things like setting table properties, storage locations etc)
+       that is different from Trino
+     - Used for *most* DDL, with some exceptions that get routed to the Trino engine instead:
+        - CREATE [EXTERNAL] TABLE (without AS SELECT)
+        - ALTER
+        - DROP
+
+    Trino:
+      - Uses double quotes to quote identifiers
+      - Used for DDL operations that involve SELECT queries, eg:
+        - CREATE VIEW / DROP VIEW
+        - CREATE TABLE... AS SELECT
+      - Used for DML operations
+        - SELECT, INSERT, UPDATE, DELETE, MERGE
+
+    The SQLGlot Athena dialect tries to identify which engine a query would be routed to and then uses the
+    tokenizer / parser / generator for that engine. This is unfortunately necessary, as there are certain
+    incompatibilities between the engines' dialects and thus can't be handled by a single, unifying dialect.
+
+    References:
+    - https://docs.aws.amazon.com/athena/latest/ug/ddl-reference.html
+    - https://docs.aws.amazon.com/athena/latest/ug/dml-queries-functions-operators.html
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        self._hive = Hive(**kwargs)
+        self._trino = Trino(**kwargs)
+
+    def tokenize(self, sql: str, **opts) -> t.List[Token]:
+        opts["hive"] = self._hive
+        opts["trino"] = self._trino
+        return super().tokenize(sql, **opts)
+
+    def parse(self, sql: str, **opts) -> t.List[t.Optional[exp.Expression]]:
+        opts["hive"] = self._hive
+        opts["trino"] = self._trino
+        return super().parse(sql, **opts)
+
+    def parse_into(
+        self, expression_type: exp.IntoType, sql: str, **opts
+    ) -> t.List[t.Optional[exp.Expression]]:
+        opts["hive"] = self._hive
+        opts["trino"] = self._trino
+        return super().parse_into(expression_type, sql, **opts)
+
+    def generate(self, expression: exp.Expression, copy: bool = True, **opts) -> str:
+        opts["hive"] = self._hive
+        opts["trino"] = self._trino
+        return super().generate(expression, copy=copy, **opts)
+
+    # This Tokenizer consumes a combination of HiveQL and Trino SQL and then processes the tokens
+    # to disambiguate which dialect needs to be actually used in order to tokenize correctly.
+    class Tokenizer(tokens.Tokenizer):
+        IDENTIFIERS = Trino.Tokenizer.IDENTIFIERS + Hive.Tokenizer.IDENTIFIERS
+        STRING_ESCAPES = Trino.Tokenizer.STRING_ESCAPES + Hive.Tokenizer.STRING_ESCAPES
+        HEX_STRINGS = Trino.Tokenizer.HEX_STRINGS + Hive.Tokenizer.HEX_STRINGS
+        UNICODE_STRINGS = Trino.Tokenizer.UNICODE_STRINGS + Hive.Tokenizer.UNICODE_STRINGS
+
+        NUMERIC_LITERALS = {
+            **Trino.Tokenizer.NUMERIC_LITERALS,
+            **Hive.Tokenizer.NUMERIC_LITERALS,
+        }
+
+        KEYWORDS = {
+            **Hive.Tokenizer.KEYWORDS,
+            **Trino.Tokenizer.KEYWORDS,
+            "UNLOAD": TokenType.COMMAND,
+        }
+
+        def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+            hive = kwargs.pop("hive", None) or Hive()
+            trino = kwargs.pop("trino", None) or Trino()
+
+            super().__init__(*args, **kwargs)
+
+            self._hive_tokenizer = hive.tokenizer(*args, **{**kwargs, "dialect": hive})
+            self._trino_tokenizer = _TrinoTokenizer(*args, **{**kwargs, "dialect": trino})
+
+        def tokenize(self, sql: str) -> t.List[Token]:
+            tokens = super().tokenize(sql)
+
+            if _tokenize_as_hive(tokens):
+                return [Token(TokenType.HIVE_TOKEN_STREAM, "")] + self._hive_tokenizer.tokenize(sql)
+
+            return self._trino_tokenizer.tokenize(sql)
+
+    class Parser(parser.Parser):
+        def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+            hive = kwargs.pop("hive", None) or Hive()
+            trino = kwargs.pop("trino", None) or Trino()
+
+            super().__init__(*args, **kwargs)
+
+            self._hive_parser = hive.parser(*args, **{**kwargs, "dialect": hive})
+            self._trino_parser = _TrinoParser(*args, **{**kwargs, "dialect": trino})
+
+        def parse(
+            self, raw_tokens: t.List[Token], sql: t.Optional[str] = None
+        ) -> t.List[t.Optional[exp.Expression]]:
+            if raw_tokens and raw_tokens[0].token_type == TokenType.HIVE_TOKEN_STREAM:
+                return self._hive_parser.parse(raw_tokens[1:], sql)
+
+            return self._trino_parser.parse(raw_tokens, sql)
+
+        def parse_into(
+            self,
+            expression_types: exp.IntoType,
+            raw_tokens: t.List[Token],
+            sql: t.Optional[str] = None,
+        ) -> t.List[t.Optional[exp.Expression]]:
+            if raw_tokens and raw_tokens[0].token_type == TokenType.HIVE_TOKEN_STREAM:
+                return self._hive_parser.parse_into(expression_types, raw_tokens[1:], sql)
+
+            return self._trino_parser.parse_into(expression_types, raw_tokens, sql)
+
+    class Generator(generator.Generator):
+        def __init__(self, *args: t.Any, **kwargs: t.Any) -> None:
+            hive = kwargs.pop("hive", None) or Hive()
+            trino = kwargs.pop("trino", None) or Trino()
+
+            super().__init__(*args, **kwargs)
+
+            self._hive_generator = _HiveGenerator(*args, **{**kwargs, "dialect": hive})
+            self._trino_generator = _TrinoGenerator(*args, **{**kwargs, "dialect": trino})
+
+        def generate(self, expression: exp.Expression, copy: bool = True) -> str:
+            if _generate_as_hive(expression):
+                generator = self._hive_generator
+            else:
+                generator = self._trino_generator
+
+            return generator.generate(expression, copy=copy)
+
+
+def _tokenize_as_hive(tokens: t.List[Token]) -> bool:
+    if len(tokens) < 2:
+        return False
+
+    first, second, *rest = tokens
+
+    first_type = first.token_type
+    first_text = first.text.upper()
+    second_type = second.token_type
+    second_text = second.text.upper()
+
+    if first_type in (TokenType.DESCRIBE, TokenType.SHOW) or first_text == "MSCK REPAIR":
+        return True
+
+    if first_type in (TokenType.ALTER, TokenType.CREATE, TokenType.DROP):
+        if second_text in ("DATABASE", "EXTERNAL", "SCHEMA"):
+            return True
+        if second_type == TokenType.VIEW:
+            return False
+
+        return all(t.token_type != TokenType.SELECT for t in rest)
+
+    return False
 
 
 def _generate_as_hive(expression: exp.Expression) -> bool:
     if isinstance(expression, exp.Create):
         if expression.kind == "TABLE":
-            properties: t.Optional[exp.Properties] = expression.args.get("properties")
+            properties = expression.args.get("properties")
+
+            # CREATE EXTERNAL TABLE is Hive
             if properties and properties.find(exp.ExternalProperty):
-                return True  # CREATE EXTERNAL TABLE is Hive
+                return True
 
+            # Any CREATE TABLE other than CREATE TABLE ... AS <query> is Hive
             if not isinstance(expression.expression, exp.Query):
-                return True  # any CREATE TABLE other than CREATE TABLE AS SELECT is Hive
+                return True
         else:
-            return expression.kind != "VIEW"  # CREATE VIEW is never Hive but CREATE SCHEMA etc is
-
-    # https://docs.aws.amazon.com/athena/latest/ug/ddl-reference.html
-    elif isinstance(expression, (exp.Alter, exp.Drop, exp.Describe)):
+            # CREATE VIEW is Trino, but CREATE SCHEMA, CREATE DATABASE, etc, is Hive
+            return expression.kind != "VIEW"
+    elif isinstance(expression, (exp.Alter, exp.Drop, exp.Describe, exp.Show)):
         if isinstance(expression, exp.Drop) and expression.kind == "VIEW":
-            # DROP VIEW is Trino (I guess because CREATE VIEW is)
+            # DROP VIEW is Trino, because CREATE VIEW is as well
             return False
 
-        # Everything else is Hive
+        # Everything else, e.g., ALTER statements, is Hive
         return True
 
     return False
 
 
 def _is_iceberg_table(properties: exp.Properties) -> bool:
-    table_type_property = next(
-        (
-            p
-            for p in properties.expressions
-            if isinstance(p, exp.Property) and p.name == "table_type"
-        ),
-        None,
-    )
-    return bool(table_type_property and table_type_property.text("value").lower() == "iceberg")
+    for p in properties.expressions:
+        if isinstance(p, exp.Property) and p.name == "table_type":
+            return p.text("value").lower() == "iceberg"
+
+    return False
 
 
 def _location_property_sql(self: Athena.Generator, e: exp.LocationProperty):
@@ -64,6 +236,7 @@ def _partitioned_by_property_sql(self: Athena.Generator, e: exp.PartitionedByPro
     # ref: https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html#ctas-table-properties
 
     prop_name = "partitioned_by"
+
     if isinstance(e.parent, exp.Properties):
         if _is_iceberg_table(e.parent):
             prop_name = "partitioning"
@@ -71,97 +244,45 @@ def _partitioned_by_property_sql(self: Athena.Generator, e: exp.PartitionedByPro
     return f"{prop_name}={self.sql(e, 'this')}"
 
 
-class Athena(Trino):
-    """
-    Over the years, it looks like AWS has taken various execution engines, bolted on AWS-specific modifications and then
-    built the Athena service around them.
+# Athena extensions to Hive's generator
+class _HiveGenerator(Hive.Generator):
+    def alter_sql(self, expression: exp.Alter) -> str:
+        # Package any ALTER TABLE ADD actions into a Schema object, so it gets generated as
+        # `ALTER TABLE .. ADD COLUMNS(...)`, instead of `ALTER TABLE ... ADD COLUMN`, which
+        # is invalid syntax on Athena
+        if isinstance(expression, exp.Alter) and expression.kind == "TABLE":
+            if expression.actions and isinstance(expression.actions[0], exp.ColumnDef):
+                new_actions = exp.Schema(expressions=expression.actions)
+                expression.set("actions", [new_actions])
 
-    Thus, Athena is not simply hosted Trino, it's more like a router that routes SQL queries to an execution engine depending
-    on the query type.
+        return super().alter_sql(expression)
 
-    As at 2024-09-10, assuming your Athena workgroup is configured to use "Athena engine version 3", the following engines exist:
 
-    Hive:
-     - Accepts mostly the same syntax as Hadoop / Hive
-     - Uses backticks to quote identifiers
-     - Has a distinctive DDL syntax (around things like setting table properties, storage locations etc) that is different from Trino
-     - Used for *most* DDL, with some exceptions that get routed to the Trino engine instead:
-        - CREATE [EXTERNAL] TABLE (without AS SELECT)
-        - ALTER
-        - DROP
+# Athena extensions to Trino's tokenizer
+class _TrinoTokenizer(Trino.Tokenizer):
+    KEYWORDS = {
+        **Trino.Tokenizer.KEYWORDS,
+        "UNLOAD": TokenType.COMMAND,
+    }
 
-    Trino:
-      - Uses double quotes to quote identifiers
-      - Used for DDL operations that involve SELECT queries, eg:
-        - CREATE VIEW / DROP VIEW
-        - CREATE TABLE... AS SELECT
-      - Used for DML operations
-        - SELECT, INSERT, UPDATE, DELETE, MERGE
 
-    The SQLGlot Athena dialect tries to identify which engine a query would be routed to and then uses the parser / generator for that engine
-    rather than trying to create a universal syntax that can handle both types.
-    """
+# Athena extensions to Trino's parser
+class _TrinoParser(Trino.Parser):
+    STATEMENT_PARSERS = {
+        **Trino.Parser.STATEMENT_PARSERS,
+        TokenType.USING: lambda self: self._parse_as_command(self._prev),
+    }
 
-    class Tokenizer(Trino.Tokenizer):
-        """
-        The Tokenizer is flexible enough to tokenize queries across both the Hive and Trino engines
-        """
 
-        IDENTIFIERS = ['"', "`"]
-        STRING_ESCAPES = ["'", "\\"]
-        KEYWORDS = {
-            **Hive.Tokenizer.KEYWORDS,
-            **Trino.Tokenizer.KEYWORDS,
-            "UNLOAD": TokenType.COMMAND,
-        }
+# Athena extensions to Trino's generator
+class _TrinoGenerator(Trino.Generator):
+    PROPERTIES_LOCATION = {
+        **Trino.Generator.PROPERTIES_LOCATION,
+        exp.LocationProperty: exp.Properties.Location.POST_WITH,
+    }
 
-    class Parser(Trino.Parser):
-        """
-        Parse queries for the Athena Trino execution engine
-        """
-
-        STATEMENT_PARSERS = {
-            **Trino.Parser.STATEMENT_PARSERS,
-            TokenType.USING: lambda self: self._parse_as_command(self._prev),
-        }
-
-    class _HiveGenerator(Hive.Generator):
-        def alter_sql(self, expression: exp.Alter) -> str:
-            # package any ALTER TABLE ADD actions into a Schema object
-            # so it gets generated as `ALTER TABLE .. ADD COLUMNS(...)`
-            # instead of `ALTER TABLE ... ADD COLUMN` which is invalid syntax on Athena
-            if isinstance(expression, exp.Alter) and expression.kind == "TABLE":
-                if expression.actions and isinstance(expression.actions[0], exp.ColumnDef):
-                    new_actions = exp.Schema(expressions=expression.actions)
-                    expression.set("actions", [new_actions])
-
-            return super().alter_sql(expression)
-
-    class Generator(Trino.Generator):
-        """
-        Generate queries for the Athena Trino execution engine
-        """
-
-        PROPERTIES_LOCATION = {
-            **Trino.Generator.PROPERTIES_LOCATION,
-            exp.LocationProperty: exp.Properties.Location.POST_WITH,
-        }
-
-        TRANSFORMS = {
-            **Trino.Generator.TRANSFORMS,
-            exp.PartitionedByProperty: _partitioned_by_property_sql,
-            exp.LocationProperty: _location_property_sql,
-        }
-
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-
-            hive_kwargs = {**kwargs, "dialect": "hive"}
-
-            self._hive_generator = Athena._HiveGenerator(*args, **hive_kwargs)
-
-        def generate(self, expression: exp.Expression, copy: bool = True) -> str:
-            if _generate_as_hive(expression):
-                return self._hive_generator.generate(expression, copy)
-
-            return super().generate(expression, copy)
+    TRANSFORMS = {
+        **Trino.Generator.TRANSFORMS,
+        exp.PartitionedByProperty: _partitioned_by_property_sql,
+        exp.LocationProperty: _location_property_sql,
+    }

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1034,22 +1034,20 @@ class Dialect(metaclass=_Dialect):
             for expression in self.parse(sql)
         ]
 
-    def tokenize(self, sql: str) -> t.List[Token]:
-        return self.tokenizer.tokenize(sql)
+    def tokenize(self, sql: str, **opts) -> t.List[Token]:
+        return self.tokenizer(**opts).tokenize(sql)
 
-    @property
-    def tokenizer(self) -> Tokenizer:
-        return self.tokenizer_class(dialect=self)
+    def tokenizer(self, **opts) -> Tokenizer:
+        return self.tokenizer_class(**{"dialect": self, **opts})
 
-    @property
-    def jsonpath_tokenizer(self) -> JSONPathTokenizer:
-        return self.jsonpath_tokenizer_class(dialect=self)
+    def jsonpath_tokenizer(self, **opts) -> JSONPathTokenizer:
+        return self.jsonpath_tokenizer_class(**{"dialect": self, **opts})
 
     def parser(self, **opts) -> Parser:
-        return self.parser_class(dialect=self, **opts)
+        return self.parser_class(**{"dialect": self, **opts})
 
     def generator(self, **opts) -> Generator:
-        return self.generator_class(dialect=self, **opts)
+        return self.generator_class(**{"dialect": self, **opts})
 
     def generate_values_aliases(self, expression: exp.Values) -> t.List[exp.Identifier]:
         return [

--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -41,7 +41,7 @@ def parse(path: str, dialect: DialectType = None) -> exp.JSONPath:
     """Takes in a JSON path string and parses it into a JSONPath expression."""
     from sqlglot.dialects import Dialect
 
-    jsonpath_tokenizer = Dialect.get_or_raise(dialect).jsonpath_tokenizer
+    jsonpath_tokenizer = Dialect.get_or_raise(dialect).jsonpath_tokenizer()
     tokens = jsonpath_tokenizer.tokenize(path)
     size = len(tokens)
 

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -21,12 +21,13 @@ def pushdown_predicates(expression, dialect=None):
     Returns:
         sqlglot.Expression: optimized expression
     """
+    from sqlglot.dialects.athena import Athena
     from sqlglot.dialects.presto import Presto
 
     root = build_scope(expression)
 
     dialect = Dialect.get_or_raise(dialect)
-    unnest_requires_cross_join = isinstance(dialect, Presto)
+    unnest_requires_cross_join = isinstance(dialect, (Athena, Presto))
 
     if root:
         scope_ref_count = root.ref_count()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1895,7 +1895,7 @@ class Parser(metaclass=_Parser):
             stmt.add_comments(comments, prepend=True)
             return stmt
 
-        if self._match_set(self.dialect.tokenizer.COMMANDS):
+        if self._match_set(self.dialect.tokenizer_class.COMMANDS):
             return self._parse_command()
 
         expression = self._parse_expression()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -427,6 +427,9 @@ class TokenType(AutoName):
     NAMESPACE = auto()
     EXPORT = auto()
 
+    # sentinel
+    HIVE_TOKEN_STREAM = auto()
+
 
 _ALL_TOKEN_TYPES = list(TokenType)
 _TOKEN_TYPE_TO_INDEX = {token_type: i for i, token_type in enumerate(_ALL_TOKEN_TYPES)}
@@ -1014,7 +1017,10 @@ class Tokenizer(metaclass=_Tokenizer):
     )
 
     def __init__(
-        self, dialect: DialectType = None, use_rs_tokenizer: t.Optional[bool] = None
+        self,
+        dialect: DialectType = None,
+        use_rs_tokenizer: t.Optional[bool] = None,
+        **opts: t.Any,
     ) -> None:
         from sqlglot.dialects import Dialect
 


### PR DESCRIPTION
Fixes #5267

This PR is a refactor of the Athena implementation. It was motivated by the linked issue, but its value extends beyond that– in other words, the ticket is not the only issue that I expect to be fixed by this PR.

TL;DR: Athena will now act as a proper router to either Hive or Trino, depending on the statement type (1, 2). Until now, it only routed the AST to the correct generator, but this was not enough, because the _lexical_ syntaxes of Hive and Trino contain incompatibilities, such as different string escapes, making them tricky to handle with a single tokenizer.

The way is implemented is that Athena now tokenizes the input string once, using a superset tokenizer that consumes both HiveQL and Trino SQL, and then re-tokenizes depending on what it finds in the token stream. Some rules have been implemented to decide whether the Hive or Trino dialect will be used post-tokenization.

In order to avoid having to re-detect what dialect a token stream corresponds to in the parsing stage, I've introduced a sentinel token type called `HIVE_TOKEN_STREAM` that is prepended in token streams corresponding to Hive inputs. This way, we can simply peek into the stream during parsing and figure out what parser to use. Of course, before parsing the token is popped from the stream, since it's not really a valid token.

Lastly, to support the routing mechanism, I changed `tokenizer` and `json_path_tokenizer` to proper methods, instead of `@property` ones. This was necessary in order to propagate the correct dialect instances for Hive and Trino in each `tokenize` invocation.

References:
1. https://docs.aws.amazon.com/athena/latest/ug/dml-queries-functions-operators.html
2. https://docs.aws.amazon.com/athena/latest/ug/ddl-reference.html