### PR TITLE
databricks parse numeric to_char to cast

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -100,7 +100,7 @@ class Databricks(Spark):
             exp.JSONExtractScalar: _jsonextract_sql,
             exp.JSONPathRoot: lambda *_: "",
             exp.ToChar: lambda self, e: (
-                self.cast_sql(e.this, exp.DataType.build("STRING"))
+                self.cast_sql(exp.Cast(this=e.this, to=exp.DataType(this="STRING")))
                 if e.args.get("is_numeric")
                 else self.function_fallback_sql(e)
             ),

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -347,8 +347,9 @@ class Spark2(Hive):
                 arg, (exp.JSONExtract, exp.JSONExtractScalar)
             ) and not arg.args.get("variant_extract")
 
-            # We can't use a non-nested type (eg. STRING) as a schema
-            if expression.to.args.get("nested") and (is_parse_json(arg) or is_json_extract):
+            # Make sure 'to' exists and has args before accessing 'nested'
+            to = getattr(expression, "to", None) or expression.args.get("to")
+            if to is not None and to.args.get("nested") and (is_parse_json(arg) or is_json_extract):
                 schema = f"'{self.sql(expression, 'to')}'"
                 return self.func("FROM_JSON", arg if is_json_extract else arg.this, schema)
 

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -390,16 +390,14 @@ class TestDatabricks(Validator):
             """CREATE FUNCTION a() ENVIRONMENT (dependencies = '["foo1==1", "foo2==2"]', environment_version = 'None')"""
         )
 
+    def test_to_char_is_numeric_transpile_to_cast(self):
+        # The input SQL simulates a TO_CHAR with is_numeric flag set (from dremio dialect)
+        sql = "SELECT TO_CHAR(12345, '#')"
+        expression = parse_one(sql, read="dremio")
 
-def test_to_char_is_numeric_transpile_to_cast():
-    # The input SQL simulates a TO_CHAR with is_numeric flag set (from dremio dialect)
-    sql = "SELECT TO_CHAR(12345, '#')"
-    expression = parse_one(sql, read="dremio")
+        to_char_exp = expression.find(exp.ToChar)
+        assert to_char_exp is not None
+        assert to_char_exp.args.get("is_numeric") is True
 
-    to_char_exp = expression.find(exp.ToChar)
-    assert to_char_exp is not None
-    assert to_char_exp.args.get("is_numeric") is True
-
-    result = transpile(sql, read="dremio", write="databricks")[0]
-
-    assert "CAST(12345 AS STRING)" in result
+        result = transpile(sql, read="dremio", write="databricks")[0]
+        assert "CAST(12345 AS STRING)" in result


### PR DESCRIPTION
Uses the dremio is_numeric arg to cast dremio to_char to strings.  Doing this to databricks for now as that is what I currently need. Can make a dialects.py utility function for this if that is preferred.