### PR TITLE
fix(merge_subqueries): Do not replace literals in GROUP BY

### DIFF
--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -539,3 +539,7 @@ INNER JOIN (
 ) AS t3
   ON t0.id = t3.id;
 WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t3.cid AS cid FROM t0 AS t0 INNER JOIN (SELECT t1.id AS id, t2.cid AS cid FROM t1 AS t1 RIGHT JOIN t2 AS t2 ON t1.cid = t2.cid) AS t3 ON t0.id = t3.id;
+
+# title: Dont replace GROUP and ORDER BY if expression is literal
+WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a;
+WITH t1 AS (SELECT 1 AS col) SELECT 6 AS a, SUM(t1.col) AS b FROM t1 AS t1 GROUP BY a ORDER BY a;


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6823

The `merge_subqueries` rule intends to optimize a derived table away by replacing its column references in the outer scope by the underlying expression from the inner one, e.g:

```Python3
>>> import sqlglot
>>> from sqlglot.optimizer.qualify import qualify
>>> from sqlglot.optimizer.merge_subqueries import merge_subqueries
>>> sql = "WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a"
>>> optimized = merge_subqueries(qualify(sqlglot.parse_one(sql)))
>>> print(optimized.sql())
WITH "t1" AS (SELECT 1 AS "col") SELECT 6 AS "a", SUM("t1"."col") AS "b" FROM "t1" AS "t1" GROUP BY 6 ORDER BY "a"
```

<br />


However, this is not correct for the references in `GROUP BY` & `ORDER BY` as an integer literal in that context denotes column position and not an actual value, e.g:

```SQL
# Original
duckdb> WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a;
┌───────┬────────┐
│   a   │   b    │
│ int32 │ int128 │
├───────┼────────┤
│   6   │   1    │
└───────┴────────┘


# Optimized
D WITH "t1" AS (SELECT 1 AS "col") SELECT 6 AS "a", SUM("t1"."col") AS "b" FROM "t1" AS "t1" GROUP BY 6 ORDER BY "a";
Binder Error:
GROUP BY term out of range - should be between 1 and 2
```


<br />

PS: I remember this bug has been fixed before such as in [this commit](https://github.com/tobymao/sqlglot/commit/20bb11c7bed2ea8987b468d00facef18e9d510b7#diff-48483497c37809125bd2c0c4824971b36b83e4f81ed8ee8e6d589923f17282a3), I'm not sure if we can somehow generalize it across the optimizer