### PR TITLE
fix(spark, databricks): make_interval week

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -959,7 +959,7 @@ class BigQuery(Dialect):
         def _parse_make_interval(self) -> exp.MakeInterval:
             expr = exp.MakeInterval()
 
-            for arg_key in expr.arg_types:
+            for arg_key in ["year", "month", "day", "hour", "minute", "second"]:
                 value = self._parse_lambda()
 
                 if not value:

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6591,6 +6591,7 @@ class MakeInterval(Func):
     arg_types = {
         "year": False,
         "month": False,
+        "week": False,
         "day": False,
         "hour": False,
         "minute": False,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -175,6 +175,7 @@ class TestBigQuery(Validator):
         self.validate_identity("BEGIN DECLARE y INT64", check_command_warning=True)
         self.validate_identity("LOOP SET x = x + 1", check_command_warning=True)
         self.validate_identity("REPEAT SET x = x + 1", check_command_warning=True)
+        self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 1, 12, 30, 10)")
         self.validate_identity(
             "WHILE i < ARRAY_LENGTH(batches) DO SET x = batches[OFFSET(i)]",
             check_command_warning=True,

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -241,6 +241,7 @@ class TestDatabricks(Validator):
         self.validate_identity("CURRENT_TIMEZONE()")
         self.validate_identity("CURDATE()", "CURRENT_DATE")
         self.validate_identity("CURDATE", "CURRENT_DATE")
+        self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -928,6 +928,7 @@ TBLPROPERTIES (
         )
         self.validate_identity("BITMAP_OR_AGG(x)")
         self.validate_identity("SELECT ELT(2, 'foo', 'bar', 'baz') AS Result")
+        self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
 
     def test_bool_or(self):
         self.validate_all(


### PR DESCRIPTION
```sql
SELECT make_interval(100,11,12,13,14,14,15)
```

```python
class MakeInterval(Func):
    arg_types = {
        "year": False,
        "month": False,
        "week": False,
        "day": False,
        "hour": False,
        "minute": False,
        "second": False,
    }
```

[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/make_interval)
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#make_interval)