### PR TITLE
feat(exasol): mapped STRPOS to INSTR in exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -6,6 +6,7 @@ from sqlglot.dialects.dialect import (
     binary_from_function,
     build_formatted_time,
     timestrtotime_sql,
+    strposition_sql,
 )
 from sqlglot.helper import seq_get
 from sqlglot.generator import unsupported_args
@@ -158,6 +159,12 @@ class Exasol(Dialect):
                 e.this,
                 "'UTC'",
                 e.args.get("zone"),
+            ),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/instr.htm
+            exp.StrPosition: lambda self, e: (
+                strposition_sql(
+                    self, e, func_name="INSTR", supports_position=True, supports_occurrence=True
+                )
             ),
         }
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -276,6 +276,16 @@ class TestExasol(Validator):
                 },
             ),
         )
+        self.validate_all(
+            "STRPOS(haystack, needle)",
+            write={
+                "exasol": "INSTR(haystack, needle)",
+                "bigquery": "INSTR(haystack, needle)",
+                "databricks": "LOCATE(needle, haystack)",
+                "oracle": "INSTR(haystack, needle)",
+                "presto": "STRPOS(haystack, needle)",
+            },
+        )
 
     def test_datetime_functions(self):
         formats = {


### PR DESCRIPTION
This involves mapping STR_POSITION in sqlglot to [INSTR](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/instr.htm) in exasol