### PR TITLE
feat(optimizer)!: Annotate `DAYNAME` for Base Dialect

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -190,6 +190,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.Concat,
             exp.ConcatWs,
             exp.Chr,
+            exp.Dayname,
             exp.DateToDateStr,
             exp.DPipe,
             exp.GroupConcat,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -143,6 +143,9 @@ INT;
 LENGTH(tbl.bin_col);
 INT;
 
+DAYNAME(tbl.date_col);
+VARCHAR;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
This PR annotate `DAYNAME` for Base Dialect

**Documentations:**
- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/dayname)
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#dayname)
- [DuckDB](https://duckdb.org/docs/stable/sql/functions/date#daynamedate)
- [Snowflake](https://docs.snowflake.com/en/sql-reference/functions/dayname)
- [Oracle](https://docs.oracle.com/cd/E57340_01/DR/DayName.html)