### PR TITLE
feat(singlestore): Fixed generation of exp.DatetimeTrunc and exp.DateTrunc

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -11,7 +11,6 @@ from sqlglot.dialects.dialect import (
     bool_xor_sql,
     count_if_to_sum,
     timestamptrunc_sql,
-    unit_to_str,
 )
 from sqlglot.dialects.mysql import MySQL, _remove_ts_or_ds_to_date, date_add_sql
 from sqlglot.expressions import DataType
@@ -292,9 +291,7 @@ class SingleStore(MySQL):
             exp.Time: unsupported_args("zone")(lambda self, e: f"{self.sql(e, 'this')} :> TIME"),
             exp.DatetimeAdd: _remove_ts_or_ds_to_date(date_add_sql("ADD")),
             exp.DatetimeTrunc: unsupported_args("zone")(timestamptrunc_sql()),
-            exp.DateTrunc: unsupported_args("zone")(
-                lambda self, e: self.func("DATE_TRUNC", unit_to_str(e), e.this)
-            ),
+            exp.DateTrunc: unsupported_args("zone")(timestamptrunc_sql()),
             exp.JSONExtract: unsupported_args(
                 "only_json_types",
                 "expressions",

--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -10,6 +10,8 @@ from sqlglot.dialects.dialect import (
     rename_func,
     bool_xor_sql,
     count_if_to_sum,
+    timestamptrunc_sql,
+    unit_to_str,
 )
 from sqlglot.dialects.mysql import MySQL, _remove_ts_or_ds_to_date, date_add_sql
 from sqlglot.expressions import DataType
@@ -289,6 +291,10 @@ class SingleStore(MySQL):
             e: f"(DATE_FORMAT({self.sql(e, 'this')}, {SingleStore.DATEINT_FORMAT}) :> INT)",
             exp.Time: unsupported_args("zone")(lambda self, e: f"{self.sql(e, 'this')} :> TIME"),
             exp.DatetimeAdd: _remove_ts_or_ds_to_date(date_add_sql("ADD")),
+            exp.DatetimeTrunc: unsupported_args("zone")(timestamptrunc_sql()),
+            exp.DateTrunc: unsupported_args("zone")(
+                lambda self, e: self.func("DATE_TRUNC", unit_to_str(e), e.this)
+            ),
             exp.JSONExtract: unsupported_args(
                 "only_json_types",
                 "expressions",

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -489,3 +489,10 @@ class TestSingleStore(Validator):
                 "singlestore": "SELECT DATE_ADD(NOW(), INTERVAL '1' MONTH)",
             },
         )
+        self.validate_all(
+            "SELECT DATE_TRUNC('MINUTE', '2016-08-08 12:05:31')",
+            read={
+                "bigquery": "SELECT DATETIME_TRUNC('2016-08-08 12:05:31', MINUTE)",
+                "singlestore": "SELECT DATE_TRUNC('MINUTE', '2016-08-08 12:05:31')",
+            },
+        )


### PR DESCRIPTION
[DATE_TRUNC](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/date-trunc/)