### PR TITLE
feat(databricks): use regexp_like as it exists

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -104,9 +104,9 @@ class Databricks(Spark):
                 if e.args.get("is_numeric")
                 else self.function_fallback_sql(e)
             ),
-            exp.RegexpLike: lambda self, e: self.function_fallback_sql(e),
         }
 
+        TRANSFORMS.pop(exp.RegexpLike)
         TRANSFORMS.pop(exp.TryCast)
 
         TYPE_MAPPING = {

--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -104,6 +104,7 @@ class Databricks(Spark):
                 if e.args.get("is_numeric")
                 else self.function_fallback_sql(e)
             ),
+            exp.RegexpLike: lambda self, e: self.function_fallback_sql(e),
         }
 
         TRANSFORMS.pop(exp.TryCast)

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -406,3 +406,6 @@ class TestDatabricks(Validator):
 
         result = transpile(sql, read="dremio", write="databricks")[0]
         assert "CAST(12345 AS STRING)" in result
+
+    def test_regexp_like(self):
+        self.validate_identity("REGEXP_LIKE(x, y)")


### PR DESCRIPTION
Databricks has a regexp_like function.  This is preferred over the inherited rlike from spark which is missing that function.

https://docs.databricks.com/aws/en/sql/language-manual/functions/regexp_like