### PR TITLE
feat(optimizer)!: parse and annotate type for bq JSON_ARRAY_APPEND

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -554,6 +554,7 @@ class BigQuery(Dialect):
         exp.Grouping: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.IgnoreNulls: lambda self, e: self._annotate_by_args(e, "this"),
         exp.JSONArray: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
+        exp.JSONArrayAppend: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONBool: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BOOLEAN),
         exp.JSONExtractScalar: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.VARCHAR

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6635,6 +6635,13 @@ class JSONFormat(Func):
     _sql_names = ["JSON_FORMAT"]
 
 
+class JSONArrayAppend(Func):
+    arg_types = {"this": True, "expressions": True}
+    is_var_len_args = True
+    _sql_names = ["JSON_ARRAY_APPEND"]
+
+
+
 # https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_member-of
 class JSONArrayContains(Binary, Predicate, Func):
     arg_types = {"this": True, "expression": True, "json_type": False}

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6641,7 +6641,6 @@ class JSONArrayAppend(Func):
     _sql_names = ["JSON_ARRAY_APPEND"]
 
 
-
 # https://dev.mysql.com/doc/refman/8.0/en/json-search-functions.html#operator_member-of
 class JSONArrayContains(Binary, Predicate, Func):
     arg_types = {"this": True, "expression": True, "json_type": False}

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1803,6 +1803,9 @@ WHERE
             "OCTET_LENGTH(b'foo')",
             "BYTE_LENGTH(b'foo')",
         )
+        self.validate_identity(
+            """JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', [1, 2], append_each_element => FALSE)"""
+        )
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4188,3 +4188,16 @@ FROM subquery2""",
                 "duckdb": "FORMAT('str fmt1 fmt2', 1, 'a')",
             },
         )
+
+    def test_json_array_append(self):
+        self.validate_all(
+            """JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', 1)""",
+            read={
+                "": """JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', 1)""",
+                "bigquery": """JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', 1)""",
+            },
+            write={
+                "bigquery": """JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', 1)""",
+                "mysql": """JSON_ARRAY_APPEND('["a", "b", "c"]', '$', 1)""",
+            },
+        )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1111,6 +1111,14 @@ ARRAY<STRING>;
 JSON_EXTRACT_ARRAY(JSON_OBJECT('fruits', ['apples', 'oranges', 'grapes']), '$.fruits');
 ARRAY<JSON>;
 
+# dialect: bigquery
+JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', 1);
+JSON;
+
+# dialect: bigquery
+JSON_ARRAY_APPEND(PARSE_JSON('["a", "b", "c"]'), '$', [1, 2], append_each_element => FALSE);
+JSON;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for `JSON_ARRAY_APPEND`

**DOCS**
[BigQuery JSON_ARRAY_APPEND](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_array_append)
[MySQL JSON_ARRAY_APPEND](https://dev.mysql.com/doc/refman/8.4/en/json-modification-functions.html#function_json-array-append)