### PR TITLE
feat(singlestore): Fixed time formatting

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -1,5 +1,94 @@
+from sqlglot.dialects.dialect import build_formatted_time
 from sqlglot.dialects.mysql import MySQL
+import typing as t
+from sqlglot import exp, Dialect
+from sqlglot.generator import unsupported_args
+from sqlglot.helper import seq_get
 
 
 class SingleStore(MySQL):
     SUPPORTS_ORDER_BY_ALL = True
+
+    TIME_MAPPING: t.Dict[str, str] = {
+        "AM": "%p",  # Meridian indicator with or without periods
+        "A.M.": "%p",  # Meridian indicator with or without periods
+        "PM": "%p",  # Meridian indicator with or without periods
+        "P.M.": "%p",  # Meridian indicator with or without periods
+        "D": "%u",  # Day of week (1-7)
+        "DD": "%d",  # day of month (1-31)
+        "DY": "%a",  # abbreviated name of day
+        "HH": "%I",  # Hour of day (1-12)
+        "HH12": "%I",  # alias for HH
+        "HH24": "%H",  # Hour of day (0-23)
+        "MI": "%M",  # Minute (0-59)
+        "MM": "%m",  # Month (01-12; January = 01)
+        "MON": "%b",  # Abbreviated name of month
+        "MONTH": "%B",  # Name of month
+        "SS": "%S",  # Second (0-59)
+        "RR": "%y",  # 15
+        "YY": "%y",  # 15
+        "YYYY": "%Y",  # 2015
+        "FF6": "%f",  # only 6 digits are supported in python formats
+    }
+
+    class Parser(MySQL.Parser):
+        FUNCTIONS = {
+            **MySQL.Parser.FUNCTIONS,
+            "TO_DATE": build_formatted_time(exp.StrToDate, "singlestore"),
+            "TO_TIMESTAMP": build_formatted_time(exp.StrToTime, "singlestore"),
+            "TO_CHAR": build_formatted_time(exp.TimeToStr, "singlestore"),
+            "STR_TO_DATE": build_formatted_time(exp.StrToDate, "mysql"),
+            "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "mysql"),
+            # The first argument is converted to TIME(6)
+            # This is needed because exp.TimeToStr is converted to DATE_FORMAT
+            # which interprets the first argument as DATETIME and fails to parse
+            # string literals like '12:05:47' without a date part.
+            "TIME_FORMAT": lambda args: exp.TimeToStr(
+                this=exp.Cast(
+                    this=seq_get(args, 0),
+                    to=exp.DataType.build(
+                        exp.DataType.Type.TIME,
+                        expressions=[exp.DataTypeParam(this=exp.Literal.number(6))],
+                    ),
+                ),
+                format=Dialect["mysql"].format_time(seq_get(args, 1)),
+            ),
+        }
+
+    class Generator(MySQL.Generator):
+        TRANSFORMS = {
+            **MySQL.Generator.TRANSFORMS,
+            exp.StrToDate: lambda self, e: self.func(
+                "STR_TO_DATE",
+                e.this,
+                self.format_time(
+                    e,
+                    inverse_time_mapping=Dialect["mysql"].INVERSE_TIME_MAPPING,
+                    inverse_time_trie=Dialect["mysql"].INVERSE_TIME_TRIE,
+                ),
+            ),
+            exp.TimeToStr: lambda self, e: self.func(
+                "DATE_FORMAT",
+                e.this,
+                self.format_time(
+                    e,
+                    inverse_time_mapping=Dialect["mysql"].INVERSE_TIME_MAPPING,
+                    inverse_time_trie=Dialect["mysql"].INVERSE_TIME_TRIE,
+                ),
+            ),
+            exp.StrToTime: lambda self, e: self.func(
+                "STR_TO_DATE",
+                e.this,
+                self.format_time(
+                    e,
+                    inverse_time_mapping=Dialect["mysql"].INVERSE_TIME_MAPPING,
+                    inverse_time_trie=Dialect["mysql"].INVERSE_TIME_TRIE,
+                ),
+            ),
+        }
+
+        @unsupported_args("format")
+        @unsupported_args("action")
+        @unsupported_args("default")
+        def cast_sql(self, expression: exp.Cast) -> str:  # type: ignore
+            return f"{self.sql(expression, 'this')} :> {self.sql(expression, 'to')}"

--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -2,7 +2,6 @@ from sqlglot.dialects.dialect import build_formatted_time
 from sqlglot.dialects.mysql import MySQL
 import typing as t
 from sqlglot import exp, Dialect
-from sqlglot.generator import unsupported_args
 from sqlglot.helper import seq_get
 
 
