### PR TITLE
feat(optimizer)!: Annotate `CURRENT_DATABASE()` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -20,11 +20,17 @@ EXPRESSION_METADATA = {
             exp.Tanh,
         }
     },
+    **{
+        expr_type: {"returns": exp.DataType.Type.VARCHAR}
+        for expr_type in {
+            exp.CurrentCatalog,
+            exp.CurrentDatabase,
+        }
+    },
     exp.Coalesce: {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },
     exp.Encode: {"returns": exp.DataType.Type.BINARY},
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
     exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
-    exp.CurrentCatalog: {"returns": exp.DataType.Type.VARCHAR},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -519,6 +519,10 @@ DOUBLE;
 CURRENT_CATALOG();
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+CURRENT_DATABASE();
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `CURRENT_DATABASE()` for Hive, Spark, and DBX

**Documentations:**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#current_database)
- [Databricks](https://docs.databricks.com/gcp/en/sql/language-manual/functions/current_database)

**Hive:**
```python
SELECT typeof(CURRENT_DATABASE()), version()
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| string  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```

**Spark:**
```python
SELECT typeof(CURRENT_DATABASE()), version()
+--------------------------+--------------------+
|typeof(current_database())|           version()|
+--------------------------+--------------------+
|                    string|3.5.5 7c29c664cdc...|
+--------------------------+--------------------+
```

**Databricks:**
```python
SELECT typeof(CURRENT_DATABASE()), version()
|typeof(current_schema())|version()|
|---|---|
|string|4.0.0 0000000000000000000000000000000000000000|
```