### PR TITLE
feat(optimizer)!: annotate type for bq STRING_AGG

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -519,6 +519,7 @@ class BigQuery(Dialect):
                 exp.ArgMin,
                 exp.DateTrunc,
                 exp.FirstValue,
+                exp.GroupConcat,
                 exp.IgnoreNulls,
                 exp.JSONExtract,
                 exp.Lead,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1507,6 +1507,14 @@ NUMERIC;
 SAFE_NEGATE(CAST(1 AS BIGNUMERIC));
 BIGNUMERIC;
 
+# dialect: bigquery
+STRING_AGG(tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.bin_col);
+BINARY;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotaion for bq `STRING_AGG`

**DOCS**
[BigQuery STRING_AGG](https://cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#string_agg)