### PR TITLE
feat(snowflake)!: annotate type for REGR_VALX

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -607,6 +607,7 @@ class Snowflake(Dialect):
             exp.Degrees,
             exp.Exp,
             exp.MonthsBetween,
+            exp.RegrValx,
             exp.Sin,
             exp.Sinh,
             exp.Tan,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7432,6 +7432,10 @@ class RegexpCount(Func):
     }
 
 
+class RegrValx(Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class Repeat(Func):
     arg_types = {"this": True, "times": True}
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -91,6 +91,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT DEGREES(PI() / 3)")
         self.validate_identity("SELECT DEGREES(1)")
         self.validate_identity("SELECT RADIANS(180)")
+        self.validate_identity("SELECT REGR_VALX(y, x)")
         self.validate_identity("SELECT RANDOM()")
         self.validate_identity("SELECT RANDOM(123)")
         self.validate_identity("PARSE_URL('https://example.com/path')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2408,6 +2408,10 @@ MONTHS_BETWEEN(tbl.timestamp_col, CAST('2019-02-15 01:00:00' AS TIMESTAMP));
 DOUBLE;
 
 # dialect: snowflake
+REGR_VALX(1.0, 2.0);
+DOUBLE;
+
+# dialect: snowflake
 'foo' REGEXP 'bar';
 BOOLEAN;
 


### PR DESCRIPTION
Annotate types for REGR_VALX

https://docs.snowflake.com/en/sql-reference/functions/regr_valx

  | Platform   | Supported | Argument Type  | Return Type |
  |------------|-----------|----------------|-------------|
  | Snowflake  | Yes       | DOUBLE, DOUBLE | DOUBLE      |
  | BigQuery   | No        | N/A            | N/A         |
  | Redshift   | No        | N/A            | N/A         |
  | PostgreSQL | No        | N/A            | N/A         |
  | Databricks | No        | N/A            | N/A         |
  | DuckDB     | No        | N/A            | N/A         |
  | TSQL       | No        | N/A            | N/A         |