### PR TITLE
feat(optimizer)!: annotate type for bigquery MD5

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -504,6 +504,7 @@ class BigQuery(Dialect):
         ),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
+        exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
         exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -765,6 +765,10 @@ BINARY;
 SOUNDEX('foo');
 STRING;
 
+# dialect: bigquery
+MD5('foo');
+BINARY;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for BigQuery `MD5`

**DOCS**
[BigQuery MD5](https://cloud.google.com/bigquery/docs/reference/standard-sql/hash_functions#md5)