### PR TITLE
feat(duckDB): Add transpilation support for ANY_VALUE function with HAVING MAX and MIN clauses

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -282,10 +282,10 @@ def _cast_to_blob(self: DuckDB.Generator, expression: exp.Expression, result_sql
 
 
 def _anyvalue_sql(self: DuckDB.Generator, expression: exp.AnyValue) -> str:
-    # Transform ANY_VALUE(expr HAVING MAX/MIN having_expr) to ARG_MAX/ARG_MIN
+    # Transform ANY_VALUE(expr HAVING MAX/MIN having_expr) to ARG_MAX_NULL/ARG_MIN_NULL
     having = expression.this
     if isinstance(having, exp.HavingMax):
-        func_name = "ARG_MAX" if having.args.get("max") else "ARG_MIN"
+        func_name = "ARG_MAX_NULL" if having.args.get("max") else "ARG_MIN_NULL"
         return self.func(func_name, having.this, having.expression)
     return self.function_fallback_sql(expression)
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -115,21 +115,27 @@ class TestBigQuery(Validator):
             "SELECT ANY_VALUE(fruit HAVING MAX sold) FROM Store",
             write={
                 "bigquery": "SELECT ANY_VALUE(fruit HAVING MAX sold) FROM Store",
-                "duckdb": "SELECT ARG_MAX(fruit, sold) FROM Store",
+                "duckdb": "SELECT ARG_MAX_NULL(fruit, sold) FROM Store",
             },
         )
         self.validate_all(
             "SELECT ANY_VALUE(fruit HAVING MIN sold) FROM Store",
             write={
                 "bigquery": "SELECT ANY_VALUE(fruit HAVING MIN sold) FROM Store",
-                "duckdb": "SELECT ARG_MIN(fruit, sold) FROM Store",
+                "duckdb": "SELECT ARG_MIN_NULL(fruit, sold) FROM Store",
             },
         )
         self.validate_all(
             "SELECT category, ANY_VALUE(product HAVING MAX price), ANY_VALUE(product HAVING MIN cost), ANY_VALUE(supplier) FROM products GROUP BY category",
             write={
                 "bigquery": "SELECT category, ANY_VALUE(product HAVING MAX price), ANY_VALUE(product HAVING MIN cost), ANY_VALUE(supplier) FROM products GROUP BY category",
-                "duckdb": "SELECT category, ARG_MAX(product, price), ARG_MIN(product, cost), ANY_VALUE(supplier) FROM products GROUP BY category",
+                "duckdb": "SELECT category, ARG_MAX_NULL(product, price), ARG_MIN_NULL(product, cost), ANY_VALUE(supplier) FROM products GROUP BY category",
+            },
+        )
+        self.validate_all(
+            'WITH data AS (SELECT "A" AS fruit, 20 AS sold UNION ALL SELECT NULL AS fruit, 25 AS sold) SELECT ANY_VALUE(fruit HAVING MAX sold) FROM data',
+            write={
+                "duckdb": "WITH data AS (SELECT 'A' AS fruit, 20 AS sold UNION ALL SELECT NULL AS fruit, 25 AS sold) SELECT ARG_MAX_NULL(fruit, sold) FROM data",
             },
         )
         self.validate_identity("SELECT `project-id`.udfs.func(call.dir)")


### PR DESCRIPTION
Add transpilation support for ANY_VALUE function with HAVING MAX and MIN clauses.

