### PR TITLE
feat(optimizer)!: annotate type for bq DATETIME_TRUNC

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -518,6 +518,7 @@ class BigQuery(Dialect):
                 exp.ArgMax,
                 exp.ArgMin,
                 exp.DateTrunc,
+                exp.DatetimeTrunc,
                 exp.FirstValue,
                 exp.GroupConcat,
                 exp.IgnoreNulls,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1515,6 +1515,14 @@ STRING;
 STRING_AGG(tbl.bin_col);
 BINARY;
 
+# dialect: bigquery
+DATETIME_TRUNC(DATETIME "2008-12-25 15:30:00", DAY);
+DATETIME;
+
+# dialect: bigquery
+DATETIME_TRUNC(TIMESTAMP "2008-12-25 15:30:00", DAY);
+TIMESTAMP;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `DATETIME_TRUNC`

**DOCS**
[BigQuery DATIME_TRUNC](https://cloud.google.com/bigquery/docs/reference/standard-sql/datetime_functions#datetime_trunc)