### PR TITLE
feat(optimizer)!: Annotate `ASINH` for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -9,6 +9,7 @@ EXPRESSION_METADATA = {
         exp_type: {"returns": exp.DataType.Type.DOUBLE}
         for exp_type in {
             exp.Acosh,
+            exp.Asinh,
             exp.Atanh,
             exp.Sec,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -467,6 +467,14 @@ DOUBLE;
 COS(tbl.double_col);
 DOUBLE;
 
+# dialect: spark, databricks
+ASINH(tbl.int_col);
+DOUBLE;
+
+# dialect: spark, databricks
+ASINH(tbl.double_col);
+DOUBLE;
+
 # dialect: hive, spark2, spark, databricks
 ATAN(tbl.int_col);
 DOUBLE;


### PR DESCRIPTION
This PR annotate `ASINH` for **Spark** and **DBX**

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#asinh) **Since: 3.0.0**
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/asinh)

**Spark:**
```python
SELECT typeof(asinh(0)), version()
+----------------+--------------------+
|typeof(ASINH(0))|           version()|
+----------------+--------------------+
|          double|3.5.5 7c29c664cdc...|
+----------------+--------------------+
```

**DBX:**
```python
SELECT typeof(asinh(0)), version()
|typeof(ASINH(0))|version()|
|---|---|
|double|4.0.0 0000000000000000000000000000000000000000|
```

**Hive:**
```python
SELECT asinh(0), version()
Hive Version: _c0
4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function asinh; Query ID: hive_20260120024838_2a2c051a-fb49-475a-88f1-54291ff5961a (state=42000,code=10011)
```