**Issue:**
```
Transpilation:

python -m sqlglot --read bigquery --write duckdb 'WITH Store AS (SELECT 20 AS sold, "apples" AS fruit UNION ALL SELECT 30 AS sold, "pears" AS fruit UNION ALL SELECT 30 AS sold, "bananas" AS fruit UNION ALL SELECT 10 AS sold, "oranges" AS fruit) SELECT ANY_VALUE(fruit HAVING MAX sold) AS a_highest_selling_fruit FROM Store' --no-pretty
-->
WITH "Store" AS (SELECT 20 AS "sold", 'apples' AS "fruit" UNION ALL SELECT 30 AS "sold", 'pears' AS "fruit" UNION ALL SELECT 30 AS "sold", 'bananas' AS "fruit" UNION ALL SELECT 10 AS "sold", 'oranges' AS "fruit") SELECT ANY_VALUE("fruit" HAVING MAX "sold") AS "a_highest_selling_fruit" FROM "Store"

Duckdb:
duckdb -c "WITH "Store" AS (SELECT 20 AS "sold", 'apples' AS "fruit" UNION ALL SELECT 30 AS "sold", 'pears' AS "fruit" UNION ALL SELECT 30 AS "sold", 'bananas' AS "fruit" UNION ALL SELECT 10 AS "sold", 'oranges' AS "fruit") SELECT ANY_VALUE("fruit" HAVING MAX "sold") AS "a_highest_selling_fruit" FROM "Store""
Parser Error:
syntax error at or near "HAVING"

LINE 1: ... SELECT 10 AS sold, 'oranges' AS fruit) SELECT ANY_VALUE(fruit HAVING MAX sold) AS a_highest_selling_fruit FROM Store
```

**Fix:**
Transform `ANY_VALUE(expr HAVING MAX/MIN having_expr)` to` ARG_MAX/ARG_MIN`
MAX:
```
python -m sqlglot --read bigquery --write duckdb 'WITH Store AS (SELECT 20 AS sold, "apples" AS fruit UNION ALL SELECT 30 AS sold, "pears" AS fruit UNION ALL SELECT 30 AS sold, "bananas" AS fruit UNION ALL SELECT 10 AS sold, "oranges" AS fruit) SELECT ANY_VALUE(fruit HAVING MAX sold) AS a_highest_selling_fruit FROM Store' --no-pretty
--> WITH "Store" AS (SELECT 20 AS "sold", 'apples' AS "fruit" UNION ALL SELECT 30 AS "sold", 'pears' AS "fruit" UNION ALL SELECT 30 AS "sold", 'bananas' AS "fruit" UNION ALL SELECT 10 AS "sold", 'oranges' AS "fruit") SELECT ARG_MAX("fruit", "sold") AS "a_highest_selling_fruit" FROM "Store"

sqlglot % duckdb -c "WITH "Store" AS (SELECT 20 AS "sold", 'apples' AS "fruit" UNION ALL SELECT 30 AS "sold", 'pears' AS "fruit" UNION ALL SELECT 30 AS "sold", 'bananas' AS "fruit" UNION ALL SELECT 10 AS "sold", 'oranges' AS "fruit") SELECT ARG_MAX("fruit", "sold") AS "a_highest_selling_fruit" FROM "Store""
┌─────────────────────────┐
│ a_highest_selling_fruit │
│         varchar         │
├─────────────────────────┤
│ pears                   │
└─────────────────────────┘
```

MIN:
```
python -m sqlglot --read bigquery --write duckdb 'WITH Store AS (SELECT 20 AS sold, "apples" AS fruit UNION ALL SELECT 30 AS sold, "pears" AS fruit UNION ALL SELECT 30 AS sold, "bananas" AS fruit UNION ALL SELECT 10 AS sold, "oranges" AS fruit) SELECT ANY_VALUE(fruit HAVING MIN sold) AS a_lowest_selling_fruit FROM Store' --no-pretty
--> WITH "Store" AS (SELECT 20 AS "sold", 'apples' AS "fruit" UNION ALL SELECT 30 AS "sold", 'pears' AS "fruit" UNION ALL SELECT 30 AS "sold", 'bananas' AS "fruit" UNION ALL SELECT 10 AS "sold", 'oranges' AS "fruit") SELECT ARG_MIN("fruit", "sold") AS "a_lowest_selling_fruit" FROM "Store"

sqlglot % duckdb -c "WITH "Store" AS (SELECT 20 AS "sold", 'apples' AS "fruit" UNION ALL SELECT 30 AS "sold", 'pears' AS "fruit" UNION ALL SELECT 30 AS "sold", 'bananas' AS "fruit" UNION ALL SELECT 10 AS "sold", 'oranges' AS "fruit") SELECT ARG_MIN("fruit", "sold") AS "a_lowest_selling_fruit" FROM "Store""
┌────────────────────────┐
│ a_lowest_selling_fruit │
│        varchar         │
├────────────────────────┤
│ oranges                │
└────────────────────────┘
```