### PR TITLE
feat(optimizer)!: annotate type for bq FIRST_VALUE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -514,12 +514,14 @@ class BigQuery(Dialect):
         exp.DateFromUnixDate: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATE),
         exp.DateTrunc: lambda self, e: self._annotate_by_args(e, "this"),
         exp.FarmFingerprint: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
+        exp.FirstValue: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Unhex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Float64: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.GenerateTimestampArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<TIMESTAMP>", dialect="bigquery")
         ),
         exp.Grouping: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
+        exp.IgnoreNulls: lambda self, e: self._annotate_by_args(e, "this"),
         exp.JSONArray: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONBool: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BOOLEAN),
         exp.JSONExtractScalar: lambda self, e: self._annotate_with_type(
@@ -542,6 +544,7 @@ class BigQuery(Dialect):
         exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.RegexpInstr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.Replace: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.RespectNulls: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Reverse: lambda self, e: self._annotate_by_args(e, "this"),
         exp.RowNumber: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.SafeConvertBytesToString: lambda self, e: self._annotate_with_type(

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -923,6 +923,30 @@ BIGINT;
 ROW_NUMBER() OVER (ORDER BY 1);
 BIGINT;
 
+# dialect: bigquery
+FIRST_VALUE(tbl.bigint_col);
+BIGINT;
+
+# dialect: bigquery
+FIRST_VALUE(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+FIRST_VALUE(tbl.bigint_col RESPECT NULLS);
+BIGINT;
+
+# dialect: bigquery
+FIRST_VALUE(tbl.bigint_col IGNORE NULLS);
+BIGINT;
+
+# dialect: bigquery
+FIRST_VALUE(tbl.str_col RESPECT NULLS);
+STRING;
+
+# dialect: bigquery
+FIRST_VALUE(tbl.str_col IGNORE NULLS);
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `FIRST_VALUE`

**DOCS**
[BigQuery FIRST_VALUE](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#first_value)