### PR TITLE
Chore: Fix integration test condition for skipping fork PRs

### DIFF
--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
     name: Run Integration Tests
     runs-on: ubuntu-latest
     needs: should-run
-    if: needs.should-run.outputs.skip == 'false' && github.event.repository.fork != true
+    if: needs.should-run.outputs.skip == 'false' && github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Acquire credentials
         id: app-token


### PR DESCRIPTION
My [previous fix](https://github.com/tobymao/sqlglot/pull/6582) did not seem to do the trick for [external PRs failing on appId](https://github.com/tobymao/sqlglot/actions/runs/20342127561/job/58444259662?pr=6591); I believe this is because `github.event.repository.fork` checks if _our_ repo is a fork of something else, not if the repo of the PR is a fork of ours.

Instead, I now gave [this a shot](https://github.com/orgs/community/discussions/25217) which compares the repo names i.e PRs coming from maintainers are opened from `tobymao/sqlglot` (`base.repo.full_name` or otherwise `github.repository`) while external PRs are opened from `<contributor>/sqlglot` (`head.repo.full_name`)