### PR TITLE
feat(optimizer)!: Annotate `MD5(expr)` for Hive, Spark and DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -36,6 +36,7 @@ EXPRESSION_METADATA = {
             exp.CurrentSchema,
             exp.CurrentUser,
             exp.Hex,
+            exp.MD5,
             exp.Soundex,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -612,6 +612,10 @@ INT;
 SECOND(tbl.timestamp_col);
 INT;
 
+# dialect: hive, spark2, spark, databricks
+MD5(tbl.str_col);
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `MD5(expr)` function for Hive, Spark and DBX

[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#md5)
[DBX](https://docs.databricks.com/aws/en/sql/language-manual/functions/md5)

```sql
SELECT typeof(md5('Spark')), version()
```

**Spark:**
```python
+------------------+--------------------+
|typeof(md5(Spark))|           version()|
+------------------+--------------------+
|            string|3.5.5 7c29c664cdc...|
+------------------+--------------------+
```

**Hive:**
```python
+---------+--------------------------------------------------+--+
|   _c0   |                       _c1                        |
+---------+--------------------------------------------------+--+
| string  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+---------+--------------------------------------------------+--+
```