### PR TITLE
feat(singlestore): Fixed generation of exp.StartsWith

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -324,6 +324,9 @@ class SingleStore(MySQL):
                     e.args.get("parameters"),
                 )
             ),
+            exp.StartsWith: lambda self, e: self.func(
+                "REGEXP_INSTR", e.this, self.func("CONCAT", exp.Literal.string("^"), e.expression)
+            ),
         }
         TRANSFORMS.pop(exp.JSONExtractScalar)
 

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -398,3 +398,10 @@ class TestSingleStore(Validator):
                 "singlestore": "SELECT REGEXP_SUBSTR('adog', 'O', 1, 1, 'c')",
             },
         )
+        self.validate_all(
+            "SELECT REGEXP_INSTR('abcd', CONCAT('^', 'ab'))",
+            read={
+                "": "SELECT STARTS_WITH('abcd', 'ab')",
+                "singlestore": "SELECT REGEXP_INSTR('abcd', CONCAT('^', 'ab'))",
+            },
+        )


### PR DESCRIPTION
[REGEXP_INSTR](https://docs.singlestore.com/cloud/reference/sql-reference/regular-expression-functions/regexp-instr/)
[CONCAT](https://docs.singlestore.com/cloud/reference/sql-reference/string-functions/concat/)