### PR TITLE
feat(duckDB)!: Add support for shorthand struct array literals in duckDB.

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -576,6 +576,7 @@ class Hive(Dialect):
             exp.ApproxDistinct: approx_count_distinct_sql,
             exp.ArgMax: arg_max_or_min_no_count("MAX_BY"),
             exp.ArgMin: arg_max_or_min_no_count("MIN_BY"),
+            exp.Array: transforms.preprocess([transforms.inherit_struct_field_names]),
             exp.ArrayConcat: rename_func("CONCAT"),
             exp.ArrayToString: lambda self, e: self.func("CONCAT_WS", e.expression, e.this),
             exp.ArraySort: _array_sort_sql,

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -426,13 +426,18 @@ class Presto(Dialect):
             exp.DataType.Type.TIMETZ: "TIME",
         }
 
+        def _array_sql_with_struct_inheritance(self, expression: exp.Array) -> str:
+            """Generate ARRAY[...] SQL with struct field name inheritance preprocessing."""
+            transformed = transforms.inherit_struct_field_names(expression)
+            return f"ARRAY[{self.expressions(transformed, flat=True)}]"
+
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: rename_func("ARBITRARY"),
             exp.ApproxQuantile: rename_func("APPROX_PERCENTILE"),
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),
-            exp.Array: lambda self, e: f"ARRAY[{self.expressions(e, flat=True)}]",
+            exp.Array: lambda self, e: self._array_sql_with_struct_inheritance(e),
             exp.ArrayAny: rename_func("ANY_MATCH"),
             exp.ArrayConcat: rename_func("CONCAT"),
             exp.ArrayContains: rename_func("CONTAINS"),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1525,6 +1525,7 @@ class Snowflake(Dialect):
             exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
             exp.ArgMax: rename_func("MAX_BY"),
             exp.ArgMin: rename_func("MIN_BY"),
