### PR TITLE
fix(optimizer): avoid removing non-number string literals from WHERE clause

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -1125,7 +1125,7 @@ def remove_where_true(expression):
 
 def always_true(expression):
     return (isinstance(expression, exp.Boolean) and expression.this) or (
-        isinstance(expression, exp.Literal) and not is_zero(expression)
+        isinstance(expression, exp.Literal) and expression.is_number and not is_zero(expression)
     )
 
 

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -568,6 +568,12 @@ DATE_ADD(x, 1, 'MONTH');
 DATE_ADD(x, 1);
 DATE_ADD(x, 1, 'DAY');
 
+SELECT 1 WHERE 'foo';
+SELECT 1 WHERE 'foo';
+
+SELECT 1 WHERE NOT 'foo';
+SELECT 1 WHERE NOT 'foo';
+
 --------------------------------------
 -- Comparisons
 --------------------------------------


### PR DESCRIPTION
Fixes #6128

This PR avoids removing string literals where there aren't a valid number from `WHERE` clause.

For example:
```
mysql> SELECT 1 WHERE 'foo';
Empty set, 1 warning (0.001 sec)

mysql> SELECT 1 WHERE NOT 'foo';
+---+
| 1 |
+---+
| 1 |
+---+
1 row in set, 1 warning (0.001 sec)
```