### PR TITLE
feat(snowflake)!: handle overflow values in DATE_FROM_PARTS for DuckDB

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -77,6 +77,15 @@ def _build_approx_top_k(args: t.List) -> exp.ApproxTopK:
     return exp.ApproxTopK.from_arg_list(args)
 
 
+def _build_date_from_parts(args: t.List) -> exp.DateFromParts:
+    return exp.DateFromParts(
+        year=seq_get(args, 0),
+        month=seq_get(args, 1),
+        day=seq_get(args, 2),
+        allow_overflow=True,
+    )
+
+
 def _build_datetime(
     name: str, kind: exp.DataType.Type, safe: bool = False
 ) -> t.Callable[[t.List], exp.Func]:
@@ -759,6 +768,8 @@ class Snowflake(Dialect):
             "BITMAP_OR_AGG": exp.BitmapOrAgg.from_arg_list,
             "BOOLXOR": _build_bitwise(exp.Xor, "BOOLXOR"),
             "DATE": _build_datetime("DATE", exp.DataType.Type.DATE),
+            "DATEFROMPARTS": _build_date_from_parts,
+            "DATE_FROM_PARTS": _build_date_from_parts,
             "DATE_TRUNC": _date_trunc_to_time,
             "DATEADD": _build_date_time_add(exp.DateAdd),
             "DATEDIFF": _build_datediff,

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6694,7 +6694,7 @@ class TimeTrunc(Func, TimeUnit):
 
 class DateFromParts(Func):
     _sql_names = ["DATE_FROM_PARTS", "DATEFROMPARTS"]
-    arg_types = {"year": True, "month": False, "day": False}
+    arg_types = {"year": True, "month": False, "day": False, "allow_overflow": False}
 
 
 class TimeFromParts(Func):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2195,6 +2195,64 @@ class TestSnowflake(Validator):
         self.validate_identity("LOCALTIMESTAMP()", "CURRENT_TIMESTAMP()")
         self.validate_identity("LOCALTIMESTAMP(3)", "CURRENT_TIMESTAMP(3)")
 
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2026, 1, 100)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2026, 1, 100)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2026, 1, 1) + INTERVAL (1 - 1) MONTH + INTERVAL (100 - 1) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2026, 14, 32)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2026, 14, 32)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2026, 1, 1) + INTERVAL (14 - 1) MONTH + INTERVAL (32 - 1) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2026, 0, 0)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2026, 0, 0)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2026, 1, 1) + INTERVAL (0 - 1) MONTH + INTERVAL (0 - 1) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2026, -14, -32)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2026, -14, -32)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2026, 1, 1) + INTERVAL (-14 - 1) MONTH + INTERVAL (-32 - 1) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2024, 1, 60)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2024, 1, 60)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2024, 1, 1) + INTERVAL (1 - 1) MONTH + INTERVAL (60 - 1) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2026, NULL, 100)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2026, NULL, 100)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2026, 1, 1) + INTERVAL (NULL - 1) MONTH + INTERVAL (100 - 1) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(2024 + 2, 1 + 2, 2 + 3)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(2024 + 2, 1 + 2, 2 + 3)",
+                "duckdb": "SELECT CAST(MAKE_DATE(2024 + 2, 1, 1) + INTERVAL ((1 + 2) - 1) MONTH + INTERVAL ((2 + 3) - 1) DAY AS DATE)",
+            },
+        )
+
+        self.validate_all(
+            "SELECT DATE_FROM_PARTS(year, month, date)",
+            write={
+                "snowflake": "SELECT DATE_FROM_PARTS(year, month, date)",
+                "duckdb": "SELECT CAST(MAKE_DATE(year, 1, 1) + INTERVAL (month - 1) MONTH + INTERVAL (date - 1) DAY AS DATE)",
+            },
+        )
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",


### PR DESCRIPTION
Snowflake [`DATE_FROM_PARTS(year, month, day)`](https://docs.snowflake.com/en/sql-reference/functions/date_from_parts) transpiles to DuckDB [`MAKE_DATE(year, month, day)`](https://duckdb.org/docs/stable/sql/functions/date#make_dateyear-month-day).

Snowflake's `month` and `day` input can be outside the respective `1-12` and `1-31` values, while DuckDB cannot handle these values.
Example:
```
Snowflake: SELECT DATE_FROM_PARTS(2026, 1, 100) AS day_100;
2026-04-10

DuckDB: SELECT MAKE_DATE(2026, 1, 100)
Conversion Error:
Date out of range: 2026-1-100
```

However, DuckDB's [`INTERVAL`](https://duckdb.org/docs/stable/sql/data_types/interval) type can handle/convert out of range values. In the DuckDB generator, we can create a base date, `MAKE_DATE(<year_input>, 1, 1)`, then add the `month` and `year` afterwards (while subtracting by 1 to account for the base date setting them to 1).
```
DuckDB: SELECT CAST(MAKE_DATE(2026, 1, 1) + INTERVAL (1 - 1) MONTH + INTERVAL (100 - 1) DAY AS DATE)
2026-04-10
```