### PR TITLE
feat(exasol): add HASH_MD5 functionality to exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -61,6 +61,7 @@ class Exasol(Dialect):
             "EDIT_DISTANCE": exp.Levenshtein.from_arg_list,
             "HASH_SHA": exp.SHA.from_arg_list,
             "HASH_SHA1": exp.SHA.from_arg_list,
+            "HASH_MD5": exp.MD5.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1),
@@ -177,6 +178,7 @@ class Exasol(Dialect):
             ),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_sha%5B1%5D.htm#HASH_SHA%5B1%5D
             exp.SHA: rename_func("HASH_SHA"),
+            exp.MD5: rename_func("HASH_MD5"),
             # https://docs.exasol.com/db/latest/sql/create_view.htm
             exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
         }

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -415,3 +415,16 @@ class TestExasol(Validator):
                 "trino": "SHA1(x)",
             },
         )
+        self.validate_all(
+            "HASH_MD5(x)",
+            write={
+                "exasol": "HASH_MD5(x)",
+                "": "MD5(x)",
+                "bigquery": "TO_HEX(MD5(x))",
+                "clickhouse": "LOWER(HEX(MD5(x)))",
+                "hive": "MD5(x)",
+                "presto": "LOWER(TO_HEX(MD5(x)))",
+                "spark": "MD5(x)",
+                "trino": "LOWER(TO_HEX(MD5(x)))",
+            },
+        )


### PR DESCRIPTION
This involves adding [HASH_MD5](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_md5.htm) built -in function to exasol dialect in sqlglot.