### PR TITLE
fix(duckdb)!: Preserve identifier name in `STRUCT` for all identifiers

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -367,16 +367,16 @@ def _struct_sql(self: DuckDB.Generator, expression: exp.Struct) -> str:
 
     for i, expr in enumerate(expression.expressions):
         is_property_eq = isinstance(expr, exp.PropertyEQ)
+        this = expr.this
         value = expr.expression if is_property_eq else expr
 
         if is_bq_inline_struct:
             args.append(self.sql(value))
         else:
-            if is_property_eq:
-                if isinstance(expr.this, exp.Identifier):
-                    key = self.sql(exp.Literal.string(expr.name))
-                else:
-                    key = self.sql(expr.this)
+            if isinstance(this, exp.Identifier):
+                key = self.sql(exp.Literal.string(expr.name))
+            elif is_property_eq:
+                key = self.sql(this)
             else:
                 key = self.sql(exp.Literal.string(f"_{i}"))
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -419,7 +419,7 @@ LANGUAGE js AS
             "SELECT STRUCT(1, 2, 3), STRUCT(), STRUCT('abc'), STRUCT(1, t.str_col), STRUCT(1 as a, 'abc' AS b), STRUCT(str_col AS abc)",
             write={
                 "bigquery": "SELECT STRUCT(1, 2, 3), STRUCT(), STRUCT('abc'), STRUCT(1, t.str_col), STRUCT(1 AS a, 'abc' AS b), STRUCT(str_col AS abc)",
-                "duckdb": "SELECT {'_0': 1, '_1': 2, '_2': 3}, {}, {'_0': 'abc'}, {'_0': 1, '_1': t.str_col}, {'a': 1, 'b': 'abc'}, {'abc': str_col}",
+                "duckdb": "SELECT {'_0': 1, '_1': 2, '_2': 3}, {}, {'_0': 'abc'}, {'_0': 1, 'str_col': t.str_col}, {'a': 1, 'b': 'abc'}, {'abc': str_col}",
                 "hive": "SELECT STRUCT(1, 2, 3), STRUCT(), STRUCT('abc'), STRUCT(1, t.str_col), STRUCT(1, 'abc'), STRUCT(str_col)",
                 "spark2": "SELECT STRUCT(1, 2, 3), STRUCT(), STRUCT('abc'), STRUCT(1, t.str_col), STRUCT(1 AS a, 'abc' AS b), STRUCT(str_col AS abc)",
                 "spark": "SELECT STRUCT(1, 2, 3), STRUCT(), STRUCT('abc'), STRUCT(1, t.str_col), STRUCT(1 AS a, 'abc' AS b), STRUCT(str_col AS abc)",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6729

Consider this BQ query:

```SQL
bq> WITH t AS (SELECT 1 AS a), t2 AS (SELECT STRUCT(a) AS col FROM t) SELECT col.a FROM t2;
1
```

<br />

- Transpilation before this PR:
```SQL
D WITH t AS (SELECT 1 AS a), t2 AS (SELECT {'_0': a} AS col FROM t) SELECT col.a FROM t2;
Binder Error:
Could not find key "a" in struct

Candidate Entries: "_0"
```

<br />

- Transpilation after this PR
```SQL
D WITH t AS (SELECT 1 AS a), t2 AS (SELECT {'a': a} AS col FROM t) SELECT col.a FROM t2;
┌───────┐
│   a   │
│ int32 │
├───────┤
│   1   │
└───────┘
```