### PR TITLE
feat(optimizer)!: annotate type for MAKE_INTERVAL

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -697,6 +697,10 @@ class Dialect(metaclass=_Dialect):
             exp.StrPosition,
             exp.TsOrDiToDi,
         },
+        exp.DataType.Type.INTERVAL: {
+            exp.Interval,
+            exp.MakeInterval,
+        },
         exp.DataType.Type.JSON: {
             exp.ParseJSON,
         },
@@ -801,7 +805,6 @@ class Dialect(metaclass=_Dialect):
         ),
         exp.Greatest: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.If: lambda self, e: self._annotate_by_args(e, "true", "false"),
-        exp.Interval: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
         exp.Least: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Literal: lambda self, e: self._annotate_literal(e),
         exp.Map: lambda self, e: self._annotate_map(e),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -533,6 +533,10 @@ BOOLEAN;
 LOGICAL_OR(tbl.bool_col);
 BOOLEAN;
 
+# dialect: bigquery
+MAKE_INTERVAL(1, 6, 15);
+INTERVAL;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds support for the type annotation of `MAKE_INTERVAL`

**DOCS**
[BigQuery MAKE_INTERVAL](https://cloud.google.com/bigquery/docs/reference/standard-sql/interval_functions#make_interval)