### PR TITLE
feat(optimizer)!: Annotate `FACTORIAL(expr)` for DuckDB

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -51,6 +51,7 @@ from sqlglot.generator import unsupported_args
 from sqlglot.helper import is_date_unit, seq_get
 from sqlglot.tokens import TokenType
 from sqlglot.parser import binary_range_parser
+from sqlglot.typing.duckdb import EXPRESSION_METADATA
 
 # Regex to detect time zones in timestamps of the form [+|-]TT[:tt]
 # The pattern matches timezone offsets that appear after the time portion
@@ -1288,6 +1289,8 @@ class DuckDB(Dialect):
         **Dialect.DATE_PART_MAPPING,
         "DAYOFWEEKISO": "ISODOW",
     }
+
+    EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
 
     DATE_PART_MAPPING.pop("WEEKDAY")
 

--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.typing import EXPRESSION_METADATA
+
+EXPRESSION_METADATA = {
+    **EXPRESSION_METADATA,
+    **{
+        expr_type: {"returns": exp.DataType.Type.INT128}
+        for expr_type in {
+            exp.Factorial,
+        }
+    },
+}

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5587,3 +5587,7 @@ VARCHAR;
 # dialect: duckdb 
 GET_BIT(tbl.str_col, tbl.int_col);
 INT;
+
+# dialect: duckdb
+FACTORIAL(tbl.int_col);
+HUGEINT


### PR DESCRIPTION
#### This PR adds the type annotation for `exp.Factorial` to return `DataType.Type.INT128`, DuckDB factorial function returns a `HUGEINT` (128-bit integer) 

```python
duckdb> select typeof(factorial(9));
┌──────────────────────┐
│ typeof(factorial(9)) │
╞══════════════════════╡
│ HUGEINT              │
└──────────────────────┘
```

**Official Documentation**
https://duckdb.org/docs/stable/sql/functions/numeric#factorialx
