### PR TITLE
feat(snowflake)!: Transpilation of BASE64_DECODE_STRING and BASE64_DECODE_BINARY from Snowflake to DuckDB

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2595,24 +2595,24 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
-            "SELECT BASE64_DECODE_STRING('test', '-_+')",
+            "SELECT BASE64_DECODE_STRING('U25vd2ZsYWtl', '-_+')",
             write={
-                "snowflake": "SELECT BASE64_DECODE_STRING('test', '-_+')",
-                "duckdb": "SELECT DECODE(FROM_BASE64(REPLACE(REPLACE(REPLACE('test', '-', '+'), '_', '/'), '+', '=')))",
+                "snowflake": "SELECT BASE64_DECODE_STRING('U25vd2ZsYWtl', '-_+')",
+                "duckdb": "SELECT DECODE(FROM_BASE64(REPLACE(REPLACE(REPLACE('U25vd2ZsYWtl', '-', '+'), '_', '/'), '+', '=')))",
             },
         )
         self.validate_all(
-            "SELECT BASE64_DECODE_BINARY('U25vd2ZsYWtl')",
+            "SELECT BASE64_DECODE_BINARY(x)",
             write={
-                "snowflake": "SELECT BASE64_DECODE_BINARY('U25vd2ZsYWtl')",
-                "duckdb": "SELECT FROM_BASE64('U25vd2ZsYWtl')",
+                "snowflake": "SELECT BASE64_DECODE_BINARY(x)",
+                "duckdb": "SELECT FROM_BASE64(x)",
             },
         )
         self.validate_all(
-            "SELECT BASE64_DECODE_BINARY('test', '-_+')",
+            "SELECT BASE64_DECODE_BINARY(x, '-_+')",
             write={
-                "snowflake": "SELECT BASE64_DECODE_BINARY('test', '-_+')",
-                "duckdb": "SELECT FROM_BASE64(REPLACE(REPLACE(REPLACE('test', '-', '+'), '_', '/'), '+', '='))",
+                "snowflake": "SELECT BASE64_DECODE_BINARY(x, '-_+')",
+                "duckdb": "SELECT FROM_BASE64(REPLACE(REPLACE(REPLACE(x, '-', '+'), '_', '/'), '+', '='))",
             },
         )
 


### PR DESCRIPTION
This transpiles Snowflake [BASE64_DECODE_STRING](https://docs.snowflake.com/en/sql-reference/functions/base64_decode_string) and [BASE64_DECODE_BINARY](https://docs.snowflake.com/en/sql-reference/functions/base64_decode_binary) to DuckDB with support custom alphabet via chained `REPLACE()` calls.

| Snowflake | DuckDB |
|-----------|--------|
| `BASE64_DECODE_STRING('...')` | `DECODE(FROM_BASE64('...'))` |
| `BASE64_DECODE_BINARY('...')` | `FROM_BASE64('...')` |

Custom alphabet (e.g., `-_+` for URL-safe base64) is converted to standard base64 via `REPLACE()` before decoding.