### PR TITLE
feat(optimizer)!: annotate type for LAST_VALUE

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -797,6 +797,7 @@ class Dialect(metaclass=_Dialect):
         exp.Interval: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
         exp.Least: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Literal: lambda self, e: self._annotate_literal(e),
+        exp.LastValue: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Map: lambda self, e: self._annotate_map(e),
         exp.Max: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Min: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
@@ -815,6 +816,7 @@ class Dialect(metaclass=_Dialect):
         exp.TryCast: lambda self, e: self._annotate_with_type(e, e.args["to"]),
         exp.Unnest: lambda self, e: self._annotate_unnest(e),
         exp.VarMap: lambda self, e: self._annotate_map(e),
+        exp.Window: lambda self, e: self._annotate_by_args(e, "this"),
     }
 
     # Specifies what types a given type can be coerced into

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -64,6 +64,9 @@ ARRAY<STRING>;
 CHR(65);
 STRING;
 
+LAST_VALUE(tbl.bigint_col) OVER (ORDER BY tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
This PR adds support for the annotate type of `LAST_VALUE`

[BigQuery LAST_VALUE](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#last_value)