### PR TITLE
feat(optimizer)!: annotate type for Snowflake COSH function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -565,6 +565,7 @@ class Snowflake(Dialect):
         **Dialect.TYPE_TO_EXPRESSIONS,
         exp.DataType.Type.DOUBLE: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.DOUBLE],
+            exp.Cosh,
             exp.Cot,
             exp.Sin,
             exp.Tan,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5553,6 +5553,10 @@ class Tan(Func):
     pass
 
 
+class Cosh(Func):
+    pass
+
+
 class CosineDistance(Func):
     arg_types = {"this": True, "expression": True}
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2108,6 +2108,7 @@ OPTIONS (
         self.validate_identity(
             "SELECT * FROM ML.PREDICT(MODEL mydataset.mymodel, (SELECT custom_label, column1, column2 FROM mydataset.mytable), STRUCT(0.55 AS threshold))"
         )
+        self.validate_identity("SELECT COSH(1.5)")
         self.validate_identity(
             "SELECT * FROM ML.PREDICT(MODEL `my_project`.my_dataset.my_model, (SELECT * FROM input_data))"
         )

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -7,6 +7,7 @@ class TestDatabricks(Validator):
     dialect = "databricks"
 
     def test_databricks(self):
+        self.validate_identity("SELECT COSH(1.5)")
         null_type = exp.DataType.build("VOID", dialect="databricks")
         self.assertEqual(null_type.sql(), "NULL")
         self.assertEqual(null_type.sql("databricks"), "VOID")

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -9,6 +9,7 @@ class TestDuckDB(Validator):
     dialect = "duckdb"
 
     def test_duckdb(self):
+        self.validate_identity("SELECT COSH(1.5)")
         with self.assertRaises(ParseError):
             parse_one("1 //", read="duckdb")
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -8,6 +8,7 @@ class TestPostgres(Validator):
     dialect = "postgres"
 
     def test_postgres(self):
+        self.validate_identity("SELECT COSH(1.5)")
         self.validate_identity(
             "select count() OVER(partition by a order by a range offset preceding exclude current row)",
             "SELECT COUNT() OVER (PARTITION BY a ORDER BY a range BETWEEN offset preceding AND CURRENT ROW EXCLUDE CURRENT ROW)",

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -6,6 +6,7 @@ class TestRedshift(Validator):
     dialect = "redshift"
 
     def test_redshift(self):
+        self.validate_identity("SELECT COSH(1.5)")
         self.validate_all(
             "SELECT SPLIT_TO_ARRAY('12,345,6789')",
             write={

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -49,6 +49,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT SOUNDEX_P123(column_name)")
         self.validate_identity("SELECT ABS(x)")
         self.validate_identity("SELECT SIGN(x)")
+        self.validate_identity("SELECT COSH(1.5)")
         self.validate_identity("SELECT JAROWINKLER_SIMILARITY('hello', 'world')")
         self.validate_identity("SELECT TRANSLATE(column_name, 'abc', '123')")
         self.validate_identity("SELECT UNICODE(column_name)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1632,6 +1632,10 @@ COLLATE('hello', 'utf8');
 VARCHAR;
 
 # dialect: snowflake
+COSH(1.5);
+DOUBLE;
+
+# dialect: snowflake
 COMPRESS('Hello World', 'SNAPPY');
 BINARY;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/cosh

Platform Support:
Platform | Supported | Arguments | Return Type | Notes
Snowflake | Yes | Numeric or convertible | Numeric | Snowflake native COSH function
BigQuery | Yes | Numeric coercible to FLOAT64 | FLOAT64 | Native COSH function
Redshift | Yes | Numeric | Numeric | Based on PostgreSQL compatibility
PostgreSQL | Yes | Numeric | Numeric | Standard function
Databricks | Yes | Numeric | DOUBLE | Native COSH function
DuckDB | Yes | Numeric | Numeric | Native COSH function
TSQL | No | N/A | N/A | No native COSH, compute via formula