### PR TITLE
feat(optimizer)!: annotate type for bigquery JSON_VALUE_ARRAY

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -459,6 +459,9 @@ class BigQuery(Dialect):
         exp.JSONExtractScalar: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.VARCHAR
         ),
+        exp.JSONValueArray: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.build("ARRAY<VARCHAR>")
+        ),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -635,6 +635,10 @@ JSON;
 JSON_VALUE(JSON '{"foo": "1" }', '$.foo');
 STRING;
 
+# dialect: bigquery
+JSON_VALUE_ARRAY(JSON '["a","b"]');
+ARRAY<STRING>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation support for `JSON_VALUE_ARRAY` of BigQuery

**DOCS**
[BigQuery JSON_VALUE_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_value_array)