### PR TITLE
feat(optimizer)!: parse and annotate type support for bigquery JSON_ARRAY

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -455,6 +455,7 @@ class BigQuery(Dialect):
         exp.Corr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarSamp: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
+        exp.JSONArray: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
@@ -619,6 +620,9 @@ class BigQuery(Dialect):
         FUNCTION_PARSERS = {
             **parser.Parser.FUNCTION_PARSERS,
             "ARRAY": lambda self: self.expression(exp.Array, expressions=[self._parse_statement()]),
+            "JSON_ARRAY": lambda self: self.expression(
+                exp.JSONArray, expressions=self._parse_csv(self._parse_bitwise)
+            ),
             "MAKE_INTERVAL": lambda self: self._parse_make_interval(),
             "FEATURES_AT_TIME": lambda self: self._parse_features_at_time(),
         }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6338,7 +6338,7 @@ class JSONBObjectAgg(AggFunc):
 # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_ARRAY.html
 class JSONArray(Func):
     arg_types = {
-        "expressions": True,
+        "expressions": False,
         "null_handling": False,
         "return_type": False,
         "strict": False,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2687,3 +2687,10 @@ OPTIONS (
                 "snowflake": "SELECT id, DATEADD(MONTH, CAST(mnth AS INT), CAST(start_month AS DATE)) + 1 AS a_mnth FROM t, LATERAL FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (DATEDIFF(MONTH, start_month, DATE_TRUNC('MONTH', CURRENT_DATE)) + 1 - 1) + 1)) AS _t0(seq, key, path, index, mnth, this)",
             },
         )
+
+    def test_json_array(self):
+        self.validate_identity("JSON_ARRAY()")
+        self.validate_identity("JSON_ARRAY(10)")
+        self.validate_identity("JSON_ARRAY([])")
+        self.validate_identity("JSON_ARRAY(STRUCT(10 AS a, 'foo' AS b))")
+        self.validate_identity("JSON_ARRAY(10, ['foo', 'bar'], [20, 30])")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -623,6 +623,14 @@ BIGINT;
 BIT_COUNT(tbl.bin_col);
 BIGINT;
 
+# dialect: bigquery
+JSON_ARRAY(10);
+JSON;
+
+# dialect: bigquery
+JSON_ARRAY(10, [1, 2]);
+JSON;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for BigQuery `JSON_ARRAY`.

**DOCS**
[BigQuery JSON_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_array)