### PR TITLE
feat(spark,databricks)!: annotate the CURRENT_TIMEZONE

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -6,4 +6,7 @@ from sqlglot.typing.spark2 import EXPRESSION_METADATA
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
+    exp.CurrentTimezone: {
+        "returns": exp.DataType.Type.VARCHAR,
+    },
 }

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -55,7 +55,4 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         )
     },
-    exp.CurrentTimezone: {
-        "returns": exp.DataType.Type.VARCHAR,
-    },
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -335,7 +335,7 @@ BINARY;
 ENCODE(tbl.bin_col, tbl.bin_col);
 BINARY;
 
-# dialect: spark2, spark, databricks
+# dialect: spark, databricks
 CURRENT_TIMEZONE();
 STRING;
 


### PR DESCRIPTION
This PR implements annotation support for `CURRENT_TIMEZONE()` in both the Spark and Databricks dialects.

```python
Select(
  expressions=[
    CurrentTimezone(_type=DataType(this=Type.VARCHAR))],
  _type=DataType(this=Type.UNKNOWN))
```

[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/current_timezone)
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#current_timezone)