### PR TITLE
feat(optimizer)!: annotate type for bigquery MIN/MAX BY

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -474,6 +474,8 @@ class BigQuery(Dialect):
                 exp.Substring,
             )
         },
+        exp.ArgMax: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.ArgMin: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Array: _annotate_array,
         exp.ArrayConcat: lambda self, e: self._annotate_by_args(e, "this", "expressions"),
         exp.Ascii: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -769,6 +769,22 @@ STRING;
 MD5('foo');
 BINARY;
 
+# dialect: bigquery
+MAX_BY(tbl.str_col, tbl.bigint_col);
+STRING;
+
+# dialect: bigquery
+MAX_BY(tbl.bigint_col, tbl.str_col);
+BIGINT;
+
+# dialect: bigquery
+MIN_BY(tbl.str_col, tbl.bigint_col);
+STRING;
+
+# dialect: bigquery
+MIN_BY(tbl.bigint_col, tbl.str_col);
+BIGINT;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for BigQuery `MIN BY` and `MAX BY`

**DOCS**
[BigQuery MIN_BY](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#min_by)
[BigQuery MAX_BY](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#max_by)