### PR TITLE
Chore(optimizer): add annotation tests for NVL2

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -59,6 +59,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT HEX_ENCODE('Hello World', 1)")
         self.validate_identity("SELECT HEX_ENCODE('Hello World', 0)")
         self.validate_identity("SELECT NEXT_DAY('2025-10-15', 'FRIDAY')")
+        self.validate_identity("SELECT NVL2(col1, col2, col3)")
         self.validate_identity("SELECT CHR(8364)")
         self.validate_identity("SELECT COMPRESS('Hello World', 'ZLIB')")
         self.validate_identity("SELECT DECOMPRESS_BINARY('compressed_data', 'SNAPPY')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2372,6 +2372,10 @@ MONTHNAME(CAST('2024-05-09 08:50:57' AS TIMESTAMP));
 VARCHAR;
 
 # dialect: snowflake
+NVL2(col1, col2, col3);
+UNKNOWN;
+
+# dialect: snowflake
 NULLIFZERO(5);
 INT;
 


### PR DESCRIPTION
NVL2 is already implemented. Adding some annotation tests

https://docs.snowflake.com/en/sql-reference/functions/nvl2

  | Platform   | Supported | Argument Type                          | Return Type            |
  |------------|-----------|----------------------------------------|------------------------|
  | Snowflake  | Yes       | expr1, expr2, expr3 (compatible types) | Type of expr2 or expr3 |
  | BigQuery   | No        | N/A                                    | N/A                    |
  | Redshift   | No        | N/A                                    | N/A                    |
  | PostgreSQL | No        | N/A                                    | N/A                    |
  | Databricks | Yes       | expr1, expr2, expr3 (any types)        | Type of expr2 or expr3 |
  | DuckDB     | No        | N/A                                    | N/A                    |
  | TSQL       | No        | N/A                                    | N/A                    |