### PR TITLE
feat(singelstore): Removed redundant deletions from TRANSFORMS

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -242,13 +242,6 @@ class SingleStore(MySQL):
             exp.DayOfMonth: rename_func("DAY"),
         }
         TRANSFORMS.pop(exp.JSONExtractScalar)
-        TRANSFORMS.pop(exp.JSONPathFilter)
-        TRANSFORMS.pop(exp.JSONPathRecursive)
-        TRANSFORMS.pop(exp.JSONPathScript)
-        TRANSFORMS.pop(exp.JSONPathSelector)
-        TRANSFORMS.pop(exp.JSONPathSlice)
-        TRANSFORMS.pop(exp.JSONPathUnion)
-        TRANSFORMS.pop(exp.JSONPathWildcard)
 
         # https://docs.singlestore.com/cloud/reference/sql-reference/restricted-keywords/list-of-restricted-keywords/
         RESERVED_KEYWORDS = {


### PR DESCRIPTION
Following JSON path parts should be removed [here](https://github.com/tobymao/sqlglot/blob/deebf0c3cc379e28c4ab66b6bb7a9c84c14e88c6/sqlglot/generator.py#L69)