### PR TITLE
feat(duckdb): `INSTALL extension`

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -304,6 +304,9 @@ class DuckDB(Dialect):
             "CHAR": TokenType.TEXT,
             "DATETIME": TokenType.TIMESTAMPNTZ,
             "DETACH": TokenType.DETACH,
+            "EXCLUDE": TokenType.EXCEPT,
+            "FORCE": TokenType.FORCE,
+            "INSTALL": TokenType.INSTALL,
             "LOGICAL": TokenType.BOOLEAN,
             "ONLY": TokenType.ONLY,
             "PIVOT_WIDER": TokenType.PIVOT,
@@ -468,6 +471,8 @@ class DuckDB(Dialect):
             **parser.Parser.STATEMENT_PARSERS,
             TokenType.ATTACH: lambda self: self._parse_attach_detach(),
             TokenType.DETACH: lambda self: self._parse_attach_detach(is_attach=False),
+            TokenType.FORCE: lambda self: self._parse_force(),
+            TokenType.INSTALL: lambda self: self._parse_install(),
             TokenType.SHOW: lambda self: self._parse_show(),
         }
 
@@ -604,6 +609,26 @@ class DuckDB(Dialect):
 
         def _parse_show_duckdb(self, this: str) -> exp.Show:
             return self.expression(exp.Show, this=this)
+
+        def _parse_force(self) -> exp.Install:
+            # FORCE can only be followed by INSTALL in DuckDB
+            if not self._match(TokenType.INSTALL):
+                self.raise_error("Expected INSTALL after FORCE")
+
+            return self._parse_install(force=True)
+
+        def _parse_install(self, force: bool = False) -> exp.Install:
+            # Parse extension name (can be a string path or identifier)
+            this = self._parse_string() or self._parse_id_var()
+
+            # Parse optional FROM clause
+            from_ = None
+            if self._match(TokenType.FROM):
+                from_ = self._parse_string() or self._parse_id_var()
+                if not from_:
+                    self.raise_error("Expected repository name after FROM")
+
+            return self.expression(exp.Install, this=this, from_=from_, force=force)
 
         def _parse_primary(self) -> t.Optional[exp.Expression]:
             if self._match_pair(TokenType.HASH, TokenType.NUMBER):
@@ -927,6 +952,13 @@ class DuckDB(Dialect):
 
         def show_sql(self, expression: exp.Show) -> str:
             return f"SHOW {expression.name}"
+
+        def install_sql(self, expression: exp.Install) -> str:
+            force = "FORCE " if expression.args.get("force") else ""
+            this = self.sql(expression, "this")
+            from_ = expression.args.get("from_")
+            from_clause = f" FROM {self.sql(from_)}" if from_ else ""
+            return f"{force}INSTALL {this}{from_clause}"
 
         def fromiso8601timestamp_sql(self, expression: exp.FromISO8601Timestamp) -> str:
             return self.sql(exp.cast(expression.this, exp.DataType.Type.TIMESTAMPTZ))

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1584,6 +1584,11 @@ class Detach(Expression):
     arg_types = {"this": True, "exists": False}
 
 
+# https://duckdb.org/docs/sql/statements/load_and_install.html
+class Install(Expression):
+    arg_types = {"this": True, "from_": False, "force": False}
+
+
 # https://duckdb.org/docs/guides/meta/summarize.html
 class Summarize(Expression):
     arg_types = {"this": True, "table": False}

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -313,6 +313,7 @@ class TokenType(AutoName):
     INDEX = auto()
     INNER = auto()
     INSERT = auto()
