### PR TITLE
feat(snowflake)!: annotation support for CURRENT_ACCOUNT_NAME

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6318,6 +6318,10 @@ class CurrentAccount(Func):
     arg_types = {}
 
 
+class CurrentAccountName(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -374,6 +374,7 @@ EXPRESSION_METADATA = {
             exp.Collate,
             exp.Collation,
             exp.CurrentAccount,
+            exp.CurrentAccountName,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -242,6 +242,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT AI_CLASSIFY('text', ['travel', 'cooking'])")
         self.validate_identity("SELECT OBJECT_CONSTRUCT()")
         self.validate_identity("SELECT CURRENT_ACCOUNT()")
+        self.validate_identity("SELECT CURRENT_ACCOUNT_NAME()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2293,6 +2293,10 @@ CURRENT_ACCOUNT();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_ACCOUNT_NAME();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_ACCOUNT_NAME in Snowflake function annotations.

Handle it as a no-argument

Add basic annotation + round-trip tests.
Verified the typeOf and verified function support in other dialects 