### PR TITLE
Feat(snowflake): Type annotation for TO_BOOLEAN, TO_DECIMAL/NUMERIC/NUMBER, TO_DOUBLE, TO_DATE, TO_TIME

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -791,11 +791,14 @@ class Snowflake(Dialect):
             ),
             "TO_CHAR": build_timetostr_or_tochar,
             "TO_DATE": _build_datetime("TO_DATE", exp.DataType.Type.DATE),
-            "TO_NUMBER": lambda args: exp.ToNumber(
-                this=seq_get(args, 0),
-                format=seq_get(args, 1),
-                precision=seq_get(args, 2),
-                scale=seq_get(args, 3),
+            **dict.fromkeys(
+                ("TO_DECIMAL", "TO_NUMBER", "TO_NUMERIC"),
+                lambda args: exp.ToNumber(
+                    this=seq_get(args, 0),
+                    format=seq_get(args, 1),
+                    precision=seq_get(args, 2),
+                    scale=seq_get(args, 3),
+                ),
             ),
             "TO_TIME": _build_datetime("TO_TIME", exp.DataType.Type.TIME),
             "TO_TIMESTAMP": _build_datetime("TO_TIMESTAMP", exp.DataType.Type.TIMESTAMP),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -266,7 +266,14 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT TO_TIMESTAMP_NTZ(x) FROM t")
         self.validate_identity("SELECT TO_TIMESTAMP_LTZ(x) FROM t")
         self.validate_identity("SELECT TO_TIMESTAMP_TZ(x) FROM t")
-        self.validate_identity("TO_DECIMAL(expr, fmt, precision, scale)")
+        self.validate_identity("TO_DECIMAL(expr)", "TO_NUMBER(expr)")
+        self.validate_identity("TO_DECIMAL(expr, fmt)", "TO_NUMBER(expr, fmt)")
+        self.validate_identity(
+            "TO_DECIMAL(expr, fmt, precision, scale)", "TO_NUMBER(expr, fmt, precision, scale)"
+        )
+        self.validate_identity("TO_NUMBER(expr)")
+        self.validate_identity("TO_NUMBER(expr, fmt)")
+        self.validate_identity("TO_NUMBER(expr, fmt, precision, scale)")
         self.validate_identity("TO_DECFLOAT('123.456')")
         self.validate_identity("TO_DECFLOAT('1,234.56', '999,999.99')")
         self.validate_identity("TRY_TO_DECFLOAT('123.456')")
@@ -300,6 +307,11 @@ class TestSnowflake(Validator):
         self.validate_identity("TRY_TO_NUMBER('123.45')")
         self.validate_identity("TRY_TO_NUMBER('123.45', '999.99')")
         self.validate_identity("TRY_TO_NUMBER('123.45', '999.99', 10, 2)")
+        self.validate_identity("TO_NUMERIC('123.45')", "TO_NUMBER('123.45')")
+        self.validate_identity("TO_NUMERIC('123.45', '999.99')", "TO_NUMBER('123.45', '999.99')")
+        self.validate_identity(
+            "TO_NUMERIC('123.45', '999.99', 10, 2)", "TO_NUMBER('123.45', '999.99', 10, 2)"
+        )
         self.validate_identity("TRY_TO_NUMERIC('123.45')", "TRY_TO_NUMBER('123.45')")
         self.validate_identity(
             "TRY_TO_NUMERIC('123.45', '999.99')", "TRY_TO_NUMBER('123.45', '999.99')"

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3581,12 +3581,32 @@ TRY_TO_BOOLEAN('true');
 BOOLEAN;
 
 # dialect: snowflake
+TO_DATE('2024-01-31');
+DATE;
+
+# dialect: snowflake
+TO_DATE('2024-01-31', 'AUTO');
+DATE;
+
+# dialect: snowflake
 TRY_TO_DATE('2024-01-31');
 DATE;
 
 # dialect: snowflake
 TRY_TO_DATE('2024-01-31', 'AUTO');
 DATE;
+
+# dialect: snowflake
+TO_DECIMAL('123.45');
+DECIMAL(38, 0);
+
+# dialect: snowflake
+TO_DECIMAL('123.45', '999.99');
+DECIMAL(38, 0);
+
+# dialect: snowflake
+TO_DECIMAL('123.45', '999.99', 10, 2);
+DECIMAL(38, 0);
 
 # dialect: snowflake
 TRY_TO_DECIMAL('123.45');
@@ -3599,6 +3619,14 @@ DECIMAL(38, 0);
 # dialect: snowflake
 TRY_TO_DECIMAL('123.45', '999.99', 10, 2);
 DECIMAL(38, 0);
+
+# dialect: snowflake
+TO_DOUBLE('123.456');
+DOUBLE;
+
+# dialect: snowflake
+TO_DOUBLE('123.456', '999.99');
+DOUBLE;
 
 # dialect: snowflake
 TRY_TO_DOUBLE('123.456');
@@ -3633,6 +3661,18 @@ TRY_TO_FILE('file.csv', '/relativepath/');
 FILE;
 
 # dialect: snowflake
+TO_NUMBER('123.45');
+DECIMAL(38, 0);
+
+# dialect: snowflake
+TO_NUMBER('123.45', '999.99');
+DECIMAL(38, 0);
+
+# dialect: snowflake
+TO_NUMBER('123.45', '999.99', 10, 2);
+DECIMAL(38, 0);
+
+# dialect: snowflake
 TRY_TO_NUMBER('123.45');
 DECIMAL(38, 0);
 
@@ -3655,6 +3695,14 @@ DECIMAL(38, 0);
 # dialect: snowflake
 TRY_TO_NUMERIC('123.45', '999.99', 10, 2);
 DECIMAL(38, 0);
+
+# dialect: snowflake
+TO_TIME('12:30:00');
+TIME;
+
+# dialect: snowflake
+TO_TIME('12:30:00', 'AUTO');
+TIME;
 
 # dialect: snowflake
 TRY_TO_TIME('12:30:00');


### PR DESCRIPTION
Mostly tests, but added support for to_decimal and to_number, which are [synonyms](https://docs.snowflake.com/en/sql-reference/functions/to_decimal) for the existing to_numeric.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/to_boolean 
https://docs.snowflake.com/en/sql-reference/functions/to_decimal  
https://docs.snowflake.com/en/sql-reference/functions/to_double  
https://docs.snowflake.com/en/sql-reference/functions/to_date 
https://docs.snowflake.com/en/sql-reference/functions/to_time 