### PR TITLE
feat(optimizer)!: annotate type for LAG

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -450,6 +450,7 @@ class BigQuery(Dialect):
         exp.Corr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarSamp: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
+        exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Sign: lambda self, e: self._annotate_by_args(e, "this"),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -585,6 +585,14 @@ DOUBLE;
 DATETIME(2025, 1, 1, 12, 0, 0);
 DATETIME;
 
+# dialect: bigquery
+LAG(tbl.bigint_col, 1 , 2.5) OVER (ORDER BY tbl.bigint_col);
+DOUBLE;
+
+# dialect: bigquery
+LAG(tbl.bigint_col, 1 , 2) OVER (ORDER BY tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `LAG`

**DOCS**
[BigQuery LAG](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#lag)