### PR TITLE
feat(duckdb): transpile DECFLOAT type to DECIMAL(38, 5)

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -991,6 +991,7 @@ class DuckDB(Dialect):
             exp.DataType.Type.BPCHAR: "TEXT",
             exp.DataType.Type.CHAR: "TEXT",
             exp.DataType.Type.DATETIME: "TIMESTAMP",
+            exp.DataType.Type.DECFLOAT: "DECIMAL(38, 5)",
             exp.DataType.Type.FLOAT: "REAL",
             exp.DataType.Type.JSONB: "JSON",
             exp.DataType.Type.NCHAR: "TEXT",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -3151,8 +3151,20 @@ STORAGE_ALLOWED_LOCATIONS=('s3://mybucket1/path1/', 's3://mybucket2/path2/')""",
                 )
 
     def test_decfloat(self):
-        self.validate_identity("SELECT CAST(1.5 AS DECFLOAT)")
-        self.validate_identity("CREATE TABLE t (x DECFLOAT)")
+        self.validate_all(
+            "SELECT CAST(1.5 AS DECFLOAT)",
+            write={
+                "snowflake": "SELECT CAST(1.5 AS DECFLOAT)",
+                "duckdb": "SELECT CAST(1.5 AS DECIMAL(38, 5))",
+            },
+        )
+        self.validate_all(
+            "CREATE TABLE t (x DECFLOAT)",
+            write={
+                "snowflake": "CREATE TABLE t (x DECFLOAT)",
+                "duckdb": "CREATE TABLE t (x DECIMAL(38, 5))",
+            },
+        )
 
     def test_copy(self):
         self.validate_identity("COPY INTO test (c1) FROM (SELECT $1.c1 FROM @mystage)")


### PR DESCRIPTION
Transpile Snowflake [DECFLOAT](https://docs.snowflake.com/en/sql-reference/data-types-numeric#decfloat) to BigQuery [DECIMAL(38, 5)](https://duckdb.org/docs/stable/sql/data_types/numeric#fixed-point-decimals)

Snowflake:
```
SELECT 
  CAST(123.456 AS DECFLOAT) AS example_a,           
  CAST(123 AS DECFLOAT) as example_b;
+-----------------------+
| EXAMPLE_A | EXAMPLE_B |
|-----------+-----------|
| 123.456   | 123       |
+-----------------------+

```
DuckDB Before:
```
D SELECT
    CAST(123.456 AS DECFLOAT) AS example_a,
    CAST(123 AS DECFLOAT) AS example_b;
Catalog Error:
Type with name DECFLOAT does not exist!
Did you mean "JSON"?
```

After:
```
D SELECT
    CAST(123.456 AS DECIMAL(38, 5)) AS example_a,
    CAST(123 AS DECIMAL(38, 5)) AS example_b;
┌───────────────┬───────────────┐
│   example_a   │   example_b   │
│ decimal(38,5) │ decimal(38,5) │
├───────────────┼───────────────┤
│   123.45600   │   123.00000   │
└───────────────┴───────────────┘
```