### PR TITLE
fix(duckdb): transpile ADD_MONTHS

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -669,6 +669,14 @@ class DuckDB(Dialect):
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
+            exp.AddMonths: lambda self, e: _date_delta_sql(
+                self,
+                exp.DateAdd(
+                    this=e.this,
+                    expression=e.expression,
+                    unit=exp.var("MONTH"),
+                ),
+            ),
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.Array: inline_array_unless_query,
             exp.ArrayFilter: rename_func("LIST_FILTER"),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1240,6 +1240,20 @@ class TestSnowflake(Validator):
         self.validate_identity("ALTER TABLE foo ADD IF NOT EXISTS col1 INT, IF NOT EXISTS col2 INT")
         self.validate_identity("ALTER TABLE foo ADD col1 INT, IF NOT EXISTS col2 INT")
         self.validate_identity("ALTER TABLE IF EXISTS foo ADD IF NOT EXISTS col1 INT")
+        self.validate_all(
+            "SELECT ADD_MONTHS('2023-01-31', 1)",
+            write={
+                "duckdb": "SELECT CAST('2023-01-31' AS DATE) + INTERVAL 1 MONTH",
+                "snowflake": "SELECT ADD_MONTHS('2023-01-31', 1)",
+            },
+        )
+        self.validate_all(
+            "SELECT ADD_MONTHS('2023-01-31'::timestamp, 1)",
+            write={
+                "duckdb": "SELECT CAST('2023-01-31' AS TIMESTAMP) + INTERVAL 1 MONTH",
+                "snowflake": "SELECT ADD_MONTHS(CAST('2023-01-31' AS TIMESTAMP), 1)",
+            },
+        )
 
     def test_null_treatment(self):
         self.validate_all(


### PR DESCRIPTION
Fixes #5505 

**DOCS**
[Snowflake ADD_MONTHS](https://docs.snowflake.com/en/sql-reference/functions/add_months)