### PR TITLE
Chore(optimizer): add type annotations for BOOLXOR

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -46,6 +46,8 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BIT_LENGTH(x'A1B2')")
         self.validate_identity("SELECT BOOLNOT(0)")
         self.validate_identity("SELECT BOOLNOT(-3.79)")
+        self.validate_identity("SELECT BOOLXOR(2, 0)")
+        self.validate_identity("SELECT BOOLXOR(NULL, NULL)")
         self.validate_identity("SELECT RTRIMMED_LENGTH(' ABCD ')")
         self.validate_identity("SELECT HEX_DECODE_STRING('48656C6C6F')")
         self.validate_identity("SELECT HEX_ENCODE('Hello World')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1656,6 +1656,14 @@ BOOLNOT(NULL);
 BOOLEAN;
 
 # dialect: snowflake
+BOOLXOR(2, 0);
+BOOLEAN;
+
+# dialect: snowflake
+BOOLXOR(NULL, NULL);
+BOOLEAN;
+
+# dialect: snowflake
 CHARINDEX('world', 'hello world');
 INT;
 


### PR DESCRIPTION
Annotate type for snowflake BOOLXOR function.

https://docs.snowflake.com/en/sql-reference/functions/boolxor

  | Platform         | Supported | Argument Type                          | Return Type | Notes                                                                                  |
  |------------------|-----------|----------------------------------------|-------------|----------------------------------------------------------------------------------------|
  | Snowflake        | ✅ Yes     | Two numeric expressions (expr1, expr2) | BOOLEAN     | Computes Boolean XOR of numeric expressions. Non-zero = TRUE, zero = FALSE             |
  | BigQuery         | ❌ No      | N/A                                    | N/A         | Has bitwise XOR operator (^) and BIT_XOR aggregate function, but no boolean BOOLXOR    |
  | Redshift         | ❌ No      | N/A                                    | N/A         | Function not available                                                                 |
  | PostgreSQL       | ❌ No      | N/A                                    | N/A         | Has bitwise XOR (#) operator, but no boolean XOR. Custom functions can be created      |
  | Databricks       | ❌ No      | N/A                                    | N/A         | Has bit_xor(expr) aggregate function for bitwise operations, but no boolean BOOLXOR    |
  | DuckDB           | ❌ No      | N/A                                    | N/A         | Has bitwise XOR functions for bitstrings and bit_xor aggregate, but no boolean BOOLXOR |
  | T-SQL/SQL Server | ❌ No      | N/A                                    | N/A         | Has bitwise XOR operator (^), but no boolean BOOLXOR function                          |
