### PR TITLE
fix(snowflake): Enable parsing of COPY INTO without files list

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2197,7 +2197,7 @@ class Copy(DML):
     arg_types = {
         "this": True,
         "kind": True,
-        "files": True,
+        "files": False,
         "credentials": False,
         "format": False,
         "params": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4579,8 +4579,8 @@ class Generator(metaclass=_Generator):
 
         credentials = self.sql(expression, "credentials")
         credentials = self.seg(credentials) if credentials else ""
-        kind = self.seg("FROM" if expression.args.get("kind") else "TO")
         files = self.expressions(expression, key="files", flat=True)
+        kind = self.seg("FROM" if expression.args.get("kind") else "TO") if files else ""
 
         sep = ", " if self.dialect.COPY_PARAMS_ARE_CSV else " "
         params = self.expressions(
@@ -4596,7 +4596,7 @@ class Generator(metaclass=_Generator):
         if params:
             if self.COPY_PARAMS_ARE_WRAPPED:
                 params = f" WITH ({params})"
-            elif not self.pretty:
+            elif not self.pretty and (files or credentials):
                 params = f" {params}"
 
         return f"COPY{this}{kind} {files}{credentials}{params}"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8370,6 +8370,13 @@ class Parser(metaclass=_Parser):
         kind = self._match(TokenType.FROM) or not self._match_text_seq("TO")
 
         files = self._parse_csv(self._parse_file_location)
+        if self._curr and self._curr.token_type == TokenType.EQ:
+            # Backtrack one token since we've consumed the lhs of a parameter assignment here.
+            # This can happen for Snowflake dialect. Instead, we'd like to parse the parameter
+            # list via `_parse_wrapped(..)` below.
+            self._advance(-1)
+            files = []
+
         credentials = self._parse_credentials()
 
         self._match_text_seq("WITH")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8370,7 +8370,7 @@ class Parser(metaclass=_Parser):
         kind = self._match(TokenType.FROM) or not self._match_text_seq("TO")
 
         files = self._parse_csv(self._parse_file_location)
-        if self._curr and self._curr.token_type == TokenType.EQ:
+        if self._match(TokenType.EQ, advance=False):
             # Backtrack one token since we've consumed the lhs of a parameter assignment here.
             # This can happen for Snowflake dialect. Instead, we'd like to parse the parameter
             # list via `_parse_wrapped(..)` below.

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2676,6 +2676,7 @@ STORAGE_ALLOWED_LOCATIONS=('s3://mybucket1/path1/', 's3://mybucket2/path2/')""",
         self.validate_identity(
             """COPY INTO @my_stage/result/data FROM (SELECT * FROM orderstiny) FILE_FORMAT = (TYPE='csv')"""
         )
+        self.validate_identity("COPY INTO mytable FILE_FORMAT = (TYPE='csv')")
         self.validate_identity(
             """COPY INTO MY_DATABASE.MY_SCHEMA.MY_TABLE FROM @MY_DATABASE.MY_SCHEMA.MY_STAGE/my_path FILE_FORMAT = (FORMAT_NAME=MY_DATABASE.MY_SCHEMA.MY_FILE_FORMAT)"""
         )


### PR DESCRIPTION
## Motivation

This PR adds support for `COPY INTO` statements without file list. This is a special syntax supported in Snowflake to load data into a table from a [table stage](https://docs.snowflake.com/en/user-guide/data-load-local-file-system-create-stage#table-stages). (see [docs here](https://docs.snowflake.com/en/sql-reference/sql/copy-into-table#loading-using-pattern-matching))

For example, the following statement is valid syntax in Snowflake: 
```
COPY INTO mytable FILE_FORMAT = (TYPE='csv')
```

With the current version of sqlglot, parsing this expression fails with:
```
../../sqlglot/__init__.py:139: in parse_one
    result = dialect.parse(sql, **opts)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
../../sqlglot/dialects/dialect.py:1083: in parse
    return self.parser(**opts).parse(self.tokenize(sql), sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:1618: in parse
    return self._parse(
../../sqlglot/parser.py:1687: in _parse
    expressions.append(parse_method(self))
                       ^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:1920: in _parse_statement
    stmt = self.STATEMENT_PARSERS[self._prev.token_type](self)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:845: in <lambda>
    TokenType.COPY: lambda self: self._parse_copy(),
                                 ^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:8377: in _parse_copy
    params = self._parse_wrapped(self._parse_copy_parameters, optional=True)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:7329: in _parse_wrapped
    parse_result = parse_method()
                   ^^^^^^^^^^^^^^
../../sqlglot/parser.py:8318: in _parse_copy_parameters
    param = self.expression(exp.CopyParameter, this=option)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:1751: in expression
    return self.validate_expression(instance)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../sqlglot/parser.py:1771: in validate_expression
    self.raise_error(error_message)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <sqlglot.dialects.snowflake.Snowflake.Parser object at 0x103e7d630>
message = "Required keyword: 'this' missing for <class 'sqlglot.expressions.CopyParameter'>"
token = <Token token_type: TokenType.L_PAREN, text: (, line: 1, col: 33, start: 32, end: 32, comments: []>

    def raise_error(self, message: str, token: t.Optional[Token] = None) -> None:
        """
        Appends an error in the list of recorded errors or raises it, depending on the chosen
        error level setting.
        """
        token = token or self._curr or self._prev or Token.string("")
        start = token.start
        end = token.end + 1
        start_context = self.sql[max(start - self.error_message_context, 0) : start]
        highlight = self.sql[start:end]
        end_context = self.sql[end : end + self.error_message_context]
    
        error = ParseError.new(
            f"{message}. Line {token.line}, Col: {token.col}.\n"
            f"  {start_context}\033[4m{highlight}\033[0m{end_context}",
            description=message,
            line=token.line,
            col=token.col,
            start_context=start_context,
            highlight=highlight,
            end_context=end_context,
        )
    
        if self.error_level == ErrorLevel.IMMEDIATE:
>           raise error
E           sqlglot.errors.ParseError: Required keyword: 'this' missing for <class 'sqlglot.expressions.CopyParameter'>. Line 1, Col: 33.
E             COPY INTO mytable FILE_FORMAT = (TYPE='csv')

../../sqlglot/parser.py:1731: ParseError
```

## Changes

The PR adjusts the logic to enable parsing of such COPY statements:
* set the `files` argument as optional in the `exp.Copy` class
* adjust logic in `Parser._parse_copy(..)` to handle the case where we're hitting a `TokenType.EQ`, which indicates that we need to backtrack and treat the tokens as a parameter assignment list instead
* adjust logic in `Generator.copy_sql(..)` to render out the correct expression
* add a simple test case to cover this expression syntax