### PR TITLE
feat(bigquery): Add support for vector_search function. Move predict to BigQuery dialect.

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -1028,17 +1028,16 @@ class BigQuery(Dialect):
             return expr
 
         def _parse_vector_search(self) -> exp.VectorSearch:
-            base_table = (
-                self._match(TokenType.TABLE) and self._parse_table()
-            ) or self._parse_select(nested=True)
+            self._match(TokenType.TABLE)
+            base_table = self._parse_table()
+
             self._match(TokenType.COMMA)
 
             column_to_search = self._parse_bitwise()
             self._match(TokenType.COMMA)
 
-            query_table = (
-                self._match(TokenType.TABLE) and self._parse_table()
-            ) or self._parse_select(nested=True)
+            self._match(TokenType.TABLE)
+            query_table = self._parse_table()
 
             expr = self.expression(
                 exp.VectorSearch,
@@ -1049,7 +1048,7 @@ class BigQuery(Dialect):
 
             while self._match(TokenType.COMMA):
                 # query_column_to_search can be named argument or positional
-                if self._curr.token_type == TokenType.STRING:
+                if self._match(TokenType.STRING, advance=False):
                     query_column = self._parse_string()
                     expr.set("query_column_to_search", query_column)
                 else:

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -699,6 +699,7 @@ class BigQuery(Dialect):
                 exp.JSONArray, expressions=self._parse_csv(self._parse_bitwise)
             ),
             "MAKE_INTERVAL": lambda self: self._parse_make_interval(),
+            "PREDICT": lambda self: self._parse_predict(),
             "FEATURES_AT_TIME": lambda self: self._parse_features_at_time(),
             "GENERATE_EMBEDDING": lambda self: self._parse_generate_embedding(),
         }
@@ -980,6 +981,34 @@ class BigQuery(Dialect):
 
             return expr
 
+        def _parse_predict(self) -> exp.Predict:
+            self._match_text_seq("MODEL")
+            this = self._parse_table()
+
+            self._match(TokenType.COMMA)
+            self._match_text_seq("TABLE")
+
+            return self.expression(
+                exp.Predict,
+                this=this,
+                expression=self._parse_table(),
+                params_struct=self._match(TokenType.COMMA) and self._parse_bitwise(),
+            )
+
+        def _parse_generate_embedding(self) -> exp.GenerateEmbedding:
+            self._match_text_seq("MODEL")
+            this = self._parse_table()
+
+            self._match(TokenType.COMMA)
+            self._match_text_seq("TABLE")
+
+            return self.expression(
+                exp.GenerateEmbedding,
+                this=this,
+                expression=self._parse_table(),
+                params_struct=self._match(TokenType.COMMA) and self._parse_bitwise(),
+            )
+
         def _parse_features_at_time(self) -> exp.FeaturesAtTime:
             expr = self.expression(
                 exp.FeaturesAtTime,
@@ -996,20 +1025,6 @@ class BigQuery(Dialect):
                     expr.set(arg.this.name, arg)
 
             return expr
-
-        def _parse_generate_embedding(self) -> exp.GenerateEmbedding:
-            self._match_text_seq("MODEL")
-            this = self._parse_table()
-
-            self._match(TokenType.COMMA)
-            self._match_text_seq("TABLE")
-
-            return self.expression(
-                exp.GenerateEmbedding,
-                this=this,
-                expression=self._parse_table(),
-                params_struct=self._match(TokenType.COMMA) and self._parse_bitwise(),
-            )
 
         def _parse_export_data(self) -> exp.Export:
             self._match_text_seq("DATA")

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -1011,11 +1011,10 @@ class BigQuery(Dialect):
             )
 
         def _parse_features_at_time(self) -> exp.FeaturesAtTime:
