### PR TITLE
feat(trino): add JSON_VALUE function support with RETURNING clause

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -21,6 +21,7 @@ class Trino(Presto):
             **Presto.Parser.FUNCTION_PARSERS,
             "TRIM": lambda self: self._parse_trim(),
             "JSON_QUERY": lambda self: self._parse_json_query(),
+            "JSON_VALUE": lambda self: self._parse_json_value(),
             "LISTAGG": lambda self: self._parse_string_agg(),
         }
 
@@ -58,6 +59,21 @@ class Trino(Presto):
                 option=self._parse_var_from_options(self.JSON_QUERY_OPTIONS, raise_unmatched=False),
                 json_query=True,
                 quote=self._parse_json_query_quote(),
+                on_condition=self._parse_on_condition(),
+            )
+
+        def _parse_json_value(self) -> exp.JSONValue:
+            this = self._parse_bitwise()
+            self._match(TokenType.COMMA)
+            path = self._parse_bitwise()
+
+            returning = self._match(TokenType.RETURNING) and self._parse_type()
+
+            return self.expression(
+                exp.JSONValue,
+                this=this,
+                path=path,  # Keep as literal string for Trino's JSON path syntax
+                returning=returning,
                 on_condition=self._parse_on_condition(),
             )
 

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -5,6 +5,9 @@ class TestTrino(Validator):
     dialect = "trino"
 
     def test_trino(self):
+        self.validate_identity(
+            "JSON_VALUE(jl.extra_attributes, 'lax $.amount_source' RETURNING VARCHAR)"
+        )
         self.validate_identity("JSON_QUERY(m.properties, 'lax $.area' OMIT QUOTES NULL ON ERROR)")
         self.validate_identity("JSON_EXTRACT(content, json_path)")
         self.validate_identity("JSON_QUERY(content, 'lax $.HY.*')")


### PR DESCRIPTION
Description:
  ## Summary
  - Add support for Trino's JSON_VALUE function with RETURNING clause
  - Handles Trino-specific JSON path syntax like 'lax $.field'

  ## Changes
  - Added JSON_VALUE to Trino dialect's FUNCTION_PARSERS dictionary
  - Implemented `_parse_json_value()` method that:
    - Parses JSON input expression and path
    - Handles RETURNING clause for type specification
    - Supports ON EMPTY/ON ERROR conditions
  - Added test case to validate JSON_VALUE parsing

  ## Test Plan
  - ✅ Added unit test in test_trino.py
  - ✅ All existing tests pass (`make unit`)
  - ✅ Code style checks pass (`make style`)
  - ✅ Tested with example: `JSON_VALUE(jl.extra_attributes, 'lax $.amount_source' RETURNING VARCHAR)`

  Fixes parsing error when using JSON_VALUE with RETURNING clause in Trino dialect.

  The PR follows all CONTRIBUTING.md requirements:
  - Small, focused changes
  - Includes tests
  - Follows Conventional Commits format
  - All tests pass and code is linted