### PR TITLE
feat(optimizer)!: annotate type for bq RAND

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -622,6 +622,7 @@ class BigQuery(Dialect):
         exp.RegexpExtractAll: lambda self, e: self._annotate_by_args(e, "this", array=True),
         exp.RegexpInstr: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
         exp.RowNumber: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.BIGINT),
+        exp.Rand: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.DOUBLE),
         exp.SafeConvertBytesToString: lambda self, e: self._annotate_with_type(
             e, exp.DataType.Type.VARCHAR
         ),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1227,6 +1227,10 @@ BOOLEAN;
 CBRT(27);
 DOUBLE;
 
+# dialect: bigquery
+RAND();
+DOUBLE;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `RAND`

**DOCS**
[BigQuery RAND](https://cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#rand)