### PR TITLE
feat(singlestore): Fixed parsing of columns with table name

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -198,7 +198,7 @@ class SingleStore(MySQL):
         CAST_COLUMN_OPERATORS = {TokenType.COLON_GT, TokenType.NCOLON_GT}
 
         COLUMN_OPERATORS = {
-            TokenType.DOT: None,
+            **MySQL.Parser.COLUMN_OPERATORS,
             TokenType.COLON_GT: lambda self, this, to: self.expression(
                 exp.Cast,
                 this=this,
@@ -219,6 +219,11 @@ class SingleStore(MySQL):
                 exp.JSONExtractScalar, json_type="DOUBLE"
             )([this, exp.Literal.string(path.name)]),
         }
+        COLUMN_OPERATORS.pop(TokenType.ARROW)
+        COLUMN_OPERATORS.pop(TokenType.DARROW)
+        COLUMN_OPERATORS.pop(TokenType.HASH_ARROW)
+        COLUMN_OPERATORS.pop(TokenType.DHASH_ARROW)
+        COLUMN_OPERATORS.pop(TokenType.PLACEHOLDER)
 
     class Generator(MySQL.Generator):
         SUPPORTED_JSON_PATH_PARTS = {

--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -198,6 +198,7 @@ class SingleStore(MySQL):
         CAST_COLUMN_OPERATORS = {TokenType.COLON_GT, TokenType.NCOLON_GT}
 
         COLUMN_OPERATORS = {
+            TokenType.DOT: None,
             TokenType.COLON_GT: lambda self, this, to: self.expression(
                 exp.Cast,
                 this=this,

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -682,3 +682,6 @@ class TestSingleStore(Validator):
                 "": "CREATE TABLE testTypes (a VARBINARY)",
             },
         )
+
+    def test_column_with_tablename(self):
+        self.validate_identity("SELECT `t0`.`name` FROM `t0`")


### PR DESCRIPTION
Without this column operator, dialect fails to parse expressions like ``` `t0`.`name` ```