### PR TITLE
Fix: Handle edge cases in  for DuckDB `RANGE` to Spark SEQUENCE transpi…

### DIFF
--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -219,6 +219,20 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
+            "SELECT RANGE(5, 1, -1)",
+            write={
+                "duckdb": "SELECT RANGE(5, 1, -1)",
+                "spark": "SELECT SEQUENCE(5, 2, -1)",
+            },
+        )
+        self.validate_all(
+            "SELECT RANGE(5, 1, 0)",
+            write={
+                "duckdb": "SELECT RANGE(5, 1, 0)",
+                "spark": "SELECT ARRAY()",
+            },
+        )
+        self.validate_all(
             "WITH t AS (SELECT 5 AS c) SELECT RANGE(1, c) FROM t",
             write={
                 "duckdb": "WITH t AS (SELECT 5 AS c) SELECT RANGE(1, c) FROM t",


### PR DESCRIPTION
…lation

## Problem

When transpiling DuckDB's `RANGE` (exclusive end) to Spark's `SEQUENCE` (inclusive end), the condition for returning an empty array only checked `start >= end`, which fails for:
- Negative steps: `RANGE(5, 1, -1)` incorrectly returned `[]` instead of `[5, 4, 3, 2]`
- Zero step: `RANGE(5, 1, 0)` was not handled

## Solution

Updated the empty array condition to handle all cases:
- `step == 0`: always empty
- `step > 0 AND start >= end`: empty
- `step < 0 AND start <= end`: empty