### PR TITLE
feat(exasol): Add support for date difference functions in Exasol dialect

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -27,6 +27,7 @@ def _sha2_sql(self: Exasol.Generator, expression: exp.SHA2) -> str:
     func_name = "HASH_SHA256" if length == "256" else "HASH_SHA512"
     return self.func(func_name, expression.this)
 
+
 def _date_diff_sql(self: Exasol.Generator, expression: exp.DateDiff | exp.TsOrDsDiff) -> str:
     unit = expression.text("unit").upper() or "DAY"
     func_name = self.DATE_DIFF_FUNCTION_BY_UNIT.get(unit)

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -203,14 +203,6 @@ class Exasol(Dialect):
             exp.DataType.Type.DATETIME: "TIMESTAMP",
         }
 
-        DATE_DIFF_FUNCTION_BY_UNIT = {
-            "DAY": "DAYS_BETWEEN",
-            "YEAR": "YEARS_BETWEEN",
-            "HOUR": "HOURS_BETWEEN",
-            "MINUTE": "MINUTES_BETWEEN",
-            "SECOND": "SECONDS_BETWEEN",
-        }
-
         def datatype_sql(self, expression: exp.DataType) -> str:
             # Exasol supports a fixed default precision of 3 for TIMESTAMP WITH LOCAL TIME ZONE
             # and does not allow specifying a different custom precision

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -228,7 +228,6 @@ class Exasol(Dialect):
 
         DATE_DIFF_FUNCTION_BY_UNIT = {
             "DAY": "DAYS_BETWEEN",
-            "MONTH": "ADD_MONTHS",
             "YEAR": "YEARS_BETWEEN",
             "HOUR": "HOURS_BETWEEN",
             "MINUTE": "MINUTES_BETWEEN",

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -440,9 +440,8 @@ class TestExasol(Validator):
 
         for func_name, (unit, alias) in date_between_test_cases.items():
             with self.subTest(f"Testing {func_name}"):
-                exasol_sql = f"SELECT {func_name}(CAST('2000-02-28 00:00:00' AS TIMESTAMP), CURRENT_TIMESTAMP()) AS {alias}"
                 write = {
-                    "exasol": exasol_sql,
+                    "exasol": f"SELECT {func_name}(CAST('2000-02-28 00:00:00' AS TIMESTAMP), CURRENT_TIMESTAMP()) AS {alias}",
                     "bigquery": f"SELECT DATE_DIFF(CAST('2000-02-28 00:00:00' AS DATETIME), CURRENT_TIMESTAMP(), {unit}) AS {alias}",
                     "duckdb": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
                     "presto": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -440,7 +440,6 @@ class TestExasol(Validator):
 
         for func_name, (unit, alias) in date_between_test_cases.items():
             with self.subTest(f"Testing {func_name}"):
-
                 exasol_sql = f"SELECT {func_name}(CAST('2000-02-28 00:00:00' AS TIMESTAMP), CURRENT_TIMESTAMP()) AS {alias}"
                 write = {
                     "exasol": exasol_sql,

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -430,6 +430,33 @@ class TestExasol(Validator):
                     write=write,
                 )
 
+        date_between_test_cases = {
+            "DAYS_BETWEEN": ("DAY", "days_between"),
+            "YEARS_BETWEEN": ("YEAR", "years_between"),
+            "HOURS_BETWEEN": ("HOUR", "hours_between"),
+            "MINUTES_BETWEEN": ("MINUTE", "minutes_between"),
+            "SECONDS_BETWEEN": ("SECOND", "seconds_between"),
+        }
+
+        for func_name, (unit, alias) in date_between_test_cases.items():
+            with self.subTest(f"Testing {func_name}"):
+
+                exasol_sql = f"SELECT {func_name}(CAST('2000-02-28 00:00:00' AS TIMESTAMP), CURRENT_TIMESTAMP()) AS {alias}"
+                write = {
+                    "exasol": exasol_sql,
+                    "bigquery": f"SELECT DATE_DIFF(CAST('2000-02-28 00:00:00' AS DATETIME), CURRENT_TIMESTAMP(), {unit}) AS {alias}",
+                    "duckdb": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
+                    "presto": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
+                    "redshift": f"SELECT DATEDIFF({unit}, GETDATE(), CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
+                    "snowflake": f"SELECT DATEDIFF({unit}, CURRENT_TIMESTAMP(), CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
+                    "tsql": f"SELECT DATEDIFF({unit}, GETDATE(), CAST('2000-02-28 00:00:00' AS DATETIME2)) AS {alias}",
+                }
+
+                self.validate_all(
+                    f"SELECT {func_name}(TIMESTAMP '2000-02-28 00:00:00', CURRENT_TIMESTAMP) AS {alias}",
+                    write=write,
+                )
+
     def test_number_functions(self):
         self.validate_identity("SELECT TRUNC(123.456, 2) AS TRUNC")
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -403,56 +403,38 @@ class TestExasol(Validator):
                 "databricks": "SELECT DATE_TRUNC('MINUTE', CAST('2006-12-31 23:59:59' AS TIMESTAMP)) AS DATE_TRUNC",
             },
         )
