### PR TITLE
Fix(fabric): cast datetimeoffset to datetime2

### DIFF
--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -18,7 +18,6 @@ def _cap_data_type_precision(expression: exp.DataType, max_precision: int = 6) -
     if precision_param and precision_param.this.is_int:
         current_precision = precision_param.this.to_py()
         target_precision = min(current_precision, max_precision)
-
     else:
         target_precision = max_precision
 

--- a/sqlglot/dialects/fabric.py
+++ b/sqlglot/dialects/fabric.py
@@ -103,7 +103,7 @@ class Fabric(TSQL):
             if expression.is_type(exp.DataType.Type.TIMESTAMPTZ):
                 at_time_zone = expression.find_ancestor(exp.AtTimeZone, exp.Select)
 
-                # Return normal cast, ff the expression is not in an AT TIME ZONE context
+                # Return normal cast, if the expression is not in an AT TIME ZONE context
                 if not isinstance(at_time_zone, exp.AtTimeZone):
                     return super().cast_sql(expression, safe_prefix)
 

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -36,44 +36,52 @@ class TestFabric(Validator):
         self.validate_identity("CAST(x AS TIME)", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2)", "CAST(x AS DATETIME2(6))")
         self.validate_identity(
-            "CAST(x AS DATETIMEOFFSET) AT TIME ZONE 'UTC'",
-            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+            "CAST(x AS TIMESTAMPTZ)",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
         )
 
         # Precision <= 6 should be preserved
         self.validate_identity("CAST(x AS TIME(3))", "CAST(x AS TIME(3))")
         self.validate_identity("CAST(x AS DATETIME2(3))", "CAST(x AS DATETIME2(3))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET(3)) AT TIME ZONE 'UTC'")
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(3))",
+            "CAST(CAST(x AS DATETIMEOFFSET(3)) AT TIME ZONE 'UTC' AS DATETIME2(3))",
+        )
 
         self.validate_identity("CAST(x AS TIME(6))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(6))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity("CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'")
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(6))",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
+        )
 
         # Precision > 6 should be capped at 6
         self.validate_identity("CAST(x AS TIME(7))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(7))", "CAST(x AS DATETIME2(6))")
         self.validate_identity(
-            "CAST(x AS DATETIMEOFFSET(7)) AT TIME ZONE 'UTC'",
-            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+            "CAST(x AS TIMESTAMPTZ(7))",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
         )
 
         self.validate_identity("CAST(x AS TIME(9))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(9))", "CAST(x AS DATETIME2(6))")
         self.validate_identity(
-            "CAST(x AS DATETIMEOFFSET(9)) AT TIME ZONE 'UTC'",
-            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+            "CAST(x AS TIMESTAMPTZ(9))",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
         )
 
-    def test_timestamptz_handling(self):
-        # TIMESTAMPTZ should be converted to UTC when not in an AT TIME ZONE expression
+    def test_timestamptz_without_at_time_zone(self):
+        # TIMESTAMPTZ should be converted to UTC when not in an AT TIME ZONE expression and then cast to TIMESTAMP
         self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ)", "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'"
+            "CAST(x AS TIMESTAMPTZ)",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
         )
 
+    def test_timestamptz_with_at_time_zone(self):
         # TIMESTAMPTZ should be DATETIMEOFFSET when in an AT TIME ZONE expression
         self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ) AT TIME ZONE 'UTC'",
-            "CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC'",
+            "CAST(x AS TIMESTAMPTZ) AT TIME ZONE 'Pacific Standard Time'",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6)) AT TIME ZONE 'Pacific Standard Time'",
         )
 
     def test_unix_to_time(self):

--- a/tests/dialects/test_fabric.py
+++ b/tests/dialects/test_fabric.py
@@ -35,53 +35,57 @@ class TestFabric(Validator):
         # Default precision should be 6
         self.validate_identity("CAST(x AS TIME)", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2)", "CAST(x AS DATETIME2(6))")
-        self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ)",
-            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
-        )
 
         # Precision <= 6 should be preserved
         self.validate_identity("CAST(x AS TIME(3))", "CAST(x AS TIME(3))")
         self.validate_identity("CAST(x AS DATETIME2(3))", "CAST(x AS DATETIME2(3))")
-        self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ(3))",
-            "CAST(CAST(x AS DATETIMEOFFSET(3)) AT TIME ZONE 'UTC' AS DATETIME2(3))",
-        )
 
         self.validate_identity("CAST(x AS TIME(6))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(6))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ(6))",
-            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
-        )
 
         # Precision > 6 should be capped at 6
         self.validate_identity("CAST(x AS TIME(7))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(7))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ(7))",
-            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
-        )
 
         self.validate_identity("CAST(x AS TIME(9))", "CAST(x AS TIME(6))")
         self.validate_identity("CAST(x AS DATETIME2(9))", "CAST(x AS DATETIME2(6))")
