### PR TITLE
feat(optimizer)!: annotate type for Snowflake SINH function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -571,6 +571,7 @@ class Snowflake(Dialect):
             exp.Degrees,
             exp.Exp,
             exp.Sin,
+            exp.Sinh,
             exp.Tan,
             exp.Asin,
             exp.Cbrt,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -21,6 +21,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT GET(a, b)")
         self.validate_identity("SELECT TAN(x)")
         self.validate_identity("SELECT COS(x)")
+        self.validate_identity("SELECT SINH(1.5)")
         self.validate_identity("SELECT MOD(x, y)", "SELECT x % y")
         self.validate_identity("SELECT ROUND(x)")
         self.validate_identity("SELECT ROUND(123.456, -1)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2244,6 +2244,14 @@ SIN(tbl.double_col);
 DOUBLE;
 
 # dialect: snowflake
+SINH(1);
+DOUBLE;
+
+# dialect: snowflake
+SINH(1.5);
+DOUBLE;
+
+# dialect: snowflake
 SIGN(tbl.double_col);
 INT;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/sinh

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | Numeric | FLOAT
BigQuery | Yes | FLOAT64 | FLOAT64
Redshift | No | - | -
PostgreSQL | Yes | DOUBLE PRECISION, NUMERIC | Same as input
Databricks | Yes | DOUBLE | DOUBLE
DuckDB | Yes | DOUBLE, DECIMAL | DOUBLE
TSQL | No | - | -