### PR TITLE
fix(parser)!: add support for GROUPING_ID() for Spark/DBX

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5843,7 +5843,7 @@ class Grouping(AggFunc):
 
 
 class GroupingId(AggFunc):
-    arg_types = {"expressions": True}
+    arg_types = {"expressions": False}
     is_var_len_args = True
 
 

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -242,6 +242,7 @@ class TestDatabricks(Validator):
         self.validate_identity("CURDATE()", "CURRENT_DATE")
         self.validate_identity("CURDATE", "CURRENT_DATE")
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
+        self.validate_identity("SELECT name, GROUPING_ID() FROM customer GROUP BY ROLLUP (name)")
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -940,6 +940,7 @@ TBLPROPERTIES (
         self.validate_identity("BITMAP_OR_AGG(x)")
         self.validate_identity("SELECT ELT(2, 'foo', 'bar', 'baz') AS Result")
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
+        self.validate_identity("SELECT name, GROUPING_ID() FROM customer GROUP BY ROLLUP (name)")
 
     def test_bool_or(self):
         self.validate_all(


### PR DESCRIPTION
fixes: #6784 