### PR TITLE
feat(mysql)!: handle BINARY keyword

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6877,7 +6877,7 @@ class Parser(metaclass=_Parser):
 
         if self._match(TokenType.USING):
             to: t.Optional[exp.Expression] = self.expression(
-                exp.CharacterSet, this=self._parse_var()
+                exp.CharacterSet, this=self._parse_var(tokens={TokenType.BINARY})
             )
         elif self._match(TokenType.COMMA):
             to = self._parse_types()

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -573,6 +573,9 @@ class TestMySQL(Validator):
                 "mysql": "CAST(x AS CHAR CHARACTER SET latin1)",
             },
         )
+        self.validate_identity(
+            "CONVERT('a' USING binary)", "CAST('a' AS CHAR CHARACTER SET binary)"
+        )
 
     def test_match_against(self):
         self.validate_all(


### PR DESCRIPTION
This PR fixes a parsing error when using `CONVERT(... USING binary)` in the MySQL dialect.

```sql
SELECT CONVERT('a' USING binary)
```

[Documentation](https://dev.mysql.com/doc/refman/8.4/en/cast-functions.html#operator_binary)