### PR TITLE
fix(duckdb): Parse `ROW` type as `STRUCT`

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -311,6 +311,7 @@ class DuckDB(Dialect):
             "PIVOT_WIDER": TokenType.PIVOT,
             "POSITIONAL": TokenType.POSITIONAL,
             "RESET": TokenType.COMMAND,
+            "ROW": TokenType.STRUCT,
             "SIGNED": TokenType.INT,
             "STRING": TokenType.TEXT,
             "SUMMARIZE": TokenType.SUMMARIZE,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1075,6 +1075,13 @@ class TestDuckDB(Validator):
         self.validate_identity("SELECT * FROM t LIMIT 10 PERCENT")
         self.validate_identity("SELECT * FROM t LIMIT 10%", "SELECT * FROM t LIMIT 10 PERCENT")
 
+        self.validate_identity(
+            "SELECT CAST(ROW(1, 2) AS ROW(a INTEGER, b INTEGER))",
+            "SELECT CAST(ROW(1, 2) AS STRUCT(a INT, b INT))",
+        )
+
+        self.validate_identity("SELECT row")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6012

Notice how `CAST AS ROW` is rewritten into `CAST AS STRUCT`:

 
```SQL
D SELECT CAST(ROW(1, 2) AS ROW(a INTEGER, b INTEGER));
┌────────────────────────────────────────────────────────┐
│ CAST(main."row"(1, 2) AS STRUCT(a INTEGER, b INTEGER)) │
│              struct(a integer, b integer)              │
├────────────────────────────────────────────────────────┤
│ {'a': 1, 'b': 2}                                       │
└────────────────────────────────────────────────────────┘
```

<br/>

The equality also holds true:

```SQL
D SELECT CAST(ROW(1, 2) AS ROW(a INTEGER, b INTEGER)) = CAST(ROW(1, 2) AS STRUCT(a INTEGER, b INTEGER));
┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ (CAST(main."row"(1, 2) AS STRUCT(a INTEGER, b INTEGER)) = CAST(main."row"(1, 2) AS STRUCT(a INTEGER, b INTEGER))) │
│                                                      boolean                                                      │
├───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ true                                                                                                              │
└───────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```


Docs
--------
[DuckDB STRUCT](https://duckdb.org/docs/stable/sql/data_types/struct.html)