### PR TITLE
feat(optimizer)!: parse and annotate type for ASCII

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -446,6 +446,7 @@ class BigQuery(Dialect):
             )
         },
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
+        exp.Ascii: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.Concat: _annotate_concat,
         exp.Corr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5468,6 +5468,10 @@ class Array(Func):
     is_var_len_args = True
 
 
+class Ascii(Func):
+    pass
+
+
 # https://docs.snowflake.com/en/sql-reference/functions/to_array
 class ToArray(Func):
     pass

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1757,6 +1757,7 @@ WHERE
 
         self.validate_identity("ARRAY_FIRST(['a', 'b'])")
         self.validate_identity("ARRAY_LAST(['a', 'b'])")
+        self.validate_identity("ASCII('A')")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -593,6 +593,10 @@ DOUBLE;
 LAG(tbl.bigint_col, 1 , 2) OVER (ORDER BY tbl.bigint_col);
 BIGINT;
 
+# dialect: bigquery
+ASCII('A');
+BIGINT;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `ASCII`

**DOCS**
[BigQuery ASCII](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#ascii)