### PR TITLE
feat(bigquery): Add support for `ML.GENERATE_TEXT_EMBEDDING(...)`

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -863,6 +863,9 @@ class BigQuery(Dialect):
             "TRANSLATE": lambda self: self._parse_translate(),
             "FEATURES_AT_TIME": lambda self: self._parse_features_at_time(),
             "GENERATE_EMBEDDING": lambda self: self._parse_ml(exp.GenerateEmbedding),
+            "GENERATE_TEXT_EMBEDDING": lambda self: self._parse_ml(
+                exp.GenerateEmbedding, is_text=True
+            ),
             "VECTOR_SEARCH": lambda self: self._parse_vector_search(),
             "FORECAST": lambda self: self._parse_ml(exp.MLForecast),
         }
@@ -1148,7 +1151,7 @@ class BigQuery(Dialect):
 
             return expr
 
-        def _parse_ml(self, expr_type: t.Type[E]) -> E:
+        def _parse_ml(self, expr_type: t.Type[E], **kwargs) -> E:
             self._match_text_seq("MODEL")
             this = self._parse_table()
 
@@ -1167,6 +1170,7 @@ class BigQuery(Dialect):
                 this=this,
                 expression=expression,
                 params_struct=self._parse_bitwise(),
+                **kwargs,
             )
 
         def _parse_translate(self) -> exp.Translate | exp.MLTranslate:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7001,7 +7001,7 @@ class FeaturesAtTime(Func):
 
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-embedding
 class GenerateEmbedding(Func):
-    arg_types = {"this": True, "expression": True, "params_struct": False}
+    arg_types = {"this": True, "expression": True, "params_struct": False, "is_text": False}
 
 
 class MLForecast(Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4235,7 +4235,8 @@ class Generator(metaclass=_Generator):
         return self._ml_sql(expression, "PREDICT")
 
     def generateembedding_sql(self, expression: exp.GenerateEmbedding) -> str:
-        return self._ml_sql(expression, "GENERATE_EMBEDDING")
+        name = "GENERATE_TEXT_EMBEDDING" if expression.args.get("is_text") else "GENERATE_EMBEDDING"
+        return self._ml_sql(expression, name)
 
     def mltranslate_sql(self, expression: exp.MLTranslate) -> str:
         return self._ml_sql(expression, "TRANSLATE")


### PR DESCRIPTION
BigQuery supports `ML.GENERATE_TEXT_EMBEDDING(...)` which I couldn't find documentation for; It seems to me that it was deprecated in favor of`ML.GENERATE_EMBEDDING(...)`, but it still exists:

```SQL
bigquery> SELECT * FROM ML.GENERATE_TEXT_EMBEDDING(TABLE vaggelis.foo):

No matching signature for ML.GENERATE_TEXT_EMBEDDING Argument types: TABLE<col INT64> Signature: ML.GENERATE_TEXT_EMBEDDING(MODEL, TABLE, [STRUCT]) Signature requires at least 2 arguments, found 1 argument at [1:15]
```



To enable backwards compatibility without breaking any of the 2 functions, this PR adds a new arg in `exp.GenerateEmbedding`.


Docs
-------
[BQ GENERATE_EMBEDDING](https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-generate-embedding) | [BQ GENERATE_TEXT_EMBEDDING mention](https://cloud.google.com/bigquery/docs/release-notes#August_24_2023)
