### PR TITLE
feat(optimizer)!: Annotate `COS` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -14,6 +14,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
+            exp.Cos,
             exp.Sin,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5599,3 +5599,11 @@ DOUBLE;
 # dialect: duckdb
 SIN(tbl.double_col);
 DOUBLE;
+
+# dialect: duckdb
+COS(tbl.int_col);
+DOUBLE;
+
+# dialect: duckdb
+COS(tbl.double_col);
+DOUBLE;


### PR DESCRIPTION
**This PR annotate `COS(expr)` for DuckDB as `DOUBLE`**

```python
duckdb> select typeof(cos(1)), typeof(cos(1.2));
┌────────────────┬──────────────────┐
│ typeof(cos(1)) ┆ typeof(cos(1.2)) │
╞════════════════╪══════════════════╡
│ DOUBLE         ┆ DOUBLE           │
└────────────────┴──────────────────┘
```

Official documentation:
https://duckdb.org/docs/stable/sql/functions/numeric#cosx