### PR TITLE
feat(singlestore): Fixed parsing/generation of exp.DateBin

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -113,6 +113,11 @@ class SingleStore(MySQL):
             % 7,
             "UNIX_TIMESTAMP": exp.StrToUnix.from_arg_list,
             "FROM_UNIXTIME": build_formatted_time(exp.UnixToTime, "mysql"),
+            "TIME_BUCKET": lambda args: exp.DateBin(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                origin=seq_get(args, 2),
+            ),
             "BSON_EXTRACT_BSON": build_json_extract_path(exp.JSONBExtract),
             "BSON_EXTRACT_STRING": build_json_extract_path(
                 exp.JSONBExtractScalar, json_type="STRING"
@@ -263,6 +268,9 @@ class SingleStore(MySQL):
                 ),
             ),
             exp.UnixToTimeStr: lambda self, e: f"FROM_UNIXTIME({self.sql(e, 'this')}) :> TEXT",
+            exp.DateBin: unsupported_args("unit", "zone")(
+                lambda self, e: self.func("TIME_BUCKET", e.this, e.expression, e.args.get("origin"))
+            ),
             exp.JSONExtract: unsupported_args(
                 "only_json_types",
                 "expressions",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5998,7 +5998,7 @@ class DateAdd(Func, IntervalOp):
 
 
 class DateBin(Func, IntervalOp):
-    arg_types = {"this": True, "expression": True, "unit": False, "zone": False}
+    arg_types = {"this": True, "expression": True, "unit": False, "zone": False, "origin": False}
 
 
 class DateSub(Func, IntervalOp):

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -412,3 +412,13 @@ class TestSingleStore(Validator):
                 "singlestore": "SELECT CONV('f', 16, 10)",
             },
         )
+
+    def test_time_functions(self):
+        self.validate_all(
+            "SELECT TIME_BUCKET('1d', '2019-03-14 06:04:12', '2019-03-13 03:00:00')",
+            read={
+                # unit and zone parameters are not supported in SingleStore, so they are ignored
+                "": "SELECT DATE_BIN('1d', '2019-03-14 06:04:12', DAY, 'UTC', '2019-03-13 03:00:00')",
+                "singlestore": "SELECT TIME_BUCKET('1d', '2019-03-14 06:04:12', '2019-03-13 03:00:00')",
+            },
+        )


### PR DESCRIPTION
[TIME_BUCKET](https://docs.singlestore.com/cloud/reference/sql-reference/time-series-functions/time-bucket/)