### PR TITLE
Feat(exasol): qualify bare stars to facilitate transpilation

### DIFF
--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -37,7 +37,7 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            'SELECT A.*, B.*, 3 FROM "A" JOIN "B" ON 1 = 1',
+            'SELECT "A".*, "B".*, 3 FROM "A" JOIN "B" ON 1 = 1',
             read={
                 "": 'SELECT *, 3 FROM "A" JOIN "B" ON 1=1',
             },


### PR DESCRIPTION
**What motivated this PR?**
Exasol doesn't support a bare * alongside other select items. 

**How is the existing logic in main incorrect?**
For example, when transpiling `SELECT *, 1 FROM TEST` to Exasol, the query returned (`SELECT *, 1 FROM TEST`) would fail because Exasol requires that the bare * is scoped with an alias.

**How does the PR address the aforementioned issues?**
The PR preprocesses SELECT by transforming unscoped star to <alias>.* and attaching TableAlias.
Fix: `SELECT *, 1 FROM TEST` -> `SELECT T.*, 1 FROM TEST AS T`

**Provide documentation for the SQL functions involved in the implementation & explain whether semantics change / are preserved**
The issue is not specifically stated in the documentation, but I can provide a screenshot if required