### PR TITLE
feat(duckdb): Add transpilation support for REVERSE function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -2732,6 +2732,10 @@ class DuckDB(Dialect):
             result_sql = self.func("UPPER", _cast_to_varchar(expression.this))
             return _gen_with_cast_to_blob(self, expression, result_sql)
 
+        def reverse_sql(self, expression: exp.Reverse) -> str:
+            result_sql = self.func("REVERSE", _cast_to_varchar(expression.this))
+            return _gen_with_cast_to_blob(self, expression, result_sql)
+
         def base64encode_sql(self, expression: exp.Base64Encode) -> str:
             # DuckDB TO_BASE64 requires BLOB input
             # Snowflake BASE64_ENCODE accepts both VARCHAR and BINARY - for VARCHAR it implicitly


### PR DESCRIPTION

Snowflake supports text or binary expressions but DuckDb supports only varchar. Added support to transpile snowflake binary values as well. 
```
 python3 << 'EOF'                                                                                                                           
from sqlglot import parse_one
from sqlglot.optimizer.annotate_types import annotate_types

query = "SELECT REVERSE('Hello') AS string_test, REVERSE(HEX_DECODE_BINARY('414243')) AS binary_hex_test, REVERSE(TO_BINARY('ABC', 'UTF-8')) AS binary_utf8_test"
tree = parse_one(query, read='snowflake')
annotated = annotate_types(tree, dialect='snowflake')
duckdb_query = annotated.sql('duckdb')

print(duckdb_query)
EOF
SELECT REVERSE('Hello') AS string_test, CAST(REVERSE(CAST(UNHEX('414243') AS TEXT)) AS BLOB) AS binary_hex_test, CAST(REVERSE(CAST(ENCODE('ABC') AS TEXT)) AS BLOB) AS binary_utf8_test

 duckdb -c "SELECT REVERSE('Hello') AS string_test, CAST(REVERSE(CAST(UNHEX('414243') AS TEXT)) AS BLOB) AS binary_hex_test, CAST(REVERSE(CAST(ENCODE('ABC') AS TEXT)) AS BLOB) AS binary_utf8_test"
┌─────────────┬─────────────────┬──────────────────┐
│ string_test │ binary_hex_test │ binary_utf8_test │
│   varchar   │      blob       │       blob       │
├─────────────┼─────────────────┼──────────────────┤
│ olleH       │ CBA             │ CBA              │
```