### PR TITLE
feat(optimizer)!: Add expression class, annotate types for snowflake BASE64_DECODE_STRING and BASE64_ENCODE functions

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -537,6 +537,8 @@ class Snowflake(Dialect):
         },
         exp.DataType.Type.VARCHAR: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.VARCHAR],
+            exp.Base64DecodeString,
+            exp.Base64Encode,
             exp.MD5,
             exp.AIAgg,
             exp.AIClassify,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6418,6 +6418,14 @@ class Base64DecodeBinary(Func):
     arg_types = {"this": True, "alphabet": False}
 
 
+class Base64DecodeString(Func):
+    arg_types = {"this": True, "alphabet": False}
+
+
+class Base64Encode(Func):
+    arg_types = {"this": True, "max_line_length": False, "alphabet": False}
+
+
 # https://trino.io/docs/current/functions/datetime.html#from_iso8601_timestamp
 class FromISO8601Timestamp(Func):
     _sql_names = ["FROM_ISO8601_TIMESTAMP"]

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -29,11 +29,6 @@ class TestSnowflake(Validator):
         expr.selects[0].assert_is(exp.AggFunc)
         self.assertEqual(expr.sql(dialect="snowflake"), "SELECT APPROX_TOP_K(C4, 3, 5) FROM t")
 
-        self.validate_identity("SELECT BASE64_DECODE_BINARY('SGVsbG8=')")
-        self.validate_identity(
-            "SELECT BASE64_DECODE_BINARY('SGVsbG8=', 'ABCDEFGHwxyz0123456789+/')"
-        )
-
         self.validate_identity("SELECT BIT_LENGTH('abc')")
         self.validate_identity("SELECT BIT_LENGTH(x'A1B2')")
         self.validate_identity("SELECT HEX_DECODE_STRING('48656C6C6F')")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1343,6 +1343,23 @@ class TestSnowflake(Validator):
             "SELECT ILIKE(col, 'pattern', '!')", "SELECT col ILIKE 'pattern' ESCAPE '!'"
         )
 
+        self.validate_identity("SELECT BASE64_DECODE_BINARY('SGVsbG8=')")
+        self.validate_identity(
+            "SELECT BASE64_DECODE_BINARY('SGVsbG8=', 'ABCDEFGHwxyz0123456789+/')"
+        )
+
+        self.validate_identity("SELECT BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=')")
+        self.validate_identity(
+            "SELECT BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')"
+        )
+
+        # Test BASE64_ENCODE function
+        self.validate_identity("SELECT BASE64_ENCODE('Hello World')")
+        self.validate_identity("SELECT BASE64_ENCODE('Hello World', 76)")
+        self.validate_identity(
+            "SELECT BASE64_ENCODE('Hello World', 76, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')"
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1353,7 +1353,6 @@ class TestSnowflake(Validator):
             "SELECT BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')"
         )
 
-        # Test BASE64_ENCODE function
         self.validate_identity("SELECT BASE64_ENCODE('Hello World')")
         self.validate_identity("SELECT BASE64_ENCODE('Hello World', 76)")
         self.validate_identity(

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1580,6 +1580,10 @@ BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=');
 VARCHAR;
 
 # dialect: snowflake
+BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/');
+VARCHAR;
+
+# dialect: snowflake
 BIT_LENGTH('abc');
 INT;
 
@@ -1601,6 +1605,10 @@ VARCHAR;
 
 # dialect: snowflake
 BASE64_ENCODE('Hello World', 76);
+VARCHAR;
+
+# dialect: snowflake
+BASE64_ENCODE('Hello World', 76, 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/');
 VARCHAR;
 
 # dialect: snowflake

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1576,6 +1576,10 @@ BASE64_DECODE_BINARY('SGVsbG8=');
 BINARY;
 
 # dialect: snowflake
+BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=');
+VARCHAR;
+
+# dialect: snowflake
 BIT_LENGTH('abc');
 INT;
 
@@ -1593,6 +1597,10 @@ BINARY;
 
 # dialect: snowflake
 HEX_DECODE_STRING('48656C6C6F');
+VARCHAR;
+
+# dialect: snowflake
+BASE64_ENCODE('Hello World', 76);
 VARCHAR;
 
 # dialect: snowflake


### PR DESCRIPTION
Closes https://fivetran.atlassian.net/browse/RD-1035998 
Add expression class, Annotate types for snowflake BASE64_DECODE_STRING and BASE64_ENCODE functions.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/base64_decode_string
https://docs.snowflake.com/en/sql-reference/functions/base64_encode