@@ -10,21 +9,17 @@ class SingleStore(MySQL):
     SUPPORTS_ORDER_BY_ALL = True
 
     TIME_MAPPING: t.Dict[str, str] = {
-        "AM": "%p",  # Meridian indicator with or without periods
-        "A.M.": "%p",  # Meridian indicator with or without periods
-        "PM": "%p",  # Meridian indicator with or without periods
-        "P.M.": "%p",  # Meridian indicator with or without periods
         "D": "%u",  # Day of week (1-7)
-        "DD": "%d",  # day of month (1-31)
+        "DD": "%d",  # day of month (01-31)
         "DY": "%a",  # abbreviated name of day
-        "HH": "%I",  # Hour of day (1-12)
+        "HH": "%I",  # Hour of day (01-12)
         "HH12": "%I",  # alias for HH
-        "HH24": "%H",  # Hour of day (0-23)
-        "MI": "%M",  # Minute (0-59)
+        "HH24": "%H",  # Hour of day (00-23)
+        "MI": "%M",  # Minute (00-59)
         "MM": "%m",  # Month (01-12; January = 01)
         "MON": "%b",  # Abbreviated name of month
         "MONTH": "%B",  # Name of month
-        "SS": "%S",  # Second (0-59)
+        "SS": "%S",  # Second (00-59)
         "RR": "%y",  # 15
         "YY": "%y",  # 15
         "YYYY": "%Y",  # 2015
@@ -86,9 +81,3 @@ class SingleStore(MySQL):
                 ),
             ),
         }
-
-        @unsupported_args("format")
-        @unsupported_args("action")
-        @unsupported_args("default")
-        def cast_sql(self, expression: exp.Cast) -> str:  # type: ignore
-            return f"{self.sql(expression, 'this')} :> {self.sql(expression, 'to')}"

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -36,5 +36,5 @@ class TestSingleStore(Validator):
         self.validate_identity("SELECT DATE_FORMAT(NOW(), '%Y-%m-%d %h:%i:%s')")
         self.validate_identity(
             "SELECT TIME_FORMAT('12:05:47', '%s, %i, %h')",
-            write_sql="SELECT DATE_FORMAT('12:05:47' :> TIME(6), '%s, %i, %h')",
+            write_sql="SELECT DATE_FORMAT(CAST('12:05:47' AS TIME(6)), '%s, %i, %h')",
         )

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -22,19 +22,16 @@ class TestSingleStore(Validator):
     def test_time_formatting(self):
         self.validate_identity(
             "SELECT TO_DATE('03/01/2019', 'MM/DD/YYYY') AS result",
-            write_sql="SELECT STR_TO_DATE('03/01/2019', '%m/%d/%Y') AS result",
         )
         self.validate_identity(
             "SELECT TO_TIMESTAMP('The date and time are 01/01/2018 2:30:15.123456', 'The date and time are MM/DD/YYYY HH12:MI:SS.FF6') AS result",
-            write_sql="SELECT STR_TO_DATE('The date and time are 01/01/2018 2:30:15.123456', 'The date and time are %m/%d/%Y %h:%i:%s.%f') AS result",
         )
         self.validate_identity(
             "SELECT TO_CHAR('2018-03-01', 'MM/DD')",
-            write_sql="SELECT DATE_FORMAT('2018-03-01', '%m/%d')",
         )
         self.validate_identity("SELECT STR_TO_DATE('March 3rd, 2015', '%M %D, %Y')")
         self.validate_identity("SELECT DATE_FORMAT(NOW(), '%Y-%m-%d %h:%i:%s')")
         self.validate_identity(
             "SELECT TIME_FORMAT('12:05:47', '%s, %i, %h')",
-            write_sql="SELECT DATE_FORMAT(CAST('12:05:47' AS TIME(6)), '%s, %i, %h')",
+            "SELECT DATE_FORMAT(CAST('12:05:47' AS TIME(6)), '%s, %i, %h')",
         )

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -18,3 +18,23 @@ class TestSingleStore(Validator):
             "SELECT `data`.`id` AS `my_id` FROM `data` AS `data` WHERE `data`.`my_id` = 1 GROUP BY `data`.`my_id` HAVING `data`.`id` = 1",
             ast.sql(dialect=self.dialect),
         )
+
+    def test_time_formatting(self):
+        self.validate_identity(
+            "SELECT TO_DATE('03/01/2019', 'MM/DD/YYYY') AS result",
+            write_sql="SELECT STR_TO_DATE('03/01/2019', '%m/%d/%Y') AS result",
+        )
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP('The date and time are 01/01/2018 2:30:15.123456', 'The date and time are MM/DD/YYYY HH12:MI:SS.FF6') AS result",
+            write_sql="SELECT STR_TO_DATE('The date and time are 01/01/2018 2:30:15.123456', 'The date and time are %m/%d/%Y %h:%i:%s.%f') AS result",
+        )
+        self.validate_identity(
+            "SELECT TO_CHAR('2018-03-01', 'MM/DD')",
+            write_sql="SELECT DATE_FORMAT('2018-03-01', '%m/%d')",
+        )
+        self.validate_identity("SELECT STR_TO_DATE('March 3rd, 2015', '%M %D, %Y')")
+        self.validate_identity("SELECT DATE_FORMAT(NOW(), '%Y-%m-%d %h:%i:%s')")
+        self.validate_identity(
+            "SELECT TIME_FORMAT('12:05:47', '%s, %i, %h')",
+            write_sql="SELECT DATE_FORMAT('12:05:47' :> TIME(6), '%s, %i, %h')",
+        )


### PR DESCRIPTION
SingleStore uses different time formatting formats in different functions.
One of the formats is compatible with MySQL
Related documentation:
 * [TO_DATE](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/to-date/)
 * [TO_TIMESTAMP](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/to-timestamp/)
 * [TO_CHAR](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/to-char/)
 * [STR_TO_DATE](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/str-to-date/)
 * [DATE_FORMAT](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/date-format/)
 * [TIME_FORMAT](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/time-format/)
