### PR TITLE
feat(optimizer)!: annotate type for bq IS_INF, IS_NAN

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -576,6 +576,8 @@ class BigQuery(Dialect):
             e, exp.DataType.build("ARRAY<TIMESTAMP>", dialect="bigquery")
         ),
         exp.Grouping: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
+        exp.IsInf: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BOOLEAN),
+        exp.IsNan: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BOOLEAN),
         exp.JSONArray: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONArrayAppend: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),
         exp.JSONArrayInsert: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.JSON),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1215,6 +1215,14 @@ BIGNUMERIC;
 ABS(CAST(1 AS FLOAT64));
 FLOAT64;
 
+# dialect: bigquery
+IS_INF(1);
+BOOLEAN;
+
+# dialect: bigquery
+IS_NAN(1);
+BOOLEAN;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `IS_INF`, `IS_NAN`

**DOCS**
[BigQuery IS_INF](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#is_inf)
[BigQuery IS_NAN](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#is_nan)