### PR TITLE
feat(optimizer)!: Annotate `RANDN` function for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -49,6 +49,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
         for expr_type in {
             exp.Atan2,
             exp.Cot,
+            exp.Randn,
         }
     },
     exp.Concat: {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -427,6 +427,10 @@ VARCHAR;
 SHA2(tbl.str_col, tbl.int_col);
 VARCHAR;
 
+# dialect: spark2, spark, databricks
+RANDN();
+DOUBLE;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `RANDN` for `Spark` and `DBX`

Documentation:
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#randn)
- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/randn)

**Hive:**
```python
SELECT RANDN()
Hive Version: _c0
4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function RANDN; Query ID: hive_20260115162129_77d9f3d9-3463-4139-b106-71c33676c3f7 (state=42000,code=10011)
```

**Spark2:**
```python
SELECT RANDN()
Spark Version: 2.4.8
+--------------------------+
|randn(3206637487788310311)|
+--------------------------+
|       -1.4410678821918217|
+--------------------------+
```

**Spark:**
```python
SELECT RANDN(), typeof(RANDN()), version()
+-------------------+---------------+--------------------+
|            randn()|typeof(randn())|           version()|
+-------------------+---------------+--------------------+
|-0.3416942000728911|         double|3.5.5 7c29c664cdc...|
+-------------------+---------------+--------------------+
```

**DBX:**
```python
SELECT RANDN(), typeof(RANDN()), version()
randn()	typeof(randn())	version()
-0.06768684792739503	double	4.0.0 0000000000000000000000000000000000000000
```
