### PR TITLE
feat(exasol): add var_pop built in function to exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -24,6 +24,7 @@ class Exasol(Dialect):
                 position=seq_get(args, 3),
                 occurrence=seq_get(args, 4),
             ),
+            "VAR_POP": exp.VariancePop.from_arg_list,
         }
 
     class Generator(generator.Generator):
@@ -85,5 +86,8 @@ class Exasol(Dialect):
             ),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm
             exp.Mod: rename_func("MOD"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/regexp_replace.htm
             exp.RegexpReplace: unsupported_args("modifiers")(rename_func("REGEXP_REPLACE")),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/var_pop.htm
+            exp.VariancePop: rename_func("VAR_POP"),
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -181,6 +181,21 @@ class TestExasol(Validator):
                 "duckdb": "SELECT department, ALL (age >= 30) AS EVERY FROM employee_table GROUP BY department",
             },
         )
+        (
+            self.validate_all(
+                "SELECT VAR_POP(current_salary)",
+                write={
+                    "exasol": "SELECT VAR_POP(current_salary)",
+                    "duckdb": "SELECT VAR_POP(current_salary)",
+                    "presto": "SELECT VAR_POP(current_salary)",
+                },
+                read={
+                    "exasol": "SELECT VAR_POP(current_salary)",
+                    "duckdb": "SELECT VAR_POP(current_salary)",
+                    "presto": "SELECT VAR_POP(current_salary)",
+                },
+            ),
+        )
 
     def test_stringFunctions(self):
         self.validate_all(
@@ -217,21 +232,6 @@ class TestExasol(Validator):
                     "exasol": "REGEXP_REPLACE(subject, pattern, replacement, position, occurrence)",
                     "snowflake": "REGEXP_REPLACE(subject, pattern, replacement, position, occurrence)",
                     "spark": "REGEXP_REPLACE(subject, pattern, replacement, position, occurrence)",
-                },
-            ),
-        )
-        (
-            self.validate_all(
-                "SELECT VAR_POP(current_salary)",
-                write={
-                    "exasol": "SELECT VAR_POP(current_salary)",
-                    "duckdb": "SELECT VAR_POP(current_salary)",
-                    "presto": "SELECT VAR_POP(current_salary)",
-                },
-                read={
-                    "exasol": "SELECT VAR_POP(current_salary)",
-                    "duckdb": "SELECT VAR_POP(current_salary)",
-                    "presto": "SELECT VAR_POP(current_salary)",
                 },
             ),
         )

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -220,3 +220,18 @@ class TestExasol(Validator):
                 },
             ),
         )
+        (
+            self.validate_all(
+                "SELECT VAR_POP(current_salary)",
+                write={
+                    "exasol": "SELECT VAR_POP(current_salary)",
+                    "duckdb": "SELECT VAR_POP(current_salary)",
+                    "presto": "SELECT VAR_POP(current_salary)",
+                },
+                read={
+                    "exasol": "SELECT VAR_POP(current_salary)",
+                    "duckdb": "SELECT VAR_POP(current_salary)",
+                    "presto": "SELECT VAR_POP(current_salary)",
+                },
+            ),
+        )


### PR DESCRIPTION
This involves adding [VAR_POP](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/var_pop.htm) built -in function to exasol dialect in sqlglot.