### PR TITLE
feat: parse to_char date literals

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -2030,7 +2030,7 @@ def build_timetostr_or_tochar(args: t.List, dialect: DialectType) -> exp.TimeToS
             annotate_types(this, dialect=dialect)
 
         is_temporal = this.is_type(*exp.DataType.TEMPORAL_TYPES)
-        is_string_literal = isinstance(format_str, exp.Literal) and isinstance(format_str.this, str)
+        is_string_literal = format_str.is_string
 
         if is_temporal or is_string_literal:
             try:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -2029,15 +2029,15 @@ def build_timetostr_or_tochar(args: t.List, dialect: DialectType) -> exp.TimeToS
 
             annotate_types(this, dialect=dialect)
 
-        is_temporal = this.is_type(*exp.DataType.TEMPORAL_TYPES)
-        is_string_literal = format_str.is_string
+        dialect_name = dialect.__class__.__name__.lower()
 
-        if is_temporal or is_string_literal:
-            format_str_value = format_str.name
-            if is_valid_time_format(format_str_value, dialect.__class__.__name__.lower()):
-                return build_formatted_time(
-                    exp.TimeToStr, dialect.__class__.__name__.lower(), default=True
-                )(args)
+        is_temporal = this.is_type(*exp.DataType.TEMPORAL_TYPES)
+        is_valid_format = format_str.is_string and is_valid_time_format(
+            format_str.name, dialect_name
+        )
+
+        if is_temporal or is_valid_format:
+            return build_formatted_time(exp.TimeToStr, dialect_name, default=True)(args)
 
     return exp.ToChar.from_arg_list(args)
 

--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -36,14 +36,14 @@ def _date_delta_sql(name: str) -> t.Callable[[Dremio.Generator, DATE_DELTA], str
 
 
 def to_char_is_numeric_handler(args: t.List, dialect: DialectType) -> exp.TimeToStr | exp.ToChar:
-    expression = build_timetostr_or_tochar(args, dialect)
     fmt = seq_get(args, 1)
 
-    if fmt and isinstance(expression, exp.ToChar) and fmt.is_string and "#" in fmt.name:
-        # Only mark as numeric if format is a literal containing #
-        expression.set("is_numeric", True)
+    if fmt and isinstance(fmt, exp.Literal) and fmt.is_string and "#" in fmt.name:
+        expr = exp.ToChar.from_arg_list(args)
+        expr.set("is_numeric", True)
+        return expr
 
-    return expression
+    return build_timetostr_or_tochar(args, dialect)
 
 
 def build_date_delta_with_cast_interval(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -845,6 +845,8 @@ class TestDialect(Validator):
                 "presto": "DATE_FORMAT(x, '%Y-%m-%d')",
                 "redshift": "TO_CHAR(x, 'YYYY-MM-DD')",
                 "doris": "DATE_FORMAT(x, '%Y-%m-%d')",
+                "dremio": "TO_CHAR(x, 'yyyy-mm-dd')",
+                "databricks": "DATE_FORMAT(x, 'yyyy-MM-dd')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -148,12 +148,6 @@ class TestDremio(Validator):
         to_char = self.validate_identity("TO_CHAR(3.14, columnname)").assert_is(exp.ToChar)
         assert not to_char.args.get("is_numeric")
 
-        to_char = self.validate_identity("TO_CHAR(123, 'abcd')").assert_is(exp.ToChar)
-        assert not to_char.args.get("is_numeric")
-
-        to_char = self.validate_identity("TO_CHAR(3.14, UPPER('abcd'))").assert_is(exp.ToChar)
-        assert not to_char.args.get("is_numeric")
-
     def test_date_add(self):
         self.validate_identity("SELECT DATE_ADD(col, 1)")
         self.validate_identity("SELECT DATE_ADD(col, CAST(1 AS INTERVAL HOUR))")

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -119,7 +119,6 @@ class TestDremio(Validator):
             read={
                 "dremio": f"SELECT TO_CHAR({ts}, 'yy-ddd hh24:mi:ss.fff tzd')",
                 "postgres": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.US TZ')",
-                "oracle": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FF6 %Z')",
                 "duckdb": f"SELECT STRFTIME({ts}, '%y-%j %H:%M:%S.%f %Z')",
             },
             write={
@@ -127,6 +126,7 @@ class TestDremio(Validator):
                 "postgres": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.US TZ')",
                 "oracle": f"SELECT TO_CHAR({ts}, 'YY-DDD HH24:MI:SS.FF6 %Z')",
                 "duckdb": f"SELECT STRFTIME({ts}, '%y-%j %H:%M:%S.%f %Z')",
+                "databricks": "SELECT DATE_FORMAT(CAST('2025-06-24 12:34:56' AS TIMESTAMP), 'yy-DD HH:mm:ss.SSSSSS z')",
             },
         )
 


### PR DESCRIPTION
Currently to_char is not parsing date formats if the format is a literal.  This breaks most transpiles as the expression in practice is a column name and not a recognized temporal type.

This checks if it is a string literal and attempts to build a formatted time.