### PR TITLE
feat(dremio): Add support for DATE_ADD and DATE_SUB

### DIFF
--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -978,6 +978,7 @@ class TestDialect(Validator):
             "DATE_ADD(x, 1, 'DAY')",
             read={
                 "snowflake": "DATEADD('DAY', 1, x)",
+                "dremio": "DATE_ADD(x, 1)",
             },
             write={
                 "bigquery": "DATE_ADD(x, INTERVAL 1 DAY)",
@@ -994,6 +995,7 @@ class TestDialect(Validator):
                 "starrocks": "DATE_ADD(x, INTERVAL 1 DAY)",
                 "tsql": "DATEADD(DAY, 1, x)",
                 "doris": "DATE_ADD(x, INTERVAL 1 DAY)",
+                "dremio": "DATE_ADD(x, 1)",
             },
         )
         self.validate_all(
@@ -1008,6 +1010,7 @@ class TestDialect(Validator):
                 "spark": "DATE_ADD(x, 1)",
                 "starrocks": "DATE_ADD(x, INTERVAL 1 DAY)",
                 "doris": "DATE_ADD(x, INTERVAL 1 DAY)",
+                "dremio": "DATE_ADD(x, 1)",
             },
         )
         self.validate_all(
@@ -1196,6 +1199,7 @@ class TestDialect(Validator):
                 "hive": "DATE_ADD(CAST('2020-01-01' AS DATE), 1)",
                 "presto": "DATE_ADD('DAY', 1, CAST('2020-01-01' AS DATE))",
                 "spark": "DATE_ADD(CAST('2020-01-01' AS DATE), 1)",
+                "dremio": "DATE_ADD(CAST('2020-01-01' AS DATE), 1)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -129,3 +129,30 @@ class TestDremio(Validator):
                 "duckdb": f"SELECT STRFTIME({ts}, '%y-%j %H:%M:%S.%f %Z')",
             },
         )
+
+    def test_time_diff(self):
+        self.validate_identity("SELECT DATE_ADD(col, 1)")
+        self.validate_identity("SELECT DATE_ADD(col, CAST(1 AS INTERVAL HOUR))")
+        self.validate_identity(
+            "SELECT DATE_ADD(TIMESTAMP '2022-01-01 12:00:00', CAST(-1 AS INTERVAL HOUR))",
+            "SELECT DATE_ADD(CAST('2022-01-01 12:00:00' AS TIMESTAMP), CAST(-1 AS INTERVAL HOUR))",
+        )
+        self.validate_identity(
+            "SELECT DATE_ADD(col, 2, 'HOUR')", "SELECT TIMESTAMPADD(HOUR, 2, col)"
+        )
+
+        self.validate_identity("SELECT DATE_SUB(col, 1)")
+        self.validate_identity("SELECT DATE_SUB(col, CAST(1 AS INTERVAL HOUR))")
+        self.validate_identity(
+            "SELECT DATE_SUB(TIMESTAMP '2022-01-01 12:00:00', CAST(-1 AS INTERVAL HOUR))",
+            "SELECT DATE_SUB(CAST('2022-01-01 12:00:00' AS TIMESTAMP), CAST(-1 AS INTERVAL HOUR))",
+        )
+        self.validate_identity(
+            "SELECT DATE_SUB(col, 2, 'HOUR')", "SELECT TIMESTAMPADD(HOUR, -2, col)"
+        )
+
+        self.validate_identity("SELECT DATE_ADD(col, 2, 'DAY')", "SELECT DATE_ADD(col, 2)")
+
+        self.validate_identity(
+            "SELECT DATE_SUB(col, a, 'HOUR')", "SELECT TIMESTAMPADD(HOUR, a * -1, col)"
+        )


### PR DESCRIPTION
Currently Dremio dialect doesn't have proper support for `DATE_ADD` and `DATE_SUB` functions, as described in https://github.com/tobymao/sqlglot/issues/5404

In Dremio `DAY` unit is used by default in this functions, and shouldn't be specified. To correctly process units when parsed from different dialects, we can use `TIMESTAMPADD` function instead.

Link to relevant docs:
- https://docs.dremio.com/current/reference/sql/sql-functions/functions/DATE_ADD/
- https://docs.dremio.com/current/reference/sql/sql-functions/functions/DATE_SUB/
- https://docs.dremio.com/cloud/reference/sql/sql-functions/functions/TIMESTAMPADD/