### PR TITLE
fix(parser): allow LIMIT % OFFSET

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4786,8 +4786,13 @@ class Parser(metaclass=_Parser):
                 # Parsing LIMIT x% (i.e x PERCENT) as a term leads to an error, since
                 # we try to build an exp.Mod expr. For that matter, we backtrack and instead
                 # consume the factor plus parse the percentage separately
-                expression = self._try_parse(self._parse_term) or self._parse_factor()
-
+                index = self._index
+                expression = self._try_parse(self._parse_term)
+                if isinstance(expression, exp.Mod):
+                    self._retreat(index)
+                    expression = self._parse_factor()
+                elif not expression:
+                    expression = self._parse_factor()
             limit_options = self._parse_limit_options()
 
             if self._match(TokenType.COMMA):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1114,6 +1114,11 @@ class TestDuckDB(Validator):
         self.validate_identity("SELECT * FROM t LIMIT 10 PERCENT")
         self.validate_identity("SELECT * FROM t LIMIT 10%", "SELECT * FROM t LIMIT 10 PERCENT")
 
+        self.validate_identity("SELECT * FROM t LIMIT 10 PERCENT OFFSET 1")
+        self.validate_identity(
+            "SELECT * FROM t LIMIT 10% OFFSET 1", "SELECT * FROM t LIMIT 10 PERCENT OFFSET 1"
+        )
+
         self.validate_identity(
             "SELECT CAST(ROW(1, 2) AS ROW(a INTEGER, b INTEGER))",
             "SELECT CAST(ROW(1, 2) AS STRUCT(a INT, b INT))",


### PR DESCRIPTION
we currently support LIMIT x%. this extends support for LIMIT x% OFFSET y, which is also valid in DuckDB. It was producing parsing error as raised in [#6166 ](https://github.com/tobymao/sqlglot/issues/6166)
```
D SELECT * FROM UNNEST(['hello', 'world']) LIMIT 50%;
┌─────────┐
│ unnest  │
│ varchar │
├─────────┤
│ hello   │
└─────────┘

D SELECT * FROM UNNEST(['hello', 'world']) LIMIT 50% OFFSET 1;
┌─────────┐
│ unnest  │
│ varchar │
├─────────┤
│ world   │
└─────────┘
```

