### PR TITLE
feat(optimizer)!: Annotate `CURRENT_SCHEMA()` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -25,6 +25,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.CurrentCatalog,
             exp.CurrentDatabase,
+            exp.CurrentSchema,
         }
     },
     exp.Coalesce: {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -523,6 +523,10 @@ STRING;
 CURRENT_DATABASE();
 STRING;
 
+# dialect: hive, spark, databricks
+CURRENT_SCHEMA();
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `CURRENT_SCHEMA()` for Hive, Spark and DBX

**Documentations:**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#current_schema) **Since:** 3.4.0
- [DBX](https://docs.databricks.com/gcp/en/sql/language-manual/functions/current_schema)

**Hive:**
```python
SELECT typeof(current_schema()), version()
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| string  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```