### PR TITLE
fix(duckdb): Use ->> operator for Snowflake JSON extraction

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1346,7 +1346,12 @@ class DuckDB(Dialect):
             exp.Ceil: _ceil_floor,
             exp.Floor: _ceil_floor,
             exp.JSONBExists: rename_func("JSON_EXISTS"),
-            exp.JSONExtract: _arrow_json_extract_sql,
+            exp.JSONExtract: lambda self, e: _arrow_json_extract_sql(
+                self,
+                exp.JSONExtractScalar(**e.args)
+                if e.args.get("requires_json") or e.args.get("variant_extract")
+                else e,
+            ),
             exp.JSONExtractArray: _json_extract_value_array_sql,
             exp.JSONFormat: _json_format_sql,
             exp.JSONValueArray: _json_extract_value_array_sql,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -969,7 +969,7 @@ class TestSnowflake(Validator):
             """WITH vartab(v) AS (select parse_json('[{"attr": [{"name": "banana"}]}]')) SELECT GET_PATH(v, '[0].attr[0].name') FROM vartab""",
             write={
                 "bigquery": """WITH vartab AS (SELECT PARSE_JSON('[{"attr": [{"name": "banana"}]}]') AS v) SELECT JSON_EXTRACT(v, '$[0].attr[0].name') FROM vartab""",
-                "duckdb": """WITH vartab(v) AS (SELECT JSON('[{"attr": [{"name": "banana"}]}]')) SELECT v -> '$[0].attr[0].name' FROM vartab""",
+                "duckdb": """WITH vartab(v) AS (SELECT JSON('[{"attr": [{"name": "banana"}]}]')) SELECT v ->> '$[0].attr[0].name' FROM vartab""",
                 "mysql": """WITH vartab(v) AS (SELECT '[{"attr": [{"name": "banana"}]}]') SELECT JSON_EXTRACT(v, '$[0].attr[0].name') FROM vartab""",
                 "presto": """WITH vartab(v) AS (SELECT JSON_PARSE('[{"attr": [{"name": "banana"}]}]')) SELECT JSON_EXTRACT(v, '$[0].attr[0].name') FROM vartab""",
                 "snowflake": """WITH vartab(v) AS (SELECT PARSE_JSON('[{"attr": [{"name": "banana"}]}]')) SELECT GET_PATH(v, '[0].attr[0].name') FROM vartab""",
@@ -980,7 +980,7 @@ class TestSnowflake(Validator):
             """WITH vartab(v) AS (select parse_json('{"attr": [{"name": "banana"}]}')) SELECT GET_PATH(v, 'attr[0].name') FROM vartab""",
             write={
                 "bigquery": """WITH vartab AS (SELECT PARSE_JSON('{"attr": [{"name": "banana"}]}') AS v) SELECT JSON_EXTRACT(v, '$.attr[0].name') FROM vartab""",
-                "duckdb": """WITH vartab(v) AS (SELECT JSON('{"attr": [{"name": "banana"}]}')) SELECT v -> '$.attr[0].name' FROM vartab""",
+                "duckdb": """WITH vartab(v) AS (SELECT JSON('{"attr": [{"name": "banana"}]}')) SELECT v ->> '$.attr[0].name' FROM vartab""",
                 "mysql": """WITH vartab(v) AS (SELECT '{"attr": [{"name": "banana"}]}') SELECT JSON_EXTRACT(v, '$.attr[0].name') FROM vartab""",
                 "presto": """WITH vartab(v) AS (SELECT JSON_PARSE('{"attr": [{"name": "banana"}]}')) SELECT JSON_EXTRACT(v, '$.attr[0].name') FROM vartab""",
                 "snowflake": """WITH vartab(v) AS (SELECT PARSE_JSON('{"attr": [{"name": "banana"}]}')) SELECT GET_PATH(v, 'attr[0].name') FROM vartab""",
@@ -992,7 +992,7 @@ class TestSnowflake(Validator):
             write={
                 "bigquery": """SELECT JSON_EXTRACT(PARSE_JSON('{"fruit":"banana"}'), '$.fruit')""",
                 "databricks": """SELECT PARSE_JSON('{"fruit":"banana"}'):fruit""",
-                "duckdb": """SELECT JSON('{"fruit":"banana"}') -> '$.fruit'""",
+                "duckdb": """SELECT JSON('{"fruit":"banana"}') ->> '$.fruit'""",
                 "mysql": """SELECT JSON_EXTRACT('{"fruit":"banana"}', '$.fruit')""",
                 "presto": """SELECT JSON_EXTRACT(JSON_PARSE('{"fruit":"banana"}'), '$.fruit')""",
                 "snowflake": """SELECT GET_PATH(PARSE_JSON('{"fruit":"banana"}'), 'fruit')""",
@@ -1322,7 +1322,7 @@ class TestSnowflake(Validator):
         self.validate_all(
             '''SELECT PARSE_JSON('{"a": {"b c": "foo"}}'):a:"b c"''',
             write={
-                "duckdb": """SELECT JSON('{"a": {"b c": "foo"}}') -> '$.a."b c"'""",
+                "duckdb": """SELECT JSON('{"a": {"b c": "foo"}}') ->> '$.a."b c"'""",
                 "mysql": """SELECT JSON_EXTRACT('{"a": {"b c": "foo"}}', '$.a."b c"')""",
                 "snowflake": """SELECT GET_PATH(PARSE_JSON('{"a": {"b c": "foo"}}'), 'a["b c"]')""",
             },


### PR DESCRIPTION
When transpiling a JSON extraction from Snowflake to DuckDB, SQLGlot uses the -> operator. In DuckDB, -> returns a JSON object. When comparing this result to a standard VARCHAR, DATE, or INT, DuckDB throws a Conversion Error: Malformed JSON.

```
D CREATE OR REPLACE TABLE test AS SELECT JSON('{"test_date": "2025-10-01"}') AS test_date;
D SELECT
    (
      test_date -> '$.test_date'
    ) = '2025-12-01'
  FROM test
  ;
Conversion Error:
Malformed JSON at byte 4 of input: unexpected content after document.  Input: "2025-12-01"

LINE 4:   ) = '2025-12-01'
```

However this works as expected in Snowflake:
```
CREATE OR REPLACE TEMPORARY TABLE test_data AS 
SELECT PARSE_JSON('{"test_date": "2025-12-01"') AS test;

SELECT test:test_date = '2025-12-01'
FROM test_data;
```

To resolve this we need to transpile to the `->>` operator, which will work as it does in Snowflake
```
D SELECT
    (
      test_date ->> '$.test_date'
    ) = '2025-12-01'
  FROM test
  ;
┌────────────────────────────────────────────────┐
│ ((test_date ->> '$.test_date') = '2025-12-01') │
│                    boolean                     │
├────────────────────────────────────────────────┤
│ false                                          │
└────────────────────────────────────────────────┘
```

In DuckDB `->>` still allows chaining
```
CREATE OR REPLACE TABLE test_json (data JSON);
INSERT INTO test_json VALUES ('{"outer": {"inner": "target_value"}}');
SELECT * FROM test_json;

D SELECT data->>'outer'->>'inner' FROM test_json;
┌────────────────────────────────────┐
│ (("data" ->> 'outer') ->> 'inner') │
│              varchar               │
├────────────────────────────────────┤
│ target_value                       │
└────────────────────────────────────┘
D SELECT data->'outer'->>'inner' FROM test_json;
┌───────────────────────────────────┐
│ (("data" -> 'outer') ->> 'inner') │
│              varchar              │
├───────────────────────────────────┤
│ target_value                      │
└───────────────────────────────────┘
```

Resolves https://github.com/tobymao/sqlglot/issues/6661