### PR TITLE
feat(optimizer)!: parse and annotate type for bq NORMALIZE_AND_CASEFOLD

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -688,6 +688,9 @@ class BigQuery(Dialect):
             "JSON_VALUE_ARRAY": _build_extract_json_with_default_path(exp.JSONValueArray),
             "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
             "MD5": exp.MD5Digest.from_arg_list,
+            "NORMALIZE_AND_CASEFOLD": lambda args: exp.Normalize(
+                this=seq_get(args, 0), form=seq_get(args, 1), is_casefold=True
+            ),
             "TO_HEX": _build_to_hex,
             "PARSE_DATE": lambda args: build_formatted_time(exp.StrToDate, "bigquery")(
                 [seq_get(args, 1), seq_get(args, 0)]
@@ -1197,6 +1200,11 @@ class BigQuery(Dialect):
             exp.MD5: lambda self, e: self.func("TO_HEX", self.func("MD5", e.this)),
             exp.MD5Digest: rename_func("MD5"),
             exp.Min: min_or_least,
+            exp.Normalize: lambda self, e: self.func(
+                "NORMALIZE_AND_CASEFOLD" if e.args.get("is_casefold") else "NORMALIZE",
+                e.this,
+                e.args.get("form"),
+            ),
             exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
             exp.RegexpExtract: lambda self, e: self.func(
                 "REGEXP_EXTRACT",

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6793,7 +6793,7 @@ class Nvl2(Func):
 
 
 class Normalize(Func):
-    arg_types = {"this": True, "form": False}
+    arg_types = {"this": True, "form": False, "is_casefold": False}
 
 
 class Overlay(Func):

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1793,6 +1793,8 @@ WHERE
         self.validate_identity("FLOAT64(PARSE_JSON('9.8'))")
         self.validate_identity("FLOAT64(PARSE_JSON('9.8'), wide_number_mode => 'round')")
         self.validate_identity("FLOAT64(PARSE_JSON('9.8'), wide_number_mode => 'exact')")
+        self.validate_identity("NORMALIZE_AND_CASEFOLD('foo')")
+        self.validate_identity("NORMALIZE_AND_CASEFOLD('foo', NFKC)")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -899,6 +899,14 @@ STRING;
 NORMALIZE('\u00ea', NFKC);
 STRING;
 
+# dialect: bigquery
+NORMALIZE_AND_CASEFOLD('\u00ea', NFKC);
+STRING;
+
+# dialect: bigquery
+NORMALIZE_AND_CASEFOLD('\u00ea', NFKC);
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `NORMALIZE_AND_CASEFOLD`

**DOCS**
[BigQuery NORMALIZE_AND_CASEFOLD](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#normalize_and_casefold)