### PR TITLE
feat(snowflake)!: support transpilation of TRY_TO_BOOLEAN from Snowflake to DuckDB

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -302,10 +302,10 @@ class TestSnowflake(Validator):
         self.validate_identity("TRY_TO_DECFLOAT('1,234.56', '999,999.99')")
         self.validate_identity("TRY_TO_BINARY('48656C6C6F')")
         self.validate_identity("TRY_TO_BINARY('48656C6C6F', 'HEX')")
-        self.validate_identity("TRY_TO_BOOLEAN('true')")
         self.validate_all(
             "TRY_TO_BOOLEAN('true')",
             write={
+                "snowflake": "TRY_TO_BOOLEAN('true')",
                 "duckdb": "CASE WHEN UPPER(CAST('true' AS TEXT)) = 'ON' THEN TRUE WHEN UPPER(CAST('true' AS TEXT)) = 'OFF' THEN FALSE ELSE TRY_CAST('true' AS BOOLEAN) END",
             },
         )
@@ -985,7 +985,7 @@ class TestSnowflake(Validator):
         self.validate_all(
             "SELECT To_BOOLEAN('T')",
             write={
-                "duckdb": "SELECT CASE WHEN ISNAN(TRY_CAST('T' AS REAL)) OR ISINF(TRY_CAST('T' AS REAL)) THEN ERROR('TO_BOOLEAN: Non-numeric values NaN and INF are not supported') WHEN UPPER(CAST('T' AS TEXT)) = 'ON' THEN TRUE WHEN UPPER(CAST('T' AS TEXT)) = 'OFF' THEN FALSE ELSE CAST('T' AS BOOLEAN) END",
+                "duckdb": "SELECT CASE WHEN UPPER(CAST('T' AS TEXT)) = 'ON' THEN TRUE WHEN UPPER(CAST('T' AS TEXT)) = 'OFF' THEN FALSE WHEN ISNAN(TRY_CAST('T' AS REAL)) OR ISINF(TRY_CAST('T' AS REAL)) THEN ERROR('TO_BOOLEAN: Non-numeric values NaN and INF are not supported') ELSE CAST('T' AS BOOLEAN) END",
             },
         )
         self.validate_all(


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/functions/try_to_boolean

DuckDB's TRY_CAST can handle almost all the  valid strings that can be parsed by Snowlflake's TRY_TO_BOOLEAN to be true or false. The exceptions are 'on', 'off' which aren't considered valid by DuckDB's TRY_CAST so we need to handle them specifically. For invalid strings, TRY_CAST returns NULL, just like TRY_TO_BOOLEAN.

The one thing that is not addresses here is the NULL input. While it's not documented by Snowflake, TRY_TO_BOOLEAN will throw an error if the input is NULL, but DuckDb's TRY_CAST will return NULL. @georgesittas should we handle this case as well?