### PR TITLE
Chore(optimizer)!: Annotate types for BigQuery's AVG function

### DIFF
--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -101,6 +101,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"annotator": lambda self, e: _annotate_math_functions(self, e)}
         for expr_type in {
+            exp.Avg,
             exp.Ceil,
             exp.Exp,
             exp.Floor,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -409,6 +409,18 @@ EXP(tbl.bignum_col);
 BIGDECIMAL;
 
 # dialect: bigquery
+AVG(1);
+FLOAT64;
+
+# dialect: bigquery
+AVG(5.5);
+FLOAT64;
+
+# dialect: bigquery
+AVG(tbl.bignum_col);
+BIGNUMERIC;
+
+# dialect: bigquery
 CONCAT(tbl.str_col, tbl.str_col);
 STRING;
 


### PR DESCRIPTION
BigQuery documentation on its AVG function: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#avg