### PR TITLE
feat(tsql)!: Annotate `STUFF` for TSQL

### DIFF
--- a/sqlglot/typing/tsql.py
+++ b/sqlglot/typing/tsql.py
@@ -18,7 +18,13 @@ EXPRESSION_METADATA = {
             exp.Tan,
         }
     },
+    **{
+        expr_type: {"returns": exp.DataType.Type.VARCHAR}
+        for expr_type in {
+            exp.Soundex,
+            exp.Stuff,
+        }
+    },
     exp.CurrentTimezone: {"returns": exp.DataType.Type.NVARCHAR},
     exp.Radians: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
-    exp.Soundex: {"returns": exp.DataType.Type.VARCHAR},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5556,6 +5556,10 @@ NVARCHAR;
 SOUNDEX(tbl.str_col);
 VARCHAR;
 
+# dialect: tsql
+STUFF(tbl.str_col, tbl.int_col, tbl.int_col, tbl.str_col);
+VARCHAR;
+
 --------------------------------------
 -- MySQL
 --------------------------------------


### PR DESCRIPTION
This PR annotate `STUFF ( character_expression , start , length , replace_with_expression )` function for TSQL

[T-SQL](https://learn.microsoft.com/en-us/sql/t-sql/functions/stuff-transact-sql?view=sql-server-ver17)

```sql
SELECT SQL_VARIANT_PROPERTY(STUFF('abcdef', 2, 3, 'ijklmn'), 'BaseType') AS [DataType1];
```

<img width="234" height="131" alt="image" src="https://github.com/user-attachments/assets/7abe9f68-bb09-436a-9836-27ec42692955" />
