### PR TITLE
Chore: Fix UNNEST qualification regression

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1138,7 +1138,12 @@ class DuckDB(Dialect):
                 alias = expression.args.get("alias")
                 if alias:
                     expression.set("alias", None)
-                    alias = exp.TableAlias(this=seq_get(alias.args.get("columns"), 0))
+                    this = (
+                        alias.this.copy()
+                        if alias.args.get("column_only")
+                        else seq_get(alias.args.get("columns"), 0)
+                    )
+                    alias = exp.TableAlias(this=this)
 
                 unnest_sql = super().unnest_sql(expression)
                 select = exp.Select(expressions=[unnest_sql]).subquery(alias)

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -459,12 +459,13 @@ def _eliminate_dot_variant_lookup(expression: exp.Expression) -> exp.Expression:
         unnest_aliases = set()
         for unnest in find_all_in_scope(expression, exp.Unnest):
             unnest_alias = unnest.args.get("alias")
-            if (
-                isinstance(unnest_alias, exp.TableAlias)
-                and (unnest_alias.args.get("column_only") or not unnest_alias.this)
-                and len(unnest_alias.columns) == 1
-            ):
-                unnest_aliases.add(unnest_alias.columns[0].name)
+            if isinstance(unnest_alias, exp.TableAlias):
+                column_only = unnest_alias.args.get("column_only")
+                if column_only and not unnest_alias.columns:
+                    unnest_alias.set("columns", [unnest_alias.this.copy()])
+
+                if (column_only or not unnest_alias.this) and len(unnest_alias.columns) == 1:
+                    unnest_aliases.add(unnest_alias.columns[0].name)
 
         if unnest_aliases:
             for c in find_all_in_scope(expression, exp.Column):

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -326,7 +326,10 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             struct_type = exp.DataType(
                 this=exp.DataType.Type.STRUCT,
                 expressions=[
-                    exp.ColumnDef(this=exp.to_identifier(select.output_name), kind=select.type)
+                    exp.ColumnDef(
+                        this=exp.to_identifier(select.output_name),
+                        kind=select.type.copy() if select.type else None,
+                    )
                     for select in scope.expression.selects
                 ],
                 nested=True,

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -133,7 +133,6 @@ def qualify_tables(
                     and dialect.UNNEST_COLUMN_ONLY
                     and not table_alias.columns
                 ):
-                    table_alias.set("columns", [table_alias.this.copy()])
                     table_alias.set("column_only", True)
 
                 udtf.set("alias", table_alias)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2229,7 +2229,7 @@ OPTIONS (
 
         self.assertEqual(
             ast.sql("bigquery"),
-            "SELECT x, ys, zs FROM UNNEST([STRUCT('x' AS x, ['y1', 'y2', 'y3'] AS y, ['z1', 'z2', 'z3'] AS z)]) AS _q_0 CROSS JOIN UNNEST(y) AS ys CROSS JOIN UNNEST(z) AS zs",
+            "SELECT x, ys, zs FROM UNNEST([STRUCT('x' AS x, ['y1', 'y2', 'y3'] AS y, ['z1', 'z2', 'z3'] AS z)]) CROSS JOIN UNNEST(y) AS ys CROSS JOIN UNNEST(z) AS zs",
         )
         self.assertEqual(
             ast.sql("duckdb"),

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -833,7 +833,12 @@ SELECT CAST(c.f AS VARCHAR(MAX)) AS f, e AS e FROM a.b AS c, c.d AS e;
 # dialect: bigquery
 # execute: false
 WITH cte AS (SELECT 1 AS col) SELECT * FROM cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE col = 1));
-WITH cte AS (SELECT 1 AS col) SELECT cte.col AS col, _q_1 AS _q_1 FROM cte AS cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE cte.col = 1)) AS _q_1;
+WITH cte AS (SELECT 1 AS col) SELECT * FROM cte AS cte LEFT JOIN UNNEST((SELECT ARRAY_AGG(DISTINCT x) AS agg FROM UNNEST([1]) AS x WHERE cte.col = 1));
+
+# dialect: bigquery
+# execute: false
+WITH scores AS (SELECT * FROM UNNEST((SELECT ARRAY<STRUCT<percentile STRING, value INT64, score FLOAT64>>[("p10", 1, 0.0)]))) SELECT percentile FROM scores;
+WITH scores AS (SELECT * FROM UNNEST((SELECT ARRAY<STRUCT<percentile STRING, value INT64, score FLOAT64>>[('p10', 1, 0.0)] AS _col_0))) SELECT scores.percentile AS percentile FROM scores AS scores;
 
 --------------------------------------
 -- Window functions


### PR DESCRIPTION
Given a query such as:

```Python3
>>> sql = """
... WITH scores as (
...   select *
...   from unnest((
...       select 
...         ARRAY<STRUCT<percentile STRING, value INT64, score FLOAT64>>[("p10", 1, 0.0)]
...     )
...   )
... )
... SELECT percentile FROM scores
... """

```


<br/>

- Before:
```Python3
>>> qualify(sqlglot.parse_one(sql, dialect="bigquery"), dialect="bigquery").sql("bigquery")
Traceback (most recent call last):
  File "<python-input-4>", line 1, in <module>
    qualify(sqlglot.parse_one(sql, dialect="bigquery"), dialect="bigquery").sql("bigquery")
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/vaggelisd/Desktop/tobiko/sqlglot/sqlglot/optimizer/qualify.py", line 102, in qualify
    validate_qualify_columns_func(expression)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/vaggelisd/Desktop/tobiko/sqlglot/sqlglot/optimizer/qualify_columns.py", line 126, in validate_qualify_columns
    raise OptimizeError(f"Column '{column}' could not be resolved{for_table}")
sqlglot.errors.OptimizeError: Column '"percentile"' could not be resolved
```

<br/>

- After
```Python3
>>> qualify(sqlglot.parse_one(sql, dialect="bigquery"), dialect="bigquery").sql("bigquery")
"WITH `scores` AS (SELECT * FROM UNNEST((SELECT ARRAY<STRUCT<`percentile` STRING, `value` INT64, `score` FLOAT64>>[('p10', 1, 0.0)] AS `_col_0`))) SELECT `scores`.`percentile` AS `percentile` FROM `scores` AS `scores`"
```


The "regression" was introduced by https://github.com/tobymao/sqlglot/pull/5451 which always added a column alias in `TableAlias`. This caused `Resolver::get_table(...)` to not classify  the `scores` CTE as "source without schema" and thus couldn't qualify the left over columns.

The "regression" is quoted because the qualification before that PR used to work (and now works again) due to SQLGlot's flexibility / fallback mechanism; In contrast, we could actually enhance the `STRUCT` expand logic to also cover the case of `UNNEST((SELECT ARRAY<STRUCT>(...)))` properly.

