### PR TITLE
feat(optimizer)!: annotate type for bq PERCENTILE_DISC

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -541,6 +541,7 @@ class BigQuery(Dialect):
             e, exp.DataType.Type.BIGDECIMAL
         ),
         exp.ParseNumeric: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DECIMAL),
+        exp.PercentileDisc: lambda self, e: self._annotate_by_args(e, "this"),
         exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.RegexpInstr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.Replace: lambda self, e: self._annotate_by_args(e, "this"),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -948,7 +948,7 @@ FIRST_VALUE(tbl.str_col IGNORE NULLS);
 STRING;
 
 # dialect: bigquery
-PERCENTILE_DISC(tbl.bigint, 0.5) OVER (ORDER BY 1);
+PERCENTILE_DISC(tbl.bigint_col, 0.5) OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery
@@ -956,7 +956,7 @@ PERCENTILE_DISC(tbl.str_col, 0.5) OVER (ORDER BY 1);
 STRING;
 
 # dialect: bigquery
-PERCENTILE_DISC(tbl.bigint, 0.5 RESPECT NULLS) OVER (ORDER BY 1);
+PERCENTILE_DISC(tbl.bigint_col, 0.5 RESPECT NULLS) OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery
@@ -964,7 +964,7 @@ PERCENTILE_DISC(tbl.str_col, 0.5 RESPECT NULLS) OVER (ORDER BY 1);
 STRING;
 
 # dialect: bigquery
-PERCENTILE_DISC(tbl.bigint, 0.5 IGNORE NULLS) OVER (ORDER BY 1);
+PERCENTILE_DISC(tbl.bigint_col, 0.5 IGNORE NULLS) OVER (ORDER BY 1);
 BIGINT;
 
 # dialect: bigquery

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -947,6 +947,30 @@ STRING;
 FIRST_VALUE(tbl.str_col IGNORE NULLS);
 STRING;
 
+# dialect: bigquery
+PERCENTILE_DISC(tbl.bigint, 0.5) OVER (ORDER BY 1);
+BIGINT;
+
+# dialect: bigquery
+PERCENTILE_DISC(tbl.str_col, 0.5) OVER (ORDER BY 1);
+STRING;
+
+# dialect: bigquery
+PERCENTILE_DISC(tbl.bigint, 0.5 RESPECT NULLS) OVER (ORDER BY 1);
+BIGINT;
+
+# dialect: bigquery
+PERCENTILE_DISC(tbl.str_col, 0.5 RESPECT NULLS) OVER (ORDER BY 1);
+STRING;
+
+# dialect: bigquery
+PERCENTILE_DISC(tbl.bigint, 0.5 IGNORE NULLS) OVER (ORDER BY 1);
+BIGINT;
+
+# dialect: bigquery
+PERCENTILE_DISC(tbl.str_col, 0.5 IGNORE NULLS) OVER (ORDER BY 1);
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `PERCENTILE_DISC`

**DOCS**
[BigQuery PERCENTILE_DISC](https://cloud.google.com/bigquery/docs/reference/standard-sql/navigation_functions#percentile_disc)