### PR TITLE
feat(optimizer)!: annotate type for bigquery TO_HEX

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -526,6 +526,7 @@ class BigQuery(Dialect):
         ),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
+        exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -526,7 +526,7 @@ class BigQuery(Dialect):
         ),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
-        exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
+        exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -829,7 +829,7 @@ BINARY;
 
 # dialect: bigquery
 TO_HEX(b'foo');
-BINARY;
+STRING;
 
 --------------------------------------
 -- Snowflake

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -827,6 +827,10 @@ ARRAY<STRUCT<BIGINT, BIGINT>>;
 FROM_HEX('foo');
 BINARY;
 
+# dialect: bigquery
+TO_HEX(b'foo');
+BINARY;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation support for `TO_HEX`

**DOCS**
[BigQuery TO_HEX](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#to_hex)