### PR TITLE
feat(singelstore): Removed redundant casting for DAY function

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -136,6 +136,7 @@ class SingleStore(MySQL):
                 this=seq_get(args, 0),
                 format=MySQL.format_time(exp.Literal.string("%W")),
             ),
+            "DAY": lambda args: exp.Day(this=seq_get(args, 0)),
         }
 
         CAST_COLUMN_OPERATORS = {TokenType.COLON_GT, TokenType.NCOLON_GT}

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -233,4 +233,8 @@ class TestSingleStore(Validator):
                 "singlestore": "SELECT DAY('2014-04-18')",
                 "": "SELECT DAY_OF_MONTH('2014-04-18')",
             },
+            write={
+                "singlestore": "SELECT DAY('2014-04-18')",
+                "": "SELECT DAY('2014-04-18')",
+            },
         )


### PR DESCRIPTION
MySQL dialects adds a redundant cast inside the DAY function.
```
            "DAY": lambda args: exp.Day(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
```
Removed it in SingleStore.