### PR TITLE
feat(optimizer)!: Annotate `SECOND` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -51,6 +51,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.Month,
             exp.Quarter,
+            exp.Second,
         }
     },
     exp.Coalesce: {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -604,6 +604,10 @@ BIGINT;
 QUARTER(tbl.date_col);
 INT;
 
+# dialect: hive, spark2, spark, databricks
+SECOND(tbl.timestamp_col);
+INT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate the `SECOND` function for **Hive, Spark and DBX**

**Official Documentations:**
- [DBX](https://docs.databricks.com/aws/en/sql/language-manual/functions/second)
- [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#second)

**Spark:**
```python
SELECT typeof(second('2018-02-14 12:58:59')), version()
+-----------------------------------+--------------------+
|typeof(second(2018-02-14 12:58:59))|           version()|
+-----------------------------------+--------------------+
|                                int|3.5.5 7c29c664cdc...|
+-----------------------------------+--------------------+
```

**DBX:**
```python
SELECT typeof(second('2018-02-14 12:58:59')), version()
|typeof(second(2018-02-14 12:58:59))|version()|
|---|---|
|int|4.0.0 0000000000000000000000000000000000000000|
```

**Hive:**
```python
SELECT typeof(second('2018-02-14 12:58:59')), version()
+------+--------------------------------------------------+--+
| _c0  |                       _c1                        |
+------+--------------------------------------------------+--+
| int  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+------+--------------------------------------------------+--+
```