### PR TITLE
fix(optimizer): Fix SEMI/ANTI join handling in optimizer rules

### DIFF
--- a/sqlglot/optimizer/eliminate_joins.py
+++ b/sqlglot/optimizer/eliminate_joins.py
@@ -32,6 +32,9 @@ def eliminate_joins(expression):
 
         # Reverse the joins so we can remove chains of unused joins
         for join in reversed(joins):
+            if join.is_semi_or_anti_join:
+                continue
+
             alias = join.alias_or_name
             if _should_eliminate_join(scope, join, alias):
                 join.pop()

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -523,6 +523,12 @@ class Scope:
             for _, source in scope.selected_sources.values():
                 scope_ref_count[id(source)] += 1
 
+            for name in scope._semi_anti_join_tables:
+                # semi/anti join sources are not actually selected but we still need to
+                # increment their ref count to avoid them being optimized away
+                if name in scope.sources:
+                    scope_ref_count[id(scope.sources[name])] += 1
+
         return scope_ref_count
 
 

--- a/tests/fixtures/optimizer/eliminate_ctes.sql
+++ b/tests/fixtures/optimizer/eliminate_ctes.sql
@@ -114,3 +114,30 @@ WHERE
       a
     FROM q
   );
+
+
+# Title: Do not remove CTE if it is an RHS of a SEMI/ANTI join
+WITH t1 AS (
+  SELECT
+    1 AS foo
+), t2 AS (
+  SELECT
+    1 AS foo
+)
+SELECT
+  *
+FROM t1
+LEFT ANTI JOIN t2
+  ON t1.foo = t2.foo;
+WITH t1 AS (
+  SELECT
+    1 AS foo
+), t2 AS (
+  SELECT
+    1 AS foo
+)
+SELECT
+  *
+FROM t1
+LEFT ANTI JOIN t2
+  ON t1.foo = t2.foo

--- a/tests/fixtures/optimizer/eliminate_joins.sql
+++ b/tests/fixtures/optimizer/eliminate_joins.sql
@@ -315,3 +315,22 @@ CROSS JOIN (
     y.b
   FROM y
 ) AS y;
+
+
+# title: Do not remove left anti join
+SELECT
+  x.b
+FROM x
+LEFT ANTI JOIN (
+  SELECT
+    1 AS b
+) AS sub
+  ON x.b = sub.b;
+SELECT
+  x.b
+FROM x
+LEFT ANTI JOIN (
+  SELECT
+    1 AS b
+) AS sub
+  ON x.b = sub.b;


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5481

Consider the following query:

```SQL
WITH 
 t1 AS (SELECT 1 AS col),
 t2 AS (SELECT 1 AS col) 
SELECT * FROM t1 LEFT ANTI JOIN t2 ON t1.col = t2.col
```

There are 2 different issues at play:
1. In `eliminate_joins.py`, this is incorrectly thought to be a simple `LEFT JOIN` which is trivially optimized away:

```Python3
>>> import sqlglot
>>> from sqlglot.optimizer.eliminate_joins import eliminate_joins
>>> sql = "WITH t1 AS (SELECT 1 AS col), t2 AS (SELECT 1 AS col) SELECT * FROM t1 LEFT ANTI JOIN t2 ON t1.col = t2.col"
'WITH t1 AS (SELECT 1 AS col), t2 AS (SELECT 1 AS col) SELECT * FROM t1'
```

<br/>


2. In `eliminate_ctes.py`, `t2` is removed as unused. [Previous work](https://github.com/tobymao/sqlglot/pull/4622) excluded SEMI/ANTI join RHS sources from being considered `selected_sources`, as this was messing with `qualify` and in reality these sources are only used for row filtering. However, this also leads to this error since these sources don't increment their `ref_count` on those joins:

```Python3
>>> eliminate_ctes(sqlglot.parse_one(sql)).sql()
'WITH t1 AS (SELECT 1 AS col) SELECT * FROM t1 LEFT ANTI JOIN t2 ON t1.col = t2.col'
```
