### PR TITLE
Chore(optimizer): add type annotation tests for snowflake TIMEDIFF

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1828,10 +1828,6 @@ class TestSnowflake(Validator):
             "DATEDIFF(DAY, CAST('2007-12-25' AS DATE), CAST('2008-12-25' AS DATE))",
         )
         self.validate_identity(
-            "TIMEDIFF(YEAR, '2017-01-01', '2019-01-01')",
-            "DATEDIFF(YEAR, '2017-01-01', '2019-01-01')",
-        )
-        self.validate_identity(
             "TIMESTAMPDIFF(DAY, CAST('2007-12-25' AS DATE), CAST('2008-12-25' AS DATE))",
             "DATEDIFF(DAY, CAST('2007-12-25' AS DATE), CAST('2008-12-25' AS DATE))",
         )


### PR DESCRIPTION
Annotate type for snowflake TIMEDIFF function.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/timediff

| Platform   | Supported | Argument Type                                         | Return Type |
  |------------|-----------|-------------------------------------------------------|-------------|
  | Snowflake  | Yes       | (date_part, date/time/timestamp, date/time/timestamp) | INTEGER     |
  | BigQuery   | No*       | N/A                                                   | N/A         |
  | Redshift   | No*       | N/A                                                   | N/A         |
  | PostgreSQL | No        | N/A                                                   | N/A         |
  | Databricks | Yes       | (unit, start_timestamp, end_timestamp)                | BIGINT      |
  | DuckDB     | No*       | N/A                                                   | N/A         |
  | T-SQL      | No*       | N/A                                                   | N/A         |

