### PR TITLE
feat(snowflake):  synonyms for DOUBLE

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1537,6 +1537,7 @@ class Snowflake(Dialect):
         TYPE_MAPPING = {
             **generator.Generator.TYPE_MAPPING,
             exp.DataType.Type.BIGDECIMAL: "DOUBLE",
+            exp.DataType.Type.FLOAT: "DOUBLE",
             exp.DataType.Type.NESTED: "OBJECT",
             exp.DataType.Type.STRUCT: "OBJECT",
             exp.DataType.Type.TEXT: "VARCHAR",


### PR DESCRIPTION
This PR maps all the synonyms of `DOUBLE`. 

Note from docs: `[1] A known issue in Snowflake displays FLOAT, FLOAT4, FLOAT8, REAL, DOUBLE, and DOUBLE PRECISION as FLOAT, even though they are stored as DOUBLE.`

[Snowflake DOUBLE PRECISION, REAL, FLOAT, FLOAT4, FLOAT8](https://docs.snowflake.com/en/sql-reference/intro-summary-data-types)
