### PR TITLE
feat(duckdb): Handle NULL args for some date/time functions where Duckdb needs explicit cast for NULL + INTERVAL

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2557,6 +2557,37 @@ class TestSnowflake(Validator):
 
         self.validate_identity("DATEADD(y, 5, x)", "DATEADD(YEAR, 5, x)")
         self.validate_identity("DATEADD(y, 5, x)", "DATEADD(YEAR, 5, x)")
+
+        # Test NULL handling for date/time add operations
+        self.validate_all(
+            "SELECT TIMESTAMPADD(DAY, 5, NULL)",
+            write={
+                "duckdb": "SELECT CAST(NULL AS TIMESTAMP) + INTERVAL 5 DAY",
+                "snowflake": "SELECT DATEADD(DAY, 5, NULL)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATEADD(DAY, 5, NULL)",
+            write={
+                "duckdb": "SELECT CAST(NULL AS TIMESTAMP) + INTERVAL 5 DAY",
+                "snowflake": "SELECT DATEADD(DAY, 5, NULL)",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMEADD(HOUR, 2, NULL)",
+            write={
+                "duckdb": "SELECT CAST(NULL AS TIME) + INTERVAL 2 HOUR",
+                "snowflake": "SELECT TIMEADD(HOUR, 2, NULL)",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMPADD(NANOSECOND, 100, NULL)",
+            write={
+                "duckdb": "SELECT NULL",
+                "snowflake": "SELECT DATEADD(NANOSECOND, 100, NULL)",
+            },
+        )
+
         self.validate_identity("DATE_PART(yyy, x)", "DATE_PART(YEAR, x)")
         self.validate_identity("DATE_TRUNC(yr, x)", "DATE_TRUNC('YEAR', x)")
 


### PR DESCRIPTION
`TIMESTAMPADD` with NULL input fails to transpile correctly to DuckDB. The generated SQL `"NULL + INTERVAL amount UNIT"` causes a binder error because DuckDB cannot infer the type of `NULL` for the `INTERVAL` addition operation.

Eg:
`add_null: ERROR - Binder Error: Could not choose a best candidate function for the function call "+(NULL, INTERVAL)"`

After:
```
duckdb -c "SELECT CAST('2020-01-01' AS DATE) + INTERVAL 3 YEAR AS add_years, CAST('2020-01-01' AS DATE) + INTERVAL 2 QUARTER AS add_quarters, CAST('2020-01-01' AS DATE) + INTERVAL 5 MONTH AS add_months, CAST('2020-01-01' AS DATE) + INTERVAL 4 WEEK AS add_weeks, CAST('2020-01-01' AS DATE) + INTERVAL 100 DAY AS add_days, CAST('2023-01-01 10:00:00' AS TIMESTAMP) + INTERVAL 12 HOUR AS add_hours, CAST('2023-01-01 10:00:00' AS TIMESTAMP) + INTERVAL 45 MINUTE AS add_minutes, CAST('2023-01-01 10:00:00' AS TIMESTAMP) + INTERVAL 30 SECOND AS add_seconds, CAST('2023-01-01 10:00:00.000' AS TIMESTAMP) + INTERVAL 500 MILLISECOND AS add_milliseconds, CAST('2023-01-01 10:00:00.000000' AS TIMESTAMP) + INTERVAL 500 MICROSECOND AS add_microseconds, MAKE_TIMESTAMP_NS(EPOCH_NS(CAST(CAST('2023-01-01 10:00:00.000000000' AS TIMESTAMP) AS TIMESTAMP_NS)) + 100) AS add_nanoseconds, CAST('2020-01-01' AS DATE) + INTERVAL (-100) DAY AS subtract_days, CAST('10:00:00' AS TIME) + INTERVAL 2 HOUR AS add_hours_time, CAST(NULL AS TIMESTAMP) + INTERVAL 5 DAY AS add_null"
┌─────────────────────┬─────────────────────┬─────────────────────┬─────────────────────┬─────────────────────┬───┬──────────────────────┬──────────────────────┬─────────────────────┬────────────────┬───────────┐
│      add_years      │    add_quarters     │     add_months      │      add_weeks      │      add_days       │ … │   add_microseconds   │   add_nanoseconds    │    subtract_days    │ add_hours_time │ add_null  │
│      timestamp      │      timestamp      │      timestamp      │      timestamp      │      timestamp      │   │      timestamp       │     timestamp_ns     │      timestamp      │      time      │ timestamp │
├─────────────────────┼─────────────────────┼─────────────────────┼─────────────────────┼─────────────────────┼───┼──────────────────────┼──────────────────────┼─────────────────────┼────────────────┼───────────┤
│ 2023-01-01 00:00:00 │ 2020-07-01 00:00:00 │ 2020-06-01 00:00:00 │ 2020-01-29 00:00:00 │ 2020-04-10 00:00:00 │ … │ 2023-01-01 10:00:0…  │ 2023-01-01 10:00:0…  │ 2019-09-23 00:00:00 │ 12:00:00       │ NULL      │
├─────────────────────┴─────────────────────┴─────────────────────┴─────────────────────┴─────────────────────┴───┴──────────────────────┴──────────────────────┴─────────────────────┴────────────────┴───────────┤
│ 1 rows                                                                                                                                                                                     14 columns (10 shown) │
```