### PR TITLE
feat(doris): Override table_sql to avoid AS keyword in UPDATE and DELETE statements

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -684,8 +684,6 @@ class Doris(MySQL):
             create_sql = ", ".join(self.sql(e) for e in create_expressions)
             return f"PARTITION BY RANGE ({partition_expressions}) ({create_sql})"
 
-
-
         def table_sql(self, expression: exp.Table, sep: str = " AS ") -> str:
             """Override table_sql to avoid AS keyword in UPDATE and DELETE statements."""
             # Check if this table is part of an UPDATE or DELETE statement or their clauses

--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -683,3 +683,15 @@ class Doris(MySQL):
             # Handle both static and dynamic partition definitions
             create_sql = ", ".join(self.sql(e) for e in create_expressions)
             return f"PARTITION BY RANGE ({partition_expressions}) ({create_sql})"
+
+
+
+        def table_sql(self, expression: exp.Table, sep: str = " AS ") -> str:
+            """Override table_sql to avoid AS keyword in UPDATE and DELETE statements."""
+            # Check if this table is part of an UPDATE or DELETE statement or their clauses
+            current = expression.parent
+            while current:
+                if isinstance(current, (exp.Update, exp.Delete)):
+                    return super().table_sql(expression, sep=" ")
+                current = getattr(current, 'parent', None)
+            return super().table_sql(expression, sep=sep)

--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -687,9 +687,6 @@ class Doris(MySQL):
         def table_sql(self, expression: exp.Table, sep: str = " AS ") -> str:
             """Override table_sql to avoid AS keyword in UPDATE and DELETE statements."""
             # Check if this table is part of an UPDATE or DELETE statement or their clauses
-            current = expression.parent
-            while current:
-                if isinstance(current, (exp.Update, exp.Delete)):
-                    return super().table_sql(expression, sep=" ")
-                current = getattr(current, "parent", None)
+            if expression.find_ancestor(exp.Update, exp.Delete):
+                return super().table_sql(expression, sep=" ")
             return super().table_sql(expression, sep=sep)

--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -693,5 +693,5 @@ class Doris(MySQL):
             while current:
                 if isinstance(current, (exp.Update, exp.Delete)):
                     return super().table_sql(expression, sep=" ")
-                current = getattr(current, 'parent', None)
+                current = getattr(current, "parent", None)
             return super().table_sql(expression, sep=sep)


### PR DESCRIPTION
This PR implements an override of the table_sql method for the Doris dialect to resolve the issue #5512 where the AS keyword should not be used in UPDATE and DELETE statements.

### Changes Made
- File : sqlglot/dialects/doris.py
- Feature : Override table_sql method to use space separator instead of "AS" keyword in UPDATE and DELETE statements
- Implementation : Check parent nodes of the expression to determine if it's within an UPDATE or DELETE statement, and use space separator accordingly

