### PR TITLE
feat(snowflake)!: annotation support for CURRENT REGION. 

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6340,6 +6340,10 @@ class CurrentUser(Func):
     arg_types = {"this": False}
 
 
+class CurrentRegion(Func):
+    arg_types = {}
+
+
 class UtcDate(Func):
     arg_types = {}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -360,6 +360,7 @@ EXPRESSION_METADATA = {
             exp.Chr,
             exp.Collate,
             exp.Collation,
+            exp.CurrentRegion,
             exp.DecompressString,
             exp.HexDecodeString,
             exp.HexEncode,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -229,6 +229,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT AI_SUMMARIZE_AGG(review)")
         self.validate_identity("SELECT AI_CLASSIFY('text', ['travel', 'cooking'])")
         self.validate_identity("SELECT OBJECT_CONSTRUCT()")
+        self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT YEAR(CURRENT_TIMESTAMP())")
         self.validate_identity("SELECT YEAROFWEEK(CURRENT_TIMESTAMP())")
         self.validate_identity("SELECT YEAROFWEEKISO(CURRENT_TIMESTAMP())")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2165,6 +2165,10 @@ CONVERT_TIMEZONE('America/Los_Angeles', 'America/New_York', '2024-08-06 09:10:00
 TIMESTAMPNTZ;
 
 # dialect: snowflake
+CURRENT_REGION();
+VARCHAR;
+
+# dialect: snowflake
 DATEDIFF('year', tbl.date_col, tbl.date_col);
 INT;
 


### PR DESCRIPTION
Returns the name of the region for the account where the current user is logged in.

return type - VARCHAR