### PR TITLE
fix(expression)!: update parent of json-arrayagg

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7118,7 +7118,7 @@ class JSONArray(Func):
 
 
 # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/JSON_ARRAYAGG.html
-class JSONArrayAgg(Func):
+class JSONArrayAgg(AggFunc):
     arg_types = {
         "this": True,
         "order": False,


### PR DESCRIPTION
updates the class definition
`JSONArrayAgg` -> to inherit  `AggFunc` instead of the generic Func.