### PR TITLE
feat(optimizer)!: Annotate `QUARTER(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -27,4 +27,5 @@ EXPRESSION_METADATA = {
             exp.Tan,
         }
     },
+    exp.Quarter: {"returns": exp.DataType.Type.BIGINT},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5689,3 +5689,19 @@ BOOLEAN;
 # dialect: duckdb
 RANDOM();
 DOUBLE;
+
+# dialect: duckdb
+QUARTER(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb
+QUARTER(tbl.timestamp_col);
+BIGINT;
+
+# dialect: duckdb
+QUARTER(tbl.interval_col);
+BIGINT;
+
+# dialect: duckdb
+QUARTER(tbl.timestamp_tz_col);
+BIGINT;


### PR DESCRIPTION
**This PR annotate `QUARTER(expr)` for DuckDB** as `BIGINT`

```python
duckdb> select quarter();
Binder Error: No function matches the given name and argument types 'quarter()'. You might need to add explicit type casts.
        Candidate functions:
        quarter(DATE) -> BIGINT
        quarter(INTERVAL) -> BIGINT
        quarter(TIMESTAMP) -> BIGINT
        quarter(TIMESTAMP WITH TIME ZONE) -> BIGINT
```

```python

duckdb> select typeof(quarter(DATE '1992-02-15'));
┌───────────────────────────────────────────────┐
│ typeof("quarter"(CAST('1992-02-15' AS DATE))) │
╞═══════════════════════════════════════════════╡
│ BIGINT                                        │
└───────────────────────────────────────────────┘
```

```python
duckdb> SELECT typeof(quarter(TIMESTAMP '2024-10-20 14:30:00'));
┌─────────────────────────────────────────────────────────────┐
│ typeof("quarter"(CAST('2024-10-20 14:30:00' AS TIMESTAMP))) │
╞═════════════════════════════════════════════════════════════╡
│ BIGINT                                                      │
└─────────────────────────────────────────────────────────────┘
```

```python
duckdb> SELECT typeof(quarter(INTERVAL '9 months')) as qtr;
┌────────┐
│ qtr    │
╞════════╡
│ BIGINT │
└────────┘
```

```python
duckdb> SELECT typeof(quarter(TIMESTAMPTZ '2024-01-01 00:00:00+02'));
┌───────────────────────────────────────────────────────────────────────────────┐
│ typeof("quarter"(CAST('2024-01-01 00:00:00+02' AS TIMESTAMP WITH TIME ZONE))) │
╞═══════════════════════════════════════════════════════════════════════════════╡
│ BIGINT                                                                        │
└───────────────────────────────────────────────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/datepart#quarterdate