### PR TITLE
feat(optimizer)!: annotate type for LOGICAL_AND and LOGICAL_OR

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -647,6 +647,8 @@ class Dialect(metaclass=_Dialect):
             exp.Between,
             exp.Boolean,
             exp.In,
+            exp.LogicalAnd,
+            exp.LogicalOr,
             exp.RegexpLike,
         },
         exp.DataType.Type.DATE: {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -527,6 +527,12 @@ ARRAY<DOUBLE>;
 INT64(JSON '999');
 BIGINT;
 
+LOGICAL_AND(tbl.bool_col);
+BOOLEAN;
+
+LOGICAL_OR(tbl.bool_col);
+BOOLEAN;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds support for the type annotation of `LOGICAL_AND` and `LOGICAL_OR`.

**DOCS**
[BigQuery LOGICAL_AND](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#logical_and)
[BigQuery LOGICAL_OR](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#logical_or)