### PR TITLE
fix(doris, starrocks)!: Fix `UPDATE` statement for multi table updates

### DIFF
--- a/sqlglot/dialects/doris.py
+++ b/sqlglot/dialects/doris.py
@@ -178,6 +178,7 @@ class Doris(MySQL):
         VARCHAR_REQUIRES_SIZE = False
         WITH_PROPERTIES_PREFIX = "PROPERTIES"
         RENAME_TABLE_WITH_DB = False
+        UPDATE_STATEMENT_SUPPORTS_FROM = True
 
         TYPE_MAPPING = {
             **MySQL.Generator.TYPE_MAPPING,

--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -126,6 +126,7 @@ class StarRocks(MySQL):
         VARCHAR_REQUIRES_SIZE = False
         PARSE_JSON_NAME: t.Optional[str] = "PARSE_JSON"
         WITH_PROPERTIES_PREFIX = "PROPERTIES"
+        UPDATE_STATEMENT_SUPPORTS_FROM = True
 
         # StarRocks doesn't support "IS TRUE/FALSE" syntax.
         IS_BOOL_ALLOWED = False

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -193,23 +193,8 @@ class TestMySQL(Validator):
         self.validate_identity("ALTER TABLE t ALTER INDEX i VISIBLE")
         self.validate_identity("ALTER TABLE t ALTER COLUMN c SET INVISIBLE")
         self.validate_identity("ALTER TABLE t ALTER COLUMN c SET VISIBLE")
-
-    def test_update_from_to_join(self):
-        # MySQL multi-table UPDATE requires qualified columns in SET to avoid ambiguity
-        self.validate_all(
-            "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a WHERE foo.id = bar.id",
-            read={
-                "postgres": "UPDATE foo SET a = bar.a FROM bar WHERE foo.id = bar.id",
-                "mysql": "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a WHERE foo.id = bar.id",
-            },
-        )
-
-        # Multiple columns in SET clause
-        self.validate_all(
-            "UPDATE t1 JOIN t2 ON TRUE SET t1.id = t2.id, t1.name = t2.name WHERE t1.x = t2.x",
-            read={
-                "postgres": "UPDATE t1 SET id = t2.id, name = t2.name FROM t2 WHERE t1.x = t2.x",
-            },
+        self.validate_identity(
+            "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a WHERE foo.id = bar.id"
         )
 
     def test_identity(self):

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1022,6 +1022,17 @@ FROM json_data, field_ids""",
         width_bucket = self.validate_identity("WIDTH_BUCKET(10, 5, 15, 25)")
         self.assertIsNone(width_bucket.args.get("threshold"))
 
+        self.validate_all(
+            "UPDATE foo SET a = bar.a, b = bar.b FROM bar WHERE foo.id = bar.id",
+            write={
+                "postgres": "UPDATE foo SET a = bar.a, b = bar.b FROM bar WHERE foo.id = bar.id",
+                "doris": "UPDATE foo SET a = bar.a, b = bar.b FROM bar WHERE foo.id = bar.id",
+                "starrocks": "UPDATE foo SET a = bar.a, b = bar.b FROM bar WHERE foo.id = bar.id",
+                "mysql": "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a, foo.b = bar.b WHERE foo.id = bar.id",
+                "singlestore": "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a, foo.b = bar.b WHERE foo.id = bar.id",
+            },
+        )
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(


### PR DESCRIPTION
Follow up of https://github.com/tobymao/sqlglot/pull/6655

This PR fixes the generation of the MySQL-subset dialects Doris & Starrocks as they do support `FROM` clause in their `UPDATE` statement syntax, unlike MySQL & SingleStore.

Docs
----------
[SingleStore](https://docs.singlestore.com/cloud/reference/sql-reference/data-manipulation-language-dml/update/) | [Doris](https://doris.apache.org/docs/3.x/sql-manual/sql-statements/data-modification/DML/UPDATE) | [Starrocks](https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/UPDATE/#multi-table-update)