### PR TITLE
feat(duckdb): transpile TimeSub

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -775,6 +775,7 @@ class DuckDB(Dialect):
             exp.Struct: _struct_sql,
             exp.Transform: rename_func("LIST_TRANSFORM"),
             exp.TimeAdd: date_delta_to_binary_interval_op(),
+            exp.TimeSub: date_delta_to_binary_interval_op(),
             exp.Time: no_time_sql,
             exp.TimeDiff: _timediff_sql,
             exp.Timestamp: no_timestamp_sql,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -830,6 +830,13 @@ LANGUAGE js AS
             },
         )
         self.validate_all(
+            "SELECT TIME_SUB(CAST('09:05:03' AS TIME), INTERVAL 2 HOUR)",
+            write={
+                "bigquery": "SELECT TIME_SUB(CAST('09:05:03' AS TIME), INTERVAL '2' HOUR)",
+                "duckdb": "SELECT CAST('09:05:03' AS TIME) - INTERVAL '2' HOUR",
+            },
+        )
+        self.validate_all(
             "LOWER(TO_HEX(x))",
             write={
                 "": "LOWER(HEX(x))",


### PR DESCRIPTION
bigquery has `TIME_SUB` function to subtract units of time from a time object: https://cloud.google.com/bigquery/docs/reference/standard-sql/time_functions#time_sub`

duckdb uses timestamp operators: https://duckdb.org/docs/stable/sql/functions/timestamp#timestamp-operators