### PR TITLE
feat(optimizer)!: add annotation for `ACOS` function for Hive and related dialects

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -8,6 +8,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
+            exp.Acos,
             exp.Cosh,
             exp.Sinh,
             exp.Tanh,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -343,6 +343,14 @@ STRING;
 UNIX_TIMESTAMP();
 BIGINT;
 
+# dialect: hive, spark2, spark, databricks
+ACOS(tbl.int_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+ACOS(tbl.double_col);
+DOUBLE;
+
 # dialect: spark2, spark, databricks
 ATAN2(tbl.int_col, tbl.int_col);
 DOUBLE;


### PR DESCRIPTION
This PR support the annotation for `ACOS` function for `Hive`, `Spark`, `DBX`

Documentation:
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/acos)
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#acos)

**Hive:**
```python
Hive Version: _c0
4.1.0
SELECT ACOS(1), typeof(ACOS(1))
+------+---------+--+
| _c0  |   _c1   |
+------+---------+--+
| 0.0  | double  |
+------+---------+--+
```

**Spark2:**
```python
Spark Version: 2.4.8
SELECT ACOS(1)
+-----------------------+
|ACOS(CAST(1 AS DOUBLE))|
+-----------------------+
|                    0.0|
+-----------------------+
```

**Spark:**
```python
SELECT ACOS(1), typeof(ACOS(1))
+-------+---------------+
|ACOS(1)|typeof(ACOS(1))|
+-------+---------------+
|    0.0|         double|
+-------+---------------+
```

**Databricks:**
```python
SELECT ACOS(1), typeof(ACOS(1))
ACOS(1)	typeof(ACOS(1))
0	double
```

**This case just for clearity:**
```python
SELECT acos(2), typeof(acos(2))
+-------+---------------+
|ACOS(2)|typeof(ACOS(2))|
+-------+---------------+
|    NaN|         double|
+-------+---------------+
```