### PR TITLE
feat(optimizer): Annotate type for snowflake ROUND function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -665,6 +665,7 @@ class Snowflake(Dialect):
                 exp.Right,
                 exp.Stuff,
                 exp.Substring,
+                exp.Round,
             )
         },
         **{

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -21,6 +21,9 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT GET(a, b)")
         self.validate_identity("SELECT TAN(x)")
         self.validate_identity("SELECT COS(x)")
+        self.validate_identity("SELECT ROUND(x)")
+        self.validate_identity("SELECT ROUND(123.456, -1)")
+        self.validate_identity("SELECT ROUND(123.456, 2, 'HALF_AWAY_FROM_ZERO')")
         self.assertEqual(
             # Ensures we don't fail when generating ParseJSON with the `safe` arg set to `True`
             self.validate_identity("""SELECT TRY_PARSE_JSON('{"x: 1}')""").sql(),

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2072,6 +2072,18 @@ REVERSE(NULL);
 VARCHAR;
 
 # dialect: snowflake
+ROUND(42);
+INT;
+
+# dialect: snowflake
+ROUND(tbl.bigint_col, -1);
+BIGINT;
+
+# dialect: snowflake
+ROUND(tbl.double_col, 0, 'HALF_TO_EVEN');
+DOUBLE;
+
+# dialect: snowflake
 RIGHT('hello world', 5);
 VARCHAR;
 


### PR DESCRIPTION
Annotate type for snowflake ROUND function.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/round 


Platform | Supported | Argument Type | Return Type
-- | -- | -- | --
Snowflake | ✅ Yes | NUMERIC, INT (scale), STRING (mode) | Preserves input type
BigQuery | ✅ Yes | NUMERIC, INT (scale) | Preserves input type
Redshift | ✅ Yes | NUMERIC, INT (scale) | Preserves input type
PostgreSQL | ✅ Yes | NUMERIC, INT (scale) | Preserves input type
Databricks | ✅ Yes | NUMERIC, INT (scale) | Preserves input type
DuckDB | ✅ Yes | NUMERIC, INT (scale) | Preserves input type
T-SQL | ✅ Yes | NUMERIC, INT (scale), INT (function) | Preserves input type


</body>
</html>
