### PR TITLE
chore(optimizer)!: annotate type SHA1, SHA256, SHA512 for BigQuery

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -447,6 +447,8 @@ class BigQuery(Dialect):
         },
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Concat: _annotate_concat,
+        exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
+        exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Split: lambda self, e: self._annotate_by_args(e, "this", array=True),
     }

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -647,8 +647,6 @@ class Dialect(metaclass=_Dialect):
         },
         exp.DataType.Type.BINARY: {
             exp.FromBase64,
-            exp.SHA,
-            exp.SHA2,
         },
         exp.DataType.Type.BOOLEAN: {
             exp.Between,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -82,12 +82,6 @@ BIGINT;
 STARTS_WITH(tbl.str_col, prefix);
 BOOLEAN;
 
-SHA(str_col);
-BINARY;
-
-SHA2(str_col);
-BINARY;
-
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------
@@ -557,6 +551,18 @@ BOOLEAN;
 # dialect: bigquery
 MAKE_INTERVAL(1, 6, 15);
 INTERVAL;
+
+# dialect: bigquery
+SHA1(str_col);
+BINARY;
+
+# dialect: bigquery
+SHA256(str_col);
+BINARY;
+
+# dialect: bigquery
+SHA512(str_col);
+BINARY;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
This PR makes annotation of `SHA` functions only related to BigQuery dialect.
Other dialects aren't return the same type. 

**DOCS**
[BigQuery SHA functions](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions#sha1)