### PR TITLE
Feat(DuckDB): Transpile unix_seconds to epoch

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -806,7 +806,11 @@ class DuckDB(Dialect):
             ),
             exp.UnixMicros: lambda self, e: self.func("EPOCH_US", _implicit_datetime_cast(e.this)),
             exp.UnixMillis: lambda self, e: self.func("EPOCH_MS", _implicit_datetime_cast(e.this)),
-            exp.UnixSeconds: lambda self, e: self.func("EPOCH", _implicit_datetime_cast(e.this)),
+            exp.UnixSeconds: lambda self, e: self.sql(
+                exp.cast(
+                    self.func("EPOCH", _implicit_datetime_cast(e.this)), exp.DataType.Type.BIGINT
+                )
+            ),
             exp.UnixToStr: lambda self, e: self.func(
                 "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)
             ),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2516,7 +2516,7 @@ OPTIONS (
             write={
                 "spark": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
                 "databricks": "SELECT UNIX_SECONDS('2008-12-25 15:30:00+00')",
-                "duckdb": "SELECT EPOCH(CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ))",
+                "duckdb": "SELECT CAST(EPOCH(CAST('2008-12-25 15:30:00+00' AS TIMESTAMPTZ)) AS BIGINT)",
                 "snowflake": "SELECT TIMESTAMPDIFF(SECONDS, CAST('1970-01-01 00:00:00+00' AS TIMESTAMPTZ), '2008-12-25 15:30:00+00')",
             },
         )


### PR DESCRIPTION
In dialects like BigQuery, `unix_seconds` returns the number of seconds since 1970-01-01 00:00:00 UTC.
See: https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions#unix_seconds

The DuckDB equivalent is `epoch`.
See: https://duckdb.org/docs/stable/sql/functions/timestamp#epochtimestamp