### PR TITLE
feat: add parsing/generating for BigQuery `DECLARE`

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1589,7 +1589,7 @@ class Declare(Expression):
 
 
 class DeclareItem(Expression):
-    arg_types = {"this": True, "kind": True, "default": False}
+    arg_types = {"this": True, "kind": False, "default": False}
 
 
 class Set(Expression):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1776,12 +1776,6 @@ WHERE
             transpile("DATE_ADD(x, day)", read="bigquery")
 
     def test_warnings(self):
-        with self.assertLogs(parser_logger) as cm:
-            self.validate_identity(
-                "/* some comment */ DECLARE foo DATE DEFAULT DATE_SUB(current_date, INTERVAL 2 day)"
-            )
-            self.assertIn("contains unsupported syntax", cm.output[0])
-
         with self.assertLogs(helper_logger) as cm:
             self.validate_identity(
                 "WITH cte(c) AS (SELECT * FROM t) SELECT * FROM cte",
@@ -2695,3 +2689,29 @@ OPTIONS (
         self.validate_identity("JSON_ARRAY([])")
         self.validate_identity("JSON_ARRAY(STRUCT(10 AS a, 'foo' AS b))")
         self.validate_identity("JSON_ARRAY(10, ['foo', 'bar'], [20, 30])")
+
+    def test_declare(self):
+        # supported cases
+        self.validate_identity("DECLARE X INT", "DECLARE X INT64")
+        self.validate_identity("DECLARE X INT DEFAULT 1", "DECLARE X INT64 DEFAULT 1")
+        self.validate_identity("DECLARE X FLOAT64 DEFAULT .9", "DECLARE X FLOAT64 DEFAULT 0.9")
+        self.validate_identity(
+            "DECLARE X INT DEFAULT (SELECT MAX(col) FROM foo)",
+            "DECLARE X INT64 DEFAULT (SELECT MAX(col) FROM foo)",
+        )
+        self.validate_identity("DECLARE X,Y,Z INT", "DECLARE X, Y, Z INT64")
+        self.validate_identity("DECLARE X,Y,Z INT DEFAULT 42", "DECLARE X, Y, Z INT64 DEFAULT 42")
+        self.validate_identity(
+            "DECLARE X,Y,Z INT DEFAULT (SELECT 42)", "DECLARE X, Y, Z INT64 DEFAULT (SELECT 42)"
+        )
+        self.validate_identity(
+            "DECLARE START_DATE DATE DEFAULT CURRENT_DATE() - 1",
+            "DECLARE START_DATE DATE DEFAULT CURRENT_DATE - 1",
+        )
+        self.validate_identity(
+            "DECLARE TS TIMESTAMP DEFAULT CURRENT_TIMESTAMP() - INTERVAL '1' HOUR",
+            "DECLARE TS TIMESTAMP DEFAULT CURRENT_TIMESTAMP() - INTERVAL '1' HOUR",
+        )
+        self.validate_identity(
+            "DECLARE START_DATE DEFAULT CURRENT_DATE", "DECLARE START_DATE DEFAULT CURRENT_DATE"
+        )


### PR DESCRIPTION
See documentation [here](https://cloud.google.com/bigquery/docs/reference/standard-sql/procedural-language#declare)

Note that because BigQuery can infer the variable type from the default value, I had to make `kind` optional in the `Declare` token.