### PR TITLE
fix(optimizer): avoid merging subquery with JOIN when outer query uses JOIN

### DIFF
--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -513,26 +513,29 @@ select cte.mult from cte;
 SELECT x.a * x.b AS mult FROM x AS x;
 
 # title: avoid merging subquery with JOIN
-WITH 
-t0 AS (
-  SELECT 5 as id
-),
-t1 AS (
-  SELECT 1 AS id, 'US' AS cid
-),
-t2 AS (
-  SELECT 1 AS id, 'US' AS cid
+WITH t0 AS (
+  SELECT
+    5 AS id
+), t1 AS (
+  SELECT
+    1 AS id,
+    'US' AS cid
+), t2 AS (
+  SELECT
+    1 AS id,
+    'US' AS cid
 )
 SELECT
   t0.id,
   t3.cid AS cid
 FROM t0
-CROSS JOIN (
+INNER JOIN (
   SELECT
     t1.id,
     t2.cid
   FROM t1
   RIGHT JOIN t2
     ON t1.cid = t2.cid
-) AS t3;
-WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t3.cid AS cid FROM t0 AS t0 CROSS JOIN (SELECT t1.id AS id, t2.cid AS cid FROM t1 AS t1 RIGHT JOIN t2 AS t2 ON t1.cid = t2.cid) AS t3;
+) AS t3
+  ON t0.id = t3.id;
+WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t3.cid AS cid FROM t0 AS t0 INNER JOIN (SELECT t1.id AS id, t2.cid AS cid FROM t1 AS t1 RIGHT JOIN t2 AS t2 ON t1.cid = t2.cid) AS t3 ON t0.id = t3.id;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -512,7 +512,7 @@ with cte as (
 select cte.mult from cte;
 SELECT x.a * x.b AS mult FROM x AS x;
 
-# title: replace INNER JOIN with LEFT JOIN when it exists in a subquery used as the RHS of a LEFT JOIN
+# title: avoid merging subquery with JOIN
 WITH 
 t0 AS (
   SELECT 5 as id
@@ -527,70 +527,12 @@ SELECT
   t0.id,
   t3.cid AS cid
 FROM t0
-LEFT JOIN (
+CROSS JOIN (
   SELECT
     t1.id,
     t2.cid
   FROM t1
-  INNER JOIN t2
+  RIGHT JOIN t2
     ON t1.cid = t2.cid
-) AS t3
-  ON t0.id = t3.id;
-WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t2.cid AS cid FROM t0 AS t0 LEFT JOIN t1 AS t1 ON t0.id = t1.id LEFT JOIN t2 AS t2 ON t1.cid = t2.cid;
-
-# title: preserve INNER JOIN when it exists in a subquery used as the RHS of a RIGHT JOIN
-WITH 
-t0 AS (
-  SELECT 5 as id
-),
-t1 AS (
-  SELECT 1 AS id, 'US' AS cid
-),
-t2 AS (
-  SELECT 1 AS id, 'US' AS cid
-)
-SELECT
-  t0.id,
-  t3.cid AS cid
-FROM t0
-RIGHT JOIN (
-  SELECT
-    t1.id,
-    t2.cid
-  FROM t1
-  INNER JOIN t2
-    ON t1.cid = t2.cid
-) AS t3
-  ON t0.id = t3.id;
-WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t2.cid AS cid FROM t0 AS t0 RIGHT JOIN t1 AS t1 ON t0.id = t1.id INNER JOIN t2 AS t2 ON t1.cid = t2.cid;
-
-# title: replace multiple INNER JOINS with LEFT JOINS when they exist in a subquery used as the RHS of a LEFT JOIN
-WITH
-t0 AS (
-  SELECT 5 as id
-),
-t1 AS (
-  SELECT 1 AS id, 'US' AS cid
-),
-t2 AS (
-  SELECT 1 AS id, 'US' AS cid
-),
-t3 AS (
-  SELECT 1 AS id, 'CA' AS cid
-)
-SELECT
-  t0.id,
-  t4.cid AS cid
-FROM t0
-LEFT JOIN (
-  SELECT
-    t1.id,
-    t3.cid
-  FROM t1
-  INNER JOIN t2
-    ON t1.cid = t2.cid
-  INNER JOIN t3
-    ON t2.id = t3.id
-) AS t4
-  ON t0.id = t4.id;
-WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid), t3 AS (SELECT 1 AS id, 'CA' AS cid) SELECT t0.id AS id, t3.cid AS cid FROM t0 AS t0 LEFT JOIN t1 AS t1 ON t0.id = t1.id LEFT JOIN t2 AS t2 ON t1.cid = t2.cid LEFT JOIN t3 AS t3 ON t2.id = t3.id;
+) AS t3;
+WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t3.cid AS cid FROM t0 AS t0 CROSS JOIN (SELECT t1.id AS id, t2.cid AS cid FROM t1 AS t1 RIGHT JOIN t2 AS t2 ON t1.cid = t2.cid) AS t3;

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -472,17 +472,22 @@ FROM (
       alias_1.id = alias_2.id
     )
 ) AS main_query;
+WITH "alias_2" AS (
+  SELECT
+    "company_table_2"."id" AS "id"
+  FROM "company_table" AS "company_table_2"
+  LEFT JOIN "unlocked" AS "unlocked"
+    ON "company_table_2"."id" = "unlocked"."company_id"
+  WHERE
+    CASE WHEN "unlocked"."company_id" IS NULL THEN 0 ELSE 1 END = FALSE
+    AND NOT "company_table_2"."id" IS NULL
+)
 SELECT
   "company_table"."id" AS "id",
   "company_table"."score" AS "score"
 FROM "company_table" AS "company_table"
-JOIN "company_table" AS "company_table_2"
-  ON "company_table"."id" = "company_table_2"."id"
-LEFT JOIN "unlocked" AS "unlocked"
-  ON "company_table_2"."id" = "unlocked"."company_id"
-WHERE
-  CASE WHEN "unlocked"."company_id" IS NULL THEN 0 ELSE 1 END = FALSE
-  AND NOT "company_table_2"."id" IS NULL;
+JOIN "alias_2" AS "alias_2"
+  ON "alias_2"."id" = "company_table"."id";
 
 # title: db.table alias clash
 # execute: false

--- a/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
+++ b/tests/fixtures/optimizer/tpc-ds/tpc-ds.sql
@@ -198,24 +198,34 @@ WITH "wscs" AS (
     ON "date_dim"."d_date_sk" = "wscs"."sold_date_sk"
   GROUP BY
     "date_dim"."d_week_seq"
+), "z" AS (
+  SELECT
+    "wswscs"."d_week_seq" AS "d_week_seq2",
+    "wswscs"."sun_sales" AS "sun_sales2",
+    "wswscs"."mon_sales" AS "mon_sales2",
+    "wswscs"."tue_sales" AS "tue_sales2",
+    "wswscs"."wed_sales" AS "wed_sales2",
+    "wswscs"."thu_sales" AS "thu_sales2",
+    "wswscs"."fri_sales" AS "fri_sales2",
+    "wswscs"."sat_sales" AS "sat_sales2"
+  FROM "wswscs" AS "wswscs"
+  JOIN "date_dim" AS "date_dim"
+    ON "date_dim"."d_week_seq" = "wswscs"."d_week_seq" AND "date_dim"."d_year" = 1999
 )
 SELECT
   "wswscs"."d_week_seq" AS "d_week_seq1",
-  ROUND("wswscs"."sun_sales" / "wswscs_2"."sun_sales", 2) AS "_col_1",
-  ROUND("wswscs"."mon_sales" / "wswscs_2"."mon_sales", 2) AS "_col_2",
-  ROUND("wswscs"."tue_sales" / "wswscs_2"."tue_sales", 2) AS "_col_3",
-  ROUND("wswscs"."wed_sales" / "wswscs_2"."wed_sales", 2) AS "_col_4",
-  ROUND("wswscs"."thu_sales" / "wswscs_2"."thu_sales", 2) AS "_col_5",
-  ROUND("wswscs"."fri_sales" / "wswscs_2"."fri_sales", 2) AS "_col_6",
-  ROUND("wswscs"."sat_sales" / "wswscs_2"."sat_sales", 2) AS "_col_7"
+  ROUND("wswscs"."sun_sales" / "z"."sun_sales2", 2) AS "_col_1",
+  ROUND("wswscs"."mon_sales" / "z"."mon_sales2", 2) AS "_col_2",
+  ROUND("wswscs"."tue_sales" / "z"."tue_sales2", 2) AS "_col_3",
+  ROUND("wswscs"."wed_sales" / "z"."wed_sales2", 2) AS "_col_4",
+  ROUND("wswscs"."thu_sales" / "z"."thu_sales2", 2) AS "_col_5",
+  ROUND("wswscs"."fri_sales" / "z"."fri_sales2", 2) AS "_col_6",
+  ROUND("wswscs"."sat_sales" / "z"."sat_sales2", 2) AS "_col_7"
 FROM "wswscs" AS "wswscs"
 JOIN "date_dim" AS "date_dim"
   ON "date_dim"."d_week_seq" = "wswscs"."d_week_seq" AND "date_dim"."d_year" = 1998
-JOIN "wswscs" AS "wswscs_2"
-  ON "wswscs"."d_week_seq" = "wswscs_2"."d_week_seq" - 53
-JOIN "date_dim" AS "date_dim_2"
-  ON "date_dim_2"."d_week_seq" = "wswscs_2"."d_week_seq"
-  AND "date_dim_2"."d_year" = 1999
+JOIN "z" AS "z"
+  ON "wswscs"."d_week_seq" = "z"."d_week_seq2" - 53
 ORDER BY
   "d_week_seq1";
 


### PR DESCRIPTION
  We were incorrectly merging subqueries that contained `JOINs` when the outer query also used a `JOIN` clause. This changed join precedence and produced incorrect results.

```
  WITH
    t0 AS (SELECT 5 as id),
    t1 AS (SELECT 1 AS id, 'US' AS cid),
    t2 AS (SELECT 1 AS id, 'US' AS cid)
  SELECT t0.id, t3.cid AS cid
  FROM t0
  INNER JOIN (
    SELECT t1.id, t2.cid
    FROM t1
    RIGHT JOIN t2 ON t1.cid = t2.cid
  ) AS t3 ON t0.id = t3.id;
  ┌───────┬─────────┐
  │  id   │   cid   │
  │ int32 │ varchar │
  ├───────┴─────────┤
  │     0 rows      │
  └─────────────────┘

  ======= Optimized (previous version) =======
  WITH
    t0 AS (SELECT 5 as id),
    t1 AS (SELECT 1 AS id, 'US' AS cid),
    t2 AS (SELECT 1 AS id, 'US' AS cid)
  SELECT t0.id, t2.cid AS cid
  FROM t0
  INNER JOIN t1 ON t0.id = t1.id
  RIGHT JOIN t2 ON t1.cid = t2.cid;
  ┌───────┬─────────┐
  │  id   │   cid   │
  │ int32 │ varchar │
  ├───────┼─────────┤
  │ NULL  │ US      │
  └───────┴─────────┘
```

In the original query, the subquery's `t1 RIGHT JOIN t2` executes first, then `t0` performs an `INNER JOIN` with that result. Since `t0.id = 5` has no match in the subquery result, it returns 0 rows.

In the incorrectly optimized query, `t0 INNER JOIN t1` executes first (produces 0 rows), then `RIGHT JOIN t2` preserves all rows from `t2`, incorrectly returning 1 row.

The logic of merging these types of subqueries is complex. So, this PR avoids of merging them for now.