### PR TITLE
feat(optimizer)!: annotate type for Snowflake ATANH function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -573,6 +573,7 @@ class Snowflake(Dialect):
             exp.Sin,
             exp.Tan,
             exp.Asin,
+            exp.Atanh,
             exp.Cbrt,
         },
         exp.DataType.Type.INT: {

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -59,6 +59,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT SOUNDEX_P123(column_name)")
         self.validate_identity("SELECT ABS(x)")
         self.validate_identity("SELECT ASIN(0.5)")
+        self.validate_identity("SELECT ATANH(0.5)")
         self.validate_identity("SELECT CBRT(27.0)")
         self.validate_identity("SELECT SIGN(x)")
         self.validate_identity("SELECT COSH(1.5)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1548,6 +1548,10 @@ ASIN(tbl.double_col);
 DOUBLE;
 
 # dialect: snowflake
+ATANH(tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
 CBRT(tbl.double_col);
 DOUBLE;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/atanh

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | Numeric (FLOAT) | FLOAT
BigQuery | Yes | FLOAT64 | FLOAT64
Redshift | No | - | -
PostgreSQL | Yes | DOUBLE PRECISION/NUMERIC | DOUBLE PRECISION
Databricks | Yes | DOUBLE | DOUBLE
DuckDB | Yes | DOUBLE/NUMERIC | DOUBLE
TSQL | No | - | -