### PR TITLE
fix(postgres): corrected handling of ToChar for Postgres. 

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -710,7 +710,9 @@ class Postgres(Dialect):
             exp.TimestampTrunc: timestamptrunc_sql(zone=True),
             exp.TimeStrToTime: timestrtotime_sql,
             exp.TimeToStr: lambda self, e: self.func("TO_CHAR", e.this, self.format_time(e)),
-            exp.ToChar: lambda self, e: self.function_fallback_sql(e),
+            exp.ToChar: lambda self, e: self.function_fallback_sql(e)
+            if e.args.get("format")
+            else self.tochar_sql(e),
             exp.Trim: trim_sql,
             exp.TryCast: no_trycast_sql,
             exp.TsOrDsAdd: _date_add_sql("+"),

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -336,10 +336,8 @@ class TestExasol(Validator):
                 "SELECT TO_CHAR(CAST('1999-12-31' AS DATE)) AS TO_CHAR",
                 write={
                     "exasol": "SELECT TO_CHAR(CAST('1999-12-31' AS DATE)) AS TO_CHAR",
-                    "redshift": "SELECT TO_CHAR(CAST('1999-12-31' AS DATE)) AS TO_CHAR",
                     "presto": "SELECT DATE_FORMAT(CAST('1999-12-31' AS DATE)) AS TO_CHAR",
                     "oracle": "SELECT TO_CHAR(CAST('1999-12-31' AS DATE)) AS TO_CHAR",
-                    "postgres": "SELECT TO_CHAR(CAST('1999-12-31' AS DATE)) AS TO_CHAR",
                 },
                 read={
                     "exasol": "SELECT TO_CHAR(DATE '1999-12-31') AS TO_CHAR",

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -236,7 +236,6 @@ class TestOracle(Validator):
             "SELECT TO_CHAR(TIMESTAMP '1999-12-01 10:00:00')",
             write={
                 "oracle": "SELECT TO_CHAR(CAST('1999-12-01 10:00:00' AS TIMESTAMP))",
-                "postgres": "SELECT TO_CHAR(CAST('1999-12-01 10:00:00' AS TIMESTAMP))",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Transpiling to Postgres fails when there is a TO_CHAR() function with a single argument. Unlike other dialects, Postgres requires 2 arguments, and so falling back to the original function will produce invalid SQL. Here's some sample code to demonstrate the issue.

```python
#!/usr/bin/env python3
"""Test case demonstrating TO_CHAR conversion failure."""
import sqlglot

# Minimal SELECT statement
sql = "SELECT TO_CHAR(99)"

print(f"Original SQL: {sql}")

# Parse as Snowflake (or any other dialect that supports TO_CHAR(number))
snowflake_parsed = sqlglot.parse_one(sql, read="snowflake")
print(f"Parsed as Snowflake: {snowflake_parsed}")

# Convert to Postgres
postgres_sql = snowflake_parsed.sql(dialect="postgres")
print(f"Converted to Postgres: {postgres_sql}")

# Try to parse the Postgres output again - this will fail
try:
    reparsed = sqlglot.parse_one(postgres_sql, read="postgres")
    print(f"Reparsed successfully: {reparsed}")
except sqlglot.errors.ParseError as e:
    print(f"ParseError: {e}")
``` 