### PR TITLE
feat(optimizer)!: annotate type for bigquery TIMESTAMP_TRUNC

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -506,6 +506,7 @@ class BigQuery(Dialect):
         exp.TimestampFromParts: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.DATETIME
         ),
+        exp.TimestampTrunc: lambda self, e: self._annotate_by_args(e, "this"),
         exp.TimeFromParts: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.TsOrDsToTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.TimeTrunc: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -697,6 +697,14 @@ TIMESTAMP;
 DATE_TRUNC(DATETIME '2008-12-25', MONTH);
 DATETIME;
 
+# dialect: bigquery
+TIMESTAMP_TRUNC(TIMESTAMP "2008-12-25 15:30:00+00", DAY, "UTC");
+TIMESTAMP;
+
+# dialect: bigquery
+TIMESTAMP_TRUNC(DATETIME "2008-12-25 15:30:00", DAY);
+DATETIME;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `TIMESTAMP_TRUNC` 

**DOCS**
[BigQuery TIMESTAMP_TRUNC](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#timestamp_trunc)