### PR TITLE
fix(mysql)!: support named primary keys for mysql

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6512,6 +6512,13 @@ class Parser(metaclass=_Parser):
             and self._prev.token_type == TokenType.DESC
         )
 
+        if (
+            self._curr.text.upper() not in self.CONSTRAINT_PARSERS
+            and self._next
+            and self._next.token_type == TokenType.L_PAREN
+        ):
+            self._parse_id_var()
+
         if not in_props and not self._match(TokenType.L_PAREN, advance=False):
             return self.expression(
                 exp.PrimaryKeyColumnConstraint,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -96,6 +96,19 @@ class TestMySQL(Validator):
             "CREATE TABLE test_table (id INT AUTO_INCREMENT, PRIMARY KEY (id) USING HASH)"
         )
         self.validate_identity(
+            "CREATE TABLE test (id INT, PRIMARY KEY pk_name (id))",
+            "CREATE TABLE test (id INT, PRIMARY KEY (id))",
+        )
+        self.validate_identity(
+            "CREATE TABLE test (id INT, PRIMARY KEY `pk_name` (id))",
+            "CREATE TABLE test (id INT, PRIMARY KEY (id))",
+        )
+        self.validate_identity(
+            'CREATE TABLE test (id INT, PRIMARY KEY "pk_name" (id))',
+            "CREATE TABLE test (id INT, PRIMARY KEY (id))",
+        )
+        self.validate_identity("CREATE TABLE test (id INT, CONSTRAINT pk_name PRIMARY KEY (id))")
+        self.validate_identity(
             "CREATE TABLE test (a INT, b INT GENERATED ALWAYS AS (a + a) STORED)"
         )
         self.validate_identity(


### PR DESCRIPTION
Issue: https://github.com/tobymao/sqlglot/issues/6382

Problem: MySQL supports supplying a name for primary key (which is silently discarded), we currently fail when the next token isn't '('

Solution: Check if there is an identifier followed by the expected '(', if so advance and discard the identifier, unless it is a known constraint keyword 

Testing: ran parse_one locally:
`Create(
  this=Schema(
    this=Table(
      this=Identifier(this=test, quoted=False)),
    expressions=[
      ColumnDef(
        this=Identifier(this=id, quoted=False),
        kind=DataType(this=Type.INT, nested=False)),
      ColumnDef(
        this=Identifier(this=value, quoted=False),
        kind=DataType(
          this=Type.VARCHAR,
          expressions=[
            DataTypeParam(
              this=Literal(this=5, is_string=False))],
          nested=False)),
      PrimaryKey(
        expressions=[
          Identifier(this=id, quoted=False)],
        include=IndexParameters())]),
  kind=TABLE)` 