### PR TITLE
fix(snowflake): allow exclude as id var

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -552,6 +552,7 @@ class Snowflake(Dialect):
 
         ID_VAR_TOKENS = {
             *parser.Parser.ID_VAR_TOKENS,
+            TokenType.EXCEPT,
             TokenType.MATCH_CONDITION,
         }
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -89,6 +89,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT TRIM(COALESCE(TO_CHAR(CAST(c AS TIME)), '')) FROM t")
         self.validate_identity("SELECT GET_PATH(PARSE_JSON(foo), 'bar')")
         self.validate_identity("SELECT GET_PATH(foo, 'bar')")
+        self.validate_identity("SELECT a, exclude, b FROM xxx")
         self.validate_identity(
             "SELECT * FROM table AT (TIMESTAMP => '2024-07-24') UNPIVOT(a FOR b IN (c)) AS pivot_table"
         )


### PR DESCRIPTION
In snowflake, `EXCLUDE` is a star operator used like `SELECT * EXCLUDE id FROM tbl`. 

sqlglot does not currently allow it to be used as a column name, like `SELECT id, exclude, item FROM tbl`. 

`EXCLUDE` is [not a reserved Snowflake keyword](https://docs.snowflake.com/en/sql-reference/reserved-keywords) so is allowed as an unquoted column name.