### PR TITLE
feat(oracle): add NUMTODSINTERVAL and NUMTOYMINTERVAL functions

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -108,6 +108,8 @@ class Oracle(Dialect):
             **parser.Parser.FUNCTIONS,
             "CONVERT": exp.ConvertToCharset.from_arg_list,
             "NVL": lambda args: build_coalesce(args, is_nvl=True),
+            "NUMTODSINTERVAL": exp.NumTodsinterval.from_arg_list,
+            "NUMTOYMINTERVAL": exp.NumToyminterval.from_arg_list,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "TO_CHAR": build_timetostr_or_tochar,
             "TO_TIMESTAMP": _build_to_timestamp,
@@ -310,6 +312,8 @@ class Oracle(Dialect):
             exp.LogicalOr: rename_func("MAX"),
             exp.LogicalAnd: rename_func("MIN"),
             exp.Mod: rename_func("MOD"),
+            exp.NumTodsinterval: lambda self, e: self.func("NUMTODSINTERVAL", e.this, e.expression),
+            exp.NumToyminterval: lambda self, e: self.func("NUMTOYMINTERVAL", e.this, e.expression),
             exp.Rand: rename_func("DBMS_RANDOM.VALUE"),
             exp.Select: transforms.preprocess(
                 [

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5563,6 +5563,34 @@ class ToDouble(Func):
     }
 
 
+# https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/NUMTODSINTERVAL.html
+class NumTodsinterval(Func):
+    """
+    Oracle NUMTODSINTERVAL function - converts a number to an INTERVAL DAY TO SECOND literal.
+
+    Syntax: NUMTODSINTERVAL(n, 'interval_unit')
+    Examples:
+        NUMTODSINTERVAL(1, 'DAY') -> creates 1-day interval
+        NUMTODSINTERVAL(30, 'MINUTE') -> creates 30-minute interval
+    """
+
+    arg_types = {"this": True, "expression": True}
+
+
+# https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/NUMTOYMINTERVAL.html
+class NumToyminterval(Func):
+    """
+    Oracle NUMTOYMINTERVAL function - converts a number to an INTERVAL YEAR TO MONTH literal.
+
+    Syntax: NUMTOYMINTERVAL(n, 'interval_unit')
+    Examples:
+        NUMTOYMINTERVAL(2, 'YEAR') -> creates 2-year interval
+        NUMTOYMINTERVAL(6, 'MONTH') -> creates 6-month interval
+    """
+
+    arg_types = {"this": True, "expression": True}
+
+
 class Columns(Func):
     arg_types = {"this": True, "unpack": False}
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -735,6 +735,39 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
             "ANALYZE TABLE tbl VALIDATE STRUCTURE CASCADE COMPLETE OFFLINE INTO db.tbl"
         )
 
+    def test_interval_functions(self):
+        self.validate_all(
+            "NUMTODSINTERVAL(100, 'HOUR')",
+            write={
+                "oracle": "NUMTODSINTERVAL(100, 'HOUR')",
+                "": "NUM_TODSINTERVAL(100, 'HOUR')",
+            },
+        )
+
+        self.validate_all(
+            "NUMTOYMINTERVAL(15, 'MONTH')",
+            write={
+                "oracle": "NUMTOYMINTERVAL(15, 'MONTH')",
+                "": "NUM_TOYMINTERVAL(15, 'MONTH')",
+            },
+        )
+
+        self.validate_all(
+            "NUMTODSINTERVAL(1.5, 'DAY')",
+            write={
+                "oracle": "NUMTODSINTERVAL(1.5, 'DAY')",
+                "": "NUM_TODSINTERVAL(1.5, 'DAY')",
+            },
+        )
+
+        self.validate_all(
+            "NUMTOYMINTERVAL(2.5, 'YEAR')",
+            write={
+                "oracle": "NUMTOYMINTERVAL(2.5, 'YEAR')",
+                "": "NUM_TOYMINTERVAL(2.5, 'YEAR')",
+            },
+        )
+
     def test_prior(self):
         self.validate_identity(
             "SELECT id, PRIOR name AS parent_name, name FROM tree CONNECT BY NOCYCLE PRIOR id = parent_id"


### PR DESCRIPTION
Adds support for Oracle's NUMTODSINTERVAL and NUMTOYMINTERVAL functions for converting numbers to intervals.