### PR TITLE
fix(singlestore)!: support RECORD type in singlestore

### DIFF
--- a/sqlglot/dialects/singlestore.py
+++ b/sqlglot/dialects/singlestore.py
@@ -82,6 +82,7 @@ class SingleStore(MySQL):
             "::$": TokenType.DCOLONDOLLAR,
             "::%": TokenType.DCOLONPERCENT,
             "::?": TokenType.DCOLONQMARK,
+            "RECORD": TokenType.STRUCT,
         }
 
     class Parser(MySQL.Parser):
@@ -328,6 +329,7 @@ class SingleStore(MySQL):
         SUPPORTS_UESCAPE = False
         NULL_ORDERING_SUPPORTED = True
         MATCH_AGAINST_TABLE_PREFIX = "TABLE "
+        STRUCT_DELIMITER = ("(", ")")
 
         @staticmethod
         def _unicode_substitute(m: re.Match[str]) -> str:
@@ -613,7 +615,6 @@ class SingleStore(MySQL):
             exp.DataType.Type.SERIAL,
             exp.DataType.Type.SMALLSERIAL,
             exp.DataType.Type.SMALLMONEY,
-            exp.DataType.Type.STRUCT,
             exp.DataType.Type.SUPER,
             exp.DataType.Type.TIMETZ,
             exp.DataType.Type.TIMESTAMPNTZ,
@@ -654,6 +655,7 @@ class SingleStore(MySQL):
             exp.DataType.Type.LINESTRING: "GEOGRAPHY",
             exp.DataType.Type.POLYGON: "GEOGRAPHY",
             exp.DataType.Type.MULTIPOLYGON: "GEOGRAPHY",
+            exp.DataType.Type.STRUCT: "RECORD",
             exp.DataType.Type.JSONB: "BSON",
             exp.DataType.Type.TIMESTAMP: "TIMESTAMP",
             exp.DataType.Type.TIMESTAMP_S: "TIMESTAMP",

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -20,6 +20,7 @@ class TestSingleStore(Validator):
         self.validate_identity("SELECT 1")
         self.validate_identity("SELECT * FROM `users` ORDER BY ALL")
         self.validate_identity("SELECT ELT(2, 'foo', 'bar', 'baz')")
+        self.validate_identity("SELECT TO_JSON(ROW(1, 2) :> RECORD(a INT, b INT))")
 
     def test_byte_strings(self):
         self.validate_identity("SELECT e'text'")


### PR DESCRIPTION
This PR adds support for the `RECORD` type in the `singlestore` dialect

```sql
SELECT TO_JSON(ROW(1, 2) :> RECORD(a INT, b INT))
```

[Documentation](https://docs.singlestore.com/cloud/reference/sql-reference/json-functions/to-json/#:~:text=SELECT%20TO_JSON(ROW(1%2C2)%3A%3ERECORD(a%20INT%2C%20b%20INT))%20AS%20RowOutput%3B)