### PR TITLE
feat(snowflake)!: type annotation for BITMAP_BUCKET_NUMBER function.

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5632,6 +5632,10 @@ class BitwiseCount(Func):
     pass
 
 
+class BitmapBucketNumber(Func):
+    pass
+
+
 class BitmapCount(Func):
     pass
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -123,6 +123,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.BIGINT}
         for expr_type in {
             exp.BitmapBitPosition,
+            exp.BitmapBucketNumber,
             exp.BitmapCount,
             exp.Factorial,
             exp.GroupingId,

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -13,6 +13,7 @@ class TestDatabricks(Validator):
         self.assertEqual(null_type.sql("databricks"), "VOID")
 
         self.validate_identity("SELECT BITMAP_BIT_POSITION(10)")
+        self.validate_identity("SELECT BITMAP_BUCKET_NUMBER(32769)")
         self.validate_identity("SELECT BITMAP_CONSTRUCT_AGG(value)")
         self.validate_identity("SELECT EXP(1)")
         self.validate_identity("REGEXP_LIKE(x, y)")

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -17,6 +17,7 @@ class TestOracle(Validator):
         )
         self.parse_one("ALTER TABLE tbl_name DROP FOREIGN KEY fk_symbol").assert_is(exp.Alter)
 
+        self.validate_identity("SELECT BITMAP_BUCKET_NUMBER(32769)")
         self.validate_identity("SELECT BITMAP_CONSTRUCT_AGG(value)")
         self.validate_identity("DBMS_RANDOM.NORMAL")
         self.validate_identity("DBMS_RANDOM.VALUE(low, high)").assert_is(exp.Rand)

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -48,6 +48,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT BIT_LENGTH('abc')")
         self.validate_identity("SELECT BIT_LENGTH(x'A1B2')")
         self.validate_identity("SELECT BITMAP_BIT_POSITION(10)")
+        self.validate_identity("SELECT BITMAP_BUCKET_NUMBER(32769)")
         self.validate_identity("SELECT BITMAP_CONSTRUCT_AGG(value)")
         self.validate_identity(
             "SELECT BITMAP_COUNT(BITMAP_CONSTRUCT_AGG(value)) FROM TABLE(FLATTEN(INPUT => ARRAY_CONSTRUCT(1, 2, 3, 5)))",

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1661,6 +1661,10 @@ BITMAP_BIT_POSITION(tbl.int_col);
 BIGINT;
 
 # dialect: snowflake
+BITMAP_BUCKET_NUMBER(tbl.int_col);
+BIGINT;
+
+# dialect: snowflake
 BITMAP_CONSTRUCT_AGG(tbl.int_col);
 BINARY;
 


### PR DESCRIPTION
Added type annotation for BITMAP_BUCKET_NUMBER to return INT.

Ensures consistent typing behavior for bitmap-related aggregation and analytics functions in Snowflake.