### PR TITLE
feat(duckdb): Add transpilation support for FLATTEN (ARRAY_FLATTEN)

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -821,6 +821,7 @@ class Snowflake(Dialect):
                 step=seq_get(args, 2),
             ),
             "ARRAY_SORT": exp.SortArray.from_arg_list,
+            "ARRAY_FLATTEN": exp.Flatten.from_arg_list,
             "BITAND": _build_bitwise(exp.BitwiseAnd, "BITAND"),
             "BIT_AND": _build_bitwise(exp.BitwiseAnd, "BITAND"),
             "BITNOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),
@@ -1758,6 +1759,7 @@ class Snowflake(Dialect):
             exp.YearOfWeekIso: rename_func("YEAROFWEEKISO"),
             exp.Xor: rename_func("BOOLXOR"),
             exp.ByteLength: rename_func("OCTET_LENGTH"),
+            exp.Flatten: rename_func("ARRAY_FLATTEN"),
             exp.ArrayConcatAgg: lambda self, e: self.func(
                 "ARRAY_FLATTEN", exp.ArrayAgg(this=e.this)
             ),


### PR DESCRIPTION
`ARRAY_FLATTEN` function from Snowflake is not transpiling to DuckDB's `FLATTEN` function. SQLGlot currently parses `ARRAY_FLATTEN` as an Anonymous function without mapping it to the internal Flatten expression type, resulting in failed transpilation to DuckDB.

```
 python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT ARRAY_FLATTEN([[1, 2, 3], [4], [5, 6]]) AS result\", read='snowflake', write='duckdb')[0])" | duckdb
 DuckDB: SELECT FLATTEN([[1, 2, 3], [4], [5, 6]]) AS result
┌────────────────────┐
│       result       │
│      int32[]       │
├────────────────────┤
│ [1, 2, 3, 4, 5, 6] │
└────────────────────┘
```