### PR TITLE
fix(mysql)!: support order by clause for mysql delete statement

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -2141,6 +2141,7 @@ class Delete(DML):
         "using": False,
         "where": False,
         "returning": False,
+        "order": False,
         "limit": False,
         "tables": False,  # Multiple-Table Syntax (MySQL)
         "cluster": False,  # Clickhouse

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1504,13 +1504,14 @@ class Generator(metaclass=_Generator):
         cluster = f" {cluster}" if cluster else ""
         where = self.sql(expression, "where")
         returning = self.sql(expression, "returning")
+        order = self.sql(expression, "order")
         limit = self.sql(expression, "limit")
         tables = self.expressions(expression, key="tables")
         tables = f" {tables}" if tables else ""
         if self.RETURNING_END:
-            expression_sql = f"{this}{using}{cluster}{where}{returning}{limit}"
+            expression_sql = f"{this}{using}{cluster}{where}{returning}{order}{limit}"
         else:
-            expression_sql = f"{returning}{this}{using}{cluster}{where}{limit}"
+            expression_sql = f"{returning}{this}{using}{cluster}{where}{order}{limit}"
         return self.prepend_ctes(expression, f"DELETE{tables}{expression_sql}")
 
     def drop_sql(self, expression: exp.Drop) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3134,6 +3134,7 @@ class Parser(metaclass=_Parser):
             cluster=self._match(TokenType.ON) and self._parse_on_property(),
             where=self._parse_where(),
             returning=returning or self._parse_returning(),
+            order=self._parse_order(),
             limit=self._parse_limit(),
         )
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -22,6 +22,7 @@ class TestMySQL(Validator):
         self.validate_identity("CREATE TABLE temp (id SERIAL PRIMARY KEY)")
         self.validate_identity("UPDATE items SET items.price = 0 WHERE items.id >= 5 LIMIT 10")
         self.validate_identity("DELETE FROM t WHERE a <= 10 LIMIT 10")
+        self.validate_identity("DELETE FROM t FORCE INDEX (idx) WHERE a > 5 ORDER BY id")
         self.validate_identity("CREATE TABLE foo (a BIGINT, INDEX USING BTREE (b))")
         self.validate_identity("CREATE TABLE foo (a BIGINT, FULLTEXT INDEX (b))")
         self.validate_identity("CREATE TABLE foo (a BIGINT, SPATIAL INDEX (b))")


### PR DESCRIPTION
Issue: https://github.com/tobymao/sqlglot/issues/6372

Problem: SQLGlot's DELETE statement parser didn't support ORDER BY clauses, which are valid in MySQL. The error message was misleading: FORCE INDEX parsing worked fine, but the parser failed when it encountered ORDER BY after the WHERE clause.

Solution: Added ORDER BY support to DELETE statements

Testing: ran parse_one locally:
`Delete(
  this=Table(
    this=Identifier(this=sample_delete_table, quoted=False),
    hints=[
      IndexTableHint(
        this=FORCE,
        expressions=[
          Identifier(this=idx_expiration, quoted=False)])]),
  where=Where(
    this=LTE(
      this=Column(
        this=Identifier(this=expiration, quoted=False)),
      expression=Paren(
        this=Sub(
          this=Anonymous(this=now),
          expression=Interval(
            this=Literal(this='30', is_string=True),
            unit=Var(this=MINUTE)))))),
  order=Order(
    expressions=[
      Ordered(
        this=Column(
          this=Identifier(this=expiration, quoted=False)),
        nulls_first=True)]))`