### PR TITLE
Fix: precedence issue with column operator parsing

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -459,12 +459,16 @@ class Postgres(Dialect):
 
         COLUMN_OPERATORS = {
             **parser.Parser.COLUMN_OPERATORS,
-            TokenType.ARROW: lambda self, this, path: build_json_extract_path(
-                exp.JSONExtract, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
-            )([this, path]),
-            TokenType.DARROW: lambda self, this, path: build_json_extract_path(
-                exp.JSONExtractScalar, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
-            )([this, path]),
+            TokenType.ARROW: lambda self, this, path: self.validate_expression(
+                build_json_extract_path(
+                    exp.JSONExtract, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
+                )([this, path])
+            ),
+            TokenType.DARROW: lambda self, this, path: self.validate_expression(
+                build_json_extract_path(
+                    exp.JSONExtractScalar, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
+                )([this, path])
+            ),
         }
 
         def _parse_query_parameter(self) -> t.Optional[exp.Expression]:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5691,7 +5691,7 @@ class Parser(metaclass=_Parser):
                 if not field:
                     self.raise_error("Expected type")
             elif op and self._curr:
-                field = self._parse_column_reference() or self._parse_bracket()
+                field = self._parse_column_reference() or self._parse_bitwise()
                 if isinstance(field, exp.Column) and self._match(TokenType.DOT, advance=False):
                     field = self._parse_column_ops(field)
             else:

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -162,6 +162,10 @@ class TestPostgres(Validator):
             "ORDER BY 2, 3"
         )
         self.validate_identity(
+            "x::JSON -> 'duration' ->> -1",
+            "JSON_EXTRACT_PATH_TEXT(CAST(x AS JSON) -> 'duration', -1)",
+        ).assert_is(exp.JSONExtractScalar).this.assert_is(exp.JSONExtract)
+        self.validate_identity(
             "SELECT SUBSTRING('Thomas' FOR 3 FROM 2)",
             "SELECT SUBSTRING('Thomas' FROM 2 FOR 3)",
         )


### PR DESCRIPTION
A couple of issues being addressed by this PR

- The way postgres instantiated `JSONExtract*` expressions resulted in not checking their args, i.e. we could get a corrupted AST
- We weren't parsing `"x::JSON -> 'duration' ->> -1` properly:

```python
>>> import sqlglot
>>> sqlglot.parse_one("x::JSON -> 'duration' ->> -1", "postgres")
Sub(
  this=JSONExtractScalar(
    this=JSONExtract(
      this=Cast(
        this=Column(
          this=Identifier(this=x, quoted=False)),
        to=DataType(this=Type.JSON, nested=False)),
      expression=JSONPath(
        expressions=[
          JSONPathRoot(),
          JSONPathKey(this=duration)]),
      only_json_types=True)),
  expression=Literal(this=1, is_string=False))
```

Notice the incorrect `Sub` node.