### PR TITLE
feat(optimizer)!: Annotate `SOUNDEX(expr)` for TSQL

### DIFF
--- a/sqlglot/typing/tsql.py
+++ b/sqlglot/typing/tsql.py
@@ -20,4 +20,5 @@ EXPRESSION_METADATA = {
     },
     exp.CurrentTimezone: {"returns": exp.DataType.Type.NVARCHAR},
     exp.Radians: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
+    exp.Soundex: {"returns": exp.DataType.Type.VARCHAR},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5552,6 +5552,10 @@ FLOAT;
 CURRENT_TIMEZONE();
 NVARCHAR;
 
+# dialect: tsql
+SOUNDEX(tbl.str_col);
+VARCHAR;
+
 --------------------------------------
 -- MySQL
 --------------------------------------


### PR DESCRIPTION
This PR annotate SOUNDEX as `VARCHAR` for T-SQL

[T-SQL](https://learn.microsoft.com/en-us/sql/t-sql/functions/soundex-transact-sql?view=sql-server-ver17)

```sql
SELECT SQL_VARIANT_PROPERTY(SOUNDEX('Smith'), 'BaseType') AS [DataType]
```

<img width="249" height="139" alt="image" src="https://github.com/user-attachments/assets/0bdab647-d948-4856-a857-8b40f704c278" />

