### PR TITLE
fix(optimizer)!: Annotate `MONTH` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -33,4 +33,5 @@ EXPRESSION_METADATA = {
     exp.Encode: {"returns": exp.DataType.Type.BINARY},
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
     exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
+    exp.Month: {"returns": exp.DataType.Type.INT},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -523,6 +523,10 @@ STRING;
 CURRENT_DATABASE();
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+MONTH(tbl.date_col);
+INT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR fix the issue with `MONTH` initially annotated as `TINYINT` due to base, Hive, Spark, DBX returns `INT`

- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/month)
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#month)

**Hive:**
```python
SELECT typeof(month('2016-07-30')), version()
+------+--------------------------------------------------+--+
| _c0  |                       _c1                        |
+------+--------------------------------------------------+--+
| int  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+------+--------------------------------------------------+--+
```

**Spark:**
```python
SELECT typeof(month('2016-07-30')), version()
+-------------------------+--------------------+
|typeof(month(2016-07-30))|           version()|
+-------------------------+--------------------+
|                      int|3.5.5 7c29c664cdc...|
+-------------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(month('2016-07-30')), version()
|typeof(month(2016-07-30))|version()|
|---|---|
|int|4.0.0 0000000000000000000000000000000000000000|
```