### PR TITLE
feat(databricks)!: support comma-separated syntax for OVERLAY function

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 from collections import defaultdict
-import typing as t
 
 from sqlglot import exp, transforms, jsonpath, parser
 from sqlglot.dialects.dialect import (
@@ -75,20 +74,6 @@ class Databricks(Spark):
                 to=to,
             ),
         }
-
-        def _parse_overlay(self) -> exp.Overlay:
-            def _parse_overlay_arg(text: str) -> t.Optional[exp.Expression]:
-                return (
-                    self._match(TokenType.COMMA) or self._match_text_seq(text)
-                ) and self._parse_bitwise()
-
-            return self.expression(
-                exp.Overlay,
-                this=self._parse_bitwise(),
-                expression=_parse_overlay_arg("PLACING"),
-                from_=_parse_overlay_arg("FROM"),
-                for_=_parse_overlay_arg("FOR"),
-            )
 
     class Generator(Spark.Generator):
         TABLESAMPLE_SEED_KEYWORD = "REPEATABLE"

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8749,12 +8749,17 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_overlay(self) -> exp.Overlay:
+        def _parse_overlay_arg(text: str) -> t.Optional[exp.Expression]:
+            return (
+                self._match(TokenType.COMMA) or self._match_text_seq(text)
+            ) and self._parse_bitwise()
+
         return self.expression(
             exp.Overlay,
             this=self._parse_bitwise(),
-            expression=self._match_text_seq("PLACING") and self._parse_bitwise(),
-            from_=self._match_text_seq("FROM") and self._parse_bitwise(),
-            for_=self._match_text_seq("FOR") and self._parse_bitwise(),
+            expression=_parse_overlay_arg("PLACING"),
+            from_=_parse_overlay_arg("FROM"),
+            for_=_parse_overlay_arg("FOR"),
         )
 
     def _parse_format_name(self) -> exp.Property:


### PR DESCRIPTION
Previously, the parser defaulted to the strict ANSI implementation, causing a ParseError when encountering the 
comma-separated variant.

SQL:
```sql
SELECT overlay('Spark SQL', 'ANSI ', 7, 0)
```

[Databricks Docs](https://docs.databricks.com/aws/en/sql/language-manual/functions/overlay#:~:text=SELECT%20overlay(%27Spark%20SQL%27%2C%20%27ANSI%20%27%2C%207%2C%200)%3B)