### PR TITLE
feat(snowflake)!: Annotated type for ARRAY_CONSTRUCT_COMPACT

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6030,7 +6030,7 @@ class ArrayConcatAgg(AggFunc):
 
 
 class ArrayConstructCompact(Func):
-    arg_types = {"expressions": True}
+    arg_types = {"expressions": False}
     is_var_len_args = True
 
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -190,6 +190,7 @@ EXPRESSION_METADATA = {
             exp.ApproxTopK,
             exp.ApproxTopKEstimate,
             exp.ArrayAgg,
+            exp.ArrayConstructCompact,
             exp.ArrayUniqueAgg,
             exp.ArrayUnionAgg,
             exp.RegexpExtractAll,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1665,6 +1665,14 @@ ADD_MONTHS(tbl.timestamp_col, -1);
 TIMESTAMP;
 
 # dialect: snowflake
+ARRAY_CONSTRUCT_COMPACT();
+ARRAY;
+
+# dialect: snowflake
+ARRAY_CONSTRUCT_COMPACT(1, null, 2);
+ARRAY;
+
+# dialect: snowflake
 ASIN(tbl.double_col);
 DOUBLE;
 


### PR DESCRIPTION
Updated ArrayConstructCompact, as [ARRAY_CONSTRUCT_COMPACT](https://docs.snowflake.com/en/sql-reference/functions/array_construct_compact) allows for zero parameters. 

I noticed this is incompatible with Spark's version [ARRAY_COMPACT](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.functions.array_compact.html), which only supports this function with 1 (or more) parameters.  I'm not sure how to handle this type of incompatibility between databases.