### PR TITLE
chore(optimizer): add tests for Snowflake DATE_FROM_PARTS function

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -114,6 +114,7 @@ class TestSnowflake(Validator):
         self.validate_identity("RM @parquet_stage", check_command_warning=True)
         self.validate_identity("REMOVE @parquet_stage", check_command_warning=True)
         self.validate_identity("SELECT TIMESTAMP_FROM_PARTS(d, t)")
+        self.validate_identity("SELECT DATE_FROM_PARTS(1977, 8, 7)")
         self.validate_identity("SELECT GET_PATH(v, 'attr[0].name') FROM vartab")
         self.validate_identity("SELECT TO_ARRAY(CAST(x AS ARRAY))")
         self.validate_identity("SELECT TO_ARRAY(CAST(['test'] AS VARIANT))")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1692,6 +1692,10 @@ DEGREES(1);
 DOUBLE;
 
 # dialect: snowflake
+DATE_FROM_PARTS(1977, 8, 7);
+DATE;
+
+# dialect: snowflake
 DECOMPRESS_BINARY('compressed_data', 'SNAPPY');
 BINARY;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/date_from_parts

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | DATE_FROM_PARTS(year, month, day) All args: INTEGER | DATE
BigQuery | Yes (equivalent: DATE) | DATE(year, month, day) All args: INTEGER | DATE
Redshift | No (not present) | - | -
PostgreSQL | Yes (equivalent: MAKE_DATE) | MAKE_DATE(year, month, day) All args: INTEGER | DATE
Databricks | Yes (equivalent: MAKE_DATE) | MAKE_DATE(year, month, day) All args: INTEGER | DATE
DuckDB | Yes (equivalent: MAKE_DATE) | MAKE_DATE(year, month, day) All args: INTEGER | DATE
TSQL | Yes (equivalent: DATEFROMPARTS) | DATEFROMPARTS(year, month, day) All args: INTEGER | DATE