### PR TITLE
fix!: Fix `LATERAL VIEW POSEXPLODE` transpilation

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -19,6 +19,7 @@ from sqlglot.helper import (
     seq_get,
     suggest_closest_match_and_fail,
     to_bool,
+    ensure_list,
 )
 from sqlglot.jsonpath import JSONPathTokenizer, parse as parse_json_path
 from sqlglot.parser import Parser
@@ -2289,17 +2290,40 @@ def build_regexp_extract(expr_type: t.Type[E]) -> t.Callable[[t.List, Dialect], 
 
 
 def explode_to_unnest_sql(self: Generator, expression: exp.Lateral) -> str:
-    if isinstance(expression.this, exp.Explode):
-        return self.sql(
-            exp.Join(
-                this=exp.Unnest(
-                    expressions=[expression.this.this],
-                    alias=expression.args.get("alias"),
-                    offset=isinstance(expression.this, exp.Posexplode),
-                ),
-                kind="cross",
-            )
+    this = expression.this
+    alias = expression.args.get("alias")
+
+    cross_join_expr: t.Optional[exp.Expression] = None
+    if isinstance(this, exp.Posexplode) and alias:
+        # Spark's `FROM x LATERAL VIEW POSEXPLODE(y) t AS pos, col` has the following semantics:
+        # - The first column is the position and the rest (1 for array, 2 for maps) are the exploded values
+        # - The position is 0-based whereas WITH ORDINALITY is 1-based
+        # For that matter, we must (1) subtract 1 from the ORDINALITY position and (2) rearrange the columns accordingly, returning:
+        # `FROM x CROSS JOIN LATERAL (SELECT pos - 1 AS pos, col FROM UNNEST(y) WITH ORDINALITY AS t(col, pos))
+        pos, cols = alias.columns[0], alias.columns[1:]
+
+        cols = ensure_list(cols)
+        lateral_subquery = exp.select(
+            exp.alias_(pos - 1, pos),
+            *cols,
+        ).from_(
+            exp.Unnest(
+                expressions=[this.this],
+                offset=True,
+                alias=exp.TableAlias(this=alias.this, columns=[*cols, pos]),
+            ),
         )
+
+        cross_join_expr = exp.Lateral(this=lateral_subquery.subquery())
+    elif isinstance(this, exp.Explode):
+        cross_join_expr = exp.Unnest(
+            expressions=[this.this],
+            alias=alias,
+        )
+
+    if cross_join_expr:
+        return self.sql(exp.Join(this=cross_join_expr, kind="cross"))
+
     return self.lateral_sql(expression)
 
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6836

Hive hierarchy supports `LATERAL VIEW POSEXPLODE` i.e an enumerated `EXPLODE` with the following semantics:
- Column aliases are required (query errors without them)
- The `pos` column is 0-based and precedes the exploded values 
- The number of exploded values may differ depending on the `ARRAY` vs `MAP` input

An example:

```SQL
# Array based: LATERAL appends result set [pos, col]
spark-sql (default)> WITH x AS (SELECT 'a,b,c' AS col) 
SELECT * FROM x LATERAL VIEW POSEXPLODE(SPLIT(col, ',')) t AS pos, col;

col     pos     col
a,b,c   0       a
a,b,c   1       b
a,b,c   2       c

# Map based: LATERAL appends result set [pos, key, value]
spark-sql (default)> with x as (select 'key' as col) 
SELECT * FROM x LATERAL VIEW POSEXPLODE(MAP(col, 'val', 'foo', 'val2')) AS pos, key, value;

col     pos     key     value
key     0       key     val
key     1       foo     val2
```

<br />

Currently, our transpilation towards Presto/Trino & DuckDB is broken because: 
1. The `pos` is reversed and 
2. The `WITH ORDINALITY` clause is 1-based:

```SQL
# (Before) Transpiled DuckDB 
duckdb> WITH x AS (SELECT 'a,b,c' AS col) 
SELECT * FROM x CROSS JOIN UNNEST(STR_SPLIT_REGEX(col, ',')) WITH ORDINALITY AS t(pos, col);

┌─────────┬─────────┬───────┐
│   col   │   pos   │  col  │
│ varchar │ varchar │ int64 │
├─────────┼─────────┼───────┤
│ a,b,c   │ c       │     3 │
│ a,b,c   │ b       │     2 │
│ a,b,c   │ a       │     1 │
└─────────┴─────────┴───────┘



# (Before) Transpiled Presto/Trino:
trino> WITH x AS (SELECT 'a,b,c' AS col) 
SELECT * FROM x CROSS JOIN UNNEST(REGEXP_SPLIT(col, ',')) WITH ORDINALITY AS t(pos, col);

  col  | pos | col
-------+-----+-----
 a,b,c | a   |   1
 a,b,c | b   |   2
 a,b,c | c   |   3
```

<br />

This PR fixes the transpilation by (1) reversing the columns to match the `pos` position and (2) subtracting 1 from the `WITH ORDINALITY` column:

```SQL
# (After) Transpiled DuckDB 
duckdb> WITH x AS (SELECT 'a,b,c' AS col) 
SELECT * FROM x CROSS JOIN LATERAL (SELECT pos - 1 AS pos, col FROM UNNEST(STR_SPLIT_REGEX(col, ',')) WITH ORDINALITY AS t(col, pos));

┌─────────┬───────┬─────────┐
│   col   │  pos  │   col   │
│ varchar │ int64 │ varchar │
├─────────┼───────┼─────────┤
│ a,b,c   │     2 │ c       │
│ a,b,c   │     1 │ b       │
│ a,b,c   │     0 │ a       │
└─────────┴───────┴─────────┘



# (After) Transpiled Presto/Trino:
trino> WITH x AS (SELECT 'a,b,c' AS col) 
SELECT * FROM x CROSS JOIN LATERAL (SELECT pos - 1 AS pos, col FROM UNNEST(REGEXP_SPLIT(col, ',')) WITH ORDINALITY AS t(col, pos));

  col  | pos | col
-------+-----+-----
 a,b,c |   0 | a
 a,b,c |   1 | b
 a,b,c |   2 | c
```


Docs
----------
[Spark / DBX POSEXPLODE](https://docs.databricks.com/aws/en/sql/language-manual/functions/posexplode) | [Spark / DBX LATERAL VIEW](https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-lateral-view.html) | [DuckDB WITH ORDINALITY](https://duckdb.org/docs/stable/sql/query_syntax/from#table-functions) | [Presto/Trino WITH ORDINALITY](https://prestodb.io/docs/current/sql/select.html#unnest)