### PR TITLE
fix: Remove TokenType.APPLY from excluded table alias tokens

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -577,7 +577,6 @@ class Parser(metaclass=_Parser):
 
     TABLE_ALIAS_TOKENS = ID_VAR_TOKENS - {
         TokenType.ANTI,
-        TokenType.APPLY,
         TokenType.ASOF,
         TokenType.FULL,
         TokenType.LEFT,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2527,6 +2527,23 @@ class TestDialect(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT * FROM (SELECT 1 AS col) AS apply",
+            read={
+                "": "SELECT * FROM (SELECT 1 AS col) apply",
+                "hive": "SELECT * FROM (SELECT 1 AS col) apply",
+                "postgres": "SELECT * FROM (SELECT 1 AS col) apply",
+                "duckdb": "SELECT * FROM (SELECT 1 AS col) apply",
+                "presto": "SELECT * FROM (SELECT 1 AS col) apply",
+                "spark": "SELECT * FROM (SELECT 1 AS col) apply",
+                "spark2": "SELECT * FROM (SELECT 1 AS col) apply",
+                "trino": "SELECT * FROM (SELECT 1 AS col) apply",
+                "snowflake": "SELECT * FROM (SELECT 1 AS col) apply",
+                "bigquery": "SELECT * FROM (SELECT 1 AS col) apply",
+                "athena": "SELECT * FROM (SELECT 1 AS col) apply",
+            },
+        )
+
     def test_nullsafe_eq(self):
         self.validate_all(
             "SELECT a IS NOT DISTINCT FROM b",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5591

Consider this query which can't be parsed today:

```Python3
>>> import sqlglot
>>> sqlglot.parse_one("SELECT * FROM (SELECT 1 AS col) apply")
Traceback (most recent call last):
  ...
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 37.
  SELECT * FROM (SELECT 1 AS col) apply
```

However, this doesn't seem to be a problem for any engine (tested it personally across most major dialects). This token was introduced [on this commit](https://github.com/tobymao/sqlglot/pull/641/files#diff-9b1dac9e0bc983d20fca22326adf2c9d74deb06cc2c2a486139f332c6b492dc6), but it looks like the follow set removed from `TABLE_ALIAS_TOKENS` should be `{TokenType.CROSS, TokenType.OUTER}` instead of `{TokenType.APPLY}`