### PR TITLE
fix(lineage): correct star detection and add join star tests

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -232,7 +232,7 @@ def to_node(
             )
 
     # if the select is a star add all scope sources as downstreams
-    if select.is_star:
+    if isinstance(select, exp.Star):
         for source in scope.sources.values():
             if isinstance(source, Scope):
                 source = source.expression


### PR DESCRIPTION

## Summary

This PR fixes incorrect lineage logic when processing **qualified star** (`x.*`) selections in SQL queries.

### Background

The lineage logic currently treats both **qualified star** (`x.*`) and **unqualified star** (`*`) the same way — relying on the `is_star` method.
When a star sign is detected, the function adds **all scope sources** as downstreams.

Example:

```sql
SELECT x.*, y.col
FROM x
JOIN y USING (uid);
```

#### Current Behavior
Lineage downstreams produced for `*`:
```
x.*, y.*, x.*
```
- extra `y.*` is added when function adds **all scope sources** as downstreams.
- extra `x.*` is added since the column expression is `Column` instead of `Star` so that it get processed as a normal column again.

#### Expected Behavior
Only the qualified star target (`x.*`) should be produced:
```
x.*
```

### Root Cause

The `is_star` method does not distinguish between:
- **Unqualified star** (`*`) → should pull all columns from all sources
- **Qualified star** (`x.*`) → should pull all columns only from the given table/alias

By treating `x.*` as a star affecting all sources, the lineage function incorrectly adds extra downstreams from other tables in scope.

### Fix

- Updated star detection logic to differentiate qualified vs. unqualified star
- Treat **qualified star** (`x.*`) as a normal column, only affecting its specific source
- Ensure unqualified star (`*`) still expands to all scope sources
 
### Tests

Added 2 new test cases for:
1. Qualified star parsing (`x.*` with joins)
2. Unqualified star parsing (`*` with joins)
 
---

