### PR TITLE
fix(generator): Wrap CONCAT items with COALESCE less aggressively

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2998,7 +2998,14 @@ class Generator(metaclass=_Generator):
             args = [exp.cast(e, exp.DataType.Type.TEXT) for e in args]
 
         if not self.dialect.CONCAT_COALESCE and expression.args.get("coalesce"):
-            args = [exp.func("coalesce", e, exp.Literal.string("")) for e in args]
+            # Wrap with COALESCE if the arg could be NULL i.e is already exp.Null or an expression with columns
+            # that could be evaluated to NULL
+            args = [
+                exp.func("coalesce", e, exp.Literal.string(""))
+                if (isinstance(e, exp.Null) or e.find(exp.Column))
+                else e
+                for e in args
+            ]
 
         return args
 

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -40,7 +40,7 @@ class TestDremio(Validator):
             "SELECT CONCAT('a', NULL)",
             write={
                 "dremio": "SELECT CONCAT('a', NULL)",
-                "": "SELECT CONCAT(COALESCE('a', ''), COALESCE(NULL, ''))",
+                "": "SELECT CONCAT('a', COALESCE(NULL, ''))",
             },
         )
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -476,7 +476,7 @@ class TestDuckDB(Validator):
             "SELECT STRFTIME(CAST('2020-01-01' AS TIMESTAMP), CONCAT('%Y', '%m'))",
             write={
                 "duckdb": "SELECT STRFTIME(CAST('2020-01-01' AS TIMESTAMP), CONCAT('%Y', '%m'))",
-                "spark": "SELECT DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP_NTZ), CONCAT(COALESCE('yyyy', ''), COALESCE('MM', '')))",
+                "spark": "SELECT DATE_FORMAT(CAST('2020-01-01' AS TIMESTAMP_NTZ), CONCAT('yyyy', 'MM'))",
                 "tsql": "SELECT FORMAT(CAST('2020-01-01' AS DATETIME2), CONCAT('yyyy', 'MM'))",
             },
         )
@@ -1022,6 +1022,21 @@ class TestDuckDB(Validator):
         )
         self.validate_identity("LISTAGG(x, ', ')")
         self.validate_identity("STRING_AGG(x, ', ')", "LISTAGG(x, ', ')")
+
+        self.validate_all(
+            "SELECT CONCAT(foo)",
+            write={
+                "duckdb": "SELECT CONCAT(foo)",
+                "spark": "SELECT CONCAT(COALESCE(foo, ''))",
+            },
+        )
+        self.validate_all(
+            "SELECT CONCAT(COALESCE(['abc'], []), ['bcg'])",
+            write={
+                "duckdb": "SELECT CONCAT(COALESCE(['abc'], []), ['bcg'])",
+                "spark": "SELECT CONCAT(COALESCE(ARRAY('abc'), ARRAY()), ARRAY('bcg'))",
+            },
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
SQLGlot employs a transformation to transpile `CONCAT(...)` into `CONCAT(COALESCE(..., ''))` between dialects with different `NULL` semantics, e.g:

```SQL
# DuckDB: Evaluates to empty string
duckdb> SELECT CONCAT(NULL) = '';
┌─────────────────────┐
│ (concat(NULL) = '') │
│       boolean       │
├─────────────────────┤
│ true                │
└─────────────────────┘

# Spark: Evaluates to `NULL`:
spark-sql > SELECT CONCAT(NULL) IS NULL;
true

# Spark: Wrapped with COALESCE evalutes to empty string
spark-sql > SELECT CONCAT(COALESCE(NULL, '')) = '';
(concat(coalesce(NULL, )) = )
true
```

<br/>

This transformation already happens on main today, but is done so preemptively:

```Python3
>>> sqlglot.parse_one("SELECT CONCAT(NULL)", dialect="duckdb").sql("spark")
"SELECT CONCAT(COALESCE(NULL, ''))"
```

<br/>

This PR relaxes the `COALESCE` wrapping (since as the issue shows it can lead to errors) by only doing so if the expression _could_ be evaluated to `NULL`.