### PR TITLE
feat(fabric): update TIMESTAMPTZ handling to include casting to DATETIME2

### DIFF
--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -98,9 +98,10 @@ class Fabric(TSQL):
             if expression.to and expression.to.is_type(exp.DataType.Type.TIMESTAMPTZ):
                 attimezone = expression.find_ancestor(exp.AtTimeZone, exp.Select)
                 if not isinstance(attimezone, exp.AtTimeZone):
-                    # We're not inside an AT TIME ZONE, so wrap the cast in AT TIME ZONE 'UTC'
+                    # We're not inside an AT TIME ZONE, so wrap the cast in AT TIME ZONE 'UTC' and cast it to TIMESTAMP
                     at_time_zone = exp.AtTimeZone(this=expression, zone=exp.Literal.string("UTC"))
-                    return self.sql(at_time_zone)
+                    cast = exp.cast(at_time_zone, exp.DataType.Type.TIMESTAMP)
+                    return self.sql(cast)
 
             return super().cast_sql(expression, safe_prefix)
 

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -65,9 +65,10 @@ class TestFabric(Validator):
         )
 
     def test_timestamptz_handling(self):
-        # TIMESTAMPTZ should be converted to UTC when not in an AT TIME ZONE expression
+        # TIMESTAMPTZ should be converted to UTC and cast to DATETIME2 when not in an AT TIME ZONE expression
         self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'"
+            "CAST(x AS TIMESTAMPTZ)",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
         )
 
         # TIMESTAMPTZ should be DATETIMEOFFSET when in an AT TIME ZONE expression


### PR DESCRIPTION
This pull request updates the handling of `TIMESTAMPTZ` data type in the `Fabric` SQL dialect. The changes ensure that when `TIMESTAMPTZ` is not within an `AT TIME ZONE` expression, it is both converted to UTC and cast to `TIMESTAMP`. Corresponding test cases have been updated to validate this behavior.

### Updates to `TIMESTAMPTZ` handling:

* **Enhancement in `cast_sql` method**:
  - Modified the logic to wrap `TIMESTAMPTZ` in `AT TIME ZONE 'UTC'` and cast it to `TIMESTAMP` when not inside an `AT TIME ZONE` expression.

* **Test case adjustments**:
  - Updated the `test_timestamptz_handling` test to validate that `TIMESTAMPTZ` is converted to UTC and cast to `DATETIME2` when outside an `AT TIME ZONE` expression.