### PR TITLE
feat(optimizer)!: annotate type for LAST_DAY

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -674,6 +674,7 @@ class Dialect(metaclass=_Dialect):
             exp.DateFromParts,
             exp.DateStrToDate,
             exp.DiToDate,
+            exp.LastDay,
             exp.StrToDate,
             exp.TimeStrToDate,
             exp.TsOrDsToDate,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -91,6 +91,9 @@ INT;
 UNICODE('bcd');
 INT;
 
+LAST_DAY(tbl.timestamp_col);
+DATE;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `LAST_DAY`.

**DOCS**
[BigQuery LAST_DAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#last_day)
[Databricks LAST_DAY](http://docs.databricks.com/aws/en/sql/language-manual/functions/last_day)
[Doris LAST_DAY](https://doris.apache.org/docs/2.0/sql-manual/sql-functions/date-time-functions/last-day)
[MySQL LAST_DAY](https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_last-day)
[Snowflake LAST_DAY](https://docs.snowflake.com/en/sql-reference/functions/last_day)
[Redshift LAST_DAY](https://docs.aws.amazon.com/redshift/latest/dg/r_LAST_DAY.html)
[DuckDB LAST_DAY](https://duckdb.org/docs/stable/sql/functions/date.html#last_daydate)