### PR TITLE
feat(snowflake): MD5Digest transpiling to MD5_BINARY

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1312,6 +1312,7 @@ class Snowflake(Dialect):
                 ]
             ),
             exp.SHA: rename_func("SHA1"),
+            exp.MD5Digest: rename_func("MD5_BINARY"),
             exp.LowerHex: rename_func("TO_CHAR"),
             exp.SortArray: rename_func("ARRAY_SORT"),
             exp.StarMap: rename_func("OBJECT_CONSTRUCT"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3013,5 +3013,5 @@ OPTIONS (
             write={
                 "bigquery": "SELECT MD5('abc')",
                 "snowflake": "SELECT MD5_BINARY('abc')",
-            }
+            },
         )

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3006,3 +3006,12 @@ OPTIONS (
                 "snowflake": "SELECT TO_CHAR(SHA1('abc'))",
             },
         )
+
+    def test_md5(self):
+        self.validate_all(
+            "SELECT MD5('abc')",
+            write={
+                "bigquery": "SELECT MD5('abc')",
+                "snowflake": "SELECT MD5_BINARY('abc')",
+            }
+        )


### PR DESCRIPTION
Continuation of  #5852 

🐛 Correct BigQuery to Snowflake MD5 transpilation

This PR fixes an issue where BigQuery's MD5 function was incorrectly transpiled to MD5_DIGEST for Snowflake, which is not a valid function. This error caused the transpiled queries to fail. 🚨

The fix correctly maps BigQuery's MD5 to Snowflake's native MD5_BINARY function, ensuring the resulting query is syntactically valid and can execute. A new test case has been added to verify this behavior. 🧪

⚠️ Important Notes on Dialect Discrepancies
While this change produces executable SQL, it's important to be aware of key differences in the function's output between the two dialects:

Output Format: In BigQuery, the result is a base64 encoded string. In Snowflake, the output isn't encoded.

Semantic Equivalence: As a result, the outputs are not directly comparable. To get the same results users will have to wrap the MD5_BINARY call with BASE64_ENCODE call.

This fix prioritizes generating executable SQL, leaving any data-level transformations to achieve semantic equivalence up to the end-user. ✅