### PR TITLE
feat(singlestore): Marked exp.All as unsupported

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -1324,3 +1324,7 @@ class SingleStore(MySQL):
                 res = exp.Cast(this=res, to=returning)
 
             return self.sql(res)
+
+        def all_sql(self, expression: exp.All) -> str:
+            self.unsupported("ALL subquery predicate is not supported in SingleStore")
+            return super().all_sql(expression)


### PR DESCRIPTION
SingleStore supports only [EXISTS](https://docs.singlestore.com/cloud/reference/sql-reference/data-manipulation-language-dml/exists-and-not-exists/) subquery predicate.