### PR TITLE
fix(clickhouse)!: variable arguments for XOR function

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6967,6 +6967,7 @@ class Or(Connector, Func):
 
 class Xor(Connector, Func):
     arg_types = {"this": False, "expression": False, "expressions": False}
+    is_var_len_args = True
 
 
 class If(Func):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -443,6 +443,7 @@ class TestClickhouse(Validator):
                 "mysql": "SELECT 1 XOR 0 XOR 1",
             },
         )
+        self.validate_identity("SELECT xor(0, 1, 1, 0)")
         self.validate_all(
             "CONCAT(a, b)",
             read={


### PR DESCRIPTION
This PR updates the `Xor` expression to support variable arguments. This is necessary for the `clickhouse` dialect, where the xor function can accept more than two arguments.

Syntax:
```sql
xor(val1, val2[, ...])
```

[Documentation](https://clickhouse.com/docs/sql-reference/functions/logical-functions#xor)