### PR TITLE
Improve predict parsing for bigquery, add expression check in ml functions

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1718,10 +1718,23 @@ WHERE
             },
         )
 
+        # ML functions
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL myproject.mydataset.mymodel, TABLE myproject.mydataset.mytable)"
+        ).find(exp.From).this.this.assert_is(exp.Predict)
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL myproject.mydataset.mymodel, (SELECT * FROM mytable))"
+        ).find(exp.From).this.this.assert_is(exp.Predict)
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL myproject.mydataset.mymodel, TABLE myproject.mydataset.mytable, STRUCT(0.5 AS threshold, TRUE AS keep_original_columns))"
+        ).find(exp.From).this.this.assert_is(exp.Predict)
+
         self.validate_identity(
             "SELECT * FROM ML.FEATURES_AT_TIME(TABLE mydataset.feature_table, time => '2022-06-11 10:00:00+00', num_rows => 1, ignore_feature_nulls => TRUE)"
-        )
-        self.validate_identity("SELECT * FROM ML.FEATURES_AT_TIME((SELECT 1), num_rows => 1)")
+        ).find(exp.From).this.this.assert_is(exp.FeaturesAtTime)
+        self.validate_identity("SELECT * FROM ML.FEATURES_AT_TIME((SELECT 1), num_rows => 1)").find(
+            exp.From
+        ).this.this.assert_is(exp.FeaturesAtTime)
 
         self.validate_identity(
             "EXPORT DATA OPTIONS (URI='gs://path*.csv.gz', FORMAT='CSV') AS SELECT * FROM all_rows"


### PR DESCRIPTION
## Summary

Add specific parsing for BigQuery `ML PREDICT` function in the SQL parser. 
Ensure correct handling and validation of its parameters. 
It also introduces expressions checks to improve the accuracy of existing tests for ML functions.

### BigQuery ML function parsing changes

* Added a `_parse_predict` method to the BigQuery parser to handle the `ML.PREDICT` function, including validation for [allowed parameters](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict) (`THRESHOLD`, `KEEP_ORIGINAL_COLUMNS`, `TRIAL_ID`) in the third argument struct.
* Registered the new `PREDICT` function parser in the BigQuery dialect's function parser mapping.

### Test improvements

* Added tests for various valid `ML.PREDICT` function usages, including cases with and without the optional struct parameter, and verified that the parsed expression is of type `exp.Predict`.
* Updated existing tests for `ML.FEATURES_AT_TIME` to assert the correct parsed expression type, improving test accuracy.