### PR TITLE
feat(optimizer)!: Annotate `HEX` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -35,6 +35,7 @@ EXPRESSION_METADATA = {
             exp.CurrentDatabase,
             exp.CurrentSchema,
             exp.CurrentUser,
+            exp.Hex,
         }
     },
     exp.Coalesce: {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -580,6 +580,10 @@ STRING;
 UNHEX(tbl.str_col);
 BINARY;
 
+# dialect: hive, spark2, spark, databricks
+HEX(tbl.str_col);
+VARCHAR;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
**Documentations**
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#hex)
- [Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/hex)

**Hive:**
```python
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| string  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```