### PR TITLE
feat(singlestore): Added handling of UTC_DATE and exp.CurrentDate

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6006,6 +6006,10 @@ class CurrentUser(Func):
     arg_types = {"this": False}
 
 
+class UtcDate(Func):
+    arg_types = {}
+
+
 class DateAdd(Func, IntervalOp):
     arg_types = {"this": True, "expression": True, "unit": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -216,6 +216,7 @@ class Generator(metaclass=_Generator):
         exp.UsingData: lambda self, e: f"USING DATA {self.sql(e, 'this')}",
         exp.Uuid: lambda *_: "UUID()",
         exp.UppercaseColumnConstraint: lambda *_: "UPPERCASE",
+        exp.UtcDate: lambda self, e: self.sql(exp.CurrentDate(this=exp.Literal.string("UTC"))),
         exp.VarMap: lambda self, e: self.func("MAP", e.args["keys"], e.args["values"]),
         exp.ViewAttributeProperty: lambda self, e: f"WITH {self.sql(e, 'this')}",
         exp.VolatileProperty: lambda *_: "VOLATILE",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -641,6 +641,7 @@ class Parser(metaclass=_Parser):
         TokenType.TIMESTAMP,
         TokenType.TIMESTAMPTZ,
         TokenType.TRUNCATE,
+        TokenType.UTC_DATE,
         TokenType.WINDOW,
         TokenType.XOR,
         *TYPE_TOKENS,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -423,6 +423,7 @@ class TokenType(AutoName):
     WINDOW = auto()
     WITH = auto()
     UNIQUE = auto()
+    UTC_DATE = auto()
     VERSION_SNAPSHOT = auto()
     TIMESTAMP_SNAPSHOT = auto()
     OPTION = auto()
@@ -857,6 +858,7 @@ class Tokenizer(metaclass=_Tokenizer):
         "UPDATE": TokenType.UPDATE,
         "USE": TokenType.USE,
         "USING": TokenType.USING,
+        "UTC_DATE": TokenType.UTC_DATE,
         "UUID": TokenType.UUID,
         "VALUES": TokenType.VALUES,
         "VIEW": TokenType.VIEW,

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -560,6 +560,21 @@ class TestSingleStore(Validator):
                 "singlestore": "SELECT DATEDIFF('2009-12-31', '2009-01-01') AS numweeks",
             },
         )
+        self.validate_all(
+            "SELECT CURRENT_DATE()",
+            read={
+                "": "SELECT CURRENT_DATE()",
+                "singlestore": "SELECT CURRENT_DATE",
+            },
+        )
+        self.validate_all(
+            "SELECT UTC_DATE()",
+            read={
+                "": "SELECT CURRENT_DATE('UTC')",
+                "singlestore": "SELECT UTC_DATE",
+            },
+            write={"": "SELECT CURRENT_DATE('UTC')"},
+        )
 
     def test_types(self):
         self.validate_all(


### PR DESCRIPTION
[UTC_DATE](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/utc-date/)
[CURRENT_DATE](https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/current-date-and-curdate/)