### PR TITLE
feat(snowflake)!: annotate types for REGR_AVGX

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7461,6 +7461,10 @@ class RegrAvgy(Func):
     arg_types = {"this": True, "expression": True}
 
 
+class RegrAvgx(Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class Repeat(Func):
     arg_types = {"this": True, "times": True}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -191,6 +191,7 @@ EXPRESSION_METADATA = {
             exp.Degrees,
             exp.Exp,
             exp.MonthsBetween,
+            exp.RegrAvgx,
             exp.RegrAvgy,
             exp.RegrValx,
             exp.RegrValy,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -96,6 +96,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT RADIANS(180)")
         self.validate_identity("SELECT REGR_VALX(y, x)")
         self.validate_identity("SELECT REGR_VALY(y, x)")
+        self.validate_identity("SELECT REGR_AVGX(y, x)")
         self.validate_identity("SELECT REGR_AVGY(y, x)")
         self.validate_all(
             "SELECT SKEW(a)",

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2708,6 +2708,10 @@ MONTHS_BETWEEN(tbl.timestamp_col, CAST('2019-02-15 01:00:00' AS TIMESTAMP));
 DOUBLE;
 
 # dialect: snowflake
+REGR_AVGX(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
 REGR_AVGY(tbl.double_col, tbl.double_col);
 DOUBLE;
 


### PR DESCRIPTION
Annotate types for REGR_AVGX

https://docs.snowflake.com/en/sql-reference/functions/regr_avgx

REGR_AVGX returns DOUBLE/FLOAT type even if the inputs are integers