### PR TITLE
fix(optimizer): allow aliased negative integer literal as group by column

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -322,7 +322,9 @@ def _expand_alias_refs(
             if table and (not alias_expr or skip_replace):
                 column.set("table", table)
             elif not column.table and alias_expr and not skip_replace:
-                if isinstance(alias_expr, exp.Literal) and (literal_index or resolve_table):
+                if (isinstance(alias_expr, exp.Literal) or alias_expr.is_number) and (
+                    literal_index or resolve_table
+                ):
                     if literal_index:
                         column.replace(exp.Literal.number(i))
                 else:
@@ -442,6 +444,7 @@ def _expand_positional_references(
 
                 if (
                     isinstance(select, exp.CONSTANTS)
+                    or select.is_number
                     or select.find(exp.Explode, exp.Unnest)
                     or ambiguous
                 ):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -621,6 +621,12 @@ SELECT :with,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:expr
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)
 
     def test_expand_alias_refs(self):
+        # check negative integer literal as group by column
+        self.assertEqual(
+            optimizer.optimize("SELECT -99 AS e GROUP BY e").sql(),
+            'SELECT -99 AS "e" GROUP BY 1',
+        )
+
         # check order of lateral expansion with no schema
         self.assertEqual(
             optimizer.optimize("SELECT a + 1 AS d, d + 1 AS e FROM x WHERE e > 1 GROUP BY e").sql(),


### PR DESCRIPTION
Consider a query with an aliased integer literal projection that is used in group by: `SELECT 99 as x GROUP BY x`

The optimizer replaces the group by column reference `x` with a positional reference `1`:
```
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer import optimize
>>>
>>> optimize(parse_one("SELECT 99 as x GROUP BY x")).sql()
'SELECT 99 AS "x" GROUP BY 1'
```

However, it errors when the integer literal is negative:
```
>>> optimize(parse_one("SELECT -99 as x GROUP BY x")).sql()
Traceback (most recent call last):
    return scope.expression.selects[int(node.this) - 1].assert_is(exp.Alias)
                                    ^^^^^^^^^^^^^^
TypeError: int() argument must be a string, a bytes-like object or a real number, not 'Literal'
```

This PR fixes the optimizer such that negative integers are optimized like positive integers.