### PR TITLE
chore(optimizer): Annotate type for sqrt function

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -816,6 +816,7 @@ class TestSnowflake(Validator):
                 "tsql": "SQUARE(x)",
             },
         )
+        self.validate_identity("SELECT SQRT(x)")
         self.validate_all(
             "DIV0(foo, bar)",
             write={

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2156,6 +2156,10 @@ SPACE(NULL);
 VARCHAR;
 
 # dialect: snowflake
+SQRT(tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
 SPLIT('hello world', ' ');
 ARRAY;
 


### PR DESCRIPTION
Annotate type for sqrt function.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/sqrt