### PR TITLE
feat(optimizer)!: annotate and add tests for snowflake LENGTH and LOWER functions

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -509,6 +509,7 @@ class Snowflake(Dialect):
     ANNOTATORS = {
         **Dialect.ANNOTATORS,
         exp.ConcatWs: lambda self, e: self._annotate_by_args(e, "expressions"),
+        exp.Length: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INT),
         exp.Reverse: _annotate_reverse,
         **{
             expr_type: lambda self, e: self._annotate_by_args(e, "this")

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -508,9 +508,6 @@ class Snowflake(Dialect):
 
     ANNOTATORS = {
         **Dialect.ANNOTATORS,
-        exp.ConcatWs: lambda self, e: self._annotate_by_args(e, "expressions"),
-        exp.Length: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INT),
-        exp.Reverse: _annotate_reverse,
         **{
             expr_type: lambda self, e: self._annotate_by_args(e, "this")
             for expr_type in (
@@ -519,6 +516,9 @@ class Snowflake(Dialect):
                 exp.Substring,
             )
         },
+        exp.ConcatWs: lambda self, e: self._annotate_by_args(e, "expressions"),
+        exp.Length: lambda self, e: self._annotate_with_type(e, exp.DataType.Type.INT),
+        exp.Reverse: _annotate_reverse,
     }
 
     TIME_MAPPING = {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1684,6 +1684,14 @@ LENGTH(tbl.bin_col);
 INT;
 
 # dialect: snowflake
+LEN(tbl.str_col);
+INT;
+
+# dialect: snowflake
+LEN(tbl.bin_col);
+INT;
+
+# dialect: snowflake
 LOWER(tbl.str_col);
 VARCHAR;
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1675,6 +1675,18 @@ BINARY;
 RIGHT(tbl.str_col, NULL);
 STRING;
 
+# dialect: snowflake
+LENGTH(tbl.str_col);
+INT;
+
+# dialect: snowflake
+LENGTH(tbl.bin_col);
+INT;
+
+# dialect: snowflake
+LOWER(tbl.str_col);
+VARCHAR;
+
 --------------------------------------
 -- T-SQL
 --------------------------------------


### PR DESCRIPTION
Annotate and add tests for snowflake LENGTH and LOWER functions.

Documentation: 
https://docs.snowflake.com/en/sql-reference/functions/length
https://docs.snowflake.com/en/sql-reference/functions/lower