### PR TITLE
fix(spark): Allow exprs besides aggregation functions in PIVOT

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -174,6 +174,12 @@ class Spark(Spark2):
                 return self.expression(exp.ComputedColumnConstraint, this=this.expression)
             return this
 
+        def _parse_pivot_aggregation(self) -> t.Optional[exp.Expression]:
+            # Spark 3+ and Databricks support non aggregate functions in PIVOT too, e.g
+            # PIVOT (..., 'foo' AS bar FOR col_to_pivot IN (...))
+            aggregate_expr = self._parse_function() or self._parse_disjunction()
+            return self._parse_alias(aggregate_expr)
+
     class Generator(Spark2.Generator):
         SUPPORTS_TO_NUMBER = True
         PAD_FILL_PATTERN_IS_REQUIRED = False

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -649,6 +649,17 @@ TBLPROPERTIES (
             },
         )
 
+        self.validate_all(
+            "SELECT * FROM quarterly_sales PIVOT(SUM(amount) AS amount, 'dummy' AS bar FOR quarter IN ('2023_Q1'))",
+            read={
+                "spark": "SELECT * FROM quarterly_sales PIVOT(SUM(amount) amount, 'dummy' bar FOR quarter IN ('2023_Q1'))",
+                "databricks": "SELECT * FROM quarterly_sales PIVOT(SUM(amount) amount, 'dummy' bar FOR quarter IN ('2023_Q1'))",
+            },
+            write={
+                "databricks": "SELECT * FROM quarterly_sales PIVOT(SUM(amount) AS amount, 'dummy' AS bar FOR quarter IN ('2023_Q1'))",
+            },
+        )
+
         for data_type in (
             "BOOLEAN",
             "DATE",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6684

Spark3+ and Databricks allow expressions beyond strictly aggregation functions, e.g:

```SQL
spark-sql (default)> WITH quarterly_sales AS (
                   >   SELECT
                   >     1 AS emp_id,
                   >     10000 AS amount,
                   >     '2023_Q1' AS quarter
                   > )
                   > SELECT
                   >   *
                   > FROM quarterly_sales
                   > PIVOT(SUM(amount) AS amount, 1 = 1 AS bar FOR quarter IN ('2023_Q1'));
emp_id  2023_Q1_amount  2023_Q1_bar
1       10000   true

```

<br />

Spark 2 does not seem to handle PIVOTs and other dialects like DuckDB don't handle expressions other than aggfuncs.