### PR TITLE
feat(optimizer)!: bq annotate type for INITCAP

### DIFF
--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -302,6 +302,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.CodePointsToString,
             exp.Format,
+            exp.Initcap,
             exp.JSONExtractScalar,
             exp.JSONType,
             exp.LaxString,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1739,6 +1739,14 @@ STRING;
 r'a';
 STRING;
 
+# dialect: bigquery
+INITCAP('foo');
+STRING;
+
+# dialect: bigquery
+INITCAP('foo', 'f');
+STRING;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for `INITCAP` bq function.

**DOCS**
[BigQuery INITCAP](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#initcap)