### PR TITLE
feat(optimizer)!: annotate type for Snowflake DATE_TRUNC function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -678,6 +678,8 @@ class Snowflake(Dialect):
                 exp.Substring,
                 exp.Round,
                 exp.Ceil,
+                exp.DateTrunc,
+                exp.TimestampTrunc,
             )
         },
         **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1800,6 +1800,18 @@ CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00
 TIMESTAMPNTZ;
 
 # dialect: snowflake
+DATE_TRUNC('year', TO_DATE('2024-05-09'));
+DATE;
+
+# dialect: snowflake
+DATE_TRUNC('minute', TO_TIME('08:50:48'));
+TIME;
+
+# dialect: snowflake
+DATE_TRUNC('minute', TO_TIMESTAMP('2024-05-09 08:50:57.891'));
+TIMESTAMP;
+
+# dialect: snowflake
 EDITDISTANCE('hello', 'world');
 INT;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/date_trunc

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | DATE_TRUNC(part, date_or_timestamp) -part: STRING -date_or_timestamp: DATE/TIMESTAMP/STRING | DATE or TIMESTAMP
BigQuery | Yes | DATE_TRUNC(date_or_timestamp, part) -date_or_timestamp: DATE -part: STRING (e.g., 'YEAR', 'MONTH') | DATE
Redshift | Yes | DATE_TRUNC(part, date_or_timestamp) -part: STRING -date_or_timestamp: TIMESTAMP | TIMESTAMP
PostgreSQL | Yes | DATE_TRUNC(part, date_or_timestamp) -part: STRING -date_or_timestamp: DATE/TIMESTAMP/INTERVAL | TIMESTAMP
Databricks | Yes | DATE_TRUNC(part, date_or_timestamp) -part: STRING -date_or_timestamp: DATE/TIMESTAMP | DATE or TIMESTAMP
DuckDB | Yes | DATE_TRUNC(part, date_or_timestamp) -part: STRING -date_or_timestamp: DATE/TIMESTAMP | DATE or TIMESTAMP
TSQL | Yes (as DATETRUNC) | DATETRUNC(part, date_or_timestamp) -part: STRING -date_or_timestamp: DATE/TIME/DATETIME | same type as input