### PR TITLE
Feat!: improve BigQuery `UNNEST` transpilation

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -461,7 +461,7 @@ def _eliminate_dot_variant_lookup(expression: exp.Expression) -> exp.Expression:
             unnest_alias = unnest.args.get("alias")
             if (
                 isinstance(unnest_alias, exp.TableAlias)
-                and not unnest_alias.this
+                and (unnest_alias.args.get("column_only") or not unnest_alias.this)
                 and len(unnest_alias.columns) == 1
             ):
                 unnest_aliases.add(unnest_alias.columns[0].name)

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1677,7 +1677,7 @@ class ProjectionDef(Expression):
 
 
 class TableAlias(Expression):
-    arg_types = {"this": False, "columns": False}
+    arg_types = {"this": False, "columns": False, "column_only": False}
 
     @property
     def columns(self):

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -128,6 +128,14 @@ def qualify_tables(
                 table_alias = udtf.args.get("alias") or exp.TableAlias(
                     this=exp.to_identifier(next_alias_name())
                 )
+                if (
+                    isinstance(udtf, exp.Unnest)
+                    and dialect.UNNEST_COLUMN_ONLY
+                    and not table_alias.columns
+                ):
+                    table_alias.set("columns", [table_alias.this.copy()])
+                    table_alias.set("column_only", True)
+
                 udtf.set("alias", table_alias)
 
                 if not table_alias.name:

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -812,8 +812,9 @@ SELECT c.f::VARCHAR(MAX) AS f, e AS e FROM a.b AS c, c.d AS e;
 SELECT CAST(c.f AS VARCHAR(MAX)) AS f, e AS e FROM a.b AS c, c.d AS e;
 
 # dialect: bigquery
+# execute: false
 WITH cte AS (SELECT 1 AS col) SELECT * FROM cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE col = 1));
-WITH cte AS (SELECT 1 AS col) SELECT * FROM cte AS cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE cte.col = 1));
+WITH cte AS (SELECT 1 AS col) SELECT cte.col AS col, _q_1 AS _q_1 FROM cte AS cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE cte.col = 1)) AS _q_1;
 
 --------------------------------------
 -- Window functions


### PR DESCRIPTION
This PR aims to improve the transpilation of `UNNEST` expressions in BigQuery that are transformed using `qualify_tables`:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.qualify_tables import qualify_tables
>>>
>>> sql = """
...         SELECT x, ys, zs
...         FROM UNNEST([STRUCT('x' AS x, ['y1', 'y2', 'y3'] AS y, ['z1', 'z2', 'z3'] AS z)]),
...         UNNEST(y) AS ys,
...         UNNEST(z) AS zs
... """
>>>
>>> ast = parse_one(sql, "bigquery")
>>> qualified = qualify_tables(ast, dialect="bigquery")
>>>
>>> print(ast.sql("snowflake", pretty=True))  # `_q_0.y` is an invalid reference so this query can't be executed
SELECT
  _q_0.x,
  ys,
  zs
FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('x', 'x', 'y', ['y1', 'y2', 'y3'], 'z', ['z1', 'z2', 'z3'])])) AS _q_0(seq, key, path, index, value, this)
CROSS JOIN TABLE(FLATTEN(INPUT => _q_0.y)) AS _q_1(seq, key, path, index, ys, this)
CROSS JOIN TABLE(FLATTEN(INPUT => _q_0.z)) AS _q_2(seq, key, path, index, zs, this)
```