### PR TITLE
fix!: duckdb week/quarter support

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp, generator, parser, tokens, transforms
+
 from sqlglot.expressions import DATA_TYPE
 from sqlglot.dialects.dialect import (
     Dialect,
@@ -990,20 +991,6 @@ class DuckDB(Dialect):
                     expression.set("method", exp.var("RESERVOIR"))
 
             return super().tablesample_sql(expression, tablesample_keyword=tablesample_keyword)
-
-        def interval_sql(self, expression: exp.Interval) -> str:
-            multiplier: t.Optional[int] = None
-            unit = expression.text("unit").lower()
-
-            if unit.startswith("week"):
-                multiplier = 7
-            if unit.startswith("quarter"):
-                multiplier = 90
-
-            if multiplier:
-                return f"({multiplier} * {super().interval_sql(exp.Interval(this=expression.this, unit=exp.var('DAY')))})"
-
-            return super().interval_sql(expression)
 
         def columndef_sql(self, expression: exp.ColumnDef, sep: str = " ") -> str:
             if isinstance(expression.parent, exp.UserDefinedFunction):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3213,7 +3213,7 @@ FROM subquery2""",
             write={
                 "bigquery": "SELECT * FROM UNNEST(GENERATE_DATE_ARRAY(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1' WEEK))",
                 "databricks": "SELECT * FROM EXPLODE(SEQUENCE(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1' WEEK))",
-                "duckdb": "SELECT * FROM UNNEST(CAST(GENERATE_SERIES(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), (7 * INTERVAL '1' DAY)) AS DATE[]))",
+                "duckdb": "SELECT * FROM UNNEST(CAST(GENERATE_SERIES(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1' WEEK) AS DATE[]))",
                 "mysql": "WITH RECURSIVE _generated_dates(date_value) AS (SELECT CAST('2020-01-01' AS DATE) AS date_value UNION ALL SELECT CAST(DATE_ADD(date_value, INTERVAL 1 WEEK) AS DATE) FROM _generated_dates WHERE CAST(DATE_ADD(date_value, INTERVAL 1 WEEK) AS DATE) <= CAST('2020-02-01' AS DATE)) SELECT * FROM (SELECT date_value FROM _generated_dates) AS _generated_dates",
                 "postgres": "SELECT * FROM (SELECT CAST(value AS DATE) FROM GENERATE_SERIES(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1 WEEK') AS _t(value)) AS _unnested_generate_series",
                 "presto": "SELECT * FROM UNNEST(SEQUENCE(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), (1 * INTERVAL '7' DAY)))",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1042,10 +1042,10 @@ class TestDuckDB(Validator):
         )
         self.validate_all(
             "SELECT INTERVAL '1 quarter'",
-            write={"duckdb": "SELECT (90 * INTERVAL '1' DAY)"},
+            write={"duckdb": "SELECT INTERVAL '1' QUARTER"},
         )
         self.validate_all(
-            "SELECT ((DATE_TRUNC('DAY', CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP) + INTERVAL (0 - ((ISODOW(CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP)) % 7) - 1 + 7) % 7) DAY) + (7 * INTERVAL (-5) DAY))) AS t1",
+            "SELECT ((DATE_TRUNC('DAY', CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP) + INTERVAL (0 - ((ISODOW(CAST(CAST(DATE_TRUNC('DAY', CURRENT_TIMESTAMP) AS DATE) AS TIMESTAMP)) % 7) - 1 + 7) % 7) DAY) + INTERVAL (-5) WEEK)) AS t1",
             read={
                 "presto": "SELECT ((DATE_ADD('week', -5, DATE_TRUNC('DAY', DATE_ADD('day', (0 - MOD((DAY_OF_WEEK(CAST(CAST(DATE_TRUNC('DAY', NOW()) AS DATE) AS TIMESTAMP)) % 7) - 1 + 7, 7)), CAST(CAST(DATE_TRUNC('DAY', NOW()) AS DATE) AS TIMESTAMP)))))) AS t1",
             },


### PR DESCRIPTION
This logic was originally added in 2023: https://github.com/tobymao/sqlglot/pull/1780

I can see quarter was at least added in 2024: https://github.com/duckdb/duckdb/pull/11898

Tested and confirmed that `0.10.3` added quarter support and week support is in `0.10.2` so not sure when that was added.

The original logic actually has a bug for quarter since it converted a quarter to 90 days but that isn't correct when doing additions and subtractions to dates. 

```
conn.execute("SELECT DATE_ADD(TIMESTAMP'2020-01-01 00:00:00', INTERVAL 1 QUARTER)").fetchall()
[(datetime.datetime(2020, 4, 1, 0, 0),)]
conn.execute("SELECT DATE_ADD(TIMESTAMP'2020-01-01 00:00:00', INTERVAL 90 DAY)").fetchall()
[(datetime.datetime(2020, 3, 31, 0, 0),)]
```

The previous week logic looks fine but isn't needed anymore:
```
conn.execute("SELECT INTERVAL (-5) WEEK").fetchall()
[(datetime.timedelta(days=-35),)]
```