### PR TITLE
feat(optimizer)!: annotate type for bigquery DATE_TRUNC

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -486,6 +486,7 @@ class BigQuery(Dialect):
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarSamp: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.DateFromUnixDate: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATE),
+        exp.DateTrunc: lambda self, e: self._annotate_by_args(e, "this"),
         exp.GenerateTimestampArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<TIMESTAMP>", dialect="bigquery")
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -685,6 +685,18 @@ TIME;
 DATE_FROM_UNIX_DATE(1);
 DATE;
 
+# dialect: bigquery
+DATE_TRUNC(DATE '2008-12-25', MONTH);
+DATE;
+
+# dialect: bigquery
+DATE_TRUNC(TIMESTAMP '2008-12-25', MONTH);
+TIMESTAMP;
+
+# dialect: bigquery
+DATE_TRUNC(DATETIME '2008-12-25', MONTH);
+DATETIME;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
ThIs PR adds type annotation for `DATE_TRUNC` of BigQuery

**DOCS**
[BigQuery DATE_TRUNC](https://cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date_trunc)