### PR TITLE
feat(exasol): map STR_TO_TIME to TO_DATE and

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -5,6 +5,7 @@ from sqlglot.dialects.dialect import (
     rename_func,
     binary_from_function,
     build_formatted_time,
+    timestrtotime_sql,
 )
 from sqlglot.helper import seq_get
 from sqlglot.generator import unsupported_args
@@ -142,6 +143,8 @@ class Exasol(Dialect):
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
             exp.TimeToStr: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
+            exp.TimeStrToTime: timestrtotime_sql,
+            exp.StrToTime: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
         }
 
         def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -356,5 +356,7 @@ class TestExasol(Validator):
             "TIME_TO_STR(b, '%Y-%m-%d %H:%M:%S')",
             "TO_CHAR(b, 'YYYY-MM-DD HH:MI:SS')",
         )
-        self.validate_identity("SELECT TIME_TO_STR(CAST(STR_TO_TIME(date, '%Y%m%d') AS DATE), '%a') AS day_of_week", "SELECT TO_CHAR(CAST(TO_DATE(date, 'YYYYMMDD') AS DATE), 'DY') AS day_of_week")
-  
+        self.validate_identity(
+            "SELECT TIME_TO_STR(CAST(STR_TO_TIME(date, '%Y%m%d') AS DATE), '%a') AS day_of_week",
+            "SELECT TO_CHAR(CAST(TO_DATE(date, 'YYYYMMDD') AS DATE), 'DY') AS day_of_week",
+        )

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -356,3 +356,5 @@ class TestExasol(Validator):
             "TIME_TO_STR(b, '%Y-%m-%d %H:%M:%S')",
             "TO_CHAR(b, 'YYYY-MM-DD HH:MI:SS')",
         )
+        self.validate_identity("SELECT TIME_TO_STR(CAST(STR_TO_TIME(date, '%Y%m%d') AS DATE), '%a') AS day_of_week", "SELECT TO_CHAR(CAST(TO_DATE(date, 'YYYYMMDD') AS DATE), 'DY') AS day_of_week")
+  


### PR DESCRIPTION
This involves mapping STR_TO _TIME function in sqlglot to [TO_DATE](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm) exasol built -in function to exasol dialect in sqlglot