### PR TITLE
feat(duckdb): UPPER() handles byte input

### DIFF
--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -900,6 +900,20 @@ LANGUAGE js AS
                 "trino": "LOWER(TO_HEX(x))",
             },
         )
+
+        sql = "UPPER(CAST('hello' AS BYTES))"
+        expr = self.parse_one(sql)
+        qualified = qualify(expr, dialect="bigquery")
+        annotated = annotate_types(qualified, dialect="bigquery")
+        self.assertEqual(
+            annotated.sql("duckdb"), "CAST(UPPER(CAST(CAST('hello' AS BLOB) AS TEXT)) AS BLOB)"
+        )
+
+        sql = "UPPER('hello')"
+        expr = self.parse_one(sql)
+        annotated = annotate_types(expr, dialect="bigquery")
+        self.assertEqual(annotated.sql("duckdb"), "UPPER('hello')")
+
         self.validate_all(
             "UPPER(TO_HEX(x))",
             read={

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1166,6 +1166,9 @@ class TestDuckDB(Validator):
         self.assertEqual(
             annotate_types(self.parse_one("LOWER('HELLO')")).sql("duckdb"), "LOWER('HELLO')"
         )
+        self.assertEqual(
+            annotate_types(self.parse_one("UPPER('hello')")).sql("duckdb"), "UPPER('hello')"
+        )
 
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
BigQuery [UPPER()](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#upper) supports VARCHAR -> VARCHAR AND BYTES -> BYTES
DuckDB [upper()](https://duckdb.org/docs/stable/sql/functions/text#upperstring) supports VARCHAR -> VARCHAR

To improve transpilation from BigQuery, this PR allows DuckDB to handle `byte` input by casting it to `varchar` and casting the upper expression to `blob`. Created helper method to handle casting logic, as this mirrors the work done for LOWER transpilation https://github.com/tobymao/sqlglot/pull/6218

BigQuery:
```
SELECT 
  UPPER(CAST('hello' as BYTES)) as upper_byte, 
  TYPEOF(CAST('hello' as BYTES)) as type_upper_byte, 
  UPPER('hello') AS upper_str, 
  TYPEOF(UPPER('hello')) as type_upper_str;"

+------------+-----------------+-----------+----------------+
| upper_byte | type_upper_byte | upper_str | type_upper_str |
+------------+-----------------+-----------+----------------+
|   SEVMTE8= | BYTES           | HELLO     | STRING         |
+------------+-----------------+-----------+----------------+
```

DuckDB:
```
D SELECT UPPER(CAST('hello' as BLOB)) as upper_byte, TYPEOF(CAST('hello' as BLOB)) as type_upper_byte;
Binder Error:
No function matches the given name and argument types 'upper(BLOB)'. You might need to add explicit type casts.
        Candidate functions:
        upper(VARCHAR) -> VARCHAR

D SELECT UPPER('hello') AS upper_str;
┌───────────┐
│ upper_str │
│  varchar  │
├───────────┤
│ HELLO     │
└───────────┘
```