### PR TITLE
feat(hive, spark): Add support for LOCATION in ADD PARTITION

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -4942,7 +4942,7 @@ class AddConstraint(Expression):
 
 
 class AddPartition(Expression):
-    arg_types = {"this": True, "exists": False}
+    arg_types = {"this": True, "exists": False, "location": False}
 
 
 class AttachOption(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3549,7 +3549,9 @@ class Generator(metaclass=_Generator):
 
     def addpartition_sql(self, expression: exp.AddPartition) -> str:
         exists = "IF NOT EXISTS " if expression.args.get("exists") else ""
-        return f"ADD {exists}{self.sql(expression.this)}"
+        location = self.sql(expression, "location")
+        location = f" {location}" if location else ""
+        return f"ADD {exists}{self.sql(expression.this)}{location}"
 
     def distinct_sql(self, expression: exp.Distinct) -> str:
         this = self.expressions(expression, flat=True)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7394,7 +7394,11 @@ class Parser(metaclass=_Parser):
             exists = self._parse_exists(not_=True)
             if self._match_pair(TokenType.PARTITION, TokenType.L_PAREN, advance=False):
                 return self.expression(
-                    exp.AddPartition, exists=exists, this=self._parse_field(any_token=True)
+                    exp.AddPartition,
+                    exists=exists,
+                    this=self._parse_field(any_token=True),
+                    location=self._match_text_seq("LOCATION", advance=False)
+                    and self._parse_property(),
                 )
 
             return None

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -216,6 +216,21 @@ class TestHive(Validator):
             },
         )
 
+        self.validate_all(
+            "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+            read={
+                "spark2": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+                "spark": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+                "databricks": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+            },
+            write={
+                "hive": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+                "spark2": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+                "spark": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+                "databricks": "ALTER TABLE db.example_table ADD PARTITION(col_a = 'a') LOCATION 'b'",
+            },
+        )
+
     def test_lateral_view(self):
         self.validate_all(
             "SELECT a, b FROM x LATERAL VIEW EXPLODE(y) t AS a LATERAL VIEW EXPLODE(z) u AS b",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5457

Did not find it in [Spark's syntax](https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-alter-table.html#add-partition) specs but it seems to execute fine:

```SQL
spark-sql (default)> CREATE TABLE tbl (x INT, y INT) PARTITIONED BY (x);
Time taken: 0.188 seconds

spark-sql (default)> ALTER TABLE tbl ADD PARTITION(x = 2) LOCATION 'b';
Time taken: 0.183 seconds
``` 

Docs
----------
[Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AddPartitions) | [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-ddl-alter-table-manage-partition#syntax-1)