### PR TITLE
feat(snowflake)!: annotation support for APPROX_TOP_K_ESTIMATE 

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5741,6 +5741,10 @@ class ApproxTopKCombine(AggFunc):
     arg_types = {"this": True, "expression": False}
 
 
+class ApproxTopKEstimate(Func):
+    arg_types = {"this": True, "expression": False}
+
+
 class ApproxTopSum(AggFunc):
     arg_types = {"this": True, "expression": True, "count": True}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -123,6 +123,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.ARRAY}
         for expr_type in (
             exp.ApproxTopK,
+            exp.ApproxTopKEstimate,
             exp.ArrayAgg,
             exp.RegexpExtractAll,
             exp.Split,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -58,6 +58,8 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT APPROX_TOP_K_ACCUMULATE(col, 10)")
         self.validate_identity("SELECT APPROX_TOP_K_COMBINE(state, 2)")
         self.validate_identity("SELECT APPROX_TOP_K_COMBINE(state)")
+        self.validate_identity("SELECT APPROX_TOP_K_ESTIMATE(state_column, 4)")
+        self.validate_identity("SELECT APPROX_TOP_K_ESTIMATE(state_column)")
         self.validate_identity("SELECT EQUAL_NULL(1, 2)")
         self.validate_identity("SELECT EXP(1)")
         self.validate_identity("SELECT FACTORIAL(5)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3533,6 +3533,14 @@ APPROX_TOP_K_COMBINE(tbl.state_col);
 OBJECT;
 
 # dialect: snowflake
+APPROX_TOP_K_ESTIMATE(tbl.state_col, 4);
+ARRAY;
+
+# dialect: snowflake
+APPROX_TOP_K_ESTIMATE(tbl.state_col);
+ARRAY;
+
+# dialect: snowflake
 APPROX_COUNT_DISTINCT(tbl.str_col);
 BIGINT;
 


### PR DESCRIPTION
Registers the function in the Snoflake dialect.
Adds a type rule returning ARRAY
Adds identity + annotation tests to confirm correct round-trip and type inference.
Verified typeOf on snowflake.