### PR TITLE
fix(snowflake)!: Remove `UNKNOWN` type from `TRY_CAST`

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -511,6 +511,10 @@ class Dialect(metaclass=_Dialect):
     # Whether ADD is present for each column added by ALTER TABLE
     ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN = True
 
+    # Whether the value/LHS of the TRY_CAST(<value> AS <type>) should strictly be a
+    # STRING type (Snowflake's case) or can be of any type
+    TRY_CAST_REQUIRES_STRING: t.Optional[bool] = None
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5755,6 +5755,7 @@ class Cast(Func):
         "safe": False,
         "action": False,
         "default": False,
+        "requires_string": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5755,7 +5755,6 @@ class Cast(Func):
         "safe": False,
         "action": False,
         "default": False,
-        "requires_string": False,
     }
 
     @property
@@ -5786,7 +5785,7 @@ class Cast(Func):
 
 
 class TryCast(Cast):
-    pass
+    arg_types = {**Cast.arg_types, "requires_string": False}
 
 
 # https://clickhouse.com/docs/sql-reference/data-types/newjson#reading-json-paths-as-sub-columns

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8647,7 +8647,7 @@ class Parser(metaclass=_Parser):
 
         return self.expression(exp.Declare, expressions=expressions)
 
-    def build_cast(self, strict: bool, **kwargs) -> exp.Cast | exp.TryCast:
+    def build_cast(self, strict: bool, **kwargs) -> exp.Cast:
         exp_class = exp.Cast if strict else exp.TryCast
 
         if exp_class == exp.TryCast:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -763,6 +763,7 @@ class Parser(metaclass=_Parser):
             exp.Cast if self.STRICT_CAST else exp.TryCast,
             this=this,
             to=to,
+            requires_string=self.dialect.TRY_CAST_REQUIRES_STRING,
         ),
         TokenType.ARROW: lambda self, this, path: self.expression(
             exp.JSONExtract,
@@ -6545,6 +6546,7 @@ class Parser(metaclass=_Parser):
             safe=safe,
             action=self._parse_var_from_options(self.CAST_ACTIONS, raise_unmatched=False),
             default=default,
+            requires_string=self.dialect.TRY_CAST_REQUIRES_STRING,
         )
 
     def _parse_string_agg(self) -> exp.GroupConcat:
@@ -6613,7 +6615,13 @@ class Parser(metaclass=_Parser):
         else:
             to = None
 
-        return self.expression(exp.Cast if strict else exp.TryCast, this=this, to=to, safe=safe)
+        return self.expression(
+            exp.Cast if strict else exp.TryCast,
+            this=this,
+            to=to,
+            safe=safe,
+            requires_string=self.dialect.TRY_CAST_REQUIRES_STRING,
+        )
 
     def _parse_xml_table(self) -> exp.XMLTable:
         namespaces = None

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -414,6 +414,13 @@ LANGUAGE js AS
             },
         )
         self.validate_all(
+            "SAFE_CAST(x AS TIMESTAMP)",
+            write={
+                "bigquery": "SAFE_CAST(x AS TIMESTAMP)",
+                "snowflake": "CAST(x AS TIMESTAMPTZ)",
+            },
+        )
+        self.validate_all(
             "SELECT t.c1, h.c2, s.c3 FROM t1 AS t, UNNEST(t.t2) AS h, UNNEST(h.t3) AS s",
             write={
                 "bigquery": "SELECT t.c1, h.c2, s.c3 FROM t1 AS t CROSS JOIN UNNEST(t.t2) AS h CROSS JOIN UNNEST(h.t3) AS s",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2605,10 +2605,10 @@ STORAGE_ALLOWED_LOCATIONS=('s3://mybucket1/path1/', 's3://mybucket2/path2/')""",
             },
         )
         self.validate_all(
-            "TRY_CAST(x AS TEXT)",
+            "TRY_CAST('val' AS TEXT)",
             read={
-                "hive": "CAST(x AS STRING)",
-                "snowflake": "TRY_CAST(x AS TEXT)",
+                "hive": "CAST('val' AS STRING)",
+                "snowflake": "TRY_CAST('val' AS TEXT)",
             },
         )
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2618,12 +2618,15 @@ STORAGE_ALLOWED_LOCATIONS=('s3://mybucket1/path1/', 's3://mybucket2/path2/')""",
         expression = parse_one("SELECT CAST(t.x AS STRING) FROM t", read="hive")
 
         for value_type in ("string", "int"):
-            func = "TRY_CAST" if value_type == "string" else "CAST"
+            with self.subTest(
+                f"Testing Hive -> Snowflake CAST/TRY_CAST conversion for {value_type}"
+            ):
+                func = "TRY_CAST" if value_type == "string" else "CAST"
 
-            expression = annotate_types(expression, schema={"t": {"x": value_type}})
-            self.assertEqual(
-                expression.sql(dialect="snowflake"), f"SELECT {func}(t.x AS TEXT) FROM t"
-            )
+                expression = annotate_types(expression, schema={"t": {"x": value_type}})
+                self.assertEqual(
+                    expression.sql(dialect="snowflake"), f"SELECT {func}(t.x AS TEXT) FROM t"
+                )
 
     def test_copy(self):
         self.validate_identity("COPY INTO test (c1) FROM (SELECT $1.c1 FROM @mystage)")


### PR DESCRIPTION
https://github.com/tobymao/sqlglot/pull/2560 made it so that Snowflake's `TRY_CAST` is generated only if the value is of type `{TEXT, UNKNOWN}`; The latter was added to preserve roundtrips but can hurt transpilation attempts coming from other dialects.

To fix this, this PR adds a new boolean arg to `exp.Cast` and removes `UNKNOWN` types from that branch as a "best effort" transpilation attempt.