### PR TITLE
feat(optimizer)!: annotate type for bq JSON_QUERY/JSON_QUERY_ARRAY

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -558,6 +558,8 @@ class BigQuery(Dialect):
         exp.JSONExtractScalar: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.VARCHAR
         ),
+        exp.JSONExtract: lambda self, e: self._annotate_by_args(e, "this"),
+        exp.JSONExtractArray: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.JSONValueArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1075,6 +1075,22 @@ DOUBLE;
 JSON_OBJECT('foo', 10, 'bar', TRUE);
 JSON;
 
+# dialect: bigquery
+JSON_QUERY('{"fruits": ["apples", "oranges", "grapes"]}', '$.fruits');
+STRING;
+
+# dialect: bigquery
+JSON_QUERY(JSON_OBJECT('fruits', ['apples', 'oranges', 'grapes']), '$.fruits');
+JSON;
+
+# dialect: bigquery
+JSON_QUERY_ARRAY('{"fruits": ["apples", "oranges", "grapes"]}', '$.fruits');
+ARRAY<STRING>;
+
+# dialect: bigquery
+JSON_QUERY_ARRAY(JSON_OBJECT('fruits', ['apples', 'oranges', 'grapes']), '$.fruits');
+ARRAY<JSON>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `JSON_QUERY` and `JSON_QUERY_ARRAY`

**DOCS**
[BigQuery JSON_QUERY](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_query)
[BigQuery JSON_QUERY_ARRAY](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_query_array)