### PR TITLE
Support postgres omitted interval span unit

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -375,6 +375,8 @@ class Postgres(Dialect):
         VAR_SINGLE_TOKENS = {"$"}
 
     class Parser(parser.Parser):
+        SUPPORTS_OMITTED_INTERVAL_SPAN_UNIT = True
+
         PROPERTY_PARSERS = {
             **parser.Parser.PROPERTY_PARSERS,
             "SET": lambda self: self.expression(exp.SetConfigProperty, this=self._parse_set()),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8562,8 +8562,10 @@ def parse_identifier(name: str | Identifier, dialect: DialectType = None) -> Ide
 INTERVAL_STRING_RE = re.compile(r"\s*(-?[0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]+)\s*")
 
 # Matches day-time interval strings that contain a number of days, a space,
-# and a time component in the format hh:[mm:[ss[.ff]]]
-INTERVAL_DAY_TIME_RE = re.compile(r"^\s*(-?[0-9]+)\s+(\d{1,2}:\d{0,2}(?::\d{0,2}(?:\.\d+)?)?)\s*$")
+# and a time in hh:[mm:[ss[.ff]]] format
+INTERVAL_DAY_TIME_RE = re.compile(
+    r"\s*(-?[0-9]+(?:\.\d+)?)\s+(\d{1,2}:\d{0,2}(?::\d{0,2}(?:\.\d+)?)?)\s*"
+)
 
 
 def to_interval(interval: str | Literal) -> Interval:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8561,6 +8561,10 @@ def parse_identifier(name: str | Identifier, dialect: DialectType = None) -> Ide
 
 INTERVAL_STRING_RE = re.compile(r"\s*(-?[0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]+)\s*")
 
+# Matches day-time interval strings that contain a number of days, a space,
+# and a time component in the format hh:[mm:[ss[.ff]]]
+INTERVAL_DAY_TIME_RE = re.compile(r"^\s*(-?[0-9]+)\s+(\d{1,2}:\d{0,2}(?::\d{0,2}(?:\.\d+)?)?)\s*$")
+
 
 def to_interval(interval: str | Literal) -> Interval:
     """Builds an interval expression from a string like '1 day' or '5 months'."""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3284,7 +3284,7 @@ class Generator(metaclass=_Generator):
         if self.SINGLE_STRING_INTERVAL:
             this = expression.this.name if expression.this else ""
             if this:
-                if unit and isinstance(unit_expression, exp.IntervalSpan):
+                if unit_expression and isinstance(unit_expression, exp.IntervalSpan):
                     return f"INTERVAL '{this}'{unit}"
                 return f"INTERVAL '{this}{unit}'"
             return f"INTERVAL{unit}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3275,14 +3275,19 @@ class Generator(metaclass=_Generator):
         return f"(SELECT {self.sql(unnest)})"
 
     def interval_sql(self, expression: exp.Interval) -> str:
-        unit = self.sql(expression, "unit")
+        unit_expression = expression.args.get("unit")
+        unit = self.sql(unit_expression) if unit_expression else ""
         if not self.INTERVAL_ALLOWS_PLURAL_FORM:
             unit = self.TIME_PART_SINGULARS.get(unit, unit)
         unit = f" {unit}" if unit else ""
 
         if self.SINGLE_STRING_INTERVAL:
             this = expression.this.name if expression.this else ""
-            return f"INTERVAL '{this}{unit}'" if this else f"INTERVAL{unit}"
+            if this:
+                if unit and isinstance(unit_expression, exp.IntervalSpan):
+                    return f"INTERVAL '{this}'{unit}"
+                return f"INTERVAL '{this}{unit}'"
+            return f"INTERVAL{unit}"
 
         this = self.sql(expression, "this")
         if this:

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1637,3 +1637,19 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
                     self.validate_identity(
                         f"BEGIN {keyword} {level}, {level}", f"BEGIN {level}, {level}"
                     ).assert_is(exp.Transaction)
+
+    def test_interval_span(self):
+        for time_str in ["1 01:", "1 01:", "1 01:00", "1 01:00"]:
+            self.validate_identity(f"INTERVAL '{time_str}'", f"INTERVAL '{time_str}' DAY TO MINUTE")
+            # explicit SECOND overrides inference to MINUTE
+            self.validate_identity(f"INTERVAL '{time_str}' DAY TO SECOND")
+
+        for time_str in ["1 01:01:", "1 01:01:", "1 01:01:01", "1 01:01:01.01"]:
+            self.validate_identity(f"INTERVAL '{time_str}'", f"INTERVAL '{time_str}' DAY TO SECOND")
+            # explicit MINUTE overrides inference to SECOND
+            self.validate_identity(f"INTERVAL '{time_str}' DAY TO MINUTE")
+
+        # Ensure AND is not consumed as a unit following an omitted-span interval
+        day_time_str = "a > INTERVAL '1 00:00' AND TRUE"
+        self.validate_identity(day_time_str, "a > INTERVAL '1 00:00' DAY TO MINUTE AND TRUE")
+        self.assertIsInstance(self.parse_one(day_time_str), exp.And)

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1639,12 +1639,19 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
                     ).assert_is(exp.Transaction)
 
     def test_interval_span(self):
