### PR TITLE
feat(optimizer)!: Annotate `DATE_FROM_UNIX_DATE(tbl.int_col)` for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -16,4 +16,5 @@ EXPRESSION_METADATA = {
     exp.CurrentTimezone: {"returns": exp.DataType.Type.VARCHAR},
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DataType.Type.BINARY},
+    exp.DateFromUnixDate: {"returns": exp.DataType.Type.DATE},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -523,6 +523,10 @@ STRING;
 CURRENT_DATABASE();
 STRING;
 
+# dialect: spark, databricks
+DATE_FROM_UNIX_DATE(tbl.int_col);
+DATE;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `DATE_FROM_UNIX_DATE(tbl.int_col)` for Spark and DBX

**Documentations:**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#date_from_unix_date) **Since:** 3.1.0
- [DBX](https://docs.databricks.com/gcp/en/sql/language-manual/functions/date_from_unix_date)

**Hive:**
```python
SELECT date_from_unix_date(1)
Hive Version: _c0
4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function date_from_unix_date; Query ID: hive_20260117044103_ad85ecc9-9b11-4394-a636-b28d8753fb88 (state=42000,code=10011)
```

**Spark:**
```python
SELECT typeof(date_from_unix_date(1)), version()
+------------------------------+--------------------+
|typeof(date_from_unix_date(1))|           version()|
+------------------------------+--------------------+
|                          date|3.5.5 7c29c664cdc...|
+------------------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(date_from_unix_date(1)), version()
|typeof(date_from_unix_date(1))|version()|
|---|---|
|date|4.0.0 0000000000000000000000000000000000000000|
```