### PR TITLE
feat(optimizer)!: annotate type for bq CONTAINS_SUBSTR

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -507,7 +507,7 @@ class BigQuery(Dialect):
             e, exp.DataType.Type.VARCHAR
         ),
         exp.Concat: _annotate_concat,
-        exp.Contains: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
+        exp.Contains: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BOOLEAN),
         exp.Corr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarSamp: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5942,8 +5942,9 @@ class ConcatWs(Concat):
     _sql_names = ["CONCAT_WS"]
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#contains_substr
 class Contains(Func):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": True, "json_scope": False}
 
 
 # https://docs.oracle.com/cd/B13789_01/server.101/b10759/operators004.htm#i1035022

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1693,9 +1693,7 @@ WHERE
             },
         )
 
-        self.validate_identity(
-            "CONTAINS_SUBSTR(a, b, json_scope => 'JSON_KEYS_AND_VALUES')"
-        ).assert_is(exp.Anonymous)
+        self.validate_identity("CONTAINS_SUBSTR(a, b, json_scope => 'JSON_KEYS_AND_VALUES')")
 
         self.validate_all(
             """CONTAINS_SUBSTR(a, b)""",

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -883,6 +883,14 @@ FLOAT64;
 FLOAT64(PARSE_JSON('9.8'), wide_number_mode => 'round');
 FLOAT64;
 
+# dialect: bigquery
+CONTAINS_SUBSTR('aa', 'a');
+STRING;
+
+# dialect: bigquery
+CONTAINS_SUBSTR(PARSE_JSON('{"lunch":"soup"}'), 'lunch', json_scope => 'JSON_VALUES');
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -885,11 +885,11 @@ FLOAT64;
 
 # dialect: bigquery
 CONTAINS_SUBSTR('aa', 'a');
-STRING;
+BOOLEAN;
 
 # dialect: bigquery
 CONTAINS_SUBSTR(PARSE_JSON('{"lunch":"soup"}'), 'lunch', json_scope => 'JSON_VALUES');
-STRING;
+BOOLEAN;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
This PR adds parsing support for 3-arg `CONTAINS_SUBSTR` and also type annotation

**DOCS**
[BigQuery CONTAINS_SUBSTR](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#contains_substr)