### PR TITLE
Fix!: support BIT_X aggregates again for duckdb, postgres

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -365,6 +365,9 @@ class DuckDB(Dialect):
             "ANY_VALUE": lambda args: exp.IgnoreNulls(this=exp.AnyValue.from_arg_list(args)),
             "ARRAY_REVERSE_SORT": _build_sort_array_desc,
             "ARRAY_SORT": exp.SortArray.from_arg_list,
+            "BIT_AND": exp.BitwiseAndAgg.from_arg_list,
+            "BIT_OR": exp.BitwiseOrAgg.from_arg_list,
+            "BIT_XOR": exp.BitwiseXorAgg.from_arg_list,
             "DATEDIFF": _build_date_diff,
             "DATE_DIFF": _build_date_diff,
             "DATE_TRUNC": date_trunc_to_time,
@@ -649,7 +652,10 @@ class DuckDB(Dialect):
             exp.ArrayUniqueAgg: lambda self, e: self.func(
                 "LIST", exp.Distinct(expressions=[e.this])
             ),
+            exp.BitwiseAndAgg: rename_func("BIT_AND"),
+            exp.BitwiseOrAgg: rename_func("BIT_OR"),
             exp.BitwiseXor: rename_func("XOR"),
+            exp.BitwiseXorAgg: rename_func("BIT_XOR"),
             exp.CommentColumnConstraint: no_comment_column_constraint_sql,
             exp.CosineDistance: rename_func("LIST_COSINE_DISTANCE"),
             exp.CurrentDate: lambda *_: "CURRENT_DATE",

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -386,6 +386,9 @@ class Postgres(Dialect):
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            "BIT_AND": exp.BitwiseAndAgg.from_arg_list,
+            "BIT_OR": exp.BitwiseOrAgg.from_arg_list,
+            "BIT_XOR": exp.BitwiseXorAgg.from_arg_list,
             "DATE_TRUNC": build_timestamp_trunc,
             "DIV": lambda args: exp.cast(
                 binary_from_function(exp.IntDiv)(args), exp.DataType.Type.DECIMAL
@@ -584,7 +587,10 @@ class Postgres(Dialect):
             exp.AnyValue: _versioned_anyvalue_sql,
             exp.ArrayConcat: lambda self, e: self.arrayconcat_sql(e, name="ARRAY_CAT"),
             exp.ArrayFilter: filter_array_using_unnest,
+            exp.BitwiseAndAgg: rename_func("BIT_AND"),
+            exp.BitwiseOrAgg: rename_func("BIT_OR"),
             exp.BitwiseXor: lambda self, e: self.binary(e, "#"),
+            exp.BitwiseXorAgg: rename_func("BIT_XOR"),
             exp.ColumnDef: transforms.preprocess([_auto_increment_to_serial, _serial_to_generated]),
             exp.CurrentDate: no_paren_current_date_sql,
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2929,46 +2929,58 @@ OPTIONS (
             "BIT_AND(x)",
             read={
                 "bigquery": "BIT_AND(x)",
-                "spark": "BIT_AND(x)",
                 "databricks": "BIT_AND(x)",
-                "mysql": "BIT_AND(x)",
                 "dremio": "BIT_AND(x)",
+                "duckdb": "BIT_AND(x)",
+                "mysql": "BIT_AND(x)",
+                "postgres": "BIT_AND(x)",
+                "spark": "BIT_AND(x)",
             },
             write={
-                "spark": "BIT_AND(x)",
                 "databricks": "BIT_AND(x)",
-                "mysql": "BIT_AND(x)",
                 "dremio": "BIT_AND(x)",
+                "duckdb": "BIT_AND(x)",
+                "mysql": "BIT_AND(x)",
+                "postgres": "BIT_AND(x)",
+                "spark": "BIT_AND(x)",
             },
         )
         self.validate_all(
             "BIT_OR(x)",
             read={
                 "bigquery": "BIT_OR(x)",
-                "spark": "BIT_OR(x)",
                 "databricks": "BIT_OR(x)",
-                "mysql": "BIT_OR(x)",
                 "dremio": "BIT_OR(x)",
+                "duckdb": "BIT_OR(x)",
+                "mysql": "BIT_OR(x)",
+                "postgres": "BIT_OR(x)",
+                "spark": "BIT_OR(x)",
             },
             write={
-                "spark": "BIT_OR(x)",
                 "databricks": "BIT_OR(x)",
-                "mysql": "BIT_OR(x)",
                 "dremio": "BIT_OR(x)",
+                "duckdb": "BIT_OR(x)",
+                "mysql": "BIT_OR(x)",
+                "postgres": "BIT_OR(x)",
+                "spark": "BIT_OR(x)",
             },
         )
         self.validate_all(
             "BIT_XOR(x)",
             read={
                 "bigquery": "BIT_XOR(x)",
-                "spark": "BIT_XOR(x)",
                 "databricks": "BIT_XOR(x)",
+                "duckdb": "BIT_XOR(x)",
                 "mysql": "BIT_XOR(x)",
+                "postgres": "BIT_XOR(x)",
+                "spark": "BIT_XOR(x)",
             },
             write={
-                "spark": "BIT_XOR(x)",
                 "databricks": "BIT_XOR(x)",
+                "duckdb": "BIT_XOR(x)",
                 "mysql": "BIT_XOR(x)",
+                "postgres": "BIT_XOR(x)",
+                "spark": "BIT_XOR(x)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
#5831 removed the `_sql_names` entry from some `Bitwise<X>Agg` expressions, resulting in a slight regression when it comes to representing `BIT_<X>` aggregates in certain dialects. For example, DuckDB supports `BIT_XOR` as an aggregate function, but now it's parsed as `Anonymous`. This PR fixes this.
