### PR TITLE
Fix deprecated warning when building the package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,12 @@ dynamic = ["version", "optional-dependencies"]
 description = "An easily customizable SQL parser and transpiler"
 readme = "README.md"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
-license = { file = "LICENSE" }
+license-files = ["LICENSE"]
 requires-python = ">= 3.9"
-classifiers=[
+classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: SQL",
     "Programming Language :: Python :: 3 :: Only",
@@ -35,7 +34,7 @@ fallback_version = "0.0.0"
 local_scheme = "no-local-version"
 
 [tool.setuptools.packages.find]
-include=["sqlglot", "sqlglot.*"]
+include = ["sqlglot", "sqlglot.*"]
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]


### PR DESCRIPTION
## Description

[AUR](https://aur.archlinux.org/packages/python-sqlglot) package maintainer here.

When building the package we get this warning

```
--- SNIP ---
/usr/lib/python3.13/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated                                  
!!                                                                                                                                                                                             
                                                                                                                                                                                               
        ********************************************************************************                                                                                                       
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).               
                                                                                                                                                                                               
        By 2026-Feb-18, you need to update your project and remove deprecated calls                                                                                                            
        or your builds will no longer be supported.                                                                                                                                            
                                                                                                                                                                                               
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.                                                                                         
        ********************************************************************************                                                                                                       
                                                                                                                                                                                               
!!
--- SNIP ---
```

This PR fixes deprecated `license` specification format in `pyproject.toml`.

The change should be backward compatible as per specification:

> The legacy deprecated Core Metadata `License` field, `license` key table subkeys (`text` and `file`) in the `pyproject.toml` `[project]` table and license classifiers retain backwards compatibility. A removal is left to a future PEP and a new version of the Core Metadata specification.

https://peps.python.org/pep-0639/#backwards-compatibility