### PR TITLE
feat(duckdb): Add transpilation support for CEIL function

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4069,3 +4069,23 @@ FROM SEMANTIC_VIEW(
                 "duckdb": "SELECT ROUND(FLOOR(1.234 * POWER(10, CAST(1.5 AS INT))) / POWER(10, CAST(1.5 AS INT)), CAST(1.5 AS INT))"
             },
         )
+
+    def test_ceil(self):
+        self.validate_all(
+            "SELECT CEIL(1.753, 2)",
+            write={"duckdb": "SELECT ROUND(CEIL(1.753 * POWER(10, 2)) / POWER(10, 2), 2)"},
+        )
+        self.validate_all(
+            "SELECT CEIL(123.45, -1)",
+            write={"duckdb": "SELECT ROUND(CEIL(123.45 * POWER(10, -1)) / POWER(10, -1), -1)"},
+        )
+        self.validate_all(
+            "SELECT CEIL(a + b, 2)",
+            write={"duckdb": "SELECT ROUND(CEIL((a + b) * POWER(10, 2)) / POWER(10, 2), 2)"},
+        )
+        self.validate_all(
+            "SELECT CEIL(1.234, 1.5)",
+            write={
+                "duckdb": "SELECT ROUND(CEIL(1.234 * POWER(10, CAST(1.5 AS INT))) / POWER(10, CAST(1.5 AS INT)), CAST(1.5 AS INT))"
+            },
+        )


### PR DESCRIPTION
Add transpilation support for CEIL function.

DuckDB does not support the optional scale parameter in CEIL function that Snowflake provides. When transpiling CEIL(value, scale) from Snowflake to DuckDB, the query fails with "No function matches the given name and argument types" error. This prevents transpilation of queries that use CEIL with precision control.
```
SELECT CEIL(135) AS ceil_int, CEIL(135.135) AS ceil_float, CEIL(-975.975) AS ceil_neg_float, CEIL(CAST(10.5 AS DECIMAL(10, 2))) AS ceil_decimal, CEIL(0.0) AS ceil_zero, CEIL(-0.1) AS ceil_neg_small, CEIL(NULL) AS ceil_null, CEIL(135.135, 1) AS ceil_with_scale_pos, CEIL(135.135, -2) AS ceil_with_scale_neg, CEIL(135.135, 0) AS ceil_with_scale_zero, CEIL(CAST(99.999 AS DOUBLE)) AS ceil_float_type, CEIL(CAST(12345.6789 AS DECIMAL(15, 4))) AS ceil_decimal_precise



Binder Error:
No function matches the given name and argument types 'ceil(DECIMAL(6,3), INTEGER_LITERAL)'. You might need to add explicit type casts.
        Candidate functions:
        ceil(FLOAT) -> FLOAT
        ceil(DOUBLE) -> DOUBLE
        ceil(DECIMAL) -> DECIMAL
LINE 1: ..., CEIL(-0.1) AS ceil_neg_small, CEIL(NULL) AS ceil_null, CEIL(135.135, 1) AS ceil_with_scale_pos, CEIL(135.135, ...
```

After:
 ```
"SELECT CEIL(135) AS ceil_int, CEIL(135.135) AS ceil_float, CEIL(-975.975) AS ceil_neg_float, CEIL(CAST(10.5 AS DECIMAL(10, 2))) AS ceil_decimal, CEIL(0.0) AS ceil_zero, CEIL(-0.1) AS ceil_neg_small, CEIL(NULL) AS ceil_null, ROUND(CEIL(135.135 * POWER(10, 1)) / POWER(10, 1), 1) AS ceil_with_scale_pos, ROUND(CEIL(135.135 * POWER(10, -2)) / POWER(10, -2), -2) AS ceil_with_scale_neg, ROUND(CEIL(135.135 * POWER(10, 0)) / POWER(10, 0), 0) AS ceil_with_scale_zero, CEIL(CAST(99.999 AS DOUBLE)) AS ceil_float_type, CEIL(CAST(12345.6789 AS DECIMAL(15, 4))) AS ceil_decimal_precise"
┌──────────┬──────────────┬────────────────┬───────────────┬──────────────┬────────────────┬───┬─────────────────────┬─────────────────────┬──────────────────────┬─────────────────┬──────────────────────┐
│ ceil_int │  ceil_float  │ ceil_neg_float │ ceil_decimal  │  ceil_zero   │ ceil_neg_small │ … │ ceil_with_scale_pos │ ceil_with_scale_neg │ ceil_with_scale_zero │ ceil_float_type │ ceil_decimal_precise │
│  double  │ decimal(6,0) │  decimal(6,0)  │ decimal(10,0) │ decimal(2,0) │  decimal(2,0)  │   │       double        │       double        │        double        │     double      │    decimal(15,0)     │
├──────────┼──────────────┼────────────────┼───────────────┼──────────────┼────────────────┼───┼─────────────────────┼─────────────────────┼──────────────────────┼─────────────────┼──────────────────────┤
│  135.0   │     136      │      -975      │      11       │      0       │       0        │ … │        135.2        │        200.0        │        136.0         │      100.0      │        12346         │
├──────────┴──────────────┴────────────────┴───────────────┴──────────────┴────────────────┴───┴─────────────────────┴─────────────────────┴──────────────────────┴─────────────────┴──────────────────────┤
│ 1 rows                                                                                                                                                                             12 columns (11 shown) │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```