### PR TITLE
feat: Add support for BETWEEN flags

### DIFF
--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -83,6 +83,7 @@ class Dremio(Dialect):
         JOIN_HINTS = False
         LIMIT_ONLY_LITERALS = True
         MULTI_ARG_DISTINCT = False
+        SUPPORTS_BETWEEN_FLAGS = True
 
         # https://docs.dremio.com/current/reference/sql/data-types/
         TYPE_MAPPING = {

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -561,6 +561,7 @@ class Postgres(Dialect):
         ARRAY_CONCAT_IS_VAR_LEN = False
         SUPPORTS_MEDIAN = False
         ARRAY_SIZE_DIM_REQUIRED = True
+        SUPPORTS_BETWEEN_FLAGS = True
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -935,11 +935,14 @@ class Expression(metaclass=_Expression):
             ),
         )
 
-    def between(self, low: t.Any, high: t.Any, copy: bool = True, **opts) -> Between:
+    def between(
+        self, low: t.Any, high: t.Any, copy: bool = True, kind: str | None = None, **opts
+    ) -> Between:
         return Between(
             this=maybe_copy(self, copy),
             low=convert(low, copy=copy, **opts),
             high=convert(high, copy=copy, **opts),
+            kind=kind,
         )
 
     def is_(self, other: ExpOrStr) -> Is:
@@ -5224,7 +5227,7 @@ class FormatPhrase(Expression):
 
 
 class Between(Predicate):
-    arg_types = {"this": True, "low": True, "high": True}
+    arg_types = {"this": True, "low": True, "high": True, "kind": False}
 
 
 class Bracket(Condition):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4992,10 +4992,23 @@ class Parser(metaclass=_Parser):
         return this
 
     def _parse_between(self, this: t.Optional[exp.Expression]) -> exp.Between:
+        kind = None
+        if self._match(TokenType.SYMMETRIC):
+            kind = "SYMMETRIC"
+        elif self._match(TokenType.ASYMMETRIC):
+            kind = "ASYMMETRIC"
+
         low = self._parse_bitwise()
         self._match(TokenType.AND)
         high = self._parse_bitwise()
