### PR TITLE
fix(doris/starrocks): remove equal sign from CREATE TABLE comment

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -72,6 +72,7 @@ class Doris(MySQL):
             exp.Map: rename_func("ARRAY_MAP"),
             exp.RegexpLike: rename_func("REGEXP"),
             exp.RegexpSplit: rename_func("SPLIT_BY_STRING"),
+            exp.SchemaCommentProperty: lambda self, e: self.naked_property(e),
             exp.Split: rename_func("SPLIT_BY_STRING"),
             exp.StringToArray: rename_func("SPLIT_BY_STRING"),
             exp.StrToUnix: lambda self, e: self.func("UNIX_TIMESTAMP", e.this, self.format_time(e)),

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -156,6 +156,7 @@ class StarRocks(MySQL):
             exp.JSONExtract: arrow_json_extract_sql,
             exp.Property: property_sql,
             exp.RegexpLike: rename_func("REGEXP"),
+            exp.SchemaCommentProperty: lambda self, e: self.naked_property(e),
             exp.StDistance: st_distance_sphere,
             exp.StrToUnix: lambda self, e: self.func("UNIX_TIMESTAMP", e.this, self.format_time(e)),
             exp.TimestampTrunc: lambda self, e: self.func("DATE_TRUNC", unit_to_str(e), e.this),


### PR DESCRIPTION
There is no equal sign in table comment

https://doris.apache.org/docs/sql-manual/sql-statements/table-and-view/table/CREATE-TABLE
https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE/