### PR TITLE
Fix!: remove `unalias_group_by` transformation since it is unsafe

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -531,7 +531,6 @@ class Hive(Dialect):
 
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
-            exp.Group: transforms.preprocess([transforms.unalias_group]),
             exp.Property: property_sql,
             exp.AnyValue: rename_func("FIRST"),
             exp.ApproxDistinct: approx_count_distinct_sql,

--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -307,7 +307,6 @@ class Oracle(Dialect):
             ),
             exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, e.unit),
             exp.EuclideanDistance: rename_func("L2_DISTANCE"),
-            exp.Group: transforms.preprocess([transforms.unalias_group]),
             exp.ILike: no_ilike_sql,
             exp.LogicalOr: rename_func("MAX"),
             exp.LogicalAnd: rename_func("MIN"),

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -475,7 +475,6 @@ class Presto(Dialect):
             e: f"WITH_TIMEZONE({self.sql(e, 'this')}, {self.sql(e, 'zone')}) AT TIME ZONE 'UTC'",
             exp.GenerateSeries: sequence_sql,
             exp.GenerateDateArray: sequence_sql,
-            exp.Group: transforms.preprocess([transforms.unalias_group]),
             exp.If: if_sql(),
             exp.ILike: no_ilike_sql,
             exp.Initcap: _initcap_sql,

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -230,7 +230,6 @@ class Spark(Spark2):
         }
         TRANSFORMS.pop(exp.AnyValue)
         TRANSFORMS.pop(exp.DateDiff)
