### PR TITLE
Revert "feat: support Doris range partitioning"

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -8,11 +8,8 @@ from sqlglot.dialects.dialect import (
     rename_func,
     time_format,
     unit_to_str,
-    parse_partitioning_granularity_dynamic,
-    parse_partition_by_opt_range,
 )
 from sqlglot.dialects.mysql import MySQL
-from sqlglot.tokens import TokenType
 
 
 def _lag_lead_sql(self, expression: exp.Lag | exp.Lead) -> str:
@@ -46,72 +43,7 @@ class Doris(MySQL):
             **MySQL.Parser.PROPERTY_PARSERS,
             "PROPERTIES": lambda self: self._parse_wrapped_properties(),
             "UNIQUE": lambda self: self._parse_composite_key_property(exp.UniqueKeyProperty),
-            "PARTITION BY": lambda self: self._parse_partition_by_opt_range(),
         }
-
-        def _parse_partitioning_granularity_dynamic(self) -> exp.PartitionByRangePropertyDynamic:
-            return parse_partitioning_granularity_dynamic(
-                self,
-                "FROM",
-                "TO",
-                "INTERVAL",
-                lambda self: self.expression(
-                    exp.Interval, this=self._parse_number(), unit=self._parse_var()
-                ),
-            )
-
-        def _parse_partition_definition(self):
-            # Handles: PARTITION `p2018` VALUES [(...), (...)), PARTITION `other` VALUES LESS THAN (MAXVALUE)
-            self._match_text_seq("PARTITION")
-            name = self._parse_id_var()
-            if self._match_text_seq("VALUES"):
-                if self._match_text_seq("LESS", "THAN"):
-                    # VALUES LESS THAN (...)
-                    value = self._parse_wrapped_csv(self._parse_expression)
-                    if isinstance(value, list) and len(value) == 1:
-                        value = value[0]
-                    return self.expression(
-                        exp.Partition,
-                        expressions=[
-                            self.expression(
-                                exp.PartitionRange,
-                                this=name,
-                                expression=value,
-                            )
-                        ],
-                    )
-                elif self._match(TokenType.L_BRACKET):
-                    # VALUES [(...), (...))
-                    values = self._parse_csv(
-                        lambda: self._parse_wrapped_csv(self._parse_expression)
-                    )
-                    self._match(TokenType.R_BRACKET)
-                    return self.expression(
-                        exp.Partition,
-                        expressions=[
-                            self.expression(
-                                exp.PartitionRange,
-                                this=name,
-                                expression=values,
-                            )
-                        ],
-                    )
-                else:
-                    self.raise_error("Unsupported VALUES syntax in PARTITION definition")
-            else:
-                self.raise_error("Expecting VALUES in PARTITION definition")
-
-        def _parse_partition_by_opt_range(
-            self,
-        ) -> exp.PartitionedByProperty | exp.PartitionByRangeProperty:
-            return parse_partition_by_opt_range(
-                self,
-                range_kw="RANGE",
-                dynamic_kw="FROM",
-                dynamic_parser=lambda: self._parse_partitioning_granularity_dynamic(),
-                static_kw="PARTITION",
-                static_parser=lambda: self._parse_partition_definition(),
-            )
 
     class Generator(MySQL.Generator):
         LAST_DAY_SUPPORTS_DATE_PART = False
@@ -643,20 +575,3 @@ class Doris(MySQL):
             "xor",
             "year",
         }
