### PR TITLE
feat(mysql)!: annotation support for ELT function

### DIFF
--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -5,5 +5,6 @@ from sqlglot.typing import EXPRESSION_METADATA
 
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
+    **{expr_type: {"returns": exp.DataType.Type.VARCHAR} for expr_type in (exp.Elt,)},
     exp.Localtime: {"returns": exp.DataType.Type.DATETIME},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4842,3 +4842,7 @@ INT;
 # dialect: mysql
 LOCALTIME;
 DATETIME;
+
+# dialect: mysql
+ELT(1, 'a', 'b');
+VARCHAR;


### PR DESCRIPTION
```sql
ELT(1, 'a', 'b', 'c')
```
**Before:**
```python
Elt(
  this=Literal(this=1, is_string=False, _type=DataType(this=Type.INT)),
  expressions=[
    Literal(this='a', is_string=True, _type=DataType(this=Type.VARCHAR)),
    Literal(this='b', is_string=True, _type=DataType(this=Type.VARCHAR)),
    Literal(this='c', is_string=True, _type=DataType(this=Type.VARCHAR))],
  _type=DataType(this=Type.UNKNOWN))
```

**After:**
```python
Elt(
  this=Literal(this=1, is_string=False, _type=DataType(this=Type.INT)),
  expressions=[
    Literal(this='a', is_string=True, _type=DataType(this=Type.VARCHAR)),
    Literal(this='b', is_string=True, _type=DataType(this=Type.VARCHAR)),
    Literal(this='c', is_string=True, _type=DataType(this=Type.VARCHAR))],
  _type=DataType(this=Type.VARCHAR))
```

[Documentation](https://dev.mysql.com/doc/refman/8.4/en/string-functions.html#:~:text=Return%20string%20at%20index%20number)