### PR TITLE
feat(tsql)!: Parse `ATN2` as `ATAN2` expression for `T-SQL`

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -601,6 +601,7 @@ class TSQL(Dialect):
 
         FUNCTIONS = {
             **parser.Parser.FUNCTIONS,
+            "ATN2": exp.Atan2.from_arg_list,
             "CHARINDEX": lambda args: exp.StrPosition(
                 this=seq_get(args, 1),
                 substr=seq_get(args, 0),
@@ -1058,6 +1059,7 @@ class TSQL(Dialect):
         TRANSFORMS = {
             **generator.Generator.TRANSFORMS,
             exp.AnyValue: any_value_to_max_sql,
+            exp.Atan2: rename_func("ATN2"),
             exp.ArrayToString: rename_func("STRING_AGG"),
             exp.AutoIncrementColumnConstraint: lambda *_: "IDENTITY",
             exp.Ceil: rename_func("CEILING"),

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -19,6 +19,7 @@ class TestTSQL(Validator):
         # tsql allows .. which means use the default schema
         self.validate_identity("SELECT * FROM a..b")
 
+        self.validate_identity("SELECT ATN2(x, y)")
         self.validate_identity("SELECT EXP(1)")
         self.validate_identity("SELECT SYSDATETIMEOFFSET()")
         self.validate_identity("SELECT COMPRESS('Hello World')")


### PR DESCRIPTION
### This PR addresses an issue where ATN2 in TSQL was being parsed as an `Anonymous` expression instead of exp.Atan2.

```python
from sqlglot import parse_one, exp
from sqlglot.optimizer.annotate_types import annotate_types

sql = "SELECT ATN2(1.00, 2)"

dialect = "tsql"

expression = parse_one(sql, dialect=dialect)
annotated_expression = annotate_types(expression, dialect=dialect)
print(repr(annotated_expression))

print(expression.sql(dialect=dialect))
```

**Before:**
```python
Select(
  expressions=[
    Anonymous(
      this=ATN2,
      expressions=[
        Literal(this=1.00, is_string=False, _type=DataType(this=Type.DOUBLE)),
        Literal(this=2, is_string=False, _type=DataType(this=Type.INT))],
      _type=DataType(this=Type.UNKNOWN))],
  _type=DataType(this=Type.UNKNOWN))
SELECT ATN2(1.00, 2)
```

**After:**
````python
Select(
  expressions=[
    Atan2(
      this=Literal(this=1.00, is_string=False, _type=DataType(this=Type.DOUBLE)),
      expression=Literal(this=2, is_string=False, _type=DataType(this=Type.INT)),
      _type=DataType(this=Type.UNKNOWN))],
  _type=DataType(this=Type.UNKNOWN))
SELECT ATN2(1.00, 2)
```