### PR TITLE
fix(presto): don't overwrite_types when annotating types in struct_sql()

### DIFF
--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -711,9 +711,8 @@ class Presto(Dialect):
         def struct_sql(self, expression: exp.Struct) -> str:
             from sqlglot.optimizer.annotate_types import annotate_types
 
-            expression = annotate_types(
-                expression, dialect=self.dialect, overwrite_types=False
-            )
+            if not expression.type:
+                expression = annotate_types(expression, dialect=self.dialect)
             values: t.List[str] = []
             schema: t.List[str] = []
             unknown_type = False


### PR DESCRIPTION
I found the problem originally at https://github.com/ibis-project/ibis/pull/11772#issuecomment-3807988748

[sqlglot warns when compiling a sge.Struct on trino/presto if the type of any of the fields can't be inferred](https://github.com/tobymao/sqlglot/blob/fc55b9889bcb1e0dad404dc15d357d8c755d85e6/sqlglot/dialects/presto.py#L711-L737)

To get around this, I had to add a `sge.Cast()` around the [`param` in this line](https://github.com/ibis-project/ibis/blob/f47a5f5ddd75f835bc59c230b2071a0f3f1d5da1/ibis/backends/sql/compilers/trino.py#L195) in ibis so that sqlglot can infer the datatype of that struct field.

But, this is unideal because it then results in an actual CAST() in the generated SQL. We could avoid this if

1. I manually annotated the type myself, eg 
```python
value_sge_type = self.type_mapper.from_ibis(op.arg.dtype.value_type)
value_property = sge.PropertyEQ(this=value, expression=param)
value_property.type = value_sge_type

# ...
sge.Struct(
    expressions=[
        sge.PropertyEQ(this=keep, expression=body),
        value_property,
    ]
)
```
2. and then this PR is merged, which would prevent annotate_types() from overwriting the manual type annotation I added.

I didn't add a test because I wasn't sure the format you are looking for, or if this warrants one. I can if you pseudocode it for me, eg perhaps manually annotate a type to a sge.Indentifier and then ensure that there is no warning?

At a larger scale, I'm not sure if it is the right idea to require that the fields of a struct be typed at compile time. This example use in ibis is a good counterexample, I don't think ibis should be required to give hints to sqlglot in this case. For example, right after sqlglot carefully compiles the struct with an exact type, then [the outer usage just immediately blows away that cast with our own override cast](https://github.com/ibis-project/ibis/blob/f47a5f5ddd75f835bc59c230b2071a0f3f1d5da1/ibis/backends/sql/compilers/trino.py#L191). Ideally sqlglot could look at the entire expression structure to be able to see where the inner struct cast is needed. But I realize that is a lot harder to implement, when every expression can compile in a self contained way without needing to look at the larger context :)