### PR TITLE
feat(duckdb): Add support to transpile binary args for bitwise operators

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1576,11 +1576,6 @@ class Snowflake(Dialect):
             return super().values_sql(expression, values_as_table=values_as_table)
 
         def datatype_sql(self, expression: exp.DataType) -> str:
-            # Convert BIT to VARBINARY for Snowflake compatibility
-            # DuckDB uses BIT for bitwise operations, but Snowflake doesn't support BIT type
-            if expression.is_type(exp.DataType.Type.BIT):
-                return "VARBINARY"
-
             expressions = expression.expressions
             if expressions and expression.is_type(*exp.DataType.STRUCT_TYPES):
                 for field_type in expressions:


### PR DESCRIPTION
Add type support to transpile binary args for bitwise operators.

```
================================================================================
TEST 1: NUMERIC BITOR
================================================================================

Snowflake Query:
SELECT BITOR(255, 3840) AS result;

Snowflake Output:
Result
4095

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile('SELECT BITOR(255, 3840) AS result', read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT 255 | 3840 AS result

DuckDB Output:
┌────────┐
│ result │
│ int32  │
├────────┤
│   4095 │
└────────┘

================================================================================
TEST 2: BINARY BITOR
================================================================================

Snowflake Query:
SELECT BITOR(x'FF', x'0F') AS result;

Snowflake Output:
RESULT
FF

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT BITOR(x'FF', x'0F') AS result\", read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT CAST(CAST(UNHEX('FF') AS BIT) | CAST(UNHEX('0F') AS BIT) AS BLOB) AS result

DuckDB Output:
┌────────┐
│ result │
│  blob  │
├────────┤
│ \xFF   │
└────────┘

================================================================================
TEST 3: NUMERIC BITAND
================================================================================

Snowflake Query:
SELECT BITAND(255, 3840) AS result;

Snowflake Output:
Result
0

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile('SELECT BITAND(255, 3840) AS result', read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT 255 & 3840 AS result

DuckDB Output:
┌────────┐
│ result │
│ int32  │
├────────┤
│      0 │
└────────┘

================================================================================
TEST 4: BINARY BITAND
================================================================================

Snowflake Query:
SELECT BITAND(x'FF', x'0F') AS result;

Snowflake Output:
RESULT
0F

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT BITAND(x'FF', x'0F') AS result\", read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT CAST(CAST(UNHEX('FF') AS BIT) & CAST(UNHEX('0F') AS BIT) AS BLOB) AS result

DuckDB Output:
┌────────┐
│ result │
│  blob  │
├────────┤
│ \x0F   │
└────────┘

================================================================================
TEST 5: NUMERIC BITXOR
================================================================================

Snowflake Query:
SELECT BITXOR(255, 3840) AS result;

Snowflake Output:
RESULT
4095

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile('SELECT BITXOR(255, 3840) AS result', read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT XOR(255, 3840) AS result

DuckDB Output:
┌────────┐
│ result │
│ int32  │
├────────┤
│   4095 │
└────────┘

================================================================================
TEST 6: BINARY BITXOR
================================================================================

Snowflake Query:
SELECT BITXOR(x'FF', x'0F') AS result;

Snowflake Output:
RESULT
F0

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT BITXOR(x'FF', x'0F') AS result\", read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT CAST(XOR(CAST(UNHEX('FF') AS BIT), CAST(UNHEX('0F') AS BIT)) AS BLOB) AS result

DuckDB Output:
┌────────┐
│ result │
│  blob  │
├────────┤
│ \xF0   │
└────────┘

================================================================================
TEST 7: NUMERIC BITNOT
================================================================================

Snowflake Query:
SELECT BITNOT(255) AS result;

Snowflake Output:
Result
-256

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile('SELECT BITNOT(255) AS result', read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT ~255 AS result

DuckDB Output:
┌────────┐
│ result │
│ int32  │
├────────┤
│   -256 │
└────────┘

================================================================================
TEST 8: BINARY BITNOT
================================================================================

Snowflake Query:
SELECT BITNOT(x'FF') AS result;

Snowflake Output:
RESULT
00

Transpilation Command:
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT BITNOT(x'FF') AS result\", read='snowflake', write='duckdb')[0])"

Transpiled DuckDB Query:
SELECT CAST(~CAST(UNHEX('FF') AS BIT) AS BLOB) AS result

DuckDB Output:
┌────────┐
│ result │
│  blob  │
├────────┤
│ \x00   │
└────────┘
```