### PR TITLE
Fix(optimizer)!: use column name in struct type annotation

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -593,13 +593,17 @@ class TypeAnnotator(metaclass=_TypeAnnotator):
     def _annotate_struct_value(
         self, expression: exp.Expression
     ) -> t.Optional[exp.DataType] | exp.ColumnDef:
-        alias = expression.args.get("alias")
-        if alias:
+        # Case: STRUCT(key AS value)
+        if alias := expression.args.get("alias"):
             return exp.ColumnDef(this=alias.copy(), kind=expression.type)
 
-        # Case: key = value or key := value
+        # Case: STRUCT(key = value) or STRUCT(key := value)
         if expression.expression:
             return exp.ColumnDef(this=expression.this.copy(), kind=expression.expression.type)
+
+        # Case: STRUCT(c)
+        if isinstance(expression, exp.Column):
+            return exp.ColumnDef(this=expression.this.copy(), kind=expression.type)
 
         return expression.type
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1527,6 +1527,10 @@ TIMESTAMP;
 GENERATE_UUID();
 STRING;
 
+# dialect: bigquery
+STRUCT(tbl.str_col);
+STRUCT<str_col STRING>;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
Prior to this fix, the assertion in `test_struct_annotation_bigquery` would fail because the type showed up as `UNKNOWN`, which is incorrect.
