### PR TITLE
feat(optimizer)!: parse and annotate type for bq JSON_REMOVE

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -565,11 +565,12 @@ class BigQuery(Dialect):
         exp.JSONKeysAtDepth: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
         ),
+        exp.JSONObject: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
+        exp.JSONRemove: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
+        exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.JSONValueArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
         ),
-        exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
-        exp.JSONObject: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.Lag: lambda self, e: self._annotate_by_args(e, "this", "default"),
         exp.Lead: lambda self, e: self._annotate_by_args(e, "this"),
         exp.LowerHex: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -156,6 +156,7 @@ class SQLite(Dialect):
         EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
         SUPPORTS_MEDIAN = False
         JSON_KEY_VALUE_PAIR_SEP = ","
+        PARSE_JSON_NAME: t.Optional[str] = None
 
         SUPPORTED_JSON_PATH_PARTS = {
             exp.JSONPathKey,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6531,6 +6531,12 @@ class JSONValueArray(Func):
     arg_types = {"this": True, "expression": False}
 
 
+class JSONRemove(Func):
+    arg_types = {"this": True, "expressions": True}
+    is_var_len_args = True
+    _sql_names = ["JSON_REMOVE"]
+
+
 # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_TABLE.html
 class JSONTable(Func):
     arg_types = {

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4214,3 +4214,17 @@ FROM subquery2""",
                 "mysql": """JSON_ARRAY_INSERT('["a", ["b", "c"], "d"]', '$[1]', 1)""",
             },
         )
+
+    def test_json_remove(self):
+        self.validate_all(
+            """JSON_REMOVE(PARSE_JSON('["a", ["b", "c"], "d"]'), '$[1]', '$[1]')""",
+            read={
+                "": """JSON_REMOVE(PARSE_JSON('["a", ["b", "c"], "d"]'), '$[1]', '$[1]')""",
+                "bigquery": """JSON_REMOVE(PARSE_JSON('["a", ["b", "c"], "d"]'), '$[1]', '$[1]')""",
+            },
+            write={
+                "bigquery": """JSON_REMOVE(PARSE_JSON('["a", ["b", "c"], "d"]'), '$[1]', '$[1]')""",
+                "mysql": """JSON_REMOVE('["a", ["b", "c"], "d"]', '$[1]', '$[1]')""",
+                "sqlite": """JSON_REMOVE('["a", ["b", "c"], "d"]', '$[1]', '$[1]')""",
+            },
+        )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1147,6 +1147,10 @@ ARRAY<STRING>;
 JSON_KEYS(PARSE_JSON('{"a": {"b":1}}'), 1, node => 'lax');
 ARRAY<STRING>;
 
+# dialect: bigquery
+JSON_REMOVE(PARSE_JSON('["a", ["b", "c"], "d"]'), '$[1]', '$[1]');
+JSON;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation for `JSON_REMOVE`

Also, removes the `JSON_PARSE` (which doesn't exist) from SQLite to make testing simpler. 

**DOCS**
[BigQuery JSON_REMOVE](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_remove)
[MySQL JSON_REMOVE](https://dev.mysql.com/doc/refman/8.4/en/json-modification-functions.html#function_json-remove)
[SQLite JSON_REMOVE](https://www.sqlite.org/json1.html#jrm)
