### PR TITLE
feat(optimizer)!: Annotate `UNHEX` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -6,6 +6,13 @@ from sqlglot.typing import EXPRESSION_METADATA
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
+        expr_type: {"returns": exp.DataType.Type.BINARY}
+        for expr_type in {
+            exp.Encode,
+            exp.Unhex,
+        }
+    },
+    **{
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
             exp.Acos,
@@ -33,7 +40,6 @@ EXPRESSION_METADATA = {
     exp.Coalesce: {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },
-    exp.Encode: {"returns": exp.DataType.Type.BINARY},
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
     exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
     exp.Month: {"returns": exp.DataType.Type.INT},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -551,6 +551,10 @@ STRING;
 CURRENT_USER();
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+UNHEX(tbl.str_col);
+BINARY;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `UNHEX` for **Hive**, **Spark** and **DBX**

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#unhex) **Since:** 1.5.0
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/unhex)

**Hive:**
```python
SELECT typeof(unhex('537061726B2053514C')), version()
Hive Version: _c0
4.1.0
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| binary  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```

**Spark:**
```python
SELECT typeof(unhex('537061726B2053514C')), version()
+---------------------------------+--------------------+
|typeof(unhex(537061726B2053514C))|           version()|
+---------------------------------+--------------------+
|                           binary|3.5.5 7c29c664cdc...|
+---------------------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(unhex('537061726B2053514C')), version()
|typeof(unhex(537061726B2053514C))|version()|
|---|---|
|binary|4.0.0 0000000000000000000000000000000000000000|
```