### PR TITLE
annotate type for IS[NOT]NULL function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -707,6 +707,7 @@ class Snowflake(Dialect):
         exp.DataType.Type.BOOLEAN: {
             *Dialect.TYPE_TO_EXPRESSIONS[exp.DataType.Type.BOOLEAN],
             exp.Boolnot,
+            exp.Is,
             exp.Search,
         },
         exp.DataType.Type.DATE: {

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -28,6 +28,10 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT ROUND(123.456, -1)")
         self.validate_identity("SELECT ROUND(123.456, 2, 'HALF_AWAY_FROM_ZERO')")
 
+        # IS NULL and IS NOT NULL tests
+        self.validate_identity("x IS NULL")
+        self.validate_identity("x IS NOT NULL", "NOT x IS NULL")
+
         self.validate_identity("SELECT FLOOR(x)")
         self.validate_identity("SELECT FLOOR(135.135, 1)")
         self.validate_identity("SELECT FLOOR(x, -1)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2068,6 +2068,14 @@ HOUR(CAST('08:50:57' AS TIME));
 INT;
 
 # dialect: snowflake
+tbl.str_col IS NULL;
+BOOLEAN;
+
+# dialect: snowflake
+tbl.str_col IS NOT NULL;
+BOOLEAN;
+
+# dialect: snowflake
 INITCAP('hello world');
 VARCHAR;
 


### PR DESCRIPTION

Annotate Type for Snowflake IS [ NOT ] NULL Function
https://docs.snowflake.com/en/sql-reference/functions/is-null

`<html><head></head><body>
Platform | Supported | Argument Type | Return Type | Notes
-- | -- | -- | -- | --
Snowflake | ✅ Yes | Any expression | BOOLEAN | Fully supports IS NULL and IS NOT NULL predicates. See docs.
BigQuery | ✅ Yes | Any expression | BOOLEAN | Supports standard SQL IS NULL / IS NOT NULL.
Redshift | ✅ Yes | Any expression | BOOLEAN | Follows standard SQL behavior.
PostgreSQL | ✅ Yes | Any expression | BOOLEAN | Full support for IS NULL and IS NOT NULL.
Databricks (Spark) | ✅ Yes | Any expression | BOOLEAN | Uses standard SQL null predicates. Also supports isnull() function for some APIs.
DuckDB | ✅ Yes | Any expression | BOOLEAN | Follows ANSI SQL behavior for null checking.
T-SQL / SQL Server | ✅ Yes | Any expression | BOOLEAN-like (BIT in conditionals) | Supports IS NULL / IS NOT NULL. Evaluates to logical TRUE/FALSE.

</body></html>| Platform               | Supported | Argument Type  | Return Type                          | Notes                                                                                                                             |
| ---------------------- | --------- | -------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
| **Snowflake**          | ✅ Yes     | Any expression | BOOLEAN                              | Fully supports `IS NULL` and `IS NOT NULL` predicates. See [[docs](https://docs.snowflake.com/en/sql-reference/functions/is-null)](https://docs.snowflake.com/en/sql-reference/functions/is-null). |
| **BigQuery**           | ✅ Yes     | Any expression | BOOLEAN                              | Supports standard SQL `IS NULL` / `IS NOT NULL`.                                                                                  |
| **Redshift**           | ✅ Yes     | Any expression | BOOLEAN                              | Follows standard SQL behavior.                                                                                                    |
| **PostgreSQL**         | ✅ Yes     | Any expression | BOOLEAN                              | Full support for `IS NULL` and `IS NOT NULL`.                                                                                     |
| **Databricks (Spark)** | ✅ Yes     | Any expression | BOOLEAN                              | Uses standard SQL null predicates. Also supports `isnull()` function for some APIs.                                               |
| **DuckDB**             | ✅ Yes     | Any expression | BOOLEAN                              | Follows ANSI SQL behavior for null checking.                                                                                      |
| **T-SQL / SQL Server** | ✅ Yes     | Any expression | BOOLEAN-like (`BIT` in conditionals) | Supports `IS NULL` / `IS NOT NULL`. Evaluates to logical TRUE/FALSE.                                                              |`