### PR TITLE
feat(exasol): add mapping to TIME_TO_STR in exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -141,6 +141,7 @@ class Exasol(Dialect):
             exp.ToChar: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
+            exp.TimeToStr: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
         }
 
         def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -352,3 +352,7 @@ class TestExasol(Validator):
                 "duckdb": "SELECT CAST('2012-05-10 12:00:00' AS TIMESTAMP) AT TIME ZONE 'Europe/Berlin' AT TIME ZONE 'America/New_York'",
             },
         )
+        self.validate_all(
+            "TIME_TO_STR(b, '%Y-%m-%d %H:%M:%S')",
+            write={"exasol": "TO_CHAR(b, 'YYYY-MM-DD HH:MI:SS')"},
+        )


### PR DESCRIPTION
This involves mapping TIME_TO_STR function in sqlglot to [TO_CHAR](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_char%20(datetime).htm) exasol built -in function to exasol dialect in sqlglot