### PR TITLE
fix(tsql): change READ_ONLY to READONLY

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -624,7 +624,7 @@ class TSQL(Dialect):
             ("ENCRYPTION", "RECOMPILE", "SCHEMABINDING", "NATIVE_COMPILATION", "EXECUTE"), tuple()
         )
 
-        COLUMN_DEFINITION_MODES = {"OUT", "OUTPUT", "READ_ONLY"}
+        COLUMN_DEFINITION_MODES = {"OUT", "OUTPUT", "READONLY"}
 
         RETURNS_TABLE_TOKENS = parser.Parser.ID_VAR_TOKENS - {
             TokenType.TABLE,

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -494,7 +494,7 @@ class TestTSQL(Validator):
         self.validate_identity("CREATE PROCEDURE test(@v1 INTEGER = 1, @v2 CHAR(1) = 'c')")
         self.validate_identity("DECLARE @v1 AS INTEGER = 1, @v2 AS CHAR(1) = 'c'")
 
-        for output in ("OUT", "OUTPUT", "READ_ONLY"):
+        for output in ("OUT", "OUTPUT", "READONLY"):
             self.validate_identity(
                 f"CREATE PROCEDURE test(@v1 INTEGER = 1 {output}, @v2 CHAR(1) {output})"
             )


### PR DESCRIPTION
In PR #4704, support was added for OUT, OUTPUT, and READ_ONLY parameter modifiers.

However, READ_ONLY is not correct -- it should be READONLY.

See the documentation for procedures and functions:

https://learn.microsoft.com/en-us/sql/t-sql/statements/create-procedure-transact-sql?view=sql-server-ver16#readonly 
https://learn.microsoft.com/en-us/sql/t-sql/statements/create-function-transact-sql?view=sql-server-ver17#readonly