### PR TITLE
feat(optimizer)!: annotate type for bq DATE_ADD

### DIFF
--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -165,6 +165,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.ArgMax,
             exp.ArgMin,
+            exp.DateAdd,
             exp.DateTrunc,
             exp.DatetimeTrunc,
             exp.FirstValue,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2028,6 +2028,66 @@ STRING;
 r'a';
 STRING;
 
+# dialect: bigquery
+DATE_ADD(DATE '2008-12-25', INTERVAL 5 DAY);
+DATE;
+
+# dialect: bigquery
+DATE_ADD(DATE '2008-12-25', INTERVAL 2 WEEK);
+DATE;
+
+# dialect: bigquery
+DATE_ADD(DATE '2008-12-25', INTERVAL 3 MONTH);
+DATE;
+
+# dialect: bigquery
+DATE_ADD(DATE '2008-12-25', INTERVAL 1 QUARTER);
+DATE;
+
+# dialect: bigquery
+DATE_ADD(DATE '2008-12-25', INTERVAL 2 YEAR);
+DATE;
+
+# dialect: bigquery
+DATE_ADD(TIMESTAMP '2008-12-25 15:30:00', INTERVAL 5 DAY);
+TIMESTAMP;
+
+# dialect: bigquery
+DATE_ADD(TIMESTAMP '2008-12-25 15:30:00', INTERVAL 2 HOUR);
+TIMESTAMP;
+
+# dialect: bigquery
+DATE_ADD(TIMESTAMP '2008-12-25 15:30:00', INTERVAL 30 MINUTE);
+TIMESTAMP;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 5 DAY);
+DATETIME;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 2 WEEK);
+DATETIME;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 3 MONTH);
+DATETIME;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 1 QUARTER);
+DATETIME;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 2 YEAR);
+DATETIME;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 2 HOUR);
+DATETIME;
+
+# dialect: bigquery
+DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 30 MINUTE);
+DATETIME;
+
 --------------------------------------
 -- Snowflake
 --------------------------------------


### PR DESCRIPTION
This PR adds type annotation for BQ `DATE_ADD`

**DOCS**
[BQ DATE_ADD](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date_add)