### PR TITLE
feat(duckdb): Add support for `CREATE MACRO`

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -325,6 +325,7 @@ class DuckDB(Dialect):
             "INSTALL": TokenType.INSTALL,
             "INT8": TokenType.BIGINT,
             "LOGICAL": TokenType.BOOLEAN,
+            "MACRO": TokenType.FUNCTION,
             "ONLY": TokenType.ONLY,
             "PIVOT_WIDER": TokenType.PIVOT,
             "POSITIONAL": TokenType.POSITIONAL,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1994,3 +1994,13 @@ class TestDuckDB(Validator):
         self.validate_identity(
             "WITH RECURSIVE tbl(a, b) USING KEY (a, b) AS (SELECT a, b FROM (VALUES (1, 3), (2, 4)) AS t(a, b) UNION SELECT a + 1, b FROM tbl WHERE a < 3) SELECT * FROM tbl"
         )
+
+    def test_udf(self):
+        for keyword in ("FUNCTION", "MACRO"):
+            with self.subTest(f"Testing DuckDB's UDF for keyword: {keyword}"):
+                self.validate_identity(f"SELECT {keyword}")
+
+                self.validate_identity(f"CREATE {keyword} add(a, b) AS a + b")
+                self.validate_identity(
+                    f"CREATE {keyword} ifelse(a, b, c) AS CASE WHEN a THEN b ELSE c END"
+                )


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6290

DuckDB suggests that `CREATE MACRO` & `CREATE FUNCTION` [are aliases](https://duckdb.org/docs/stable/sql/statements/create_macro#:~:text=Macros%20are%20schema%2Ddependent%2C%20and%20have%20an%20alias%2C%20FUNCTION%3A), as the issue highlighted as well.