### PR TITLE
feat(optimizer)!: annotate type for bq NTH_VALUE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -535,6 +535,7 @@ class BigQuery(Dialect):
         exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.MD5Digest: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
         exp.Normalize: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
+        exp.NthValue: lambda self, e: self._annotate_by_args(e, "this"),
         exp.ParseTime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.TIME),
         exp.ParseDatetime: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATETIME),
         exp.ParseBignumeric: lambda self, e: self._annotate_with_type(

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -924,27 +924,51 @@ ROW_NUMBER() OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery
-FIRST_VALUE(tbl.bigint_col);
+FIRST_VALUE(tbl.bigint_col) OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery
-FIRST_VALUE(tbl.str_col);
+FIRST_VALUE(tbl.str_col) OVER (ORDER BY 1);
 STRING;
 
 # dialect: bigquery
-FIRST_VALUE(tbl.bigint_col RESPECT NULLS);
+FIRST_VALUE(tbl.bigint_col RESPECT NULLS) OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery
-FIRST_VALUE(tbl.bigint_col IGNORE NULLS);
+FIRST_VALUE(tbl.bigint_col IGNORE NULLS) OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery
-FIRST_VALUE(tbl.str_col RESPECT NULLS);
+FIRST_VALUE(tbl.str_col RESPECT NULLS) OVER (ORDER BY 1);
 STRING;
 
 # dialect: bigquery
-FIRST_VALUE(tbl.str_col IGNORE NULLS);
+FIRST_VALUE(tbl.str_col IGNORE NULLS) OVER (ORDER BY 1);
+STRING;
+
+# dialect: bigquery
+NTH_VALUE(tbl.bigint_col, 2) OVER (ORDER BY 1);
+BIGINT;
+
+# dialect: bigquery
+NTH_VALUE(tbl.str_col, 2) OVER (ORDER BY 1);
+STRING;
+
+# dialect: bigquery
+NTH_VALUE(tbl.bigint_col, 2 RESPECT NULLS) OVER (ORDER BY 1);
+BIGINT;
+
+# dialect: bigquery
+NTH_VALUE(tbl.str_col, 2 RESPECT NULLS) OVER (ORDER BY 1);
+STRING;
+
+# dialect: bigquery
+NTH_VALUE(tbl.bigint_col, 2 IGNORE NULLS) OVER (ORDER BY 1);
+BIGINT;
+
+# dialect: bigquery
+NTH_VALUE(tbl.str_col, 2 IGNORE NULLS) OVER (ORDER BY 1);
 STRING;
 
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `NTH_VALUE`.

Moreover, a refactor was made in the tests for window functions in order to include an `over`. 

**DOCS**
[BigQuery NTH_VALUE](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#nth_value)