### PR TITLE
fix(optimizer)!: Annotate `QUARTER(expr)` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -46,9 +46,15 @@ EXPRESSION_METADATA = {
             exp.Factorial,
         }
     },
+    **{
+        expr_type: {"returns": exp.DataType.Type.INT}
+        for expr_type in {
+            exp.Month,
+            exp.Quarter,
+        }
+    },
     exp.Coalesce: {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
-    exp.Month: {"returns": exp.DataType.Type.INT},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -600,6 +600,10 @@ STRING;
 FACTORIAL(tbl.int_col);
 BIGINT;
 
+# dialect: hive, spark2, spark, databricks
+QUARTER(tbl.date_col);
+INT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
Initially it is annotated as `TINYINT` because of base, now annotate to `INT`

[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/quarter)
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#quarter) = **Since: 1.5.0**

**Hive:**
```python
SELECT typeof(quarter('2016-08-31')), version()
+------+--------------------------------------------------+--+
| _c0  |                       _c1                        |
+------+--------------------------------------------------+--+
| int  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+------+--------------------------------------------------+--+
```

**Spark:**
```python
SELECT typeof(quarter('2016-08-31')), version()
+---------------------------+--------------------+
|typeof(quarter(2016-08-31))|           version()|
+---------------------------+--------------------+
|                        int|3.5.5 7c29c664cdc...|
+---------------------------+--------------------+

```

**Databricks:**
```python
SELECT typeof(quarter('2016-08-31')), version()
|typeof(quarter(2016-08-31))|version()|
|---|---|
|int|4.0.0 0000000000000000000000000000000000000000|
```