### PR TITLE
Chore(optimizer): add annotation tests for IFF

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -52,7 +52,6 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BOOLAND(1, -2)")
         self.validate_identity("SELECT BOOLXOR(2, 0)")
         self.validate_identity("SELECT BOOLOR(1, 0)")
-        self.validate_identity("SELECT IFF(condition, value1, value2)")
         self.validate_identity("SELECT IS_NULL_VALUE(GET_PATH(payload, 'field'))")
         self.validate_identity("SELECT RTRIMMED_LENGTH(' ABCD ')")
         self.validate_identity("SELECT HEX_DECODE_STRING('48656C6C6F')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2236,6 +2236,10 @@ IFF(TRUE, 42, 0);
 INT;
 
 # dialect: snowflake
+IFF(TRUE, 42, NULL);
+INT;
+
+# dialect: snowflake
 IFF(col1 > 0, 'yes', 'no');
 VARCHAR;
 


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/functions/iff

IFF is already annotated. We are just adding snowflake tests

 Platform   | Supported | Argument Type                                                                                   | Return Type                                   |
  |------------|-----------|-------------------------------------------------------------------------------------------------|-----------------------------------------------|
  | Snowflake  | ✅ Yes     | IFF(condition, expr1, expr2) - boolean condition, any two expressions                           | Same type as expr1/expr2 (must be compatible) |
  | BigQuery   | ✅ Yes     | IF(condition, true_result, false_result) - boolean expression, any two expressions of same type | Same type as true_result/false_result         |
  | Redshift   | ❌ No      | N/A - Use CASE WHEN instead                                                                     | N/A                                           |
  | PostgreSQL | ❌ No      | N/A - Use CASE WHEN instead (can create custom function)                                        | N/A                                           |
  | Databricks | ✅ Yes     | iff(cond, expr1, expr2) - boolean condition, any two expressions                                | Type of expr1/expr2                           |
  | DuckDB     | ✅ Yes     | if(condition, value_if_true, value_if_false) - boolean condition, any two expressions           | Same type as value expressions                |
  | TSQL       | ✅ Yes     | IIF(boolean_expression, true_value, false_value) - boolean expression, any two expressions      | Same type as true/false values                |
