### PR TITLE
feat(optimizer)!: annotate type for Snowflake COS function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -565,6 +565,7 @@ class Snowflake(Dialect):
         **Dialect.TYPE_TO_EXPRESSIONS,
         exp.DataType.Type.DOUBLE: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.DOUBLE],
+            exp.Cos,
             exp.Cot,
             exp.Sin,
             exp.Tan,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5525,6 +5525,10 @@ class Coth(Func):
     pass
 
 
+class Cos(Func):
+    pass
+
+
 class Csc(Func):
     pass
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -20,6 +20,7 @@ class TestSnowflake(Validator):
 
         self.validate_identity("SELECT GET(a, b)")
         self.validate_identity("SELECT TAN(x)")
+        self.validate_identity("SELECT COS(x)")
         self.assertEqual(
             # Ensures we don't fail when generating ParseJSON with the `safe` arg set to `True`
             self.validate_identity("""SELECT TRY_PARSE_JSON('{"x: 1}')""").sql(),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1696,6 +1696,10 @@ COT(tbl.double_col);
 DOUBLE;
 
 # dialect: snowflake
+COS(tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
 CONCAT('Hello', 'World!');
 VARCHAR;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/cos

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | Numeric (Radians) | FLOAT
BigQuery | Yes | FLOAT64 (Radians) | FLOAT64
Redshift | Yes | DOUBLE PRECISION (Radians) | DOUBLE PRECISION
PostgreSQL | Yes | DOUBLE PRECISION (Radians) | DOUBLE PRECISION
Databricks | Yes | DOUBLE (Radians) | DOUBLE
DuckDB | Yes | DOUBLE (Radians) | DOUBLE
TSQL | Yes | FLOAT (Radians) | FLOAT