### PR TITLE
feat(snowflake)!: Type annotation for COVAR_POP and COVAR_SAMP

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -8332,11 +8332,11 @@ class WidthBucket(Func):
 
 
 class CovarSamp(Binary, AggFunc):
-    pass
+    arg_types = {"this": True, "x": False}
 
 
 class CovarPop(Binary, AggFunc):
-    pass
+    arg_types = {"this": True, "x": False}
 
 
 class Week(Func):

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -335,6 +335,8 @@ EXPRESSION_METADATA = {
             exp.Cbrt,
             exp.Cosh,
             exp.CosineDistance,
+            exp.CovarPop,
+            exp.CovarSamp,
             exp.DotProduct,
             exp.EuclideanDistance,
             exp.ManhattanDistance,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1777,6 +1777,22 @@ CBRT(tbl.double_col);
 DOUBLE;
 
 # dialect: snowflake
+COVAR_POP(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
+COVAR_SAMP(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: snowflake
+COVAR_POP(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
+DOUBLE;
+
+# dialect: snowflake
+COVAR_SAMP(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
+DOUBLE;
+
+# dialect: snowflake
 AI_AGG('foo', 'bar');
 VARCHAR;
 


### PR DESCRIPTION
Add type annotations for COVAR_POP and COVAR_SAMP.

Documentation:
https://docs.snowflake.com/en/sql-reference/functions/covar_samp 
https://docs.snowflake.com/en/sql-reference/functions/covar_pop 