### PR TITLE
feat(optimizer)!: annotate type for bigquery REGEXP_EXTRACT_ALL

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -506,6 +506,7 @@ class BigQuery(Dialect):
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
+        exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.Reverse: lambda self, e: self._annotate_by_args(e, "this"),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -737,6 +737,14 @@ BINARY;
 REVERSE(b'1a3');
 BINARY;
 
+# dialect: bigquery
+REGEXP_EXTRACT_ALL('Try `func(x)` or `func(y)`', '`(.+?)`');
+ARRAY<STRING>;
+
+# dialect: bigquery
+REGEXP_EXTRACT_ALL(b'\x48\x65\x6C\x6C\x6F', b'(\x6C+)');
+ARRAY<BINARY>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for BigQuery `REGEXP_EXTRACT_ALL`

**DOCS**
[BigQuery REGEXP_EXTRACT_ALL](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#regexp_extract_all)