### PR TITLE
feat(optimizer)!: Annotate SIN, COS, TAN for Hive and inherited dialects

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -9,8 +9,11 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
             exp.Acos,
+            exp.Cos,
             exp.Cosh,
+            exp.Sin,
             exp.Sinh,
+            exp.Tan,
             exp.Tanh,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -445,6 +445,30 @@ DOUBLE;
 BIT_LENGTH(tbl.str_col);
 INT;
 
+# dialect: hive, spark2, spark, databricks
+SIN(tbl.int_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+SIN(tbl.double_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+COS(tbl.int_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+COS(tbl.double_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+TAN(tbl.int_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+TAN(tbl.double_col);
+DOUBLE;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `SIN`, `COS` and `TAN` for Hive and its derivatives

Documentation:
- Spark
  - [Sin](https://spark.apache.org/docs/latest/api/sql/index.html#sin)
  - [Cos](https://spark.apache.org/docs/latest/api/sql/index.html#cos)
  - [Tan](https://spark.apache.org/docs/latest/api/sql/index.html#tan)

- Databricks
  - [Sin](https://docs.databricks.com/aws/en/sql/language-manual/functions/sin)
  - [Cos](https://docs.databricks.com/aws/en/sql/language-manual/functions/cos)
  - [Tan](https://docs.databricks.com/aws/en/sql/language-manual/functions/tan)

**Hive:**
```python
SELECT sin(0), typeof(sin(0)), cos(0), typeof(cos(0)), tan(0), typeof(tan(0)), version()
+------+---------+------+---------+------+---------+--------------------------------------------------+--+
| _c0  |   _c1   | _c2  |   _c3   | _c4  |   _c5   |                       _c6                        |
+------+---------+------+---------+------+---------+--------------------------------------------------+--+
| 0.0  | double  | 1.0  | double  | 0.0  | double  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+------+---------+------+---------+------+---------+--------------------------------------------------+--+
```

**Spark2:**
```python
SELECT sin(0), cos(0), tan(0)
Spark Version: 2.4.8
+----------------------+----------------------+----------------------+
|SIN(CAST(0 AS DOUBLE))|COS(CAST(0 AS DOUBLE))|TAN(CAST(0 AS DOUBLE))|
+----------------------+----------------------+----------------------+
|                   0.0|                   1.0|                   0.0|
+----------------------+----------------------+----------------------+
```

**Spark:**
```python
SELECT sin(0), typeof(sin(0)), cos(0), typeof(cos(0)), tan(0), typeof(tan(0)), version()
+------+--------------+------+--------------+------+--------------+--------------------+
|SIN(0)|typeof(SIN(0))|COS(0)|typeof(COS(0))|TAN(0)|typeof(TAN(0))|           version()|
+------+--------------+------+--------------+------+--------------+--------------------+
|   0.0|        double|   1.0|        double|   0.0|        double|3.5.5 7c29c664cdc...|
+------+--------------+------+--------------+------+--------------+--------------------+
```

**DBX:**
```python
SELECT sin(0), typeof(sin(0)), cos(0), typeof(cos(0)), tan(0), typeof(tan(0)), version()
SIN(0)	typeof(SIN(0))	COS(0)	typeof(COS(0))	TAN(0)	typeof(TAN(0))	version()
0	double	1	double	0	double	4.0.0 0000000000000000000000000000000000000000
```