### PR TITLE
feat(mysql): Add support for `SELECT DISTINCTROW`

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -195,6 +195,7 @@ class MySQL(Dialect):
             # The DESCRIBE and EXPLAIN statements are synonyms.
             # https://dev.mysql.com/doc/refman/8.4/en/explain.html
             "BLOB": TokenType.BLOB,
+            "DISTINCTROW": TokenType.DISTINCT,
             "EXPLAIN": TokenType.DESCRIBE,
             "FORCE": TokenType.FORCE,
             "IGNORE": TokenType.IGNORE,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -295,6 +295,10 @@ class TestMySQL(Validator):
         self.validate_identity("SELECT @var1, @var2 := @var1")
         self.validate_identity("SELECT @var1 := COUNT(*) FROM t1")
 
+        self.validate_identity(
+            "SELECT DISTINCTROW tbl.col FROM tbl", "SELECT DISTINCT tbl.col FROM tbl"
+        )
+
     def test_types(self):
         for char_type in MySQL.Generator.CHAR_CAST_MAPPING:
             with self.subTest(f"MySQL cast into {char_type}"):


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5445

The only reference that I could find in [MySQL docs](https://dev.mysql.com/doc/refman/9.1/en/select.html) mentions that `DISTINCTROW` is a synonym for `DISTINCT`.