### PR TITLE
feat(doris): update exp.UniqueKeyProperty SQL generation logic

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3033,7 +3033,7 @@ class PartitionByRangePropertyDynamic(Expression):
 
 # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE/
 class UniqueKeyProperty(Property):
-    arg_types = {"expressions": True}
+    arg_types = {"expressions": True, "unique": False}
 
 
 # https://www.postgresql.org/docs/current/sql-createtable.html

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4030,7 +4030,8 @@ class Generator(metaclass=_Generator):
 
     # https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE/
     def uniquekeyproperty_sql(self, expression: exp.UniqueKeyProperty) -> str:
-        return f"UNIQUE KEY ({self.expressions(expression, flat=True)})"
+        key_word = "UNIQUE KEY" if expression.args.get("unique", True) else "KEY"
+        return f"{key_word} ({self.expressions(expression, flat=True)})"
 
     # https://docs.starrocks.io/docs/sql-reference/sql-statements/data-definition/CREATE_TABLE/#distribution_desc
     def distributedbyproperty_sql(self, expression: exp.DistributedByProperty) -> str:

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -119,6 +119,7 @@ class TestDoris(Validator):
     def test_key(self):
         self.validate_identity("CREATE TABLE test_table (c1 INT, c2 INT) UNIQUE KEY (c1)")
         self.validate_identity("CREATE TABLE test_table (c1 INT, c2 INT) DUPLICATE KEY (c1)")
+        self.validate_identity("CREATE MATERIALIZED VIEW test_table (c1 INT, c2 INT) KEY (c1)")
 
     def test_distributed(self):
         self.validate_identity(


### PR DESCRIPTION
update `exp.UniqueKeyProperty` SQL generation logic to support the `KEY` in materialized views
https://doris.apache.org/docs/sql-manual/sql-statements/table-and-view/async-materialized-view/CREATE-ASYNC-MATERIALIZED-VIEW