+            exp.Array: transforms.preprocess([transforms.inherit_struct_field_names]),
             exp.ArrayConcat: lambda self, e: self.arrayconcat_sql(e, name="ARRAY_CAT"),
             exp.ArrayContains: lambda self, e: self.func(
                 "ARRAY_CONTAINS",

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2339,12 +2339,6 @@ OPTIONS (
             },
         )
         self.validate_all(
-            "SELECT * FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92)])",
-            write={
-                "duckdb": "SELECT * FROM (SELECT UNNEST([{'name': 'Alice', 'score': 85}, {'name': 'Bob', 'score': 92}], max_depth => 2))",
-            },
-        )
-        self.validate_all(
             "SELECT MAX_BY(name, score) FROM table1",
             write={
                 "bigquery": "SELECT MAX_BY(name, score) FROM table1",
@@ -2356,12 +2350,6 @@ OPTIONS (
             write={
                 "bigquery": "SELECT MIN_BY(product, price) FROM table1",
                 "duckdb": "SELECT ARG_MIN(product, price) FROM table1",
-            },
-        )
-        self.validate_all(
-            "SELECT * FROM UNNEST([STRUCT('Alice' AS name, STRUCT(85 AS math, 90 AS english) AS scores), STRUCT('Bob' AS name, STRUCT(92 AS math, 88 AS english) AS scores)])",
-            write={
-                "duckdb": "SELECT * FROM (SELECT UNNEST([{'name': 'Alice', 'scores': {'math': 85, 'english': 90}}, {'name': 'Bob', 'scores': {'math': 92, 'english': 88}}], max_depth => 2))",
             },
         )
 
@@ -2410,6 +2398,34 @@ OPTIONS (
             write={
                 "bigquery": "WITH Races AS (SELECT '800M' AS race) SELECT race, participant FROM Races AS r CROSS JOIN UNNEST([STRUCT('Rudisha' AS name, [23.4, 26.3, 26.4, 26.1] AS laps)]) AS participant",
                 "duckdb": "WITH Races AS (SELECT '800M' AS race) SELECT race, participant FROM Races AS r CROSS JOIN (SELECT UNNEST([{'name': 'Rudisha', 'laps': [23.4, 26.3, 26.4, 26.1]}], max_depth => 2)) AS participant",
+            },
+        )
+
+        self.validate_all(
+            "SELECT * FROM UNNEST([STRUCT('Alice' AS name, STRUCT(85 AS math, 90 AS english) AS scores), STRUCT('Bob' AS name, STRUCT(92 AS math, 88 AS english) AS scores)])",
+            write={
+                "bigquery": "SELECT * FROM UNNEST([STRUCT('Alice' AS name, STRUCT(85 AS math, 90 AS english) AS scores), STRUCT('Bob' AS name, STRUCT(92 AS math, 88 AS english) AS scores)])",
+                "duckdb": "SELECT * FROM (SELECT UNNEST([{'name': 'Alice', 'scores': {'math': 85, 'english': 90}}, {'name': 'Bob', 'scores': {'math': 92, 'english': 88}}], max_depth => 2))",
+                "snowflake": "SELECT * FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('name', 'Alice', 'scores', OBJECT_CONSTRUCT('math', 85, 'english', 90)), OBJECT_CONSTRUCT('name', 'Bob', 'scores', OBJECT_CONSTRUCT('math', 92, 'english', 88))])) AS _t0(seq, key, path, index, value, this)",
+                "presto": "SELECT * FROM UNNEST(ARRAY[CAST(ROW('Alice', CAST(ROW(85, 90) AS ROW(math INTEGER, english INTEGER))) AS ROW(name VARCHAR, scores ROW(math INTEGER, english INTEGER))), CAST(ROW('Bob', CAST(ROW(92, 88) AS ROW(math INTEGER, english INTEGER))) AS ROW(name VARCHAR, scores ROW(math INTEGER, english INTEGER)))])",
+                "trino": "SELECT * FROM UNNEST(ARRAY[CAST(ROW('Alice', CAST(ROW(85, 90) AS ROW(math INTEGER, english INTEGER))) AS ROW(name VARCHAR, scores ROW(math INTEGER, english INTEGER))), CAST(ROW('Bob', CAST(ROW(92, 88) AS ROW(math INTEGER, english INTEGER))) AS ROW(name VARCHAR, scores ROW(math INTEGER, english INTEGER)))])",
+                "spark2": "SELECT * FROM EXPLODE(ARRAY(STRUCT('Alice' AS name, STRUCT(85 AS math, 90 AS english) AS scores), STRUCT('Bob' AS name, STRUCT(92 AS math, 88 AS english) AS scores)))",
+                "databricks": "SELECT * FROM EXPLODE(ARRAY(STRUCT('Alice' AS name, STRUCT(85 AS math, 90 AS english) AS scores), STRUCT('Bob' AS name, STRUCT(92 AS math, 88 AS english) AS scores)))",
+                "hive": "SELECT * FROM EXPLODE(ARRAY(STRUCT('Alice', STRUCT(85, 90)), STRUCT('Bob', STRUCT(92, 88))))",
+            },
+        )
+
+        self.validate_all(
+            "SELECT * FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95)])",
+            write={
+                "bigquery": "SELECT * FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95)])",
+                "duckdb": "SELECT * FROM (SELECT UNNEST([{'name': 'Alice', 'score': 85}, {'name': 'Bob', 'score': 92}, {'name': 'Diana', 'score': 95}], max_depth => 2))",
+                "snowflake": "SELECT * FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('name', 'Alice', 'score', 85), OBJECT_CONSTRUCT('name', 'Bob', 'score', 92), OBJECT_CONSTRUCT('name', 'Diana', 'score', 95)])) AS _t0(seq, key, path, index, value, this)",
+                "presto": "SELECT * FROM UNNEST(ARRAY[CAST(ROW('Alice', 85) AS ROW(name VARCHAR, score INTEGER)), CAST(ROW('Bob', 92) AS ROW(name VARCHAR, score INTEGER)), CAST(ROW('Diana', 95) AS ROW(name VARCHAR, score INTEGER))])",
+                "trino": "SELECT * FROM UNNEST(ARRAY[CAST(ROW('Alice', 85) AS ROW(name VARCHAR, score INTEGER)), CAST(ROW('Bob', 92) AS ROW(name VARCHAR, score INTEGER)), CAST(ROW('Diana', 95) AS ROW(name VARCHAR, score INTEGER))])",
+                "spark2": "SELECT * FROM EXPLODE(ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS name, 92 AS score), STRUCT('Diana' AS name, 95 AS score)))",
+                "databricks": "SELECT * FROM EXPLODE(ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS name, 92 AS score), STRUCT('Diana' AS name, 95 AS score)))",
+                "hive": "SELECT * FROM EXPLODE(ARRAY(STRUCT('Alice', 85), STRUCT('Bob', 92), STRUCT('Diana', 95)))",
             },
         )
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -6,6 +6,7 @@ from sqlglot.transforms import (
     eliminate_join_marks,
     eliminate_qualify,
     eliminate_window_clause,
+    inherit_struct_field_names,
     remove_precision_parameterized_types,
 )
 
@@ -288,4 +289,75 @@ class TestTransforms(unittest.TestCase):
             eliminate_window_clause,
             "SELECT LAST_VALUE(c) OVER (a) AS c2 FROM (SELECT LAST_VALUE(i) OVER (a) AS c FROM p WINDOW a AS (PARTITION BY x)) AS q(c) WINDOW a AS (PARTITION BY y)",
             "SELECT LAST_VALUE(c) OVER (PARTITION BY y) AS c2 FROM (SELECT LAST_VALUE(i) OVER (PARTITION BY x) AS c FROM p) AS q(c)",
+        )
+
+    def test_inherit_struct_field_names(self):
+        # Basic case: field names inherited from first struct
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS name, 92 AS score), STRUCT('Diana' AS name, 95 AS score))",
+        )
+
+        # Single struct in array: no inheritance needed
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score))",
+        )
+
+        # Empty array: no change
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY()",
+            "SELECT ARRAY()",
+        )
+
+        # First struct has no field names: no inheritance
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice', 85), STRUCT('Bob', 92))",
+            "SELECT ARRAY(STRUCT('Alice', 85), STRUCT('Bob', 92))",
+        )
+
+        # Mismatched field counts: skip inheritance
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob'))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob'))",
+        )
+
+        # Struct already has field names: don't override
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS fullname, 92 AS points))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS fullname, 92 AS points))",
+        )
+
+        # Mixed: some structs inherit, some already have names
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Carol' AS name, 88 AS score), STRUCT('Diana', 95))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS name, 92 AS score), STRUCT('Carol' AS name, 88 AS score), STRUCT('Diana' AS name, 95 AS score))",
+        )
+
+        # Non-struct elements: no change
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(1, 2, 3)",
+            "SELECT ARRAY(1, 2, 3)",
+        )
+
+        # Multiple arrays: each processed independently
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92)), ARRAY(STRUCT('X' AS col), STRUCT('Y'))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob' AS name, 92 AS score)), ARRAY(STRUCT('X' AS col), STRUCT('Y' AS col))",
+        )
+
+        # Partial field names in first struct: inherit only the named ones
+        self.validate(
+            inherit_struct_field_names,
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85), STRUCT('Bob', 92))",
+            "SELECT ARRAY(STRUCT('Alice' AS name, 85), STRUCT('Bob', 92))",
         )


