### PR TITLE
fix(trino): mark as supporting `...EXCEPT ALL`

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -69,6 +69,7 @@ class Trino(Presto):
             )
 
     class Generator(Presto.Generator):
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = True
         PROPERTIES_LOCATION = {
             **Presto.Generator.PROPERTIES_LOCATION,
             exp.LocationProperty: exp.Properties.Location.POST_WITH,


### PR DESCRIPTION
This is for `SELECT * FROM t1 INTERSECT/EXCEPT ALL SELECT * FROM t2`
Trino inherits the dialect from Presto. Presto doesn't support the `ALL` modifier, but trino does, see https://github.com/trinodb/trino/pull/5890

We ran into this in ibis, where we are indeed able to compile and successfully execute the ALL modifier, but as soon as [we turned on sqlglot errors](https://github.com/ibis-project/ibis/pull/11772), we then started getting spurious sqlglot errors: https://github.com/ibis-project/ibis/actions/runs/19549750869/job/55977864377?pr=11772