### PR TITLE
feat(optimizer)!: Annotate `MONTHNAME` for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -16,4 +16,5 @@ EXPRESSION_METADATA = {
     exp.CurrentTimezone: {"returns": exp.DataType.Type.VARCHAR},
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DataType.Type.BINARY},
+    exp.Monthname: {"returns": exp.DataType.Type.VARCHAR},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -523,6 +523,10 @@ STRING;
 CURRENT_DATABASE();
 STRING;
 
+# dialect: spark, databricks
+MONTHNAME(tbl.date_col);
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `MONTHNAME` for Spark and DBX

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#monthname) **Since**: 4.0.0

**Hive:**
```python
Hive Version: _c0
4.1.0
SELECT MONTHNAME('2008-02-20'), version()
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function MONTHNAME; Query ID: hive_20260117052318_dbf40196-69ce-4c22-9d30-451295ffd3dc (state=42000,code=10011)
```

**DBX:**
```python
SELECT typeof(MONTHNAME('2008-02-20')), version()
|typeof(monthname(2008-02-20))|version()|
|---|---|
|string|4.0.0 0000000000000000000000000000000000000000|
```