### PR TITLE
feat(spark,databricks)!: annotate the LOCALTIMESTAMP

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -14,6 +14,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.dialects.hive import _build_with_ignore_nulls
 from sqlglot.dialects.spark2 import Spark2, temporary_storage_provider, _build_as_cast
+from sqlglot.typing.spark import EXPRESSION_METADATA
 from sqlglot.helper import ensure_list, seq_get
 from sqlglot.tokens import TokenType
 from sqlglot.transforms import (
@@ -112,6 +113,7 @@ def _groupconcat_sql(self: Spark.Generator, expression: exp.GroupConcat) -> str:
 class Spark(Spark2):
     SUPPORTS_ORDER_BY_ALL = True
     SUPPORTS_NULL_TYPE = True
+    EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
 
     class Tokenizer(Spark2.Tokenizer):
         STRING_ESCAPES_ALLOWED_IN_RAW_STRINGS = False

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.typing.spark2 import EXPRESSION_METADATA
+
+EXPRESSION_METADATA = {
+    **EXPRESSION_METADATA,
+    exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
+}

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -55,5 +55,4 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         )
     },
-    exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMP},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -323,9 +323,10 @@ INTERVAL;
 COALESCE(tbl.bin_col, tbl.str_col);
 BINARY;
 
-# dialect: spark2, spark, databricks
+# dialect: spark, databricks
 LOCALTIMESTAMP();
-TIMESTAMP;
+TIMESTAMPNTZ;
+
 # dialect: hive, spark2, spark, databricks
 ENCODE(tbl.str_col, tbl.str_col);
 BINARY;


### PR DESCRIPTION
This PR implements annotation support for `LOCALTIMESTAMP()` in both the Spark and Databricks dialects.

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#localtimestamp)
Databricks:
```bash
localtimestamp()
2026-01-10T10:29:09.768
```