### PR TITLE
feat(optimizer)!: annotate type for MINHASH_COMBINE

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5746,6 +5746,11 @@ class Minhash(AggFunc):
     is_var_len_args = True
 
 
+# https://docs.snowflake.com/en/sql-reference/functions/minhash_combine
+class MinhashCombine(AggFunc):
+    pass
+
+
 # https://docs.snowflake.com/en/sql-reference/functions/approximate_similarity
 class ApproximateSimilarity(AggFunc):
     _sql_names = ["APPROXIMATE_SIMILARITY", "APPROXIMATE_JACCARD_INDEX"]

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -289,6 +289,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.VARIANT}
         for expr_type in {
             exp.Minhash,
+            exp.MinhashCombine,
         }
     },
     exp.ArgMax: {"annotator": _annotate_arg_max_min},

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -45,6 +45,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT MINHASH(5, col)")
         self.validate_identity("SELECT MINHASH(5, col1, col2)")
         self.validate_identity("SELECT MINHASH(5, *)")
+        self.validate_identity("SELECT MINHASH_COMBINE(minhash_col)")
         self.validate_identity("SELECT APPROXIMATE_SIMILARITY(minhash_col)")
         self.validate_identity(
             "SELECT APPROXIMATE_JACCARD_INDEX(minhash_col)",

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3521,6 +3521,10 @@ MINHASH(5, *);
 VARIANT;
 
 # dialect: snowflake
+MINHASH_COMBINE(tbl.variant_col);
+VARIANT;
+
+# dialect: snowflake
 APPROXIMATE_SIMILARITY(tbl.variant_col);
 DOUBLE;
 


### PR DESCRIPTION
docs: https://docs.snowflake.com/en/sql-reference/functions/minhash_combine

not supported by any other significant db engine