### PR TITLE
Fix!: remove AM/PM entries from postgres, oracle `TIME_MAPPING`

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -52,10 +52,6 @@ class Oracle(Dialect):
     # https://docs.oracle.com/database/121/SQLRF/sql_elements004.htm#SQLRF00212
     # https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
     TIME_MAPPING = {
-        "AM": "%p",  # Meridian indicator with or without periods
-        "A.M.": "%p",  # Meridian indicator with or without periods
-        "PM": "%p",  # Meridian indicator with or without periods
-        "P.M.": "%p",  # Meridian indicator with or without periods
         "D": "%u",  # Day of week (1-7)
         "DAY": "%A",  # name of day
         "DD": "%d",  # day of month (1-31)

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -274,8 +274,6 @@ class Postgres(Dialect):
     TABLESAMPLE_SIZE_IS_PERCENT = True
 
     TIME_MAPPING = {
-        "AM": "%p",
-        "PM": "%p",
         "d": "%u",  # 1-based day of week
         "D": "%u",  # 1-based day of week
         "dd": "%d",  # day of month

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -88,7 +88,7 @@ class TestOracle(Validator):
         )
         self.validate_identity(
             "SELECT CAST('January 15, 1989, 11:00 A.M.' AS DATE DEFAULT NULL ON CONVERSION ERROR, 'Month dd, YYYY, HH:MI A.M.') FROM DUAL",
-            "SELECT TO_DATE('January 15, 1989, 11:00 A.M.', 'Month dd, YYYY, HH12:MI P.M.') FROM DUAL",
+            "SELECT TO_DATE('January 15, 1989, 11:00 A.M.', 'Month dd, YYYY, HH12:MI A.M.') FROM DUAL",
         )
         self.validate_identity(
             "SELECT TRUNC(SYSDATE)",
@@ -338,6 +338,18 @@ class TestOracle(Validator):
         )
         self.validate_identity("CREATE OR REPLACE FORCE VIEW foo1.foo2")
         self.validate_identity("TO_TIMESTAMP('foo')")
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 AM', 'DD Mon YYYY HH12:MI AM')"
+        )
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 PM', 'DD Mon YYYY HH12:MI PM')"
+        )
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 A.M.', 'DD Mon YYYY HH12:MI A.M.')"
+        )
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 P.M.', 'DD Mon YYYY HH12:MI P.M.')"
+        )
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -138,6 +138,12 @@ class TestPostgres(Validator):
             "SELECT TO_TIMESTAMP(1284352323.5), TO_TIMESTAMP('05 Dec 2000', 'DD Mon YYYY')"
         )
         self.validate_identity(
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 AM', 'DD Mon YYYY HH:MI AM')"
+        )
+        self.validate_identity(
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 PM', 'DD Mon YYYY HH:MI PM')"
+        )
+        self.validate_identity(
             "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss"
         )
         self.validate_identity(


### PR DESCRIPTION
See https://github.com/tobymao/sqlglot/pull/5476#discussion_r2231075745 for reference.
