### PR TITLE
feat(duckdb): Add transpilation support for nanoseconds used in date/time functions.

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2483,20 +2483,13 @@ class TestSnowflake(Validator):
                 "snowflake": "DATEDIFF(NANOSECOND, '2023-01-01 10:00:00.000000000', '2023-01-01 10:00:00.123456789')",
             },
         )
-        self.validate_all(
-            "DATEDIFF(NANOSECOND, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP), CAST('2023-01-01 10:00:00.987654321' AS TIMESTAMP))",
-            write={
-                "duckdb": "EPOCH_NS(CAST('2023-01-01 10:00:00.987654321' AS TIMESTAMP_NS)) - EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS))",
-                "snowflake": "DATEDIFF(NANOSECOND, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP), CAST('2023-01-01 10:00:00.987654321' AS TIMESTAMP))",
-            },
-        )
 
-        # Test TIMEDIFF with NANOSECOND - DuckDB uses EPOCH_NS for nanosecond precision
+        # Test DATEDIFF with NANOSECOND on columns
         self.validate_all(
-            "TIMEDIFF(NANOSECOND, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP), CAST('2023-01-01 10:00:00.123456789' AS TIMESTAMP))",
+            "DATEDIFF(NANOSECOND, start_time, end_time)",
             write={
-                "duckdb": "EPOCH_NS(CAST('2023-01-01 10:00:00.123456789' AS TIMESTAMP_NS)) - EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS))",
-                "snowflake": "DATEDIFF(NANOSECOND, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP), CAST('2023-01-01 10:00:00.123456789' AS TIMESTAMP))",
+                "duckdb": "EPOCH_NS(CAST(end_time AS TIMESTAMP_NS)) - EPOCH_NS(CAST(start_time AS TIMESTAMP_NS))",
+                "snowflake": "DATEDIFF(NANOSECOND, start_time, end_time)",
             },
         )
 
@@ -2508,20 +2501,13 @@ class TestSnowflake(Validator):
                 "snowflake": "DATEADD(NANOSECOND, 123456789, '2023-01-01 10:00:00.000000000')",
             },
         )
-        self.validate_all(
-            "DATEADD(NANOSECOND, 999999999, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP))",
-            write={
-                "duckdb": "MAKE_TIMESTAMP_NS(EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) + 999999999)",
-                "snowflake": "DATEADD(NANOSECOND, 999999999, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP))",
-            },
-        )
 
-        # Test TIMEADD with NANOSECOND - DuckDB uses MAKE_TIMESTAMP_NS
+        # Test DATEADD with NANOSECOND on columns
         self.validate_all(
-            "TIMEADD(NANOSECOND, 123456789, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP))",
+            "DATEADD(NANOSECOND, nano_offset, timestamp_col)",
             write={
-                "duckdb": "MAKE_TIMESTAMP_NS(EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) + 123456789)",
-                "snowflake": "TIMEADD(NANOSECOND, 123456789, CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP))",
+                "duckdb": "MAKE_TIMESTAMP_NS(EPOCH_NS(CAST(timestamp_col AS TIMESTAMP_NS)) + nano_offset)",
+                "snowflake": "DATEADD(NANOSECOND, nano_offset, timestamp_col)",
             },
         )
 


### PR DESCRIPTION
**Issue:** DuckDB does not support `NANOSECOND` as a unit in `DATE_DIFF()` or `INTERVAL` operations. 

**Solution:** To enable Snowflake → DuckDB transpilation with nanosecond precision, following workaround implemented:
`EPOCH_NS()`: Converts `TIMESTAMP_NS` to nanoseconds since Unix epoch (returns INT64)
`make_timestamp_ns()`: Converts nanoseconds (INT64) to `TIMESTAMP_NS`


Snowflake:
```
SELECT DATEDIFF(NANOSECOND, '2023-01-01 10:00:00.000000000', '2023-01-01 10:00:00.123456789') AS datediff_result, DATEADD(NANOSECOND, 123456789, '2023-01-01 10:00:00.000000000') AS dateadd_result, TIMEDIFF(NANOSECOND, '2023-01-01 10:00:00.000000000', '2023-01-01 10:00:00.123456789') AS timediff_result, TIMEADD(NANOSECOND, 987654321, '2023-01-01 10:00:00.000000000') AS timeadd_result, TIMESTAMPDIFF(NANOSECOND, '2023-01-01 10:00:00.000000000', '2023-01-01 10:00:00.999999999') AS timestampdiff_result, TIMESTAMPADD(NANOSECOND, 555555555, '2023-01-01 10:00:00.000000000') AS timestampadd_result;


DATEDIFF_RESULT | DATEADD_RESULT | TIMEDIFF_RESULT | TIMEADD_RESULT | TIMESTAMPDIFF_RESULT | TIMESTAMPADD_RESULT

123456789 | 2023-01-01 10:00:00.123 | 123456789 | 2023-01-01 10:00:00.987 | 999999999 | 2023-01-01 10:00:00.555
```

Duckdb (after transpilation):
```
SELECT EPOCH_NS(CAST('2023-01-01 10:00:00.123456789' AS TIMESTAMP_NS)) - EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) AS datediff_result, MAKE_TIMESTAMP_NS(EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) + 123456789) AS dateadd_result, EPOCH_NS(CAST('2023-01-01 10:00:00.123456789' AS TIMESTAMP_NS)) - EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) AS timediff_result, MAKE_TIMESTAMP_NS(EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) + 987654321) AS timeadd_result, EPOCH_NS(CAST('2023-01-01 10:00:00.999999999' AS TIMESTAMP_NS)) - EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) AS timestampdiff_result, MAKE_TIMESTAMP_NS(EPOCH_NS(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP_NS)) + 555555555) AS timestampadd_result

┌─────────────────┬───────────────────────────────┬─────────────────┬───────────────────────────────┬──────────────────────┬───────────────────────────────┐
│ datediff_result │        dateadd_result         │ timediff_result │        timeadd_result         │ timestampdiff_result │      timestampadd_result      │
│      int64      │         timestamp_ns          │      int64      │         timestamp_ns          │        int64         │         timestamp_ns          │
├─────────────────┼───────────────────────────────┼─────────────────┼───────────────────────────────┼──────────────────────┼───────────────────────────────┤
│    123456789    │ 2023-01-01 10:00:00.123456789 │    123456789    │ 2023-01-01 10:00:00.987654321 │      999999999       │ 2023-01-01 10:00:00.555555555 │
└─────────────────┴───────────────────────────────┴─────────────────┴───────────────────────────────┴──────────────────────┴───────────────────────────────┘


```

**Function Mapping Summary:** 
Snowflake Function | DuckDB Transpilation
-- | --
DATEDIFF(NANOSECOND, start, end) | EPOCH_NS(end) - EPOCH_NS(start)
DATEADD(NANOSECOND, n, ts) | MAKE_TIMESTAMP_NS(EPOCH_NS(ts) + n)
TIMEDIFF(NANOSECOND, start, end) | EPOCH_NS(end) - EPOCH_NS(start)
TIMEADD(NANOSECOND, n, ts) | MAKE_TIMESTAMP_NS(EPOCH_NS(ts) + n)
TIMESTAMPDIFF(NANOSECOND, start, end) | EPOCH_NS(end) - EPOCH_NS(start)
TIMESTAMPADD(NANOSECOND, n, ts) | MAKE_TIMESTAMP_NS(EPOCH_NS(ts) + n)

