### PR TITLE
Chore(optimizer)!: Annotate types for BigQuery's SAFE_DIVIDE function

### DIFF
--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -268,6 +268,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.PercentileCont,
             exp.SafeAdd,
+            exp.SafeDivide,
             exp.SafeMultiply,
             exp.SafeSubtract,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -421,6 +421,42 @@ AVG(tbl.bignum_col);
 BIGNUMERIC;
 
 # dialect: bigquery
+SAFE_DIVIDE(tbl.int_col, tbl.int_col);
+INT64;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.int_col, tbl.bignum_col);
+BIGNUMERIC;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.int_col, tbl.double_col);
+FLOAT64;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.bignum_col, tbl.int_col);
+BIGNUMERIC;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.bignum_col, tbl.bignum_col);
+BIGNUMERIC;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.bignum_col, tbl.double_col);
+FLOAT64;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.double_col, tbl.int_col);
+FLOAT64;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.double_col, tbl.bignum_col);
+FLOAT64;
+
+# dialect: bigquery
+SAFE_DIVIDE(tbl.double_col, tbl.double_col);
+FLOAT64;
+
+# dialect: bigquery
 CONCAT(tbl.str_col, tbl.str_col);
 STRING;
 


### PR DESCRIPTION
BigQuery documentation on its SAFE_DIVIDE function: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#safe_divide