### PR TITLE
feat(optimizer)!: Annotate `FACTORIAL(expr)` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -39,10 +39,16 @@ EXPRESSION_METADATA = {
             exp.Soundex,
         }
     },
+    **{
+        expr_type: {"returns": exp.DataType.Type.BIGINT}
+        for expr_type in {
+            exp.StrToUnix,
+            exp.Factorial,
+        }
+    },
     exp.Coalesce: {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
-    exp.StrToUnix: {"returns": exp.DataType.Type.BIGINT},
     exp.Month: {"returns": exp.DataType.Type.INT},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -596,6 +596,10 @@ STRING;
 SESSION_USER();
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+FACTORIAL(tbl.int_col);
+BIGINT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#factorial)
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/factorial)

**Spark:**
```python
SELECT typeof(factorial(21)), version()
+---------------------+--------------------+
|typeof(factorial(21))|           version()|
+---------------------+--------------------+
|               bigint|3.5.5 7c29c664cdc...|
+---------------------+--------------------+
```

**Hive:**
```python
SELECT typeof(factorial(5)), version()
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| bigint  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```