### PR TITLE
feat(optimizer)!: Annotate `ACOSH` function for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -8,4 +8,5 @@ EXPRESSION_METADATA = {
     exp.CurrentTimezone: {"returns": exp.DataType.Type.VARCHAR},
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DataType.Type.BINARY},
+    exp.Acosh: {"returns": exp.DataType.Type.DOUBLE},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -355,6 +355,14 @@ DOUBLE;
 ATAN2(tbl.double_col, tbl.int_col);
 DOUBLE;
 
+# dialect: spark, databricks
+ACOSH(tbl.double_col);
+DOUBLE;
+
+# dialect: spark, databricks
+ACOSH(tbl.int_col);
+DOUBLE;
+
 # dialect: spark2, spark, databricks
 COT(tbl.int_col);
 DOUBLE;


### PR DESCRIPTION
This PR annotate the `ACOSH` for Spark and DBX

Documentation
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#acosh)
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/acosh)

**Hive:**
```python
SELECT acosh(1)
Hive Version: _c0
4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function acosh; Query ID: hive_20260115123357_a9f46b84-dcf0-49a9-9e28-6cc5e073a4a5 (state=42000,code=10011)
```

**Spark2:**
```python
SELECT acosh(1)
Spark Version: 2.4.8
Undefined function: 'acosh'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.; line 1 pos 7
```

**Spark:**
```python
SELECT acosh(0),typeof(acosh(0)),version()
+--------+----------------+--------------------+
|ACOSH(0)|typeof(ACOSH(0))|           version()|
+--------+----------------+--------------------+
|     NaN|          double|3.5.5 7c29c664cdc...|
+--------+----------------+--------------------+
```

**DBX:**
```python
SELECT acosh(0),typeof(acosh(0)),version()
ACOSH(0)	typeof(ACOSH(0))	version()
NaN	double	4.0.0 0000000000000000000000000000000000000000
```
