### PR TITLE
Feat(snowflake): improve transpilation of queries with UNNEST sources

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -31,8 +31,8 @@ from sqlglot.dialects.dialect import (
     groupconcat_sql,
 )
 from sqlglot.generator import unsupported_args
-from sqlglot.helper import flatten, is_float, is_int, seq_get
-from sqlglot.optimizer.scope import find_all_in_scope
+from sqlglot.helper import find_new_name, flatten, is_float, is_int, seq_get
+from sqlglot.optimizer.scope import build_scope, find_all_in_scope
 from sqlglot.tokens import TokenType
 
 if t.TYPE_CHECKING:
@@ -335,6 +335,91 @@ def _json_extract_value_array_sql(
     return self.func("TRANSFORM", json_extract, transform_lambda)
 
 
+def _qualify_unnested_columns(expression: exp.Expression) -> exp.Expression:
+    if isinstance(expression, exp.Select):
+        scope = build_scope(expression)
+        if not scope:
+            return expression
+
+        unnests = list(scope.find_all(exp.Unnest))
+
+        if not unnests:
+            return expression
+
+        taken_source_names = set(scope.sources)
+        column_source: t.Dict[str, exp.Identifier] = {}
+
+        unnest_identifier: t.Optional[exp.Identifier] = None
+        orig_expression = expression.copy()
+
+        for unnest in unnests:
+            if not isinstance(unnest.parent, (exp.From, exp.Join)):
+                continue
+
+            # Try to infer column names produced by an unnest operator. This is only possible
+            # when we can peek into the (statically known) contents of the unnested value.
+            unnest_columns: t.Set[str] = set()
+            for unnest_expr in unnest.expressions:
+                if not isinstance(unnest_expr, exp.Array):
+                    continue
+
+                for array_expr in unnest_expr.expressions:
+                    if not (
+                        isinstance(array_expr, exp.Struct)
+                        and array_expr.expressions
+                        and all(
+                            isinstance(struct_expr, exp.PropertyEQ)
+                            for struct_expr in array_expr.expressions
+                        )
+                    ):
+                        continue
+
+                    unnest_columns.update(
+                        struct_expr.this.name.lower() for struct_expr in array_expr.expressions
+                    )
+                    break
+
+                if unnest_columns:
+                    break
+
+            unnest_alias = unnest.args.get("alias")
+            if not unnest_alias:
+                alias_name = find_new_name(taken_source_names, "value")
+                taken_source_names.add(alias_name)
+
+                # Produce a `TableAlias` AST similar to what is produced for BigQuery. This
+                # will be corrected later, when we generate SQL for the `Unnest` AST node.
+                aliased_unnest = exp.alias_(unnest, None, table=[alias_name])
+                scope.replace(unnest, aliased_unnest)
+
+                unnest_identifier = aliased_unnest.args["alias"].columns[0]
+            else:
+                alias_columns = getattr(unnest_alias, "columns", [])
+                unnest_identifier = unnest_alias.this or seq_get(alias_columns, 0)
+
+            if not isinstance(unnest_identifier, exp.Identifier):
+                return orig_expression
+
+            column_source.update({c.lower(): unnest_identifier for c in unnest_columns})
+
+        for column in scope.columns:
+            if column.table:
+                continue
+
+            table = column_source.get(column.name.lower())
+            if (
+                unnest_identifier
+                and not table
+                and len(scope.sources) == 1
+                and column.name.lower() != unnest_identifier.name.lower()
+            ):
+                table = unnest_identifier
+
+            column.set("table", table and table.copy())
+
+    return expression
+
+
 def _eliminate_dot_variant_lookup(expression: exp.Expression) -> exp.Expression:
     if isinstance(expression, exp.Select):
         # This transformation is used to facilitate transpilation of BigQuery `UNNEST` operations
@@ -358,7 +443,13 @@ def _eliminate_dot_variant_lookup(expression: exp.Expression) -> exp.Expression:
                 if c.table in unnest_aliases:
                     bracket_lhs = c.args["table"]
                     bracket_rhs = exp.Literal.string(c.name)
-                    c.replace(exp.Bracket(this=bracket_lhs, expressions=[bracket_rhs]))
+                    bracket = exp.Bracket(this=bracket_lhs, expressions=[bracket_rhs])
+
+                    if c.parent is expression:
+                        # Retain column projection names by using aliases
+                        c.replace(exp.alias_(bracket, c.this.copy()))
+                    else:
+                        c.replace(bracket)
 
     return expression
 
@@ -1129,6 +1220,7 @@ class Snowflake(Dialect):
                     transforms.explode_projection_to_unnest(),
                     transforms.eliminate_semi_and_anti_joins,
                     _transform_generate_date_array,
+                    _qualify_unnested_columns,
                     _eliminate_dot_variant_lookup,
                 ]
             ),

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3218,7 +3218,7 @@ FROM subquery2""",
                 "postgres": "SELECT * FROM (SELECT CAST(value AS DATE) FROM GENERATE_SERIES(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1 WEEK') AS _t(value)) AS _unnested_generate_series",
                 "presto": "SELECT * FROM UNNEST(SEQUENCE(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), (1 * INTERVAL '7' DAY)))",
                 "redshift": "WITH RECURSIVE _generated_dates(date_value) AS (SELECT CAST('2020-01-01' AS DATE) AS date_value UNION ALL SELECT CAST(DATEADD(WEEK, 1, date_value) AS DATE) FROM _generated_dates WHERE CAST(DATEADD(WEEK, 1, date_value) AS DATE) <= CAST('2020-02-01' AS DATE)) SELECT * FROM (SELECT date_value FROM _generated_dates) AS _generated_dates",
-                "snowflake": "SELECT * FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this))",
+                "snowflake": "SELECT * FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _t0(seq, key, path, index, value, this))",
                 "spark": "SELECT * FROM EXPLODE(SEQUENCE(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), INTERVAL '1' WEEK))",
                 "trino": "SELECT * FROM UNNEST(SEQUENCE(CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE), (1 * INTERVAL '7' DAY)))",
                 "tsql": "WITH _generated_dates(date_value) AS (SELECT CAST('2020-01-01' AS DATE) AS date_value UNION ALL SELECT CAST(DATEADD(WEEK, 1, date_value) AS DATE) FROM _generated_dates WHERE CAST(DATEADD(WEEK, 1, date_value) AS DATE) <= CAST('2020-02-01' AS DATE)) SELECT * FROM (SELECT date_value AS date_value FROM _generated_dates) AS _generated_dates",
@@ -3253,7 +3253,7 @@ FROM subquery2""",
         self.validate_all(
             "SELECT ARRAY_LENGTH(GENERATE_DATE_ARRAY(DATE '2020-01-01', DATE '2020-02-01', INTERVAL 1 WEEK))",
             write={
-                "snowflake": "SELECT ARRAY_SIZE((SELECT ARRAY_AGG(*) FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _u(seq, key, path, index, value, this))))",
+                "snowflake": "SELECT ARRAY_SIZE((SELECT ARRAY_AGG(*) FROM (SELECT DATEADD(WEEK, CAST(value AS INT), CAST('2020-01-01' AS DATE)) AS value FROM TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(WEEK, CAST('2020-01-01' AS DATE), CAST('2020-02-01' AS DATE)) + 1 - 1) + 1))) AS _t0(seq, key, path, index, value, this))))",
             },
         )
 


### PR DESCRIPTION
Transpiling BigQuery queries to Snowflake is not always correct today. One example is:

```sql
-- BigQuery input
SELECT x FROM UNNEST([STRUCT('x' AS x)])

-- Snowflake output, produced by SQLGlot's transpiler
SELECT x FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('x', 'x')])) AS _u(seq, key, path, index, value, this)
```

The transpiler's output is not valid Snowflake, because the identifier `x` referenced in the projection list does not exist. Instead, only the identifiers mentioned in the table alias are visible, and accessing `x` requires extracting it from `value`.

To address this issue, I implemented a rule that conditionally qualifies `UNNEST` sources and the columns they produce, if we can statically determine them.

After this rule is applied, a followup rule, already in effect today, takes care of converting the qualified columns into the proper bracket expressions used to extract values out of `VARIANT` objects, which leads to a correct transpilation.