### PR TITLE
fix(parser): JOIN with nested rhs pipe syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3207,7 +3207,8 @@ class Parser(metaclass=_Parser):
             # Support parentheses for duckdb FROM-first syntax
             select = self._parse_select(from_=from_)
             if select:
-                select.set("from", from_)
+                if not select.args.get("from"):
+                    select.set("from", from_)
                 this = select
             else:
                 this = exp.select("*").from_(t.cast(exp.From, from_))

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -63,6 +63,10 @@ class TestPipeSyntax(Validator):
             "FROM (SELECT x1 FROM (SELECT 1 as x1) |> SELECT x1) |> SELECT x1",
             "SELECT * FROM (WITH __tmp2 AS (SELECT x1 FROM ((WITH __tmp1 AS (SELECT x1 FROM (SELECT 1 AS x1)) SELECT * FROM __tmp1))) SELECT * FROM __tmp2)",
         )
+        self.validate_identity(
+            "SELECT * FROM t1 LEFT JOIN (FROM t2 |> SELECT id) ON t1.id = t2.id",
+            "SELECT * FROM t1 LEFT JOIN (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM t2) ON t1.id = t2.id",
+        )
 
     def test_order_by(self):
         self.validate_identity("FROM x |> ORDER BY x1", "SELECT * FROM x ORDER BY x1")

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -64,8 +64,12 @@ class TestPipeSyntax(Validator):
             "SELECT * FROM (WITH __tmp2 AS (SELECT x1 FROM ((WITH __tmp1 AS (SELECT x1 FROM (SELECT 1 AS x1)) SELECT * FROM __tmp1))) SELECT * FROM __tmp2)",
         )
         self.validate_identity(
-            "SELECT * FROM t1 LEFT JOIN (FROM t2 |> SELECT id) ON t1.id = t2.id",
-            "SELECT * FROM t1 LEFT JOIN (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM t2) ON t1.id = t2.id",
+            "SELECT * FROM (FROM t2 |> SELECT id)",
+            "SELECT * FROM (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM __tmp1)",
+        )
+        self.validate_identity(
+            "SELECT * FROM t1 LEFT JOIN (FROM t2 |> SELECT id) ON TRUE",
+            "SELECT * FROM t1 LEFT JOIN (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM __tmp1) ON TRUE",
         )
 
     def test_order_by(self):


### PR DESCRIPTION
This PR fixes the following:
```
Input:
 SELECT * FROM (FROM t2 |> SELECT id)
 
Output:
SELECT * FROM (WITH __tmp1 AS (SELECT id FROM t2) SELECT * FROM __tmp1)
```