### PR TITLE
feat(optimizer)!: parse and annotate type for bq DENSE_RANK

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -542,6 +542,7 @@ class BigQuery(Dialect):
         exp.CumeDist: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.DateFromUnixDate: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DATE),
         exp.DateTrunc: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.DenseRank: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.FarmFingerprint: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.FirstValue: lambda self, e: self._annotate_by_args(e, "this"),
         exp.Unhex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6203,6 +6203,11 @@ class DecodeCase(Func):
     is_var_len_args = True
 
 
+class DenseRank(AggFunc):
+    arg_types = {"expressions": False}
+    is_var_len_args = True
+
+
 class DiToDate(Func):
     pass
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -353,6 +353,9 @@ class TestOracle(Validator):
         self.validate_identity(
             "SELECT CUME_DIST(15, 0.05) WITHIN GROUP (ORDER BY col1, col2) FROM t"
         )
+        self.validate_identity(
+            "SELECT DENSE_RANK(15, 0.05) WITHIN GROUP (ORDER BY col1, col2) FROM t"
+        )
 
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -904,3 +904,4 @@ SELECT ARG_MIN(DISTINCT selected_col, filtered_col) FROM table
 a.b.c.D()
 a.b.c.d.e.f.G()
 SELECT CUME_DIST() OVER (ORDER BY 1) FROM (SELECT 1)
+SELECT DENSE_RANK() OVER (ORDER BY 1) FROM (SELECT 1)

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1055,6 +1055,10 @@ FLOAT64;
 CUME_DIST() OVER (ORDER BY 1);
 DOUBLE;
 
+# dialect: bigquery
+DENSE_RANK() OVER (ORDER BY 1);
+BIGINT;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `DENSE_RANK`

**DOCS**
[BigQuery DENSE_RANK](https://cloud.google.com/bigquery/docs/reference/standard-sql/numbering_functions#dense_rank)
[T-SQL DENSE_RANK](https://learn.microsoft.com/en-us/sql/t-sql/functions/dense-rank-transact-sql?view=sql-server-ver17)
[Snowflake DENSE_RANK](https://docs.snowflake.com/en/sql-reference/functions/dense_rank)
[Oracle DENSE_RANK](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/DENSE_RANK.html)
[Clickhouse dense_rank - denseRank](https://clickhouse.com/docs/sql-reference/window-functions/dense_rank)
[Redshift DENSE_RANK](https://docs.aws.amazon.com/redshift/latest/dg/r_WF_DENSE_RANK.html)
[Spark DENSE_RANK](https://docs.databricks.com/gcp/en/sql/language-manual/functions/dense_rank)
[MySQL DENSE_RANK](https://dev.mysql.com/doc/refman/8.4/en/window-function-descriptions.html)
[Presto DENSE_RANK](https://prestodb.io/docs/current/functions/window.html)
[Trino DENSE_RANK](https://trino.io/docs/current/functions/window.html#dense_rank)
[Doris DENSE_RANK](https://doris.apache.org/docs/3.0/sql-manual/sql-functions/window-functions/dense-rank)
[SQLite DENSE_RANK](https://sqlite.org/windowfunctions.html)
[Postgres DENSE_RANK](https://www.postgresql.org/docs/current/functions-window.html)
[DuckDB DENSE_RANK](https://duckdb.org/docs/stable/sql/functions/window_functions.html#rank_dense)