### PR TITLE
feat(bigquery)!: Support type inference for BQ SAFE functions

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -1078,8 +1078,27 @@ class BigQuery(Dialect):
                             exp.NetHost, this=seq_get(this.expression.expressions, 0)
                         )
                 elif prefix_name == "SAFE":
+                    args = this.expression.expressions
                     if func_name == "TIMESTAMP":
-                        this = _build_timestamp(this.expression.expressions)
+                        this = _build_timestamp(args)
+                        this.set("safe", True)
+                    elif func_name == "PARSE_DATE":
+                        this = build_formatted_time(exp.StrToDate, "bigquery")(
+                            [seq_get(args, 1), seq_get(args, 0)]
+                        )
+                        this.set("safe", True)
+                    elif func_name == "PARSE_DATETIME":
+                        this = build_formatted_time(exp.ParseDatetime, "bigquery")(
+                            [seq_get(args, 1), seq_get(args, 0)]
+                        )
+                        this.set("safe", True)
+                    elif func_name == "PARSE_TIME":
+                        this = build_formatted_time(exp.ParseTime, "bigquery")(
+                            [seq_get(args, 1), seq_get(args, 0)]
+                        )
+                        this.set("safe", True)
+                    elif func_name == "PARSE_TIMESTAMP":
+                        this = _build_parse_timestamp(args)
                         this.set("safe", True)
 
             return this

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -7418,11 +7418,11 @@ class ParseIp(Func):
 
 
 class ParseTime(Func):
-    arg_types = {"this": True, "format": True}
+    arg_types = {"this": True, "format": True, "safe": False}
 
 
 class ParseDatetime(Func):
-    arg_types = {"this": True, "format": False, "zone": False}
+    arg_types = {"this": True, "format": False, "zone": False, "safe": False}
 
 
 class Least(Func):

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -239,6 +239,12 @@ EXPRESSION_METADATA = {
         }
     },
     **{
+        expr_type: {"returns": exp.DataType.Type.DATE}
+        for expr_type in {
+            exp.StrToDate,
+        }
+    },
+    **{
         expr_type: {"returns": exp.DataType.Type.DATETIME}
         for expr_type in {
             exp.ParseDatetime,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -517,6 +517,30 @@ TIMESTAMP(tbl.str_col);
 TIMESTAMPTZ;
 
 # dialect: bigquery
+SAFE.PARSE_DATE('%Y-%m-%d', '2024-01-15');
+DATE;
+
+# dialect: bigquery
+PARSE_DATE('%Y-%m-%d', '2024-01-15');
+DATE;
+
+# dialect: bigquery
+SAFE.PARSE_DATETIME('%Y-%m-%d %H:%M:%S', '2024-01-15 10:30:00');
+DATETIME;
+
+# dialect: bigquery
+SAFE.PARSE_TIME('%H:%M:%S', '10:30:00');
+TIME;
+
+# dialect: bigquery
+SAFE.PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S', '2024-01-15 10:30:00');
+TIMESTAMPTZ;
+
+# dialect: bigquery
+PARSE_TIMESTAMP('%Y-%m-%d %H:%M:%S', '2024-01-15 10:30:00');
+TIMESTAMPTZ;
+
+# dialect: bigquery
 CONCAT(tbl.str_col, tbl.str_col);
 STRING;
 


### PR DESCRIPTION
Problem: Optimizer sometimes fails because type inference for safe date/time functions are returning unknown

Solution: Add support for BQ safe date/time functions 

Testing: Added unit tests, manually verified:
`optimize("select safe.parse_date('%m/%d/%Y', '01/15/2024')", dialect="bigquery").selects[0].type`