### PR TITLE
feat(optimizer)!: Annotate ATAN2 for Spark & DBX 

### DIFF
--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -55,4 +55,5 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT
         )
     },
+    exp.Atan2: {"returns": exp.DataType.Type.DOUBLE},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -343,6 +343,19 @@ STRING;
 UNIX_TIMESTAMP();
 BIGINT;
 
+# dialect: spark2, spark, databricks
+ATAN2(tbl.int_col, tbl.int_col);
+DOUBLE;
+
+# dialect: spark2, spark, databricks
+ATAN2(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: spark2, spark, databricks
+ATAN2(tbl.double_col, tbl.int_col);
+DOUBLE;
+
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR implements annotation support for `ATAN2(col1,col2)` in Spark, Spark2 and Databricks dialects.

SQL:
```sql
SELECT atan2(0, 0);
```

```python
Select(
  expressions=[
    Atan2(
      this=Literal(this=0, is_string=False, _type=DataType(this=Type.INT)),
      expression=Literal(this=0, is_string=False, _type=DataType(this=Type.INT)),
      _type=DataType(this=Type.DOUBLE))],
  _type=DataType(this=Type.UNKNOWN))
```

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#atan2)
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/atan2)

