### PR TITLE
feat(optimizer)!: Annotate type for snowflake COT, SIN and TAN functions

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -540,6 +540,12 @@ class Snowflake(Dialect):
 
     TYPE_TO_EXPRESSIONS = {
         **Dialect.TYPE_TO_EXPRESSIONS,
+        exp.DataType.Type.DOUBLE: {
+            *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.DOUBLE],
+            exp.Cot,
+            exp.Sin,
+            exp.Tan,
+        },
         exp.DataType.Type.INT: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.INT],
             exp.Ascii,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5549,6 +5549,10 @@ class Sinh(Func):
     pass
 
 
+class Tan(Func):
+    pass
+
+
 class CosineDistance(Func):
     arg_types = {"this": True, "expression": True}
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -19,6 +19,7 @@ class TestSnowflake(Validator):
         self.assertEqual(ast.sql("snowflake"), "DATEADD(MONTH, n, d)")
 
         self.validate_identity("SELECT GET(a, b)")
+        self.validate_identity("SELECT TAN(x)")
         self.assertEqual(
             # Ensures we don't fail when generating ParseJSON with the `safe` arg set to `True`
             self.validate_identity("""SELECT TRY_PARSE_JSON('{"x: 1}')""").sql(),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1668,6 +1668,10 @@ COLLATION('hello');
 VARCHAR;
 
 # dialect: snowflake
+COT(tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
 CONCAT('Hello', 'World!');
 VARCHAR;
 
@@ -2136,6 +2140,10 @@ SHA2_HEX('foo', null);
 VARCHAR;
 
 # dialect: snowflake
+SIN(tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
 SOUNDEX(tbl.str_col);
 VARCHAR;
 
@@ -2222,6 +2230,10 @@ BINARY;
 # dialect: snowflake
 SUBSTR(tbl.str_col, NULL);
 STRING;
+
+# dialect: snowflake
+TAN(tbl.double_col);
+DOUBLE;
 
 # dialect: snowflake
 TRANSLATE('hello world', 'elo', 'XYZ');


### PR DESCRIPTION
Annotate type for snowflake COT, SIN and TAN functions.

Documentation:

https://docs.snowflake.com/en/sql-reference/functions/cot
https://docs.snowflake.com/en/sql-reference/functions/sin
https://docs.snowflake.com/en/sql-reference/functions/tan