### PR TITLE
fix(dialect) Annotate type for snowflake TIMESTAMPADD function

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1821,10 +1821,6 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_identity(
-            "TIMESTAMPADD(DAY, 5, CAST('2008-12-25' AS DATE))",
-            "DATEADD(DAY, 5, CAST('2008-12-25' AS DATE))",
-        )
-        self.validate_identity(
             "DATEDIFF(DAY, CAST('2007-12-25' AS DATE), CAST('2008-12-25' AS DATE))"
         )
         self.validate_identity(


### PR DESCRIPTION
Platform | Supported | Argument Type | Return Type
Snowflake | Yes | String (date part), Integer (amount), Date/Timestamp (input date) | Date/Timestamp
BigQuery | Yes (as TIMESTAMP_ADD / DATETIME_ADD / DATE_ADD) | Date/Datetime/Timestamp, Interval (INTEGER), String (date part granularity) | Same as input type
Redshift | Yes | String (date part), Integer (amount), Date/Timestamp | Date/Timestamp
PostgreSQL | No (use INTERVAL addition or functions like DATE + INTERVAL or AGE) | N/A | N/A
Databricks | Yes | Date/Timestamp, Integer/Interval | Date/Timestamp
DuckDB | No (use INTERVAL addition: DATE + INTERVAL) | N/A | N/A
TSQL | Yes | String (date part), Integer (amount), Date/Timestamp | Date/Timestamp