### PR TITLE
feat(parser): Extend support for `IS UNKOWN` across all dialects

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -894,8 +894,6 @@ class BigQuery(Dialect):
         RANGE_PARSERS = parser.Parser.RANGE_PARSERS.copy()
         RANGE_PARSERS.pop(TokenType.OVERLAPS)
 
-        NULL_TOKENS = {TokenType.NULL, TokenType.UNKNOWN}
-
         DASHED_TABLE_PART_FOLLOW_TOKENS = {TokenType.DOT, TokenType.L_PAREN, TokenType.R_PAREN}
 
         STATEMENT_PARSERS = {

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1427,7 +1427,7 @@ class Parser(metaclass=_Parser):
 
     DISTINCT_TOKENS = {TokenType.DISTINCT}
 
-    NULL_TOKENS = {TokenType.NULL}
+    NULL_TOKENS = {TokenType.NULL, TokenType.UNKNOWN}
 
     UNNEST_OFFSET_ALIAS_TOKENS = TABLE_ALIAS_TOKENS - SET_OPERATIONS
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -87,7 +87,6 @@ class TestBigQuery(Validator):
         self.validate_identity("SELECT * FROM dataset.my_table TABLESAMPLE SYSTEM (10 PERCENT)")
         self.validate_identity("TIME('2008-12-25 15:30:00+08')")
         self.validate_identity("TIME('2008-12-25 15:30:00+08', 'America/Los_Angeles')")
-        self.validate_identity("SELECT test.Unknown FROM test")
         self.validate_identity(r"SELECT '\n\r\a\v\f\t'")
         self.validate_identity("SELECT * FROM tbl FOR SYSTEM_TIME AS OF z")
         self.validate_identity("SELECT PARSE_TIMESTAMP('%c', 'Thu Dec 25 07:30:00 2008', 'UTC')")
@@ -1191,26 +1190,6 @@ LANGUAGE js AS
         self.validate_all(
             "SELECT ARRAY(SELECT * FROM foo JOIN bla ON x = y)",
             write={"bigquery": "SELECT ARRAY(SELECT * FROM foo JOIN bla ON x = y)"},
-        )
-        self.validate_all(
-            "x IS unknown",
-            write={
-                "bigquery": "x IS NULL",
-                "duckdb": "x IS NULL",
-                "presto": "x IS NULL",
-                "hive": "x IS NULL",
-                "spark": "x IS NULL",
-            },
-        )
-        self.validate_all(
-            "x IS NOT unknown",
-            write={
-                "bigquery": "NOT x IS NULL",
-                "duckdb": "NOT x IS NULL",
-                "presto": "NOT x IS NULL",
-                "hive": "NOT x IS NULL",
-                "spark": "NOT x IS NULL",
-            },
         )
         self.validate_all(
             "CURRENT_TIMESTAMP()",

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4201,3 +4201,33 @@ FROM subquery2""",
                 "postgres": """JSON_STRIP_NULLS(CAST('[{"f1":1,"f2":null},2,null,3]' AS JSON))""",
             },
         )
+
+    def test_is_unknown(self):
+        # In many dialects `<...> IS UNKNOWN` is equivalent to `<...> IS NULL`
+        self.validate_all(
+            "x IS NULL",
+            read={
+                "": "x IS UNKNOWN",
+                "bigquery": "x IS UNKNOWN",
+                "mysql": "x IS UNKNOWN",
+                "postgres": "x IS UNKNOWN",
+                "redshift": "x IS UNKNOWN",
+                "duckdb": "x IS UNKNOWN",
+                "spark": "x IS UNKNOWN",
+                "databricks": "x IS UNKNOWN",
+            },
+        )
+
+        self.validate_all(
+            "NOT x IS NULL",
+            read={
+                "": "x IS NOT UNKNOWN",
+                "bigquery": "x IS NOT UNKNOWN",
+                "mysql": "x IS NOT UNKNOWN",
+                "postgres": "x IS NOT UNKNOWN",
+                "redshift": "x IS NOT UNKNOWN",
+                "duckdb": "x IS NOT UNKNOWN",
+                "spark": "x IS NOT UNKNOWN",
+                "databricks": "x IS NOT UNKNOWN",
+            },
+        )

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -931,3 +931,5 @@ SELECT COSINE_DISTANCE(v1, v2)
 SELECT EUCLIDEAN_DISTANCE(v1, v2)
 FOO(values.c)
 case.*
+SELECT unknown
+SELECT test.Unknown FROM test


### PR DESCRIPTION
Many dialects such as  Spark3, Postgres, DuckDB etc support the `IS [NOT] UNKNOWN` predicate which is equivalent to `IS [NOT] NULL`, e.g:

```SQL
spark-sql (default)> select null is unknown;
(NULL IS NULL)
true

postgres> select NULL IS UNKNOWN;
 ?column?
----------
 t

duckdb> select NULL IS UNKNOWN;
┌────────────────┐
│ (NULL IS NULL) │
│    boolean     │
├────────────────┤
│ true           │
└────────────────┘
```


<br/>

Support for this predicate existed already for SQLGLot's BigQuery dialect through `NULL_TOKENS`; This PR extends it across the base parser since it appears to be a SQL standard keyword.


This should be a safe generalization as:

1. The `UNKNOWN` token is already defined in the base tokenizer
2. The base parser's `_parse_null()` function is only called for the RHS of `IS` predicate, so its scope is very limited ([Past PR](https://github.com/tobymao/sqlglot/pull/2260))

Docs
-----------
[S/O UNKNOWN vs NULL](https://stackoverflow.com/questions/41180547/is-sql-unknown-identical-to-null) | [Postgres](https://www.postgresql.org/docs/8.1/functions-comparison.html) | [Spark](https://spark.apache.org/docs/latest/sql-ref-null-semantics.html) | [MySQL](https://stackoverflow.com/questions/15124490/mysql-unknown)   