### PR TITLE
feat(singlestore): Added parsing of MONTHNAME function

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -89,6 +89,10 @@ class SingleStore(MySQL):
                 ),
                 DataType.Type.INT,
             ),
+            "MONTHNAME": lambda args: exp.TimeToStr(
+                this=seq_get(args, 0),
+                format=MySQL.format_time(exp.Literal.string("%M")),
+            ),
             "UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
             "FROM_UNIXTIME": build_formatted_time(exp.UnixToTime, "mysql"),
             "BSON_EXTRACT_BSON": build_json_extract_path(exp.JSONBExtract),

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -206,3 +206,6 @@ class TestSingleStore(Validator):
             "SELECT MICROSECOND('2009-02-13 23:31:30.123456')",
             "SELECT DATE_FORMAT('2009-02-13 23:31:30.123456' :> TIME(6), '%f') :> INT",
         )
+        self.validate_identity(
+            "SELECT MONTHNAME('2014-04-18')", "SELECT DATE_FORMAT('2014-04-18', '%M')"
+        )


### PR DESCRIPTION
Documentation:
 * [MONTHNAME](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/monthname/)
 * [DATE_FORMAT](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/date-format/)