### PR TITLE
feat(duckdb): Add transpilation support for SPACE function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -2922,6 +2922,15 @@ class DuckDB(Dialect):
                 _cast_to_varchar(expression.expression),
             )
 
+        def space_sql(self, expression: exp.Space) -> str:
+            # DuckDB's REPEAT requires BIGINT for the count parameter
+            return self.sql(
+                exp.Repeat(
+                    this=exp.Literal.string(" "),
+                    times=exp.cast(expression.this, exp.DataType.Type.BIGINT),
+                )
+            )
+
         def tablefromrows_sql(self, expression: exp.TableFromRows) -> str:
             # For GENERATOR, unwrap TABLE() - just emit the Generator (becomes RANGE)
             if isinstance(expression.this, exp.Generator):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -5635,6 +5635,34 @@ FROM SEMANTIC_VIEW(
             },
         )
 
+    def test_space(self):
+        # Integer literal
+        self.validate_all(
+            "SELECT SPACE(5)",
+            write={
+                "snowflake": "SELECT REPEAT(' ', 5)",
+                "duckdb": "SELECT REPEAT(' ', CAST(5 AS BIGINT))",
+            },
+        )
+
+        # Float literal (tests rounding behavior)
+        self.validate_all(
+            "SELECT SPACE(3.7)",
+            write={
+                "snowflake": "SELECT REPEAT(' ', 3.7)",
+                "duckdb": "SELECT REPEAT(' ', CAST(3.7 AS BIGINT))",
+            },
+        )
+
+        # NULL value
+        self.validate_all(
+            "SELECT SPACE(NULL)",
+            write={
+                "snowflake": "SELECT REPEAT(' ', NULL)",
+                "duckdb": "SELECT REPEAT(' ', CAST(NULL AS BIGINT))",
+            },
+        )
+
     def test_directed_joins(self):
         self.validate_identity("SELECT * FROM a CROSS DIRECTED JOIN b USING (id)")
         self.validate_identity("SELECT * FROM a INNER DIRECTED JOIN b USING (id)")


### PR DESCRIPTION
The transpilation of SPACE() to REPEAT() fails in DuckDB when the input argument is a FLOAT or DECIMAL type because DuckDB's REPEAT() function strictly requires the second argument (repeat count) to be of type BIGINT. SQLGlot currently transpiles SPACE(n) to REPEAT(' ', n) without adding the necessary type cast, causing runtime errors.
Fix: Added a custom space_sql method in the DuckDB dialect to wrap the count argument with CAST to BIGINT.

After Fix:
```
 python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT SPACE(5) AS space_integer, SPACE(3.7) AS space_float, SPACE(CAST(4.9 AS DECIMAL(10,2))) AS space_decimal, SPACE(0) AS space_zero, SPACE(NULL) AS space_null\", read='snowflake', write='duckdb')[0])" | duckdb
┌───────────────┬─────────────┬───────────────┬────────────┬────────────┐
│ space_integer │ space_float │ space_decimal │ space_zero │ space_null │
│    varchar    │   varchar   │    varchar    │  varchar   │  varchar   │
├───────────────┼─────────────┼───────────────┼────────────┼────────────┤
│               │             │               │            │ NULL       │
└───────────────┴─────────────┴───────────────┴────────────┴────────────┘
```