### PR TITLE
feat(optimizer)!: annotate type for Snowflake FACTORIAL function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -631,6 +631,7 @@ class Snowflake(Dialect):
         },
         exp.DataType.Type.BIGINT: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.BIGINT],
+            exp.Factorial,
             exp.MD5NumberLower64,
             exp.MD5NumberUpper64,
         },

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6406,6 +6406,10 @@ class Exp(Func):
     pass
 
 
+class Factorial(Func):
+    pass
+
+
 # https://docs.snowflake.com/en/sql-reference/functions/flatten
 class Explode(Func, UDTF):
     arg_types = {"this": True, "expressions": False}

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -40,6 +40,7 @@ class TestSnowflake(Validator):
         self.assertEqual(expr.sql(dialect="snowflake"), "SELECT APPROX_TOP_K(C4, 3, 5) FROM t")
 
         self.validate_identity("SELECT EXP(1)")
+        self.validate_identity("SELECT FACTORIAL(5)")
         self.validate_identity("SELECT BIT_LENGTH('abc')")
         self.validate_identity("SELECT BIT_LENGTH(x'A1B2')")
         self.validate_identity("SELECT RTRIMMED_LENGTH(' ABCD ')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1776,6 +1776,10 @@ EXP(5.5);
 DOUBLE;
 
 # dialect: snowflake
+FACTORIAL(5);
+BIGINT;
+
+# dialect: snowflake
 FLOOR(42);
 INT;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/factorial

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | Integer | Numeric
BigQuery | Yes | INT64 | INT64
Redshift | No | - | -
PostgreSQL | Yes | Integer | Numeric
Databricks | Yes | Integer | BIGINT
DuckDB | Yes | Integer | BIGINT
TSQL | No | - | -