-            expr = self.expression(
-                exp.FeaturesAtTime,
-                this=(self._match(TokenType.TABLE) and self._parse_table())
-                or self._parse_select(nested=True),
-            )
+            self._match(TokenType.TABLE)
+            this = self._parse_table()
+
+            expr = self.expression(exp.FeaturesAtTime, this=this)
 
             while self._match(TokenType.COMMA):
                 arg = self._parse_lambda()

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6766,6 +6766,19 @@ class GenerateEmbedding(Func):
     arg_types = {"this": True, "expression": True, "params_struct": False}
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/search_functions#vector_search
+class VectorSearch(Func):
+    arg_types = {
+        "this": True,
+        "column_to_search": True,
+        "query_table": True,
+        "query_column_to_search": False,
+        "top_k": False,
+        "distance_type": False,
+        "options": False,
+    }
+
+
 class Pow(Binary, Func):
     _sql_names = ["POWER", "POW"]
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4191,6 +4191,39 @@ class Generator(metaclass=_Generator):
         parameters = self.sql(expression, "params_struct")
         return self.func("GENERATE_EMBEDDING", model, table, parameters or None)
 
+    def featuresattime_sql(self, expression: exp.FeaturesAtTime) -> str:
+        this_sql = self.sql(expression, "this")
+        if isinstance(expression.this, exp.Table):
+            this_sql = f"TABLE {this_sql}"
+
+        return self.func(
+            "FEATURES_AT_TIME",
+            this_sql,
+            expression.args.get("time"),
+            expression.args.get("num_rows"),
+            expression.args.get("ignore_feature_nulls"),
+        )
+
+    def vectorsearch_sql(self, expression: exp.VectorSearch) -> str:
+        this_sql = self.sql(expression, "this")
+        if isinstance(expression.this, exp.Table):
+            this_sql = f"TABLE {this_sql}"
+
+        query_table = self.sql(expression, "query_table")
+        if isinstance(expression.args.get("query_table"), exp.Table):
+            query_table = f"TABLE {query_table}"
+
+        return self.func(
+            "VECTOR_SEARCH",
+            this_sql,
+            expression.args.get("column_to_search"),
+            query_table,
+            expression.args.get("query_column_to_search"),
+            expression.args.get("top_k"),
+            expression.args.get("distance_type"),
+            expression.args.get("options"),
+        )
+
     def forin_sql(self, expression: exp.ForIn) -> str:
         this = self.sql(expression, "this")
         expression_sql = self.sql(expression, "expression")
@@ -4897,19 +4930,6 @@ class Generator(metaclass=_Generator):
         value = self.sql(expression, "expression")
         value = f" {value}" if value else ""
         return f"{this}{value}"
