### PR TITLE
feat(snowflake): support GETDATE, SYSDATE, SYSTIMESTAMP

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -833,6 +833,7 @@ class Snowflake(Dialect):
             "ILIKE": build_like(exp.ILike),
             "SEARCH": _build_search,
             "SKEW": exp.Skewness.from_arg_list,
+            "SYSTIMESTAMP": exp.CurrentTimestamp.from_arg_list,
             "WEEKISO": exp.WeekOfYear.from_arg_list,
             "WEEKOFYEAR": exp.Week.from_arg_list,
         }

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6426,10 +6426,6 @@ class Sysdate(Func):
     arg_types = {}
 
 
-class Systimestamp(Func):
-    arg_types = {}
-
-
 class CurrentOrganizationName(Func):
     arg_types = {}
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1927,9 +1927,9 @@ class TestSnowflake(Validator):
                 "databricks": "UNIFORM(1, 10, 5)",
             },
         )
-        self.validate_identity("SELECT SYSDATE()")
-        self.validate_identity("SELECT SYSTIMESTAMP()")
-        self.validate_identity("SELECT GETDATE()", "SELECT CURRENT_TIMESTAMP()")
+        self.validate_identity("SYSDATE()")
+        self.validate_identity("SYSTIMESTAMP()", "CURRENT_TIMESTAMP()")
+        self.validate_identity("GETDATE()", "CURRENT_TIMESTAMP()")
 
     def test_null_treatment(self):
         self.validate_all(


### PR DESCRIPTION
Add support for the following Snowflake functions:
- `SYSDATE()`: returns current timestamp in the UTC https://docs.snowflake.com/en/sql-reference/functions/sysdate 
- `SYSTIMESTAMP()`: returns the current system time in the local time zone, alias for CURRENT_TIMESTAMP https://docs.snowflake.com/en/sql-reference/functions/systimestamp
- `GETDATE()`: returns the current system time in the local time zone, alias for CURRENT_TIMESTAMP https://docs.snowflake.com/en/sql-reference/functions/getdate
```
>>> parse_one("SELECT SYSDATE(), SYSTIMESTAMP(), GETDATE()", "snowflake")
Select(
  expressions=[
    Sysdate(),
    CurrentTimestamp(),
    CurrentTimestamp()])
```
Executed Snowflake:
```
SELECT SYSDATE() AS sysdate_func, GETDATE() AS getdate_func, SYSTIMESTAMP() AS systs_func, CURRENT_TIMESTAMP() AS current_ts_func
+-------------------------------------------------------------------------------------------------------------------------------------+
| SYSDATE_FUNC               | GETDATE_FUNC                     | SYSTS_FUNC                       | CURRENT_TS_FUNC                  |
|----------------------------+----------------------------------+----------------------------------+----------------------------------|
| 2025-12-16 17:38:04.205000 | 2025-12-16 09:38:04.205000-08:00 | 2025-12-16 09:38:04.205000-08:00 | 2025-12-16 09:38:04.205000-08:00 |
+-------------------------------------------------------------------------------------------------------------------------------------+

```