### PR TITLE
fix(snowflake): Correctly transpile quoted multi-part identifiers

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1727,8 +1727,15 @@ class Snowflake(Dialect):
 
                 this = annotate_types(this, dialect=self.dialect)
 
-            if not isinstance(this, exp.Dot) and this.is_type(exp.DataType.Type.STRUCT):
-                # Generate colon notation for the top level STRUCT
-                return f"{self.sql(this)}:{self.sql(expression, 'expression')}"
+            if not isinstance(this, exp.Dot):
+                this_sql = self.sql(this)
+                if this.is_type(exp.DataType.Type.STRUCT):
+                    # Generate colon notation for the top level STRUCT
+                    return f"{this_sql}:{self.sql(expression, 'expression')}"
+
+                if "." in this_sql:
+                    # Fix notation of imports of fields or UDFs when stated explicitly
+                    this_sql = this_sql.replace(".", "\".\"")
+                    return f"{this_sql}.{self.sql(expression, 'expression')}"
 
             return super().dot_sql(expression)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3032,3 +3032,13 @@ OPTIONS (
                 "snowflake": """SELECT TO_JSON(OBJECT_CONSTRUCT('name', 'Alice')) AS json_data""",
             },
         )
+
+    def test_import_notation(self):
+        self.validate_all(
+            """SELECT `project.dataset`.udf(col) FROM `project.dataset`.table""",
+            write={
+                "bigquery": """SELECT `project.dataset`.udf(col) FROM `project.dataset.table`""",
+                "snowflake": """SELECT \"project\".\"dataset\".udf(col) FROM \"project\".\"dataset\".\"table\"""",
+            },
+        )
+


### PR DESCRIPTION
🐛 Currently, when transpiling a BigQuery query that contains a UDF call with a quoted, multi-part identifier (e.g., project.dataset), the transpiler generates an invalid query for Snowflake. The entire identifier is wrapped in a single pair of quotes, which Snowflake interprets as a single entity rather than a qualified path.

Example of the Issue: : 👉

When transpiling the following BigQuery query:

SELECT `project.dataset`.udf()

The incorrect Snowflake output is: ❌

`SELECT "project.dataset".udf()`

This is not valid in Snowflake.

The Fix: 🔧

This PR modifies the snowflake generation logic to correctly split multi-part identifiers and quote each part individually. This ensures that the resulting query is valid and correctly references the database/schema and the function.

With this fix, the output is now the correct and valid Snowflake query: ✅

`SELECT "project"."dataset".udf()`

A test case was added. 🧪