### PR TITLE
feat(optimizer)!: parse and annotate type for bq CODE_POINTS_TO_BYTES

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -502,6 +502,9 @@ class BigQuery(Dialect):
         exp.BitwiseCountAgg: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.ByteLength: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.ByteString: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
+        exp.CodePointsToBytes: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.BINARY
+        ),
         exp.CodePointsToString: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.VARCHAR
         ),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5612,6 +5612,10 @@ class ToDouble(Func):
     }
 
 
+class CodePointsToBytes(Func):
+    pass
+
+
 class Columns(Func):
     arg_types = {"this": True, "unpack": False}
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1780,6 +1780,7 @@ WHERE
         self.validate_identity("APPROX_TOP_COUNT(col, 2)")
         self.validate_identity("ARPOX_TOP_SUM(col, 1.5, 2)")
         self.validate_identity("FROM_HEX('foo')")
+        self.validate_identity("CODE_POINTS_TO_BYTES([65, 98])")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -831,6 +831,10 @@ BINARY;
 TO_HEX(b'foo');
 STRING;
 
+# dialect: bigquery
+CODE_POINTS_TO_BYTES([65, 98]);
+BINARY;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for `CODE_POINTS_TO_BYTES`

**DOCS**
[BigQuery CODE_POINTS_TO_BYTES](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#code_points_to_bytes)