-        self.validate_identity(
-            "CAST(x AS TIMESTAMPTZ(9))",
-            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
-        )
 
     def test_timestamptz_without_at_time_zone(self):
-        # TIMESTAMPTZ should be converted to UTC when not in an AT TIME ZONE expression and then cast to TIMESTAMP
+        # TIMESTAMPTZ should be cast to TIMESTAMP when not in an AT TIME ZONE
         self.validate_identity(
             "CAST(x AS TIMESTAMPTZ)",
-            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6))",
+            "CAST(x AS DATETIME2(6))",
+        )
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(3))",
+            "CAST(x AS DATETIME2(3))",
+        )
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(6))",
+            "CAST(x AS DATETIME2(6))",
+        )
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(9))",
+            "CAST(x AS DATETIME2(6))",
         )
 
     def test_timestamptz_with_at_time_zone(self):
-        # TIMESTAMPTZ should be DATETIMEOFFSET when in an AT TIME ZONE expression
+        # TIMESTAMPTZ should be DATETIMEOFFSET when in an AT TIME ZONE expression and then cast to TIMESTAMP
         self.validate_identity(
             "CAST(x AS TIMESTAMPTZ) AT TIME ZONE 'Pacific Standard Time'",
-            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'UTC' AS DATETIME2(6)) AT TIME ZONE 'Pacific Standard Time'",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'Pacific Standard Time' AS DATETIME2(6))",
+        )
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(3)) AT TIME ZONE 'Pacific Standard Time'",
+            "CAST(CAST(x AS DATETIMEOFFSET(3)) AT TIME ZONE 'Pacific Standard Time' AS DATETIME2(3))",
+        )
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(6)) AT TIME ZONE 'Pacific Standard Time'",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'Pacific Standard Time' AS DATETIME2(6))",
+        )
+        self.validate_identity(
+            "CAST(x AS TIMESTAMPTZ(9)) AT TIME ZONE 'Pacific Standard Time'",
+            "CAST(CAST(x AS DATETIMEOFFSET(6)) AT TIME ZONE 'Pacific Standard Time' AS DATETIME2(6))",
         )
 
     def test_unix_to_time(self):


### PR DESCRIPTION
This pull request refines how the Fabric dialect handles temporal data types and refactors precision capping for these types. It also updates the handling of `TIMESTAMPTZ` casts to transform it into `TIMESTAMP`.

### Enhancements to temporal type handling:

* **Precision capping logic**: Added `_cap_data_type_precision` helper function to cap the precision of temporal types to a maximum of 6 digits and default to 6 if no precision is specified. (`sqlglot/dialects/fabric.py`, [sqlglot/dialects/fabric.pyL3-R30](diffhunk://#diff-ec3f7bdb2c80d6a8318d44a7f5fcb07a5aa1a3f4f3641156eb9f14b1a0931f6aL3-R30))
* **Updated SQL generation for temporal types**: Modified `datatype_sql` and `cast_sql` methods to use `_cap_data_type_precision` for temporal types, ensuring capped precision and consistent handling of `TIMESTAMPTZ` casts. (`sqlglot/dialects/fabric.py`, [sqlglot/dialects/fabric.pyL62-R124](diffhunk://#diff-ec3f7bdb2c80d6a8318d44a7f5fcb07a5aa1a3f4f3641156eb9f14b1a0931f6aL62-R124))

### Test updates:

* **Precision capping tests**: Updated `test_precision_capping` to validate capped precision for temporal types and ensure consistent handling of `TIMESTAMPTZ` casts. (`tests/dialects/test_fabric.py`, [tests/dialects/test_fabric.pyL39-R84](diffhunk://#diff-4e9274522d52bed321c05a42ca1956bf400b6421ecd08157e6499f431670ede7L39-R84))
* **Additional `TIMESTAMPTZ` tests**: Added `test_timestamptz_without_at_time_zone` and `test_timestamptz_with_at_time_zone` to verify correct transformation of `TIMESTAMPTZ` casts with and without `AT TIME ZONE`. (`tests/dialects/test_fabric.py`, [tests/dialects/test_fabric.pyL39-R84](diffhunk://#diff-4e9274522d52bed321c05a42ca1956bf400b6421ecd08157e6499f431670ede7L39-R84))