### PR DESCRIPTION
The current transpilation converts MAX_BY to ARG_MAX but loses struct field names, causing incorrect results in DuckDB.

```
bq --project_id fivetran-wild-west query --use_legacy_sql=false "SELECT MAX_BY(name, score) FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95)])"
+-------+
|  f0_  |
+-------+
| Diana |
+-------+

python3 -c "import sqlglot as sg; print(sg.transpile(\"SELECT MAX_BY(name, score) FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95)])\", read='bigquery', write='duckdb')[0])"
-->SELECT ARG_MAX(name, score) FROM (SELECT UNNEST([{'name': 'Alice', 'score': 85}, {'_0': 'Bob', '_1': 92}, {'_0': 'Diana', '_1': 95}], max_depth => 2))


duckdb -c "SELECT ARG_MAX(name, score) FROM (SELECT UNNEST([{'name': 'Alice', 'score': 85}, {'_0': 'Bob', '_1': 92}, {'_0': 'Diana', '_1': 95}], max_depth => 2))"
┌────────────────────────┐
│ arg_max("name", score) │
│        varchar         │
├────────────────────────┤
│ Alice                  │
└────────────────────────┘
```

After testing the new code changes:

```
sqlglot % bq --project_id fivetran-wild-west query --use_legacy_sql=false "SELECT MAX_BY(name, score) FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95)])"
+-------+
|  f0_  |
+-------+
| Diana |
+-------+

sqlglot % python3 -c "import sqlglot as sg; print(sg.transpile(\"SELECT MAX_BY(name, score) FROM UNNEST([STRUCT('Alice' AS name, 85 AS score), STRUCT('Bob', 92), STRUCT('Diana', 95)])\", read='bigquery', write='duckdb')[0])"

SELECT ARG_MAX(name, score) FROM (SELECT UNNEST([{'name': 'Alice', 'score': 85}, {'name': 'Bob', 'score': 92}, {'name': 'Diana', 'score': 95}], max_depth => 2))

sqlglot % 

sqlglot % duckdb -c "SELECT ARG_MAX(name, score) FROM (SELECT UNNEST([{'name': 'Alice', 'score': 85}, {'name': 'Bob', 'score': 92}, {'name': 'Diana', 'score': 95}], max_depth => 2))"
┌────────────────────────┐
│ arg_max("name", score) │
│        varchar         │
├────────────────────────┤
│ Diana                  │
└────────────────────────┘
```