### PR TITLE
feat(optimizer)!: annotate type for bq LEAD

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -532,6 +532,7 @@ class BigQuery(Dialect):
         ),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
+        exp.Lead: lambda self, e: self._annotate_by_args(e, "this"),
         exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Normalize: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -947,6 +947,22 @@ STRING;
 FIRST_VALUE(tbl.str_col IGNORE NULLS);
 STRING;
 
+# dialect: bigquery
+LEAD(tbl.bigint_col);
+BIGINT;
+
+# dialect: bigquery
+LEAD(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+LEAD(tbl.bigint_col, 2);
+BIGINT;
+
+# dialect: bigquery
+LEAD(tbl.str_col, 2);
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `LEAD`

**DOCS**
[BigQuery LEAD](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#lead)