### PR TITLE
fix(optimizer)!: Annotate `DAYOFWEEK` for MySQL

### DIFF
--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -7,4 +7,5 @@ EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{expr_type: {"returns": exp.DataType.Type.VARCHAR} for expr_type in (exp.Elt,)},
     exp.Localtime: {"returns": exp.DataType.Type.DATETIME},
+    exp.DayOfWeek: {"returns": exp.DataType.Type.INT},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5564,6 +5564,10 @@ DATETIME;
 ELT(1, 'a', 'b');
 VARCHAR;
 
+# dialect: mysql
+DAYOFWEEK(tbl.date_col);
+INT;
+
 --------------------------------------
 -- DuckDB
 --------------------------------------


### PR DESCRIPTION
This PR annotate `DAYOFWEEK` to `INT` instead of `TINYINT` present in base annotator

**SQL:**
```sql
CREATE TEMPORARY TABLE test_type AS 
SELECT DAYOFWEEK('2007-02-03');
DESCRIBE test_type;
```

```python
Output:

68 ms
+-------------------------+------+------+-----+---------+-------+
| Field                   | Type | Null | Key | Default | Extra |
+-------------------------+------+------+-----+---------+-------+
| DAYOFWEEK('2007-02-03') | int  | YES  |     | NULL    | NULL  |
+-------------------------+------+------+-----+---------+-------+
```