### PR TITLE
refactor: replace direct arg manipulation

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -769,7 +769,9 @@ class ClickHouse(Dialect):
         ) -> t.Optional[exp.Join]:
             join = super()._parse_join(skip_join_token=skip_join_token, parse_bracket=True)
             if join:
-                join.set("global", join.args.pop("method", None))
+                method = join.args.get("method")
+                join.set("method", None)
+                join.set("global", method)
 
                 # tbl ARRAY JOIN arr <-- this should be a `Column` reference, not a `Table`
                 # https://clickhouse.com/docs/en/sql-reference/statements/select/array-join

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1196,7 +1196,7 @@ def no_paren_current_date_sql(self: Generator, expression: exp.CurrentDate) -> s
 def no_recursive_cte_sql(self: Generator, expression: exp.With) -> str:
     if expression.args.get("recursive"):
         self.unsupported("Recursive CTEs are unsupported")
-        expression.args["recursive"] = False
+        expression.set("recursive", False)
     return self.with_sql(expression)
 
 

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1038,8 +1038,8 @@ class DuckDB(Dialect):
                 if isinstance(expression.this, exp.Unnest):
                     return super().join_sql(expression.on(exp.true()))
 
-                expression.args.pop("side", None)
-                expression.args.pop("kind", None)
+                expression.set("side", None)
+                expression.set("kind", None)
 
             return super().join_sql(expression)
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -67,7 +67,7 @@ def _date_add_sql(kind: str) -> t.Callable[[Postgres.Generator, DATE_ADD_OR_SUB]
 
         e = self._simplify_unless_literal(expression.expression)
         if isinstance(e, exp.Literal):
-            e.args["is_string"] = True
+            e.set("is_string", True)
         elif e.is_number:
             e = exp.Literal.string(e.to_py())
         else:

--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -1219,7 +1219,8 @@ class TSQL(Dialect):
 
         def create_sql(self, expression: exp.Create) -> str:
             kind = expression.kind
-            exists = expression.args.pop("exists", None)
+            exists = expression.args.get("exists")
+            expression.set("exists", None)
 
             like_property = expression.find(exp.LikeProperty)
             if like_property:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1008,8 +1008,8 @@ class Expression(metaclass=_Expression):
 
     def div(self, other: ExpOrStr, typed: bool = False, safe: bool = False) -> Div:
         div = self._binop(Div, other)
-        div.args["typed"] = typed
-        div.args["safe"] = safe
+        div.set("typed", typed)
+        div.set("safe", safe)
         return div
 
     def asc(self, nulls_first: bool = True) -> Ordered:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -162,7 +162,7 @@ def _pop_table_column_aliases(derived_tables: t.List[exp.CTE | exp.Subquery]) ->
             continue
         table_alias = derived_table.args.get("alias")
         if table_alias:
-            table_alias.args.pop("columns", None)
+            table_alias.set("columns", None)
 
 
 def _expand_using(scope: Scope, resolver: Resolver) -> t.Dict[str, t.Any]:
@@ -239,7 +239,7 @@ def _expand_using(scope: Scope, resolver: Resolver) -> t.Dict[str, t.Any]:
                 if join_table not in tables:
                     tables[join_table] = None
 
-        join.args.pop("using")
+        join.set("using", None)
         join.set("on", exp.and_(*conditions, copy=False))
 
     if column_tables:

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -72,7 +72,8 @@ def qualify_tables(
             if isinstance(derived_table, exp.Subquery):
                 unnested = derived_table.unnest()
                 if isinstance(unnested, exp.Table):
-                    joins = unnested.args.pop("joins", None)
+                    joins = unnested.args.get("joins")
+                    unnested.set("joins", None)
                     derived_table.this.replace(exp.select("*").from_(unnested.copy(), copy=False))
                     derived_table.this.set("joins", joins)
 

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -189,7 +189,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     # exists queries should not have any selects as it only checks if there are any rows
     # all selects will be added by the optimizer and only used for join keys
     if isinstance(parent_predicate, exp.Exists):
-        select.args["expressions"] = []
+        select.set("expressions", [])
 
     for key, alias in key_aliases.items():
         if key in group_by:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3571,7 +3571,8 @@ class Parser(metaclass=_Parser):
 
                         this.set(key, expression)
                         if key == "limit":
-                            offset = expression.args.pop("offset", None)
+                            offset = expression.args.get("offset")
+                            expression.set("offset", None)
 
                             if offset:
                                 offset = exp.Offset(expression=offset)
@@ -5271,8 +5272,8 @@ class Parser(metaclass=_Parser):
             this = self.expression(klass, this=this, comments=comments, expression=expression)
 
             if isinstance(this, exp.Div):
-                this.args["typed"] = self.dialect.TYPED_DIVISION
-                this.args["safe"] = self.dialect.SAFE_DIVISION
+                this.set("typed", self.dialect.TYPED_DIVISION)
+                this.set("safe", self.dialect.SAFE_DIVISION)
 
         return this
 

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -650,8 +650,8 @@ def eliminate_full_outer_join(expression: exp.Expression) -> exp.Expression:
             anti_join_clause = exp.select("1").from_(expression.args["from"]).where(join_conditions)
             expression_copy.args["joins"][index].set("side", "right")
             expression_copy = expression_copy.where(exp.Exists(this=anti_join_clause).not_())
-            expression_copy.args.pop("with", None)  # remove CTEs from RIGHT side
-            expression.args.pop("order", None)  # remove order by from LEFT side
+            expression_copy.set("with", None)  # remove CTEs from RIGHT side
+            expression.set("order", None)  # remove order by from LEFT side
 
             return exp.union(expression, expression_copy, copy=False, distinct=False)
 


### PR DESCRIPTION
[PR motivation: expression comparison issue from public slack](https://tobiko-data.slack.com/archives/C0448SFS3PF/p1760009858851469)

This PR mades the codebase more robust after the change #5966 .

We avoid manipulating the args of an expression directly. For example `args.pop()`, avoids invalidating the cached hash, and as a result the comparison between two expression may be invalid.