-
-        def partition_sql(self, expression: exp.Partition) -> str:
-            parent = expression.parent
-            if isinstance(parent, exp.PartitionByRangeProperty):
-                return ", ".join(self.sql(e) for e in expression.expressions)
-            return super().partition_sql(expression)
-
-        def partitionrange_sql(self, expression: exp.PartitionRange) -> str:
-            # Doris expects: PARTITION <name> VALUES LESS THAN (<value>) or VALUES [(<tuple>), ...)
-            name = self.sql(expression, "this")
-            value = expression.expression
-            if isinstance(value, list):
-                # Output as VALUES [(item1), (item2))
-                value_sql = ", ".join(f"({self.sql(v)})" for v in value)
-                return f"PARTITION {name} VALUES [{value_sql})"
-            value_sql = self.sql(value)
-            return f"PARTITION {name} VALUES LESS THAN ({value_sql})"

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -94,7 +94,6 @@ class TestDoris(Validator):
         self.validate_identity(
             "CREATE TABLE IF NOT EXISTS example_tbl_unique (user_id BIGINT NOT NULL, user_name VARCHAR(50) NOT NULL, city VARCHAR(20), age SMALLINT, sex TINYINT) UNIQUE KEY (user_id, user_name) DISTRIBUTED BY HASH (user_id) BUCKETS 10 PROPERTIES ('enable_unique_key_merge_on_write'='true')"
         )
-        self.validate_identity("INSERT OVERWRITE TABLE test PARTITION(p1, p2) VALUES (1, 2)")
 
     def test_time(self):
         self.validate_identity("TIMESTAMP('2022-01-01')")
@@ -111,27 +110,3 @@ class TestDoris(Validator):
         self.validate_identity("ANALYZE TABLE tbl")
         self.validate_identity("ANALYZE DATABASE db")
         self.validate_identity("ANALYZE TABLE TBL(c1, c2)")
-
-    def test_key(self):
-        self.validate_identity("CREATE TABLE test_table (c1 INT, c2 INT) UNIQUE KEY (c1)")
-        self.validate_identity("CREATE TABLE test_table (c1 INT, c2 INT) DUPLICATE KEY (c1)")
-
-    def test_distributed(self):
-        self.validate_identity(
-            "CREATE TABLE test_table (c1 INT, c2 INT) UNIQUE KEY (c1) DISTRIBUTED BY HASH (c1)"
-        )
-        self.validate_identity("CREATE TABLE test_table (c1 INT, c2 INT) DISTRIBUTED BY RANDOM")
-        self.validate_identity(
-            "CREATE TABLE test_table (c1 INT, c2 INT) DISTRIBUTED BY RANDOM BUCKETS 1"
-        )
-
-    def test_partitionbyrange(self):
-        self.validate_identity(
-            "CREATE TABLE test_table (c1 INT, c2 DATE) PARTITION BY RANGE (`c2`) (PARTITION `p201701` VALUES LESS THAN ('2017-02-01'), PARTITION `p201702` VALUES LESS THAN ('2017-03-01'))"
-        )
-        self.validate_identity(
-            "CREATE TABLE test_table (c1 INT, c2 DATE) PARTITION BY RANGE (`c2`) (PARTITION `p201701` VALUES [('2017-01-01'), ('2017-02-01')), PARTITION `other` VALUES LESS THAN (MAXVALUE))"
-        )
-        self.validate_identity(
-            'CREATE TABLE test_table (c1 INT, c2 DATE) PARTITION BY RANGE (`c2`) (FROM ("2000-11-14") TO ("2021-11-14") INTERVAL 2 YEAR)'
-        )


### PR DESCRIPTION
Reverts tobymao/sqlglot#5402

@xinge-ji it looks like the parser doesn't properly recognize Doris' syntax:

```
'CREATE TABLE test_table (c1 INT, c2 DATE) PARTITION BY RANGE (`c2`) (PARTITION `p201701` VALUES [('2' contains unsupported syntax. Falling back to parsing as a 'Command'.
'CREATE TABLE test_table (c1 INT, c2 DATE) PARTITION BY RANGE (`c2`) (FROM ("2000-11-14") TO ("2021-1' contains unsupported syntax. Falling back to parsing as a 'Command'.
```

Can you actually revert to your first commit where you only modified the Doris dialect, and let StarRocks be the way it was before? Also make sure that there are no warnings, i.e. we can actually parse those statements you added in the test suite.

Thanks!