### PR TITLE
fix(snowflake): transpile bigquery GENERATE_DATE_ARRAY with column access

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -264,7 +264,7 @@ def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
                 else sequence_value_name.name
             )
             for column in select.selects:
-                if column.this.name == replace_column_name:
+                if column.this.name.lower() == replace_column_name.lower():
                     column.replace(date_add.as_(column.alias_or_name))
             lateral = exp.Lateral(this=unnest_parent.this.pop())
             unnest_parent.replace(exp.Join(this=lateral))

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -263,9 +263,17 @@ def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
                 if isinstance(sequence_value_name, str)
                 else sequence_value_name.name
             )
-            for column in select.selects:
-                if column.this.name.lower() == replace_column_name.lower():
-                    column.replace(date_add.as_(column.alias_or_name))
+
+            scope = build_scope(select)
+            if scope:
+                for column in scope.columns:
+                    if column.name.lower() == replace_column_name.lower():
+                        column.replace(
+                            date_add.as_(replace_column_name)
+                            if isinstance(column.parent, exp.Select)
+                            else date_add
+                        )
+
             lateral = exp.Lateral(this=unnest_parent.this.pop())
             unnest_parent.replace(exp.Join(this=lateral))
     else:

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -245,7 +245,7 @@ def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
     # We'll add the next sequence value to the starting date and project the result
     date_add = _build_date_time_add(exp.DateAdd)(
         [unit, exp.cast(sequence_value_name, "int"), exp.cast(start, "date")]
-    ).as_(sequence_value_name)
+    )
 
     # We use DATEDIFF to compute the number of sequence values needed
     number_sequence = Snowflake.Parser.FUNCTIONS["ARRAY_GENERATE_RANGE"](
@@ -253,7 +253,27 @@ def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
     )
 
     unnest.set("expressions", [number_sequence])
-    unnest.replace(exp.select(date_add).from_(unnest.copy()).subquery(unnest_alias))
+
+    unnest_parent = unnest.parent
+    if isinstance(unnest_parent, exp.Join):
+        select = unnest_parent.parent
+        if isinstance(select, exp.Select):
+            replace_column_name = (
+                sequence_value_name
+                if isinstance(sequence_value_name, str)
+                else sequence_value_name.name
+            )
+            for column in select.selects:
+                if column.this.name == replace_column_name:
+                    column.replace(date_add.as_(column.alias_or_name))
+            lateral = exp.Lateral(this=unnest_parent.this.pop())
+            unnest_parent.replace(exp.Join(this=lateral))
+    else:
+        unnest.replace(
+            exp.select(date_add.as_(sequence_value_name))
+            .from_(unnest.copy())
+            .subquery(unnest_alias)
+        )
 
 
 def _transform_generate_date_array(expression: exp.Expression) -> exp.Expression:
@@ -1403,10 +1423,20 @@ class Snowflake(Dialect):
             if not table_input.startswith("INPUT =>"):
                 table_input = f"INPUT => {table_input}"
 
-            explode = f"TABLE(FLATTEN({table_input}))"
+            expression_parent = expression.parent
+
+            explode = (
+                f"FLATTEN({table_input})"
+                if isinstance(expression_parent, exp.Lateral)
+                else f"TABLE(FLATTEN({table_input}))"
+            )
             alias = self.sql(unnest_alias)
             alias = f" AS {alias}" if alias else ""
