### PR TITLE
Chore: bump min. supported version to python 3.9

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -55,13 +55,13 @@ jobs:
     - uses: actions/setup-python@v5
       if: matrix.os == 'windows'
       with:
-        python-version: '3.8'
+        python-version: '3.9'
         architecture: ${{ matrix.python-architecture || 'x64' }}
     - name: Build wheels
       uses: PyO3/maturin-action@v1
       with:
         target: ${{ matrix.target }}
-        args: --release --out dist --interpreter 3.8 3.9 3.10 3.11 3.12 3.13
+        args: --release --out dist --interpreter 3.9 3.10 3.11 3.12 3.13
         sccache: 'true'
         manylinux: auto
         working-directory: ./sqlglotrs

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "An easily customizable SQL parser and transpiler"
 readme = "README.md"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
 license = { file = "LICENSE" }
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",

--- a/sqlglotrs/pyproject.toml
+++ b/sqlglotrs/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "sqlglotrs"
 description = "An easily customizable SQL parser and transpiler"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
Not much context here, I simply observed that Python 3.8 CI checks were taking longer and thought it's a good opportunity to deprecate it, since it's [EOL](devguide.python.org/versions/) since October 2024.

<img width="1129" alt="Screenshot 2025-07-05 at 2 27 59 PM" src="https://github.com/user-attachments/assets/89fd217c-4fcc-4342-ba8b-dea16b35d693" />