-        test_cases = {
-            "ADD_DAYS": ("DAY", "add_days"),
-            "ADD_WEEKS": ("WEEK", "add_weeks"),
-            "ADD_MONTHS": ("MONTH", "add_months"),
-            "ADD_YEARS": ("YEAR", "add_years"),
-            "ADD_HOURS": ("HOUR", "add_hours"),
-            "ADD_MINUTES": ("MINUTE", "add_minutes"),
-            "ADD_SECONDS": ("SECOND", "add_seconds"),
-        }
-
-        for func_name, (unit, alias) in test_cases.items():
-            with self.subTest(f"Testing {func_name}"):
-                write = {
-                    "exasol": f"SELECT {func_name}(CAST('2000-02-28' AS DATE), 1) AS {alias}",
-                    "bigquery": f"SELECT DATE_ADD(CAST('2000-02-28' AS DATE), INTERVAL 1 {unit}) AS {alias}",
-                    "duckdb": f"SELECT CAST('2000-02-28' AS DATE) + INTERVAL 1 {unit} AS {alias}",
-                    "presto": f"SELECT DATE_ADD('{unit}', 1, CAST('2000-02-28' AS DATE)) AS {alias}",
-                    "redshift": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE)) AS {alias}",
-                    "snowflake": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE)) AS {alias}",
-                    "tsql": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE)) AS {alias}",
+        DATE_UNITS = {"DAY", "WEEK", "MONTH", "YEAR", "HOUR", "MINUTE", "SECOND"}
+        for unit in DATE_UNITS:
+            with self.subTest(f"Testing ADD_{unit}S"):
+                write_add = {
+                    "exasol": f"SELECT ADD_{unit}S(CAST('2000-02-28' AS DATE), 1)",
+                    "bigquery": f"SELECT DATE_ADD(CAST('2000-02-28' AS DATE), INTERVAL 1 {unit})",
+                    "duckdb": f"SELECT CAST('2000-02-28' AS DATE) + INTERVAL 1 {unit}",
+                    "presto": f"SELECT DATE_ADD('{unit}', 1, CAST('2000-02-28' AS DATE))",
+                    "redshift": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE))",
+                    "snowflake": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE))",
+                    "tsql": f"SELECT DATEADD({unit}, 1, CAST('2000-02-28' AS DATE))",
                 }
 
                 self.validate_all(
-                    f"SELECT {func_name}(DATE '2000-02-28', 1) AS {alias}",
-                    write=write,
+                    f"SELECT ADD_{unit}S(DATE '2000-02-28', 1)",
+                    write=write_add,
                 )
 
-        date_between_test_cases = {
-            "DAYS_BETWEEN": ("DAY", "days_between"),
-            "YEARS_BETWEEN": ("YEAR", "years_between"),
-            "HOURS_BETWEEN": ("HOUR", "hours_between"),
-            "MINUTES_BETWEEN": ("MINUTE", "minutes_between"),
-            "SECONDS_BETWEEN": ("SECOND", "seconds_between"),
-        }
-
-        for func_name, (unit, alias) in date_between_test_cases.items():
-            with self.subTest(f"Testing {func_name}"):
-                write = {
-                    "exasol": f"SELECT {func_name}(CAST('2000-02-28 00:00:00' AS TIMESTAMP), CURRENT_TIMESTAMP()) AS {alias}",
-                    "bigquery": f"SELECT DATE_DIFF(CAST('2000-02-28 00:00:00' AS DATETIME), CURRENT_TIMESTAMP(), {unit}) AS {alias}",
-                    "duckdb": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
-                    "presto": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
-                    "redshift": f"SELECT DATEDIFF({unit}, GETDATE(), CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
-                    "snowflake": f"SELECT DATEDIFF({unit}, CURRENT_TIMESTAMP(), CAST('2000-02-28 00:00:00' AS TIMESTAMP)) AS {alias}",
-                    "tsql": f"SELECT DATEDIFF({unit}, GETDATE(), CAST('2000-02-28 00:00:00' AS DATETIME2)) AS {alias}",
+            with self.subTest(f"Testing {unit}S_BETWEEN"):
+                write_between = {
+                    "exasol": f"SELECT {unit}S_BETWEEN(CAST('2000-02-28 00:00:00' AS TIMESTAMP), CURRENT_TIMESTAMP())",
+                    "bigquery": f"SELECT DATE_DIFF(CAST('2000-02-28 00:00:00' AS DATETIME), CURRENT_TIMESTAMP(), {unit})",
+                    "duckdb": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP))",
+                    "presto": f"SELECT DATE_DIFF('{unit}', CURRENT_TIMESTAMP, CAST('2000-02-28 00:00:00' AS TIMESTAMP))",
+                    "redshift": f"SELECT DATEDIFF({unit}, GETDATE(), CAST('2000-02-28 00:00:00' AS TIMESTAMP))",
+                    "snowflake": f"SELECT DATEDIFF({unit}, CURRENT_TIMESTAMP(), CAST('2000-02-28 00:00:00' AS TIMESTAMP))",
+                    "tsql": f"SELECT DATEDIFF({unit}, GETDATE(), CAST('2000-02-28 00:00:00' AS DATETIME2))",
                 }
 
                 self.validate_all(
-                    f"SELECT {func_name}(TIMESTAMP '2000-02-28 00:00:00', CURRENT_TIMESTAMP) AS {alias}",
-                    write=write,
+                    f"SELECT {unit}S_BETWEEN(TIMESTAMP '2000-02-28 00:00:00', CURRENT_TIMESTAMP)",
+                    write=write_between,
                 )
 
     def test_number_functions(self):


### PR DESCRIPTION
This involves mapping DATE_DIFF function in exasol by adding [DAY_BETWEEN](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/days_between.htm), [YEARS_BETWEEN](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/years_between.htm), [HOURS_BETWEEN](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hours_between.htm) , [MINUTES_BETWEEN](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/minutes_between.htm) , [SECONDS_BETWEEN](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/seconds_between.htm) , built -in functions to exasol dialect in sqlglot.