-            value = "" if isinstance(expression.parent, (exp.From, exp.Join)) else f"{value} FROM "
+            value = (
+                ""
+                if isinstance(expression_parent, (exp.From, exp.Join, exp.Lateral))
+                else f"{value} FROM "
+            )
 
             return f"{value}{explode}{alias}"
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1556,20 +1556,6 @@ WHERE
             },
         )
         self.validate_all(
-            "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08')",
-            write={
-                "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL '1' DAY) AS DATE[])",
-                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' DAY)",
-            },
-        )
-        self.validate_all(
-            "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
-            write={
-                "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL '1' MONTH) AS DATE[])",
-                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
-            },
-        )
-        self.validate_all(
             "SELECT GENERATE_TIMESTAMP_ARRAY('2016-10-05 00:00:00', '2016-10-07 00:00:00', INTERVAL '1' DAY)",
             write={
                 "duckdb": "SELECT GENERATE_SERIES(CAST('2016-10-05 00:00:00' AS TIMESTAMP), CAST('2016-10-07 00:00:00' AS TIMESTAMP), INTERVAL '1' DAY)",
@@ -2661,3 +2647,33 @@ OPTIONS (
                     "databricks": f"SELECT * FROM tbl LATERAL VIEW POSEXPLODE(col) AS {alias}, ref",
                 },
             )
+
+    def test_generate_date_array(self):
+        self.validate_all(
+            "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08')",
+            write={
+                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' DAY)",
+                "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL '1' DAY) AS DATE[])",
+            },
+        )
+        self.validate_all(
+            "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
+            write={
+                "bigquery": "SELECT GENERATE_DATE_ARRAY('2016-10-05', '2016-10-08', INTERVAL '1' MONTH)",
+                "duckdb": "SELECT CAST(GENERATE_SERIES(CAST('2016-10-05' AS DATE), CAST('2016-10-08' AS DATE), INTERVAL '1' MONTH) AS DATE[])",
+            },
+        )
+        self.validate_all(
+            "SELECT id, mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+            write={
+                "bigquery": "SELECT id, mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+                "snowflake": "SELECT id, DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) AS mnth FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1) + 1)) AS _t0(seq, key, path, index, mnth, this)",
+            },
+        )
+        self.validate_all(
+            "SELECT id, mnth AS a_mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+            write={
+                "bigquery": "SELECT id, mnth AS a_mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+                "snowflake": "SELECT id, DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) AS a_mnth FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1) + 1)) AS _t0(seq, key, path, index, mnth, this)",
+            },
+        )

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2667,6 +2667,7 @@ OPTIONS (
             "SELECT id, mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
             write={
                 "bigquery": "SELECT id, mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+                "duckdb": "SELECT id, mnth FROM t CROSS JOIN UNNEST(CAST(GENERATE_SERIES(start_month, DATE_TRUNC('MONTH', CURRENT_DATE), INTERVAL '1' MONTH) AS DATE[])) AS _t0(mnth)",
                 "snowflake": "SELECT id, DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) AS mnth FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1) + 1)) AS _t0(seq, key, path, index, mnth, this)",
             },
         )
@@ -2674,6 +2675,15 @@ OPTIONS (
             "SELECT id, mnth AS a_mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
             write={
                 "bigquery": "SELECT id, mnth AS a_mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+                "duckdb": "SELECT id, mnth AS a_mnth FROM t CROSS JOIN UNNEST(CAST(GENERATE_SERIES(start_month, DATE_TRUNC('MONTH', CURRENT_DATE), INTERVAL '1' MONTH) AS DATE[])) AS _t0(mnth)",
                 "snowflake": "SELECT id, DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) AS a_mnth FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1) + 1)) AS _t0(seq, key, path, index, mnth, this)",
+            },
+        )
+        self.validate_all(
+            "SELECT id, mnth + 1 AS a_mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+            write={
+                "bigquery": "SELECT id, mnth + 1 AS a_mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE, MONTH), INTERVAL '1' MONTH)) AS mnth",
+                "duckdb": "SELECT id, mnth + 1 AS a_mnth FROM t CROSS JOIN UNNEST(CAST(GENERATE_SERIES(start_month, DATE_TRUNC('MONTH', CURRENT_DATE), INTERVAL '1' MONTH) AS DATE[])) AS _t0(mnth)",
+                "snowflake": "SELECT id, DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) + 1 AS a_mnth FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1) + 1)) AS _t0(seq, key, path, index, mnth, this)",
             },
         )


### PR DESCRIPTION
This PR adds support for the transpilation of `GENERATE_DATE_ARRAY` from BigQuery to Snowflake, when a column is an argument. 
In the previous implementation the following BigQuery query:
```
SELECT id, mnth FROM t CROSS JOIN UNNEST(GENERATE_DATE_ARRAY(start_month, DATE_TRUNC(CURRENT_DATE(), MONTH), INTERVAL 1 MONTH)) AS mnth
```
Would be transpiled into Snowflake: 
```
SELECT
  id,
  mnth
FROM t
CROSS JOIN (
  SELECT
    DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) AS mnth
  FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(
    0,
    (
      DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1
    ) + 1
  ))) AS _t1(seq, key, path, index, mnth, this)
) AS _t0(mnth)
```
Which is wrong. First, the `CROSS JOIN` doesn't allow access to the column `start_month` of table `t`. 
Moreover, based on the snowflake [docs](https://docs.snowflake.com/en/user-guide/querying-subqueries#usage-notes), subqueries with a correlation inside of `FLATTEN` are currently unsupported.

In order to solve this, I suggest to leave the basic implementation (when the `GENERATE_DATE_ARRAY` contains constant values as it is) and change the behavior for column correlation.

This PR does the following transpilation: 
```
SELECT
  id,
  DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) AS mnth
FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(
  0,
  (
    DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1
  ) + 1
)) AS _t0(seq, key, path, index, mnth, this)
```
The basic idea is up, but I believe the implementation can be better. 