### PR TITLE
chore(optimizer)!: annotate type for snowflake ARRAY_CAT

### DIFF
--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -242,6 +242,7 @@ EXPRESSION_METADATA = {
             exp.Array,
             exp.ArrayAgg,
             exp.ArrayAppend,
+            exp.ArrayConcat,
             exp.ArrayConstructCompact,
             exp.ArrayPrepend,
             exp.ArrayRemove,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -442,6 +442,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT TO_ARRAY(CAST(['test'] AS VARIANT))")
         self.validate_identity("SELECT ARRAY_UNIQUE_AGG(x)")
         self.validate_identity("SELECT ARRAY_APPEND([1, 2, 3], 4)")
+        self.validate_identity("SELECT ARRAY_CAT([1, 2], [3, 4])")
         self.validate_identity("SELECT ARRAY_PREPEND([2, 3, 4], 1)")
         self.validate_identity("SELECT ARRAY_REMOVE([1, 2, 3], 2)")
         self.validate_identity("SELECT AI_AGG(review, 'Summarize the reviews')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1772,6 +1772,10 @@ ARRAY_APPEND([1, 2, 3], 4);
 ARRAY;
 
 # dialect: snowflake
+ARRAY_CAT([1, 2], [3, 4]);
+ARRAY;
+
+# dialect: snowflake
 ARRAY_PREPEND([2, 3, 4], 1);
 ARRAY;
 


### PR DESCRIPTION
## Summary
- Added type annotation for Snowflake's ARRAY_CAT function
- ARRAY_CAT concatenates two arrays and returns an ARRAY type
- Added `exp.ArrayConcat` to the ARRAY return type section in `sqlglot/typing/snowflake.py`

## Test plan
- Added parsing test in `tests/dialects/test_snowflake.py`
- Added type annotation test in `tests/fixtures/optimizer/annotate_functions.sql`
- All tests pass (`make unit` and `make style`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)