### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery GROUPING

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -497,6 +497,7 @@ class BigQuery(Dialect):
         exp.GenerateTimestampArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<TIMESTAMP>", dialect="bigquery")
         ),
+        exp.Grouping: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.JSONArray: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONExtractScalar: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.VARCHAR

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5468,6 +5468,11 @@ class Translate(Func):
     arg_types = {"this": True, "from": True, "to": True}
 
 
+class Grouping(AggFunc):
+    arg_types = {"expressions": True}
+    is_var_len_args = True
+
+
 class Anonymous(Func):
     arg_types = {"this": True, "expressions": False}
     is_var_len_args = True

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3968,3 +3968,55 @@ FROM subquery2""",
                 "oracle": "SOUNDEX(x)",
             },
         )
+
+    def test_grouping(self):
+        self.validate_all(
+            "GROUPING(x)",
+            read={
+                "": "GROUPING(x)",
+                "bigquery": "GROUPING(x)",
+                "hive": "GROUPING(x)",
+                "spark2": "GROUPING(x)",
+                "spark": "GROUPING(x)",
+                "databricks": "GROUPING(x)",
+                "mysql": "GROUPING(x)",
+                "postgres": "GROUPING(x)",
+                "tsql": "GROUPING(x)",
+                "snowflake": "GROUPING(x)",
+                "clickhouse": "GROUPING(x)",
+                "redshift": "GROUPING(x)",
+                "oracle": "GROUPING(x)",
+            },
+            write={
+                "bigquery": "GROUPING(x)",
+                "hive": "GROUPING(x)",
+                "spark2": "GROUPING(x)",
+                "spark": "GROUPING(x)",
+                "databricks": "GROUPING(x)",
+                "mysql": "GROUPING(x)",
+                "postgres": "GROUPING(x)",
+                "tsql": "GROUPING(x)",
+                "snowflake": "GROUPING(x)",
+                "clickhouse": "GROUPING(x)",
+                "redshift": "GROUPING(x)",
+                "oracle": "GROUPING(x)",
+            },
+        )
+        self.validate_all(
+            "GROUPING(col1, col2, col3)",
+            read={
+                "": "GROUPING(col1, col2, col3)",
+                "snowflake": "GROUPING(col1, col2, col3)",
+                "mysql": "GROUPING(col1, col2, col3)",
+                "postgres": "GROUPING(col1, col2, col3)",
+                "clickhouse": "GROUPING(col1, col2, col3)",
+                "redshift": "GROUPING(col1, col2, col3)",
+            },
+            write={
+                "snowflake": "GROUPING(col1, col2, col3)",
+                "mysql": "GROUPING(col1, col2, col3)",
+                "postgres": "GROUPING(col1, col2, col3)",
+                "clickhouse": "GROUPING(col1, col2, col3)",
+                "redshift": "GROUPING(col1, col2, col3)",
+            },
+        )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -785,6 +785,14 @@ STRING;
 MIN_BY(tbl.bigint_col, tbl.str_col);
 BIGINT;
 
+# dialect: bigquery
+GROUPING(tbl.str_col);
+BIGINT;
+
+# dialect: bigquery
+GROUPING(tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for `GROUPING`

**DOCS**
[BigQuery GROUPING](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#grouping)
[T-SQL GROUPING](https://learn.microsoft.com/en-us/sql/t-sql/functions/grouping-transact-sql?view=sql-server-ver17)
[Oracle GROUPING](https://docs.oracle.com/en/database/oracle/oracle-database/23/sqlrf/GROUPING.html)
[Spark GROUPING](https://spark.apache.org/docs/latest/api/sql/index.html#grouping)
[Snowflake GROUPING](https://docs.snowflake.com/en/sql-reference/functions/grouping)
[Redshift GROUPING](https://docs.aws.amazon.com/redshift/latest/dg/r_GROUP_BY_aggregation-extensions.html)
[Clickhouse GROUPING](https://clickhouse.com/docs/sql-reference/aggregate-functions/grouping_function)
[MySQL GROUPING](https://dev.mysql.com/blog-archive/mysql-8-0-grouping-function/)
[Postgres GROUPING](https://www.postgresql.org/docs/9.5/functions-aggregate.html)
