### PR TITLE
feat(solr): initial Solr dialect

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ x + interval '1' month
 | RisingWave | Community |
 | SingleStore | Community |
 | Snowflake | Official |
+| Solr | Community |
 | Spark | Official |
 | SQLite | Official |
 | StarRocks | Official |

--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -88,6 +88,7 @@ DIALECTS = [
     "RisingWave",
     "SingleStore",
     "Snowflake",
+    "Solr",
     "Spark",
     "Spark2",
     "SQLite",

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -99,6 +99,7 @@ class Dialects(str, Enum):
     REDSHIFT = "redshift"
     RISINGWAVE = "risingwave"
     SNOWFLAKE = "snowflake"
+    SOLR = "solr"
     SPARK = "spark"
     SPARK2 = "spark2"
     SQLITE = "sqlite"

--- a/sqlglot/dialects/solr.py
+++ b/sqlglot/dialects/solr.py
@@ -1,0 +1,15 @@
+from sqlglot import tokens
+from sqlglot.dialects.dialect import Dialect, NormalizationStrategy
+
+
+# https://solr.apache.org/guide/solr/latest/query-guide/sql-query.html
+
+
+class Solr(Dialect):
+    NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
+    DPIPE_IS_STRING_CONCAT = False
+    SUPPORTS_SEMI_ANTI_JOIN = False
+
+    class Tokenizer(tokens.Tokenizer):
+        QUOTES = ["'"]
+        IDENTIFIERS = ["`"]

--- a/tests/dialects/test_solr.py
+++ b/tests/dialects/test_solr.py
@@ -8,3 +8,4 @@ class TestSolr(Validator):
         self.validate_identity("SELECT `default`.column FROM t")
         self.failureException('SELECT "column" FROM t')
         self.validate_identity("SELECT column FROM t WHERE column = 'val'")
+        self.validate_identity("a || b").assert_is(exp.Or)

--- a/tests/dialects/test_solr.py
+++ b/tests/dialects/test_solr.py
@@ -1,0 +1,10 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestSolr(Validator):
+    dialect = "solr"
+
+    def test_solr(self):
+        self.validate_identity("SELECT `default`.column FROM t")
+        self.failureException('SELECT "column" FROM t')
+        self.validate_identity("SELECT column FROM t WHERE column = 'val'")

--- a/tests/dialects/test_solr.py
+++ b/tests/dialects/test_solr.py
@@ -1,3 +1,4 @@
+from sqlglot import exp
 from tests.dialects.test_dialect import Validator
 
 


### PR DESCRIPTION
This is an initial Solr dialect. It captures:

* Literal and identifier quotation rules
* Normalization strategy
* Disabling double pipe string concatenation

Solr Query Language: https://solr.apache.org/guide/solr/latest/query-guide/sql-query.html