### PR TITLE
Chore: Fix integration test failing with empty PR description

### DIFF
--- a/.github/scripts/get_integration_test_params.py
+++ b/.github/scripts/get_integration_test_params.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     print(f"Handling event: \n" + json.dumps(event, indent=2))
 
     # for pull_request events, the body is located at github.event.pull_request.body
-    pr_description: str = event.get("pull_request", {}).get("body", "")
+    pr_description: str = event.get("pull_request", {}).get("body") or ""
 
     dialects = []
     should_run = False


### PR DESCRIPTION
Fixes issues such as https://github.com/tobymao/sqlglot/actions/runs/20333472785/job/58414157262?pr=6597

The `"body"` key might exist with the value `None` so the default value of `get` might not kick in.