### PR TITLE
feat(snowflake)!: Type annotation for ARRAY_REMOVE function

### DIFF
--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -244,6 +244,7 @@ EXPRESSION_METADATA = {
             exp.ArrayAppend,
             exp.ArrayConstructCompact,
             exp.ArrayPrepend,
+            exp.ArrayRemove,
             exp.ArrayUniqueAgg,
             exp.ArrayUnionAgg,
             exp.MapKeys,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -443,6 +443,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT ARRAY_UNIQUE_AGG(x)")
         self.validate_identity("SELECT ARRAY_APPEND([1, 2, 3], 4)")
         self.validate_identity("SELECT ARRAY_PREPEND([2, 3, 4], 1)")
+        self.validate_identity("SELECT ARRAY_REMOVE([1, 2, 3], 2)")
         self.validate_identity("SELECT AI_AGG(review, 'Summarize the reviews')")
         self.validate_identity("SELECT AI_SUMMARIZE_AGG(review)")
         self.validate_identity("SELECT AI_CLASSIFY('text', ['travel', 'cooking'])")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1753,6 +1753,10 @@ ARRAY_PREPEND([2, 3, 4], 1);
 ARRAY;
 
 # dialect: snowflake
+ARRAY_REMOVE([1, 2, 3], 2);
+ARRAY;
+
+# dialect: snowflake
 ASIN(tbl.double_col);
 DOUBLE;
 


### PR DESCRIPTION
added type and tests for [ARRAY_REMOVE](https://docs.snowflake.com/en/sql-reference/functions/array_remove)