### PR TITLE
feat(snowflake)!: annotation support for CURRENT_CLIENT

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6326,6 +6326,10 @@ class CurrentAvailableRoles(Func):
     arg_types = {}
 
 
+class CurrentClient(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -414,6 +414,7 @@ EXPRESSION_METADATA = {
             exp.CurrentAccount,
             exp.CurrentAccountName,
             exp.CurrentAvailableRoles,
+            exp.CurrentClient,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -260,6 +260,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT CURRENT_ACCOUNT()")
         self.validate_identity("SELECT CURRENT_ACCOUNT_NAME()")
         self.validate_identity("SELECT CURRENT_AVAILABLE_ROLES()")
+        self.validate_identity("SELECT CURRENT_CLIENT()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2301,6 +2301,10 @@ CURRENT_AVAILABLE_ROLES();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_CLIENT();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_CLIENT in Snowflake function annotations.

Handle it as a no-argument

Add basic annotation + round-trip tests.
Function specific to snowflake and other dialects do not support this function.