### PR TITLE
feat(snowflake)!: MAX_BY and MIN_BY 2 parameters return type annoatio…

### DIFF
--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -82,7 +82,12 @@ def _annotate_decode_case(self: TypeAnnotator, expression: exp.DecodeCase) -> ex
 
 
 def _annotate_arg_max_min(self, expression):
-    return self._annotate_by_args(expression, "this", array=bool(expression.args.get("count")))
+    self._annotate_args(expression)
+    self._set_type(
+        expression,
+        exp.DataType.Type.ARRAY if expression.args.get("count") else expression.this.type,
+    )
+    return expression
 
 
 def _annotate_within_group(self: TypeAnnotator, expression: exp.WithinGroup) -> exp.WithinGroup:

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3422,7 +3422,7 @@ VARCHAR;
 
 # dialect: snowflake
 MAX_BY('foo', tbl.bigint_col, 3);
-ARRAY<VARCHAR>;
+ARRAY;
 
 # dialect: snowflake
 MIN_BY('foo', tbl.bigint_col);
@@ -3430,7 +3430,7 @@ VARCHAR;
 
 # dialect: snowflake
 MIN_BY('foo', tbl.bigint_col, 3);
-ARRAY<VARCHAR>;
+ARRAY;
 
 # dialect: snowflake
 APPROX_PERCENTILE(tbl.bigint_col, 0.5);


### PR DESCRIPTION
We cannot infer that the result of ARRAY_AGG is ARRAY<T> even if we know the inner type T. Snowflake will not return a typed ARRAY; it returns a generic ARRAY (ARRAY<VARIANT>).
Fix to return an un-typed ARRAY.