### PR TITLE
feat(optimizer): Annotate type for snowflake ADD_MONTHS function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -670,6 +670,7 @@ class Snowflake(Dialect):
         **{
             expr_type: lambda self, e: self._annotate_by_args(e, "this")
             for expr_type in (
+                exp.AddMonths,
                 exp.Floor,
                 exp.Left,
                 exp.Pad,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1544,6 +1544,14 @@ ABS(tbl.double_col);
 DOUBLE;
 
 # dialect: snowflake
+ADD_MONTHS(tbl.date_col, 2);
+DATE;
+
+# dialect: snowflake
+ADD_MONTHS(tbl.timestamp_col, -1);
+TIMESTAMP;
+
+# dialect: snowflake
 ASIN(tbl.double_col);
 DOUBLE;
 


### PR DESCRIPTION
Annotate type for snowflake ADD_MONTHS  function.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/add_months