### PR TITLE
feat(optimizer)!: annotate type for Snowflake DATEADD function

### DIFF
--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1696,6 +1696,22 @@ DATE_PART('day', tbl.date_col);
 INT;
 
 # dialect: snowflake
+DATEADD(HOUR, 3, TO_TIME('05:00:00'));
+TIME;
+
+# dialect: snowflake
+DATEADD(YEAR, 1, TO_TIMESTAMP('2022-05-08 14:30:00'));
+TIMESTAMP;
+
+# dialect: snowflake
+DATEADD(MONTH, 1, '2023-01-31'::DATE);
+DATE;
+
+# dialect: snowflake
+DATEADD(HOUR, 2, '2022-04-05'::DATE);
+TIMESTAMPNTZ;
+
+# dialect: snowflake
 DEGREES(PI()/3);
 DOUBLE;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/dateadd

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | String (date part), Integer (amount), Date/Timestamp (input date) | Date/Timestamp
BigQuery | Yes (as DATE_ADD) | Date, Interval (INTEGER), String (date part granularity) | Date
Redshift | Yes | String (date part), Integer (amount), Date/Timestamp | Date/Timestamp
PostgreSQL | No (use INTERVAL addition or functions like DATE + INTERVAL or AGE) | N/A | N/A
Databricks | Yes | Date/Timestamp, Integer/Interval | Date/Timestamp
DuckDB | No (use INTERVAL addition: DATE + INTERVAL) | N/A | N/A
TSQL | Yes | String (date part), Integer (amount), Date/Timestamp | Date/Timestamp