### PR TITLE
feat(optimizer)!: annotate type for SHA and SHA2

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -645,6 +645,11 @@ class Dialect(metaclass=_Dialect):
             exp.UnixDate,
             exp.UnixSeconds,
         },
+        exp.DataType.Type.BINARY: {
+            exp.FromBase64,
+            exp.SHA,
+            exp.SHA2,
+        },
         exp.DataType.Type.BOOLEAN: {
             exp.Between,
             exp.Boolean,
@@ -797,7 +802,6 @@ class Dialect(metaclass=_Dialect):
         exp.Explode: lambda self, e: self._annotate_explode(e),
         exp.Extract: lambda self, e: self._annotate_extract(e),
         exp.Filter: lambda self, e: self._annotate_by_args(e, "this"),
-        exp.FromBase64: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.GenerateSeries: lambda self, e: self._annotate_by_args(
             e, "start", "end", "step", array=True
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -82,6 +82,12 @@ BIGINT;
 STARTS_WITH(tbl.str_col, prefix);
 BOOLEAN;
 
+SHA(str_col);
+BINARY;
+
+SHA2(str_col);
+BINARY;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
This PR adds support for the type annotation of `SHA` and `SHA2`. 
These expressions are used also from BigQuery with a `rename_func` in order to generate the corresponding `SHA1`, `SHA256`, `SHA512`. 

**DOCS**
[BigQuery SHA functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions#sha1)