### PR TITLE
fix(druid): array expression should use square brackets

### DIFF
--- a/sqlglot/dialects/druid.py
+++ b/sqlglot/dialects/druid.py
@@ -17,4 +17,5 @@ class Druid(Dialect):
             **generator.Generator.TRANSFORMS,
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.Mod: rename_func("MOD"),
+            exp.Array: lambda self, e: f"ARRAY[{self.expressions(e)}]",
         }

--- a/tests/dialects/test_druid.py
+++ b/tests/dialects/test_druid.py
@@ -14,6 +14,7 @@ class TestDruid(Validator):
         self.validate_identity("SELECT FLOOR(col) FROM t")
         self.validate_identity("SELECT FLOOR(price, 2) AS rounded_price FROM t")
         self.validate_identity("SELECT CURRENT_TIMESTAMP")
+        self.validate_identity("SELECT ARRAY[1, 2, 3]")
 
         # validate across all dialects
         write = {dialect.value: "FLOOR(__time TO WEEK)" for dialect in Dialects}


### PR DESCRIPTION
After upgrading from Apache Superset 5.0.0 to 6.0.0, Druid Queries were failed with the following error:
```
Uncategorized calcite error message: [java.lang.ClassCastException: class org.apache.calcite.sql.fun.SqlArrayValueConstructor cannot be cast to class org.apache.calcite.sql.SqlFunction (org.apache.calcite.sql.fun.SqlArrayValueConstructor
```

This turned out to be an issue with the Druid dialect in this library.

This PR updates the Druid Dialect for array expression to correctly translate them to `ARRAY[]` instead of `ARRAY()`