### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery CODE_POINTS_TO_STRING

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -482,6 +482,9 @@ class BigQuery(Dialect):
         exp.BitwiseXorAgg: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.BitwiseCountAgg: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.ByteLength: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
+        exp.CodePointsToString: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.VARCHAR
+        ),
         exp.Concat: _annotate_concat,
         exp.Corr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5577,6 +5577,10 @@ class ConvertTimezone(Func):
     }
 
 
+class CodePointsToString(Func):
+    pass
+
+
 class GenerateSeries(Func):
     arg_types = {"start": True, "end": True, "step": False, "is_end_exclusive": False}
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1775,6 +1775,7 @@ WHERE
         self.validate_identity("PARSE_TIME('%I:%M:%S', '07:30:00')")
         self.validate_identity("BYTE_LENGTH('foo')")
         self.validate_identity("BYTE_LENGTH(b'foo')")
+        self.validate_identity("CODE_POINTS_TO_STRING([65, 255])")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -721,6 +721,10 @@ TIME;
 BYTE_LENGTH('foo');
 BIGINT;
 
+# dialect: bigquery
+CODE_POINTS_TO_STRING([65, 255, 513, 1024]);
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for BigQuery `CODE_POINTS_TO_STRING`

**DOCS**
[BigQuery CODE_POINTS_TO_STRING](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#code_points_to_string)