+    INSTALL = auto()
     INTERSECT = auto()
     INTERVAL = auto()
     INTO = auto()

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1262,3 +1262,38 @@ FROM foo""",
 
         self.assertIsInstance(result, exp.TsOrDsToTime)
         self.assertEqual(result.sql(), "CAST('12:00:00' AS TIME)")
+
+    def test_install_expression(self):
+        # Test Install expression construction
+        install = exp.Install(this=exp.Identifier(this="httpfs"))
+        self.assertEqual(install.args["this"].name, "httpfs")
+        self.assertIsNone(install.args.get("from_"))
+        self.assertFalse(install.args.get("force", False))
+
+        # Test Install with FROM clause
+        install_with_from = exp.Install(
+            this=exp.Identifier(this="spatial"), from_=exp.Identifier(this="community")
+        )
+        self.assertEqual(install_with_from.args["this"].name, "spatial")
+        self.assertEqual(install_with_from.args["from_"].name, "community")
+        self.assertFalse(install_with_from.args.get("force", False))
+
+        # Test FORCE Install
+        force_install = exp.Install(this=exp.Identifier(this="httpfs"), force=True)
+        self.assertEqual(force_install.args["this"].name, "httpfs")
+        self.assertIsNone(force_install.args.get("from_"))
+        self.assertTrue(force_install.args.get("force", False))
+
+        # Test Install with string literal
+        install_path = exp.Install(this=exp.Literal.string("path/to/ext.duckdb_extension"))
+        self.assertEqual(install_path.args["this"].this, "path/to/ext.duckdb_extension")
+        self.assertTrue(install_path.args["this"].is_string)
+
+        # Test Install expression key
+        install = exp.Install(this=exp.Identifier(this="httpfs"))
+        self.assertEqual(install.key, "install")
+
+        # Test Install arg_types validation
+        self.assertEqual(exp.Install.arg_types["this"], True)  # Required
+        self.assertEqual(exp.Install.arg_types["from_"], False)  # Optional
+        self.assertEqual(exp.Install.arg_types["force"], False)  # Optional

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -208,3 +208,53 @@ x"""
             repr(Tokenizer().tokenize("foo")),
             "[<Token token_type: TokenType.VAR, text: foo, line: 1, col: 3, start: 0, end: 2, comments: []>]",
         )
+
+    def test_duckdb_install_tokens(self):
+        from sqlglot.dialects import DuckDB
+
+        tokenizer = DuckDB.Tokenizer()
+
+        # Test INSTALL token
+        tokens = tokenizer.tokenize("INSTALL httpfs")
+        self.assertEqual(tokens[0].token_type, TokenType.INSTALL)
+        self.assertEqual(tokens[0].text, "INSTALL")
+        self.assertEqual(tokens[1].token_type, TokenType.VAR)
+        self.assertEqual(tokens[1].text, "httpfs")
+
+        # Test FORCE token
+        tokens = tokenizer.tokenize("FORCE INSTALL httpfs")
+        self.assertEqual(tokens[0].token_type, TokenType.FORCE)
+        self.assertEqual(tokens[0].text, "FORCE")
+        self.assertEqual(tokens[1].token_type, TokenType.INSTALL)
+        self.assertEqual(tokens[1].text, "INSTALL")
+        self.assertEqual(tokens[2].token_type, TokenType.VAR)
+        self.assertEqual(tokens[2].text, "httpfs")
+
+        # Test INSTALL with FROM
+        tokens = tokenizer.tokenize("INSTALL spatial FROM community")
+        self.assertEqual(tokens[0].token_type, TokenType.INSTALL)
+        self.assertEqual(tokens[0].text, "INSTALL")
+        self.assertEqual(tokens[1].token_type, TokenType.VAR)
+        self.assertEqual(tokens[1].text, "spatial")
+        self.assertEqual(tokens[2].token_type, TokenType.FROM)
+        self.assertEqual(tokens[2].text, "FROM")
+        self.assertEqual(tokens[3].token_type, TokenType.VAR)
+        self.assertEqual(tokens[3].text, "community")
+
+        # Test INSTALL with string literal
+        tokens = tokenizer.tokenize("INSTALL 'path/to/ext.duckdb_extension'")
+        self.assertEqual(tokens[0].token_type, TokenType.INSTALL)
+        self.assertEqual(tokens[0].text, "INSTALL")
+        self.assertEqual(tokens[1].token_type, TokenType.STRING)
+        self.assertEqual(tokens[1].text, "path/to/ext.duckdb_extension")
+
+        # Test case insensitivity
+        tokens = tokenizer.tokenize("install httpfs")
+        self.assertEqual(tokens[0].token_type, TokenType.INSTALL)
+        self.assertEqual(tokens[0].text, "install")
+
+        tokens = tokenizer.tokenize("force install httpfs")
+        self.assertEqual(tokens[0].token_type, TokenType.FORCE)
+        self.assertEqual(tokens[0].text, "force")
+        self.assertEqual(tokens[1].token_type, TokenType.INSTALL)
+        self.assertEqual(tokens[1].text, "install")


### PR DESCRIPTION
Add support for parsing `INSTALL extension` in DuckDB (https://duckdb.org/docs/stable/extensions/installing_extensions.html).