### PR TITLE
feat(optimizer)!: parse and annotate type for bq OCTET_LENGTH

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -691,6 +691,7 @@ class BigQuery(Dialect):
             "NORMALIZE_AND_CASEFOLD": lambda args: exp.Normalize(
                 this=seq_get(args, 0), form=seq_get(args, 1), is_casefold=True
             ),
+            "OCTET_LENGTH": exp.ByteLength.from_arg_list,
             "TO_HEX": _build_to_hex,
             "PARSE_DATE": lambda args: build_formatted_time(exp.StrToDate, "bigquery")(
                 [seq_get(args, 1), seq_get(args, 0)]
@@ -1157,6 +1158,7 @@ class BigQuery(Dialect):
             exp.ArrayContains: _array_contains_sql,
             exp.ArrayFilter: filter_array_using_unnest,
             exp.ArrayRemove: filter_array_using_unnest,
+            exp.ByteLength: rename_func("BYTE_LENGTH"),
             exp.Cast: transforms.preprocess([transforms.remove_precision_parameterized_types]),
             exp.CollateProperty: lambda self, e: (
                 f"DEFAULT COLLATE {self.sql(e, 'this')}"

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1795,6 +1795,14 @@ WHERE
         self.validate_identity("FLOAT64(PARSE_JSON('9.8'), wide_number_mode => 'exact')")
         self.validate_identity("NORMALIZE_AND_CASEFOLD('foo')")
         self.validate_identity("NORMALIZE_AND_CASEFOLD('foo', NFKC)")
+        self.validate_identity(
+            "OCTET_LENGTH('foo')",
+            "BYTE_LENGTH('foo')",
+        )
+        self.validate_identity(
+            "OCTET_LENGTH(b'foo')",
+            "BYTE_LENGTH(b'foo')",
+        )
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -907,6 +907,10 @@ STRING;
 NORMALIZE_AND_CASEFOLD('\u00ea', NFKC);
 STRING;
 
+# dialect: bigquery
+OCTET_LENGTH("foo");
+BIGINT;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for `OCTET_LENGTH`

**DOCS**
[BigQuery OCTET_LENGTH](https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#octet_length)