### PR TITLE
feat(optimizer)!: Annotate `MONTHS_BETWEEN` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -14,6 +14,7 @@ EXPRESSION_METADATA = {
             exp.Corr,
             exp.Cos,
             exp.Cosh,
+            exp.MonthsBetween,
             exp.Sin,
             exp.Sinh,
             exp.Tan,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -523,6 +523,14 @@ STRING;
 CURRENT_DATABASE();
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+MONTHS_BETWEEN(tbl.timestamp_col, tbl.timestamp_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+MONTHS_BETWEEN(tbl.timestamp_col, tbl.timestamp_col, tbl.bool_col);
+DOUBLE;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `MONTHS_BETWEEN` for Hive, Spark and DBX

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#months_between) **Since: 1.5.0**
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/months_between)

**Hive:**
```python
SELECT typeof(months_between('1997-02-28 10:30:00', '1996-10-30'))
Hive Version: _c0
4.1.0
+---------+--+
|   _c0   |
+---------+--+
| double  |
+---------+--+
```

**Spark2:**
```python
SELECT months_between('1997-02-28 10:30:00', '1996-10-30')
Spark Version: 2.4.8
+-------------------------------------------------------------------------------------------+
|months_between(CAST(1997-02-28 10:30:00 AS TIMESTAMP), CAST(1996-10-30 AS TIMESTAMP), true)|
+-------------------------------------------------------------------------------------------+
|                                                                                 3.94959677|
+-------------------------------------------------------------------------------------------+
```

**Spark:**
```python
SELECT typeof(months_between('1997-02-28 10:30:00', '1996-10-30')), version()
+-------------------------------------------------------------+--------------------+
|typeof(months_between(1997-02-28 10:30:00, 1996-10-30, true))|           version()|
+-------------------------------------------------------------+--------------------+
|                                                       double|3.5.5 7c29c664cdc...|
+-------------------------------------------------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(months_between('1997-02-28 10:30:00', '1996-10-30')), version()
|typeof(months_between(1997-02-28 10:30:00, 1996-10-30, true))|version()|
|---|---|
|double|4.0.0 0000000000000000000000000000000000000000|
```