### PR TITLE
feat(snowflake)!: annotation support for CURRENT_TRANSACTION

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6358,6 +6358,10 @@ class CurrentVersion(Func):
     arg_types = {}
 
 
+class CurrentTransaction(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -422,6 +422,7 @@ EXPRESSION_METADATA = {
             exp.CurrentSession,
             exp.CurrentStatement,
             exp.CurrentVersion,
+            exp.CurrentTransaction,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -292,6 +292,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT CURRENT_SESSION()")
         self.validate_identity("SELECT CURRENT_STATEMENT()")
         self.validate_identity("SELECT CURRENT_VERSION()")
+        self.validate_identity("SELECT CURRENT_TRANSACTION()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2333,6 +2333,10 @@ CURRENT_VERSION();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_TRANSACTION();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_TRANSACTION in Snowflake function annotations.
Handle it as a no-argument.
Add basic annotation + round-trip tests.
Verified the typeOf for return type.