### PR TITLE
feat(optimizer)!: annotate type for bq NORMALIZE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -532,6 +532,7 @@ class BigQuery(Dialect):
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
+        exp.Normalize: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
         exp.ParseBignumeric: lambda self, e: self._annotate_with_type(

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -891,6 +891,14 @@ BOOLEAN;
 CONTAINS_SUBSTR(PARSE_JSON('{"lunch":"soup"}'), 'lunch', json_scope => 'JSON_VALUES');
 BOOLEAN;
 
+# dialect: bigquery
+NORMALIZE('\u00ea');
+STRING;
+
+# dialect: bigquery
+NORMALIZE('\u00ea', NFKC);
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `NORMALIZE`

**DOCS**
[BigQuery NORMALIZE](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#normalize)