### PR TITLE
fix(optimizer)!: Fix `simplify_parens` to not remove negated wrapped predicates

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -762,7 +762,10 @@ def simplify_parens(expression: exp.Expression, dialect: DialectType = None) -> 
             not isinstance(this, exp.Binary)
             and not (isinstance(this, (exp.Not, exp.Is)) and parent_is_predicate)
         )
-        or (isinstance(this, exp.Predicate) and not parent_is_predicate)
+        or (
+            isinstance(this, exp.Predicate)
+            and not (parent_is_predicate or isinstance(parent, exp.Neg))
+        )
         or (isinstance(this, exp.Add) and isinstance(parent, exp.Add))
         or (isinstance(this, exp.Mul) and isinstance(parent, exp.Mul))
         or (isinstance(this, exp.Mul) and isinstance(parent, (exp.Add, exp.Sub)))

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -376,6 +376,13 @@ ANY(t.value);
 SELECT (ARRAY_AGG(foo))[1];
 SELECT (ARRAY_AGG(foo))[1];
 
+SELECT -(x.a > x.b) FROM x;
+SELECT -(x.a > x.b) FROM x;
+
+SELECT (-((x.a) IS NULL)) FROM x;
+SELECT -(x.a IS NULL) FROM x;
+
+
 --------------------------------------
 -- Literals
 --------------------------------------


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6179

Consider queries such as:

```SQL
WITH t0 AS (SELECT NULL AS col) SELECT -(col IS NULL) FROM t0
```

<br/>

In dialects such as SQLIte, MySQL and Clickhouse the predicate result is first turned into an integer and then its negated, e.g:

```SQL
mysql> SELECT NULL IS NULL;
+--------------+
| NULL IS NULL |
+--------------+
|            1 |
+--------------+

mysql> SELECT -NULL;
+-------+
| -NULL |
+-------+
|  NULL |
+-------+

mysql> WITH t0 AS (SELECT NULL AS col) SELECT -(col IS NULL) FROM t0;
+----------------+
| -(col IS NULL) |
+----------------+
|             -1 |
+----------------+
```

<br />

SQLGlot currently optimizes the parenthesis which shifts the negation to the LHS instead:

```Python3
>>> optimize(sqlglot.parse_one(sql, dialect="mysql")).sql("mysql")
'WITH `t0` AS (SELECT NULL AS `col`) SELECT -`t0`.`col` IS NULL AS `_col_0` FROM `t0` AS `t0`'
```

```SQL
mysql> WITH `t0` AS (SELECT NULL AS `col`) SELECT -`t0`.`col` IS NULL AS `_col_0` FROM `t0` AS `t0`;
+--------+
| _col_0 |
+--------+
|      1 |
+--------+
```

<br />
This PR does not remove the parens in order to preserve the precedence:


```Python3
>>> optimize(sqlglot.parse_one(sql, dialect="mysql")).sql("mysql")
'WITH `t0` AS (SELECT NULL AS `col`) SELECT -(`t0`.`col` IS NULL) AS `_col_0` FROM `t0` AS `t0`'
```

```SQL
mysql> WITH `t0` AS (SELECT NULL AS `col`) SELECT -(`t0`.`col` IS NULL) AS `_col_0` FROM `t0` AS `t0`;
+--------+
| _col_0 |
+--------+
|     -1 |
+--------+
```

<br />

The same applies for other predicates, e.g:

```SQL
mysql> SELECT (4 > 3) AS c0, -(4 > 3) AS c1, -4 > 3 AS c2;
+----+----+----+
| c0 | c1 | c2 |
+----+----+----+
|  1 | -1 |  0 |
+----+----+----+
```
 