### PR TITLE
feat(tsql)!: add default precision to VARCHAR create expressions

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -897,6 +897,8 @@ class TSQL(Dialect):
                                 and not column_type.expressions
                             ):
                                 # Add default precision of 1 to VARCHAR without precision
+                                # When n isn't specified in a data definition or variable declaration statement, the default length is 1.
+                                # https://learn.microsoft.com/en-us/sql/t-sql/data-types/char-and-varchar-transact-sql?view=sql-server-ver17#remarks
                                 column_type.set("expressions", [exp.Literal.number("1")])
 
             return create

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -890,7 +890,7 @@ class TSQL(Dialect):
                 if create.kind == "TABLE" and create.this and hasattr(create.this, "expressions"):
                     for column in create.this.expressions:
                         if isinstance(column, exp.ColumnDef):
-                            column_type = column.args.get("kind")
+                            column_type = column.kind
                             if (
                                 isinstance(column_type, exp.DataType)
                                 and column_type.this == exp.DataType.Type.VARCHAR

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -395,8 +395,9 @@ def _timestrtotime_sql(self: TSQL.Generator, expression: exp.TimeStrToTime):
 def _add_default_precision_to_varchar(expression: exp.Expression) -> exp.Expression:
     """Transform function to add VARCHAR(MAX) or CHAR(MAX) for cross-dialect conversion."""
     if isinstance(expression, exp.Create) and expression.kind == "TABLE":
-        if expression.this and hasattr(expression.this, "expressions"):
-            for column in expression.this.expressions:
+        schema = expression.this if isinstance(expression.this, exp.Schema) else None
+        if schema:
+            for column in schema.expressions:
                 if isinstance(column, exp.ColumnDef):
                     column_type = column.args.get("kind")
                     if (

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -887,7 +887,7 @@ class TSQL(Dialect):
                     create.args["properties"].append("expressions", exp.TemporaryProperty())
 
                 # Transform VARCHAR without precision to VARCHAR(1)
-                if create.kind == "TABLE" and create.this and hasattr(create.this, "expressions"):
+                if create.kind == "TABLE" and isinstance(create.this, exp.Schema):
                     for column in create.this.expressions:
                         if isinstance(column, exp.ColumnDef):
                             column_type = column.kind

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -299,11 +299,30 @@ class TestTSQL(Validator):
             "CREATE TABLE t (col VARCHAR(50))",
         )
 
+        # Test CHAR without precision conversion to CHAR(1)
+        self.validate_identity(
+            "CREATE TABLE t (col CHAR)",
+            "CREATE TABLE t (col CHAR(1))",
+        )
+
+        # Test CHAR with existing precision should remain unchanged
+        self.validate_identity(
+            "CREATE TABLE t (col CHAR(10))",
+        )
+
         # Test cross-dialect conversion: non-TSQL VARCHAR -> TSQL VARCHAR(MAX)
         self.validate_all(
             "CREATE TABLE t (col VARCHAR(MAX))",
             read={
                 "postgres": "CREATE TABLE t (col VARCHAR)",
+            },
+        )
+
+        # Test cross-dialect conversion: non-TSQL CHAR -> TSQL CHAR(MAX)
+        self.validate_all(
+            "CREATE TABLE t (col CHAR(MAX))",
+            read={
+                "postgres": "CREATE TABLE t (col CHAR)",
             },
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -288,6 +288,17 @@ class TestTSQL(Validator):
             "CREATE TABLE [db].[tbl] ([a] INTEGER)",
         )
 
+        # Test VARCHAR without precision conversion to VARCHAR(1)
+        self.validate_identity(
+            "CREATE TABLE t (col VARCHAR)",
+            "CREATE TABLE t (col VARCHAR(1))",
+        )
+
+        # Test VARCHAR with existing precision should remain unchanged
+        self.validate_identity(
+            "CREATE TABLE t (col VARCHAR(50))",
+        )
+
         self.validate_identity("SELECT a = 1", "SELECT 1 AS a").selects[0].assert_is(
             exp.Alias
         ).args["alias"].assert_is(exp.Identifier)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -299,6 +299,14 @@ class TestTSQL(Validator):
             "CREATE TABLE t (col VARCHAR(50))",
         )
 
+        # Test cross-dialect conversion: non-TSQL VARCHAR -> TSQL VARCHAR(MAX)
+        self.validate_all(
+            "CREATE TABLE t (col VARCHAR(MAX))",
+            read={
+                "postgres": "CREATE TABLE t (col VARCHAR)",
+            },
+        )
+
         self.validate_identity("SELECT a = 1", "SELECT 1 AS a").selects[0].assert_is(
             exp.Alias
         ).args["alias"].assert_is(exp.Identifier)


### PR DESCRIPTION
This pull request introduces a new feature to the T-SQL dialect in `sqlglot` to automatically add a default precision (`MAX`) to `VARCHAR` data types without an explicit precision. It also includes corresponding updates to preprocessing and test cases.

### Feature Addition: Default Precision for `VARCHAR`

* **New Functionality**: Added a helper function `add_default_precision_to_varchar` in `sqlglot/dialects/tsql.py` to add a default precision (`MAX`) to `VARCHAR` expressions that lack an explicit precision. This is implemented by checking for `VARCHAR` data types and appending a `DataTypeParam` with the value `MAX` if none exists.

* **Integration with T-SQL Dialect**: Updated the T-SQL `Generator` class to include the new `add_default_precision_to_varchar` function in the preprocessing step for `CREATE` expressions. This ensures the transformation is applied during transpilation.

### Test Coverage

* **New Test Cases**: Added tests in `tests/dialects/test_tsql.py` to validate the new behavior:
  - Ensures `VARCHAR` without precision is converted to `VARCHAR(MAX)`.
  - Confirms that existing precision in `VARCHAR` is preserved.