-
-    def featuresattime_sql(self, expression: exp.FeaturesAtTime) -> str:
-        this_sql = self.sql(expression, "this")
-        if isinstance(expression.this, exp.Table):
-            this_sql = f"TABLE {this_sql}"
-
-        return self.func(
-            "FEATURES_AT_TIME",
-            this_sql,
-            expression.args.get("time"),
-            expression.args.get("num_rows"),
-            expression.args.get("ignore_feature_nulls"),
-        )
 
     def watermarkcolumnconstraint_sql(self, expression: exp.WatermarkColumnConstraint) -> str:
         return (

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4210,7 +4210,7 @@ class Generator(metaclass=_Generator):
             this_sql = f"TABLE {this_sql}"
 
         query_table = self.sql(expression, "query_table")
-        if isinstance(expression.args.get("query_table"), exp.Table):
+        if isinstance(expression.args["query_table"], exp.Table):
             query_table = f"TABLE {query_table}"
 
         return self.func(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1244,7 +1244,6 @@ class Parser(metaclass=_Parser):
         "OPENJSON": lambda self: self._parse_open_json(),
         "OVERLAY": lambda self: self._parse_overlay(),
         "POSITION": lambda self: self._parse_position(),
-        "PREDICT": lambda self: self._parse_predict(),
         "SAFE_CAST": lambda self: self._parse_cast(False, safe=True),
         "STRING_AGG": lambda self: self._parse_string_agg(),
         "SUBSTRING": lambda self: self._parse_substring(),
@@ -6919,20 +6918,6 @@ class Parser(metaclass=_Parser):
 
         return self.expression(
             exp.StrPosition, this=haystack, substr=needle, position=seq_get(args, 2)
-        )
-
-    def _parse_predict(self) -> exp.Predict:
-        self._match_text_seq("MODEL")
-        this = self._parse_table()
-
-        self._match(TokenType.COMMA)
-        self._match_text_seq("TABLE")
-
-        return self.expression(
-            exp.Predict,
-            this=this,
-            expression=self._parse_table(),
-            params_struct=self._match(TokenType.COMMA) and self._parse_bitwise(),
         )
 
     def _parse_join_hint(self, func_name: str) -> exp.JoinHint:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2064,10 +2064,10 @@ OPTIONS (
         )
         assert ast.find(exp.VectorSearch)
         self.validate_identity(
-            "SELECT * FROM VECTOR_SEARCH((SELECT * FROM mydataset.base_table), 'column_to_search', (SELECT * FROM mydataset.query_table), 'query_column_to_search')"
+            "SELECT * FROM VECTOR_SEARCH(TABLE mydataset.base_table, 'column_to_search', TABLE mydataset.query_table, query_column_to_search => 'query_column_to_search', top_k => 2, distance_type => 'cosine', options => '{\"fraction_lists_to_search\":0.15}')"
         )
         self.validate_identity(
-            "SELECT * FROM VECTOR_SEARCH((SELECT * FROM mydataset.base_table), 'column_to_search', (SELECT * FROM mydataset.query_table), query_column_to_search => 'query_column_to_search')"
+            "SELECT * FROM VECTOR_SEARCH((SELECT * FROM mydataset.base_table), 'column_to_search', (SELECT * FROM mydataset.query_table), 'query_column_to_search')"
         )
         self.validate_identity(
             "SELECT * FROM VECTOR_SEARCH(TABLE mydataset.base_table, 'column_to_search', TABLE mydataset.query_table)"

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1986,24 +1986,6 @@ WHERE
 
     def test_models(self):
         self.validate_identity(
-            "SELECT * FROM ML.PREDICT(MODEL mydataset.mymodel, (SELECT label, column1, column2 FROM mydataset.mytable))"
-        )
-        self.validate_identity(
-            "SELECT label, predicted_label1, predicted_label AS predicted_label2 FROM ML.PREDICT(MODEL mydataset.mymodel2, (SELECT * EXCEPT (predicted_label), predicted_label AS predicted_label1 FROM ML.PREDICT(MODEL mydataset.mymodel1, TABLE mydataset.mytable)))"
-        )
-        self.validate_identity(
-            "SELECT * FROM ML.PREDICT(MODEL mydataset.mymodel, (SELECT custom_label, column1, column2 FROM mydataset.mytable), STRUCT(0.55 AS threshold))"
-        )
-        self.validate_identity(
-            "SELECT * FROM ML.PREDICT(MODEL `my_project`.my_dataset.my_model, (SELECT * FROM input_data))"
-        )
-        self.validate_identity(
-            "SELECT * FROM ML.PREDICT(MODEL my_dataset.vision_model, (SELECT uri, ML.RESIZE_IMAGE(ML.DECODE_IMAGE(data), 480, 480, FALSE) AS input FROM my_dataset.object_table))"
-        )
-        self.validate_identity(
-            "SELECT * FROM ML.PREDICT(MODEL my_dataset.vision_model, (SELECT uri, ML.CONVERT_COLOR_SPACE(ML.RESIZE_IMAGE(ML.DECODE_IMAGE(data), 224, 280, TRUE), 'YIQ') AS input FROM my_dataset.object_table WHERE content_type = 'image/jpeg'))"
-        )
-        self.validate_identity(
             "CREATE OR REPLACE MODEL foo OPTIONS (model_type='linear_reg') AS SELECT bla FROM foo WHERE cond"
         )
         self.validate_identity(
@@ -2042,10 +2024,25 @@ OPTIONS (
         )
 
     def test_ml_functions(self):
-        ast = self.validate_identity("SELECT * FROM ML.FEATURES_AT_TIME((SELECT 1), num_rows => 1)")
-        assert ast.find(exp.FeaturesAtTime)
+        ast = self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL mydataset.mymodel, (SELECT label, column1, column2 FROM mydataset.mytable))"
+        )
+        assert ast.find(exp.Predict)
+
         self.validate_identity(
-            "SELECT * FROM ML.FEATURES_AT_TIME(TABLE mydataset.feature_table, time => '2022-06-11 10:00:00+00', num_rows => 1, ignore_feature_nulls => TRUE)"
+            "SELECT label, predicted_label1, predicted_label AS predicted_label2 FROM ML.PREDICT(MODEL mydataset.mymodel2, (SELECT * EXCEPT (predicted_label), predicted_label AS predicted_label1 FROM ML.PREDICT(MODEL mydataset.mymodel1, TABLE mydataset.mytable)))"
+        )
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL mydataset.mymodel, (SELECT custom_label, column1, column2 FROM mydataset.mytable), STRUCT(0.55 AS threshold))"
+        )
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL `my_project`.my_dataset.my_model, (SELECT * FROM input_data))"
+        )
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL my_dataset.vision_model, (SELECT uri, ML.RESIZE_IMAGE(ML.DECODE_IMAGE(data), 480, 480, FALSE) AS input FROM my_dataset.object_table))"
+        )
+        self.validate_identity(
+            "SELECT * FROM ML.PREDICT(MODEL my_dataset.vision_model, (SELECT uri, ML.CONVERT_COLOR_SPACE(ML.RESIZE_IMAGE(ML.DECODE_IMAGE(data), 224, 280, TRUE), 'YIQ') AS input FROM my_dataset.object_table WHERE content_type = 'image/jpeg'))"
         )
 
         ast = self.validate_identity(
@@ -2054,6 +2051,12 @@ OPTIONS (
         assert ast.find(exp.GenerateEmbedding)
         self.validate_identity(
             "SELECT * FROM ML.GENERATE_EMBEDDING(MODEL mydataset.mymodel, TABLE mydataset.mytable, STRUCT(TRUE AS flatten_json_output))"
+        )
+
+        ast = self.validate_identity("SELECT * FROM ML.FEATURES_AT_TIME((SELECT 1), num_rows => 1)")
+        assert ast.find(exp.FeaturesAtTime)
+        self.validate_identity(
+            "SELECT * FROM ML.FEATURES_AT_TIME(TABLE mydataset.feature_table, time => '2022-06-11 10:00:00+00', num_rows => 1, ignore_feature_nulls => TRUE)"
         )
 
     def test_merge(self):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2059,6 +2059,20 @@ OPTIONS (
             "SELECT * FROM ML.FEATURES_AT_TIME(TABLE mydataset.feature_table, time => '2022-06-11 10:00:00+00', num_rows => 1, ignore_feature_nulls => TRUE)"
         )
 
+        ast = self.validate_identity(
+            "SELECT * FROM VECTOR_SEARCH(TABLE mydataset.base_table, 'column_to_search', TABLE mydataset.query_table, 'query_column_to_search', top_k => 2, distance_type => 'cosine', options => '{\"fraction_lists_to_search\":0.15}')"
+        )
+        assert ast.find(exp.VectorSearch)
+        self.validate_identity(
+            "SELECT * FROM VECTOR_SEARCH((SELECT * FROM mydataset.base_table), 'column_to_search', (SELECT * FROM mydataset.query_table), 'query_column_to_search')"
+        )
+        self.validate_identity(
+            "SELECT * FROM VECTOR_SEARCH((SELECT * FROM mydataset.base_table), 'column_to_search', (SELECT * FROM mydataset.query_table), query_column_to_search => 'query_column_to_search')"
+        )
+        self.validate_identity(
+            "SELECT * FROM VECTOR_SEARCH(TABLE mydataset.base_table, 'column_to_search', TABLE mydataset.query_table)"
+        )
+
     def test_merge(self):
         self.validate_all(
             """


### PR DESCRIPTION
Add support for [BigQuery's `VECTOR_SEARCH`](https://cloud.google.com/bigquery/docs/reference/standard-sql/search_functions#vector_search)

Move `PREDICT` parser to `bigquery.py` to align with the rest of ML functions. Move its tests to test_ml_functions (from test_models) for consistency.

Rearrange order of `FEATURES_AT_TIME`, move the code closer to the other similar functions.