### PR TITLE
Fix: Only trigger integration tests on PR events

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -1,20 +1,13 @@
 name: Run Integration Tests
 
 on:
-  # note: the issue_comment event (PR's are issues) will only run the version of this workflow committed to 'main'
-  # this makes it impossible to properly test issue_comment triggers in a PR
-  # ref: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issue_comment
-  issue_comment:
-    types: [created, edited]
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   should-run:
     name: Check if integration tests should run
     runs-on: ubuntu-latest
-    # only trigger if this is a PR event and not an event on some other issue
-    if: github.event_name == 'pull_request' || github.event.issue.pull_request
     outputs:
       skip: ${{ steps.test-parameters.outputs.skip }}
       dialects: ${{ steps.test-parameters.outputs.dialects }}


### PR DESCRIPTION
This changes the integration test workflow to only trigger on `pull_request` events and removes the broken `issue_comment` support.

The problem with `issue_comment` is:
 - PR's are modeled as issues and it triggers on all issues, not just PR's
 - When triggered on a PR, it doesn't contain any useful information about the git ref's involved. that has to be fetched as a separate step
 - It only runs the workflow version committed to `main`, making it impossible to test properly in a PR.

So, I removed it in favour of just using the PR description which vastly simplifies things

/integration-tests dialect=duckdb