### PR TITLE
fix(postgres): Fix exp.WidthBucket required args

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -447,6 +447,11 @@ class Postgres(Dialect):
             "LEVENSHTEIN_LESS_EQUAL": _build_levenshtein_less_equal,
             "JSON_OBJECT_AGG": lambda args: exp.JSONObjectAgg(expressions=args),
             "JSONB_OBJECT_AGG": exp.JSONBObjectAgg.from_arg_list,
+            "WIDTH_BUCKET": lambda args: exp.WidthBucket(
+                this=seq_get(args, 0), threshold=seq_get(args, 1)
+            )
+            if len(args) == 2
+            else exp.WidthBucket.from_arg_list(args),
         }
 
         NO_PAREN_FUNCTIONS = {

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8279,7 +8279,13 @@ class Skewness(AggFunc):
 
 
 class WidthBucket(Func):
-    arg_types = {"this": True, "min_value": True, "max_value": True, "num_buckets": True}
+    arg_types = {
+        "this": True,
+        "min_value": False,
+        "max_value": False,
+        "num_buckets": False,
+        "threshold": False,
+    }
 
 
 class CovarSamp(Binary, AggFunc):

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1016,6 +1016,12 @@ FROM json_data, field_ids""",
             "SELECT SLOPE(CAST('(4,4)' AS POINT), CAST('(0,0)' AS POINT))",
         )
 
+        width_bucket = self.validate_identity("WIDTH_BUCKET(10, ARRAY[5, 15])")
+        self.assertIsNotNone(width_bucket.args.get("threshold"))
+
+        width_bucket = self.validate_identity("WIDTH_BUCKET(10, 5, 15, 25)")
+        self.assertIsNone(width_bucket.args.get("threshold"))
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6620

Postgres supports the following variants:

```SQL
width_bucket ( operand numeric, low numeric, high numeric, count integer ) → integer

width_bucket ( operand double precision, low double precision, high double precision, count integer ) → integer

width_bucket ( operand anycompatible, thresholds anycompatiblearray ) → integer
```

<br />

It is probably better to create a new arg to capture the array but didn't bother with it

Docs
-----------
[Postgres functions](https://www.postgresql.org/docs/current/functions-math.html)
