### PR TITLE
feat(optimizer)!: parse and annotate type for bq JSON_STRIP_NULLS

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -568,6 +568,7 @@ class BigQuery(Dialect):
         exp.JSONObject: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONRemove: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONSet: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
+        exp.JSONStripNulls: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONType: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.JSONValueArray: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")

--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -175,6 +175,18 @@ def _build_to_hex(args: t.List) -> exp.Hex | exp.MD5:
     return exp.MD5(this=arg.this) if isinstance(arg, exp.MD5Digest) else exp.LowerHex(this=arg)
 
 
+def _build_json_strip_nulls(args: t.List) -> exp.JSONStripNulls:
+    expression = exp.JSONStripNulls(this=seq_get(args, 0))
+
+    for arg in args[1:]:
+        if isinstance(arg, exp.Kwarg):
+            expression.set(arg.this.name.lower(), arg)
+        else:
+            expression.set("expression", arg)
+
+    return expression
+
+
 def _array_contains_sql(self: BigQuery.Generator, expression: exp.ArrayContains) -> str:
     return self.sql(
         exp.Exists(
@@ -739,6 +751,7 @@ class BigQuery(Dialect):
             "JSON_KEYS": exp.JSONKeysAtDepth.from_arg_list,
             "JSON_QUERY": parser.build_extract_json_with_path(exp.JSONExtract),
             "JSON_QUERY_ARRAY": _build_extract_json_with_default_path(exp.JSONExtractArray),
+            "JSON_STRIP_NULLS": _build_json_strip_nulls,
             "JSON_VALUE": _build_extract_json_with_default_path(exp.JSONExtractScalar),
             "JSON_VALUE_ARRAY": _build_extract_json_with_default_path(exp.JSONValueArray),
             "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6523,6 +6523,17 @@ class JSONSet(Func):
     _sql_names = ["JSON_SET"]
 
 
+# https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_strip_nulls
+class JSONStripNulls(Func):
+    arg_types = {
+        "this": True,
+        "expression": False,
+        "include_arrays": False,
+        "remove_empty": False,
+    }
+    _sql_names = ["JSON_STRIP_NULLS"]
+
+
 # https://dev.mysql.com/doc/refman/8.4/en/json-search-functions.html#function_json-value
 class JSONValue(Expression):
     arg_types = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1815,6 +1815,13 @@ WHERE
         self.validate_identity(
             """JSON_SET(PARSE_JSON('{"a": 1}'), '$.b', 999, create_if_missing => FALSE)"""
         )
+        self.validate_identity("""JSON_STRIP_NULLS(PARSE_JSON('[1, null, 2, null, [null]]'))""")
+        self.validate_identity(
+            """JSON_STRIP_NULLS(PARSE_JSON('[1, null, 2, null]'), include_arrays => FALSE)"""
+        )
+        self.validate_identity(
+            """JSON_STRIP_NULLS(PARSE_JSON('{"a": {"b": {"c": null}}, "d": [null], "e": [], "f": 1}'), include_arrays => FALSE, remove_empty => TRUE)"""
+        )
 
     def test_errors(self):
         with self.assertRaises(ParseError):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4243,3 +4243,16 @@ FROM subquery2""",
                 "doris": """JSON_SET('{"a": 1}', '$', '{"b": 2, "c": 3}')""",
             },
         )
+
+    def test_json_strip_nulls(self):
+        self.validate_all(
+            """JSON_STRIP_NULLS(PARSE_JSON('[{"f1":1,"f2":null},2,null,3]'))""",
+            read={
+                "": """JSON_STRIP_NULLS(PARSE_JSON('[{"f1":1,"f2":null},2,null,3]'))""",
+                "bigquery": """JSON_STRIP_NULLS(PARSE_JSON('[{"f1":1,"f2":null},2,null,3]'))""",
+            },
+            write={
+                "bigquery": """JSON_STRIP_NULLS(PARSE_JSON('[{"f1":1,"f2":null},2,null,3]'))""",
+                "postgres": """JSON_STRIP_NULLS(CAST('[{"f1":1,"f2":null},2,null,3]' AS JSON))""",
+            },
+        )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1159,6 +1159,18 @@ JSON;
 JSON_SET(PARSE_JSON('{"a": 1}'), '$.b', 999, create_if_missing => FALSE);
 JSON;
 
+# dialect: bigquery
+JSON_STRIP_NULLS(PARSE_JSON('[1, null, 2, null, [null]]'));
+JSON;
+
+# dialect: bigquery
+JSON_STRIP_NULLS(PARSE_JSON('[1, null, 2, null]'), include_arrays => FALSE);
+JSON;
+
+# dialect: bigquery
+JSON_STRIP_NULLS(PARSE_JSON('{"a": {"b": {"c": null}}, "d": [null], "e": [], "f": 1}'), include_arrays => FALSE, remove_empty => TRUE);
+JSON;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds parsing and type annotation support for `JSON_STRIP_NULLS`

**DOCS**
[BigQuery JSON_STRIP_NULLS](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#json_strip_nulls)
[Postgres JSON_STRIP_NULLS](https://www.postgresql.org/docs/9.5/functions-json.html)