### PR TITLE
feat(postgres): query placeholders

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -460,13 +460,12 @@ class Postgres(Dialect):
         }
 
         def _parse_query_parameter(self) -> t.Optional[exp.Expression]:
-            self._match(TokenType.MOD)
             this = (
                 self._parse_wrapped(self._parse_id_var)
                 if self._match(TokenType.L_PAREN, advance=False)
                 else None
             )
-            self._match(TokenType.VAR)
+            self._match_text_seq("S")
             return self.expression(exp.Placeholder, this=this)
 
         def _parse_operator(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -921,6 +921,9 @@ FROM json_data, field_ids""",
             },
         )
 
+        self.validate_identity("SELECT * FROM foo WHERE id = %s")
+        self.validate_identity("SELECT * FROM foo WHERE id = %(id_param)s")
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(


### PR DESCRIPTION
Fixes #5412

Support the following non-native placeholders for parameter sub:
```
SELECT * FROM foo WHERE id = %s
SELECT * FROM foo WHERE id = %(id_param)s")
```

**DOCS**
[Postgres placeholders](https://www.psycopg.org/psycopg3/docs/basic/params.html)
