### PR TITLE
feat(optimizer)!: Annotate `ATAN2(y,x)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -17,6 +17,7 @@ EXPRESSION_METADATA = {
             exp.Acosh,
             exp.Asinh,
             exp.Atanh,
+            exp.Atan2,
             exp.Acos,
             exp.Asin,
             exp.Atan,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5659,6 +5659,22 @@ ATAN(tbl.double_col);
 DOUBLE;
 
 # dialect: duckdb
+ATAN2(tbl.int_col, tbl.int_col);
+DOUBLE;
+
+# dialect: duckdb
+ATAN2(tbl.int_col, tbl.double_col);
+DOUBLE;
+
+# dialect: duckdb
+ATAN2(tbl.double_col, tbl.int_col);
+DOUBLE;
+
+# dialect: duckdb
+ATAN2(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: duckdb
 ACOSH(tbl.int_col);
 DOUBLE;
 


### PR DESCRIPTION
**This PR annotate `ATAN2(y,x)` for DuckDB**

```python
duckdb> select typeof(atan2(0.5,0.5)), typeof(atan2(1,1)), typeof(atan2(0.5,1)), typeof(atan2(1,0.5));
┌─────────────────────────┬─────────────────────┬───────────────────────┬───────────────────────┐
│ typeof(atan2(0.5, 0.5)) ┆ typeof(atan2(1, 1)) ┆ typeof(atan2(0.5, 1)) ┆ typeof(atan2(1, 0.5)) │
╞═════════════════════════╪═════════════════════╪═══════════════════════╪═══════════════════════╡
│ DOUBLE                  ┆ DOUBLE              ┆ DOUBLE                ┆ DOUBLE                │
└─────────────────────────┴─────────────────────┴───────────────────────┴───────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/numeric#atan2y-x