### PR TITLE
fix(optimizer)!: support ORDER / LIMIT expressions for BigQuery ARRAY_AGG / STRING_AGG functions

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -212,6 +212,8 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.ArraySlice,
             exp.Filter,
             exp.LastValue,
+            exp.Limit,
+            exp.Order,
             exp.SortArray,
             exp.Window,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1541,6 +1541,46 @@ STRING_AGG(tbl.bin_col);
 BINARY;
 
 # dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col ORDER BY tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col, ',' ORDER BY tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.bin_col ORDER BY tbl.bin_col);
+BINARY;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col, ',' LIMIT 10);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col, ',' ORDER BY tbl.str_col LIMIT 10);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col, ',' ORDER BY tbl.str_col LIMIT 10);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.bin_col ORDER BY tbl.bin_col LIMIT 10);
+BINARY;
+
+# dialect: bigquery
+ARRAY_AGG(tbl.int_col LIMIT 10);
+ARRAY<INT>;
+
+# dialect: bigquery
+ARRAY_AGG(DISTINCT tbl.str_col ORDER BY tbl.str_col LIMIT 10);
+ARRAY<STRING>;
+
+# dialect: bigquery
 DATETIME_TRUNC(DATETIME "2008-12-25 15:30:00", DAY);
 DATETIME;
 


### PR DESCRIPTION
Jira: https://fivetran.atlassian.net/browse/RD-1066842

Problem: STRING_AGG annotation returns UNKNOWN when ORDER BY / DISTINCT clauses used in expression

Solution: extract column being aggregated, propagate that column's type to STRING_AGG result