### PR TITLE
feat(optimizer)!: annotate type for bq TO_JSON_STRING

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -574,6 +574,7 @@ class BigQuery(Dialect):
         ),
         exp.JSONExtract: lambda self, e: self._annotate_by_args(e, "this"),
         exp.JSONExtractArray: lambda self, e: self._annotate_by_args(e, "this", array=True),
+        exp.JSONFormat: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.VARCHAR),
         exp.JSONKeysAtDepth: lambda self, e: self._annotate_with_type(
             e, exp.DataType.build("ARRAY<VARCHAR>", dialect="bigquery")
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1191,6 +1191,10 @@ BIGINT;
 LAX_STRING(PARSE_JSON('"str"'));
 STRING;
 
+# dialect: bigquery
+TO_JSON_STRING(STRUCT(1 AS id, [10,20] AS cords));
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `TO_JSON_STRING`

**DOCS**
[BigQuery TO_JSON_STRING](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#to_json_string)