-        TRANSFORMS.pop(exp.Group)
 
         def bracket_sql(self, expression: exp.Bracket) -> str:
             if expression.args.get("safe"):

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -131,39 +131,6 @@ def unnest_generate_series(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
-def unalias_group(expression: exp.Expression) -> exp.Expression:
-    """
-    Replace references to select aliases in GROUP BY clauses.
-
-    Example:
-        >>> import sqlglot
-        >>> sqlglot.parse_one("SELECT a AS b FROM x GROUP BY b").transform(unalias_group).sql()
-        'SELECT a AS b FROM x GROUP BY 1'
-
-    Args:
-        expression: the expression that will be transformed.
-
-    Returns:
-        The transformed expression.
-    """
-    if isinstance(expression, exp.Group) and isinstance(expression.parent, exp.Select):
-        aliased_selects = {
-            e.alias: i
-            for i, e in enumerate(expression.parent.expressions, start=1)
-            if isinstance(e, exp.Alias)
-        }
-
-        for group_by in expression.expressions:
-            if (
-                isinstance(group_by, exp.Column)
-                and not group_by.table
-                and group_by.name in aliased_selects
-            ):
-                group_by.replace(exp.Literal.number(aliased_selects.get(group_by.name)))
-
-    return expression
-
-
 def eliminate_distinct_on(expression: exp.Expression) -> exp.Expression:
     """
     Convert SELECT DISTINCT ON statements to a subquery with a window function.

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2475,6 +2475,25 @@ class TestDialect(Validator):
 
     def test_alias(self):
         self.validate_all(
+            "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT x AS x FROM t GROUP BY x",
+            write={
+                "": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT x AS x FROM t GROUP BY x",
+                "hive": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT x AS x FROM t GROUP BY x",
+                "oracle": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT x AS x FROM t GROUP BY x",
+                "presto": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT x AS x FROM t GROUP BY x",
+            },
+        )
+        self.validate_all(
+            "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT SUM(x) AS y, y AS x FROM t GROUP BY y",
+            write={
+                "": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT SUM(x) AS y, y AS x FROM t GROUP BY y",
+                "hive": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT SUM(x) AS y, y AS x FROM t GROUP BY y",
+                "oracle": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT SUM(x) AS y, y AS x FROM t GROUP BY y",
+                "presto": "WITH t AS (SELECT 1 AS x, 2 AS y) SELECT SUM(x) AS y, y AS x FROM t GROUP BY y",
+            },
+        )
+
+        self.validate_all(
             'SELECT 1 AS "foo"',
             read={
                 "mysql": "SELECT 1 'foo'",
@@ -2496,18 +2515,6 @@ class TestDialect(Validator):
                 with self.assertRaises(ParseError):
                     parse_one("SELECT 1 'foo'", dialect=dialect)
 
-        self.validate_all(
-            "SELECT a AS b FROM x GROUP BY b",
-            write={
-                "drill": "SELECT a AS b FROM x GROUP BY b",
-                "duckdb": "SELECT a AS b FROM x GROUP BY b",
-                "presto": "SELECT a AS b FROM x GROUP BY 1",
-                "hive": "SELECT a AS b FROM x GROUP BY 1",
-                "oracle": "SELECT a AS b FROM x GROUP BY 1",
-                "spark": "SELECT a AS b FROM x GROUP BY b",
-                "spark2": "SELECT a AS b FROM x GROUP BY 1",
-            },
-        )
         self.validate_all(
             "SELECT y x FROM my_table t",
             write={

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,7 +7,6 @@ from sqlglot.transforms import (
     eliminate_qualify,
     eliminate_window_clause,
     remove_precision_parameterized_types,
-    unalias_group,
 )
 
 
@@ -20,38 +19,6 @@ class TestTransforms(unittest.TestCase):
                 parse_one(sql, dialect=dialect).transform(transform).sql(dialect=dialect),
                 target,
             )
-
-    def test_unalias_group(self):
-        self.validate(
-            unalias_group,
-            "SELECT a, b AS b, c AS c, 4 FROM x GROUP BY a, b, x.c, 4",
-            "SELECT a, b AS b, c AS c, 4 FROM x GROUP BY a, 2, x.c, 4",
-        )
-        self.validate(
-            unalias_group,
-            "SELECT TO_DATE(the_date) AS the_date, CUSTOM_UDF(other_col) AS other_col, last_col AS aliased_last, COUNT(*) AS the_count FROM x GROUP BY TO_DATE(the_date), CUSTOM_UDF(other_col), aliased_last",
-            "SELECT TO_DATE(the_date) AS the_date, CUSTOM_UDF(other_col) AS other_col, last_col AS aliased_last, COUNT(*) AS the_count FROM x GROUP BY TO_DATE(the_date), CUSTOM_UDF(other_col), 3",
-        )
-        self.validate(
-            unalias_group,
-            "SELECT SOME_UDF(TO_DATE(the_date)) AS the_date, COUNT(*) AS the_count FROM x GROUP BY SOME_UDF(TO_DATE(the_date))",
-            "SELECT SOME_UDF(TO_DATE(the_date)) AS the_date, COUNT(*) AS the_count FROM x GROUP BY SOME_UDF(TO_DATE(the_date))",
-        )
-        self.validate(
-            unalias_group,
-            "SELECT SOME_UDF(TO_DATE(the_date)) AS new_date, COUNT(*) AS the_count FROM x GROUP BY new_date",
-            "SELECT SOME_UDF(TO_DATE(the_date)) AS new_date, COUNT(*) AS the_count FROM x GROUP BY 1",
-        )
-        self.validate(
-            unalias_group,
-            "SELECT the_date AS the_date, COUNT(*) AS the_count FROM x GROUP BY the_date",
-            "SELECT the_date AS the_date, COUNT(*) AS the_count FROM x GROUP BY 1",
-        )
-        self.validate(
-            unalias_group,
-            "SELECT a AS a FROM x GROUP BY DATE(a)",
-            "SELECT a AS a FROM x GROUP BY DATE(a)",
-        )
 
     def test_eliminate_distinct_on(self):
         self.validate(


### PR DESCRIPTION
Fixes #5995

This transformation was [introduced ~3 years ago](github.com/tobymao/sqlglot/pull/305) as a response to [this issue](https://github.com/tobymao/sqlglot/issues/304), but I think it's unsafe to use without a schema & additional logic. I've added a couple of tests in `test_dialect.py` that demonstrate the issue (both convert valid Hive SQL into invalid SQL).

Since we have `_expand_positional_references` in `qualify_columns.py`, I think there's already a path to resolving these aliases referenced in `GROUP BY` clauses, so this is not needed anymore.