### PR TITLE
fix(snowflake): transpile bigquery CURRENT_DATE with timezone

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1509,4 +1509,8 @@ class Snowflake(Dialect):
             if not zone:
                 return super().currentdate_sql(expression)
 
-            return f"TO_DATE(CONVERT_TIMEZONE({zone}, CURRENT_TIMESTAMP()))"
+            expr = exp.Cast(
+                this=exp.ConvertTimezone(target_tz=zone, timestamp=exp.CurrentTimestamp()),
+                to=exp.DataType(this=exp.DataType.Type.DATE),
+            )
+            return self.sql(expr)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1503,3 +1503,10 @@ class Snowflake(Dialect):
                     return self.sql(first_expr.subquery())
 
             return inline_array_sql(self, expression)
+
+        def currentdate_sql(self, expression: exp.CurrentDate) -> str:
+            zone = self.sql(expression, "this")
+            if not zone:
+                return super().currentdate_sql(expression)
+
+            return f"TO_DATE(CONVERT_TIMEZONE({zone}, CURRENT_TIMESTAMP()))"

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1392,9 +1392,14 @@ LANGUAGE js AS
         )
         self.validate_all(
             "CURRENT_DATE('UTC')",
+            read={
+                "bigquery": "CURRENT_DATE('UTC')",
+            },
             write={
+                "bigquery": "CURRENT_DATE('UTC')",
                 "mysql": "CURRENT_DATE AT TIME ZONE 'UTC'",
                 "postgres": "CURRENT_DATE AT TIME ZONE 'UTC'",
+                "snowflake": "CAST(CONVERT_TIMEZONE('UTC', CURRENT_TIMESTAMP()) AS DATE)",
             },
         )
         self.validate_all(
@@ -1757,13 +1762,6 @@ WHERE
 
         self.validate_identity("ARRAY_FIRST(['a', 'b'])")
         self.validate_identity("ARRAY_LAST(['a', 'b'])")
-
-        self.validate_all(
-            "CURRENT_DATE('timezone')",
-            write={
-                "snowflake": "TO_DATE(CONVERT_TIMEZONE('timezone', CURRENT_TIMESTAMP()))",
-            },
-        )
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1758,6 +1758,13 @@ WHERE
         self.validate_identity("ARRAY_FIRST(['a', 'b'])")
         self.validate_identity("ARRAY_LAST(['a', 'b'])")
 
+        self.validate_all(
+            "CURRENT_DATE('timezone')",
+            write={
+                "snowflake": "TO_DATE(CONVERT_TIMEZONE('timezone', CURRENT_TIMESTAMP()))",
+            },
+        )
+
     def test_errors(self):
         with self.assertRaises(ParseError):
             self.parse_one("SELECT * FROM a - b.c.d2")

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1392,9 +1392,6 @@ LANGUAGE js AS
         )
         self.validate_all(
             "CURRENT_DATE('UTC')",
-            read={
-                "bigquery": "CURRENT_DATE('UTC')",
-            },
             write={
                 "bigquery": "CURRENT_DATE('UTC')",
                 "mysql": "CURRENT_DATE AT TIME ZONE 'UTC'",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1167,6 +1167,9 @@ class TestSnowflake(Validator):
             },
         )
 
+        self.validate_identity("CURRENT_DATE")
+        self.validate_identity("TO_DATE(CONVERT_TIMEZONE('timezone', CURRENT_TIMESTAMP()))")
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1167,9 +1167,6 @@ class TestSnowflake(Validator):
             },
         )
 
-        self.validate_identity("CURRENT_DATE")
-        self.validate_identity("TO_DATE(CONVERT_TIMEZONE('timezone', CURRENT_TIMESTAMP()))")
-
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
This PR adds transpilation support for `CURRENT_DATE` with timezone of BigQuery to Snowflake.

Snowflake doesn't support `CURRENT_DATE('timezone')`, so we implement this by using the `CURRENT_TIMESTAMP` combined with `CONVERT_TIMEZONE` and `CAST`.

**DOCS**
[BigQuery CURRENT_DATE](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#current_date)
[Snowflake CURRENT_TIMESTAMP](https://docs.snowflake.com/en/sql-reference/functions/current_timestamp)
[Snowflake CONVERT_TIMEZONE](https://docs.snowflake.com/en/sql-reference/functions/convert_timezone)
[Snowflake TO_DATE](https://docs.snowflake.com/en/sql-reference/functions/to_date)