### PR TITLE
Feat(optimizer)!: annotate type for boolnot snowflake function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -680,7 +680,7 @@ class Snowflake(Dialect):
         },
         exp.DataType.Type.BOOLEAN: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.BOOLEAN],
-            exp.BoolNot,
+            exp.Boolnot,
             exp.Search,
         },
         exp.DataType.Type.DATE: {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5617,9 +5617,8 @@ class ByteLength(Func):
     pass
 
 
-class BoolNot(Func):
-    _sql_names = ["BOOLNOT"]
-    arg_types = {"this": True}
+class Boolnot(Func):
+    pass
 
 
 # https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#bool_for_json

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -45,7 +45,6 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BIT_LENGTH('abc')")
         self.validate_identity("SELECT BIT_LENGTH(x'A1B2')")
         self.validate_identity("SELECT BOOLNOT(0)")
-        self.validate_identity("SELECT BOOLNOT(10)")
         self.validate_identity("SELECT BOOLNOT(-3.79)")
         self.validate_identity("SELECT RTRIMMED_LENGTH(' ABCD ')")
         self.validate_identity("SELECT HEX_DECODE_STRING('48656C6C6F')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1648,10 +1648,6 @@ BIT_LENGTH(tbl.bin_col);
 INT;
 
 # dialect: snowflake
-BOOLNOT(0);
-BOOLEAN;
-
-# dialect: snowflake
 BOOLNOT(tbl.int_col);
 BOOLEAN;
 


### PR DESCRIPTION
Annotate type for snowflake BOOLNOT function.

https://docs.snowflake.com/en/sql-reference/functions/boolnot

  | Platform   | Supported | Argument Type      | Return Type |
  |------------|-----------|--------------------|-------------|
  | Snowflake  | Yes       | Numeric expression | Boolean     |
  | BigQuery   | No        | N/A                | N/A         |
  | Redshift   | No        | N/A                | N/A         |
  | PostgreSQL | No        | N/A                | N/A         |
  | Databricks | No        | N/A                | N/A         |
  | DuckDB     | No        | N/A                | N/A         |
  | T-SQL      | No        | N/A                | N/A         |