### PR TITLE
feat(exasol): Add HASHTYPE_MD5 functions to Exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -62,6 +62,7 @@ class Exasol(Dialect):
             "HASH_SHA": exp.SHA.from_arg_list,
             "HASH_SHA1": exp.SHA.from_arg_list,
             "HASH_MD5": exp.MD5.from_arg_list,
+            "HASHTYPE_MD5": exp.MD5Digest.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1),
@@ -179,6 +180,7 @@ class Exasol(Dialect):
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_sha%5B1%5D.htm#HASH_SHA%5B1%5D
             exp.SHA: rename_func("HASH_SHA"),
             exp.MD5: rename_func("HASH_MD5"),
+            exp.MD5Digest: rename_func("HASHTYPE_MD5"),
             # https://docs.exasol.com/db/latest/sql/create_view.htm
             exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
         }

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -180,6 +180,7 @@ class Exasol(Dialect):
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hash_sha%5B1%5D.htm#HASH_SHA%5B1%5D
             exp.SHA: rename_func("HASH_SHA"),
             exp.MD5: rename_func("HASH_MD5"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hashtype_md5.htm
             exp.MD5Digest: rename_func("HASHTYPE_MD5"),
             # https://docs.exasol.com/db/latest/sql/create_view.htm
             exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -428,3 +428,16 @@ class TestExasol(Validator):
                 "trino": "LOWER(TO_HEX(MD5(x)))",
             },
         )
+        self.validate_all(
+            "HASHTYPE_MD5(x)",
+            write={
+                "exasol": "HASHTYPE_MD5(x)",
+                "": "MD5_DIGEST(x)",
+                "bigquery": "MD5(x)",
+                "clickhouse": "MD5(x)",
+                "hive": "UNHEX(MD5(x))",
+                "presto": "MD5(x)",
+                "spark": "UNHEX(MD5(x))",
+                "trino": "MD5(x)",
+            },
+        )


### PR DESCRIPTION
This involves adding [HASHTYPE_MD5](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hashtype_md5.htm) built -in function to exasol dialect in sqlglot.