### PR TITLE
Fix: restore default `sql_names` for `DecodeCase`

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5387,7 +5387,9 @@ class Func(Condition):
 
     @classmethod
     def sql_name(cls):
-        return cls.sql_names()[0]
+        sql_names = cls.sql_names()
+        assert sql_names, f"Expected non-empty 'sql_names' for Func: {cls.__name__}."
+        return sql_names[0]
 
     @classmethod
     def default_parser_mappings(cls):
@@ -6084,7 +6086,6 @@ class Decode(Func):
 
 
 class DecodeCase(Func):
-    _sql_names: t.List[str] = []
     arg_types = {"expressions": True}
     is_var_len_args = True
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1556,6 +1556,10 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         qualified = optimizer.qualify.qualify(query)
         self.assertEqual(qualified.expressions[0].alias, "c")
 
+    def test_gen(self):
+        for func in exp.ALL_FUNCTIONS:
+            self.assertIsInstance(optimizer.simplify.gen(func()), str)
+
     def test_normalization_distance(self):
         def gen_expr(depth: int) -> exp.Expression:
             return parse_one(" OR ".join("a AND b" for _ in range(depth)))


### PR DESCRIPTION
This was an oversight on my end. We *always* need a non-empty `sql_names()` output for `gen`.