### PR TITLE
feat(exasol): add to_date and refactored to_char functions with respect to time mapping

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -1,11 +1,45 @@
 from __future__ import annotations
 from sqlglot import exp, generator, parser
-from sqlglot.dialects.dialect import Dialect, rename_func, binary_from_function
+from sqlglot.dialects.dialect import (
+    Dialect,
+    rename_func,
+    binary_from_function,
+    build_formatted_time,
+)
 from sqlglot.helper import seq_get
 from sqlglot.generator import unsupported_args
 
 
 class Exasol(Dialect):
+    TIME_MAPPING = {
+        "y": "%Y",
+        "Y": "%Y",
+        "yyyy": "%Y",
+        "YYYY": "%Y",
+        "yy": "%y",
+        "YY": "%y",
+        "mm": "%m",
+        "MM": "%m",
+        "MONTH": "%B",
+        "MON": "%b",
+        "dd": "%d",
+        "DD": "%d",
+        "D": "%w",
+        "DAY": "%A",
+        "DY": "%a",
+        "H12": "%I",
+        "H24": "%-I",
+        "HH": "%-I",
+        "ID": "%u",
+        "vW": "%V",
+        "IW": "%V",
+        "vYYY": "%G",
+        "IYYY": "%G",
+        "MI": "%M",
+        "SS": "%S",
+        "Z": "%z",
+    }
+
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
@@ -26,7 +60,12 @@ class Exasol(Dialect):
             ),
             "VAR_POP": exp.VariancePop.from_arg_list,
             "APPROXIMATE_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
-            "TO_CHAR": exp.ToChar.from_arg_list,
+            "TO_CHAR": lambda args: build_formatted_time(exp.ToChar, "exasol")(
+                [seq_get(args, 0), seq_get(args, 1)]
+            ),
+            "TO_DATE": lambda args: build_formatted_time(exp.TsOrDsToDate, "exasol")(
+                [seq_get(args, 0), seq_get(args, 1)]
+            ),
         }
 
     class Generator(generator.Generator):
@@ -97,5 +136,7 @@ class Exasol(Dialect):
                 rename_func("APPROXIMATE_COUNT_DISTINCT")
             ),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_char%20(datetime).htm
-            exp.ToChar: rename_func("TO_CHAR"),
+            exp.ToChar: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm
+            exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
         }

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -12,8 +12,6 @@ from sqlglot.generator import unsupported_args
 
 class Exasol(Dialect):
     TIME_MAPPING = {
-        "y": "%Y",
-        "Y": "%Y",
         "yyyy": "%Y",
         "YYYY": "%Y",
         "yy": "%y",
@@ -24,12 +22,11 @@ class Exasol(Dialect):
         "MON": "%b",
         "dd": "%d",
         "DD": "%d",
-        "D": "%w",
         "DAY": "%A",
         "DY": "%a",
         "H12": "%I",
-        "H24": "%-I",
-        "HH": "%-I",
+        "H24": "%H",
+        "HH": "%H",
         "ID": "%u",
         "vW": "%V",
         "IW": "%V",
@@ -39,7 +36,6 @@ class Exasol(Dialect):
         "SS": "%S",
         "uW": "%W",
         "UW": "%U",
-        "VW": "%U",
         "Z": "%z",
     }
 

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -37,6 +37,9 @@ class Exasol(Dialect):
         "IYYY": "%G",
         "MI": "%M",
         "SS": "%S",
+        "uW": "%W",
+        "UW": "%U",
+        "VW": "%U",
         "Z": "%z",
     }
 
@@ -60,12 +63,8 @@ class Exasol(Dialect):
             ),
             "VAR_POP": exp.VariancePop.from_arg_list,
             "APPROXIMATE_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
-            "TO_CHAR": lambda args: build_formatted_time(exp.ToChar, "exasol")(
-                [seq_get(args, 0), seq_get(args, 1)]
-            ),
-            "TO_DATE": lambda args: build_formatted_time(exp.TsOrDsToDate, "exasol")(
-                [seq_get(args, 0), seq_get(args, 1)]
-            ),
+            "TO_CHAR": build_formatted_time(exp.ToChar, "exasol"),
+            "TO_DATE": build_formatted_time(exp.TsOrDsToDate, "exasol"),
         }
 
     class Generator(generator.Generator):

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -276,3 +276,68 @@ class TestExasol(Validator):
                 },
             ),
         )
