### PR TITLE
chore: add uv support to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 .PHONY: install install-dev install-pre-commit test unit style check docs docs-serve
 
+ifdef UV
+    PIP := uv pip
+else
+    PIP := pip
+endif
+
 install:
-	pip install -e .
+	$(PIP) install -e .
 
 bench: install-dev-rs-release
 	python -m benchmarks.bench
@@ -17,7 +23,7 @@ install-dev-rs:
 	cd sqlglotrs/ && python -m maturin develop
 
 install-dev-core:
-	pip install -e ".[dev]"
+	$(PIP) install -e ".[dev]"
 
 install-dev: install-dev-core install-dev-rs
 


### PR DESCRIPTION
Allows users to set `UV=1` and use uv instead of pip for managing packages.

Matches what is done in SQLMesh: https://github.com/TobikoData/sqlmesh/blob/bf40bbeafc07723d76d64da44c635387cda57b62/Makefile#L3-L7