### PR TITLE
feat(singlestore): Fixed generation of exp.Collate

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -1609,3 +1609,8 @@ class SingleStore(MySQL):
                     return f"DECIMAL({precision})"
 
             return super().datatype_sql(expression)
+
+        def collate_sql(self, expression: exp.Collate) -> str:
+            # SingleStore does not support setting a collation for column in the SELECT query,
+            # so we cast column to a LONGTEXT type with specific collation
+            return self.binary(expression, ":> LONGTEXT COLLATE")

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -699,3 +699,15 @@ class TestSingleStore(Validator):
 
     def test_column_with_tablename(self):
         self.validate_identity("SELECT `t0`.`name` FROM `t0`")
+
+    def test_collate_sql(self):
+        self.validate_all(
+            "SELECT name :> LONGTEXT COLLATE 'utf8mb4_bin' FROM `users`",
+            read={
+                "": "SELECT name COLLATE 'utf8mb4_bin' FROM users",
+            },
+        )
+        self.validate_identity(
+            "SELECT name :> LONGTEXT COLLATE 'utf8mb4_bin' FROM `users`",
+            "SELECT name :> LONGTEXT :> LONGTEXT COLLATE 'utf8mb4_bin' FROM `users`",
+        )


### PR DESCRIPTION
SingleStore does not support setting a collation for a column in the SELECT query, so we cast the column to a LONGTEXT type with a specific collation
Example: `SELECT name :> LONGTEXT COLLATE 'utf8mb4_bin' FROM users`