### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery APPROX_TOP_COUNT

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -295,6 +295,22 @@ def _annotate_math_functions(self: TypeAnnotator, expression: E) -> E:
     return expression
 
 
+def _annotate_by_args_approx_top(self: TypeAnnotator, expression: exp.ApproxTopK) -> exp.ApproxTopK:
+    self._annotate_args(expression)
+
+    struct_type = exp.DataType(
+        this=exp.DataType.Type.STRUCT,
+        expressions=[expression.this.type, exp.DataType(this=exp.DataType.Type.BIGINT)],
+        nested=True,
+    )
+    self._set_type(
+        expression,
+        exp.DataType(this=exp.DataType.Type.ARRAY, expressions=[struct_type], nested=True),
+    )
+
+    return expression
+
+
 @unsupported_args("ins_cost", "del_cost", "sub_cost")
 def _levenshtein_sql(self: BigQuery.Generator, expression: exp.Levenshtein) -> str:
     max_dist = expression.args.get("max_dist")
@@ -473,7 +489,7 @@ class BigQuery(Dialect):
                 exp.Substring,
             )
         },
-        exp.ApproxTopK: lambda self, e: self._annotate_by_agg_func_arg(e),
+        exp.ApproxTopK: lambda self, e: _annotate_by_args_approx_top(self, e),
         exp.ArgMax: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ArgMin: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Array: _annotate_array,

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -473,6 +473,7 @@ class BigQuery(Dialect):
                 exp.Substring,
             )
         },
+        exp.ApproxTopK: lambda self, e: self._annotate_by_agg_func_arg(e),
         exp.ArgMax: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ArgMin: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Array: _annotate_array,
@@ -624,6 +625,7 @@ class BigQuery(Dialect):
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            "APPROX_TOP_COUNT": exp.ApproxTopK.from_arg_list,
             "CONTAINS_SUBSTR": _build_contains_substring,
             "DATE": _build_date,
             "DATE_ADD": build_date_delta_with_interval(exp.DateAdd),
@@ -1059,6 +1061,7 @@ class BigQuery(Dialect):
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
+            exp.ApproxTopK: rename_func("APPROX_TOP_COUNT"),
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ArgMax: arg_max_or_min_no_count("MAX_BY"),
             exp.ArgMin: arg_max_or_min_no_count("MIN_BY"),

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -651,18 +651,3 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             self._set_type(expression, exp.DataType.Type.UNKNOWN)
 
         return expression
-
-    def _annotate_by_agg_func_arg(self, expression: exp.AggFunc) -> exp.AggFunc:
-        self._annotate_args(expression)
-
-        struct_type = exp.DataType(
-            this=exp.DataType.Type.STRUCT,
-            expressions=[expression.this.type, exp.DataType(this=exp.DataType.Type.BIGINT)],
-            nested=True,
-        )
-        self._set_type(
-            expression,
-            exp.DataType(this=exp.DataType.Type.ARRAY, expressions=[struct_type], nested=True),
-        )
-
-        return expression

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -651,3 +651,18 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
             self._set_type(expression, exp.DataType.Type.UNKNOWN)
 
         return expression
+
+    def _annotate_by_agg_func_arg(self, expression: exp.AggFunc) -> exp.AggFunc:
+        self._annotate_args(expression)
+
+        struct_type = exp.DataType(
+            this=exp.DataType.Type.STRUCT,
+            expressions=[expression.this.type, exp.DataType(this=exp.DataType.Type.BIGINT)],
+            nested=True,
+        )
+        self._set_type(
+            expression,
+            exp.DataType(this=exp.DataType.Type.ARRAY, expressions=[struct_type], nested=True),
+        )
+
+        return expression

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1777,6 +1777,7 @@ WHERE
         self.validate_identity("BYTE_LENGTH('foo')")
         self.validate_identity("BYTE_LENGTH(b'foo')")
         self.validate_identity("CODE_POINTS_TO_STRING([65, 255])")
+        self.validate_identity("APPROX_TOP_COUNT(col, 2)")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -801,6 +801,13 @@ BIGINT;
 FARM_FINGERPRINT(b'foo');
 BIGINT;
 
+# dialect: bigquery
+APPROX_TOP_COUNT(tbl.str_col, 2);
+ARRAY<STRUCT<STRING, BIGINT>>;
+
+# dialect: bigquery
+APPROX_TOP_COUNT(tbl.bigint_col, 2);
+ARRAY<STRUCT<BIGINT, BIGINT>>;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
This PR adds parsing and type annotation support for `APPROX_TOP_COUNT`

**DOCS**
[BigQuery APPROX_TOP_COUNT](https://cloud.google.com/bigquery/docs/reference/standard-sql/approximate_aggregate_functions#approx_top_count)