### PR TITLE
feat(hive,spark)!: Support CHANGE COLUMN statements in Hive and CHANGE/ALTER COLUMN statements in Spark

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -525,6 +525,13 @@ class Dialect(metaclass=_Dialect):
     equivalent of CREATE SCHEMA is CREATE DATABASE.
     """
 
+    ALTER_TABLE_SUPPORTS_CASCADE = False
+    """
+    Hive by default does not update the schema of existing partitions when a column is changed.
+    the CASCADE clause is used to indicate that the change should be propagated to all existing partitions.
+    the Spark dialect, while derived from Hive, does not support the CASCADE clause.
+    """
+
     # Whether ADD is present for each column added by ALTER TABLE
     ALTER_TABLE_ADD_REQUIRED_FOR_EACH_COLUMN = True
 

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -490,7 +490,9 @@ class Hive(Dialect):
                 comment = self._parse_string()
 
             if not this or not column_new or not dtype:
-                self.raise_error("Expected 'CHANGE COLUMN' to be followed by 'column_name' 'column_name' 'data_type'")
+                self.raise_error(
+                    "Expected 'CHANGE COLUMN' to be followed by 'column_name' 'column_name' 'data_type'"
+                )
 
             return self.expression(
                 exp.AlterColumn,
@@ -808,11 +810,14 @@ class Hive(Dialect):
             )
 
         def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
-
             this = self.sql(expression, "this")
             new_name = self.sql(expression, "rename_to") or this
             dtype = self.sql(expression, "dtype")
-            comment = f" COMMENT {self.sql(expression, 'comment')}" if self.sql(expression, "comment") else ""
+            comment = (
+                f" COMMENT {self.sql(expression, 'comment')}"
+                if self.sql(expression, "comment")
+                else ""
+            )
             default = self.sql(expression, "default")
             visible = expression.args.get("visible")
             allow_null = expression.args.get("allow_null")

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -213,6 +213,12 @@ class Hive(Dialect):
     REGEXP_EXTRACT_DEFAULT_GROUP = 1
     ALTER_TABLE_SUPPORTS_CASCADE = True
     CHANGE_COLUMN_STYLE = "HIVE"
+    """
+    Spark and its derivatives support both the Hive style CHANGE COLUMN syntax and more traditional ALTER/RENAME COLUMN syntax. Spark also
+    accepts ALTER COLUMN syntax when using the CHANGE COLUMN keyword but not vice versa. The Parser needs to be able to handle both styles
+    for Spark dialects and the Generator will use ALTER COLUMN syntax when possible. This also means that there are circumstances where it's
+    not possible to transpile commands from Spark to Hive due to missing information (e.g. missing data types).
+    """
 
     # https://spark.apache.org/docs/latest/sql-ref-identifier.html#description
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE

--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -483,8 +483,6 @@ class Hive(Dialect):
             if self._match(TokenType.COMMENT):
                 comment = self._parse_string()
 
-            cascade = self._match_text_seq("CASCADE")
-
             if not this or not column_new or not dtype:
                 self.raise_error("Expected 'CHANGE COLUMN' to be followed by 'column_name' 'column_name' 'data_type'")
 
@@ -494,7 +492,6 @@ class Hive(Dialect):
                 rename_to=column_new,
                 dtype=dtype,
                 comment=comment,
-                cascade=cascade
             )
 
         def _parse_partition_and_order(
@@ -810,7 +807,6 @@ class Hive(Dialect):
             new_name = self.sql(expression, "rename_to") or this
             dtype = self.sql(expression, "dtype")
             comment = f" COMMENT {self.sql(expression, 'comment')}" if self.sql(expression, "comment") else ""
-            cascade = " CASCADE" if expression.args.get("cascade") else ""
             default = self.sql(expression, "default")
             visible = expression.args.get("visible")
             allow_null = expression.args.get("allow_null")
@@ -828,7 +824,7 @@ class Hive(Dialect):
             if not dtype:
                 self.unsupported("CHANGE COLUMN without a type is not supported")
 
-            return f"CHANGE COLUMN {this} {new_name} {dtype}{comment}{cascade}"
+            return f"CHANGE COLUMN {this} {new_name} {dtype}{comment}"
 
         def alterset_sql(self, expression: exp.AlterSet) -> str:
             exprs = self.expressions(expression, flat=True)

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -376,7 +376,7 @@ class Spark2(Hive):
             if new_name == this:
                 if comment:
                     return f"ALTER COLUMN {this} COMMENT {comment}"
-                return super(Hive.Generator, self).altercolumn_sql(expression)
+                return super().altercolumn_sql(expression)
             return f"RENAME COLUMN {this} TO {new_name}"
 
         def renamecolumn_sql(self, expression: exp.RenameColumn) -> str:

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -151,6 +151,8 @@ def _annotate_by_similar_args(
 
 
 class Spark2(Hive):
+    CHANGE_COLUMN_STYLE = "SPARK"
+
     ANNOTATORS = {
         **Hive.ANNOTATORS,
         exp.Substring: lambda self, e: self._annotate_by_args(e, "this"),
@@ -234,6 +236,11 @@ class Spark2(Hive):
             "SHUFFLE_REPLICATE_NL": lambda self: self._parse_join_hint("SHUFFLE_REPLICATE_NL"),
         }
 
+        ALTER_PARSERS = {
+            **Hive.Parser.ALTER_PARSERS,
+            "ALTER": lambda self: self._parse_alter_table_alter(),
+        }
+
         def _parse_drop_column(self) -> t.Optional[exp.Drop | exp.Command]:
             return self._match_text_seq("DROP", "COLUMNS") and self.expression(
                 exp.Drop, this=self._parse_schema(), kind="COLUMNS"
@@ -248,6 +255,7 @@ class Spark2(Hive):
         QUERY_HINTS = True
         NVL2_SUPPORTED = True
         CAN_IMPLEMENT_ARRAY_ANY = True
+        ALTER_SET_TYPE = "TYPE"
 
         PROPERTIES_LOCATION = {
             **Hive.Generator.PROPERTIES_LOCATION,

--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -151,6 +151,7 @@ def _annotate_by_similar_args(
 
 
 class Spark2(Hive):
+    ALTER_TABLE_SUPPORTS_CASCADE = False
     CHANGE_COLUMN_STYLE = "SPARK"
 
     ANNOTATORS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1839,6 +1839,7 @@ class AlterColumn(Expression):
         "allow_null": False,
         "visible": False,
         "rename_to": False,
+        "cascade": False,
     }
 
 

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1838,6 +1838,7 @@ class AlterColumn(Expression):
         "comment": False,
         "allow_null": False,
         "visible": False,
+        "rename_to": False,
     }
 
 
@@ -4956,6 +4957,7 @@ class Alter(Expression):
         "cluster": False,
         "not_valid": False,
         "check": False,
+        "cascade": False,
     }
 
     @property

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1839,7 +1839,6 @@ class AlterColumn(Expression):
         "allow_null": False,
         "visible": False,
         "rename_to": False,
-        "cascade": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3621,7 +3621,11 @@ class Generator(metaclass=_Generator):
         kind = self.sql(expression, "kind")
         not_valid = " NOT VALID" if expression.args.get("not_valid") else ""
         check = " WITH CHECK" if expression.args.get("check") else ""
-        cascade = " CASCADE" if expression.args.get("cascade") and self.dialect.ALTER_TABLE_SUPPORTS_CASCADE else ""
+        cascade = (
+            " CASCADE"
+            if expression.args.get("cascade") and self.dialect.ALTER_TABLE_SUPPORTS_CASCADE
+            else ""
+        )
         this = self.sql(expression, "this")
         this = f" {this}" if this else ""
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3621,10 +3621,11 @@ class Generator(metaclass=_Generator):
         kind = self.sql(expression, "kind")
         not_valid = " NOT VALID" if expression.args.get("not_valid") else ""
         check = " WITH CHECK" if expression.args.get("check") else ""
+        cascade = " CASCADE" if expression.args.get("cascade") and self.dialect.ALTER_TABLE_SUPPORTS_CASCADE else ""
         this = self.sql(expression, "this")
         this = f" {this}" if this else ""
 
-        return f"ALTER {kind}{exists}{only}{this}{on_cluster}{check}{self.sep()}{actions_sql}{not_valid}{options}"
+        return f"ALTER {kind}{exists}{only}{this}{on_cluster}{check}{self.sep()}{actions_sql}{not_valid}{options}{cascade}"
 
     def altersession_sql(self, expression: exp.AlterSession) -> str:
         items_sql = self.expressions(expression, flat=True)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7731,7 +7731,7 @@ class Parser(metaclass=_Parser):
             actions = ensure_list(parser(self))
             not_valid = self._match_text_seq("NOT", "VALID")
             options = self._parse_csv(self._parse_property)
-            cascade = (self.dialect.ALTER_TABLE_SUPPORTS_CASCADE and self._match_text_seq("CASCADE"))
+            cascade = self.dialect.ALTER_TABLE_SUPPORTS_CASCADE and self._match_text_seq("CASCADE")
 
             if not self._curr and actions:
                 return self.expression(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1535,6 +1535,9 @@ class Parser(metaclass=_Parser):
     # Whether renaming a column with an ALTER statement requires the presence of the COLUMN keyword
     ALTER_RENAME_REQUIRES_COLUMN = True
 
+    # Whether Alter statements are allowed to contain Partition specifications
+    ALTER_TABLE_PARTITIONS = False
+
     # Whether all join types have the same precedence, i.e., they "naturally" produce a left-deep tree.
     # In standard SQL, joins that use the JOIN keyword take higher precedence than comma-joins. That is
     # to say, JOIN operators happen before comma operators. This is not the case in some dialects, such
@@ -7716,7 +7719,7 @@ class Parser(metaclass=_Parser):
             check = None
             cluster = None
         else:
-            this = self._parse_table(schema=True)
+            this = self._parse_table(schema=True, parse_partition=self.ALTER_TABLE_PARTITIONS)
             check = self._match_text_seq("WITH", "CHECK")
             cluster = self._parse_on_property() if self._match(TokenType.ON) else None
 
@@ -7728,6 +7731,7 @@ class Parser(metaclass=_Parser):
             actions = ensure_list(parser(self))
             not_valid = self._match_text_seq("NOT", "VALID")
             options = self._parse_csv(self._parse_property)
+            cascade = (self.dialect.ALTER_TABLE_SUPPORTS_CASCADE and self._match_text_seq("CASCADE"))
 
             if not self._curr and actions:
                 return self.expression(
@@ -7741,6 +7745,7 @@ class Parser(metaclass=_Parser):
                     cluster=cluster,
                     not_valid=not_valid,
                     check=check,
+                    cascade=cascade,
                 )
 
         return self._parse_as_command(start)

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -179,7 +179,7 @@ class TestHive(Validator):
         self.validate_identity("ALTER TABLE x PARTITION(y = z) ADD COLUMN a VARCHAR(10)")
         self.validate_identity(
             "ALTER TABLE x CHANGE a a VARCHAR(10)",
-            write_sql="ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)",
+            "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)",
         )
 
         self.validate_all(

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -179,7 +179,7 @@ class TestHive(Validator):
         self.validate_identity("ALTER TABLE x PARTITION(y = z) ADD COLUMN a VARCHAR(10)")
         self.validate_identity(
             "ALTER TABLE x CHANGE a a VARCHAR(10)",
-            write_sql="ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)"
+            write_sql="ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)",
         )
 
         self.validate_all(
@@ -201,7 +201,7 @@ class TestHive(Validator):
             write={
                 "hive": "ALTER TABLE x CHANGE COLUMN a b VARCHAR(10)",
                 "spark": "ALTER TABLE x RENAME COLUMN a TO b",
-            }
+            },
         )
         self.validate_all(
             "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) CASCADE",

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -203,6 +203,13 @@ class TestHive(Validator):
                 "spark": "ALTER TABLE x RENAME COLUMN a TO b",
             }
         )
+        self.validate_all(
+            "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) CASCADE",
+            write={
+                "hive": "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) CASCADE",
+                "spark": "ALTER TABLE x ALTER COLUMN a TYPE VARCHAR(10)",
+            },
+        )
 
         self.validate_identity("ALTER TABLE X ADD COLUMNS (y INT, z STRING)")
         self.validate_identity("ALTER TABLE X ADD COLUMNS (y INT, z STRING) CASCADE")

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -177,13 +177,31 @@ class TestHive(Validator):
         )
 
         self.validate_identity("ALTER TABLE x PARTITION(y = z) ADD COLUMN a VARCHAR(10)")
-        self.validate_identity("ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)")
-        self.validate_identity("ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) COMMENT 'comment'")
-        self.validate_identity("ALTER TABLE x CHANGE COLUMN a b VARCHAR(10)")
-
         self.validate_identity(
             "ALTER TABLE x CHANGE a a VARCHAR(10)",
             write_sql="ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)"
+        )
+
+        self.validate_all(
+            "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)",
+            write={
+                "hive": "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)",
+                "spark": "ALTER TABLE x ALTER COLUMN a TYPE VARCHAR(10)",
+            },
+        )
+        self.validate_all(
+            "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) COMMENT 'comment'",
+            write={
+                "hive": "ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) COMMENT 'comment'",
+                "spark": "ALTER TABLE x ALTER COLUMN a COMMENT 'comment'",
+            },
+        )
+        self.validate_all(
+            "ALTER TABLE x CHANGE COLUMN a b VARCHAR(10)",
+            write={
+                "hive": "ALTER TABLE x CHANGE COLUMN a b VARCHAR(10)",
+                "spark": "ALTER TABLE x RENAME COLUMN a TO b",
+            }
         )
 
         self.validate_identity("ALTER TABLE X ADD COLUMNS (y INT, z STRING)")

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -176,6 +176,19 @@ class TestHive(Validator):
             },
         )
 
+        self.validate_identity("ALTER TABLE x PARTITION(y = z) ADD COLUMN a VARCHAR(10)")
+        self.validate_identity("ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)")
+        self.validate_identity("ALTER TABLE x CHANGE COLUMN a a VARCHAR(10) COMMENT 'comment'")
+        self.validate_identity("ALTER TABLE x CHANGE COLUMN a b VARCHAR(10)")
+
+        self.validate_identity(
+            "ALTER TABLE x CHANGE a a VARCHAR(10)",
+            write_sql="ALTER TABLE x CHANGE COLUMN a a VARCHAR(10)"
+        )
+
+        self.validate_identity("ALTER TABLE X ADD COLUMNS (y INT, z STRING)")
+        self.validate_identity("ALTER TABLE X ADD COLUMNS (y INT, z STRING) CASCADE")
+
         self.validate_identity(
             """CREATE EXTERNAL TABLE x (y INT) ROW FORMAT SERDE 'serde' ROW FORMAT DELIMITED FIELDS TERMINATED BY '1' WITH SERDEPROPERTIES ('input.regex'='')""",
         )

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from sqlglot import exp, parse_one
 from sqlglot.dialects.dialect import Dialects
+from sqlglot.errors import UnsupportedError
 from tests.dialects.test_dialect import Validator
 
 
@@ -131,6 +132,27 @@ TBLPROPERTIES (
             write={
                 "spark": "ALTER TABLE StudentInfo ADD COLUMNS (LastName STRING, DOB TIMESTAMP)",
             },
+        )
+        self.validate_all(
+            "ALTER TABLE db.example ALTER COLUMN col_a TYPE BIGINT",
+            write={
+                "spark": "ALTER TABLE db.example ALTER COLUMN col_a TYPE BIGINT",
+                "hive": "ALTER TABLE db.example CHANGE COLUMN col_a col_a BIGINT",
+            },
+        )
+        self.validate_all(
+            "ALTER TABLE db.example CHANGE COLUMN col_a col_a BIGINT",
+            write={
+                "spark": "ALTER TABLE db.example ALTER COLUMN col_a TYPE BIGINT",
+                "hive": "ALTER TABLE db.example CHANGE COLUMN col_a col_a BIGINT",
+            },
+        )
+        self.validate_all(
+            "ALTER TABLE db.example RENAME COLUMN col_a TO col_b",
+            write={
+                "spark": "ALTER TABLE db.example RENAME COLUMN col_a TO col_b",
+                "hive": UnsupportedError,
+            }
         )
         self.validate_all(
             "ALTER TABLE StudentInfo DROP COLUMNS (LastName, DOB)",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -152,7 +152,7 @@ TBLPROPERTIES (
             write={
                 "spark": "ALTER TABLE db.example RENAME COLUMN col_a TO col_b",
                 "hive": UnsupportedError,
-            }
+            },
         )
         self.validate_all(
             "ALTER TABLE StudentInfo DROP COLUMNS (LastName, DOB)",


### PR DESCRIPTION
Documentation:

- [Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-AlterColumn)
- [Spark](https://spark.apache.org/docs/latest/sql-ref-syntax-ddl-alter-table.html#alter-or-change-column)

I validated that the test case output were considered syntactically valid by their respective engines.