### PR TITLE
feat(optimizer)!: parse and annotate type for bq SAFE_CONVERT_BYTES_TO_STRING

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -531,6 +531,9 @@ class BigQuery(Dialect):
         exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.Replace: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Reverse: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.SafeConvertBytesToString: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.VARCHAR
+        ),
         exp.Soundex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.SHA: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.SHA2: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6915,6 +6915,10 @@ class SafeDivide(Func):
     arg_types = {"this": True, "expression": True}
 
 
+class SafeConvertBytesToString(Func):
+    pass
+
+
 class SHA(Func):
     _sql_names = ["SHA", "SHA1"]
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1779,6 +1779,7 @@ WHERE
         self.validate_identity("CODE_POINTS_TO_STRING([65, 255])")
         self.validate_identity("APPROX_TOP_COUNT(col, 2)")
         self.validate_identity("ARPOX_TOP_SUM(col, 1.5, 2)")
+        self.validate_identity("SAFE_CONVERT_BYTES_TO_STRING(b'\xc2')")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -817,6 +817,10 @@ ARRAY<STRUCT<STRING, BIGINT>>;
 APPROX_TOP_SUM(tbl.bigint_col, 1.5, 2);
 ARRAY<STRUCT<BIGINT, BIGINT>>;
 
+# dialect: bigquery
+SAFE_CONVERT_BYTES_TO_STRING(b'\xc2');
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `SAFE_CONVERT_BYTES_TO_STRING`

**DOCS**
[BigQuery SAFE_CONVERT_BYTES_TO_STRING](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#safe_convert_bytes_to_string)