### PR TITLE
fix(duckdb): Transpile Spark's `FIRST(col, TRUE)`

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1119,15 +1119,20 @@ class DuckDB(Dialect):
             return super().unnest_sql(expression)
 
         def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
-            if isinstance(expression.this, self.IGNORE_RESPECT_NULLS_WINDOW_FUNCTIONS):
+            this = expression.this
+
+            if isinstance(this, self.IGNORE_RESPECT_NULLS_WINDOW_FUNCTIONS):
                 # DuckDB should render IGNORE NULLS only for the general-purpose
                 # window functions that accept it e.g. FIRST_VALUE(... IGNORE NULLS) OVER (...)
                 return super().ignorenulls_sql(expression)
 
-            if not isinstance(expression.this, exp.AnyValue):
+            if isinstance(this, exp.First):
+                this = exp.AnyValue(this=this.this)
+
+            if not isinstance(this, exp.AnyValue):
                 self.unsupported("IGNORE NULLS is not supported for non-window functions.")
 
-            return self.sql(expression, "this")
+            return self.sql(this)
 
         def respectnulls_sql(self, expression: exp.RespectNulls) -> str:
             if isinstance(expression.this, self.IGNORE_RESPECT_NULLS_WINDOW_FUNCTIONS):

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -885,6 +885,19 @@ class TestHive(Validator):
             },
         )
 
+        self.validate_all(
+            "SELECT FIRST(sample_col) IGNORE NULLS",
+            read={
+                "hive": "SELECT FIRST(sample_col, TRUE)",
+                "spark2": "SELECT FIRST(sample_col, TRUE)",
+                "spark": "SELECT FIRST(sample_col, TRUE)",
+                "databricks": "SELECT FIRST(sample_col, TRUE)",
+            },
+            write={
+                "duckdb": "SELECT ANY_VALUE(sample_col)",
+            },
+        )
+
     def test_escapes(self) -> None:
         self.validate_identity("'\n'", "'\\n'")
         self.validate_identity("'\\n'")

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -787,7 +787,7 @@ TBLPROPERTIES (
         self.validate_all(
             "SELECT ANY_VALUE(col, true), FIRST(col, true), FIRST_VALUE(col, true) OVER ()",
             write={
-                "duckdb": "SELECT ANY_VALUE(col), FIRST(col), FIRST_VALUE(col IGNORE NULLS) OVER ()"
+                "duckdb": "SELECT ANY_VALUE(col), ANY_VALUE(col), FIRST_VALUE(col IGNORE NULLS) OVER ()"
             },
         )
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/5643

```SQL
duckdb> WITH tbl AS (SELECT NULL AS col UNION ALL SELECT 1 AS col) select ANY_VALUE(col) FROM tbl;
┌────────────────┐
│ any_value(col) │
│     int32      │
├────────────────┤
│       1        │
└────────────────┘

spark2> spark.sql("with tbl as (Select NULL as col union all select 1 as col) select first(col, true) from tbl").show()
+----------+
|first(col)|
+----------+
|         1|
+----------+


spark3> WITH tbl AS (SELECT NULL AS col UNION ALL SELECT 1 AS col) select FIRST(col, TRUE) FROM tbl;
1
```