### PR TITLE
fix(snowflake): transpile BQ UNNEST with alias

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -378,7 +378,7 @@ def _qualify_unnested_columns(expression: exp.Expression) -> exp.Expression:
 
         taken_source_names = set(scope.sources)
         column_source: t.Dict[str, exp.Identifier] = {}
-        unnest_to_identifier: t.Dict[exp.Unnest, exp.Identifier] = {}  # Map UNNEST nodes to their identifiers
+        unnest_to_identifier: t.Dict[exp.Unnest, exp.Identifier] = {}
 
         unnest_identifier: t.Optional[exp.Identifier] = None
         orig_expression = expression.copy()
@@ -447,7 +447,10 @@ def _qualify_unnested_columns(expression: exp.Expression) -> exp.Expression:
             ):
                 unnest_ancestor = column.find_ancestor(exp.Unnest)
                 ancestor_identifier = unnest_to_identifier.get(unnest_ancestor)
-                if ancestor_identifier and ancestor_identifier.name.lower() == unnest_identifier.name.lower():
+                if (
+                    ancestor_identifier
+                    and ancestor_identifier.name.lower() == unnest_identifier.name.lower()
+                ):
                     continue
 
                 table = unnest_identifier

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -445,10 +445,11 @@ def _qualify_unnested_columns(expression: exp.Expression) -> exp.Expression:
                 and len(scope.sources) == 1
                 and column.name.lower() != unnest_identifier.name.lower()
             ):
-                unnest_ancestor = column.find_ancestor(exp.Unnest)
+                unnest_ancestor = column.find_ancestor(exp.Unnest, exp.Select)
                 ancestor_identifier = unnest_to_identifier.get(unnest_ancestor)
                 if (
-                    ancestor_identifier
+                    isinstance(unnest_ancestor, exp.Unnest)
+                    and ancestor_identifier
                     and ancestor_identifier.name.lower() == unnest_identifier.name.lower()
                 ):
                     continue

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1297,6 +1297,13 @@ class TestSnowflake(Validator):
             "SELECT * EXCLUDE (foo) RENAME (bar AS baz) FROM tbl",
         )
 
+        self.validate_all(
+            "WITH foo AS (SELECT [1] AS arr_1) SELECT (SELECT unnested_arr FROM TABLE(FLATTEN(INPUT => arr_1)) AS _t0(seq, key, path, index, unnested_arr, this)) AS f FROM foo",
+            read={
+                "bigquery": "WITH foo AS (SELECT [1] AS arr_1) SELECT (SELECT unnested_arr FROM UNNEST(arr_1) AS unnested_arr) AS f FROM foo",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
Fixes #5895

```
BigQuery:
WITH foo AS (SELECT [1] AS arr_1) SELECT (SELECT unnested_arr FROM UNNEST(arr_1) AS unnested_arr) AS f FROM foo

Snowflake (old output + wrong):
WITH foo AS (SELECT [1] AS arr_1) SELECT (SELECT unnested_arr FROM TABLE(FLATTEN(INPUT => unnested_arr['arr_1'])) AS _t0(seq, key, path, index, unnested_arr, this)) AS f FROM foo

Snowflake (PR's output):
WITH foo AS (SELECT [1] AS arr_1) SELECT (SELECT unnested_arr FROM TABLE(FLATTEN(INPUT => arr_1)) AS _t0(seq, key, path, index, unnested_arr, this)) AS f FROM foo
```