### PR TITLE
fix(postgres): INTERVAL type with GENERATED ALWAYS AS fails to parse

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5604,8 +5604,8 @@ class Parser(metaclass=_Parser):
             elif self._match_text_seq("WITHOUT", "TIME", "ZONE"):
                 maybe_func = False
         elif type_token == TokenType.INTERVAL:
-            unit = self._parse_var(upper=True)
-            if unit:
+            if self._curr and self._curr.text.upper() in self.dialect.VALID_INTERVAL_UNITS:
+                unit = self._parse_var(upper=True)
                 if self._match_text_seq("TO"):
                     unit = exp.IntervalSpan(this=unit, expression=self._parse_var(upper=True))
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1269,6 +1269,9 @@ FROM json_data, field_ids""",
         self.validate_identity("CREATE TABLE tbl (col UUID UNIQUE DEFAULT GEN_RANDOM_UUID())")
         self.validate_identity("CREATE TABLE tbl (col UUID, UNIQUE NULLS NOT DISTINCT (col))")
         self.validate_identity("CREATE TABLE tbl (col_a INT GENERATED ALWAYS AS (1 + 2) STORED)")
+        self.validate_identity(
+            "CREATE TABLE tbl (col_a INTERVAL GENERATED ALWAYS AS (a - b) STORED)"
+        )
 
         self.validate_identity("CREATE INDEX CONCURRENTLY ix_table_id ON tbl USING btree(id)")
         self.validate_identity(


### PR DESCRIPTION
## Summary

When parsing column definitions like `x INTERVAL GENERATED ALWAYS AS (...)`, the parser incorrectly treated `GENERATED` as an interval field qualifier (like `HOUR`, `DAY`). This happened because `_parse_var` greedily consumed any identifier after `INTERVAL` without validating it.

The fix checks if the next token is a valid interval unit (via `dialect.VALID_INTERVAL_UNITS`) before attempting to parse it as such.

## Tests

- Added test case for `INTERVAL GENERATED ALWAYS AS`, verified that this fails to parse without the fix.
- Verified existing tests still pass.
- Ran tests using `make check`

Fixes #6713