### PR TITLE
feat(optimizer)!: annotate type for STARTS_WITH

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -652,6 +652,7 @@ class Dialect(metaclass=_Dialect):
             exp.LogicalAnd,
             exp.LogicalOr,
             exp.RegexpLike,
+            exp.StartsWith,
         },
         exp.DataType.Type.DATE: {
             exp.CurrentDate,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -79,6 +79,9 @@ BIGINT;
 UNIX_SECONDS(timestamp_col);
 BIGINT;
 
+STARTS_WITH(tbl.str_col, prefix);
+BOOLEAN;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
This PR adds support for the type annotation of `STARTS_WITH`.

**DOCS**
[BigQuery STARTS_WITH](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#starts_with)