### PR TITLE
feat(snowflake)!: annotation support for CURRENT_SECONDARY_ROLES

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6342,6 +6342,10 @@ class CurrentSchemas(Func):
     arg_types = {"this": False}
 
 
+class CurrentSecondaryRoles(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -418,6 +418,7 @@ EXPRESSION_METADATA = {
             exp.CurrentDatabase,
             exp.CurrentIpAddress,
             exp.CurrentSchemas,
+            exp.CurrentSecondaryRoles,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -288,6 +288,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT CURRENT_IP_ADDRESS()")
         self.validate_identity("SELECT CURRENT_DATABASE()")
         self.validate_identity("SELECT CURRENT_SCHEMAS()")
+        self.validate_identity("SELECT CURRENT_SECONDARY_ROLES()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2317,6 +2317,10 @@ CURRENT_SCHEMAS();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_SECONDARY_ROLES();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_SECONDARY_ROLES in Snowflake function annotations.

Handle it as a no-argument

Add basic annotation + round-trip tests.
Verified the typeOf for return type