### PR TITLE
fix(clickhouse): arrays are 1-indexed

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -189,6 +189,7 @@ def _map_sql(self: ClickHouse.Generator, expression: exp.Map | exp.VarMap) -> st
 
 
 class ClickHouse(Dialect):
+    INDEX_OFFSET = 1
     NORMALIZE_FUNCTIONS: bool | str = False
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = False


### PR DESCRIPTION
Arrays in ClickHouse are starting at 1
https://clickhouse.com/docs/sql-reference/data-types/array