### PR TITLE
feat(optimizer)!: annotate type for bigquery TIME

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -504,6 +504,8 @@ class BigQuery(Dialect):
         exp.TimestampFromParts: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.DATETIME
         ),
+        exp.TimeFromParts: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
+        exp.TsOrDsToTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.TimeTrunc: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.Unicode: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
     }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -651,6 +651,18 @@ GENERATE_TIMESTAMP_ARRAY('2016-10-05', '2016-10-07', INTERVAL '1' DAY);
 ARRAY<TIMESTAMP>;
 
 # dialect: bigquery
+TIME(15, 30, 00);
+TIME;
+
+# dialect: bigquery
+TIME(TIMESTAMP "2008-12-25 15:30:00");
+TIME;
+
+# dialect: bigquery
+TIME(DATETIME "2008-12-25 15:30:00");
+TIME;
+
+# dialect: bigquery
 TIME_TRUNC(TIME "15:30:00", HOUR);
 TIME;
 


### PR DESCRIPTION
This PR adds type annotation support for `TIME`

**DOCS**
[BigQuery TIME](https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time)