### PR TITLE
feat(snowflake): Transpile BQ's `STRUCT` dot access

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1673,3 +1673,11 @@ class Snowflake(Dialect):
                 to=exp.DataType(this=exp.DataType.Type.DATE),
             )
             return self.sql(expr)
+
+        def dot_sql(self, expression: exp.Dot) -> str:
+            this = expression.this
+
+            if this.is_type(exp.DataType.Type.STRUCT):
+                return f"{self.sql(this)}:{self.sql(expression, 'expression')}"
+
+            return super().dot_sql(expression)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1677,7 +1677,13 @@ class Snowflake(Dialect):
         def dot_sql(self, expression: exp.Dot) -> str:
             this = expression.this
 
-            if this.is_type(exp.DataType.Type.STRUCT):
+            if not this.type:
+                from sqlglot.optimizer.annotate_types import annotate_types
+
+                this = annotate_types(this, dialect=self.dialect)
+
+            if not isinstance(this, exp.Dot) and this.is_type(exp.DataType.Type.STRUCT):
+                # Generate colon notation for the top level STRUCT
                 return f"{self.sql(this)}:{self.sql(expression, 'expression')}"
 
             return super().dot_sql(expression)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1762,6 +1762,14 @@ WHERE
         self.validate_identity("ARRAY_LAST(['a', 'b'])")
         self.validate_identity("JSON_TYPE(PARSE_JSON('1'))")
 
+        self.validate_all(
+            "SELECT CAST(col AS STRUCT<fld1 STRUCT<fld2 INT>>).fld1.fld2",
+            write={
+                "bigquery": "SELECT CAST(col AS STRUCT<fld1 STRUCT<fld2 INT64>>).fld1.fld2",
+                "snowflake": "SELECT CAST(col AS OBJECT(fld1 OBJECT(fld2 INT))):fld1.fld2",
+            },
+        )
+
     def test_errors(self):
         with self.assertRaises(ParseError):
             self.parse_one("SELECT * FROM a - b.c.d2")


### PR DESCRIPTION
Snowflake requires that the top-level access is done through the colon operator, while the subsequent accesses can use the dot notation.

-  Before this PR, cannot execute on Snowflake:
```Python3
>>> sql = "WITH tbl AS (SELECT STRUCT(STRUCT(1 as fld2) as fld1) AS col) select CAST(col AS STRUCT<fld1 STRUCT<fld2 INT>>).fld1.fld2 from tbl;"
>>> sqlglot.parse_one(sql, "bigquery").sql("snowflake")
'WITH tbl AS (SELECT OBJECT_CONSTRUCT('fld1', OBJECT_CONSTRUCT('fld2', 1)) AS col) SELECT CAST(col AS OBJECT(fld1 OBJECT(fld2 INT))).fld1.fld2 FROM tbl'
```

- After this PR (note the colon following the cast):

```Python3
>>> sqlglot.parse_one(sql, "bigquery").sql("snowflake")
'WITH tbl AS (SELECT OBJECT_CONSTRUCT('fld1', OBJECT_CONSTRUCT('fld2', 1)) AS col) SELECT CAST(col AS OBJECT(fld1 OBJECT(fld2 INT))):fld1.fld2 FROM tbl'
```


