### PR TITLE
feat(postgres,trino,duckdb): added support for current_catalog

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -113,6 +113,7 @@ class Databricks(Spark):
                 if e.args.get("is_numeric")
                 else self.function_fallback_sql(e)
             ),
+            exp.CurrentCatalog: lambda *_: "CURRENT_CATALOG()",
         }
 
         TRANSFORMS.pop(exp.RegexpLike)

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -296,16 +296,21 @@ class _Dialect(type):
                 no_paren_functions.pop(TokenType.LOCALTIMESTAMP, None)
             klass.parser_class.NO_PAREN_FUNCTIONS = no_paren_functions
 
-        if enum not in (
+        if enum in (
             "",
             "postgres",
             "duckdb",
-            "presto",
             "trino",
         ):
             no_paren_functions = klass.parser_class.NO_PAREN_FUNCTIONS.copy()
-            no_paren_functions.pop(TokenType.CURRENT_CATALOG, None)
+            no_paren_functions[TokenType.CURRENT_CATALOG] = exp.CurrentCatalog
             klass.parser_class.NO_PAREN_FUNCTIONS = no_paren_functions
+        else:
+            # For dialects that don't support this keyword, treat it as a regular identifier
+            # This fixes the "Unexpected token" error in BQ, Spark, etc.
+            klass.parser_class.ID_VAR_TOKENS = klass.parser_class.ID_VAR_TOKENS | {
+                TokenType.CURRENT_CATALOG,
+            }
 
         klass.VALID_INTERVAL_UNITS = {
             *klass.VALID_INTERVAL_UNITS,

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -976,7 +976,6 @@ class DuckDB(Dialect):
             exp.JSONObjectAgg: rename_func("JSON_GROUP_OBJECT"),
             exp.JSONBObjectAgg: rename_func("JSON_GROUP_OBJECT"),
             exp.DateBin: rename_func("TIME_BUCKET"),
-            exp.CurrentCatalog: lambda *_: "CURRENT_CATALOG",
         }
 
         SUPPORTED_JSON_PATH_PARTS = {

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -729,7 +729,6 @@ class Postgres(Dialect):
             exp.JSONObjectAgg: rename_func("JSON_OBJECT_AGG"),
             exp.JSONBObjectAgg: rename_func("JSONB_OBJECT_AGG"),
             exp.CountIf: count_if_to_sum,
-            exp.CurrentCatalog: lambda *_: "CURRENT_CATALOG",
         }
 
         TRANSFORMS.pop(exp.CommentColumnConstraint)

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -93,7 +93,6 @@ class Trino(Presto):
             ),
             exp.TimeStrToTime: lambda self, e: timestrtotime_sql(self, e, include_precision=True),
             exp.Trim: trim_sql,
-            exp.CurrentCatalog: lambda *_: "CURRENT_CATALOG",
         }
 
         SUPPORTED_JSON_PATH_PARTS = {

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -137,6 +137,7 @@ class Generator(metaclass=_Generator):
         exp.CopyGrantsProperty: lambda *_: "COPY GRANTS",
         exp.CredentialsProperty: lambda self,
         e: f"CREDENTIALS=({self.expressions(e, 'expressions', sep=' ')})",
+        exp.CurrentCatalog: lambda *_: "CURRENT_CATALOG",
         exp.DateFormatColumnConstraint: lambda self, e: f"FORMAT {self.sql(e, 'this')}",
         exp.DefaultColumnConstraint: lambda self, e: f"DEFAULT {self.sql(e, 'this')}",
         exp.DynamicProperty: lambda *_: "DYNAMIC",

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -289,7 +289,6 @@ class Parser(metaclass=_Parser):
         TokenType.CURRENT_TIME: exp.CurrentTime,
         TokenType.CURRENT_TIMESTAMP: exp.CurrentTimestamp,
         TokenType.CURRENT_USER: exp.CurrentUser,
-        TokenType.CURRENT_CATALOG: exp.CurrentCatalog,
         TokenType.LOCALTIME: exp.Localtime,
         TokenType.LOCALTIMESTAMP: exp.Localtimestamp,
         TokenType.CURRENT_ROLE: exp.CurrentRole,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4777,6 +4777,7 @@ FROM subquery2""",
             "snowflake",
             "spark",
             "databricks",
+            "presto",
         ]
 
         for dialect in unsupported_dialects:


### PR DESCRIPTION
Docs:
[Trino](https://trino.io/docs/current/functions/session.html#:~:text=running%20the%20query.-,current_catalog,-%23) - no_paran
[Postgres](https://www.postgresql.org/docs/current/functions-info.html#:~:text=current_catalog%20%E2%86%92%20name) - no_paran
[DuckDB](https://duckdb.org/docs/stable/sql/functions/utility#current_catalog:~:text=%5Cx02bcd%5Cx00-,current_catalog(),-Description) - no_paran and func type
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/current_catalog) - func type

The following dialects do not support this:

```code
SELECT CURRENT_CATALOG;
```

- ClickHouse
- MySQL
- Oracle
- SingleStore
- Spark

✅ Above INFO tested on the platform