### PR TITLE
feat(snowflake)!: support transpilation of BOOLAND from snowflake to duckdb

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1367,7 +1367,7 @@ class TestSnowflake(Validator):
             },
             write={
                 "snowflake": "SELECT BOOLAND(1, -2)",
-                "duckdb": "SELECT ((1) AND (-2))",
+                "duckdb": "SELECT CASE WHEN 1 IS NULL THEN NULL ELSE 1 <> 0 END AND CASE WHEN -2 IS NULL THEN NULL ELSE -2 <> 0 END",
             },
         )
         self.validate_all(


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/functions/booland

https://duckdb.org/docs/stable/sql/expressions/logical_operators

Snowflake's BOOLAND operates on numeric types and NULL, while DuckDB's AND operates on boolean values and NULL. 

If we transform each argument expr for the Snowflake BOOLAND to expr == NULL ? NULL : expr != 0, we can use DuckDB's built in AND operator to do the rest