### PR TITLE
feat(mysql): Parse `UNIQUE INDEX` constraint similar to `UNIQUE KEY`

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6194,7 +6194,7 @@ class Parser(metaclass=_Parser):
         return self._parse_id_var(any_token=False)
 
     def _parse_unique(self) -> exp.UniqueColumnConstraint:
-        self._match_text_seq("KEY")
+        self._match_texts(("KEY", "INDEX"))
         return self.expression(
             exp.UniqueColumnConstraint,
             nulls=self._match_text_seq("NULLS", "NOT", "DISTINCT"),

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -139,6 +139,10 @@ class TestMySQL(Validator):
             "CREATE TABLE `foo` (a VARCHAR(10), KEY idx_a (a DESC))",
             "CREATE TABLE `foo` (a VARCHAR(10), INDEX idx_a (a DESC))",
         )
+        self.validate_identity(
+            "CREATE TABLE `foo` (a VARCHAR(10), UNIQUE INDEX idx_a (a))",
+            "CREATE TABLE `foo` (a VARCHAR(10), UNIQUE idx_a (a))",
+        )
 
         self.validate_all(
             "insert into t(i) values (default)",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5479

MySQL `UNIQUE` syntax:

```
create_definition: {
    col_name column_definition
  | ...
  | [CONSTRAINT [symbol]] UNIQUE [INDEX | KEY]
      [index_name] [index_type] (key_part,...)
      [index_option] ...
  | ...
}
```

Docs
---------
[MySQL CREATE](https://dev.mysql.com/doc/refman/8.4/en/create-table.html)
