### PR TITLE
feat(optimizer)!: Annotate `SIN` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -11,4 +11,10 @@ EXPRESSION_METADATA = {
             exp.Factorial,
         }
     },
+    **{
+        expr_type: {"returns": exp.DataType.Type.DOUBLE}
+        for expr_type in {
+            exp.Sin,
+        }
+    },
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5590,4 +5590,12 @@ INT;
 
 # dialect: duckdb
 FACTORIAL(tbl.int_col);
-HUGEINT
+HUGEINT;
+
+# dialect: duckdb
+SIN(tbl.int_col);
+DOUBLE;
+
+# dialect: duckdb
+SIN(tbl.double_col);
+DOUBLE;


### PR DESCRIPTION
**This PR annotate `SIN(expr)` for DuckDB as `DOUBLE`**

```python
duckdb> select typeof(sin(1)), typeof(sin(1.2));
┌────────────────┬──────────────────┐
│ typeof(sin(1)) ┆ typeof(sin(1.2)) │
╞════════════════╪══════════════════╡
│ DOUBLE         ┆ DOUBLE           │
└────────────────┴──────────────────┘
```

Official documentation:
https://duckdb.org/docs/stable/sql/functions/numeric#sinx