### PR TITLE
fix(optimizer)!: qualify functions with default columns and tables as column references

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -671,6 +671,14 @@ class Dialect(metaclass=_Dialect):
     Whether JSON_EXTRACT_SCALAR returns null if a non-scalar value is selected.
     """
 
+    DEFAULT_FUNCTIONS_COLUMN_NAMES: t.Dict[t.Type[exp.Func], t.Union[str, t.Tuple[str, ...]]] = {}
+    """
+    Maps function expressions to their default output column name(s).
+
+    For example, in Postgres, generate_series function outputs a column named "generate_series" by default,
+    so we map the ExplodingGenerateSeries expression to "generate_series" string.
+    """
+
     # --- Autofilled ---
 
     tokenizer_class = Tokenizer

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -297,6 +297,11 @@ class Postgres(Dialect):
     NULL_ORDERING = "nulls_are_large"
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
     TABLESAMPLE_SIZE_IS_PERCENT = True
+    TABLES_REFERENCEABLE_AS_COLUMNS = True
+
+    DEFAULT_FUNCTIONS_COLUMN_NAMES = {
+        exp.ExplodingGenerateSeries: "generate_series",
+    }
 
     TIME_MAPPING = {
         "d": "%u",  # 1-based day of week

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -598,7 +598,7 @@ def _qualify_columns(
                 and len(column.parts) == 1
                 and column_name in scope.selected_sources
             ):
-                # BigQuery allows tables to be referenced as columns, treating them as structs
+                # BigQuery and Postgres allow tables to be referenced as columns, treating them as structs/records
                 scope.replace(column, exp.TableColumn(this=column.this))
 
     for pivot in scope.pivots:

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -287,6 +287,11 @@ SELECT DATE_TRUNC(t.col1, WEEK(MONDAY)) AS _col_0, t.col2 AS col2 FROM t AS t;
 SELECT first, second FROM (SELECT 'val' AS col, STACK(2, 1, 2, 3) AS (first, second)) AS tbl;
 SELECT tbl.first AS first, tbl.second AS second FROM (SELECT 'val' AS col, STACK(2, 1, 2, 3) AS (first, second)) AS tbl;
 
+# execute: false
+# dialect: postgres
+WITH t AS (SELECT 1 AS c) SELECT t FROM t;
+WITH t AS (SELECT 1 AS c) SELECT t AS _col_0 FROM t AS t;
+
 --------------------------------------
 -- Derived tables
 --------------------------------------

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -260,3 +260,24 @@ SELECT * FROM c.db.x AS "_1" WHERE "_1".a = (SELECT SUM("_0".c) AS c FROM c.db.y
 # canonicalize_table_aliases: true
 SELECT t.foo FROM t AS t, (SELECT t.bar FROM t AS t);
 SELECT "_2".foo FROM c.db.t AS "_2", (SELECT "_0".bar FROM c.db.t AS "_0") AS "_1";
+
+# title: Qualify GENERATE_SERIES with its default column generate_series
+# dialect: postgres
+SELECT generate_series FROM GENERATE_SERIES(1,2);
+SELECT generate_series FROM GENERATE_SERIES(1, 2) AS "_0"(generate_series);
+
+# title: Qualify GENERATE_SERIES with alias by wrapping it
+# dialect: postgres
+SELECT g FROM GENERATE_SERIES(1,2) AS g;
+SELECT g FROM GENERATE_SERIES(1, 2) AS "_0"(g);
+
+# title: Qualify GENERATE_SERIES with alias on table and columns
+# dialect: postgres
+SELECT g FROM GENERATE_SERIES(1,2) AS t(g);
+SELECT g FROM GENERATE_SERIES(1, 2) AS t(g);
+
+# title: Qualify GENERATE_SERIES with explicit column and canonicalize_table_aliases
+# dialect: postgres
+# canonicalize_table_aliases: true
+SELECT g FROM GENERATE_SERIES(1,2) AS t(g);
+SELECT g FROM GENERATE_SERIES(1, 2) AS "_0"(g);


### PR DESCRIPTION
Fixes #6358

This PR fixes the qualification of `GENERATE_SERIES` and table as column.

**GENERATE_SERIES**
```
SELECT * FROM GENERATE_SERIES(1, 2);
 generate_series 
-----------------
               1
               2
(2 rows)
```
In postgres `GENERATE_SERIES` creates a column `generate_series`, thus in order to safely qualify this we have the two following cases:

1. Without alias: we just create an alias on optimization time and use the default `generate_series` column:
```
SELECT generate_series FROM GENERATE_SERIES(1,2); => SELECT generate_series FROM GENERATE_SERIES(1, 2) AS _q_0(generate_series);
```
2. With alias: we wrap it with a generated alias from the optimizer:
```
SELECT g FROM GENERATE_SERIES(1,2) AS g; => SELECT g FROM GENERATE_SERIES(1, 2) AS _q_0(g);
```

**Table projection**
postgres supports:
```
SELECT t FROM t;
```
The type of `t` is `record`, which is an abstract type. We treat this case as the bigquerry table-column reference. 