### PR TITLE
feat(hive,spark,databricks)!: annotate the UNIX_TIMESTAMP

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -10,4 +10,5 @@ EXPRESSION_METADATA = {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },
     exp.Encode: {"returns": exp.DataType.Type.BINARY},
+    exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
 }

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -55,5 +55,4 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         )
     },
-    exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -339,7 +339,7 @@ BINARY;
 CURRENT_TIMEZONE();
 STRING;
 
-# dialect: spark2, spark, databricks
+# dialect: hive, spark2, spark, databricks
 UNIX_TIMESTAMP();
 BIGINT;
 


### PR DESCRIPTION
This PR implements annotation support for `UNIX_TIMESTAMP()` in Hive, Spark and Databricks dialects. Fixed the broken link

```sql
SELECT UNIX_TIMESTAMP()
```

```python
Select(
  expressions=[
    StrToUnix(
      this=CurrentTimestamp(_type=DataType(this=Type.TIMESTAMP)),
      format=Literal(this='%Y-%m-%d %H:%M:%S', is_string=True, _type=DataType(this=Type.VARCHAR)),
      _type=DataType(this=Type.BIGINT))],
  _type=DataType(this=Type.UNKNOWN))
```

[Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF#:~:text=bigint-,unix_timestamp(),-Gets%20current%20Unix)
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#unix_timestamp)
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/unix_timestamp)