### PR TITLE
Fix(snowflake)!: remove Sysdate in favor of CurrentTimestamp with sysdate arg

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -778,6 +778,7 @@ class Snowflake(Dialect):
             "SHA2_HEX": exp.SHA2.from_arg_list,
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "STRTOK": _build_strtok,
+            "SYSDATE": lambda args: exp.CurrentTimestamp(this=seq_get(args, 0), sysdate=True),
             "TABLE": lambda args: exp.TableFromRows(this=seq_get(args, 0)),
             "TIMEADD": _build_date_time_add(exp.TimeAdd),
             "TIMEDIFF": _build_datediff,
@@ -1416,6 +1417,9 @@ class Snowflake(Dialect):
             exp.BitwiseLeftShift: rename_func("BITSHIFTLEFT"),
             exp.BitwiseRightShift: rename_func("BITSHIFTRIGHT"),
             exp.Create: transforms.preprocess([_flatten_structured_types_unless_iceberg]),
+            exp.CurrentTimestamp: lambda self, e: self.func("SYSDATE")
+            if e.args.get("sysdate")
+            else self.function_fallback_sql(e),
             exp.DateAdd: date_delta_sql("DATEADD"),
             exp.DateDiff: date_delta_sql("DATEDIFF"),
             exp.DatetimeAdd: date_delta_sql("TIMESTAMPADD"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6422,10 +6422,6 @@ class CurrentTimezone(Func):
     arg_types = {}
 
 
-class Sysdate(Func):
-    arg_types = {}
-
-
 class CurrentOrganizationName(Func):
     arg_types = {}
 


### PR DESCRIPTION
We have a `sysdate` arg in `CurrentTimestamp` ([source](https://github.com/tobymao/sqlglot/blob/2a96d0ec7a653a3988c7a88393553ccc29e13727/sqlglot/expressions.py#L6413-L6414)), which was [used to support Oracle's concept](https://github.com/tobymao/sqlglot/pull/3935), which I imagine is similar to Snowflake's.
