### PR TITLE
feat(optimizer)!: annotate type for DATETIME

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -454,7 +454,9 @@ class BigQuery(Dialect):
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Split: lambda self, e: self._annotate_by_args(e, "this", array=True),
-        exp.TimestampFromParts: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
+        exp.TimestampFromParts: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.DATETIME
+        ),
     }
 
     def normalize_identifier(self, expression: E) -> E:

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -454,6 +454,7 @@ class BigQuery(Dialect):
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Split: lambda self, e: self._annotate_by_args(e, "this", array=True),
+        exp.TimestampFromParts: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
     }
 
     def normalize_identifier(self, expression: E) -> E:

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -578,6 +578,10 @@ DOUBLE;
 COVAR_SAMP(tbl.double_col, tbl.double_col);
 DOUBLE;
 
+# dialect: bigquery
+DATETIME(2025, 1, 1, 12, 0, 0);
+DATETIME;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds support for the type annotation of `DATETIME`

**DOCS**
[BigQuery DATETIME](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime)