### PR TITLE
Fix(tsql): do not attach limit modifier to set operation

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -658,6 +658,8 @@ class TSQL(Dialect):
             else self.expression(exp.ScopeResolution, this=this, expression=to),
         }
 
+        SET_OP_MODIFIERS = {"order", "offset"}
+
         def _parse_alter_table_set(self) -> exp.AlterSet:
             return self._parse_wrapped(super()._parse_alter_table_set)
 


### PR DESCRIPTION
See https://github.com/tobymao/sqlglot/issues/5605#issuecomment-3205279961 for context.

We cannot attach `TOP` to the set operation, if any. It clearly binds to the query operand. Only `LIMIT`, `ORDER BY` etc are ambiguous.