### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery JUSTIFY funcs

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -497,11 +497,6 @@ class BigQuery(Dialect):
             e, exp.DataType.build("ARRAY<VARCHAR>")
         ),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
-        exp.JustifyDays: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
-        exp.JustifyHours: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INTERVAL),
-        exp.JustifyInterval: lambda self, e: self._annotate_with_type(
-            e, exp.DataType.Type.INTERVAL
-        ),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -719,6 +719,9 @@ class Dialect(metaclass=_Dialect):
         },
         exp.DataType.Type.INTERVAL: {
             exp.Interval,
+            exp.JustifyDays,
+            exp.JustifyHours,
+            exp.JustifyInterval,
             exp.MakeInterval,
         },
         exp.DataType.Type.JSON: {

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3789,10 +3789,12 @@ FROM subquery2""",
                 "": "JUSTIFY_DAYS(INTERVAL '1' DAY)",
                 "bigquery": "JUSTIFY_DAYS(INTERVAL '1' DAY)",
                 "postgres": "JUSTIFY_DAYS(INTERVAL '1 DAY')",
+                "materialize": "JUSTIFY_DAYS(INTERVAL '1 DAY')",
             },
             write={
                 "bigquery": "JUSTIFY_DAYS(INTERVAL '1' DAY)",
                 "postgres": "JUSTIFY_DAYS(INTERVAL '1 DAY')",
+                "materialize": "JUSTIFY_DAYS(INTERVAL '1 DAY')",
             },
         )
         self.validate_all(
@@ -3801,10 +3803,12 @@ FROM subquery2""",
                 "": "JUSTIFY_HOURS(INTERVAL '1' HOUR)",
                 "bigquery": "JUSTIFY_HOURS(INTERVAL '1' HOUR)",
                 "postgres": "JUSTIFY_HOURS(INTERVAL '1 HOUR')",
+                "materialize": "JUSTIFY_HOURS(INTERVAL '1 HOUR')",
             },
             write={
                 "bigquery": "JUSTIFY_HOURS(INTERVAL '1' HOUR)",
                 "postgres": "JUSTIFY_HOURS(INTERVAL '1 HOUR')",
+                "materialize": "JUSTIFY_HOURS(INTERVAL '1 HOUR')",
             },
         )
         self.validate_all(
@@ -3813,9 +3817,11 @@ FROM subquery2""",
                 "": "JUSTIFY_INTERVAL(INTERVAL '1' HOUR)",
                 "bigquery": "JUSTIFY_INTERVAL(INTERVAL '1' HOUR)",
                 "postgres": "JUSTIFY_INTERVAL(INTERVAL '1 HOUR')",
+                "materialize": "JUSTIFY_INTERVAL(INTERVAL '1 HOUR')",
             },
             write={
                 "bigquery": "JUSTIFY_INTERVAL(INTERVAL '1' HOUR)",
                 "postgres": "JUSTIFY_INTERVAL(INTERVAL '1 HOUR')",
+                "materialize": "JUSTIFY_INTERVAL(INTERVAL '1 HOUR')",
             },
         )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -94,6 +94,15 @@ INT;
 LAST_DAY(tbl.timestamp_col);
 DATE;
 
+JUSTIFY_DAYS(INTERVAL '1' DAY);
+INTERVAL;
+
+JUSTIFY_HOURS(INTERVAL '1' HOUR);
+INTERVAL;
+
+JUSTIFY_INTERVAL(INTERVAL '1' HOUR);
+INTERVAL;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------
@@ -669,18 +678,6 @@ TIME;
 # dialect: bigquery
 DATE_FROM_UNIX_DATE(1);
 DATE;
-
-# dialect: bigquery
-JUSTIFY_DAYS(INTERVAL '1' DAY);
-INTERVAL;
-
-# dialect: bigquery
-JUSTIFY_HOURS(INTERVAL '1' HOUR);
-INTERVAL;
-
-# dialect: bigquery
-JUSTIFY_INTERVAL(INTERVAL '1' HOUR);
-INTERVAL;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
This PR adds parsing and type annotation for `JUSTIFY` related functions.

**DOCS**
[BigQuery JUSTIFY funcs](https://cloud.google.com/bigquery/docs/reference/standard-sql/interval_functions)
[Postgres JUSTIFY funcs](https://www.postgresql.org/docs/current/functions-datetime.html)