### PR TITLE
fix(snowflake)!: correct parsing of TO_VARCHAR

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -664,7 +664,7 @@ class Snowflake(Dialect):
             "TO_TIMESTAMP_LTZ": _build_datetime("TO_TIMESTAMP_LTZ", exp.DataType.Type.TIMESTAMPLTZ),
             "TO_TIMESTAMP_NTZ": _build_datetime("TO_TIMESTAMP_NTZ", exp.DataType.Type.TIMESTAMP),
             "TO_TIMESTAMP_TZ": _build_datetime("TO_TIMESTAMP_TZ", exp.DataType.Type.TIMESTAMPTZ),
-            "TO_VARCHAR": exp.ToChar.from_arg_list,
+            "TO_VARCHAR": build_timetostr_or_tochar,
             "VECTOR_L2_DISTANCE": exp.EuclideanDistance.from_arg_list,
             "ZEROIFNULL": _build_if_from_zeroifnull,
         }

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -717,17 +717,19 @@ class TestSnowflake(Validator):
                 "teradata": "TO_CHAR(x, y)",
             },
         )
-        self.validate_identity(
-            "TO_CHAR(foo::DATE, 'yyyy')",
-            "TO_CHAR(CAST(foo AS DATE), 'yyyy')",
-        )
-        self.validate_all(
-            "TO_CHAR(foo::TIMESTAMP, 'YYYY-MM')",
-            write={
-                "snowflake": "TO_CHAR(CAST(foo AS TIMESTAMP), 'yyyy-mm')",
-                "duckdb": "STRFTIME(CAST(foo AS TIMESTAMP), '%Y-%m')",
-            },
-        )
+        for to_func in ("TO_CHAR", "TO_VARCHAR"):
+            with self.subTest(f"Testing transpilation of {to_func}"):
+                self.validate_identity(
+                    f"{to_func}(foo::DATE, 'yyyy')",
+                    "TO_CHAR(CAST(foo AS DATE), 'yyyy')",
+                )
+                self.validate_all(
+                    f"{to_func}(foo::TIMESTAMP, 'YYYY-MM')",
+                    write={
+                        "snowflake": "TO_CHAR(CAST(foo AS TIMESTAMP), 'yyyy-mm')",
+                        "duckdb": "STRFTIME(CAST(foo AS TIMESTAMP), '%Y-%m')",
+                    },
+                )
         self.validate_all(
             "SQUARE(x)",
             write={


### PR DESCRIPTION
Fixes #5837 

In sf `TO_CHAR` and `TO_VARCHAR` are synonyms, so this pr adds a common representation that enables also transpilation for `TO_VARCHAR`

**DOCS**
[Snowflake TO_CHAR - TO_VARCHAR](https://docs.snowflake.com/en/sql-reference/functions/to_char)