### PR TITLE
feat(optimizer)!: Annotate `ATAN(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -14,6 +14,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
+            exp.Atan,
             exp.Cos,
             exp.Cot,
             exp.Rand,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5635,6 +5635,14 @@ TAN(tbl.double_col);
 DOUBLE;
 
 # dialect: duckdb
+ATAN(tbl.int_col);
+DOUBLE;
+
+# dialect: duckdb
+ATAN(tbl.double_col);
+DOUBLE;
+
+# dialect: duckdb
 ISINF(tbl.float_col);
 BOOLEAN;
 


### PR DESCRIPTION
**This PR annotate `ATAN(expr)` for DuckDB as `DOUBLE`**

```python
duckdb> select typeof(atan(0.5)), typeof(atan(1));
┌───────────────────┬─────────────────┐
│ typeof(atan(0.5)) ┆ typeof(atan(1)) │
╞═══════════════════╪═════════════════╡
│ DOUBLE            ┆ DOUBLE          │
└───────────────────┴─────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/numeric#atanx