### PR TITLE
fix(redshift): convert FETCH clauses to LIMIT for Redshift dialect

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -162,6 +162,7 @@ class Redshift(Postgres):
         ALTER_SET_TYPE = "TYPE"
         SUPPORTS_DECODE_CASE = True
         SUPPORTS_BETWEEN_FLAGS = False
+        LIMIT_FETCH = "LIMIT"
 
         # Redshift doesn't have `WITH` as part of their with_properties so we remove it
         WITH_PROPERTIES_PREFIX = " "

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -704,3 +704,12 @@ FROM (
 
         with self.assertRaises(ParseError):
             parse_one('1::"udt"', read="redshift")
+
+    def test_fetch_to_limit(self):
+        self.validate_all(
+            "SELECT * FROM t FETCH FIRST 1 ROWS ONLY",
+            write={
+                "redshift": "SELECT * FROM t LIMIT 1",
+                "postgres": "SELECT * FROM t FETCH FIRST 1 ROWS ONLY",
+            },
+        )


### PR DESCRIPTION
## Summary
- Fixed Redshift dialect to properly convert FETCH FIRST clauses to LIMIT clauses
- Added `LIMIT_FETCH = "LIMIT"` to Redshift Generator class
- Resolves issue where transpiling SQL with FETCH clauses resulted in invalid Redshift syntax

## Changes Made
- **sqlglot/dialects/redshift.py**: Added `LIMIT_FETCH = "LIMIT"` property to automatically convert FETCH to LIMIT

