### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery TRANSLATE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -520,6 +520,7 @@ class BigQuery(Dialect):
         exp.TimeFromParts: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.TsOrDsToTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.TimeTrunc: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
+        exp.Translate: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Unicode: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
     }
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5464,6 +5464,9 @@ class Transform(Func):
     arg_types = {"this": True, "expression": True}
 
 
+class Translate(Func):
+    arg_types = {"this": True, "from": True, "to": True}
+
 class Anonymous(Func):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3893,3 +3893,38 @@ FROM subquery2""",
                 "redshift": "REVERSE(x)",
             },
         )
+
+    def test_translate(self):
+        self.validate_all(
+            "TRANSLATE(x, y, z)",
+            read={
+                "": "TRANSLATE(x, y, z)",
+                "bigquery": "TRANSLATE(x, y, z)",
+                "hive": "TRANSLATE(x, y, z)",
+                "spark2": "TRANSLATE(x, y, z)",
+                "spark": "TRANSLATE(x, y, z)",
+                "databricks": "TRANSLATE(x, y, z)",
+                "postgres": "TRANSLATE(x, y, z)",
+                "tsql": "TRANSLATE(x, y, z)",
+                "snowflake": "TRANSLATE(x, y, z)",
+                "doris": "TRANSLATE(x, y, z)",
+                "trino": "TRANSLATE(x, y, z)",
+                "clickhouse": "TRANSLATE(x, y, z)",
+                "redshift": "TRANSLATE(x, y, z)",
+            },
+            write={
+                "": "TRANSLATE(x, y, z)",
+                "bigquery": "TRANSLATE(x, y, z)",
+                "hive": "TRANSLATE(x, y, z)",
+                "spark2": "TRANSLATE(x, y, z)",
+                "spark": "TRANSLATE(x, y, z)",
+                "databricks": "TRANSLATE(x, y, z)",
+                "postgres": "TRANSLATE(x, y, z)",
+                "tsql": "TRANSLATE(x, y, z)",
+                "snowflake": "TRANSLATE(x, y, z)",
+                "doris": "TRANSLATE(x, y, z)",
+                "trino": "TRANSLATE(x, y, z)",
+                "clickhouse": "TRANSLATE(x, y, z)",
+                "redshift": "TRANSLATE(x, y, z)",
+            },
+        )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -753,6 +753,14 @@ STRING;
 REPLACE(b'\x48\x65\x6C\x6C\x6F', b'\x6C\x6C', b'\x59\x59');
 BINARY;
 
+# dialect: bigquery
+TRANSLATE('AaBbCc', 'abc', '1');
+STRING;
+
+# dialect: bigquery
+TRANSLATE(b'AaBbCc', b'abc', b'123');
+BINARY;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `TRANSLATE`

**DOCS**
[BigQuery TRANSLATE](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#translate)
[Databricks TRANSLATE](https://docs.databricks.com/aws/en/sql/language-manual/functions/translate)
[Snowflake TRANSLATE](https://docs.snowflake.com/en/sql-reference/functions/translate#syntax)
[Oracle TRANSLATE](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/TRANSLATE.html)
[T-SQL TRANSLATE](https://learn.microsoft.com/en-us/sql/t-sql/functions/translate-transact-sql?view=sql-server-ver17)
[Trino TRANSLATE](https://trino.io/docs/current/functions/string.html#translate)
[Hive TRANSLATE](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27362046#LanguageManualUDF-StringFunctions)
[Spark TRANSLATE](https://spark.apache.org/docs/latest/api/sql/index.html#translate)
[Doris TRANSLATE](https://doris.apache.org/docs/sql-manual/sql-functions/scalar-functions/string-functions/translate#syntax)
[Redshift TRANSLATE](https://docs.aws.amazon.com/redshift/latest/dg/r_TRANSLATE.html)
[Postgres TRANSLATE](https://www.postgresql.org/docs/9.1/functions-string.html)
[Clickhouse TRANSLATE](https://clickhouse.com/docs/sql-reference/functions/string-replace-functions#translate)