### PR TITLE
fix(risingwave): Fix RisingWave dialect SQL for MAP datatype declaration

### DIFF
--- a/sqlglot/dialects/risingwave.py
+++ b/sqlglot/dialects/risingwave.py
@@ -78,9 +78,8 @@ class RisingWave(Postgres):
             return Generator.computedcolumnconstraint_sql(self, expression)
 
         def datatype_sql(self, expression: exp.DataType) -> str:
-
             if expression.is_type(exp.DataType.Type.MAP) and len(expression.expressions) == 2:
-                key_type,value_type = expression.expressions
+                key_type, value_type = expression.expressions
                 return f"MAP({self.sql(key_type)}, {self.sql(value_type)})"
 
             return super().datatype_sql(expression)

--- a/sqlglot/dialects/risingwave.py
+++ b/sqlglot/dialects/risingwave.py
@@ -76,3 +76,11 @@ class RisingWave(Postgres):
 
         def computedcolumnconstraint_sql(self, expression: exp.ComputedColumnConstraint) -> str:
             return Generator.computedcolumnconstraint_sql(self, expression)
+
+        def datatype_sql(self, expression: exp.DataType) -> str:
+
+            if expression.is_type(exp.DataType.Type.MAP) and len(expression.expressions) == 2:
+                key_type,value_type = expression.expressions
+                return f"MAP({self.sql(key_type)}, {self.sql(value_type)})"
+
+            return super().datatype_sql(expression)

--- a/tests/dialects/test_risingwave.py
+++ b/tests/dialects/test_risingwave.py
@@ -29,3 +29,12 @@ class TestRisingWave(Validator):
             "SELECT NULL::MAP<VARCHAR, INT> AS map_column",
             "SELECT CAST(NULL AS MAP(VARCHAR, INT)) AS map_column"
         )
+
+        self.validate_identity(
+            "CREATE TABLE t (map_col MAP(VARCHAR, INT))"
+        )
+
+        self.validate_identity(
+            "CREATE TABLE t (map_col MAP<VARCHAR, INT>)",
+            "CREATE TABLE t (map_col MAP(VARCHAR, INT))"
+        )

--- a/tests/dialects/test_risingwave.py
+++ b/tests/dialects/test_risingwave.py
@@ -21,3 +21,10 @@ class TestRisingWave(Validator):
         self.validate_identity(
             "WITH t1 AS MATERIALIZED (SELECT 1), t2 AS NOT MATERIALIZED (SELECT 2) SELECT * FROM t1, t2"
         )
+
+    def test_datatypes(self):
+        self.validate_identity("SELECT CAST(NULL AS MAP(VARCHAR, INT)) AS map_column")
+        self.validate_identity(
+                "SELECT NULL::MAP<VARCHAR, INT> AS map_column",
+                "SELECT CAST(NULL AS MAP(VARCHAR, INT) AS map_column"
+        )

--- a/tests/dialects/test_risingwave.py
+++ b/tests/dialects/test_risingwave.py
@@ -24,7 +24,8 @@ class TestRisingWave(Validator):
 
     def test_datatypes(self):
         self.validate_identity("SELECT CAST(NULL AS MAP(VARCHAR, INT)) AS map_column")
+
         self.validate_identity(
-                "SELECT NULL::MAP<VARCHAR, INT> AS map_column",
-                "SELECT CAST(NULL AS MAP(VARCHAR, INT) AS map_column"
+            "SELECT NULL::MAP<VARCHAR, INT> AS map_column",
+            "SELECT CAST(NULL AS MAP(VARCHAR, INT)) AS map_column"
         )

--- a/tests/dialects/test_risingwave.py
+++ b/tests/dialects/test_risingwave.py
@@ -27,14 +27,12 @@ class TestRisingWave(Validator):
 
         self.validate_identity(
             "SELECT NULL::MAP<VARCHAR, INT> AS map_column",
-            "SELECT CAST(NULL AS MAP(VARCHAR, INT)) AS map_column"
+            "SELECT CAST(NULL AS MAP(VARCHAR, INT)) AS map_column",
         )
 
-        self.validate_identity(
-            "CREATE TABLE t (map_col MAP(VARCHAR, INT))"
-        )
+        self.validate_identity("CREATE TABLE t (map_col MAP(VARCHAR, INT))")
 
         self.validate_identity(
             "CREATE TABLE t (map_col MAP<VARCHAR, INT>)",
-            "CREATE TABLE t (map_col MAP(VARCHAR, INT))"
+            "CREATE TABLE t (map_col MAP(VARCHAR, INT))",
         )


### PR DESCRIPTION
Before this PR the SQL generated for a MAP datatype declaration expression in the RisingWave dialect was `MAP<x, y>`, where `x` and `y` are other datatypes e.g. `MAP<VARCHAR, INT>`. 

The correct way according to the official docs here https://docs.risingwave.com/sql/data-types/map-type is instead `MAP(x, y)` e.g. `MAP(VARCHAR, INT)`
