### PR TITLE
Chore(optimizer): refactor costly scope walking loop in qualify tables

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -144,15 +144,10 @@ def qualify_tables(
                         for i in dialect.generate_values_aliases(udtf)
                     ]
                     table_alias.set("columns", column_aliases)
-            else:
-                for node in scope.walk():
-                    if (
-                        isinstance(node, exp.Table)
-                        and not node.alias
-                        and isinstance(node.parent, (exp.From, exp.Join))
-                    ):
-                        # Mutates the table by attaching an alias to it
-                        exp.alias_(node, node.name, copy=False, table=True)
+
+        for table in scope.tables:
+            if not table.alias and isinstance(table.parent, (exp.From, exp.Join)):
+                exp.alias_(table, table.name, copy=False, table=True)
 
         for column in scope.columns:
             if column.db:


### PR DESCRIPTION
IIRC, the refactored loop aimed to alias `Table` references that corresponded to CTEs, since those wouldn't show up as `Table` sources, but instead `Scope`, and hence were not aliased in [this branch](https://github.com/tobymao/sqlglot/blob/3aafca74546b932cea93ed830c021f347ae03ded/sqlglot/optimizer/qualify_tables.py#L98).

We could end up walking the scope multiple times when there were CTE references which is very inefficient. This PR makes it so that we only walk the scope's _tables_, after the sources have been visited.