### PR TITLE
feat(optimizer)!: annotate type for FROM_BASE64

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -767,7 +767,6 @@ class Dialect(metaclass=_Dialect):
         exp.ArrayReverse: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ArraySlice: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
-        exp.FromBase64: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),
         exp.Coalesce: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
@@ -784,6 +783,7 @@ class Dialect(metaclass=_Dialect):
         exp.Explode: lambda self, e: self._annotate_explode(e),
         exp.Extract: lambda self, e: self._annotate_extract(e),
         exp.Filter: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.FromBase64: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.GenerateDateArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<DATE>")
         ),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -767,6 +767,7 @@ class Dialect(metaclass=_Dialect):
         exp.ArrayReverse: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ArraySlice: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Bracket: lambda self, e: self._annotate_bracket(e),
+        exp.FromBase64: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Cast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Case: lambda self, e: self._annotate_by_args(e, "default", "ifs"),
         exp.Coalesce: lambda self, e: self._annotate_by_args(e, "this", "expressions"),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -52,6 +52,9 @@ ARRAY<DOUBLE>;
 ARRAY_SLICE([1, 1.5], 1, 2);
 ARRAY<DOUBLE>;
 
+FROM_BASE64(str_col);
+BINARY;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `FROM_BASE64` function.

**DOCS**
[BigQuery FROM_BASE64](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#from_base64)