### PR TITLE
feat(optimizer)!: annotate type for UNICODE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -459,6 +459,7 @@ class BigQuery(Dialect):
         exp.TimestampFromParts: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.DATETIME
         ),
+        exp.Unicode: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
     }
 
     def normalize_identifier(self, expression: E) -> E:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -705,6 +705,7 @@ class Dialect(metaclass=_Dialect):
             exp.DateDiff,
             exp.TimestampDiff,
             exp.TimeDiff,
+            exp.Unicode,
             exp.DateToDi,
             exp.Levenshtein,
             exp.Sign,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -88,6 +88,9 @@ BOOLEAN;
 ASCII('A');
 INT;
 
+UNICODE('bcd');
+INT;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------
@@ -598,6 +601,10 @@ BIGINT;
 
 # dialect: bigquery
 ASCII('A');
+BIGINT;
+
+# dialect: bigquery
+UNICODE('bcd');
 BIGINT;
 
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation support for `UNICODE`. 

[BigQuery UNICODE](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#unicode)