### PR TITLE
feat(duckdb): support INSTALL

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1584,6 +1584,11 @@ class Detach(Expression):
     arg_types = {"this": True, "exists": False}
 
 
+# https://duckdb.org/docs/sql/statements/load_and_install.html
+class Install(Expression):
+    arg_types = {"this": True, "from": False, "force": False}
+
+
 # https://duckdb.org/docs/guides/meta/summarize.html
 class Summarize(Expression):
     arg_types = {"this": True, "table": False}

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -5198,6 +5198,10 @@ class Generator(metaclass=_Generator):
         self.unsupported("Unsupported SHOW statement")
         return ""
 
+    def install_sql(self, expression: exp.Install) -> str:
+        self.unsupported("Unsupported INSTALL statement")
+        return ""
+
     def get_put_sql(self, expression: exp.Put | exp.Get) -> str:
         # Snowflake GET/PUT statements:
         #   PUT <file> <internalStage> <properties>

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -313,6 +313,7 @@ class TokenType(AutoName):
     INDEX = auto()
     INNER = auto()
     INSERT = auto()
+    INSTALL = auto()
     INTERSECT = auto()
     INTERVAL = auto()
     INTO = auto()

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1815,7 +1815,10 @@ class TestDuckDB(Validator):
         self.validate_identity("CREATE SEQUENCE serial START WITH 1 MAXVALUE 10 CYCLE")
 
     def test_install(self):
-        self.validate_identity("INSTALL httpfs").assert_is(exp.Install).name == "httpfs"
+        ast = self.validate_identity("INSTALL httpfs")
+        ast.assert_is(exp.Install).name == "httpfs"
+        assert isinstance(ast.this, exp.Identifier)
+
         self.validate_identity("INSTALL spatial").assert_is(exp.Install).name == "spatial"
         self.validate_identity("INSTALL httpfs FROM community")
         self.validate_identity("INSTALL spatial FROM community")

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1813,3 +1813,18 @@ class TestDuckDB(Validator):
         self.validate_identity("CREATE SEQUENCE serial START WITH 99 INCREMENT BY -1 MAXVALUE 99")
         self.validate_identity("CREATE SEQUENCE serial START WITH 1 MAXVALUE 10 NO CYCLE")
         self.validate_identity("CREATE SEQUENCE serial START WITH 1 MAXVALUE 10 CYCLE")
+
+    def test_install(self):
+        self.validate_identity("INSTALL httpfs").assert_is(exp.Install).name == "httpfs"
+        self.validate_identity("INSTALL spatial").assert_is(exp.Install).name == "spatial"
+        self.validate_identity("INSTALL httpfs FROM community")
+        self.validate_identity("INSTALL spatial FROM community")
+        self.validate_identity("INSTALL spatial FROM 'http://nightly-extensions.duckdb.org'")
+        self.validate_identity("INSTALL httpfs FROM 'https://extensions.duckdb.org'")
+        self.validate_identity("FORCE INSTALL httpfs").assert_is(exp.Install).name == "httpfs"
+        self.validate_identity("FORCE INSTALL spatial").assert_is(exp.Install).name == "spatial"
+        self.validate_identity("FORCE INSTALL httpfs FROM community")
+        self.validate_identity("FORCE INSTALL spatial FROM community")
+        self.validate_identity("FORCE INSTALL spatial FROM 'http://nightly-extensions.duckdb.org'")
+        self.validate_identity("FORCE INSTALL httpfs FROM 'https://extensions.duckdb.org'")
+        self.validate_identity("FORCE CHECKPOINT db", check_command_warning=True)


### PR DESCRIPTION
This PR adds support for the `INSTALL` of duckdb

Finishes #5882 

**DOCS**
[DuckDB INSTALL](https://duckdb.org/docs/stable/extensions/installing_extensions.html)