### PR TITLE
feat(optimizer)!: add `SHA`, `SHA1`, `SHA2` function annotations for Hive

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -14,6 +14,13 @@ EXPRESSION_METADATA = {
             exp.Tanh,
         }
     },
+    **{
+        expr_type: {"returns": exp.DataType.Type.VARCHAR}
+        for expr_type in {
+            exp.SHA,
+            exp.SHA2,
+        }
+    },
     exp.Coalesce: {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -415,6 +415,18 @@ BINARY;
 TO_BINARY(tbl.double_col, tbl.str_col);
 BINARY;
 
+# dialect: hive, spark2, spark, databricks
+SHA(tbl.str_col);
+VARCHAR;
+
+# dialect: hive, spark2, spark, databricks
+SHA1(tbl.str_col);
+VARCHAR;
+
+# dialect: hive, spark2, spark, databricks
+SHA2(tbl.str_col, tbl.int_col);
+VARCHAR;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR add annotation for `SHA`, `SHA1`, `SHA2` function annotations for Hive and related dialects

**Documentation:**
- Spark
   - [SHA](https://spark.apache.org/docs/latest/api/sql/index.html#sha)
   - [SHA1](https://spark.apache.org/docs/latest/api/sql/index.html#sha1)
   - [SHA2](https://spark.apache.org/docs/latest/api/sql/index.html#sha2)
- Databricks
   - [SHA](https://docs.databricks.com/aws/en/sql/language-manual/functions/sha)
   - [SHA1](https://docs.databricks.com/aws/en/sql/language-manual/functions/sha1)
   - [SHA2](https://docs.databricks.com/aws/en/sql/language-manual/functions/sha2)

**Hive:**
```python
SELECT SHA('a'), SHA1('a'), SHA2('a',256), typeof(SHA('a'))
Hive Version: _c0
4.1.0
+-------------------------------------------+-------------------------------------------+-------------------------------------------------------------------+---------+--+
|                    _c0                    |                    _c1                    |                                _c2                                |   _c3   |
+-------------------------------------------+-------------------------------------------+-------------------------------------------------------------------+---------+--+
| 86f7e437faa5a7fce15d1ddcb9eaeaea377667b8  | 86f7e437faa5a7fce15d1ddcb9eaeaea377667b8  | ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb  | string  |
+-------------------------------------------+-------------------------------------------+-------------------------------------------------------------------+---------+--+
```

**Spark2:**
```python
SELECT SHA('a'), SHA1('a'), SHA2('a',256)
Spark Version: 2.4.8
+-----------------------+-----------------------+----------------------------+
|sha1(CAST(a AS BINARY))|sha1(CAST(a AS BINARY))|sha2(CAST(a AS BINARY), 256)|
+-----------------------+-----------------------+----------------------------+
|   86f7e437faa5a7fce...|   86f7e437faa5a7fce...|        ca978112ca1bbdcaf...|
+-----------------------+-----------------------+----------------------------+
```

**Spark:**
```python
SELECT SHA('a'), SHA1('a'), SHA2('a',256), typeof(SHA('a'))
+--------------------+--------------------+--------------------+--------------+
|              sha(a)|             sha1(a)|        sha2(a, 256)|typeof(sha(a))|
+--------------------+--------------------+--------------------+--------------+
|86f7e437faa5a7fce...|86f7e437faa5a7fce...|ca978112ca1bbdcaf...|        string|
+--------------------+--------------------+--------------------+--------------+
```

**DBX:**
```python
SELECT SHA('a'), SHA1('a'), SHA2('a',256), typeof(SHA('a'))
sha(a)	sha1(a)	sha2(a, 256)	typeof(sha(a))
86f7e437faa5a7fce15d1ddcb9eaeaea377667b8	86f7e437faa5a7fce15d1ddcb9eaeaea377667b8	ca978112ca1bbdcafac231b39a23dc4da786eff8147c4e72b9807785afee48bb	string
```