### PR TITLE
feat(duckdb)!: support transpilation of ARRAY_REMOVE

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -14,6 +14,7 @@ from sqlglot.dialects.dialect import (
     NormalizationStrategy,
     approx_count_distinct_sql,
     array_append_sql,
+    array_compact_sql,
     array_concat_sql,
     arrow_json_extract_sql,
     binary_from_function,
@@ -1711,7 +1712,7 @@ class DuckDB(Dialect):
                 generator=inline_array_unless_query,
             ),
             exp.ArrayAppend: array_append_sql("LIST_APPEND"),
-            exp.ArrayCompact: remove_from_array_using_filter,
+            exp.ArrayCompact: array_compact_sql,
             exp.ArrayConstructCompact: lambda self, e: self.sql(
                 exp.ArrayCompact(this=exp.Array(expressions=e.expressions))
             ),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5765,7 +5765,7 @@ class JSONBool(Func):
 
 
 class ArrayRemove(Func):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": True, "null_propagation": False}
 
 
 class ParameterizedAgg(AggFunc):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1476,6 +1476,31 @@ class TestDuckDB(Validator):
             },
         )
 
+    def test_array_remove(self):
+        # Test NULL propagation with column reference: Snowflake → DuckDB
+        self.validate_all(
+            "CASE WHEN target IS NULL THEN NULL ELSE LIST_FILTER(the_array, _u -> _u <> target) END",
+            read={
+                "snowflake": "ARRAY_REMOVE(the_array, target)",
+            },
+        )
+
+        # Test literal values: Snowflake → DuckDB
+        self.validate_all(
+            "LIST_FILTER([1, 2, 3], _u -> _u <> 2)",
+            read={
+                "snowflake": "ARRAY_REMOVE([1, 2, 3], 2)",
+            },
+        )
+
+        # Test NULL literal: Snowflake → DuckDB
+        self.validate_all(
+            "CASE WHEN NULL IS NULL THEN NULL ELSE LIST_FILTER([1, 2, 3], _u -> _u <> NULL) END",
+            read={
+                "snowflake": "ARRAY_REMOVE([1, 2, 3], NULL)",
+            },
+        )
+
     def test_time(self):
         self.validate_identity("SELECT CURRENT_DATE")
         self.validate_identity("SELECT CURRENT_TIMESTAMP")


### PR DESCRIPTION
Adds transpilation support for `ARRAY_REMOVE` to DuckDB's `LIST_FILTER`

### Key changes
- Transpiles `ARRAY_REMOVE(array, value)` to `LIST_FILTER(array, _u -> _u <> value)`
- Handles `NULL` propagation semantics: wraps with `CASE WHEN value IS NULL THEN NULL ELSE ...` when transpiling from dialects that propagate `NULL`s (Snowflake) to those that don't (DuckDB)
- Optimizes literal values: skips `NULL` wrapper for non-`NULL` literals since they can't be `NULL`
- Adds `null_propagation` flag to `ArrayRemove` expression to track source dialect behavior
- Refactors `remove_from_array_using_filter` into separate `array_compact_sql` and `remove_from_array_using_filter` functions

### Tests
- `NULL` propagation with column references
- Literal value removal (optimization path)
- `NULL` literal removal (`NULL` propagation path)