### PR TITLE
feat(snowflake)!: annotation support for CURRENT_WAREHOUSE

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6362,6 +6362,10 @@ class CurrentTransaction(Func):
     arg_types = {}
 
 
+class CurrentWarehouse(Func):
+    arg_types = {}
+
+
 class CurrentDate(Func):
     arg_types = {"this": False}
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -423,6 +423,7 @@ EXPRESSION_METADATA = {
             exp.CurrentStatement,
             exp.CurrentVersion,
             exp.CurrentTransaction,
+            exp.CurrentWarehouse,
             exp.CurrentOrganizationUser,
             exp.CurrentRegion,
             exp.CurrentRole,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -293,6 +293,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT CURRENT_STATEMENT()")
         self.validate_identity("SELECT CURRENT_VERSION()")
         self.validate_identity("SELECT CURRENT_TRANSACTION()")
+        self.validate_identity("SELECT CURRENT_WAREHOUSE()")
         self.validate_identity("SELECT CURRENT_ORGANIZATION_USER()")
         self.validate_identity("SELECT CURRENT_REGION()")
         self.validate_identity("SELECT CURRENT_ROLE()")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2337,6 +2337,10 @@ CURRENT_TRANSACTION();
 VARCHAR;
 
 # dialect: snowflake
+CURRENT_WAREHOUSE();
+VARCHAR;
+
+# dialect: snowflake
 CURRENT_ORGANIZATION_USER();
 VARCHAR;
 


### PR DESCRIPTION
Register CURRENT_WAREHOUSE in Snowflake function annotations.
Handle it as a no-argument.
Add basic annotation + round-trip tests.
Verified the typeOf for return type.