### PR TITLE
Fix(DuckDB): Cast literal arg to timestamp for epoch_us function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -799,7 +799,7 @@ class DuckDB(Dialect):
                 exp.cast(e.expression, exp.DataType.Type.TIMESTAMP),
                 exp.cast(e.this, exp.DataType.Type.TIMESTAMP),
             ),
-            exp.UnixMicros: rename_func("EPOCH_US"),
+            exp.UnixMicros: lambda self, e: self.func("EPOCH_US", _implicit_datetime_cast(e.this)),
             exp.UnixToStr: lambda self, e: self.func(
                 "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)
             ),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2511,7 +2511,14 @@ OPTIONS (
             "SELECT UNIX_MICROS('2008-12-25 15:30:00+00')",
             write={
                 "bigquery": "SELECT UNIX_MICROS('2008-12-25 15:30:00+00')",
-                "duckdb": "SELECT EPOCH_US('2008-12-25 15:30:00+00')",
+                "duckdb": "SELECT EPOCH_US(CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
+            },
+        )
+        self.validate_all(
+            "SELECT UNIX_MICROS(TIMESTAMP '2008-12-25 15:30:00+00')",
+            write={
+                "bigquery": "SELECT UNIX_MICROS(CAST('2008-12-25 15:30:00+00' AS TIMESTAMP))",
+                "duckdb": "SELECT EPOCH_US(CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
             },
         )
 


### PR DESCRIPTION
The DuckDB function `epoch_us` expects its argument to be a timestamp. Related to #6127 