### PR TITLE
feat(optimizer)!: Annotate `CBRT` for Hive and inherited dialects

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -10,6 +10,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.Acos,
             exp.Atan,
+            exp.Cbrt,
             exp.Corr,
             exp.Cos,
             exp.Cosh,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -507,6 +507,14 @@ DOUBLE;
 CORR(tbl.int_col, tbl.int_col);
 DOUBLE;
 
+# dialect: hive, spark2, spark, databricks
+CBRT(tbl.double_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+CBRT(tbl.int_col);
+DOUBLE;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `CBRT` function for `Hive` and its inherited dialects

**Documentation:**
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#cbrt)
[Databricks](https://docs.databricks.com/gcp/en/sql/language-manual/functions/cbrt)

**Hive:**
```python
SELECT typeof(CBRT(1)), typeof(CBRT(1.3))
Hive Version: _c0
4.1.0
+---------+---------+--+
|   _c0   |   _c1   |
+---------+---------+--+
| double  | double  |
+---------+---------+--+
```

**Spark:**
```python
SELECT typeof(CBRT(1)), typeof(CBRT(1.3))
+---------------+-----------------+
|typeof(CBRT(1))|typeof(CBRT(1.3))|
+---------------+-----------------+
|         double|           double|
+---------------+-----------------+
```