### PR TITLE
fix(duckdb): Make `exp.DateFromParts` more lenient

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6493,7 +6493,7 @@ class TimeTrunc(Func, TimeUnit):
 
 class DateFromParts(Func):
     _sql_names = ["DATE_FROM_PARTS", "DATEFROMPARTS"]
-    arg_types = {"year": True, "month": True, "day": True}
+    arg_types = {"year": True, "month": False, "day": False}
 
 
 class TimeFromParts(Func):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1240,6 +1240,9 @@ class TestDuckDB(Validator):
         )
         self.validate_identity("SELECT GREATEST(1.0, 2.5, NULL, 3.7)")
 
+        # TODO: This is incorrect AST, DATE_PART creates a STRUCT of values but it's stored in 'year' arg
+        self.validate_identity("SELECT MAKE_DATE(DATE_PART(['year', 'month', 'day'], TODAY()))")
+
     def test_array_index(self):
         with self.assertLogs(helper_logger) as cm:
             self.validate_all(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6394

Although this is not properly documented, the following query is valid in DuckDB:

```SQL
D select MAKE_DATE(DATE_PART(['year', 'month', 'day'], TODAY())) AS col;
┌────────────┐
│    col     │
│    date    │
├────────────┤
│ 2025-11-24 │
└────────────┘
```

This is because:
- `DATE_PART` returns either an `INT64` or a `STRUCT` of values, depending on the input expression:
```SQL
D SELECT DATE_PART('day', TODAY()) AS integer, DATE_PART(['year', 'month', 'day'], TODAY()) AS strct;
┌─────────┬─────────────────────────────────────────────────────┐
│ integer │                        strct                        │
│  int64  │ struct("year" bigint, "month" bigint, "day" bigint) │
├─────────┼─────────────────────────────────────────────────────┤
│   24    │ {'year': 2025, 'month': 11, 'day': 24}              │
└─────────┴─────────────────────────────────────────────────────┘

```

- `MAKE_DATE` accepts either INT64s or a `STRUCT` which encodes those kwargs


**Note:** To properly represent that in the AST we'd have to infer whether the `MAKE_DATE` expression evaluates to an `INT64` or a `STRUCT`, but since this low ROI we instead store that in the first argument `year`. 


Docs
---------
[DuckDB MAKE_DATE](https://duckdb.org/docs/stable/sql/functions/date#make_dateyear-month-day) | [DuckDB DATE_PART](https://duckdb.org/docs/stable/sql/functions/date#date_partpart-date)