### PR TITLE
Refactor!: get rid of WeekStart in favor of Week

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -641,7 +641,7 @@ class BigQuery(Dialect):
             "FORMAT_TIMESTAMP": _build_format_time(exp.TsOrDsToTimestamp),
             "FORMAT_TIME": _build_format_time(exp.TsOrDsToTime),
             "FROM_HEX": exp.Unhex.from_arg_list,
-            "WEEK": lambda args: exp.WeekStart(this=exp.var(seq_get(args, 0))),
+            "WEEK": lambda args: exp.Week(this=exp.var(seq_get(args, 0))),
         }
         # Remove SEARCH to avoid parameter routing issues - let it fall back to Anonymous function
         FUNCTIONS.pop("SEARCH")

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1674,7 +1674,7 @@ def unit_to_str(expression: exp.Expression, default: str = "DAY") -> t.Optional[
 def unit_to_var(expression: exp.Expression, default: str = "DAY") -> t.Optional[exp.Expression]:
     unit = expression.args.get("unit")
 
-    if isinstance(unit, (exp.Var, exp.Placeholder, exp.WeekStart, exp.Column)):
+    if isinstance(unit, (exp.Var, exp.Placeholder, exp.Week, exp.Column)):
         return unit
 
     value = unit.name if unit else default

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8108,10 +8108,6 @@ class Week(Func):
     arg_types = {"this": True, "mode": False}
 
 
-class WeekStart(Expression):
-    pass
-
-
 class NextDay(Func):
     arg_types = {"this": True, "expression": True}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -226,7 +226,6 @@ class Generator(metaclass=_Generator):
         exp.VarMap: lambda self, e: self.func("MAP", e.args["keys"], e.args["values"]),
         exp.ViewAttributeProperty: lambda self, e: f"WITH {self.sql(e, 'this')}",
         exp.VolatileProperty: lambda *_: "VOLATILE",
-        exp.WeekStart: lambda self, e: f"WEEK({self.sql(e, 'this')})",
         exp.WithJournalTableProperty: lambda self, e: f"WITH JOURNAL TABLE={self.sql(e, 'this')}",
         exp.WithProcedureOptions: lambda self, e: f"WITH {self.expressions(e, flat=True)}",
         exp.WithSchemaBindingProperty: lambda self, e: f"WITH SCHEMA {self.sql(e, 'this')}",


### PR DESCRIPTION
`WeekStart` was added in [this PR](https://github.com/tobymao/sqlglot/pull/5552/files), but it appears to be redundant given that we also have `Week`, representing essentially the same concept, [added a long time ago](https://github.com/tobymao/sqlglot/commit/4f4e6a85f40c4f49bf516e948452c5237450f626). The former was added to address a qualification issue (see linked PR above).

