### PR TITLE
feat(spark,databricks)!: annotate the ENCODE function

### DIFF
--- a/sqlglot/dialects/spark2.py
+++ b/sqlglot/dialects/spark2.py
@@ -116,6 +116,7 @@ def temporary_storage_provider(expression: exp.Expression) -> exp.Expression:
 
 class Spark2(Hive):
     ALTER_TABLE_SUPPORTS_CASCADE = False
+    SUPPORTS_NULL_TYPE = True
 
     EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
 

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -42,6 +42,18 @@ def _annotate_by_similar_args(
     return expression
 
 
+def _annotate_encode(self: TypeAnnotator, expression: exp.Encode) -> exp.Encode:
+    charset = expression.args.get("charset")
+    if expression.this.is_type(exp.DataType.Type.NULL) or (
+        charset and charset.is_type(exp.DataType.Type.NULL)
+    ):
+        self._set_type(expression, exp.DataType.Type.NULL)
+    else:
+        self._set_type(expression, exp.DataType.Type.BINARY)
+
+    return expression
+
+
 EXPRESSION_METADATA: ExpressionMetadataType = {
     **HIVE_EXPRESSION_METADATA,
     exp.Substring: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
@@ -55,4 +67,5 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         )
     },
+    exp.Encode: {"annotator": lambda self, e: _annotate_encode(self, e)},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -323,6 +323,18 @@ INTERVAL;
 COALESCE(tbl.bin_col, tbl.str_col);
 BINARY;
 
+# dialect: spark2, spark, databricks
+ENCODE(tbl.str_col, tbl.str_col);
+BINARY;
+ 
+# dialect: spark2, spark, databricks 
+ENCODE(tbl.str_col, NULL);
+NULL;
+
+# dialect: spark2, spark, databricks
+ENCODE(NULL, tbl.str_col);
+NULL;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR implements annotation support for the `ENCODE()` function in both `Spark` and `Databricks` dialects. The function resolves to a `BINARY` type when valid string arguments are provided. Additionally, this update ensures consistent null-safety: if either argument is `NULL`, the result returns `NULL`.

1. If both are valid strings
```sql
SELECT ENCODE('abc', 'utf-8')
```
```python
Select(
  expressions=[
    Encode(
      this=Literal(this='abc', is_string=True, _type=DataType(this=Type.VARCHAR)),
      charset=Literal(this='utf-8', is_string=True, _type=DataType(this=Type.VARCHAR)),
      _type=DataType(this=Type.BINARY))],
  _type=DataType(this=Type.UNKNOWN))
```
-----
2. If one of the args is `NULL`
```sql
SELECT ENCODE('abc', NULL)
```
```python
Select(
  expressions=[
    Encode(
      this=Literal(this='abc', is_string=True, _type=DataType(this=Type.VARCHAR)),
      charset=Null(_type=DataType(this=Type.NULL)),
      _type=DataType(this=Type.NULL))],
  _type=DataType(this=Type.UNKNOWN))
```

[Databricks Documentation](https://docs.databricks.com/aws/en/sql/language-manual/functions/encode)
[Spark Documentation](https://spark.apache.org/docs/latest/api/sql/index.html#encode)