### PR TITLE
feat(singlestore): Fixed generation/parsing of exp.RegexpExtract

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -159,6 +159,13 @@ class SingleStore(MySQL):
                 quantile=seq_get(args, 1),
                 error_tolerance=seq_get(args, 2),
             ),
+            "REGEXP_SUBSTR": lambda args: exp.RegexpExtract(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                position=seq_get(args, 2),
+                occurrence=seq_get(args, 3),
+                parameters=seq_get(args, 4),
+            ),
         }
 
         CAST_COLUMN_OPERATORS = {TokenType.COLON_GT, TokenType.NCOLON_GT}
@@ -281,6 +288,16 @@ class SingleStore(MySQL):
             exp.Variance: rename_func("VAR_SAMP"),
             exp.Xor: bool_xor_sql,
             exp.RegexpLike: lambda self, e: self.binary(e, "RLIKE"),
+            exp.RegexpExtract: unsupported_args("group")(
+                lambda self, e: self.func(
+                    "REGEXP_SUBSTR",
+                    e.this,
+                    e.expression,
+                    e.args.get("position"),
+                    e.args.get("occurrence"),
+                    e.args.get("parameters"),
+                )
+            ),
         }
         TRANSFORMS.pop(exp.JSONExtractScalar)
 

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -336,3 +336,11 @@ class TestSingleStore(Validator):
             },
         )
         self.validate_identity("SELECT 'a' REGEXP 'b'", "SELECT 'a' RLIKE 'b'")
+        self.validate_all(
+            "SELECT REGEXP_SUBSTR('adog', 'O', 1, 1, 'c')",
+            read={
+                # group parameter is not supported in SingleStore, so it is ignored
+                "": "SELECT REGEXP_EXTRACT('adog', 'O', 1, 1, 'c', 'gr1')",
+                "singlestore": "SELECT REGEXP_SUBSTR('adog', 'O', 1, 1, 'c')",
+            },
+        )


### PR DESCRIPTION
[REGEXP_SUBSTR](https://docs.singlestore.com/cloud/reference/sql-reference/regular-expression-functions/regexp-substr/)