### PR TITLE
feat(exasol): Add support for HASH_SHA1 function

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -59,7 +59,7 @@ class Exasol(Dialect):
             "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
             "EVERY": lambda args: exp.All(this=seq_get(args, 0)),
             "EDIT_DISTANCE": exp.Levenshtein.from_arg_list,
-            "HASH_SHA1": exp.SHA.from_arg_list,
+            "HASH_SHA": exp.SHA.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1),
@@ -175,7 +175,7 @@ class Exasol(Dialect):
                 )
             ),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_sha%5B1%5D.htm#HASH_SHA%5B1%5D
-            exp.SHA: rename_func("HASH_SHA1"),
+            exp.SHA: rename_func("HASH_SHA"),
             # https://docs.exasol.com/db/latest/sql/create_view.htm
             exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
         }

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -59,6 +59,7 @@ class Exasol(Dialect):
             "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
             "EVERY": lambda args: exp.All(this=seq_get(args, 0)),
             "EDIT_DISTANCE": exp.Levenshtein.from_arg_list,
+            "HASH_SHA1": exp.SHA.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1),
@@ -173,6 +174,8 @@ class Exasol(Dialect):
                     self, e, func_name="INSTR", supports_position=True, supports_occurrence=True
                 )
             ),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_sha%5B1%5D.htm#HASH_SHA%5B1%5D
+            exp.SHA: rename_func("HASH_SHA1"),
             # https://docs.exasol.com/db/latest/sql/create_view.htm
             exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -398,3 +398,19 @@ class TestExasol(Validator):
                 "exasol": 'CREATE OR REPLACE VIEW "schema"."v" ("col" COMMENT IS \'desc\') AS SELECT "src_col" AS "col"',
             },
         )
+        self.validate_all(
+            "HASH_SHA1(x)",
+            read={
+                "clickhouse": "SHA1(x)",
+                "presto": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+            write={
+                "exasol": "HASH_SHA1(x)",
+                "clickhouse": "SHA1(x)",
+                "bigquery": "SHA1(x)",
+                "": "SHA(x)",
+                "presto": "SHA1(x)",
+                "trino": "SHA1(x)",
+            },
+        )

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -399,14 +399,14 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            "HASH_SHA1(x)",
+            "HASH_SHA(x)",
             read={
                 "clickhouse": "SHA1(x)",
                 "presto": "SHA1(x)",
                 "trino": "SHA1(x)",
             },
             write={
-                "exasol": "HASH_SHA1(x)",
+                "exasol": "HASH_SHA(x)",
                 "clickhouse": "SHA1(x)",
                 "bigquery": "SHA1(x)",
                 "": "SHA(x)",


### PR DESCRIPTION
This involves adding [HASH_SHA1](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_sha%5B1%5D.htm) built -in function to exasol dialect in sqlglot.