### PR TITLE
feat(exasol): Add support for TRUNC, TRUNCATE and DATE_TRUNC function…

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from sqlglot import exp, generator, parser, tokens
+from sqlglot.dialects.clickhouse import timestamptrunc_sql
 from sqlglot.dialects.dialect import (
     Dialect,
     rename_func,
@@ -7,16 +8,25 @@ from sqlglot.dialects.dialect import (
     build_formatted_time,
     timestrtotime_sql,
     strposition_sql,
+    unit_to_str,
 )
 from sqlglot.helper import seq_get
 from sqlglot.generator import unsupported_args
 from sqlglot.tokens import TokenType
+import typing as t
 
 
 def _sha2_sql(self: Exasol.Generator, expression: exp.SHA2) -> str:
     length = expression.text("length")
     func_name = "HASH_SHA256" if length == "256" else "HASH_SHA512"
     return self.func(func_name, expression.this)
+
+
+def _parse_trunc(args: t.List) -> exp.DateTrunc | exp.Anonymous:
+    if args and isinstance(args[0], exp.Literal) and args[0].is_number:
+        return exp.Anonymous(this="TRUNC", expressions=args)
+
+    return exp.DateTrunc(unit=seq_get(args, 1), this=seq_get(args, 0))
 
 
 class Exasol(Dialect):
@@ -63,6 +73,9 @@ class Exasol(Dialect):
             "BIT_NOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
             "BIT_LSHIFT": binary_from_function(exp.BitwiseLeftShift),
             "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
+            "DATE_TRUNC": lambda args: exp.TimestampTrunc(
+                this=seq_get(args, 1), unit=exp.var(seq_get(args, 0))
+            ),
             "EVERY": lambda args: exp.All(this=seq_get(args, 0)),
             "EDIT_DISTANCE": exp.Levenshtein.from_arg_list,
             "HASH_SHA": exp.SHA.from_arg_list,
@@ -83,6 +96,8 @@ class Exasol(Dialect):
             "HASH_SHA512": lambda args: exp.SHA2(
                 this=seq_get(args, 0), length=exp.Literal.number(512)
             ),
+            "TRUNC": _parse_trunc,
+            "TRUNCATE": _parse_trunc,
             "VAR_POP": exp.VariancePop.from_arg_list,
             "APPROXIMATE_COUNT_DISTINCT": exp.ApproxDistinct.from_arg_list,
             "TO_CHAR": build_formatted_time(exp.ToChar, "exasol"),
@@ -156,6 +171,8 @@ class Exasol(Dialect):
             exp.BitwiseXor: rename_func("BIT_XOR"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/every.htm
             exp.All: rename_func("EVERY"),
+            exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, unit_to_str(e)),
+            exp.DatetimeTrunc: timestamptrunc_sql(),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/edit_distance.htm#EDIT_DISTANCE
             exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
                 rename_func("EDIT_DISTANCE")
@@ -180,6 +197,7 @@ class Exasol(Dialect):
             exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
             exp.TimeToStr: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
             exp.TimeStrToTime: timestrtotime_sql,
+            exp.TimestampTrunc: timestamptrunc_sql(),
             exp.StrToTime: lambda self, e: self.func("TO_DATE", e.this, self.format_time(e)),
             exp.CurrentUser: lambda *_: "CURRENT_USER",
             exp.AtTimeZone: lambda self, e: self.func(

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -22,6 +22,8 @@ def _sha2_sql(self: Exasol.Generator, expression: exp.SHA2) -> str:
     return self.func(func_name, expression.this)
 
 
+# https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/trunc%5Bate%5D%20(datetime).htm
+# https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/trunc%5Bate%5D%20(number).htm
 def _parse_trunc(args: t.List) -> exp.DateTrunc | exp.Anonymous:
     if args and isinstance(args[0], exp.Literal) and args[0].is_number:
         return exp.Anonymous(this="TRUNC", expressions=args)
@@ -73,6 +75,7 @@ class Exasol(Dialect):
             "BIT_NOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
             "BIT_LSHIFT": binary_from_function(exp.BitwiseLeftShift),
             "BIT_RSHIFT": binary_from_function(exp.BitwiseRightShift),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/date_trunc.htm#DATE_TRUNC
             "DATE_TRUNC": lambda args: exp.TimestampTrunc(
                 this=seq_get(args, 1), unit=exp.var(seq_get(args, 0))
             ),

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -383,6 +383,25 @@ class TestExasol(Validator):
             "SELECT CAST(CAST(CURRENT_TIMESTAMP() AS TIMESTAMP) AT TIME ZONE 'CET' AS DATE) - 1",
             "SELECT CAST(CONVERT_TZ(CAST(CURRENT_TIMESTAMP() AS TIMESTAMP), 'UTC', 'CET') AS DATE) - 1",
         )
+        self.validate_all(
+            "SELECT TRUNC(CAST('2006-12-31' AS DATE), 'MM') AS TRUNC",
+            write={
+                "exasol": "SELECT TRUNC(CAST('2006-12-31' AS DATE), 'MM') AS TRUNC",
+                "presto": "SELECT DATE_TRUNC('MM', CAST('2006-12-31' AS DATE)) AS TRUNC",
+                "databricks": "SELECT TRUNC(CAST('2006-12-31' AS DATE), 'MM') AS TRUNC",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_TRUNC('minute', TIMESTAMP '2006-12-31 23:59:59') DATE_TRUNC",
+            write={
+                "exasol": "SELECT DATE_TRUNC('MINUTE', CAST('2006-12-31 23:59:59' AS TIMESTAMP)) AS DATE_TRUNC",
+                "presto": "SELECT DATE_TRUNC('MINUTE', CAST('2006-12-31 23:59:59' AS TIMESTAMP)) AS DATE_TRUNC",
+                "databricks": "SELECT DATE_TRUNC('MINUTE', CAST('2006-12-31 23:59:59' AS TIMESTAMP)) AS DATE_TRUNC",
+            },
+        )
+
+    def test_number_functions(self):
+        self.validate_identity("SELECT TRUNC(123.456, 2) AS TRUNC")
 
     def test_scalar(self):
         self.validate_all(


### PR DESCRIPTION
This involves adding [TRUNC(datetime)](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/trunc%5Bate%5D%20(datetime).htm), [TRUNC(number)](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/trunc%5Bate%5D%20(number).htm) and [DATE_TRUNC](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/date_trunc.htm#DATE_TRUNC) exasol function in exasol dialect…s in Exasol dialect