### PR TITLE
fix(exasol): fix TokenType.TEXT mapping in exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -93,6 +93,7 @@ class Exasol(Dialect):
             "USER": TokenType.CURRENT_USER,
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/if.htm
             "ENDIF": TokenType.END,
+            "LONG VARCHAR": TokenType.TEXT,
         }
 
     class Parser(parser.Parser):
@@ -162,7 +163,8 @@ class Exasol(Dialect):
             exp.DataType.Type.MEDIUMTEXT: "VARCHAR",
             exp.DataType.Type.TINYBLOB: "VARCHAR",
             exp.DataType.Type.TINYTEXT: "VARCHAR",
-            exp.DataType.Type.TEXT: "VARCHAR",
+            # https://docs.exasol.com/db/latest/sql_references/data_types/datatypealiases.htm
+            exp.DataType.Type.TEXT: "LONG VARCHAR",
             exp.DataType.Type.VARBINARY: "VARCHAR",
         }
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -13,7 +13,10 @@ class TestExasol(Validator):
         self.validate_identity("CAST(x AS MEDIUMTEXT)", "CAST(x AS VARCHAR)")
         self.validate_identity("CAST(x AS TINYBLOB)", "CAST(x AS VARCHAR)")
         self.validate_identity("CAST(x AS TINYTEXT)", "CAST(x AS VARCHAR)")
-        self.validate_identity("CAST(x AS TEXT)", "CAST(x AS VARCHAR)")
+        self.validate_identity("CAST(x AS TEXT)", "CAST(x AS LONG VARCHAR)")
+        self.validate_identity(
+            "SELECT CAST((CAST(202305 AS INT) - 100) AS LONG VARCHAR) AS CAL_YEAR_WEEK_ADJUSTED"
+        )
         self.validate_identity("CAST(x AS VARBINARY)", "CAST(x AS VARCHAR)")
         self.validate_identity("CAST(x AS VARCHAR)", "CAST(x AS VARCHAR)")
         self.validate_identity("CAST(x AS CHAR)", "CAST(x AS CHAR)")


### PR DESCRIPTION
Casting of TEXT to VARCHAR breaks in exasol since exasol requires length for VARCHAR to fix this it should be cast to LONG VARCHAR which doesn't require length because exasol sees it as datatype  with maximum length.
https://docs.exasol.com/db/latest/sql_references/data_types/datatypealiases.htm