-        return self.expression(exp.Between, this=this, low=low, high=high)
+
+        return self.expression(
+            exp.Between,
+            this=this,
+            low=low,
+            high=high,
+            kind=kind,
+        )
 
     def _parse_escape(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
         if not self._match(TokenType.ESCAPE):

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -236,6 +236,7 @@ class TokenType(AutoName):
     ARRAY = auto()
     ASC = auto()
     ASOF = auto()
+    ASYMMETRIC = auto()
     ATTACH = auto()
     AUTO_INCREMENT = auto()
     BEGIN = auto()
@@ -396,6 +397,7 @@ class TokenType(AutoName):
     STRAIGHT_JOIN = auto()
     STRUCT = auto()
     SUMMARIZE = auto()
+    SYMMETRIC = auto()
     TABLE_SAMPLE = auto()
     TAG = auto()
     TEMPORARY = auto()
@@ -711,6 +713,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "ASC": TokenType.ASC,
         "AS": TokenType.ALIAS,
         "ASOF": TokenType.ASOF,
+        "ASYMMETRIC": TokenType.ASYMMETRIC,
         "AUTOINCREMENT": TokenType.AUTO_INCREMENT,
         "AUTO_INCREMENT": TokenType.AUTO_INCREMENT,
         "BEGIN": TokenType.BEGIN,
@@ -838,6 +841,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "SORT BY": TokenType.SORT_BY,
         "START WITH": TokenType.START_WITH,
         "STRAIGHT_JOIN": TokenType.STRAIGHT_JOIN,
+        "SYMMETRIC": TokenType.SYMMETRIC,
         "TABLE": TokenType.TABLE,
         "TABLESAMPLE": TokenType.TABLE_SAMPLE,
         "TEMP": TokenType.TEMPORARY,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3655,3 +3655,56 @@ FROM subquery2""",
                 "mysql": "BIT_COUNT(x)",
             },
         )
+
+    def test_between(self):
+        self.validate_all(
+            "SELECT x BETWEEN 2 AND 10",
+            read={
+                "": "SELECT x BETWEEN 2 AND 10",
+                "clickhouse": "SELECT x BETWEEN 2 AND 10",
+                "dremio": "SELECT x BETWEEN 2 AND 10",
+                "duckdb": "SELECT x BETWEEN 2 AND 10",
+                "tsql": "SELECT x BETWEEN 2 AND 10",
+                "oracle": "SELECT x BETWEEN 2 AND 10",
+                "mysql": "SELECT x BETWEEN 2 AND 10",
+                "postgres": "SELECT x BETWEEN 2 AND 10",
+            },
+            write={
+                "": "SELECT x BETWEEN 2 AND 10",
+                "clickhouse": "SELECT x BETWEEN 2 AND 10",
+                "dremio": "SELECT x BETWEEN 2 AND 10",
+                "duckdb": "SELECT x BETWEEN 2 AND 10",
+                "tsql": "SELECT x BETWEEN 2 AND 10",
+                "oracle": "SELECT x BETWEEN 2 AND 10",
+                "mysql": "SELECT x BETWEEN 2 AND 10",
+                "postgres": "SELECT x BETWEEN 2 AND 10",
+            },
+        )
+
+        self.validate_all(
+            "SELECT x BETWEEN SYMMETRIC 10 AND 2",
+            write={
+                "dremio": "SELECT x BETWEEN SYMMETRIC 10 AND 2",
+                "postgres": "SELECT x BETWEEN SYMMETRIC 10 AND 2",
+                "": "SELECT (x BETWEEN 10 AND 2 OR x BETWEEN 2 AND 10)",
+                "mysql": "SELECT (x BETWEEN 10 AND 2 OR x BETWEEN 2 AND 10)",
+                "oracle": "SELECT (x BETWEEN 10 AND 2 OR x BETWEEN 2 AND 10)",
+                "duckdb": "SELECT (x BETWEEN 10 AND 2 OR x BETWEEN 2 AND 10)",
+                "clickhouse": "SELECT (x BETWEEN 10 AND 2 OR x BETWEEN 2 AND 10)",
+                "tsql": "SELECT (x BETWEEN 10 AND 2 OR x BETWEEN 2 AND 10)",
+            },
+        )
+
+        self.validate_all(
+            "SELECT x BETWEEN ASYMMETRIC 10 AND 2",
+            write={
+                "dremio": "SELECT x BETWEEN ASYMMETRIC 10 AND 2",
+                "postgres": "SELECT x BETWEEN ASYMMETRIC 10 AND 2",
+                "": "SELECT x BETWEEN 10 AND 2",
+                "mysql": "SELECT x BETWEEN 10 AND 2",
+                "oracle": "SELECT x BETWEEN 10 AND 2",
+                "duckdb": "SELECT x BETWEEN 10 AND 2",
+                "clickhouse": "SELECT x BETWEEN 10 AND 2",
+                "tsql": "SELECT x BETWEEN 10 AND 2",
+            },
+        )


### PR DESCRIPTION
Some SQL dialects support optional `ASYMMETRIC` and `SYMMETRIC` flags for `BETWEEN` expression (some context here https://dev.mysql.com/worklog/task/?id=5084)

Currently query like `SELECT expr BETWEEN SYMMETRIC low AND high` translates into `SELECT expr BETWEEN SYMMETRIC AND low AND high`

Flags behaviour for `SELECT expr BETWEEN low AND high`: 
- Adding the word `ASYMMETRIC` is harmless but achieves nothing, checks `expr >= low AND expr <= high`
- Adding the word `SYMMETRIC` checks for `expr >= low AND expr <= high OR expr >= high AND expr <= low `

```sql
SELECT 7 BETWEEN 10 AND 5;              -- FALSE
SELECT 7 BETWEEN ASYMMETRIC 10 AND 5;   -- FALSE
SELECT 7 BETWEEN SYMMETRIC 10 AND 5;    -- TRUE
```

This implementation tries to use these flags if they're supported by the dialect; otherwise, it falls back to the expanded form. From the dialects I tested, only `Dremio` and `PostgreSQL` supported them, but it's likely that others do too. Setting `SUPPORTS_BETWEEN_FLAGS = False` should be a safe default, even if a dialect does support the flags.