### PR TITLE
feat(snowflake)!: annotate type for REGR_VALY

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -608,6 +608,7 @@ class Snowflake(Dialect):
             exp.Exp,
             exp.MonthsBetween,
             exp.RegrValx,
+            exp.RegrValy,
             exp.Sin,
             exp.Sinh,
             exp.Tan,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7436,6 +7436,10 @@ class RegrValx(Func):
     arg_types = {"this": True, "expression": True}
 
 
+class RegrValy(Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class Repeat(Func):
     arg_types = {"this": True, "times": True}
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -92,6 +92,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT DEGREES(1)")
         self.validate_identity("SELECT RADIANS(180)")
         self.validate_identity("SELECT REGR_VALX(y, x)")
+        self.validate_identity("SELECT REGR_VALY(y, x)")
         self.validate_identity("SELECT RANDOM()")
         self.validate_identity("SELECT RANDOM(123)")
         self.validate_identity("PARSE_URL('https://example.com/path')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2412,6 +2412,10 @@ REGR_VALX(1.0, 2.0);
 DOUBLE;
 
 # dialect: snowflake
+REGR_VALY(1.0, 2.0);
+DOUBLE;
+
+# dialect: snowflake
 'foo' REGEXP 'bar';
 BOOLEAN;
 


### PR DESCRIPTION
Annotate types for REGR_VALY

https://docs.snowflake.com/en/sql-reference/functions/regr_valy

 | Platform   | Supported | Argument Type  | Return Type |
  |------------|-----------|----------------|-------------|
  | Snowflake  | Yes       | DOUBLE, DOUBLE | DOUBLE      |
  | BigQuery   | No        | N/A            | N/A         |
  | Redshift   | No        | N/A            | N/A         |
  | PostgreSQL | No        | N/A            | N/A         |
  | Databricks | No        | N/A            | N/A         |
  | DuckDB     | No        | N/A            | N/A         |
  | TSQL       | No        | N/A            | N/A         |

