### PR TITLE
fix: fix comment lost before GROUP, JOIN and HAVING

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -646,6 +646,8 @@ class Generator(metaclass=_Generator):
         exp.Join,
         exp.MultitableInserts,
         exp.Order,
+        exp.Group,
+        exp.Having,
         exp.Select,
         exp.SetOperation,
         exp.Update,

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3818,8 +3818,7 @@ class Parser(metaclass=_Parser):
         kwargs["pivots"] = self._parse_pivots()
 
         comments = [c for token in (method, side, kind) if token for c in token.comments]
-        if len(comments) == 0:
-            comments = join_comments
+        comments = (join_comments or []) + comments
         return self.expression(exp.Join, comments=comments, **kwargs)
 
     def _parse_opclass(self) -> t.Optional[exp.Expression]:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3761,6 +3761,7 @@ class Parser(metaclass=_Parser):
         method, side, kind = self._parse_join_parts()
         hint = self._prev.text if self._match_texts(self.JOIN_HINTS) else None
         join = self._match(TokenType.JOIN) or (kind and kind.token_type == TokenType.STRAIGHT_JOIN)
+        join_comments = self._prev_comments
 
         if not skip_join_token and not join:
             self._retreat(index)
@@ -3817,6 +3818,8 @@ class Parser(metaclass=_Parser):
         kwargs["pivots"] = self._parse_pivots()
 
         comments = [c for token in (method, side, kind) if token for c in token.comments]
+        if len(comments) == 0:
+            comments = join_comments
         return self.expression(exp.Join, comments=comments, **kwargs)
 
     def _parse_opclass(self) -> t.Optional[exp.Expression]:
@@ -4468,6 +4471,7 @@ class Parser(metaclass=_Parser):
     def _parse_group(self, skip_group_by_token: bool = False) -> t.Optional[exp.Group]:
         if not skip_group_by_token and not self._match(TokenType.GROUP_BY):
             return None
+        comments = self._prev_comments
 
         elements: t.Dict[str, t.Any] = defaultdict(list)
 
@@ -4515,7 +4519,7 @@ class Parser(metaclass=_Parser):
             if index == self._index:
                 break
 
-        return self.expression(exp.Group, **elements)  # type: ignore
+        return self.expression(exp.Group, comments=comments, **elements)  # type: ignore
 
     def _parse_cube_or_rollup(self, kind: t.Type[E], with_prefix: bool = False) -> E:
         return self.expression(
@@ -4533,7 +4537,9 @@ class Parser(metaclass=_Parser):
     def _parse_having(self, skip_having_token: bool = False) -> t.Optional[exp.Having]:
         if not skip_having_token and not self._match(TokenType.HAVING):
             return None
-        return self.expression(exp.Having, this=self._parse_assignment())
+        return self.expression(
+            exp.Having, comments=self._prev_comments, this=self._parse_assignment()
+        )
 
     def _parse_qualify(self) -> t.Optional[exp.Qualify]:
         if not self._match(TokenType.QUALIFY):

--- a/tests/fixtures/pretty.sql
+++ b/tests/fixtures/pretty.sql
@@ -494,3 +494,31 @@ WHERE
 /* 222 */
 ORDER BY
   c;
+
+SELECT
+    COUNT(*)
+FROM
+    table_a
+/* join comment */
+JOIN
+    table_b
+ON
+    table_a.id = table_b.id
+/* group by comment */
+GROUP BY
+    table_a.id
+/* having comment */
+HAVING
+    table_a.id = 1;
+SELECT
+  COUNT(*)
+FROM table_a
+/* join comment */
+JOIN table_b
+  ON table_a.id = table_b.id
+/* group by comment */
+GROUP BY
+  table_a.id
+/* having comment */
+HAVING
+  table_a.id = 1;


### PR DESCRIPTION
Fix the lost single-line comments before GROUP, JOIN and HAVING.
```SQL
SELECT
    count(*)
FROM
    table_a
/* join comment */
JOIN
    table_b
ON
    table_a.id = table_b.id
/* group by comment */
GROUP BY
    table_a.id
/* having comment */
HAVING
    table_a.id = 1
```
The AST of the aboving SQL was like this with all the comments lost:
```
Select(
  expressions=[
    Count(
      this=Star(),
      big_int=True)],
  from=From(
    this=Table(
      this=Identifier(this=table_a, quoted=False))),
  joins=[
    Join(
      this=Table(
        this=Identifier(this=table_b, quoted=False)),
      on=EQ(
        this=Column(
          this=Identifier(this=id, quoted=False),
          table=Identifier(this=table_a, quoted=False)),
        expression=Column(
          this=Identifier(this=id, quoted=False),
          table=Identifier(this=table_b, quoted=False))))],
  group=Group(
    expressions=[
      Column(
        this=Identifier(this=id, quoted=False),
        table=Identifier(this=table_a, quoted=False))]),
  having=Having(
    this=EQ(
      this=Column(
        this=Identifier(this=id, quoted=False),
        table=Identifier(this=table_a, quoted=False)),
      expression=Literal(this=1, is_string=False))))
```
I found that the prefix comments for other keywords are also lost for the same reason (e.g., IN), but currently, the issues have only been encountered with GROUP, JOIN, and HAVING when I use sqlglot, so I have only fixed these three.