### PR TITLE
feat: add `DateStrToTime`

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5990,6 +5990,10 @@ class DateStrToDate(Func):
     pass
 
 
+class DateStrToTime(Func):
+    pass
+
+
 class DateToDateStr(Func):
     pass
 
@@ -8432,6 +8436,9 @@ def convert(value: t.Any, copy: bool = False) -> Expression:
     if isinstance(value, datetime.date):
         date_literal = Literal.string(value.strftime("%Y-%m-%d"))
         return DateStrToDate(this=date_literal)
+    if isinstance(value, datetime.time):
+        time_literal = Literal.string(value.isoformat())
+        return DateStrToTime(this=time_literal)
     if isinstance(value, tuple):
         if hasattr(value, "_fields"):
             return Struct(

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5990,10 +5990,6 @@ class DateStrToDate(Func):
     pass
 
 
-class DateStrToTime(Func):
-    pass
-
-
 class DateToDateStr(Func):
     pass
 
@@ -8438,7 +8434,7 @@ def convert(value: t.Any, copy: bool = False) -> Expression:
         return DateStrToDate(this=date_literal)
     if isinstance(value, datetime.time):
         time_literal = Literal.string(value.isoformat())
-        return DateStrToTime(this=time_literal)
+        return TsOrDsToTime(this=time_literal)
     if isinstance(value, tuple):
         if hasattr(value, "_fields"):
             return Struct(

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1239,7 +1239,7 @@ FROM foo""",
 
         self.assertIsInstance(result, exp.TsOrDsToTime)
         self.assertIsInstance(result.this, exp.Literal)
-        self.assertEqual(result.this.this, "14:30:45")
+        self.assertEqual(result.sql(), "CAST('14:30:45' AS TIME)")
         self.assertTrue(result.this.is_string)
 
         # Test with microseconds
@@ -1247,22 +1247,18 @@ FROM foo""",
         result = exp.convert(time_with_microseconds)
 
         self.assertIsInstance(result, exp.TsOrDsToTime)
-        self.assertEqual(result.this.this, "09:15:30.123456")
+        self.assertEqual(result.sql(), "CAST('09:15:30.123456' AS TIME)")
 
         # Test midnight
         midnight = datetime.time(0, 0, 0)
         result = exp.convert(midnight)
 
         self.assertIsInstance(result, exp.TsOrDsToTime)
-        self.assertEqual(result.this.this, "00:00:00")
+        self.assertEqual(result.sql(), "CAST('00:00:00' AS TIME)")
 
         # Test noon
         noon = datetime.time(12, 0, 0)
         result = exp.convert(noon)
 
         self.assertIsInstance(result, exp.TsOrDsToTime)
-        self.assertEqual(result.this.this, "12:00:00")
-
-    def test_datestrtotime_function(self):
-        # Test parsing TsOrDsToTime function
-        self.assertIsInstance(parse_one("TS_OR_DS_TO_TIME('14:30:45')"), exp.TsOrDsToTime)
+        self.assertEqual(result.sql(), "CAST('12:00:00' AS TIME)")

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1236,30 +1236,30 @@ FROM foo""",
         # Test converting datetime.time objects to DateStrToTime expressions
         time_obj = datetime.time(14, 30, 45)
         result = exp.convert(time_obj)
-        
+
         self.assertIsInstance(result, exp.DateStrToTime)
         self.assertIsInstance(result.this, exp.Literal)
         self.assertEqual(result.this.this, "14:30:45")
         self.assertTrue(result.this.is_string)
-        
+
         # Test with microseconds
         time_with_microseconds = datetime.time(9, 15, 30, 123456)
         result = exp.convert(time_with_microseconds)
-        
+
         self.assertIsInstance(result, exp.DateStrToTime)
         self.assertEqual(result.this.this, "09:15:30.123456")
-        
+
         # Test midnight
         midnight = datetime.time(0, 0, 0)
         result = exp.convert(midnight)
-        
+
         self.assertIsInstance(result, exp.DateStrToTime)
         self.assertEqual(result.this.this, "00:00:00")
-        
+
         # Test noon
         noon = datetime.time(12, 0, 0)
         result = exp.convert(noon)
-        
+
         self.assertIsInstance(result, exp.DateStrToTime)
         self.assertEqual(result.this.this, "12:00:00")
 

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -682,7 +682,7 @@ class TestExpressions(unittest.TestCase):
         self.assertIsInstance(parse_one("DATE_ADD(a, 1)"), exp.DateAdd)
         self.assertIsInstance(parse_one("DATE_DIFF(a, 2)"), exp.DateDiff)
         self.assertIsInstance(parse_one("DATE_STR_TO_DATE(a)"), exp.DateStrToDate)
-        self.assertIsInstance(parse_one("DATE_STR_TO_TIME(a)"), exp.DateStrToTime)
+        self.assertIsInstance(parse_one("TS_OR_DS_TO_TIME(a)"), exp.TsOrDsToTime)
         self.assertIsInstance(parse_one("DAY(a)"), exp.Day)
         self.assertIsInstance(parse_one("EXP(a)"), exp.Exp)
         self.assertIsInstance(parse_one("FLOOR(a)"), exp.Floor)
@@ -1233,11 +1233,11 @@ FROM foo""",
         self.assertEqual(exp.parse_identifier("a ' b"), exp.to_identifier("a ' b"))
 
     def test_convert_datetime_time(self):
-        # Test converting datetime.time objects to DateStrToTime expressions
+        # Test converting datetime.time objects to TsOrDsToTime expressions
         time_obj = datetime.time(14, 30, 45)
         result = exp.convert(time_obj)
 
-        self.assertIsInstance(result, exp.DateStrToTime)
+        self.assertIsInstance(result, exp.TsOrDsToTime)
         self.assertIsInstance(result.this, exp.Literal)
         self.assertEqual(result.this.this, "14:30:45")
         self.assertTrue(result.this.is_string)
@@ -1246,23 +1246,23 @@ FROM foo""",
         time_with_microseconds = datetime.time(9, 15, 30, 123456)
         result = exp.convert(time_with_microseconds)
 
-        self.assertIsInstance(result, exp.DateStrToTime)
+        self.assertIsInstance(result, exp.TsOrDsToTime)
         self.assertEqual(result.this.this, "09:15:30.123456")
 
         # Test midnight
         midnight = datetime.time(0, 0, 0)
         result = exp.convert(midnight)
 
-        self.assertIsInstance(result, exp.DateStrToTime)
+        self.assertIsInstance(result, exp.TsOrDsToTime)
         self.assertEqual(result.this.this, "00:00:00")
 
         # Test noon
         noon = datetime.time(12, 0, 0)
         result = exp.convert(noon)
 
-        self.assertIsInstance(result, exp.DateStrToTime)
+        self.assertIsInstance(result, exp.TsOrDsToTime)
         self.assertEqual(result.this.this, "12:00:00")
 
     def test_datestrtotime_function(self):
-        # Test parsing DateStrToTime function
-        self.assertIsInstance(parse_one("DATE_STR_TO_TIME('14:30:45')"), exp.DateStrToTime)
+        # Test parsing TsOrDsToTime function
+        self.assertIsInstance(parse_one("TS_OR_DS_TO_TIME('14:30:45')"), exp.TsOrDsToTime)


### PR DESCRIPTION
I've been playing with the Python executor (building a backend for [shillelagh](https://github.com/betodealmeida/shillelagh)) and I found that there's no handling of `datetime.time` objects, so I added it in this PR.