### PR TITLE
Feat(optimizer)!: annotate type for EQUAL_NULL

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -701,6 +701,7 @@ class Snowflake(Dialect):
             exp.Boolnot,
             exp.Booland,
             exp.Boolor,
+            exp.EqualNull,
             exp.Search,
         },
         exp.DataType.Type.DATE: {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6448,6 +6448,10 @@ class Encode(Func):
     arg_types = {"this": True, "charset": True}
 
 
+class EqualNull(Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class Exp(Func):
     pass
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -41,6 +41,7 @@ class TestSnowflake(Validator):
         expr.selects[0].assert_is(exp.AggFunc)
         self.assertEqual(expr.sql(dialect="snowflake"), "SELECT APPROX_TOP_K(C4, 3, 5) FROM t")
 
+        self.validate_identity("SELECT EQUAL_NULL(1, 2)")
         self.validate_identity("SELECT EXP(1)")
         self.validate_identity("SELECT FACTORIAL(5)")
         self.validate_identity("SELECT BIT_LENGTH('abc')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1960,6 +1960,10 @@ EDITDISTANCE('hello', 'world', 3);
 INT;
 
 # dialect: snowflake
+EQUAL_NULL(1, 2);
+BOOLEAN;
+
+# dialect: snowflake
 EXTRACT(YEAR, CAST('2024-05-09' AS DATE));
 INT;
 


### PR DESCRIPTION
Annotate type for EQUAL_NULL https://docs.snowflake.com/en/sql-reference/functions/equal_null

 | Platform   | Supported | Argument Type               | Return Type |
  |------------|-----------|-----------------------------|-------------|
  | Snowflake  | ✅ Yes     | Any comparable types        | BOOLEAN     |
  | BigQuery   | ❌ No      | N/A                         | N/A         |
  | Redshift   | ❌ No      | N/A                         | N/A         |
  | PostgreSQL | ❌ No*     | N/A                         | N/A         |
  | Databricks | ✅ Yes     |  Two expressions of any type   | BOOLEAN     |
  | DuckDB     | ❌ No      | N/A                         | N/A         |
  | TSQL       | ❌ No      | N/A                         | N/A         |