### PR TITLE
feat(optimizer)!: Annotate type for snowflake TRY_HEX_DECODE_BINARY function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -569,6 +569,7 @@ class Snowflake(Dialect):
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.BINARY],
             exp.Base64DecodeBinary,
             exp.TryBase64DecodeBinary,
+            exp.TryHexDecodeBinary,
             exp.Compress,
             exp.DecompressBinary,
             exp.MD5Digest,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6449,7 +6449,7 @@ class TryBase64DecodeString(Func):
 
 # https://docs.snowflake.com/en/sql-reference/functions/try_hex_decode_binary
 class TryHexDecodeBinary(Func):
-    arg_types = {"this": True}
+    pass
 
 
 # https://trino.io/docs/current/functions/datetime.html#from_iso8601_timestamp

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6447,6 +6447,11 @@ class TryBase64DecodeString(Func):
     arg_types = {"this": True, "alphabet": False}
 
 
+# https://docs.snowflake.com/en/sql-reference/functions/try_hex_decode_binary
+class TryHexDecodeBinary(Func):
+    arg_types = {"this": True}
+
+
 # https://trino.io/docs/current/functions/datetime.html#from_iso8601_timestamp
 class FromISO8601Timestamp(Func):
     _sql_names = ["FROM_ISO8601_TIMESTAMP"]

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1402,6 +1402,8 @@ class TestSnowflake(Validator):
             "SELECT TRY_BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/')"
         )
 
+        self.validate_identity("SELECT TRY_HEX_DECODE_BINARY('48656C6C6F')")
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2160,6 +2160,10 @@ TRY_BASE64_DECODE_STRING('SGVsbG8gV29ybGQ=', 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefgh
 VARCHAR;
 
 # dialect: snowflake
+TRY_HEX_DECODE_BINARY('48656C6C6F');
+BINARY;
+
+# dialect: snowflake
 UPPER('Hello, world!');
 VARCHAR;
 


### PR DESCRIPTION
Annotate type for snowflake TRY_HEX_DECODE_BINARY function.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/try_hex_decode_binary