### PR TITLE
feat(snowflake)!: annotation support for CURRENT_SESSION

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6346,6 +6346,10 @@ class CurrentSecondaryRoles(Func):
     arg_types = {}
 
 
+class CurrentSession(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -419,6 +419,7 @@ EXPRESSION_METADATA = {
             exp.CurrentIpAddress,
             exp.CurrentSchemas,
             exp.CurrentSecondaryRoles,
+            exp.CurrentSession,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -289,6 +289,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT CURRENT_DATABASE()")
         self.validate_identity("SELECT CURRENT_SCHEMAS()")
         self.validate_identity("SELECT CURRENT_SECONDARY_ROLES()")
+        self.validate_identity("SELECT CURRENT_SESSION()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2321,6 +2321,10 @@ CURRENT_SECONDARY_ROLES();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_SESSION();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_SESSION in Snowflake function annotations.

Handle it as a no-argument

Add basic annotation + round-trip tests.
Verified the typeOf for return type