### PR TITLE
chore(exasol): implementing LAST_DAY function in exasol sqlglot dialect

### DIFF
--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -487,6 +487,28 @@ class TestExasol(Validator):
                     },
                 )
 
+                self.validate_all(
+                    f"SELECT ADD_{unit}S('2000-02-28', -'1')",
+                    read={
+                        "sqlite": f"SELECT DATE_SUB('2000-02-28', INTERVAL 1 {unit})",
+                        "bigquery": f"SELECT DATE_SUB('2000-02-28', INTERVAL 1 {unit})",
+                        "presto": f"SELECT DATE_SUB('2000-02-28', INTERVAL 1 {unit})",
+                        "redshift": f"SELECT DATE_SUB('2000-02-28', INTERVAL 1 {unit})",
+                        "snowflake": f"SELECT DATE_SUB('2000-02-28', INTERVAL 1 {unit})",
+                        "tsql": f"SELECT DATE_SUB('2000-02-28', INTERVAL 1 {unit})",
+                    },
+                )
+
+                self.validate_all(
+                    "SELECT CAST(ADD_DAYS(ADD_MONTHS(DATE_TRUNC('MONTH', DATE '2008-11-25'), 1), -1) AS DATE)",
+                    read={
+                        "snowflake": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE), MONTH)",
+                        "databricks": "SELECT LAST_DAY('2008-11-25')",
+                        "spark": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE))",
+                        "presto": "SELECT LAST_DAY_OF_MONTH(CAST('2008-11-25' AS DATE))",
+                    },
+                )
+
             with self.subTest(f"Testing {unit}S_BETWEEN"):
                 self.validate_all(
                     f"SELECT {unit}S_BETWEEN(TIMESTAMP '2000-02-28 00:00:00', CURRENT_TIMESTAMP)",


### PR DESCRIPTION
**What motivated this PR?**

Exasol does not provide a built-in LAST_DAY function, whereas several other SQL dialects—such as [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/last_day) and BigQuery—do. When transpiling queries from these dialects to Exasol using SQLGlot, LAST_DAY calls are left unsupported and cause execution errors.

**What was incorrect in the existing logic?**

When transpiling a query like:

`SELECT last_day('2009-02-12')`


from Databricks to Exasol, SQLGlot produced output that Exasol cannot execute because LAST_DAY is not implemented in the Exasol dialect. As a result, valid source queries failed at runtime on Exasol.

**How does this PR resolve the issue?**

This PR introduces proper handling of exp.LastDay by mapping it to a new no_last_day_sql implementation.
That implementation uses DATE_SUB semantics—but because Exasol does not directly support DATE_SUB, additional work was required:

Databricks DATE_SUB calls are represented in SQLGlot as exp.TsOrDsAdd

This required refactoring the existing dateadd_sql implementation into a unified _add_date_sql that supports:

exp.DateAdd

exp.TsOrDsAdd

exp.DateSub

The result is a correct and Exasol-compatible translation path for LAST_DAY.

**Documentation and semantic notes**

The refactoring ensures consistent handling of exp.DateAdd, exp.TsOrDsAdd, and exp.DateSub, mapping them to the appropriate Exasol date-arithmetic functions.

exp.LastDay is now fully supported through the no_last_day_sql function, preserving the semantic behavior expected from dialects that provide LAST_DAY.

No behavior changes for existing Exasol date arithmetic—only expanded correctness and coverage.