### PR TITLE
Fix(bigquery)!: store Query schemas in meta dict instead of type attr

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -313,9 +313,11 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                 elif (
                     isinstance(source, Scope)
                     and isinstance(source.expression, exp.Query)
-                    and source.expression.is_type(exp.DataType.Type.STRUCT)
+                    and (
+                        source.expression.meta.get("query_type") or exp.DataType.build("UNKNOWN")
+                    ).is_type(exp.DataType.Type.STRUCT)
                 ):
-                    self._set_type(table_column, source.expression.type)
+                    self._set_type(table_column, source.expression.meta["query_type"])
 
         # Then (possibly) annotate the remaining expressions in the scope
         self._maybe_annotate(scope.expression)
@@ -335,7 +337,10 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                 for cd in struct_type.expressions
                 if cd.kind
             ):
-                self._set_type(scope.expression, struct_type)
+                # We don't use `_set_type` on purpose here. If we annotated the query directly, then
+                # using it in other contexts (e.g., ARRAY(<query>)) could result in incorrect type
+                # annotations, i.e., it shouldn't be interpreted as a STRUCT value.
+                scope.expression.meta["query_type"] = struct_type
 
     def _maybe_annotate(self, expression: E) -> E:
         if id(expression) in self._visited:
@@ -463,12 +468,17 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                 self._set_type(expression, exp.DataType.Type.DOUBLE)
 
         if array:
-            self._set_type(
-                expression,
-                exp.DataType(
-                    this=exp.DataType.Type.ARRAY, expressions=[expression.type], nested=True
-                ),
-            )
+            array_arg_type = expression.type
+
+            if array_arg_type.is_type(exp.DataType.Type.UNKNOWN):
+                self._set_type(expression, exp.DataType.Type.UNKNOWN)
+            else:
+                self._set_type(
+                    expression,
+                    exp.DataType(
+                        this=exp.DataType.Type.ARRAY, expressions=[array_arg_type], nested=True
+                    ),
+                )
 
         return expression
 

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -468,17 +468,12 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
                 self._set_type(expression, exp.DataType.Type.DOUBLE)
 
         if array:
-            array_arg_type = expression.type
-
-            if array_arg_type.is_type(exp.DataType.Type.UNKNOWN):
-                self._set_type(expression, exp.DataType.Type.UNKNOWN)
-            else:
-                self._set_type(
-                    expression,
-                    exp.DataType(
-                        this=exp.DataType.Type.ARRAY, expressions=[array_arg_type], nested=True
-                    ),
-                )
+            self._set_type(
+                expression,
+                exp.DataType(
+                    this=exp.DataType.Type.ARRAY, expressions=[expression.type], nested=True
+                ),
+            )
 
         return expression
 


### PR DESCRIPTION
This PR aims to address the following bug, introduced [here](https://github.com/tobymao/sqlglot/pull/5230):

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.annotate_types import annotate_types
>>> from sqlglot.optimizer.qualify import qualify
>>>
>>> ast = parse_one("SELECT ARRAY(SELECT 'foo')", "bigquery")
>>> qualified = qualify(ast, dialect="bigquery")
>>> annotated = annotate_types(qualified, dialect="bigquery")
>>>
>>> annotated.selects[0].type
DataType(
  this=Type.ARRAY,
  expressions=[
    DataType(
      this=Type.STRUCT,
      expressions=[
        ColumnDef(
          this=Identifier(this=foo, quoted=False),
          kind=DataType(this=Type.VARCHAR))],
      nested=True)],
  nested=True)
>>> annotated.selects[0].type.sql("bigquery")
'ARRAY<STRUCT<foo STRING>>'
```

Note that BigQuery behaves differently:

```sql
SELECT ARRAY(SELECT 'foo'), TYPEOF(ARRAY(SELECT 'foo')) -- foo, ARRAY<STRING>
```