-        for time_str in ["1 01:", "1 01:", "1 01:00", "1 01:00"]:
+        for time_str in ["1 01:", "1 01:00", "1.5 01:", "-0.25 01:"]:
             self.validate_identity(f"INTERVAL '{time_str}'", f"INTERVAL '{time_str}' DAY TO MINUTE")
             # explicit SECOND overrides inference to MINUTE
             self.validate_identity(f"INTERVAL '{time_str}' DAY TO SECOND")
 
-        for time_str in ["1 01:01:", "1 01:01:", "1 01:01:01", "1 01:01:01.01"]:
+        for time_str in [
+            "1 01:01:",
+            "1 01:01:",
+            "1 01:01:01",
+            "1 01:01:01.01",
+            "1.5 01:01:",
+            "-0.25 01:01:",
+        ]:
             self.validate_identity(f"INTERVAL '{time_str}'", f"INTERVAL '{time_str}' DAY TO SECOND")
             # explicit MINUTE overrides inference to SECOND
             self.validate_identity(f"INTERVAL '{time_str}' DAY TO MINUTE")


### PR DESCRIPTION
This PR adds support for handling postgres INTERVAL literal spans that omit the span units, both parsing and inferring the correct units for transpilation.

Examples
- `INTERVAL '1 00:01'` --> `INTERVAL '1 00:01' DAY TO MINUTE`
- `INTERVAL '1 00:01:01'` --> `INTERVAL '1 00:01:01' DAY TO SECOND`

Note: an explicit unit can be present, and it overrides the value inferred from hhmmss.ff
- Example: `INTERVAL '1 01:01:01' DAY TO MINUTE` contains seconds in hhmmss, but evaluates to `1 day 01:01:00` (no seconds) in postgres

### Context: `INTERVAL`s
interval literals generally consist of the word `INTERVAL` , a string literal like `'6'` and a unit string like `DAYS`
- Example: `INTERVAL '6' DAYS`

in many dialects you may specify compound units, which we [parse into](https://github.com/tobymao/sqlglot/blob/6807a32cccf984dc13a30b815750b2c41374b845/sqlglot/parser.py#L5127) `exp.IntervalSpan` [based on the presence of "TO"](https://github.com/tobymao/sqlglot/blob/6807a32cccf984dc13a30b815750b2c41374b845/sqlglot/parser.py#L5127)
- Example: `INTERVAL '163 12:39' DAY TO MINUTE`
- Example: `INTERVAL '163 12:39:59.1' DAY TO SECOND`

### Context: postgres
Postgres lets you omit the unit strings `DAY TO MINUTE` and `DAY TO SECOND` if the second element in the literal is a `hh:[mm:[ss[.ff]]]`
- Valid examples confirmed to work in postgres 14:
  - `INTERVAL '1 01:01:01.01'`
  - `INTERVAL '1 01:01:01'`
  - `INTERVAL '1 01:01'`
  - `INTERVAL '1.5 01:'`
  - `INTERVAL '-0.25 01:'`
- Invalid example
  - No colon present: `INTERVAL '1 01'`
 
### This issue
If the span unit is omitted, we incorrectly ingest the token following the literal because we assume it's a unit like `DAY`
- Example: `a > INTERVAL '1 00:00' AND TRUE`
  - We consume `AND` so don't recognize the compound condition