### PR TITLE
feat(singlestore): Added SingleStoreDB alias to the SingleStore dialect

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -87,6 +87,7 @@ DIALECTS = [
     "Redshift",
     "RisingWave",
     "SingleStore",
+    "SingleStoreDB",
     "Snowflake",
     "Spark",
     "Spark2",

--- a/sqlglot/dialects/singlestoredb.py
+++ b/sqlglot/dialects/singlestoredb.py
@@ -1,0 +1,5 @@
+from sqlglot.dialects.singlestore import SingleStore
+
+
+class SingleStoreDB(SingleStore):
+    pass

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -412,3 +412,11 @@ class TestSingleStore(Validator):
                 "singlestore": "SELECT CONV('f', 16, 10)",
             },
         )
+
+    def test_singlestoredb_alias(self):
+        self.validate_all(
+            "SELECT 1",
+            read={
+                "singlestoredb": "SELECT 1",
+            },
+        )


### PR DESCRIPTION
This PR introduces an alias for the `singlestore` dialect under the name `singlestoredb`.
The official Python SDK, Ibis, and SQLAlchemy use `singlestoredb` as the canonical dialect/driver name.
This change makes the naming consistent across the SingleStore ecosystem, removes integration issues (especially with Ibis), and improves the developer experience without breaking existing code.