### PR TITLE
feat(optimizer)!: annotate type for bq CBRT

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -554,6 +554,7 @@ class BigQuery(Dialect):
         exp.BitwiseCountAgg: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.ByteLength: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.ByteString: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BINARY),
+        exp.Cbrt: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.CodePointsToBytes: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.BINARY
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1223,6 +1223,10 @@ BOOLEAN;
 IS_NAN(1);
 BOOLEAN;
 
+# dialect: bigquery
+CBRT(27);
+DOUBLE;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation support for `CBRT`

**DOCS**
[BigQuery CBRT](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#cbrt)