### PR TITLE
fix(exasol)!: Allow varlen args in exp.MD5Digest

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7566,7 +7566,11 @@ class MD5(Func):
 
 
 # Represents the variant of the MD5 function that returns a binary value
+# Var len args due to Exasol:
+# https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hashtype_md5.htm
 class MD5Digest(Func):
+    arg_types = {"this": True, "expressions": False}
+    is_var_len_args = True
     _sql_names = ["MD5_DIGEST"]
 
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -715,6 +715,8 @@ class TestExasol(Validator):
             "SELECT name, age, IF age < 18 THEN 'underaged' ELSE 'adult' ENDIF AS LEGALITY FROM persons"
         )
 
+        self.validate_identity("SELECT HASHTYPE_MD5(a, b, c, d)")
+
     def test_odbc_date_literals(self):
         self.validate_identity("SELECT {d'2024-01-01'}", "SELECT TO_DATE('2024-01-01')")
         self.validate_identity(


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6683

According to [Exasol docs](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/hashtype_md5.htm?Highlight=hashtype#UsageNotes) `HASHTYPE_MD5` allows var-len arguments to be passed in:

<img width="428" height="105" alt="image" src="https://github.com/user-attachments/assets/1b8cfa1c-8599-41b6-8a3d-a431c770953d" />
