### PR TITLE
feat(snowflake)!: annotation support for APPROX_PERCENTILE_ESTIMATE.

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7485,6 +7485,11 @@ class ApproxPercentileAccumulate(AggFunc):
     pass
 
 
+# https://docs.snowflake.com/en/sql-reference/functions/approx_percentile_estimate
+class ApproxPercentileEstimate(Func):
+    arg_types = {"this": True, "percentile": True}
+
+
 class Quarter(Func):
     pass
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -260,6 +260,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
+            exp.ApproxPercentileEstimate,
             exp.ApproximateSimilarity,
             exp.Asinh,
             exp.Atanh,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -56,6 +56,7 @@ class TestSnowflake(Validator):
             "SELECT APPROXIMATE_SIMILARITY(minhash_col)",
         )
         self.validate_identity("SELECT APPROX_PERCENTILE_ACCUMULATE(col)")
+        self.validate_identity("SELECT APPROX_PERCENTILE_ESTIMATE(state, 0.5)")
         self.validate_identity("SELECT APPROX_TOP_K_ACCUMULATE(col, 10)")
         self.validate_identity("SELECT APPROX_TOP_K_COMBINE(state, 2)")
         self.validate_identity("SELECT APPROX_TOP_K_COMBINE(state)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3793,6 +3793,10 @@ APPROX_PERCENTILE_ACCUMULATE(tbl.int_col);
 OBJECT;
 
 # dialect: snowflake
+APPROX_PERCENTILE_ESTIMATE(tbl.state_col, 0.5);
+DOUBLE;
+
+# dialect: snowflake
 APPROX_TOP_K_ACCUMULATE(tbl.str_col, 10);
 OBJECT;
 


### PR DESCRIPTION
This PR adds full type annotation support for the Snowflake function APPROX_PERCENTILE_ESTIMATE
Return type is DOUBLE