### PR TITLE
feat(optimizer)!: annotate type for bq JSON_OBJECT

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -559,9 +559,10 @@ class BigQuery(Dialect):
             e, exp.DataType.Type.VARCHAR
         ),
         exp.JSONValueArray: lambda self, e: self._annotate_with_type(
-            e, exp.DataType.build("ARRAY<VARCHAR>")
+            e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
         ),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
+        exp.JSONObject: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.Lead: lambda self, e: self._annotate_by_args(e, "this"),
         exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1071,6 +1071,10 @@ BIGINT;
 PERCENT_RANK() OVER (ORDER BY 1);
 DOUBLE;
 
+# dialect: bigquery
+JSON_OBJECT('foo', 10, 'bar', TRUE);
+JSON;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `JSON_OBJECT`

**DOCS**
[BigQuery JSON_OBJECT](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_object)