### PR TITLE
Fix(snowflake): properly generate inferred `STRUCT` data types

### DIFF
--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1673,3 +1673,13 @@ FROM READ_CSV('tests/fixtures/optimizer/tpc-h/nation.csv.gz', 'delimiter', '|') 
         annotated = optimizer.annotate_types.annotate_types(qualified, dialect="bigquery")
 
         assert annotated.selects[0].type == exp.DataType.build("VARCHAR")
+
+    def test_annotate_object_construct(self):
+        sql = "SELECT OBJECT_CONSTRUCT('foo', 'bar', 'a b', 'c d') AS c"
+
+        query = parse_one(sql, dialect="snowflake")
+        annotated = optimizer.annotate_types.annotate_types(query, dialect="snowflake")
+
+        self.assertEqual(
+            annotated.selects[0].type.sql("snowflake"), 'OBJECT("foo" VARCHAR, "a b" VARCHAR)'
+        )


### PR DESCRIPTION
The behavior in main today is problematic:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.annotate_types import annotate_types
>>>
>>> sql = "SELECT OBJECT_CONSTRUCT('foo', 'bar') AS c"
>>> ast = parse_one(sql, "snowflake")
>>> annotated = annotate_types(ast, dialect="snowflake")
>>>
>>> print(annotated.selects[0].type.sql("snowflake"))
OBJECT('foo' VARCHAR)
```

The last type is not valid Snowflake:

```sql
-- syntax error ... unexpected ''foo''.
-- syntax error ... unexpected ')'.
SELECT CAST(OBJECT_CONSTRUCT('foo', 'bar') AS OBJECT('foo' VARCHAR))
```

Context: this issue was observed in a Snowflake SQLMesh project: type inference produced an incorrect type and we used it in a DDL statement, resulting in a plan error.
