### PR TITLE
Chore(optimizer): Include BIGDECIMAL in numeric precedence

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -119,6 +119,7 @@ class _TypeAnnotator(type):
         numeric_precedence = (
             exp.DataType.Type.DOUBLE,
             exp.DataType.Type.FLOAT,
+            exp.DataType.Type.BIGDECIMAL,
             exp.DataType.Type.DECIMAL,
             exp.DataType.Type.BIGINT,
             exp.DataType.Type.INT,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1494,6 +1494,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
     def test_union_annotation(self):
         for left, right, expected_type in (
             ("SELECT 1::INT AS c", "SELECT 2::BIGINT AS c", "BIGINT"),
+            ("SELECT 1::INT AS c", "SELECT 2::BIGDECIMAL AS c", "BIGDECIMAL"),
             ("SELECT 1 AS c", "SELECT NULL AS c", "INT"),
             ("SELECT FOO() AS c", "SELECT 1 AS c", "UNKNOWN"),
             ("SELECT FOO() AS c", "SELECT BAR() AS c", "UNKNOWN"),


### PR DESCRIPTION
The BIGDECIMAL type was missing from the tuple of numeric precedence, preventing the optimizer from correctly annotating unions involving BIGDECIMAL (and BIGNUMERIC, which is an alias for BIGDECIMAL in BigQuery). I placed BIGDECIMAL in between DECIMAL and FLOAT after reviewing the BigQuery conversion rules here: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/conversion_rules#supertypes