### PR TITLE
feat(dremio): Add TIME_MAPPING for Dremio dialect

### DIFF
--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -13,24 +13,29 @@ class Dremio(Dialect):
 
     TIME_MAPPING = {
         # year
-        "YYYY": "%Y", "YY": "%y",
-
+        "YYYY": "%Y",
+        "YY": "%y",
         # month / day
-        "MM": "%m", "MON": "%b", "MONTH": "%B",
-        "DDD": "%j", "DD": "%d", "DY": "%a", "DAY": "%A",
-
+        "MM": "%m",
+        "MON": "%b",
+        "MONTH": "%B",
+        "DDD": "%j",
+        "DD": "%d",
+        "DY": "%a",
+        "DAY": "%A",
         # hours / minutes / seconds
-        "HH24": "%H", "HH": "%I",  # 24- / 12-hour
+        "HH24": "%H",
+        "HH": "%I",  # 24- / 12-hour
         "MI": "%M",
         "SS": "%S",
         "FFF": "%f",
-
         # ISO week / century etc.
-        "WW": "%W", "D": "%w", "CC": "%C",
-
+        "WW": "%W",
+        "D": "%w",
+        "CC": "%C",
         # timezone
         "TZD": "%Z",  # abbreviation  (UTC, PST, ...)
-        "TZO": "%z",   # numeric offset (+0200)
+        "TZO": "%z",  # numeric offset (+0200)
     }
 
     class Parser(parser.Parser):

--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -25,10 +25,12 @@ class Dremio(Dialect):
         "DAY": "%A",
         # hours / minutes / seconds
         "HH24": "%H",
+        "HH12": "%I",
         "HH": "%I",  # 24- / 12-hour
         "MI": "%M",
         "SS": "%S",
         "FFF": "%f",
+        "AMPM": "%p",
         # ISO week / century etc.
         "WW": "%W",
         "D": "%w",

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -95,36 +95,19 @@ class TestDremio(Validator):
             "SELECT COUNT(DISTINCT CASE WHEN a IS NULL THEN NULL WHEN b IS NULL THEN NULL ELSE (a, b) END) FROM t",
         )
 
-    def test_time_mapping_identity(self):
-        dremio_formats = [
-            "DDD",
-            "YYYY-MM-DD",
-            "YY/MM/DD",
-            "HH24:MI:SS",
-            "MON DD, YYYY",
-            'YYYY-MM-DD"T"HH24:MI:SS',
-            "FFF",
-            "TZD",
-            "TZO",
-            "WW",
-            "CC",
-        ]
-
-        for fmt in dremio_formats:
-            sql = f"SELECT TO_CHAR(CAST('2025-06-24 12:34:56' AS TIMESTAMP), '{fmt}')"
-            self.validate_identity(sql)
-
-    def test_time_mapping_transpile(self):
+    def test_time_mapping(self):
         ts = "CAST('2025-06-24 12:34:56' AS TIMESTAMP)"
 
         self.validate_all(
             f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
             read={
+                "dremio": f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
                 "postgres": f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
                 "oracle": f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
                 "duckdb": f"SELECT STRFTIME({ts}, '%Y-%m-%d %H:%M:%S')",
             },
             write={
+                "dremio": f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
                 "postgres": f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
                 "oracle": f"SELECT TO_CHAR({ts}, 'YYYY-MM-DD HH24:MI:SS')",
                 "duckdb": f"SELECT STRFTIME({ts}, '%Y-%m-%d %H:%M:%S')",
@@ -134,11 +117,13 @@ class TestDremio(Validator):
         self.validate_all(
             f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FFF TZD')",
             read={
+                "dremio": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FFF TZD')",
                 "postgres": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.US TZ')",
                 "oracle": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FF6 %Z')",
                 "duckdb": f"SELECT STRFTIME({ts}, '%y-%j %H:%M:%S.%f %Z')",
             },
             write={
+                "dremio": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FFF TZD')",
                 "postgres": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.US TZ')",
                 "oracle": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FF6 %Z')",
                 "duckdb": f"SELECT STRFTIME({ts}, '%y-%j %H:%M:%S.%f %Z')",


### PR DESCRIPTION
Adding `TIME_MAPPING` for Dremio dialect based on https://docs.dremio.com/current/reference/sql/sql-functions/DATE_TIME/

Also added support for `TO_CHAR` function which is needed for tests