### PR TITLE
Fix(diff)!: stop treating `None` args as leaves to be diffed

### DIFF
--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -393,8 +393,10 @@ def _get_expression_leaves(expression: exp.Expression) -> t.Iterator[exp.Express
 
 def _get_non_expression_leaves(expression: exp.Expression) -> t.Iterator[t.Tuple[str, t.Any]]:
     for arg, value in expression.args.items():
-        if isinstance(value, exp.Expression) or (
-            isinstance(value, list) and isinstance(seq_get(value, 0), exp.Expression)
+        if (
+            value is None
+            or isinstance(value, exp.Expression)
+            or (isinstance(value, list) and isinstance(seq_get(value, 0), exp.Expression))
         ):
             continue
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -345,5 +345,14 @@ class TestDiff(unittest.TestCase):
             ],
         )
 
+    def test_none_args_are_not_treated_as_leaves(self):
+        expr_src = parse_one("a.b")
+        expr_tgt = exp.Column(this=exp.to_identifier("b"), table=exp.to_identifier("a"))
+
+        self.assertEqual(set(expr_src.args), {"this", "table", "db", "catalog"})
+        self.assertEqual(set(expr_tgt.args), {"this", "table"})
+
+        self._validate_delta_only(diff_delta_only(expr_src, expr_tgt), [])
+
     def _validate_delta_only(self, actual_delta, expected_delta):
         self.assertEqual(set(actual_delta), set(expected_delta))


### PR DESCRIPTION
Fixes #6554
