### PR TITLE
feat(singlestore): Splitted truncation of multiple tables into several queries

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -1741,3 +1741,16 @@ class SingleStore(MySQL):
 
             self.unsupported("STANDARD_HASH function is not supported in SingleStore")
             return self.func("SHA", expression.this)
+
+        @unsupported_args("is_database")
+        @unsupported_args("exists")
+        @unsupported_args("cluster")
+        @unsupported_args("identity")
+        @unsupported_args("option")
+        @unsupported_args("partition")
+        def truncatetable_sql(self, expression: exp.TruncateTable) -> str:
+            statements = []
+            for expression in expression.expressions:
+                statements.append(f"TRUNCATE {self.sql(expression)}")
+
+            return "; ".join(statements)

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -872,3 +872,11 @@ class TestSingleStore(Validator):
         self.validate_identity(
             "SELECT MATCH(TABLE products2) AGAINST('search term') FROM products2"
         ).expressions[0].assert_is(exp.MatchAgainst)
+
+    def test_truncate(self):
+        self.validate_all(
+            "TRUNCATE t1; TRUNCATE t2",
+            read={
+                "": "TRUNCATE TABLE t1, t2",
+            },
+        )


### PR DESCRIPTION
[TRUNCATE](https://docs.singlestore.com/cloud/reference/sql-reference/data-definition-language-ddl/truncate/)