### PR TITLE
feat(optimizer)!: Annotate `ASIN` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -15,6 +15,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
+            exp.Asin,
             exp.Acos,
             exp.Atan,
             exp.Cbrt,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -452,6 +452,14 @@ BIT_LENGTH(tbl.str_col);
 INT;
 
 # dialect: hive, spark2, spark, databricks
+ASIN(tbl.int_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
+ASIN(tbl.double_col);
+DOUBLE;
+
+# dialect: hive, spark2, spark, databricks
 SIN(tbl.int_col);
 DOUBLE;
 


### PR DESCRIPTION
This PR annotate `ASIN` for **Hive**, **Spark** and **DBX**

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#asin) **Since: 1.4.0**
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/asin)

**Hive:**
```python
select typeof(asin(0)), version()
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| double  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```