### PR TITLE
fix(optimizer)!: precise type annotation for SF LENGTH/LEN

### DIFF
--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -555,6 +555,11 @@ EXPRESSION_METADATA = {
             e, exp.DataType.build("NUMBER(19, 0)", dialect="snowflake")
         )
     },
+    exp.Length: {
+        "annotator": lambda self, e: self._set_type(
+            e, exp.DataType.build("NUMBER(18, 0)", dialect="snowflake")
+        )
+    },
     exp.Median: {"annotator": _annotate_median},
     exp.Reverse: {"annotator": _annotate_reverse},
     exp.StrToTime: {"annotator": _annotate_str_to_time},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3049,11 +3049,19 @@ DATE;
 
 # dialect: snowflake
 LEN(tbl.str_col);
-INT;
+NUMBER(18, 0);
 
 # dialect: snowflake
 LEN(tbl.bin_col);
-INT;
+NUMBER(18, 0);
+
+# dialect: snowflake
+LENGTH(tbl.str_col);
+NUMBER(18, 0);
+
+# dialect: snowflake
+LENGTH(tbl.bin_col);
+NUMBER(18, 0);
 
 # dialect: snowflake
 LOCALTIMESTAMP;


### PR DESCRIPTION
Annotate `LENGTH/LEN` of SF with exact precision/scale.

**DOCS**
[SF LENGTH](https://docs.snowflake.com/en/sql-reference/functions/length#returns)