### PR TITLE
feat(singlestore): Fixed generation of exp.CastToStrType

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -264,6 +264,9 @@ class SingleStore(MySQL):
             exp.TryCast: unsupported_args("format", "action", "default")(
                 lambda self, e: f"{self.sql(e, 'this')} !:> {self.sql(e, 'to')}"
             ),
+            exp.CastToStrType: lambda self, e: self.sql(
+                exp.cast(e.this, DataType.build(e.args.get("to").name))
+            ),
             exp.StrToUnix: unsupported_args("format")(rename_func("UNIX_TIMESTAMP")),
             exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
             exp.TimeStrToUnix: rename_func("UNIX_TIMESTAMP"),

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -81,6 +81,13 @@ class TestSingleStore(Validator):
         self.validate_identity("SELECT '{\"a\" : 1}' :> JSON")
         self.validate_identity("SELECT NOW() !:> TIMESTAMP(6)")
         self.validate_identity("SELECT x :> GEOGRAPHYPOINT")
+        self.validate_all(
+            "SELECT age :> TEXT FROM `users`",
+            read={
+                "": "SELECT CAST(age, 'TEXT') FROM users",
+                "singlestore": "SELECT age :> TEXT FROM `users`",
+            },
+        )
 
     def test_unix_functions(self):
         self.validate_identity("SELECT FROM_UNIXTIME(1234567890)")


### PR DESCRIPTION
In SingleStore, the `CAST` function cannot process all data types, so it is replaced with a cast operator (`:>`)
[:>](https://docs.singlestore.com/cloud/reference/sql-reference/conditional-functions/cast-or-convert/#cast-operators-and)