### PR TITLE
feat(optimizer)!: Annotate `SIN`, `COS`, `TAN`, `COT` for T-SQL

### DIFF
--- a/sqlglot/typing/tsql.py
+++ b/sqlglot/typing/tsql.py
@@ -5,5 +5,14 @@ from sqlglot.typing import EXPRESSION_METADATA
 
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
+    **{
+        expr_type: {"returns": exp.DataType.Type.FLOAT}
+        for expr_type in {
+            exp.Cos,
+            exp.Cot,
+            exp.Sin,
+            exp.Tan,
+        }
+    },
     exp.Radians: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5396,6 +5396,38 @@ TIMESTAMPTZ;
 RADIANS(90);
 INT;
 
+# dialect: tsql
+SIN(tbl.int_col);
+FLOAT;
+
+# dialect: tsql
+SIN(tbl.float_col);
+FLOAT;
+
+# dialect: tsql
+COS(tbl.int_col);
+FLOAT;
+
+# dialect: tsql
+COS(tbl.float_col);
+FLOAT;
+
+# dialect: tsql
+TAN(tbl.int_col);
+FLOAT;
+
+# dialect: tsql
+TAN(tbl.float_col);
+FLOAT;
+
+# dialect: tsql
+COT(tbl.int_col);
+FLOAT;
+
+# dialect: tsql
+COT(tbl.float_col);
+FLOAT;
+
 --------------------------------------
 -- MySQL
 --------------------------------------


### PR DESCRIPTION
This PR annotate forward trigonometric functions for **T-SQL**

```python
SELECT 
    SQL_VARIANT_PROPERTY(SIN(45.175643), 'BaseType') AS SinType,
    SQL_VARIANT_PROPERTY(COS(45.175643), 'BaseType') AS CosType,
    SQL_VARIANT_PROPERTY(TAN(1), 'BaseType') AS TanType,
    SQL_VARIANT_PROPERTY(COT(1), 'BaseType') AS CotType;
```
<img width="440" height="139" alt="image" src="https://github.com/user-attachments/assets/f537229e-294c-4507-9fad-7d7851f224df" />

[Documentation](https://learn.microsoft.com/en-us/sql/t-sql/functions/mathematical-functions-transact-sql?view=sql-server-ver16#trigonometric-functions)