### PR TITLE
Added test-fast and test-fast-rs Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install install-dev install-pre-commit test unit style check docs docs-serve
+.PHONY: install install-dev install-pre-commit test test-fast test-fast-rs unit style check docs docs-serve
 
 ifdef UV
     PIP := uv pip
@@ -33,8 +33,14 @@ install-pre-commit:
 test:
 	SQLGLOTRS_TOKENIZER=0 python -m unittest
 
+test-fast:
+	SQLGLOTRS_TOKENIZER=0 python -m unittest --failfast
+
 test-rs:
 	RUST_BACKTRACE=1 python -m unittest
+
+test-fast-rs:
+	RUST_BACKTRACE=1 python -m unittest --failfast
 
 unit:
 	SKIP_INTEGRATION=1 SQLGLOTRS_TOKENIZER=0 python -m unittest


### PR DESCRIPTION
Add Makefile targets named **test-fast** and **test-fast-rs** (for Rust).

These are copies of **test** and **test-rs** and simply have --failfast flags added to copies of existing targets for quicker test debugging.  They stop at the first test failure which speeds up the development feedback loop.