### PR TITLE
feat(snowflake)!: add type annotation for BITNOT

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -635,6 +635,7 @@ class Snowflake(Dialect):
                 step=seq_get(args, 2),
             ),
             "ARRAY_SORT": exp.SortArray.from_arg_list,
+            "BITNOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
             "BITXOR": _build_bitwise(exp.BitwiseXor, "BITXOR"),
             "BIT_XOR": _build_bitwise(exp.BitwiseXor, "BITXOR"),
             "BITOR": _build_bitwise(exp.BitwiseOr, "BITOR"),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1345,6 +1345,7 @@ class TestSnowflake(Validator):
                 "snowflake": "EDITDISTANCE(col1, col2, 3)",
             },
         )
+        self.validate_identity("SELECT BITNOT(a)")
         self.validate_identity("SELECT BITOR(a, b)")
         self.validate_identity("SELECT BIT_OR(a, b)", "SELECT BITOR(a, b)")
         self.validate_identity("SELECT BITOR(a, b, 'LEFT')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1656,6 +1656,14 @@ BIT_LENGTH(tbl.bin_col);
 INT;
 
 # dialect: snowflake
+BITNOT(5);
+INT;
+
+# dialect: snowflake
+BITNOT(tbl.bin_col);
+BINARY;
+
+# dialect: snowflake
 BITOR(2, 4);
 INT;
 


### PR DESCRIPTION
  | Platform   | Supported               | Argument Type  | Return Type | Notes                                                            |
  |------------|-------------------------|----------------|-------------|------------------------------------------------------------------|
  | Snowflake  | ✅ Yes (BITNOT) | Numeric/Binary | INT/BINARY  | Returns INT for numeric input, BINARY for binary input           |
  | BigQuery   | ❌ No                    | N/A            | N/A         | Uses ~ operator instead for bitwise NOT on INT64/BYTES           |
  | Redshift   | ❌ No                    | N/A            | N/A         | Uses ~ operator for bitwise NOT on integers/VARBYTE              |
  | PostgreSQL | ❌ No                    | N/A            | N/A         | Uses ~ operator for bitwise NOT on bit strings/integers          |
  | Databricks | ❌ No                    | N/A            | N/A         | Uses ~ operator for bitwise NOT on numeric expressions           |
  | DuckDB     | ❌ No                    | N/A            | N/A         | Uses ~ operator for bitwise NOT on BITSTRING/integers            |
  | T-SQL      | ❌ No                    | N/A            | N/A         | Uses ~ operator for bitwise NOT on integers/bit/binary/varbinary |