### PR TITLE
Feat(diff)!: ignore comments in the semantic differ

### DIFF
--- a/sqlglot/diff.py
+++ b/sqlglot/diff.py
@@ -181,7 +181,7 @@ class ChangeDistiller:
     def __init__(self, f: float = 0.6, t: float = 0.6, dialect: DialectType = None) -> None:
         self.f = f
         self.t = t
-        self._sql_generator = Dialect.get_or_raise(dialect).generator()
+        self._sql_generator = Dialect.get_or_raise(dialect).generator(comments=False)
 
     def diff(
         self,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -354,5 +354,12 @@ class TestDiff(unittest.TestCase):
 
         self._validate_delta_only(diff_delta_only(expr_src, expr_tgt), [])
 
+    def test_comments_do_not_affect_diff(self):
+        expr_src = parse_one("select a from tbl")
+        expr_tgt = parse_one("select a from tbl -- this is comment")
+
+        self.assertEqual(expr_tgt.args["from_"].this.comments, [" this is comment"])
+        self._validate_delta_only(diff_delta_only(expr_src, expr_tgt), [])
+
     def _validate_delta_only(self, actual_delta, expected_delta):
         self.assertEqual(set(actual_delta), set(expected_delta))


### PR DESCRIPTION
Fixes #6673

The linked issue requested an _option_ to ignore comments, but not sure if it's worth introducing another flag for this.