### PR TITLE
fix(parser): Require an explicit alias in `SELECT *` ops

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7311,7 +7311,7 @@ class Parser(metaclass=_Parser):
         if self._match(TokenType.L_PAREN, advance=False):
             return self._parse_wrapped_csv(self._parse_expression)
 
-        expression = self._parse_expression()
+        expression = self._parse_alias(self._parse_assignment(), explicit=True)
         return [expression] if expression else None
 
     def _parse_csv(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1291,6 +1291,11 @@ class TestSnowflake(Validator):
                     },
                 )
 
+        self.validate_identity(
+            "SELECT * EXCLUDE foo RENAME bar AS baz FROM tbl",
+            "SELECT * EXCLUDE (foo) RENAME (bar AS baz) FROM tbl",
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
This is a valid Snowflake query:

```sql
snowflake> WITH tbl AS (
  SELECT
    1 AS COL1,
    2 AS COL2,
    3 AS COL3
)
SELECT
  *
  EXCLUDE COL1
  RENAME (COL3 AS COL4)
FROM TBL

COL2 | COL4
-- | --
2 | 3

```


<br/>

However, in `_parse_star_ops` we call `parse_expression` which always parses aliases, so we'd end up parsing `col1 RENAME (...)` into `col1 AS RENAME` i.e an `exp.Alias`.


The REPLACE/EXCLUDE/RENAME syntax across all dialects requires wrapped csv's for that matter, but Snowflake is an exception for a single item.


Docs
-------------
[Snowflake](https://docs.snowflake.com/en/sql-reference/sql/select#syntax) | [BigQuery](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#select_replace) | [Spark / DBX](https://docs.databricks.com/aws/en/sql/language-manual/sql-ref-syntax-qry-select) | [DuckDB](https://duckdb.org/docs/stable/sql/query_syntax/select.html#syntax)