### PR TITLE
Fix(duckdb): preserve l/r-trim syntax

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1950,11 +1950,11 @@ class DuckDB(Dialect):
             return self.func("DATE_TRUNC", unit, timestamp)
 
         def trim_sql(self, expression: exp.Trim) -> str:
-            result_sql = self.func(
-                "TRIM",
-                _cast_to_varchar(expression.this),
-                _cast_to_varchar(expression.expression),
-            )
+            expression.this.replace(_cast_to_varchar(expression.this))
+            if expression.expression:
+                expression.expression.replace(_cast_to_varchar(expression.expression))
+
+            result_sql = super().trim_sql(expression)
             return _gen_with_cast_to_blob(self, expression, result_sql)
 
         def round_sql(self, expression: exp.Round) -> str:

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -740,6 +740,13 @@ class TestSnowflake(Validator):
         )
 
         self.validate_all(
+            "SELECT LTRIM(RTRIM(col)) FROM t1",
+            write={
+                "duckdb": "SELECT LTRIM(RTRIM(col)) FROM t1",
+                "snowflake": "SELECT LTRIM(RTRIM(col)) FROM t1",
+            },
+        )
+        self.validate_all(
             "SELECT value['x'] AS x FROM TABLE(FLATTEN(INPUT => [OBJECT_CONSTRUCT('x', 'x')])) AS _t0(seq, key, path, index, value, this)",
             read={
                 "bigquery": "SELECT x FROM UNNEST([STRUCT('x' AS x)])",


### PR DESCRIPTION
Fixes #6587
