### PR TITLE
Fix(optimizer)!: Preserve struct-column parentheses for RisingWave dialect

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -748,9 +748,7 @@ def simplify_parens(expression: exp.Expression, dialect: DialectType = None) -> 
     if (
         dialect == "risingwave"
         and isinstance(parent, exp.Dot)
-        and (
-            isinstance(parent.right, (exp.Identifier, exp.Star))
-        )
+        and (isinstance(parent.right, (exp.Identifier, exp.Star)))
     ):
         return expression
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -494,6 +494,36 @@ WITH tbl1 AS (SELECT STRUCT(1 AS col1, Struct(5 AS col1)) AS col) SELECT tbl1.co
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col1) AS col) SELECT tbl1.col.* FROM tbl1;
 WITH tbl1 AS (SELECT STRUCT(1 AS col1, 2 AS col1) AS col) SELECT tbl1.col.* FROM tbl1 AS tbl1;
 
+# dialect: bigquery
+# execute: false
+# title: BigQuery - Expand struct literal
+WITH tbl1 AS (SELECT STRUCT(1 AS f0, 2 as f1) AS col) SELECT tbl1.col.* from tbl1;
+WITH tbl1 AS (SELECT STRUCT(1 AS f0, 2 AS f1) AS col) SELECT tbl1.col.f0 AS f0, tbl1.col.f1 AS f1 FROM tbl1 AS tbl1;
+
+# dialect: bigquery
+# execute: false
+# title: BigQuery - Expand top level nested struct
+SELECT one.* FROM structs;
+SELECT structs.one.a_1 AS a_1, structs.one.b_1 AS b_1 FROM structs AS structs;
+
+# dialect: risingwave
+# execute: false
+# title: RisingWave - Expand top level nested struct
+SELECT (one).* FROM structs;
+SELECT (structs.one).a_1 AS a_1, (structs.one).b_1 AS b_1 FROM structs AS structs;
+
+# dialect: bigquery
+# execute: false
+# title: BigQuery - Expand midlevel struct
+SELECT nested_0.nested_1.* FROM structs;
+SELECT structs.nested_0.nested_1.a_2 AS a_2, structs.nested_0.nested_1.nested_2 AS nested_2 FROM structs AS structs;
+
+# dialect: risingwave
+# execute: false
+# title: RisingWave - Expand midlevel struct
+SELECT ((nested_0).nested_1).* FROM structs;
+SELECT ((structs.nested_0).nested_1).a_2 AS a_2, ((structs.nested_0).nested_1).nested_2 AS nested_2 FROM structs AS structs;
+
 # title: CSV files are not scanned by default
 # execute: false
 SELECT * FROM READ_CSV('file.csv');


### PR DESCRIPTION
This PR adds logic to the optimizer to preserve (possibly) semantically significant parentheses in the RisingWave dialect, see [docs here](https://docs.risingwave.com/sql/data-types/struct#retrieve-data-in-a-struct)

A minimal example looks like follows: Assume you have a column `struct_col (STRUCT<nested_col INT>)` and wish to access the nested column to bring it up to a top-level column. The select statement in RW would be (with quoting):
```sql
SELECT
  ("table"."struct_col")."nested_col" AS top_level_col
FROM
  "table"
```

The logic added checks if the dialect is RisingWave and the given parentheses follow the pattern `(<exp>).<identifier>` to preserve semantically significant parentheses. 

In addition this PR contains a minor refactor of the complicated conditional to instead use 2 guard clauses for better clarity.


Edit: Relevant Slack discussion: https://tobiko-data.slack.com/archives/C0448SFS3PF/p1751957408688319