### PR TITLE
feat(optimizer)!: Annotate `SESSION_USER()` for Spark and DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -14,9 +14,15 @@ EXPRESSION_METADATA = {
             exp.Sec,
         }
     },
-    exp.CurrentTimezone: {"returns": exp.DataType.Type.VARCHAR},
+    **{
+        exp_type: {"returns": exp.DataType.Type.VARCHAR}
+        for exp_type in {
+            exp.CurrentTimezone,
+            exp.Monthname,
+            exp.SessionUser,
+        }
+    },
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DataType.Type.BINARY},
     exp.DateFromUnixDate: {"returns": exp.DataType.Type.DATE},
-    exp.Monthname: {"returns": exp.DataType.Type.VARCHAR},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -592,6 +592,10 @@ STRING;
 SOUNDEX(tbl.str_col);
 STRING;
 
+# dialect: spark, databricks
+SESSION_USER();
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#session_user) = **Since: 4.0.0**
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/session_user)

**Databricks:**
```python
select typeof(session_user()), version()
|typeof(session_user())|version()|
|---|---|
|string|4.0.0 0000000000000000000000000000000000000000|
```