### PR TITLE
Chore(optimizer): add annotation test for IFNULL

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -58,6 +58,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT HEX_ENCODE('Hello World')")
         self.validate_identity("SELECT HEX_ENCODE('Hello World', 1)")
         self.validate_identity("SELECT HEX_ENCODE('Hello World', 0)")
+        self.validate_identity("SELECT IFNULL(col1, col2)", "SELECT COALESCE(col1, col2)")
         self.validate_identity("SELECT NEXT_DAY('2025-10-15', 'FRIDAY')")
         self.validate_identity("SELECT NVL2(col1, col2, col3)")
         self.validate_identity("SELECT NVL(col1, col2)", "SELECT COALESCE(col1, col2)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2252,6 +2252,26 @@ IFF(TRUE, CAST('2024-01-01' AS DATE), CAST('2024-12-31' AS DATE));
 DATE;
 
 # dialect: snowflake
+IFNULL('hello', 'world');
+VARCHAR;
+
+# dialect: snowflake
+IFNULL(1, 2);
+INT;
+
+# dialect: snowflake
+IFNULL(1.5, 2.7);
+DOUBLE;
+
+# dialect: snowflake
+IFNULL(5::BIGINT, 10::BIGINT);
+BIGINT;
+
+# dialect: snowflake
+IFNULL(CAST('2024-01-01' AS DATE), CAST('2024-12-31' AS DATE));
+DATE;
+
+# dialect: snowflake
 IS_NULL_VALUE(payload:field);
 BOOLEAN;
 


### PR DESCRIPTION
IFNULL is already implemented. Adding test

https://docs.snowflake.com/en/sql-reference/functions/ifnull

| Platform   | Supported | Argument Type                                                          | Return Type                                                               |
  |------------|-----------|------------------------------------------------------------------------|---------------------------------------------------------------------------|
  | Snowflake  | ✅ Yes     | IFNULL(expr1, expr2) - two expressions of compatible type              | Same type as the returned expression (expr1 if not NULL, otherwise expr2) |
  | BigQuery   | ✅ Yes     | IFNULL(expression, value_if_null) - two compatible type expressions    | Type of first non-NULL argument                                           |
  | Redshift   | ❌ No      | N/A - Use COALESCE(expr1, expr2) or NVL(expr1, expr2) instead          | N/A                                                                       |
  | PostgreSQL | ❌ No      | N/A - Use COALESCE(expr1, expr2) instead                               | N/A                                                                       |
  | Databricks | ✅ Yes     | IFNULL(expr1, expr2) - returns expr2 if expr1 is NULL, otherwise expr1 | Type of returned expression                                               |
  | DuckDB     | ✅ Yes     | ifnull(expr, other) - two arguments, returns 'other' if 'expr' is NULL | Type of returned argument                                                 |
  | TSQL       | ❌ No      | N/A - Use ISNULL(expr, replacement) or COALESCE(expr1, expr2) instead  | N/A                                                                       |