### PR TITLE
feat(singlestore): Added parsing of MICROSECOND function

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -14,7 +14,8 @@ from sqlglot.expressions import DataType
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import seq_get
 
-def cast_to_time6(expression: exp.Expression):
+
+def cast_to_time6(expression: t.Optional[exp.Expression]):
     return exp.Cast(
         this=expression,
         to=exp.DataType.build(
@@ -22,6 +23,7 @@ def cast_to_time6(expression: exp.Expression):
             expressions=[exp.DataTypeParam(this=exp.Literal.number(6))],
         ),
     )
+
 
 class SingleStore(MySQL):
     SUPPORTS_ORDER_BY_ALL = True

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -202,3 +202,7 @@ class TestSingleStore(Validator):
             "SELECT HOUR('2009-02-13 23:31:30')",
             "SELECT DATE_FORMAT('2009-02-13 23:31:30' :> TIME(6), '%k') :> INT",
         )
+        self.validate_identity(
+            "SELECT MICROSECOND('2009-02-13 23:31:30.123456')",
+            "SELECT DATE_FORMAT('2009-02-13 23:31:30.123456' :> TIME(6), '%f') :> INT",
+        )


### PR DESCRIPTION
Documentation:

[MICROSECOND](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/microsecond/)
[DATE_FORMAT](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/date-format/)