### PR TITLE
feat(optimizer)!: bq annotate type for raw strings

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -204,6 +204,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.UnixToStr,
             exp.UnixToTimeStr,
             exp.Upper,
+            exp.RawString,
         }
     },
     **{

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -312,7 +312,6 @@ EXPRESSION_METADATA = {
             exp.SafeConvertBytesToString,
             exp.Soundex,
             exp.Uuid,
-            exp.RawString,
         }
     },
     **{


### PR DESCRIPTION
This PR adds type annotation for bigquery `r'string'` 