### PR TITLE
chore(optimizer)!: annotate snowflake ARRAY_COMPACT

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6071,6 +6071,10 @@ class ArrayConcatAgg(AggFunc):
     pass
 
 
+class ArrayCompact(Func):
+    pass
+
+
 class ArrayConstructCompact(Func):
     arg_types = {"expressions": False}
     is_var_len_args = True

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -265,6 +265,7 @@ EXPRESSION_METADATA = {
             exp.Array,
             exp.ArrayAgg,
             exp.ArrayAppend,
+            exp.ArrayCompact,
             exp.ArrayConcat,
             exp.ArrayConstructCompact,
             exp.ArrayPrepend,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -443,6 +443,7 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT ARRAY_UNIQUE_AGG(x)")
         self.validate_identity("SELECT ARRAY_APPEND([1, 2, 3], 4)")
         self.validate_identity("SELECT ARRAY_CAT([1, 2], [3, 4])")
+        self.validate_identity("SELECT ARRAY_COMPACT([1, NULL, 2, NULL, 3])")
         self.validate_identity("SELECT ARRAY_PREPEND([2, 3, 4], 1)")
         self.validate_identity("SELECT ARRAY_REMOVE([1, 2, 3], 2)")
         self.validate_identity("SELECT AI_AGG(review, 'Summarize the reviews')")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1793,6 +1793,10 @@ ARRAY_CONSTRUCT_COMPACT(1, null, 2);
 ARRAY;
 
 # dialect: snowflake
+ARRAY_COMPACT([1, null, 2]);
+ARRAY;
+
+# dialect: snowflake
 ARRAY_APPEND([1, 2, 3], 4);
 ARRAY;
 


### PR DESCRIPTION
This PR adds type annotation support for Snowflake's `ARRAY_COMPACT` function.

## Changes
- Added `ArrayCompact` expression class to `expressions.py`
- Added type annotation for `ARRAY_COMPACT` in `typing/snowflake.py`
- Added test cases in `test_snowflake.py` and `annotate_functions.sql`

## ARRAY_COMPACT Support Across Dialects

| Platform  | Supported | Arguments | Return Type |
| - | - | - | - |
| Snowflake | Yes | `array`: ARRAY (or VARIANT containing array) | ARRAY (same type as input, with NULLs removed) |
| BigQuery | No | N/A | N/A |
| Redshift | No | N/A | N/A |
| PostgreSQL | No | N/A | N/A |
| Databricks | Yes | `array`: ARRAY | ARRAY (same type as input, with NULLs removed) |
| DuckDB | No | N/A | N/A |
| TSQL | No | N/A | N/A |
| Spark | Yes | `array`: ARRAY | ARRAY (same type as input, with NULLs removed) |

**Note**: `ARRAY_COMPACT` removes NULL values from an existing array. This is different from `ARRAY_CONSTRUCT_COMPACT`, which constructs a new array while omitting NULL values during construction.