### PR TITLE
feat(singlestore): Fixed exp.Xor generation

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -8,6 +8,7 @@ from sqlglot.dialects.dialect import (
     json_extract_segments,
     json_path_key_only_name,
     rename_func,
+    bool_xor_sql,
 )
 from sqlglot.dialects.mysql import MySQL
 from sqlglot.expressions import DataType
@@ -242,6 +243,7 @@ class SingleStore(MySQL):
             exp.JSONPathRoot: lambda *_: "",
             exp.DayOfWeekIso: lambda self, e: f"(({self.func('DAYOFWEEK', e.this)} % 7) + 1)",
             exp.DayOfMonth: rename_func("DAY"),
+            exp.Xor: bool_xor_sql,
         }
         TRANSFORMS.pop(exp.JSONExtractScalar)
 

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -241,3 +241,12 @@ class TestSingleStore(Validator):
                 "": "SELECT DAY_OF_MONTH('2014-04-18')",
             },
         )
+
+    def test_logical(self):
+        self.validate_all(
+            "SELECT (TRUE AND (NOT FALSE)) OR ((NOT TRUE) AND FALSE)",
+            read={
+                "mysql": "SELECT TRUE XOR FALSE",
+                "singlestore": "SELECT (TRUE AND (NOT FALSE)) OR ((NOT TRUE) AND FALSE)",
+            },
+        )


### PR DESCRIPTION
SingleStore doesn't support the `XOR` binary operator.
Changed to expand `XOR` into `AND`/`OR`