### PR TITLE
feat(optimizer)!: Annotate `KURTOSIS` function

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -90,6 +90,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.ApproxQuantile,
             exp.Avg,
             exp.Exp,
+            exp.Kurtosis,
             exp.Ln,
             exp.Log,
             exp.Pi,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -131,6 +131,12 @@ BIGINT;
 UNIX_MILLIS(CAST('2008-12-25 15:30:00+00' AS TIMESTAMP));
 BIGINT;
 
+KURTOSIS(tbl.double_col);
+DOUBLE;
+
+KURTOSIS(tbl.int_col);
+DOUBLE;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
This PR annotate `KURTOSIS` function

Documentation:
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#kurtosis)
- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/kurtosis)
- [DuckDB](https://duckdb.org/docs/stable/sql/functions/aggregates#kurtosisx)

**DuckDB:**
```python
duckdb> SELECT typeof(kurtosis(100));
┌───────────────────────┐
│ typeof(kurtosis(100)) │
╞═══════════════════════╡
│ DOUBLE                │
└───────────────────────┘

duckdb> SELECT typeof(kurtosis(1.7));
┌───────────────────────┐
│ typeof(kurtosis(1.7)) │
╞═══════════════════════╡
│ DOUBLE                │
└───────────────────────┘
```

**DBX:**
```python
SELECT typeof(kurtosis(100)),  typeof(kurtosis(1.7));
typeof(kurtosis(100))	typeof(kurtosis(1.7))
double	double
```

**Spark:**
```python
SELECT typeof(kurtosis(100)), typeof(kurtosis(1.7)), version()
+---------------------+---------------------+--------------------+
|typeof(kurtosis(100))|typeof(kurtosis(1.7))|           version()|
+---------------------+---------------------+--------------------+
|               double|               double|3.5.5 7c29c664cdc...|
+---------------------+---------------------+--------------------+
```

**Hive:**
```python
SELECT kurtosis(1.8)
Hive Version: _c0
4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function kurtosis; Query ID: hive_20260115182726_712eafaf-cb56-4c4a-85e3-1cf27a7de492 (state=42000,code=10011)
```
