### PR TITLE
feat: mark IgnoreNulls and RespectNulls as unsupported on postgres and mysql

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -1329,6 +1329,11 @@ class MySQL(Dialect):
 
         def isascii_sql(self, expression: exp.IsAscii) -> str:
             return f"REGEXP_LIKE({self.sql(expression.this)}, '^[[:ascii:]]*$')"
+        
+        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
+            # https://dev.mysql.com/doc/refman/8.4/en/window-function-descriptions.html
+            self.unsupported("MySQL does not support IGNORE NULLS.")
+            return self.sql(expression.this)
 
         @unsupported_args("this")
         def currentschema_sql(self, expression: exp.CurrentSchema) -> str:

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -837,6 +837,16 @@ class Postgres(Dialect):
 
         def isascii_sql(self, expression: exp.IsAscii) -> str:
             return f"({self.sql(expression.this)} ~ '^[[:ascii:]]*$')"
+        
+        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
+            # https://www.postgresql.org/docs/current/functions-window.html
+            self.unsupported("PostgreSQL does not support IGNORE NULLS.")
+            return self.sql(expression.this)
+        
+        def respectnulls_sql(self, expression: exp.RespectNulls) -> str:
+                        # https://www.postgresql.org/docs/current/functions-window.html
+            self.unsupported("PostgreSQL does not support explicit RESPECT NULLS. Just use the expression directly.")
+            return self.sql(expression.this)
 
         @unsupported_args("this")
         def currentschema_sql(self, expression: exp.CurrentSchema) -> str:


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6376

- on postgres, using either IGNORE NULLS or RESPECT NULLS errors
- on mySQL, you are allowed to use RESPECT NULLS, only using IGNORE NULLS results in an error

There are probably other dialects that also need this change, but these are the ones I've discovered so far.