### PR TITLE
Chore(optimizer)!: Annotate types for BigQuery's STRING_AGG function

### DIFF
--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1577,6 +1577,54 @@ STRING_AGG(tbl.bin_col);
 BINARY;
 
 # dialect: bigquery
+STRING_AGG(tbl.str_col LIMIT 5);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col ORDER BY tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col LIMIT 5);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col ORDER BY tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col ORDER BY tbl.str_col LIMIT 5);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col, ' & ');
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col, ' & ' LIMIT 5);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(tbl.str_col, ' & ' ORDER BY tbl.str_col);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col, ' & ');
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.str_col, ' & ' ORDER BY tbl.str_col LIMIT 5);
+STRING;
+
+# dialect: bigquery
+STRING_AGG(DISTINCT tbl.bin_col, ' & ' ORDER BY tbl.bin_col LIMIT 5);
+BINARY;
+
+# dialect: bigquery
 DATETIME_TRUNC(DATETIME "2008-12-25 15:30:00", DAY);
 DATETIME;
 


### PR DESCRIPTION
BigQuery's `STRING_AGG` function accepts `STRING` or `BYTES` and returns the corresponding type. It also supports optional aggregate clauses like `LIMIT`, `ORDER BY`, and `DISTINCT`. This PR unwraps these expressions in order to annotate types.

BigQuery documentation on its `STRING_AGG` function: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/aggregate_functions#string_agg