### PR TITLE
feat(optimizer)!: annotate type for bigquery JSON_VALUE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -456,6 +456,9 @@ class BigQuery(Dialect):
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarSamp: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.JSONArray: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
+        exp.JSONExtractScalar: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.VARCHAR
+        ),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -631,6 +631,10 @@ JSON;
 JSON_ARRAY(10, [1, 2]);
 JSON;
 
+# dialect: bigquery
+JSON_VALUE(JSON '{"foo": "1" }', '$.foo');
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation support for BigQuery `JSON_VALUE` function.

**DOCS**
[BigQuery JSON_VALUE](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_value)