### PR TITLE
feat(optimizer)!: parse and annotate type for bq CUME_DIST

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -539,6 +539,7 @@ class BigQuery(Dialect):
         exp.Corr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarPop: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CovarSamp: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
+        exp.CumeDist: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.DateFromUnixDate: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATE),
         exp.DateTrunc: lambda self, e: self._annotate_by_args(e, "this"),
         exp.FarmFingerprint: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7287,6 +7287,12 @@ class Corr(Binary, AggFunc):
     pass
 
 
+# https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CUME_DIST.html
+class CumeDist(AggFunc):
+    arg_types = {"expressions": False}
+    is_var_len_args = True
+
+
 class Variance(AggFunc):
     _sql_names = ["VARIANCE", "VARIANCE_SAMP", "VAR_SAMP"]
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1045,7 +1045,7 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_identity(
-            "SELECT CUME_DIST(ORDER BY foo) OVER (ORDER BY 1) FROM (SELECT 1 AS foo)"
+            "SELECT CUME_DIST( ORDER BY foo) OVER (ORDER BY 1) FROM (SELECT 1 AS foo)"
         )
 
     def test_array_index(self):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1044,6 +1044,9 @@ class TestDuckDB(Validator):
                 "spark": "SELECT CONCAT(COALESCE(ARRAY('abc'), ARRAY()), ARRAY('bcg'))",
             },
         )
+        self.validate_identity(
+            "SELECT CUME_DIST(ORDER BY foo) OVER (ORDER BY 1) FROM (SELECT 1 AS foo)"
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -350,6 +350,9 @@ class TestOracle(Validator):
         self.validate_identity(
             "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 P.M.', 'DD Mon YYYY HH12:MI P.M.')"
         )
+        self.validate_identity(
+            "SELECT CUME_DIST(15, 0.05) WITHIN GROUP (ORDER BY col1, col2) FROM t"
+        )
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -903,3 +903,4 @@ SELECT ARG_MAX(DISTINCT selected_col, filtered_col) FROM table
 SELECT ARG_MIN(DISTINCT selected_col, filtered_col) FROM table
 a.b.c.D()
 a.b.c.d.e.f.G()
+SELECT CUME_DIST() OVER (ORDER BY 1) FROM (SELECT 1)

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1051,6 +1051,10 @@ FLOAT64;
 PERCENTILE_CONT(CAST(1 AS FLOAT64), CAST(1 AS FLOAT64)) OVER (ORDER BY 1);
 FLOAT64;
 
+# dialect: bigquery
+CUME_DIST() OVER (ORDER BY 1);
+DOUBLE;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `CUME_DIST`

[BigQuery CUME_DIST](https://cloud.google.com/bigquery/docs/reference/standard-sql/numbering_functions#cume_dist)
[T-SQL CUME_DIST](https://learn.microsoft.com/en-us/sql/t-sql/functions/cume-dist-transact-sql?view=sql-server-ver17)
[Snowflake CUME_DIST](https://learn.microsoft.com/en-us/sql/t-sql/functions/cume-dist-transact-sql?view=sql-server-ver17)
[Databricks CUME_DIST](https://docs.databricks.com/aws/en/sql/language-manual/functions/cume_dist)
[Oracle CUME_DIST](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/CUME_DIST.html)
[Redshift CUME_DIST](https://docs.aws.amazon.com/redshift/latest/dg/r_WF_CUME_DIST.html)
[Postgres CUME_DIST](https://www.postgresql.org/docs/current/functions-window.html)
[Doris CUME_DIST](https://doris.apache.org/docs/3.0/sql-manual/sql-functions/window-functions/cume-dist)
[MySQL CUME_DIST](https://dev.mysql.com/doc/refman/8.4/en/window-function-descriptions.html#function_cume-dist)
[Spark CUME_DIST](https://spark.apache.org/docs/latest/api/sql/index.html#cume_dist)
[Hive CUME_DIST](https://cwiki.apache.org/confluence/display/hive/languagemanual+windowingandanalytics)
[Presto CUME_DIST](https://prestodb.io/docs/current/functions/window.html#cume_dist-double)
[Trino CUME_DIST](https://trino.io/docs/current/functions/window.html#cume_dist)
[SQLite CUME_DIST](https://sqlite.org/windowfunctions.html)
[DuckDB CUME_DIST](https://duckdb.org/docs/stable/sql/functions/window_functions.html#cume_distorder-by-ordering)
