### PR TITLE
Fix(optimizer)!: ensure structs are annotated as unknown if any argument is unknown

### DIFF
--- a/tests/fixtures/optimizer/annotate_types.sql
+++ b/tests/fixtures/optimizer/annotate_types.sql
@@ -63,6 +63,10 @@ INT;
 STRUCT(1 AS col);
 STRUCT<col INT>;
 
+# Note: ensure the struct is annotated as UNKNOWN when any of its arguments are UNKNOWN
+STRUCT(1, f2);
+UNKNOWN;
+
 STRUCT(1 AS col, 2.5 AS row);
 STRUCT<col INT, row DOUBLE>;
 


### PR DESCRIPTION
The behavior today is shown below:

```python
>>> from sqlglot import parse_one
>>> from sqlglot.optimizer.annotate_types import annotate_types
>>>
>>> ast = parse_one("struct(1, f2)")
>>> annotate_types(ast)
Struct(
  expressions=[
    Literal(this=1, is_string=False, _type=DataType(this=Type.INT)),
    Column(
      this=Identifier(this=f2, quoted=False, _type=DataType(this=Type.UNKNOWN)),
      _type=DataType(this=Type.UNKNOWN))],
  _type=DataType(
    this=Type.STRUCT,
    expressions=[
      DataType(this=Type.INT),
      ColumnDef(
        this=Identifier(this=f2, quoted=False, _type=DataType(this=Type.UNKNOWN)),
        kind=DataType(this=Type.UNKNOWN))],
    nested=True))
```

We don't want to produce a `Type.STRUCT` annotation if any of the struct fields are unknown. This PR annotates the struct as an `UNKNOWN` if that is the case.
