### PR TITLE
fix(duckdb): Support positional index in list comprehension

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1893,7 +1893,13 @@ class Comment(Expression):
 
 
 class Comprehension(Expression):
-    arg_types = {"this": True, "expression": True, "iterator": True, "condition": False}
+    arg_types = {
+        "this": True,
+        "expression": True,
+        "position": False,
+        "iterator": True,
+        "condition": False,
+    }
 
 
 # https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#mergetree-table-ttl

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4244,10 +4244,12 @@ class Generator(metaclass=_Generator):
     def comprehension_sql(self, expression: exp.Comprehension) -> str:
         this = self.sql(expression, "this")
         expr = self.sql(expression, "expression")
+        position = self.sql(expression, "position")
+        position = f", {position}" if position else ""
         iterator = self.sql(expression, "iterator")
         condition = self.sql(expression, "condition")
         condition = f" IF {condition}" if condition else ""
-        return f"{this} FOR {expr} IN {iterator}{condition}"
+        return f"{this} FOR {expr}{position} IN {iterator}{condition}"
 
     def columnprefix_sql(self, expression: exp.ColumnPrefix) -> str:
         return f"{self.sql(expression, 'this')}({self.sql(expression, 'expression')})"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8162,6 +8162,8 @@ class Parser(metaclass=_Parser):
     ) -> t.Optional[exp.Comprehension]:
         index = self._index
         expression = self._parse_column()
+        position = self._match(TokenType.COMMA) and self._parse_column()
+
         if not self._match(TokenType.IN):
             self._retreat(index - 1)
             return None
@@ -8171,6 +8173,7 @@ class Parser(metaclass=_Parser):
             exp.Comprehension,
             this=this,
             expression=expression,
+            position=position,
             iterator=iterator,
             condition=condition,
         )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1169,6 +1169,7 @@ class TestDuckDB(Validator):
             self.validate_identity(
                 "[x.STRING_SPLIT(' ')[i] FOR x IN ['1', '2', 3] IF x.CONTAINS('1')]"
             )
+            self.validate_identity("SELECT [4, 5, 6] AS l, [x FOR x, i IN l IF i = 2] AS filtered")
             self.validate_identity(
                 """SELECT LIST_VALUE(1)[i]""",
                 """SELECT [1][i]""",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6156

Consider this DuckDB query:

```SQL
D SELECT [4, 5, 6] AS col, [x FOR x, i IN col IF i = 2] AS filtered;
┌───────────┬──────────┐
│    col    │ filtered │
│  int32[]  │ int32[]  │
├───────────┼──────────┤
│ [4, 5, 6] │ [5]      │
└───────────┴──────────┘
```

<br />

The docs mention that the Python-style list comprehension can be extended with a positional index:

> List comprehensions can also use the position of the list elements by adding a second variable. In the following example, we use x, i, where x is the value and i is the position


Docs
----------
[DuckDB List Comprehension](https://duckdb.org/docs/stable/sql/functions/list#list-comprehension)