### PR TITLE
fix(snowflake): parse OCTET_LENGTH

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -678,6 +678,7 @@ class Snowflake(Dialect):
             "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
             "NULLIFZERO": _build_if_from_nullifzero,
             "OBJECT_CONSTRUCT": _build_object_construct,
+            "OCTET_LENGTH": exp.ByteLength.from_arg_list,
             "REGEXP_EXTRACT_ALL": _build_regexp_extract(exp.RegexpExtractAll),
             "REGEXP_REPLACE": _build_regexp_replace,
             "REGEXP_SUBSTR": _build_regexp_extract(exp.RegexpExtract),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1152,7 +1152,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTLEFT(a, 1)", "SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTRIGHT(a, 1)", "SELECT BITSHIFTRIGHT(a, 1)")
-        self.validate_identity("SELECT BYTE_LENGTH('A')", "SELECT OCTET_LENGTH('A')")
+        self.validate_identity("OCTET_LENGTH('A')")
 
         self.validate_identity("CREATE TABLE t (id INT PRIMARY KEY AUTOINCREMENT)")
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1152,7 +1152,13 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTLEFT(a, 1)", "SELECT BITSHIFTLEFT(a, 1)")
         self.validate_identity("SELECT BIT_SHIFTRIGHT(a, 1)", "SELECT BITSHIFTRIGHT(a, 1)")
-        self.validate_identity("OCTET_LENGTH('A')")
+        self.validate_all(
+            "OCTET_LENGTH('A')",
+            read={
+                "bigquery": "BYTE_LENGTH('A')",
+                "snowflake": "OCTET_LENGTH('A')",
+            },
+        )
 
         self.validate_identity("CREATE TABLE t (id INT PRIMARY KEY AUTOINCREMENT)")
 


### PR DESCRIPTION
Adds parsing of OCTET_LENGTH

**DOCS**
[Snowflake OCTET_LEGNTH](https://docs.snowflake.com/en/sql-reference/functions/octet_length)