### PR TITLE
feat(exasol): add support for ADD_DAYS function in exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -100,12 +100,19 @@ class Exasol(Dialect):
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_days.htm
             "ADD_DAYS": build_date_delta(exp.DateAdd, default_unit="DAY"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_years.htm
             "ADD_YEARS": build_date_delta(exp.DateAdd, default_unit="YEAR"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_months.htm
             "ADD_MONTHS": build_date_delta(exp.DateAdd, default_unit="MONTH"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_weeks.htm
             "ADD_WEEKS": build_date_delta(exp.DateAdd, default_unit="WEEK"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_hour.htm
             "ADD_HOURS": build_date_delta(exp.DateAdd, default_unit="HOUR"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_minutes.htm
             "ADD_MINUTES": build_date_delta(exp.DateAdd, default_unit="MINUTE"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_seconds.htm
             "ADD_SECONDS": build_date_delta(exp.DateAdd, default_unit="SECOND"),
             "BIT_AND": binary_from_function(exp.BitwiseAnd),
             "BIT_OR": binary_from_function(exp.BitwiseOr),

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp, generator, parser, tokens
-from sqlglot.dialects.clickhouse import timestamptrunc_sql
+from sqlglot.dialects.clickhouse import build_date_delta, timestamptrunc_sql
 from sqlglot.dialects.dialect import (
     Dialect,
     binary_from_function,
@@ -99,6 +99,7 @@ class Exasol(Dialect):
     class Parser(parser.Parser):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            "ADD_DAYS": build_date_delta(exp.DateAdd, default_unit=None),
             "BIT_AND": binary_from_function(exp.BitwiseAnd),
             "BIT_OR": binary_from_function(exp.BitwiseOr),
             "BIT_XOR": binary_from_function(exp.BitwiseXor),
@@ -209,6 +210,8 @@ class Exasol(Dialect):
             exp.All: rename_func("EVERY"),
             exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, unit_to_str(e)),
             exp.DatetimeTrunc: timestamptrunc_sql(),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_days.htm
+            exp.DateAdd: rename_func("ADD_DAYS"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/edit_distance.htm#EDIT_DISTANCE
             exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
                 rename_func("EDIT_DISTANCE")

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -403,20 +403,32 @@ class TestExasol(Validator):
                 "databricks": "SELECT DATE_TRUNC('MINUTE', CAST('2006-12-31 23:59:59' AS TIMESTAMP)) AS DATE_TRUNC",
             },
         )
-        self.validate_all(
-            "SELECT ADD_DAYS(DATE '2000-02-28', 1) AD1",
-            write={
-                "exasol": "SELECT ADD_DAYS(CAST('2000-02-28' AS DATE), 1) AS AD1",
-                "bigquery": "SELECT DATE_ADD(CAST('2000-02-28' AS DATE), INTERVAL 1 DAY) AS AD1",
-                "duckdb": "SELECT CAST('2000-02-28' AS DATE) + INTERVAL 1 DAY AS AD1",
-                "hive": "SELECT DATE_ADD(CAST('2000-02-28' AS DATE), 1) AS AD1",
-                "presto": "SELECT DATE_ADD('DAY', 1, CAST('2000-02-28' AS DATE)) AS AD1",
-                "redshift": "SELECT DATEADD(DAY, 1, CAST('2000-02-28' AS DATE)) AS AD1",
-                "snowflake": "SELECT DATEADD(DAY, 1, CAST('2000-02-28' AS DATE)) AS AD1",
-                "spark": "SELECT DATE_ADD(CAST('2000-02-28' AS DATE), 1) AS AD1",
-                "tsql": "SELECT DATEADD(DAY, 1, CAST('2000-02-28' AS DATE)) AS AD1",
-            },
-        )
+        test_cases = {
+            "ADD_DAYS": ("DAY", "add_days"),
+            "ADD_WEEKS": ("WEEK", "add_weeks"),
+            "ADD_MONTHS": ("MONTH", "add_months"),
+            "ADD_YEARS": ("YEAR", "add_years"),
+            "ADD_HOURS": ("HOUR", "add_hours"),
+            "ADD_MINUTES": ("MINUTE", "add_minutes"),
+            "ADD_SECONDS": ("SECOND", "add_seconds"),
+        }
+
+        for func_name, (unit, alias) in test_cases.items():
+            with self.subTest(f"Testing {func_name}"):
+                write = {
+                    "exasol": f"SELECT {func_name}(CAST('2000-02-28' AS DATE), 1) AS {alias}",
+                    "bigquery": f"SELECT DATE_ADD(CAST('2000-02-28' AS DATE), INTERVAL 1 {unit}) AS {alias}",
+                    "duckdb": f"SELECT CAST('2000-02-28' AS DATE) + INTERVAL 1 {unit} AS {alias}",
+                    "presto": f"SELECT DATE_ADD('{unit}', 1, CAST('2000-02-28' AS DATE)) AS {alias}",
+                    "redshift": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE)) AS {alias}",
+                    "snowflake": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE)) AS {alias}",
+                    "tsql": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE)) AS {alias}",
+                }
+
+                self.validate_all(
+                    f"SELECT {func_name}(DATE '2000-02-28', 1) AS {alias}",
+                    write=write,
+                )
 
     def test_number_functions(self):
         self.validate_identity("SELECT TRUNC(123.456, 2) AS TRUNC")

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -403,6 +403,20 @@ class TestExasol(Validator):
                 "databricks": "SELECT DATE_TRUNC('MINUTE', CAST('2006-12-31 23:59:59' AS TIMESTAMP)) AS DATE_TRUNC",
             },
         )
+        self.validate_all(
+            "SELECT ADD_DAYS(DATE '2000-02-28', 1) AD1",
+            write={
+                "exasol": "SELECT ADD_DAYS(CAST('2000-02-28' AS DATE), 1) AS AD1",
+                "bigquery": "SELECT DATE_ADD(CAST('2000-02-28' AS DATE), INTERVAL 1 DAY) AS AD1",
+                "duckdb": "SELECT CAST('2000-02-28' AS DATE) + INTERVAL 1 DAY AS AD1",
+                "hive": "SELECT DATE_ADD(CAST('2000-02-28' AS DATE), 1) AS AD1",
+                "presto": "SELECT DATE_ADD('DAY', 1, CAST('2000-02-28' AS DATE)) AS AD1",
+                "redshift": "SELECT DATEADD(DAY, 1, CAST('2000-02-28' AS DATE)) AS AD1",
+                "snowflake": "SELECT DATEADD(DAY, 1, CAST('2000-02-28' AS DATE)) AS AD1",
+                "spark": "SELECT DATE_ADD(CAST('2000-02-28' AS DATE), 1) AS AD1",
+                "tsql": "SELECT DATEADD(DAY, 1, CAST('2000-02-28' AS DATE)) AS AD1",
+            },
+        )
 
     def test_number_functions(self):
         self.validate_identity("SELECT TRUNC(123.456, 2) AS TRUNC")


### PR DESCRIPTION
This involves adding [ADD_DAYS](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/add_days.htm) built -in function to exasol dialect in sqlglot.