### PR TITLE
feat(exasol): add add_approximate_count_distinct function

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -25,6 +25,7 @@ class Exasol(Dialect):
                 occurrence=seq_get(args, 4),
             ),
             "VAR_POP": exp.VariancePop.from_arg_list,
+            "APPROXIMATE_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
         }
 
     class Generator(generator.Generator):
@@ -90,4 +91,8 @@ class Exasol(Dialect):
             exp.RegexpReplace: unsupported_args("modifiers")(rename_func("REGEXP_REPLACE")),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/var_pop.htm
             exp.VariancePop: rename_func("VAR_POP"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/approximate_count_distinct.htm
+            exp.ApproxDistinct: unsupported_args("accuracy")(
+                rename_func("APPROXIMATE_COUNT_DISTINCT")
+            ),
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -196,6 +196,18 @@ class TestExasol(Validator):
                 },
             ),
         )
+        self.validate_all(
+            "SELECT APPROXIMATE_COUNT_DISTINCT(y)",
+            read={
+                "spark": "SELECT APPROX_COUNT_DISTINCT(y)",
+                "exasol": "SELECT APPROXIMATE_COUNT_DISTINCT(y)",
+            },
+            write={
+                "redshift": "SELECT APPROXIMATE COUNT(DISTINCT y)",
+                "spark": "SELECT APPROX_COUNT_DISTINCT(y)",
+                "exasol": "SELECT APPROXIMATE_COUNT_DISTINCT(y)",
+            },
+        )
 
     def test_stringFunctions(self):
         self.validate_all(


### PR DESCRIPTION
This involves adding [APPROXIMATE_COUNT_DISTINCT](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/approximate_count_distinct.htm) built -in function to exasol dialect in sqlglot.