### PR TITLE
feat(optimizer)!: parse and annotate type for bigquery FROM/TO_BASE32

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -668,6 +668,7 @@ class Dialect(metaclass=_Dialect):
             exp.UnixMillis,
         },
         exp.DataType.Type.BINARY: {
+            exp.FromBase32,
             exp.FromBase64,
         },
         exp.DataType.Type.BOOLEAN: {
@@ -779,6 +780,7 @@ class Dialect(metaclass=_Dialect):
             exp.TimeToStr,
             exp.TimeToTimeStr,
             exp.Trim,
+            exp.ToBase32,
             exp.ToBase64,
             exp.TsOrDsToDateStr,
             exp.UnixToStr,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6237,7 +6237,15 @@ class Floor(Func):
     arg_types = {"this": True, "decimals": False, "to": False}
 
 
+class FromBase32(Func):
+    pass
+
+
 class FromBase64(Func):
+    pass
+
+
+class ToBase32(Func):
     pass
 
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4053,3 +4053,33 @@ FROM subquery2""",
                 "redshift": "FARMFINGERPRINT64(x)",
             },
         )
+
+    def test_from_to_base32(self):
+        self.validate_all(
+            "FROM_BASE32(x)",
+            read={
+                "": "FROM_BASE32(x)",
+                "bigquery": "FROM_BASE32(x)",
+                "presto": "FROM_BASE32(x)",
+                "trino": "FROM_BASE32(x)",
+            },
+            write={
+                "bigquery": "FROM_BASE32(x)",
+                "presto": "FROM_BASE32(x)",
+                "trino": "FROM_BASE32(x)",
+            },
+        )
+        self.validate_all(
+            "TO_BASE32(x)",
+            read={
+                "": "TO_BASE32(x)",
+                "bigquery": "TO_BASE32(x)",
+                "presto": "TO_BASE32(x)",
+                "trino": "TO_BASE32(x)",
+            },
+            write={
+                "bigquery": "TO_BASE32(x)",
+                "presto": "TO_BASE32(x)",
+                "trino": "TO_BASE32(x)",
+            },
+        )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -52,6 +52,9 @@ ARRAY<DOUBLE>;
 ARRAY_SLICE([1, 1.5], 1, 2);
 ARRAY<DOUBLE>;
 
+FROM_BASE32(tbl.str_col);
+BINARY;
+
 FROM_BASE64(tbl.str_col);
 BINARY;
 
@@ -69,6 +72,9 @@ BIGINT;
 
 LAST_VALUE(tbl.bigint_col) OVER (ORDER BY tbl.bigint_col);
 BIGINT;
+
+TO_BASE32(tbl.bytes_col);
+VARCHAR;
 
 TO_BASE64(tbl.bytes_col);
 VARCHAR;


### PR DESCRIPTION
This PR adds parsing and type annotation support for `FROM_BASE32` and `TO_BASE32`

**DOCS**
[BigQuery FROM_BASE32](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#from_base32)
[BigQuery TO_BASE32](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#to_base32)
[Presto FROM_BASE32](https://prestodb.io/docs/current/functions/binary.html#from_base32-string-varbinary)
[Presto TO_BASE32](https://prestodb.io/docs/current/functions/binary.html#to_base32-binary-varchar)
[Trino FROM_BASE32](https://trino.io/docs/current/functions/binary.html#from_base32)
[Trino TO_BASE32](https://trino.io/docs/current/functions/binary.html#to_base32)