### PR TITLE
feat(dremio): support array_generate_range

### DIFF
--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -141,6 +141,7 @@ class Dremio(Dialect):
             "TO_DATE": build_formatted_time(exp.TsOrDsToDate, "dremio"),
             "DATE_ADD": build_date_delta_with_cast_interval(exp.DateAdd),
             "DATE_SUB": build_date_delta_with_cast_interval(exp.DateSub),
+            "ARRAY_GENERATE_RANGE": exp.GenerateSeries.from_arg_list,
         }
 
     class Generator(generator.Generator):
@@ -173,6 +174,7 @@ class Dremio(Dialect):
             exp.TimeToStr: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
             exp.DateAdd: _date_delta_sql("DATE_ADD"),
             exp.DateSub: _date_delta_sql("DATE_SUB"),
+            exp.GenerateSeries: rename_func("ARRAY_GENERATE_RANGE"),
         }
 
         def datatype_sql(self, expression: exp.DataType) -> str:

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -175,3 +175,10 @@ class TestDremio(Validator):
             "SELECT DATE_FORMAT(CAST('2025-08-18 15:30:00' AS TIMESTAMP), 'yyyy-mm-dd')",
             "SELECT TO_CHAR(CAST('2025-08-18 15:30:00' AS TIMESTAMP), 'yyyy-mm-dd')",
         )
+
+    def test_array_generate_range(self):
+        self.validate_all(
+            "ARRAY_GENERATE_RANGE(1, 4)",
+            read={"dremio": "ARRAY_GENERATE_RANGE(1, 4)"},
+            write={"duckdb": "GENERATE_SERIES(1, 4)"},
+        )


### PR DESCRIPTION
Support dremio array_generate_range, parsing to series and back.

https://docs.dremio.com/24.3.x/reference/sql/sql-functions/functions/ARRAY_GENERATE_RANGE/