### PR TITLE
feat(bigquery): Add support for ML.FORECAST(...)

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7004,6 +7004,10 @@ class GenerateEmbedding(Func):
     arg_types = {"this": True, "expression": True, "params_struct": False}
 
 
+class MLForecast(Func):
+    arg_types = {"this": True, "expression": False, "params_struct": False}
+
+
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/search_functions#vector_search
 class VectorSearch(Func):
     arg_types = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2151,6 +2151,17 @@ OPTIONS (
         ).find(exp.MLTranslate).assert_is(exp.MLTranslate)
         self.validate_identity("TRANSLATE(x, y, z)").assert_is(exp.Translate)
 
+        ast = self.validate_identity(
+            "SELECT * FROM ML.FORECAST(MODEL `mydataset.mymodel`, STRUCT(2 AS horizon))"
+        )
+        assert ast.find(exp.MLForecast)
+        self.validate_identity(
+            "SELECT * FROM ML.FORECAST(MODEL `mydataset.mymodel`, TABLE `mydataset.mybqtable`, STRUCT(2 AS horizon, 4 AS confidence_level))"
+        )
+        self.validate_identity(
+            "SELECT * FROM ML.FORECAST(MODEL `mydataset.mymodel`, (SELECT * FROM mydataset.query_table), STRUCT())"
+        )
+
     def test_merge(self):
         self.validate_all(
             """


### PR DESCRIPTION
Adds support for BigQuery's `ML.FORECAST(...)` and refactors the parsing & generation of ML functions to accommodate it:

```SQL
ML.FORECAST(
  MODEL `PROJECT_ID.DATASET.MODEL_NAME`,
    [{ TABLE `PROJECT_ID.DATASET.TABLE` | (QUERY_STATEMENT) } ,]
    STRUCT(
      HORIZON AS horizon,
      CONFIDENCE_LEVEL AS confidence_level)
)
```

Docs
--------
[BQ ML.FORECAST](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-forecast#syntax)