### PR TITLE
feat(optimizer)!: annotate type for UNIX_SECONDS

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -643,6 +643,7 @@ class Dialect(metaclass=_Dialect):
             exp.Int64,
             exp.Length,
             exp.UnixDate,
+            exp.UnixSeconds,
         },
         exp.DataType.Type.BOOLEAN: {
             exp.Between,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -76,6 +76,9 @@ VARCHAR;
 UNIX_DATE(tbl.date_col);
 BIGINT;
 
+UNIX_SECONDS(timestamp_col);
+BIGINT;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
This PR adds annotation support for `UNIX_SECONDS`.

**DOCS**
[BigQuery UNIX_SECONDS](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#unix_seconds)