### PR TITLE
feat(optimizer)!: annotate type for GENERATE_ARRAY

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -786,7 +786,9 @@ class Dialect(metaclass=_Dialect):
         exp.Extract: lambda self, e: self._annotate_extract(e),
         exp.Filter: lambda self, e: self._annotate_by_args(e, "this"),
         exp.FromBase64: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
-        exp.GenerateSeries: lambda self, e: self._annotate_by_args(e, "start", "end", "step"),
+        exp.GenerateSeries: lambda self, e: self._annotate_by_args(
+            e, "start", "end", "step", array=True
+        ),
         exp.GenerateDateArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<DATE>")
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -510,15 +510,15 @@ DOUBLE;
 
 # dialect: bigquery
 GENERATE_ARRAY(1, 5, 0.3);
-DOUBLE;
+ARRAY<DOUBLE>;
 
 # dialect: bigquery
 GENERATE_ARRAY(1, 5);
-BIGINT;
+ARRAY<BIGINT>;
 
 # dialect: bigquery
 GENERATE_ARRAY(1, 2.5);
-DOUBLE;
+ARRAY<DOUBLE>;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
This PR adds support for type annotation of `GENERATE_ARRAY`

**DOCS**
[BigQuery GENERATE_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/array_functions#generate_array)