### PR TITLE
fix(duckdb): support 1 arg FORMAT func

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6720,7 +6720,7 @@ class FormatJson(Expression):
 
 
 class Format(Func):
-    arg_types = {"this": True, "expressions": True}
+    arg_types = {"this": True, "expressions": False}
     is_var_len_args = True
 
 

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1150,6 +1150,9 @@ class TestDuckDB(Validator):
                     f"SELECT 1 FROM (SELECT 1) AS t(c) WHERE ((VALUES (1), (c) {option}) INTERSECT (SELECT 1))"
                 )
 
+        self.validate_identity("FORMAT('foo')")
+        self.validate_identity("FORMAT('foo', 'foo2', 'foo3')")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
Fixes #6108 

**DOCS**
[DuckDB FORMAT](https://duckdb.org/docs/stable/sql/functions/text#formatformat-)