### PR TITLE
feat(singlestore): Fixed parsing/generation of exp.RegexpExtractAll

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -159,6 +159,11 @@ class SingleStore(MySQL):
                 quantile=seq_get(args, 1),
                 error_tolerance=seq_get(args, 2),
             ),
+            "REGEXP_MATCH": lambda args: exp.RegexpExtractAll(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                parameters=seq_get(args, 2),
+            ),
         }
 
         CAST_COLUMN_OPERATORS = {TokenType.COLON_GT, TokenType.NCOLON_GT}
@@ -281,6 +286,14 @@ class SingleStore(MySQL):
             exp.Variance: rename_func("VAR_SAMP"),
             exp.Xor: bool_xor_sql,
             exp.RegexpLike: lambda self, e: self.binary(e, "RLIKE"),
+            exp.RegexpExtractAll: unsupported_args("position", "occurrence", "group")(
+                lambda self, e: self.func(
+                    "REGEXP_MATCH",
+                    e.this,
+                    e.expression,
+                    e.args.get("parameters"),
+                )
+            ),
         }
         TRANSFORMS.pop(exp.JSONExtractScalar)
 

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -336,3 +336,11 @@ class TestSingleStore(Validator):
             },
         )
         self.validate_identity("SELECT 'a' REGEXP 'b'", "SELECT 'a' RLIKE 'b'")
+        self.validate_all(
+            "SELECT REGEXP_MATCH('adog', 'O', 'c')",
+            read={
+                # group, position, occurrence parameters are not supported in SingleStore, so they are ignored
+                "": "SELECT REGEXP_EXTRACT_ALL('adog', 'O', 1, 1, 'c', 'gr1')",
+                "singlestore": "SELECT REGEXP_MATCH('adog', 'O', 'c')",
+            },
+        )


### PR DESCRIPTION
[REGEXP_MATCH](https://docs.singlestore.com/cloud/reference/sql-reference/regular-expression-functions/regexp-match/)