### PR TITLE
feat(optimizer): Annotate type for OCTET_LENGTH function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -532,6 +532,7 @@ class Snowflake(Dialect):
         exp.DataType.Type.INT: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.INT],
             exp.Ascii,
+            exp.ByteLength,
             exp.Length,
             exp.BitLength,
             exp.Levenshtein,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -42,6 +42,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT LPAD('Hello', 10, '*')")
         self.validate_identity("SELECT LPAD(tbl.bin_col, 10)")
         self.validate_identity("SELECT JAROWINKLER_SIMILARITY('hello', 'world')")
+        self.validate_identity("SELECT OCTET_LENGTH('Hello World')")
         self.validate_identity("SELECT {*} FROM my_table")
         self.validate_identity("SELECT {my_table.*} FROM my_table")
         self.validate_identity("SELECT {* ILIKE 'col1%'} FROM my_table")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1800,6 +1800,14 @@ LENGTH(tbl.bin_col);
 INT;
 
 # dialect: snowflake
+OCTET_LENGTH(tbl.str_col);
+INT;
+
+# dialect: snowflake
+OCTET_LENGTH(tbl.bin_col);
+INT;
+
+# dialect: snowflake
 LOWER(tbl.str_col);
 VARCHAR;
 


### PR DESCRIPTION
Annotate type for octet_length function.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/octet_length