+
+    def test_dateAndTimeFunctions(self):
+        self.validate_identity(
+            "SELECT TO_DATE('31-12-1999', 'dd-mm-yyyy') AS TO_DATE",
+            "SELECT TO_DATE('31-12-1999', 'DD-MM-YYYY') AS TO_DATE",
+        )
+        self.validate_identity(
+            "SELECT TO_DATE('31-12-1999', 'dd-mm-YY') AS TO_DATE",
+            "SELECT TO_DATE('31-12-1999', 'DD-MM-YY') AS TO_DATE",
+        )
+        self.validate_identity("SELECT TO_DATE('31-DECEMBER-1999', 'DD-MONTH-YYYY') AS TO_DATE")
+        self.validate_identity("SELECT TO_DATE('31-DEC-1999', 'DD-MON-YYYY') AS TO_DATE")
+        self.validate_identity("SELECT TO_CHAR(CAST('2025-07-08' AS DATE), 'D') AS day_of_week")
+        self.validate_identity("SELECT TO_CHAR(CAST('2025-07-08' AS DATE), 'DAY') AS day_of_week")
+        self.validate_identity("SELECT TO_CHAR(CAST('2025-07-08' AS DATE), 'DY') AS day_of_week")
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'HH12') AS hour_12"
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'HH24') AS hour_24"
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'ID') AS iso_weekday"
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'IW') AS iso_week_number"
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'IYYY') AS iso_year"
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'MI') AS minutes"
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'SS') AS seconds"
+        )
+
+        self.validate_all(
+            "TO_DATE(x, 'YYYY-MM-DD')",
+            write={
+                "exasol": "TO_DATE(x, 'YYYY-MM-DD')",
+                "duckdb": "CAST(x AS DATE)",
+                "hive": "TO_DATE(x)",
+                "presto": "CAST(CAST(x AS TIMESTAMP) AS DATE)",
+                "spark": "TO_DATE(x)",
+                "snowflake": "TO_DATE(x, 'yyyy-mm-DD')",
+                "databricks": "TO_DATE(x)",
+            },
+            read={"exasol": "TO_DATE(x, 'yyyy-MM-dd')"},
+        )
+        self.validate_all(
+            "TO_DATE(x, 'YYYY')",
+            write={
+                "exasol": "TO_DATE(x, 'YYYY')",
+                "duckdb": "CAST(STRPTIME(x, '%Y') AS DATE)",
+                "hive": "TO_DATE(x, 'yyyy')",
+                "presto": "CAST(DATE_PARSE(x, '%Y') AS DATE)",
+                "spark": "TO_DATE(x, 'yyyy')",
+                "snowflake": "TO_DATE(x, 'yyyy')",
+                "databricks": "TO_DATE(x, 'yyyy')",
+            },
+            read={
+                "exasol": "TO_DATE(x, 'yyyy')",
+            },
+        )

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -278,6 +278,20 @@ class TestExasol(Validator):
         )
 
     def test_dateAndTimeFunctions(self):
+        formats = {
+            "HH12": "hour_12",
+            "HH24": "hour_24",
+            "ID": "iso_weekday",
+            "IW": "iso_week_number",
+            "uW": "week_number_uW",
+            "VW": "week_number_VW",
+            "IYYY": "iso_year",
+            "MI": "minutes",
+            "SS": "seconds",
+            "D": "day_number",
+            "DAY": "day_full",
+            "DY": "day_abbr",
+        }
         self.validate_identity(
             "SELECT TO_DATE('31-12-1999', 'dd-mm-yyyy') AS TO_DATE",
             "SELECT TO_DATE('31-12-1999', 'DD-MM-YYYY') AS TO_DATE",
@@ -288,30 +302,12 @@ class TestExasol(Validator):
         )
         self.validate_identity("SELECT TO_DATE('31-DECEMBER-1999', 'DD-MONTH-YYYY') AS TO_DATE")
         self.validate_identity("SELECT TO_DATE('31-DEC-1999', 'DD-MON-YYYY') AS TO_DATE")
-        self.validate_identity("SELECT TO_CHAR(CAST('2025-07-08' AS DATE), 'D') AS day_of_week")
-        self.validate_identity("SELECT TO_CHAR(CAST('2025-07-08' AS DATE), 'DAY') AS day_of_week")
-        self.validate_identity("SELECT TO_CHAR(CAST('2025-07-08' AS DATE), 'DY') AS day_of_week")
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'HH12') AS hour_12"
-        )
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'HH24') AS hour_24"
-        )
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'ID') AS iso_weekday"
-        )
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'IW') AS iso_week_number"
-        )
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'IYYY') AS iso_year"
-        )
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'MI') AS minutes"
-        )
-        self.validate_identity(
-            "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'SS') AS seconds"
-        )
+
+        for fmt, alias in formats.items():
+            with self.subTest(f"Testing TO_CHAR with format '{fmt}'"):
+                self.validate_identity(
+                    f"SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), '{fmt}') AS {alias}"
+                )
 
         self.validate_all(
             "TO_DATE(x, 'YYYY-MM-DD')",
@@ -324,7 +320,6 @@ class TestExasol(Validator):
                 "snowflake": "TO_DATE(x, 'yyyy-mm-DD')",
                 "databricks": "TO_DATE(x)",
             },
-            read={"exasol": "TO_DATE(x, 'yyyy-MM-dd')"},
         )
         self.validate_all(
             "TO_DATE(x, 'YYYY')",
@@ -336,8 +331,5 @@ class TestExasol(Validator):
                 "spark": "TO_DATE(x, 'yyyy')",
                 "snowflake": "TO_DATE(x, 'yyyy')",
                 "databricks": "TO_DATE(x, 'yyyy')",
-            },
-            read={
-                "exasol": "TO_DATE(x, 'yyyy')",
             },
         )

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -277,7 +277,7 @@ class TestExasol(Validator):
             ),
         )
 
-    def test_dateAndTimeFunctions(self):
+    def test_datetime_functions(self):
         formats = {
             "HH12": "hour_12",
             "HH24": "hour_24",
@@ -288,7 +288,6 @@ class TestExasol(Validator):
             "IYYY": "iso_year",
             "MI": "minutes",
             "SS": "seconds",
-            "D": "day_number",
             "DAY": "day_full",
             "DY": "day_abbr",
         }


### PR DESCRIPTION
This involves adding [TO_DATE](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm) built -in function to exasol dialect in sqlglot and implementing time mappings