### PR TITLE
feat(optimizer)!: Annotate `SPACE` function to Hive

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -205,6 +205,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.UnixToTimeStr,
             exp.Upper,
             exp.RawString,
+            exp.Space,
         }
     },
     **{

--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -19,7 +19,6 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.SHA,
             exp.SHA2,
-            exp.Space,
         }
     },
     exp.Coalesce: {

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -519,7 +519,6 @@ EXPRESSION_METADATA = {
             exp.SHA2,
             exp.Soundex,
             exp.SoundexP123,
-            exp.Space,
             exp.SplitPart,
             exp.Translate,
             exp.TryBase64DecodeString,


### PR DESCRIPTION
This PR annotate `SPACE` function for Hive and its derivates

Documentation:
- [Hive](https://cwiki.apache.org/confluence/display/Hive/LanguageManual+UDF#:~:text=string-,space(int%20n),-Returns%20a%20string)
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#space)
- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/space)

**Hive:**
```python
SELECT space(2), typeof(space(2))
Hive Version: _c0
4.1.0
+------+---------+--+
| _c0  |   _c1   |
+------+---------+--+
|      | string  |
+------+---------+--+
```

**Spark2:**
```python
SELECT space(2)
Spark Version: 2.4.8
+--------+
|space(2)|
+--------+
|        |
+--------+
```

**Spark:**
```python
SELECT space(2), typeof(space(2)), version()
+--------+----------------+--------------------+
|space(2)|typeof(space(2))|           version()|
+--------+----------------+--------------------+
|        |          string|3.5.5 7c29c664cdc...|
+--------+----------------+--------------------+
```

**DBX:**
```python
SELECT space(2), typeof(space(2)), version()
space(2)	typeof(space(2))	version()
  	string	4.0.0 0000000000000000000000000000000000000000
```