### PR TITLE
feat(snowflake)!: annotation support for CURRENT_STATEMENT

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6350,6 +6350,10 @@ class CurrentSession(Func):
     arg_types = {}
 
 
+class CurrentStatement(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -420,6 +420,7 @@ EXPRESSION_METADATA = {
             exp.CurrentSchemas,
             exp.CurrentSecondaryRoles,
             exp.CurrentSession,
+            exp.CurrentStatement,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -290,6 +290,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT CURRENT_SCHEMAS()")
         self.validate_identity("SELECT CURRENT_SECONDARY_ROLES()")
         self.validate_identity("SELECT CURRENT_SESSION()")
+        self.validate_identity("SELECT CURRENT_STATEMENT()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2325,6 +2325,10 @@ CURRENT_SESSION();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_STATEMENT();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_STATEMENT in Snowflake function annotations.

Handle it as a no-argument

Add basic annotation + round-trip tests.
Verified the typeOf for return type