### PR TITLE
Better align snowflake functions to bigquery and sqlglot

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1391,6 +1391,7 @@ class Snowflake(Dialect):
             exp.VarMap: lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
             exp.WeekOfYear: rename_func("WEEKOFYEAR"),
             exp.Xor: rename_func("BOOLXOR"),
+            exp.ByteLength: rename_func("OCTET_LENGTH"),
         }
 
         SUPPORTED_JSON_PATH_PARTS = {

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1152,6 +1152,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTLEFT(a, 1)", "SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTRIGHT(a, 1)", "SELECT BITSHIFTRIGHT(a, 1)")
+        self.validate_identity("SELECT BYTE_LENGTH('A')", "SELECT OCTET_LENGTH('A')")
 
         self.validate_identity("CREATE TABLE t (id INT PRIMARY KEY AUTOINCREMENT)")
 


### PR DESCRIPTION
BYTE_LENGTH in snowflake is OCTECT_LENGTH,
exmaples:

```Big Query
WITH data AS (
  SELECT 'abc' AS test_string UNION ALL  -- 3 chars, 3 bytes (1+1+1)
  SELECT 'àbç' AS test_string UNION ALL  -- 3 chars, 5 bytes (2+1+2)
  SELECT '€' AS test_string UNION ALL    -- 1 char,  3 bytes
  SELECT '中' AS test_string UNION ALL    -- 1 char,  3 bytes
  SELECT '👍' AS test_string UNION ALL    -- 1 char,  4 bytes
  SELECT '' AS test_string               -- 0 chars, 0 bytes
)
SELECT
  test_string,
  CHAR_LENGTH(test_string) AS char_count_bq,
  BYTE_LENGTH(test_string) AS byte_count_bq
FROM data;
```

Previous result of running after sqlglot transpilation:
NO SUCH FUNCTION BYTE_LENGHT

New output after the fix:
```Snowflake
WITH data AS (
  SELECT 'abc' AS test_string UNION ALL
  SELECT 'àbç' AS test_string UNION ALL
  SELECT '€' AS test_string UNION ALL
  SELECT '中' AS test_string UNION ALL
  SELECT '👍' AS test_string UNION ALL
  SELECT '' AS test_string
)
SELECT
  test_string,
  LENGTH(test_string) AS char_count_sf,
  OCTET_LENGTH(test_string) AS byte_count_sf_native
FROM data;
```

Both qureis reutrn the same reuslt