### PR TITLE
feat(bigquery): Add support for ml.generate_embedding function

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -700,6 +700,7 @@ class BigQuery(Dialect):
             ),
             "MAKE_INTERVAL": lambda self: self._parse_make_interval(),
             "FEATURES_AT_TIME": lambda self: self._parse_features_at_time(),
+            "GENERATE_EMBEDDING": lambda self: self._parse_generate_embedding(),
         }
         FUNCTION_PARSERS.pop("TRIM")
 
@@ -995,6 +996,20 @@ class BigQuery(Dialect):
                     expr.set(arg.this.name, arg)
 
             return expr
+
+        def _parse_generate_embedding(self) -> exp.GenerateEmbedding:
+            self._match_text_seq("MODEL")
+            this = self._parse_table()
+
+            self._match(TokenType.COMMA)
+            self._match_text_seq("TABLE")
+
+            return self.expression(
+                exp.GenerateEmbedding,
+                this=this,
+                expression=self._parse_table(),
+                params_struct=self._match(TokenType.COMMA) and self._parse_bitwise(),
+            )
 
         def _parse_export_data(self) -> exp.Export:
             self._match_text_seq("DATA")

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6213,10 +6213,6 @@ class FromBase64(Func):
     pass
 
 
-class FeaturesAtTime(Func):
-    arg_types = {"this": True, "time": False, "num_rows": False, "ignore_feature_nulls": False}
-
-
 class ToBase64(Func):
     pass
 
@@ -6739,6 +6735,16 @@ class Overlay(Func):
 
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-predict#mlpredict_function
 class Predict(Func):
+    arg_types = {"this": True, "expression": True, "params_struct": False}
+
+
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-feature-time
+class FeaturesAtTime(Func):
+    arg_types = {"this": True, "time": False, "num_rows": False, "ignore_feature_nulls": False}
+
+
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-embedding
+class GenerateEmbedding(Func):
     arg_types = {"this": True, "expression": True, "params_struct": False}
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4182,6 +4182,14 @@ class Generator(metaclass=_Generator):
         parameters = self.sql(expression, "params_struct")
         return self.func("PREDICT", model, table, parameters or None)
 
+    def generateembedding_sql(self, expression: exp.GenerateEmbedding) -> str:
+        model = self.sql(expression, "this")
+        model = f"MODEL {model}"
+        table = self.sql(expression, "expression")
+        table = f"TABLE {table}" if not isinstance(expression.expression, exp.Subquery) else table
+        parameters = self.sql(expression, "params_struct")
+        return self.func("GENERATE_EMBEDDING", model, table, parameters or None)
+
     def forin_sql(self, expression: exp.ForIn) -> str:
         this = self.sql(expression, "this")
         expression_sql = self.sql(expression, "expression")


### PR DESCRIPTION
Add support for the BigQuery ML `GENERATE_EMBEDDING` [function,](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-embedding) 

Move and expanded tests for ML functions, including both `FEATURES_AT_TIME` and `GENERATE_EMBEDDING`, into a dedicated test method in `tests/dialects/test_bigquery.py`.

Note that ML.GENERATE_EMBEDDING function syntax is identical to ML.PREDICT function. This is because BigQuery has at least three types of ML. functions: 

- Table-Valued functions like the mentioned above, that are used used in FROM clauses and return tables
- Column-Valued functions that are used in SELECT clauses and return strings/int/scalar/array etc. values ([example](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-bucketize#syntax))
- Window like functions. ([Example](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-min-max-scaler#syntax))

Because of [this slack message ](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1756114416582269?thread_ts=1756112705.588209&cid=C0448SFS3PF) I opted to put GENERATE_EMBEDDING as a new function, instead of refactoring existing code to make it reusable.

Also, I don't know why ML.FEATURES_AT_TIME is in bigquery.py whereas ML.PREDICT is in the general parser file. I've opted to put the new function in bigquery.py because it's specific to bigquery, but I can move it to the general parser as well. 