### PR TITLE
fix(bigquery)!: Disable `STRING_AGG` separator canonicalization

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -1080,7 +1080,7 @@ class BigQuery(Dialect):
             ),
             exp.GenerateSeries: rename_func("GENERATE_ARRAY"),
             exp.GroupConcat: lambda self, e: groupconcat_sql(
-                self, e, func_name="STRING_AGG", within_group=False
+                self, e, func_name="STRING_AGG", within_group=False, sep=None
             ),
             exp.Hex: lambda self, e: self.func("UPPER", self.func("TO_HEX", self.sql(e, "this"))),
             exp.HexString: lambda self, e: self.hexstring_sql(e, binary_function_repr="FROM_HEX"),

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1863,12 +1863,14 @@ def groupconcat_sql(
     self: Generator,
     expression: exp.GroupConcat,
     func_name="LISTAGG",
-    sep: str = ",",
+    sep: t.Optional[str] = ",",
     within_group: bool = True,
     on_overflow: bool = False,
 ) -> str:
     this = expression.this
-    separator = self.sql(expression.args.get("separator") or exp.Literal.string(sep))
+    separator = self.sql(
+        expression.args.get("separator") or (exp.Literal.string(sep) if sep else None)
+    )
 
     on_overflow_sql = self.sql(expression, "on_overflow")
     on_overflow_sql = f" ON OVERFLOW {on_overflow_sql}" if (on_overflow and on_overflow_sql) else ""
@@ -1884,7 +1886,10 @@ def groupconcat_sql(
     if order and order.this:
         this = order.this.pop()
 
-    args = self.format_args(this, f"{separator}{on_overflow_sql}")
+    args = self.format_args(
+        this, f"{separator}{on_overflow_sql}" if separator or on_overflow_sql else None
+    )
+
     listagg: exp.Expression = exp.Anonymous(this=func_name, expressions=[args])
 
     modifiers = self.sql(limit)

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2915,15 +2915,12 @@ OPTIONS (
         self.validate_identity("STRING_AGG(DISTINCT a, ' & ')")
         self.validate_identity("STRING_AGG(a, ' & ' ORDER BY LENGTH(a))")
         self.validate_identity("STRING_AGG(foo, b'|' ORDER BY bar)")
-        self.validate_identity("STRING_AGG(a)", "STRING_AGG(a, ',')")
+        self.validate_identity("STRING_AGG(a)")
         self.validate_identity("STRING_AGG(DISTINCT v, sep LIMIT 3)")
-        self.validate_identity(
-            "STRING_AGG(DISTINCT a ORDER BY b DESC, c DESC LIMIT 10)",
-            "STRING_AGG(DISTINCT a, ',' ORDER BY b DESC, c DESC LIMIT 10)",
-        )
+        self.validate_identity("STRING_AGG(DISTINCT a ORDER BY b DESC, c DESC LIMIT 10)")
         self.validate_identity(
             "SELECT a, GROUP_CONCAT(b) FROM table GROUP BY a",
-            "SELECT a, STRING_AGG(b, ',') FROM table GROUP BY a",
+            "SELECT a, STRING_AGG(b) FROM table GROUP BY a",
         )
 
     def test_annotate_timestamps(self):


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6392

Canonicalizing `STRING_AGG` with a string literal comma separator is not correct in case the expression is of `BYTES` type:

```SQL
bq> SELECT STRING_AGG(a) FROM UNNEST([b'foo', b'bar', b'baz']) AS a
Zm9vLGJhcixiYXo= -- BASE64 decoding: foo,bar,baz

bq> SELECT STRING_AGG(a, ',') FROM UNNEST([b'foo', b'bar', b'baz']) AS a
Zm9vLGJhcixiYXo= -- BASE64 decoding: foo,bar,baz

No matching signature for aggregate function STRING_AGG Argument types: BYTES, STRING
```


Docs
---------
[BQ STRING_AGG](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#string_agg)