### PR TITLE
fix(tsql): Remove ORDER from set op modifiers too

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -658,7 +658,7 @@ class TSQL(Dialect):
             else self.expression(exp.ScopeResolution, this=this, expression=to),
         }
 
-        SET_OP_MODIFIERS = {"order", "offset"}
+        SET_OP_MODIFIERS = {"offset"}
 
         def _parse_alter_table_set(self) -> exp.AlterSet:
             return self._parse_wrapped(super()._parse_alter_table_set)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -60,8 +60,10 @@ class TestTSQL(Validator):
             "COPY INTO test_1 FROM 'path' WITH (FORMAT_NAME = test, FILE_TYPE = 'CSV', CREDENTIAL = (IDENTITY='Shared Access Signature', SECRET='token'), FIELDTERMINATOR = ';', ROWTERMINATOR = '0X0A', ENCODING = 'UTF8', DATEFORMAT = 'ymd', MAXERRORS = 10, ERRORFILE = 'errorsfolder', IDENTITY_INSERT = 'ON')"
         )
         self.validate_identity(
-            "WITH t1 AS (SELECT 1 AS a), t2 AS (SELECT 1 AS a) SELECT TOP 10 a FROM t1 UNION ALL SELECT TOP 10 a FROM t2 ORDER BY a DESC",
-            "WITH t1 AS (SELECT 1 AS a), t2 AS (SELECT 1 AS a) SELECT * FROM (SELECT TOP 10 a FROM t1 UNION ALL SELECT TOP 10 a FROM t2) AS _l_0 ORDER BY a DESC",
+            "WITH t1 AS (SELECT 1 AS a), t2 AS (SELECT 1 AS a) SELECT TOP 10 a FROM t1 UNION ALL SELECT TOP 10 a FROM t2 ORDER BY a DESC"
+        )
+        self.validate_identity(
+            "WITH t1 AS (SELECT 1 AS a), t2 AS (SELECT 1 AS a) SELECT COUNT(*) FROM (SELECT TOP 10 a FROM t1 UNION ALL SELECT TOP 10 a FROM t2 ORDER BY a DESC) AS t"
         )
         self.validate_identity(
             'SELECT 1 AS "[x]"',


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5618

I left `offset` in the modifiers due to the following scenario coming from base dialect:

```Python3
sql = "SELECT * FROM a UNION SELECT * FROM b ORDER BY x LIMIT 1"
```

<br/>

- ❌ Without any `SET_OP_MODIFIERS`, T-SQL query can't execute due to error `Invalid usage of the option FIRST in the FETCH statement`:
```Python3
>>> sqlglot.parse_one(sql, dialect="").sql("tsql")
"WITH t1 AS (SELECT 1 AS col), t2 AS (SELECT 2 AS col) 
SELECT * FROM t1 UNION SELECT * FROM t2 ORDER BY col FETCH FIRST 1 ROWS ONLY"
```


<br/>

- ✅ With `SET_OP_MODIFIERS = {"offset"}`, T-SQL query executes fine because `LIMIT` is lifted as a `TOP`
```Python3
>>> sqlglot.parse_one(sql, dialect="").sql("tsql")
"WITH t1 AS (SELECT 1 AS col), t2 AS (SELECT 2 AS col) 
SELECT TOP 1 * FROM (SELECT * FROM t1 UNION SELECT * FROM t2) AS _l_0 ORDER BY col"
```