### PR TITLE
Chore(optimizer): add type annotation tests for snowflake GREATEST

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -19,6 +19,7 @@ class TestSnowflake(Validator):
         self.assertEqual(ast.sql("snowflake"), "DATEADD(MONTH, n, d)")
 
         self.validate_identity("SELECT GET(a, b)")
+        self.validate_identity("SELECT GREATEST(1, 2, 3)")
         self.validate_identity("SELECT GREATEST_IGNORE_NULLS(1, 2, 3, NULL)")
         self.validate_identity("SELECT TAN(x)")
         self.validate_identity("SELECT COS(x)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1944,6 +1944,18 @@ FLOOR(tbl.bigint_col, -1);
 BIGINT;
 
 # dialect: snowflake
+GREATEST(tbl.bigint_col, tbl.bigint_col);
+BIGINT;
+
+# dialect: snowflake
+GREATEST(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
+GREATEST(tbl.str_col, tbl.str_col);
+VARCHAR;
+
+# dialect: snowflake
 ENDSWITH('hello world', 'world');
 BOOLEAN;
 


### PR DESCRIPTION
Annotate Type for Snowflake GREATEST Function

https://docs.snowflake.com/en/sql-reference/functions/greatest

`<html><head></head><body>
Platform | Supported | Argument Type | Return Type | Notes
-- | -- | -- | -- | --
Snowflake | ✅ Yes | Expressions of the same or implicitly convertible data types (e.g., NUMBER, VARCHAR, DATE, TIMESTAMP) | Same as input type | Returns the largest non-NULL value among arguments; ignores NULLs unless all are NULL
BigQuery | ✅ Yes | Comparable expressions (same or coercible types) | Same as input type | Behavior matches Snowflake; can compare numeric, string, or date values
Redshift | ✅ Yes | Expressions of compatible types (numeric, string, or date) | Same as input type | Returns maximum non-NULL value across arguments
PostgreSQL | ✅ Yes | Expressions of same or compatible types | Same as input type | Native support; return type determined by argument types
Databricks | ✅ Yes | Comparable expressions | Same as input type | Returns the greatest value across expressions
DuckDB | ✅ Yes | Comparable expressions (same type) | Same as input type | Returns maximum among given values; NULLs ignored
T-SQL / SQL Server | ❌ No | N/A | N/A | Does not have GREATEST; equivalent behavior can be achieved using CASE WHEN or MAX()

</body></html>`