### PR TITLE
 Feat(exasol): map weekofyear to week

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -284,6 +284,7 @@ class Exasol(Dialect):
             exp.MD5Digest: rename_func("HASHTYPE_MD5"),
             # https://docs.exasol.com/db/latest/sql/create_view.htm
             exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
+            exp.WeekOfYear: rename_func("WEEK"),
         }
 
         def converttimezone_sql(self, expression: exp.ConvertTimezone) -> str:

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -323,6 +323,7 @@ class TestExasol(Validator):
         )
         self.validate_identity("SELECT TO_DATE('31-DECEMBER-1999', 'DD-MONTH-YYYY') AS TO_DATE")
         self.validate_identity("SELECT TO_DATE('31-DEC-1999', 'DD-MON-YYYY') AS TO_DATE")
+        self.validate_identity("SELECT WEEKOFYEAR('2024-05-22')", "SELECT WEEK('2024-05-22')")
 
         for fmt, alias in formats.items():
             with self.subTest(f"Testing TO_CHAR with format '{fmt}'"):


### PR DESCRIPTION
This involves mapping the WEEKOFYEAR function in sqlglot to exasol [WEEK](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/week.htm) function in exasol dialect