### PR TITLE
feat(singlestore): Fixed generation of exp.UnicodeString

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -433,6 +433,9 @@ class Generator(metaclass=_Generator):
     # Whether the UESCAPE syntax in unicode strings is supported
     SUPPORTS_UESCAPE = True
 
+    # Function used to replace escaped unicode codes in unicode strings
+    UNICODE_SUBSTITUDE: t.ClassVar[t.Optional[t.Callable[[re.Match[str]], str]]] = None
+
     # The keyword to use when generating a star projection with excluded columns
     STAR_EXCEPT = "EXCEPT"
 
@@ -1384,7 +1387,11 @@ class Generator(metaclass=_Generator):
             escape_sql = ""
 
         if not self.dialect.UNICODE_START or (escape and not self.SUPPORTS_UESCAPE):
-            this = escape_pattern.sub(escape_substitute, this)
+            unicode_sub = type(self).UNICODE_SUBSTITUDE
+            if unicode_sub is not None:
+                this = escape_pattern.sub(unicode_sub, this)
+            else:
+                this = escape_pattern.sub(escape_substitute, this)
 
         return f"{left_quote}{this}{right_quote}{escape_sql}"
 

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -699,3 +699,9 @@ class TestSingleStore(Validator):
 
     def test_column_with_tablename(self):
         self.validate_identity("SELECT `t0`.`name` FROM `t0`")
+
+    def test_unicodestring_sql(self):
+        self.validate_all(
+            "SELECT 'data'",
+            read={"presto": "SELECT U&'d\\0061t\\0061'", "singlestore": "SELECT 'data'"},
+        )


### PR DESCRIPTION
SingleStore doesn't support providing escaped Unicode codes in the strings (like `\\0061`).
But it allows providing Unicode characters directly in String literals. Replaced unicide codes with Unicode characters.