### PR TITLE
feat(exasol): Add rank function to sqlglot expressions and parser

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -159,6 +159,7 @@ class Exasol(Dialect):
                 "'UTC'",
                 e.args.get("zone"),
             ),
+            exp.Rank: lambda self, e: self.func("RANK"),
         }
 
         def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7073,6 +7073,10 @@ class CovarPop(Binary, AggFunc):
     pass
 
 
+class Rank(Func):
+    arg_types = {"this": False}
+
+
 class Week(Func):
     arg_types = {"this": True, "mode": False}
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -274,6 +274,7 @@ class Parser(metaclass=_Parser):
         TokenType.CURRENT_TIME: exp.CurrentTime,
         TokenType.CURRENT_TIMESTAMP: exp.CurrentTimestamp,
         TokenType.CURRENT_USER: exp.CurrentUser,
+        TokenType.RANK: exp.Rank,
     }
 
     STRUCT_TYPE_TOKENS = {
@@ -626,6 +627,7 @@ class Parser(metaclass=_Parser):
         TokenType.OFFSET,
         TokenType.PRIMARY_KEY,
         TokenType.RANGE,
+        TokenType.RANK,
         TokenType.REPLACE,
         TokenType.RLIKE,
         TokenType.ROW,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -368,6 +368,7 @@ class TokenType(AutoName):
     QUALIFY = auto()
     QUOTE = auto()
     RANGE = auto()
+    RANK = auto()
     RECURSIVE = auto()
     REFRESH = auto()
     RENAME = auto()

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -381,3 +381,7 @@ class TestExasol(Validator):
                 "snowflake": "SELECT CURRENT_USER()",
             },
         )
+        self.validate_identity(
+            "SELECT rank(date) over(order by date desc) as sort_order",
+            "SELECT RANK() OVER (ORDER BY date DESC) AS sort_order",
+        )


### PR DESCRIPTION
This involves adding the [RANK](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/rank.htm) built -in function to exasol dialect in sqlglot 