### PR TITLE
feat(singlestore): fixed generation of exp.TimestampTrunc

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -301,6 +301,7 @@ class SingleStore(MySQL):
             exp.DatetimeSub: date_add_interval_sql("DATE", "SUB"),
             exp.DatetimeDiff: timestampdiff_sql,
             exp.DateTrunc: unsupported_args("zone")(timestamptrunc_sql()),
+            exp.TimestampTrunc: unsupported_args("zone")(timestamptrunc_sql()),
             exp.JSONExtract: unsupported_args(
                 "only_json_types",
                 "expressions",

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -510,3 +510,10 @@ class TestSingleStore(Validator):
                 "": "SELECT DATETIME_DIFF('2013-09-01', '2009-02-13', QUARTER)",
             },
         )
+        self.validate_all(
+            "SELECT DATE_TRUNC('MINUTE', '2016-08-08 12:05:31')",
+            read={
+                "": "SELECT TIMESTAMP_TRUNC('2016-08-08 12:05:31', MINUTE)",
+                "singlestore": "SELECT DATE_TRUNC('MINUTE', '2016-08-08 12:05:31')",
+            },
+        )


### PR DESCRIPTION
[DATE_TRUNC](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/date-trunc/)