### PR TITLE
feat(optimizer)!: annotate type for COUNTIF

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -639,6 +639,7 @@ class Dialect(metaclass=_Dialect):
         exp.DataType.Type.BIGINT: {
             exp.ApproxDistinct,
             exp.ArraySize,
+            exp.CountIf,
             exp.Length,
         },
         exp.DataType.Type.BOOLEAN: {
@@ -722,8 +723,10 @@ class Dialect(metaclass=_Dialect):
         },
         exp.DataType.Type.VARCHAR: {
             exp.ArrayConcat,
+            exp.ArrayToString,
             exp.Concat,
             exp.ConcatWs,
+            exp.Chr,
             exp.DateToDateStr,
             exp.DPipe,
             exp.GroupConcat,
@@ -762,7 +765,6 @@ class Dialect(metaclass=_Dialect):
         exp.ArrayAgg: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.ArrayConcatAgg: lambda self, e: self._annotate_by_args(e, "this"),
-        exp.ArrayToString: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TEXT),
         exp.ArrayFirst: lambda self, e: self._annotate_by_array_element(e),
         exp.ArrayLast: lambda self, e: self._annotate_by_array_element(e),
         exp.ArrayReverse: lambda self, e: self._annotate_by_args(e, "this"),
@@ -774,7 +776,6 @@ class Dialect(metaclass=_Dialect):
         exp.Count: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.BIGINT if e.args.get("big_int") else exp.DataType.Type.INT
         ),
-        exp.Chr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TEXT),
         exp.DataType: lambda self, e: self._annotate_with_type(e, e.copy()),
         exp.DateAdd: lambda self, e: self._annotate_timeunit(e),
         exp.DateSub: lambda self, e: self._annotate_timeunit(e),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -62,7 +62,10 @@ ANY_VALUE(tbl.array_col);
 ARRAY<STRING>;
 
 CHR(65);
-STRING;
+VARCHAR;
+
+COUNTIF(tbl.bigint_col > 1);
+BIGINT;
 
 --------------------------------------
 -- Spark2 / Spark3 / Databricks


### PR DESCRIPTION
This PR adds support for type annotation of `COUNTIF`.

**DOCS**
[BigQuery COUNTIF](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#countif)