### PR TITLE
fix: additional dremio to_char fix as transpile is not working

### DIFF
--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -92,6 +92,8 @@ class Dremio(Dialect):
         "tzd": "%Z",  # abbreviation (UTC, PST, ...)
         "TZO": "%z",
         "tzo": "%z",  # numeric offset (+0200)
+        # "#": "FM9999",
+        # "#.#": "FM9999.9",
     }
 
     class Parser(parser.Parser):
@@ -100,7 +102,7 @@ class Dremio(Dialect):
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
             "TO_CHAR": lambda args: (
-                exp.ToChar(this=args[0], format=args[1])
+                exp.Cast(this=args[0], to=exp.DataType.build("VARCHAR"))
                 if len(args) == 2 and (not isinstance(args[1], exp.Literal) or "#" in args[1].name)
                 else build_formatted_time(exp.TimeToStr, "dremio")(args)
             ),

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -131,9 +131,15 @@ class TestDremio(Validator):
         )
 
     def test_to_char_special(self):
-        self.validate_identity("SELECT TO_CHAR(5555, '#')").selects[0].assert_is(exp.ToChar)
-        self.validate_identity("SELECT TO_CHAR(3.14, '#.#')").selects[0].assert_is(exp.ToChar)
-        self.validate_identity("SELECT TO_CHAR(3.14, columnname)").selects[0].assert_is(exp.ToChar)
+        self.validate_identity("SELECT TO_CHAR(5555, '#')", "SELECT CAST(5555 AS VARCHAR)").selects[
+            0
+        ].assert_is(exp.Cast)
+        self.validate_identity(
+            "SELECT TO_CHAR(3.14, '#.#')", "SELECT CAST(3.14 AS VARCHAR)"
+        ).selects[0].assert_is(exp.Cast)
+        self.validate_identity(
+            "SELECT TO_CHAR(3.14, columnname)", "SELECT CAST(3.14 AS VARCHAR)"
+        ).selects[0].assert_is(exp.Cast)
 
     def test_time_diff(self):
         self.validate_identity("SELECT DATE_ADD(col, 1)")


### PR DESCRIPTION
Our prior work fixed dremio parse but transpile is still returning dremio specific format.

current logic:
```
sql = "SELECT TO_CHAR(5555.00, '#')"
transpiled = sqlglot.transpile(sql, read="dremio", write="postgres")[0]
print(transpiled)
-----OUTPUT
SELECT TO_CHAR(5555.00, '#')
```

this patch:
```
-----OUTPUT
SELECT CAST(5555.00 AS VARCHAR)
```


