### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery APPROX_TOP_SUM

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -489,6 +489,7 @@ class BigQuery(Dialect):
                 exp.Substring,
             )
         },
+        exp.ApproxTopSum: lambda self, e: _annotate_by_args_approx_top(self, e),
         exp.ApproxTopK: lambda self, e: _annotate_by_args_approx_top(self, e),
         exp.ArgMax: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ArgMin: lambda self, e: self._annotate_by_args(e, "this"),

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -345,6 +345,7 @@ class ClickHouse(Dialect):
             "LEVENSHTEINDISTANCE": exp.Levenshtein.from_arg_list,
         }
         FUNCTIONS.pop("TRANSFORM")
+        FUNCTIONS.pop("APPROX_TOP_SUM")
 
         AGG_FUNCTIONS = {
             "count",
@@ -379,6 +380,7 @@ class ClickHouse(Dialect):
             "argMax",
             "avgWeighted",
             "topK",
+            "approx_top_sum",
             "topKWeighted",
             "deltaSum",
             "deltaSumTimestamp",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5489,6 +5489,10 @@ class ApproxTopK(AggFunc):
     arg_types = {"this": True, "expression": False, "counters": False}
 
 
+class ApproxTopSum(AggFunc):
+    arg_types = {"this": True, "expression": True, "count": True}
+
+
 class FarmFingerprint(Func):
     arg_types = {"expressions": True}
     is_var_len_args = True

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1778,6 +1778,7 @@ WHERE
         self.validate_identity("BYTE_LENGTH(b'foo')")
         self.validate_identity("CODE_POINTS_TO_STRING([65, 255])")
         self.validate_identity("APPROX_TOP_COUNT(col, 2)")
+        self.validate_identity("ARPOX_TOP_SUM(col, 1.5, 2)")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1280,6 +1280,23 @@ LIFETIME(MIN 0 MAX 0)""",
 
         parse_one("foobar(x)").assert_is(exp.Anonymous)
 
+    def test_approx_top_sum(self):
+        def extract_agg_func(query):
+            return parse_one(query, read="clickhouse").selects[0]
+        
+        self.assertIsInstance(
+            extract_agg_func(
+                "SELECT approx_top_sum(N)(column, weight) FROM t"
+            ),
+            exp.ParameterizedAgg,
+        )
+        self.assertIsInstance(
+            extract_agg_func(
+                "SELECT approx_top_sum(N, reserved)(column, weight) FROM t"
+            ),
+            exp.ParameterizedAgg,
+        )
+
     def test_drop_on_cluster(self):
         for creatable in ("DATABASE", "TABLE", "VIEW", "DICTIONARY", "FUNCTION"):
             with self.subTest(f"Test DROP {creatable} ON CLUSTER"):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1283,17 +1283,13 @@ LIFETIME(MIN 0 MAX 0)""",
     def test_approx_top_sum(self):
         def extract_agg_func(query):
             return parse_one(query, read="clickhouse").selects[0]
-        
+
         self.assertIsInstance(
-            extract_agg_func(
-                "SELECT approx_top_sum(N)(column, weight) FROM t"
-            ),
+            extract_agg_func("SELECT approx_top_sum(N)(column, weight) FROM t"),
             exp.ParameterizedAgg,
         )
         self.assertIsInstance(
-            extract_agg_func(
-                "SELECT approx_top_sum(N, reserved)(column, weight) FROM t"
-            ),
+            extract_agg_func("SELECT approx_top_sum(N, reserved)(column, weight) FROM t"),
             exp.ParameterizedAgg,
         )
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1280,18 +1280,15 @@ LIFETIME(MIN 0 MAX 0)""",
 
         parse_one("foobar(x)").assert_is(exp.Anonymous)
 
-    def test_approx_top_sum(self):
-        def extract_agg_func(query):
-            return parse_one(query, read="clickhouse").selects[0]
-
-        self.assertIsInstance(
-            extract_agg_func("SELECT approx_top_sum(N)(column, weight) FROM t"),
-            exp.ParameterizedAgg,
+        self.validate_identity("SELECT approx_top_sum(column, weight) FROM t").selects[0].assert_is(
+            exp.AnonymousAggFunc
         )
-        self.assertIsInstance(
-            extract_agg_func("SELECT approx_top_sum(N, reserved)(column, weight) FROM t"),
-            exp.ParameterizedAgg,
-        )
+        self.validate_identity("SELECT approx_top_sum(N)(column, weight) FROM t").selects[
+            0
+        ].assert_is(exp.ParameterizedAgg)
+        self.validate_identity("SELECT approx_top_sum(N, reserved)(column, weight) FROM t").selects[
+            0
+        ].assert_is(exp.ParameterizedAgg)
 
     def test_drop_on_cluster(self):
         for creatable in ("DATABASE", "TABLE", "VIEW", "DICTIONARY", "FUNCTION"):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -809,6 +809,14 @@ ARRAY<STRUCT<STRING, BIGINT>>;
 APPROX_TOP_COUNT(tbl.bigint_col, 2);
 ARRAY<STRUCT<BIGINT, BIGINT>>;
 
+# dialect: bigquery
+APPROX_TOP_SUM(tbl.str_col, 1.5, 2);
+ARRAY<STRUCT<STRING, BIGINT>>;
+
+# dialect: bigquery
+APPROX_TOP_SUM(tbl.bigint_col, 1.5, 2);
+ARRAY<STRUCT<BIGINT, BIGINT>>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `APPROX_TOP_SUM`

[BigQuery APPROX_TOP_SUM](https://cloud.google.com/bigquery/docs/reference/standard-sql/approximate_aggregate_functions#approx_top_sum)
[Clickhouse approx_top_sum](https://clickhouse.com/docs/sql-reference/aggregate-functions/reference/approxtopsum)