### PR TITLE
feat(exasol): add support for CONVERT_TZ function

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -61,6 +61,12 @@ class Exasol(Dialect):
             "APPROXIMATE_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
             "TO_CHAR": build_formatted_time(exp.ToChar, "exasol"),
             "TO_DATE": build_formatted_time(exp.TsOrDsToDate, "exasol"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/convert_tz.htm
+            "CONVERT_TZ": lambda args: exp.ConvertTimezone(
+                source_tz=seq_get(args, 1),
+                target_tz=seq_get(args, 2),
+                timestamp=seq_get(args, 0),
+            ),
         }
 
     class Generator(generator.Generator):
@@ -135,3 +141,10 @@ class Exasol(Dialect):
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
         }
+
+        def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:
+            from_tz = expression.args.get("source_tz")
+            to_tz = expression.args.get("target_tz")
+            datetime = expression.args.get("timestamp")
+
+            return self.func("CONVERT_TZ", datetime, from_tz, to_tz)

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -66,6 +66,7 @@ class Exasol(Dialect):
                 source_tz=seq_get(args, 1),
                 target_tz=seq_get(args, 2),
                 timestamp=seq_get(args, 0),
+                options=seq_get(args, 3),
             ),
         }
 
@@ -146,5 +147,6 @@ class Exasol(Dialect):
             from_tz = expression.args.get("source_tz")
             to_tz = expression.args.get("target_tz")
             datetime = expression.args.get("timestamp")
+            options = expression.args.get("options")
 
-            return self.func("CONVERT_TZ", datetime, from_tz, to_tz)
+            return self.func("CONVERT_TZ", datetime, from_tz, to_tz, options)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5529,7 +5529,12 @@ class ConvertToCharset(Func):
 
 
 class ConvertTimezone(Func):
-    arg_types = {"source_tz": False, "target_tz": True, "timestamp": True}
+    arg_types = {
+        "source_tz": False,
+        "target_tz": True,
+        "timestamp": True,
+        "options": False,
+    }
 
 
 class GenerateSeries(Func):

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -332,3 +332,20 @@ class TestExasol(Validator):
                 "databricks": "TO_DATE(x, 'yyyy')",
             },
         )
+        self.validate_all(
+            "SELECT CONVERT_TZ('2012-05-10 12:00:00', 'Europe/Berlin', 'America/New_York')",
+            read={
+                "exasol": "SELECT CONVERT_TZ('2012-05-10 12:00:00', 'Europe/Berlin', 'America/New_York')",
+                "mysql": "SELECT CONVERT_TZ('2012-05-10 12:00:00', 'Europe/Berlin', 'America/New_York')",
+                "databricks": "SELECT CONVERT_TIMEZONE('Europe/Berlin', 'America/New_York', '2012-05-10 12:00:00')",
+            },
+            write={
+                "exasol": "SELECT CONVERT_TZ('2012-05-10 12:00:00', 'Europe/Berlin', 'America/New_York')",
+                "mysql": "SELECT CONVERT_TZ('2012-05-10 12:00:00', 'Europe/Berlin', 'America/New_York')",
+                "databricks": "SELECT CONVERT_TIMEZONE('Europe/Berlin', 'America/New_York', '2012-05-10 12:00:00')",
+                "snowflake": "SELECT CONVERT_TIMEZONE('Europe/Berlin', 'America/New_York', '2012-05-10 12:00:00')",
+                "spark": "SELECT CONVERT_TIMEZONE('Europe/Berlin', 'America/New_York', '2012-05-10 12:00:00')",
+                "redshift": "SELECT CONVERT_TIMEZONE('Europe/Berlin', 'America/New_York', '2012-05-10 12:00:00')",
+                "duckdb": "SELECT CAST('2012-05-10 12:00:00' AS TIMESTAMP) AT TIME ZONE 'Europe/Berlin' AT TIME ZONE 'America/New_York'",
+            },
+        )

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -332,6 +332,9 @@ class TestExasol(Validator):
                 "databricks": "TO_DATE(x, 'yyyy')",
             },
         )
+        self.validate_identity(
+            "SELECT CONVERT_TZ(CAST('2012-03-25 02:30:00' AS TIMESTAMP), 'Europe/Berlin', 'UTC', 'INVALID REJECT AMBIGUOUS REJECT') AS CONVERT_TZ"
+        )
         self.validate_all(
             "SELECT CONVERT_TZ('2012-05-10 12:00:00', 'Europe/Berlin', 'America/New_York')",
             read={


### PR DESCRIPTION
This involves adding the parsing of [CONVERT_TZ](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/convert_tz.htm) built -in function to exasol dialect in sqlglot.