### PR TITLE
feat(optimizer)!: annotate type for Snowflake CEIL function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -674,6 +674,7 @@ class Snowflake(Dialect):
                 exp.Stuff,
                 exp.Substring,
                 exp.Round,
+                exp.Ceil,
             )
         },
         **{

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -362,6 +362,12 @@ class TestSnowflake(Validator):
             "SELECT CEIL(5.3)",
         )
         self.validate_identity(
+            "SELECT CEIL(3.14)",
+        )
+        self.validate_identity(
+            "SELECT CEIL(3.14, 1)",
+        )
+        self.validate_identity(
             "CAST(x AS BYTEINT)",
             "CAST(x AS INT)",
         )

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1640,6 +1640,22 @@ CHARINDEX('world', 'hello world', 1);
 INT;
 
 # dialect: snowflake
+CEIL(3.14);
+DOUBLE;
+
+# dialect: snowflake
+CEIL(3.14::FLOAT, 1);
+FLOAT;
+
+# dialect: snowflake
+CEIL(3.14, 1);
+DOUBLE;
+
+# dialect: snowflake
+CEIL(10::NUMERIC);
+NUMBER;
+
+# dialect: snowflake
 CHAR(65);
 VARCHAR;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/ceil

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | Numeric | Same as input
BigQuery | Yes | Numeric (FLOAT64) | INT64
Redshift | Yes | Numeric | Same as input
PostgreSQL | Yes | Double precision, numeric | Same as input
Databricks | Yes | Numeric | DOUBLE
DuckDB | Yes | DOUBLE, DECIMAL | Same as input
TSQL | Yes | Numeric | Numeric