### PR TITLE
fix(parser): Allow LIMIT with % percentage

### DIFF
--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1070,6 +1070,9 @@ class TestDuckDB(Validator):
         self.validate_identity("LIST_COSINE_DISTANCE(x, y)")
         self.validate_identity("LIST_DISTANCE(x, y)")
 
+        self.validate_identity("SELECT * FROM t LIMIT 10 PERCENT")
+        self.validate_identity("SELECT * FROM t LIMIT 10%", "SELECT * FROM t LIMIT 10 PERCENT")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
The following is valid DuckDB:

```
D CREATE TABLE t AS (SELECT 1 AS col UNION ALL SELECT 2 AS col);

D SELECT * FROM t LIMIT 50 PERCENT;
┌───────┐
│  col  │
│ int32 │
├───────┤
│   1   │
└───────┘
D SELECT * FROM t LIMIT 50 %;
┌───────┐
│  col  │
│ int32 │
├───────┤
│   1   │
└───────┘
D SELECT * FROM t LIMIT 0+1;
┌───────┐
│  col  │
│ int32 │
├───────┤
│   1   │
└───────┘

```

We already parse `LIMIT x PERCENT` for T-SQL, so this PR extends that to also parse `LIMIT x %` as such.