### PR TITLE
feat(optimizer)!: Annotate `CURRENT_CATALOG()` for Hive, Spark, and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -26,4 +26,5 @@ EXPRESSION_METADATA = {
     exp.Encode: {"returns": exp.DataType.Type.BINARY},
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
     exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
+    exp.CurrentCatalog: {"returns": exp.DataType.Type.VARCHAR},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -515,6 +515,10 @@ DOUBLE;
 CBRT(tbl.int_col);
 DOUBLE;
 
+# dialect: hive, spark2, spark, databricks
+CURRENT_CATALOG();
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `CURRENT_CATALOG()` function for Hive, Spark and DBX

**Documentation:**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#current_catalog)
- [Databricks](https://docs.databricks.com/gcp/en/sql/language-manual/functions/current_catalog)

**Hive:**
```python
SELECT typeof(CURRENT_CATALOG()), version()
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| string  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```

**Spark2:**
```python
SELECT CURRENT_CATALOG()
Spark Version: 2.4.8
Undefined function: 'CURRENT_CATALOG'. This function is neither a registered temporary function nor a permanent function registered in the database 'default'.; line 1 pos 7
```

**Spark:**
```python
SELECT typeof(CURRENT_CATALOG()), version()
+-------------------------+--------------------+
|typeof(current_catalog())|           version()|
+-------------------------+--------------------+
|                   string|3.5.5 7c29c664cdc...|
+-------------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(CURRENT_CATALOG()), version()
typeof(current_catalog())	version()
string	4.0.0 0000000000000000000000000000000000000000
```

@georgesittas Hive, Spark3, DBX support this but not spark2 (support Since: 3.1.0), how we can handle this? we have to support individually or this is fine?