### PR TITLE
Chore!: remove EXCLUDE keyword mapping to TokenType.EXCEPT

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -304,7 +304,6 @@ class DuckDB(Dialect):
             "CHAR": TokenType.TEXT,
             "DATETIME": TokenType.TIMESTAMPNTZ,
             "DETACH": TokenType.DETACH,
-            "EXCLUDE": TokenType.EXCEPT,
             "LOGICAL": TokenType.BOOLEAN,
             "ONLY": TokenType.ONLY,
             "PIVOT_WIDER": TokenType.PIVOT,

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1125,7 +1125,6 @@ class Snowflake(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "FILE://": TokenType.URI_START,
             "BYTEINT": TokenType.INT,
-            "EXCLUDE": TokenType.EXCEPT,
             "FILE FORMAT": TokenType.FILE_FORMAT,
             "GET": TokenType.GET,
             "MATCH_CONDITION": TokenType.MATCH_CONDITION,


### PR DESCRIPTION
`EXCEPT` is an ANSI standard set operator that removes one rowset from another rowset (e.g., `SELECT id FROM tbl1 EXCEPT SELECT id FROM tbl2`). Sqlglot parses it in `parse_set_operation` based on token type.

Some dialects also use except as a star operator for selecting columns (e.g., `SELECT * EXCEPT(id) FROM tbl`). Sqlglot parses those in `_parse_star_operator` based on text match.

DuckDB and Snowflake use the word `EXCLUDE` for the latter operation. Currently, sqlglot incorrectly maps "EXCLUDE" to `TokenType.EXCEPT` for them, which incorrectly mixes the two usages above.