### PR TITLE
feat(optimmizer)!: Annotate `ISNAN(expr)` for Base

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -55,6 +55,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.Exists,
             exp.In,
             exp.IsInf,
+            exp.IsNan,
             exp.LogicalAnd,
             exp.LogicalOr,
             exp.RegexpLike,

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -232,7 +232,6 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.BOOLEAN}
         for expr_type in {
-            exp.IsNan,
             exp.JSONBool,
             exp.LaxBool,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -155,6 +155,9 @@ DOUBLE;
 ISINF(tbl.float_col);
 BOOLEAN;
 
+ISNAN(tbl.float_col);
+BOOLEAN;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
**This PR annotate `ISNAN(expr)` for **DuckDB** as BOOLEAN**

```python
duckdb> select typeof(isnan('NaN'::float));
┌─────────────────────────────────────┐
│ typeof(isnan(CAST('NaN' AS FLOAT))) │
╞═════════════════════════════════════╡
│ BOOLEAN                             │
└─────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/numeric#isnanx