### PR TITLE
feat(databricks):  handle unsupported isnumeric

### DIFF
--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -397,3 +397,6 @@ class TestDatabricks(Validator):
 
         result = transpile(sql, read="dremio", write="databricks")[0]
         assert "CAST(12345 AS STRING)" in result
+
+    def test_isnumeric_function(self):
+        self.validate_identity("SELECT ISNUMERIC(5)", "SELECT TRY_CAST(5 AS DOUBLE) IS NOT NULL")


### PR DESCRIPTION
Databricks doesn't have isnumeric.  The standard way is to do a try_cast.  Try cast does not exist in the parent spark dialect so implementing the transform here.

Let me know if i should move the isnumeric class up to expressions.py.  I can't find examples of other dialects trying to parse this.