### PR TITLE
feat(duckdb)!: Add transpilation support for DATE_DIFF function

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -135,7 +135,10 @@ def _build_object_construct(args: t.List) -> t.Union[exp.StarMap, exp.Struct]:
 
 def _build_datediff(args: t.List) -> exp.DateDiff:
     return exp.DateDiff(
-        this=seq_get(args, 2), expression=seq_get(args, 1), unit=map_date_part(seq_get(args, 0))
+        this=seq_get(args, 2),
+        expression=seq_get(args, 1),
+        unit=map_date_part(seq_get(args, 0)),
+        date_part_boundary=True,
     )
 
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2396,6 +2396,45 @@ class TestSnowflake(Validator):
             "DATEDIFF(DAY, CAST('2007-12-25' AS DATE), CAST('2008-12-25' AS DATE))",
         )
 
+        # Test DATEDIFF with WEEK unit - week boundary crossing
+        self.validate_all(
+            "DATEDIFF(WEEK, '2024-12-13', '2024-12-17')",
+            write={
+                "duckdb": "DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2024-12-13' AS DATE)), DATE_TRUNC('WEEK', CAST('2024-12-17' AS DATE)))",
+                "snowflake": "DATEDIFF(WEEK, '2024-12-13', '2024-12-17')",
+            },
+        )
+        self.validate_all(
+            "DATEDIFF(WEEK, '2024-12-15', '2024-12-16')",
+            write={
+                "duckdb": "DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2024-12-15' AS DATE)), DATE_TRUNC('WEEK', CAST('2024-12-16' AS DATE)))",
+                "snowflake": "DATEDIFF(WEEK, '2024-12-15', '2024-12-16')",
+            },
+        )
+
+        # Test DATEDIFF with other date parts - should not use DATE_TRUNC
+        self.validate_all(
+            "DATEDIFF(YEAR, '2020-01-15', '2023-06-20')",
+            write={
+                "duckdb": "DATE_DIFF('YEAR', CAST('2020-01-15' AS DATE), CAST('2023-06-20' AS DATE))",
+                "snowflake": "DATEDIFF(YEAR, '2020-01-15', '2023-06-20')",
+            },
+        )
+        self.validate_all(
+            "DATEDIFF(MONTH, '2020-01-15', '2023-06-20')",
+            write={
+                "duckdb": "DATE_DIFF('MONTH', CAST('2020-01-15' AS DATE), CAST('2023-06-20' AS DATE))",
+                "snowflake": "DATEDIFF(MONTH, '2020-01-15', '2023-06-20')",
+            },
+        )
+        self.validate_all(
+            "DATEDIFF(QUARTER, '2020-01-15', '2023-06-20')",
+            write={
+                "duckdb": "DATE_DIFF('QUARTER', CAST('2020-01-15' AS DATE), CAST('2023-06-20' AS DATE))",
+                "snowflake": "DATEDIFF(QUARTER, '2020-01-15', '2023-06-20')",
+            },
+        )
+
         self.validate_identity("DATEADD(y, 5, x)", "DATEADD(YEAR, 5, x)")
         self.validate_identity("DATEADD(y, 5, x)", "DATEADD(YEAR, 5, x)")
         self.validate_identity("DATE_PART(yyy, x)", "DATE_PART(YEAR, x)")


### PR DESCRIPTION

The WEEK unit in `DATEDIFF` produces different results between Snowflake and DuckDB due to fundamentally different calculation methodologies:

Snowflake: Counts the number of week boundaries crossed.

DuckDB: Performs floor(days_diff / 7) - integer division.
```

TRANSPILATION:
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT DATEDIFF(WEEK, '2020-01-15', '2023-06-20') AS diff_weeks, DATEDIFF(WEEK, '2024-12-13', '2024-12-17') AS week_monday_cross, DATEDIFF(WEEK, '2024-12-15', '2024-12-16') AS week_same_week\", read='snowflake', write='duckdb')[0])"
SELECT DATE_DIFF('WEEK', CAST('2020-01-15' AS DATE), CAST('2023-06-20' AS DATE)) AS diff_weeks, DATE_DIFF('WEEK', CAST('2024-12-13' AS DATE), CAST('2024-12-17' AS DATE)) AS week_monday_cross, DATE_DIFF('WEEK', CAST('2024-12-15' AS DATE), CAST('2024-12-16' AS DATE)) AS week_same_week

DUCKDB:
duckdb -c "SELECT DATE_DIFF('WEEK', CAST('2020-01-15' AS DATE), CAST('2023-06-20' AS DATE)) AS diff_weeks, DATE_DIFF('WEEK', CAST('2024-12-13' AS DATE), CAST('2024-12-17' AS DATE)) AS week_monday_cross, DATE_DIFF('WEEK', CAST('2024-12-15' AS DATE), CAST('2024-12-16' AS DATE)) AS week_same_week"
┌────────────┬───────────────────┬────────────────┐
│ diff_weeks │ week_monday_cross │ week_same_week │
│   int64    │       int64       │     int64      │
├────────────┼───────────────────┼────────────────┤
│    178     │         0         │       0        │
└────────────┴───────────────────┴────────────────┘
```

To fix this, enable date_part_boundary for Snowflake `DATEDIFF`.

```
TRANSPILATION:
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT DATEDIFF(WEEK, '2020-01-15', '2023-06-20') AS diff_weeks, DATEDIFF(WEEK, '2024-12-13', '2024-12-17') AS week_monday_cross, DATEDIFF(WEEK, '2024-12-15', '2024-12-16') AS week_same_week\", read='snowflake', write='duckdb')[0])"

SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2020-01-15' AS DATE)), DATE_TRUNC('WEEK', CAST('2023-06-20' AS DATE))) AS diff_weeks, DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2024-12-13' AS DATE)), DATE_TRUNC('WEEK', CAST('2024-12-17' AS DATE))) AS week_monday_cross, DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2024-12-15' AS DATE)), DATE_TRUNC('WEEK', CAST('2024-12-16' AS DATE))) AS week_same_week

DUCKDB:
"SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2020-01-15' AS DATE)), DATE_TRUNC('WEEK', CAST('2023-06-20' AS DATE))) AS diff_weeks, DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2024-12-13' AS DATE)), DATE_TRUNC('WEEK', CAST('2024-12-17' AS DATE))) AS week_monday_cross, DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2024-12-15' AS DATE)), DATE_TRUNC('WEEK', CAST('2024-12-16' AS DATE))) AS week_same_week"
┌────────────┬───────────────────┬────────────────┐
│ diff_weeks │ week_monday_cross │ week_same_week │
│   int64    │       int64       │     int64      │
├────────────┼───────────────────┼────────────────┤
│    179     │         1         │       1        │
└────────────┴───────────────────┴────────────────┘

```