### PR TITLE
feat(fabric): Ensure TIMESTAMPTZ is used with AT TIME ZONE

### DIFF
--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -65,6 +65,19 @@ class Fabric(TSQL):
         }
 
         def datatype_sql(self, expression: exp.DataType) -> str:
+            # DATETIMEOFFSET is only supported when used with AT TIME ZONE:
+            # https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql#microsoft-fabric-support
+            if expression.is_type(exp.DataType.Type.TIMESTAMPTZ):
+                parent = getattr(expression, "parent", None)
+                grandparent = getattr(parent, "parent", None) if parent else None
+
+                if not (grandparent and isinstance(grandparent, exp.AtTimeZone)):
+                    # Not used with AT TIME ZONE: treat as TIMESTAMP (DATETIME2)
+                    expression = exp.DataType(
+                        this=exp.DataType.Type.TIMESTAMP,
+                        expressions=expression.expressions,
+                    )
+
             # Check if this is a temporal type that needs precision handling. Fabric limits temporal
             # types to max 6 digits precision. When no precision is specified, we default to 6 digits.
             if (

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -68,14 +68,11 @@ class Fabric(TSQL):
             # DATETIMEOFFSET is only supported when used with AT TIME ZONE:
             # https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql#microsoft-fabric-support
             if expression.is_type(exp.DataType.Type.TIMESTAMPTZ):
-                parent = getattr(expression, "parent", None)
-                grandparent = getattr(parent, "parent", None) if parent else None
+                attimezone = expression.find_ancestor(exp.AtTimeZone, exp.Select)
 
-                if not (grandparent and isinstance(grandparent, exp.AtTimeZone)):
-                    # Not used with AT TIME ZONE: treat as TIMESTAMP (DATETIME2)
+                if not attimezone:
                     expression = exp.DataType(
-                        this=exp.DataType.Type.TIMESTAMP,
-                        expressions=expression.expressions,
+                        this=exp.DataType.Type.TIMESTAMP, expressions=expression.expressions
                     )
 
             # Check if this is a temporal type that needs precision handling. Fabric limits temporal

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -24,7 +24,6 @@ class TestFabric(Validator):
         self.validate_identity("CAST(x AS TEXT)", "CAST(x AS VARCHAR(MAX))")
         self.validate_identity("CAST(x AS TIMESTAMP)", "CAST(x AS DATETIME2(6))")
         self.validate_identity("CAST(x AS TIMESTAMPNTZ)", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIMEOFFSET(6))")
         self.validate_identity("CAST(x AS TINYINT)", "CAST(x AS SMALLINT)")
         self.validate_identity("CAST(x AS UTINYINT)", "CAST(x AS SMALLINT)")
         self.validate_identity("CAST(x AS UUID)", "CAST(x AS VARBINARY(MAX))")
@@ -36,25 +35,50 @@ class TestFabric(Validator):
         # Default precision should be 6
         self.validate_identity("CAST(x AS TIME)", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2)", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET)", "CAST(x AS DATETIMEOFFSET(6))")
+        self.validate_identity(
+            "CAST(x AS DATETIMEOFFSET) AT TIME ZONE 'UTC'",
+            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+        )
 
         # Precision <= 6 should be preserved
         self.validate_identity("CAST(x AS TIME(3))", "CAST(x AS TIME(3))")
         self.validate_identity("CAST(x AS DATETIME2(3))", "CAST(x AS DATETIME2(3))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET(3))", "CAST(x AS DATETIMEOFFSET(3))")
+        self.validate_identity(
+            "CAST(x AS DATETIMEOFFSET(3)) AT TIME ZONE 'UTC'",
+            "CAST(x AS DATETIMEOFFSET(3)) AT TIME ZONE 'UTC'",
+        )
 
         self.validate_identity("CAST(x AS TIME(6))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(6))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET(6))", "CAST(x AS DATETIMEOFFSET(6))")
+        self.validate_identity(
+            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+        )
 
         # Precision > 6 should be capped at 6
         self.validate_identity("CAST(x AS TIME(7))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(7))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET(7))", "CAST(x AS DATETIMEOFFSET(6))")
+        self.validate_identity(
+            "CAST(x AS DATETIMEOFFSET(7)) AT TIME ZONE 'UTC'",
+            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+        )
 
         self.validate_identity("CAST(x AS TIME(9))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(9))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET(9))", "CAST(x AS DATETIMEOFFSET(6))")
+        self.validate_identity(
+            "CAST(x AS DATETIMEOFFSET(9)) AT TIME ZONE 'UTC'",
+            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+        )
+
+    def test_timestamptz_handling(self):
+        # TIMESTAMPTZ should be DATETIME2 when not in an AT TIME ZONE expression
+        self.validate_identity("CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIME2(6))")
+
+        # TIMESTAMPTZ should be DATETIMEOFFSET when in an AT TIME ZONE expression
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ) AT TIME ZONE 'UTC'",
+            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+        )
 
     def test_unix_to_time(self):
         """Test UnixToTime transformation to DATEADD with microseconds"""

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -71,8 +71,10 @@ class TestFabric(Validator):
         )
 
     def test_timestamptz_handling(self):
-        # TIMESTAMPTZ should be DATETIME2 when not in an AT TIME ZONE expression
-        self.validate_identity("CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIME2(6))")
+        # TIMESTAMPTZ should be converted to UTC when not in an AT TIME ZONE expression
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'"
+        )
 
         # TIMESTAMPTZ should be DATETIMEOFFSET when in an AT TIME ZONE expression
         self.validate_identity(


### PR DESCRIPTION
This pull request updates the handling of `TIMESTAMPTZ` and `DATETIMEOFFSET` types in the Fabric SQL dialect to ensure compliance with Microsoft Fabric's requirements. It introduces logic to differentiate how `TIMESTAMPTZ` is treated based on whether it is used in an `AT TIME ZONE` expression and adjusts test cases accordingly.

### Changes to `TIMESTAMPTZ` and `DATETIMEOFFSET` handling:

* **Logic for `TIMESTAMPTZ` in `datatype_sql`:**
  - Added a check to wrap `TIMESTAMPTZ` in `AT TIME ZONE 'UTC'` when `AT TIME ZONE` is missing.

### Updates to test cases:
  
* **Modified precision handling for `DATETIMEOFFSET`:**
  - Adjusted tests to ensure `DATETIMEOFFSET` is only valid when paired with `AT TIME ZONE`, preserving precision limits.
  
* **Added new test for `TIMESTAMPTZ` behavior:**
  - Introduced a dedicated test to verify that `TIMESTAMPTZ` is used with `AT TIME ZONE`.