### PR TITLE
feat(optimizer)!: Annotate `BIT_LENGTH` for Spark and DBX

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -112,6 +112,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
         expr_type: {"returns": exp.DataType.Type.INT}
         for expr_type in {
             exp.Ascii,
+            exp.BitLength,
             exp.Ceil,
             exp.DatetimeDiff,
             exp.TimestampDiff,

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -63,5 +63,4 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
         )
     },
     exp.Substring: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
-    exp.BitLength: {"returns": exp.DataType.Type.INT},
 }


### PR DESCRIPTION
This PR annotate the `BIT_LENGTH` function for Spark and DBX

**Hive:**
```python
SELECT bit_length('Spark SQL')
Hive Version: _c0
4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function bit_length; Query ID: hive_20260115172052_3992f645-12e3-4c15-92a0-1d19aa9d3504 (state=42000,code=10011)
```

**Spark2:**
```python
SELECT bit_length('Spark SQL')
Spark Version: 2.4.8
+---------------------+
|bit_length(Spark SQL)|
+---------------------+
|                   72|
+---------------------+
```

**Spark:**
```python
SELECT bit_length('Spark SQL'), typeof(bit_length('Spark SQL')), version()
+---------------------+-----------------------------+--------------------+
|bit_length(Spark SQL)|typeof(bit_length(Spark SQL))|           version()|
+---------------------+-----------------------------+--------------------+
|                   72|                          int|3.5.5 7c29c664cdc...|
+---------------------+-----------------------------+--------------------+
```

**DBX:**
```python
SELECT bit_length('Spark SQL'), typeof(bit_length('Spark SQL')), version()
bit_length(Spark SQL)	typeof(bit_length(Spark SQL))	version()
72	int	4.0.0 0000000000000000000000000000000000000000
```
