### PR TITLE
fix(snowflake): transpile UNIX_TIMESTAMP to DATE_PART

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -347,6 +347,19 @@ def _regexpextract_sql(self, expression: exp.RegexpExtract | exp.RegexpExtractAl
     )
 
 
+def _str_to_unix_sql(self: Snowflake.Generator, expression: exp.StrToUnix) -> str:
+    this = expression.this
+
+    if not this:
+        timestamp_expr = self.sql(exp.CurrentTimestamp())
+    elif expression.args.get("format"):
+        timestamp_expr = self.func("TO_TIMESTAMP", this, self.format_time(expression))
+    else:
+        timestamp_expr = this
+
+    return self.func("DATE_PART", exp.Literal.string("epoch_second"), timestamp_expr)
+
+
 def _json_extract_value_array_sql(
     self: Snowflake.Generator, expression: exp.JSONValueArray | exp.JSONExtractArray
 ) -> str:
@@ -1270,6 +1283,7 @@ class Snowflake(Dialect):
             exp.SHA: rename_func("SHA1"),
             exp.StarMap: rename_func("OBJECT_CONSTRUCT"),
             exp.StartsWith: rename_func("STARTSWITH"),
+            exp.StrToUnix: _str_to_unix_sql,
             exp.EndsWith: rename_func("ENDSWITH"),
             exp.StrPosition: lambda self, e: strposition_sql(
                 self, e, func_name="CHARINDEX", supports_position=True

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -901,3 +901,55 @@ class TestHive(Validator):
                 "hive": "CAST(a AS BOOLEAN)",
             },
         )
+
+    def test_unix_timestamp(self):
+        self.validate_all(
+            "UNIX_TIMESTAMP('20240115 143025',  'yyyyMMdd HHmmss')",
+            write={
+                "hive": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
+                "spark2": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
+                "spark": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
+                "databricks": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('20240115 143025', 'yyyymmDD hh24miss'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP('2024/01/15 14:30',  'yyyy/MM/dd HH:mm')",
+            write={
+                "hive": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
+                "spark2": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
+                "spark": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
+                "databricks": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('2024/01/15 14:30', 'yyyy/mm/DD hh24:mi'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+            write={
+                "hive": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+                "spark2": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+                "spark": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+                "databricks": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('Jan 15, 2024 14:30:25', 'mon DD, yyyy hh24:mi:ss'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP()",
+            write={
+                "hive": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+                "spark2": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+                "spark": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+                "databricks": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP(CURRENT_TIMESTAMP(), 'yyyy-mm-DD hh24:mi:ss'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP(col)",
+            write={
+                "hive": "UNIX_TIMESTAMP(col)",
+                "spark2": "UNIX_TIMESTAMP(col)",
+                "spark": "UNIX_TIMESTAMP(col)",
+                "databricks": "UNIX_TIMESTAMP(col)",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP(col, 'yyyy-mm-DD hh24:mi:ss'))",
+            },
+        )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -863,6 +863,46 @@ TBLPROPERTIES (
                 "spark": "LISTAGG(x, ', ')",
             },
         )
+        self.validate_all(
+            "UNIX_TIMESTAMP('20240115 143025',  'yyyyMMdd HHmmss')",
+            write={
+                "spark": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
+                "databricks": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('20240115 143025', 'yyyymmDD hh24miss'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP('2024/01/15 14:30',  'yyyy/MM/dd HH:mm')",
+            write={
+                "spark": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
+                "databricks": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('2024/01/15 14:30', 'yyyy/mm/DD hh24:mi'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+            write={
+                "spark": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+                "databricks": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('Jan 15, 2024 14:30:25', 'mon DD, yyyy hh24:mi:ss'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP()",
+            write={
+                "spark": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+                "databricks": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP(CURRENT_TIMESTAMP(), 'yyyy-mm-DD hh24:mi:ss'))",
+            },
+        )
+        self.validate_all(
+            "UNIX_TIMESTAMP(col)",
+            write={
+                "spark": "UNIX_TIMESTAMP(col)",
+                "databricks": "UNIX_TIMESTAMP(col)",
+                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP(col, 'yyyy-mm-DD hh24:mi:ss'))",
+            },
+        )
 
     def test_bool_or(self):
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -863,46 +863,6 @@ TBLPROPERTIES (
                 "spark": "LISTAGG(x, ', ')",
             },
         )
-        self.validate_all(
-            "UNIX_TIMESTAMP('20240115 143025',  'yyyyMMdd HHmmss')",
-            write={
-                "spark": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
-                "databricks": "UNIX_TIMESTAMP('20240115 143025', 'yyyyMMdd HHmmss')",
-                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('20240115 143025', 'yyyymmDD hh24miss'))",
-            },
-        )
-        self.validate_all(
-            "UNIX_TIMESTAMP('2024/01/15 14:30',  'yyyy/MM/dd HH:mm')",
-            write={
-                "spark": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
-                "databricks": "UNIX_TIMESTAMP('2024/01/15 14:30', 'yyyy/MM/dd HH:mm')",
-                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('2024/01/15 14:30', 'yyyy/mm/DD hh24:mi'))",
-            },
-        )
-        self.validate_all(
-            "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
-            write={
-                "spark": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
-                "databricks": "UNIX_TIMESTAMP('Jan 15, 2024 14:30:25', 'MMM dd, yyyy HH:mm:ss')",
-                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP('Jan 15, 2024 14:30:25', 'mon DD, yyyy hh24:mi:ss'))",
-            },
-        )
-        self.validate_all(
-            "UNIX_TIMESTAMP()",
-            write={
-                "spark": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
-                "databricks": "UNIX_TIMESTAMP(CURRENT_TIMESTAMP())",
-                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP(CURRENT_TIMESTAMP(), 'yyyy-mm-DD hh24:mi:ss'))",
-            },
-        )
-        self.validate_all(
-            "UNIX_TIMESTAMP(col)",
-            write={
-                "spark": "UNIX_TIMESTAMP(col)",
-                "databricks": "UNIX_TIMESTAMP(col)",
-                "snowflake": "DATE_PART('epoch_second', TO_TIMESTAMP(col, 'yyyy-mm-DD hh24:mi:ss'))",
-            },
-        )
 
     def test_bool_or(self):
         self.validate_all(


### PR DESCRIPTION
Fixes #5546

In order to transpile the `UNIX_TIMESTAMP` into a snowflake equivalent. `DATE_PART` is used combined with `TO_TIMESTAMP`. 

**DOCS**
[Snowflake DATE_PART](https://docs.snowflake.com/en/sql-reference/functions/date_part)
[Snowflake TO_TIMESTAMP](https://docs.snowflake.com/en/sql-reference/functions/to_timestamp)
[Hive UNIX_TIMESTAMP](https://hive.apache.org/docs/latest/hive-udfs_282102277/#date-functions)
[Spark UNIX_TIMESTAMP](https://spark.apache.org/docs/latest/api/sql/index.html#unix_timestamp)
[Databricks UNIX_TIMESTAMP](https://docs.databricks.com/aws/en/sql/language-manual/functions/unix_timestamp)