### PR TITLE
fix(trino): Allow 2nd arg for FIRST/LAST functions

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5988,11 +5988,11 @@ class Lead(AggFunc):
 # some dialects have a distinction between first and first_value, usually first is an aggregate func
 # and first_value is a window func
 class First(AggFunc):
-    pass
+    arg_types = {"this": True, "expression": False}
 
 
 class Last(AggFunc):
-    pass
+    arg_types = {"this": True, "expression": False}
 
 
 class FirstValue(AggFunc):

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -44,6 +44,10 @@ class TestTrino(Validator):
             },
         )
 
+        self.validate_identity(
+            "SELECT * FROM tbl MATCH_RECOGNIZE (PARTITION BY id ORDER BY col MEASURES FIRST(col, 2) AS col1, LAST(col, 2) AS col2 PATTERN (B* A) DEFINE A AS col = 1)"
+        )
+
     def test_listagg(self):
         self.validate_identity(
             "SELECT LISTAGG(DISTINCT col, ',') WITHIN GROUP (ORDER BY col ASC) FROM tbl"


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6204


Docs
---------
[Trino MATCH_RECOGNIZE Functions](https://trino.io/docs/current/sql/match-recognize.html#logical-navigation-functions)