### PR TITLE
feat(optimizer)!: annotate type for Snowflake CONVERT_TIMEZONE function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -689,6 +689,12 @@ class Snowflake(Dialect):
             )
         },
         exp.ConcatWs: lambda self, e: self._annotate_by_args(e, "expressions"),
+        exp.ConvertTimezone: lambda self, e: self._annotate_with_type(
+            e,
+            exp.DataType.Type.TIMESTAMPNTZ
+            if e.args.get("source_tz")
+            else exp.DataType.Type.TIMESTAMPTZ,
+        ),
         exp.Reverse: _annotate_reverse,
     }
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1788,6 +1788,14 @@ CONTAINS(tbl.bin_col, NULL);
 BOOLEAN;
 
 # dialect: snowflake
+CONVERT_TIMEZONE('America/New_York', '2024-08-06 09:10:00.000');
+TIMESTAMPTZ;
+
+# dialect: snowflake
+CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00.000');
+TIMESTAMPNTZ;
+
+# dialect: snowflake
 EDITDISTANCE('hello', 'world');
 INT;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/convert_timezone

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | CONVERT_TIMEZONE(source_tz, target_tz, timestamp_expr) -source_tz,target_tz: string or identifier -timestamp_expr: TIMESTAMP | TIMESTAMP
BigQuery | No (not present) | - | -
Redshift | Yes (CONVERT_TIMEZONE) | CONVERT_TIMEZONE('source_tz','target_tz',timestamp) -source_tz,target_tz: string -timestamp: TIMESTAMP | TIMESTAMP
PostgreSQL | No (not present) | - | -
Databricks | No (not present) | - | -
DuckDB | No (not present) | - | -
TSQL | No (not present) | - | -