### PR TITLE
feat(optimizer)!: parse and annotate type for bq PARSE_BIG/NUMERIC

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -530,6 +530,10 @@ class BigQuery(Dialect):
         exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
+        exp.ParseBignumeric: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.Type.BIGDECIMAL
+        ),
+        exp.ParseNumeric: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DECIMAL),
         exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.Replace: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Reverse: lambda self, e: self._annotate_by_args(e, "this"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6605,6 +6605,14 @@ class JSONArrayContains(Binary, Predicate, Func):
     _sql_names = ["JSON_ARRAY_CONTAINS"]
 
 
+class ParseBignumeric(Func):
+    pass
+
+
+class ParseNumeric(Func):
+    pass
+
+
 class ParseJSON(Func):
     # BigQuery, Snowflake have PARSE_JSON, Presto has JSON_PARSE
     # Snowflake also has TRY_PARSE_JSON, which is represented using `safe`

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1780,6 +1780,8 @@ WHERE
         self.validate_identity("APPROX_TOP_COUNT(col, 2)")
         self.validate_identity("ARPOX_TOP_SUM(col, 1.5, 2)")
         self.validate_identity("FROM_HEX('foo')")
+        self.validate_identity("PARSE_BIGNUMERIC('1.2')")
+        self.validate_identity("PARSE_NUMERIC('1.2')")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -831,6 +831,14 @@ BINARY;
 TO_HEX(b'foo');
 STRING;
 
+# dialect: bigquery
+PARSE_BIGNUMERIC('1.2');
+BIGDECIMAL;
+
+# dialect: bigquery
+PARSE_NUMERIC('1.2');
+DECIMAL;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `PARSE_NUMERIC` and `PARSE_BIGNUMERIC`

**DOCS**
[BigQuery PARSE_NUMERIC](https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#parse_numeric)
[BigQuery PARSE_BIGNUMERIC](https://cloud.google.com/bigquery/docs/reference/standard-sql/conversion_functions#parse_bignumeric)