### PR TITLE
chore(optimizer): add tests for Snowflake DATEDIFF function

### DIFF
--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1812,6 +1812,14 @@ CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00
 TIMESTAMPNTZ;
 
 # dialect: snowflake
+DATEDIFF('year', tbl.date_col, tbl.date_col);
+INT;
+
+# dialect: snowflake
+DATEDIFF('month', tbl.timestamp_col, tbl.timestamp_col);
+INT;
+
+# dialect: snowflake
 DATE_TRUNC('year', TO_DATE('2024-05-09'));
 DATE;
 


### PR DESCRIPTION
Documentation: https://docs.snowflake.com/en/sql-reference/functions/datediff

Platform Support:
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | date_or_time_part,timestamp_expr1,timestamp_expr2(unit, start, end as date/timestamp) | Integer
BigQuery | Yes | For DATE:DATE_DIFF(date1, date2, INT64), for DATETIME:DATETIME_DIFF(datetime1, datetime2, part) | Integer
Redshift | Yes | DATEDIFF(datepart, startdate, enddate)(unit, start, end as date/timestamp) | BIGINT
PostgreSQL | No * | Not directly; use subtraction:date2 - date1orAGE(date1, date2) | Interval
Databricks | Yes | datediff(endDate, startDate)(supports date, timestamp arguments) | Integer
DuckDB | Yes | date_diff(unit, date1, date2)or direct subtraction for days | Integer/Interval
TSQL (SQL Server) | Yes | DATEDIFF(datepart, startdate, enddate)(unit, start, end as date/datetime/timestamp) | Integer