### PR TITLE
feat(optimizer)!: Annotate `TAN` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -16,6 +16,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.Cos,
             exp.Sin,
+            exp.Tan,
         }
     },
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5619,5 +5619,13 @@ COS(tbl.double_col);
 DOUBLE;
 
 # dialect: duckdb
+TAN(tbl.int_col);
+DOUBLE;
+
+# dialect: duckdb
+TAN(tbl.double_col);
+DOUBLE;
+
+# dialect: duckdb
 ISINF(tbl.float_col);
 BOOLEAN;


### PR DESCRIPTION
**This PR annotate `TAN(expr)` for DuckDB as `DOUBLE`**

```python
duckdb> select typeof(tan(1)), typeof(tan(0.34));
┌────────────────┬───────────────────┐
│ typeof(tan(1)) ┆ typeof(tan(0.34)) │
╞════════════════╪═══════════════════╡
│ DOUBLE         ┆ DOUBLE            │
└────────────────┴───────────────────┘
```

Official documentation:
https://duckdb.org/docs/stable/sql/functions/numeric#tanx