### PR TITLE
feat(clickhouse)!: support splitBy function

### DIFF
--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1568,3 +1568,4 @@ LIFETIME(MIN 0 MAX 0)""",
                 "hive": r"SPLIT(x, '\\d+')",
             },
         )
+        self.validate_identity("splitByChar('', x)")


### PR DESCRIPTION
Parse `splitByChar/splitByString` into `exp.Split`
Parse `splitByRegex` into `exp.RegexpSplit`

https://clickhouse.com/docs/sql-reference/functions/splitting-merging-functions#splitByChar