### PR TITLE
fix(optimizer)!: Annotate `CORR` for Hive and inherited dialects

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -9,6 +9,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
             exp.Acos,
+            exp.Corr,
             exp.Cos,
             exp.Cosh,
             exp.Sin,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -475,6 +475,14 @@ DOUBLE;
 TAN(tbl.double_col);
 DOUBLE;
 
+# dialect: hive, spark2, spark, databricks
+CORR(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+CORR(tbl.int_col, tbl.int_col);
+DOUBLE;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR fix the issue related to Annotation of `Corr` function

**Problem:**
```sql
SELECT corr(0,1);
```
```python
Select(
  expressions=[
    Corr(
      this=Literal(this=10, is_string=False, _type=DataType(this=Type.INT)),
      expression=Literal(this=2, is_string=False, _type=DataType(this=Type.INT)),
      _type=DataType(this=Type.INT))],
  _type=DataType(this=Type.UNKNOWN))
```

**Explanation:** `Corr` defaults to INT because it inherits from Binary expression. In sqlglot, binary expressions without an explicit return type annotation use _annotate_by_args, which propagates the input types to the output. Since we passed two integers (10, 1), the type inference engine assumed the result was also an integer.

```python
class Corr(Binary, AggFunc):
    # Correlation divides by variance(column). If a column has 0 variance, the denominator
    # is 0 - some dialects return NaN (DuckDB) while others return NULL (Snowflake).
    # `null_on_zero_variance` is set to True at parse time for dialects that return NULL.
    arg_types = {"this": True, "expression": True, "null_on_zero_variance": False}
```

**sqlglot/typing/__init__.py**
```python
EXPRESSION_METADATA: ExpressionMetadataType = {
    **{
        expr_type: {"annotator": lambda self, e: self._annotate_binary(e)}
        for expr_type in subclasses(exp.__name__, exp.Binary)
    },
```

--------
**Spark:**
```python
SELECT typeof(corr(c1, c2)), version() FROM VALUES (3, 2), (3, 3), (6, 4) as tab(c1, c2)
+--------------------+--------------------+
|typeof(corr(c1, c2))|           version()|
+--------------------+--------------------+
|              double|3.5.5 7c29c664cdc...|
+--------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(corr(c1, c2)), version() FROM VALUES (3, 2), (3, 3), (6, 4) as tab(c1, c2)
|typeof(corr(c1, c2))|version()|
|---|---|
|double|4.0.0 0000000000000000000000000000000000000000|
```

**Hive:**
```python
SELECT corr(0,1), typeof(corr(0,1))
Hive Version: _c0
4.1.0
+-------+---------+--+
|  _c0  |   _c1   |
+-------+---------+--+
| NULL  | double  |
+-------+---------+--+
```

**Documentation:**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#corr) Since: 1.6.0
- [Databricks](https://docs.databricks.com/gcp/en/sql/language-manual/functions/corr)