### PR TITLE
feat(optimizer)!: annotate TO_BINARY function for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -7,4 +7,5 @@ EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     exp.CurrentTimezone: {"returns": exp.DataType.Type.VARCHAR},
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
+    exp.ToBinary: {"returns": exp.DataType.Type.BINARY},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -387,6 +387,17 @@ DOUBLE;
 TANH(tbl.int_col);
 DOUBLE;
 
+# dialect: spark, databricks
+TO_BINARY(tbl.str_col, tbl.str_col);
+BINARY;
+
+# dialect: spark, databricks
+TO_BINARY(tbl.int_col, tbl.str_col);
+BINARY;
+
+# dialect: spark, databricks
+TO_BINARY(tbl.double_col, tbl.str_col);
+BINARY;
 
 --------------------------------------
 -- BigQuery


### PR DESCRIPTION
**Documentation:**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#to_binary)
- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/to_binary)

**Hive:**
```python
SELECT to_binary('abc', 'utf-8')
Hive Version: _c0
4.1.0
---------------------------------
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function to_binary; Query ID: hive_20260114111321_cd4465d9-3e74-4f0f-aba9-cc950a6bd840 (state=42000,code=10011)
```

**Spark2:**
```python
SELECT to_binary('abc', 'utf-8')
Spark Version: 2.4.8
"Undefined function: 'to_binary'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.; line 1 pos 7"
```

**Spark:**
```python
SELECT typeof(to_binary('abc', 'utf-8')), typeof(to_binary(4, 'utf-8')), typeof(to_binary(3.2, 'utf-8')), version()
+-----------------------------+---------------------------+-----------------------------+--------------------+
|typeof(to_binary(abc, utf-8))|typeof(to_binary(4, utf-8))|typeof(to_binary(3.2, utf-8))|           version()|
+-----------------------------+---------------------------+-----------------------------+--------------------+
|                       binary|                     binary|                       binary|3.5.5 7c29c664cdc...|
+-----------------------------+---------------------------+-----------------------------+--------------------+
```

**Databricks:**
```python
SELECT typeof(to_binary('abc', 'utf-8')), typeof(to_binary(4, 'utf-8')), typeof(to_binary(3.2, 'utf-8')), version()
------------------------------------------------------------------------------------------------
typeof(to_binary(abc, utf-8))	typeof(to_binary(4, utf-8))	typeof(to_binary(3.2, utf-8))	version()
binary	binary	binary	4.0.0 0000000000000000000000000000000000000000
```