### PR TITLE
feat(optimizer)!: parse and annotate type for bq JSON_KEYS

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -562,6 +562,9 @@ class BigQuery(Dialect):
         ),
         exp.JSONExtract: lambda self, e: self._annotate_by_args(e, "this"),
         exp.JSONExtractArray: lambda self, e: self._annotate_by_args(e, "this", array=True),
+        exp.JSONKeysAtDepth: lambda self, e: self._annotate_with_type(
+            e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
+        ),
         exp.JSONValueArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
         ),
@@ -730,6 +733,7 @@ class BigQuery(Dialect):
             "GENERATE_ARRAY": exp.GenerateSeries.from_arg_list,
             "JSON_EXTRACT_SCALAR": _build_extract_json_with_default_path(exp.JSONExtractScalar),
             "JSON_EXTRACT_ARRAY": _build_extract_json_with_default_path(exp.JSONExtractArray),
+            "JSON_KEYS": exp.JSONKeysAtDepth.from_arg_list,
             "JSON_QUERY": parser.build_extract_json_with_path(exp.JSONExtract),
             "JSON_QUERY_ARRAY": _build_extract_json_with_default_path(exp.JSONExtractArray),
             "JSON_VALUE": _build_extract_json_with_default_path(exp.JSONExtractScalar),
@@ -1248,6 +1252,7 @@ class BigQuery(Dialect):
             exp.JSONExtract: _json_extract_sql,
             exp.JSONExtractArray: _json_extract_sql,
             exp.JSONExtractScalar: _json_extract_sql,
+            exp.JSONKeysAtDepth: rename_func("JSON_KEYS"),
             exp.JSONFormat: rename_func("TO_JSON_STRING"),
             exp.Levenshtein: _levenshtein_sql,
             exp.Max: max_or_greatest,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6452,6 +6452,11 @@ class JSONKeyValue(Expression):
     arg_types = {"this": True, "expression": True}
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_keys
+class JSONKeysAtDepth(Func):
+    arg_types = {"this": True, "expression": False, "mode": False}
+
+
 class JSONObject(Func):
     arg_types = {
         "expressions": False,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1809,6 +1809,9 @@ WHERE
         self.validate_identity(
             """JSON_ARRAY_INSERT(PARSE_JSON('["a", "b", "c"]'), '$[1]', [1, 2], insert_each_element => FALSE)"""
         )
+        self.validate_identity("""JSON_KEYS(PARSE_JSON('{"a": {"b":1}}'))""")
+        self.validate_identity("""JSON_KEYS(PARSE_JSON('{"a": {"b":1}}', 1))""")
+        self.validate_identity("""JSON_KEYS(PARSE_JSON('{"a": {"b":1}}'), 1, mode => 'lax')""")
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1127,6 +1127,26 @@ JSON;
 JSON_ARRAY_INSERT(PARSE_JSON('["a", "b", "c"]'), '$[1]', [1, 2], insert_each_element => FALSE);
 JSON;
 
+# dialect: bigquery
+JSON_ARRAY_INSERT(PARSE_JSON('["a", ["b", "c"], "d"]'), '$[1]', 1);
+JSON;
+
+# dialect: bigquery
+JSON_ARRAY_INSERT(PARSE_JSON('["a", "b", "c"]'), '$[1]', [1, 2], insert_each_element => FALSE);
+JSON;
+
+# dialect: bigquery
+JSON_KEYS(PARSE_JSON('{"a": {"b":1}}'));
+ARRAY<STRING>;
+
+# dialect: bigquery
+JSON_KEYS(PARSE_JSON('{"a": {"b":1}}'), 1);
+ARRAY<STRING>;
+
+# dialect: bigquery
+JSON_KEYS(PARSE_JSON('{"a": {"b":1}}'), 1, node => 'lax');
+ARRAY<STRING>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for BigQuery `JSON_KEYS`

**DOCS**
[BigQuery JSON_KEYS](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_keys)