### PR TITLE
Feat(optimizer)!: annotate TO_HEX(MD5(...)) in BigQuery

### DIFF
--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -257,6 +257,7 @@ EXPRESSION_METADATA = {
             exp.JSONType,
             exp.LaxString,
             exp.LowerHex,
+            exp.MD5,
             exp.NetHost,
             exp.Normalize,
             exp.SafeConvertBytesToString,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -853,6 +853,10 @@ MD5('foo');
 BINARY;
 
 # dialect: bigquery
+TO_HEX(MD5('foo'));
+STRING;
+
+# dialect: bigquery
 MAX_BY(tbl.str_col, tbl.bigint_col);
 STRING;
 


### PR DESCRIPTION
Reference: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#to_hex