### PR TITLE
feat(optimizer)!: Annotate `DEGREES(expr)` for MySQL

### DIFF
--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -5,6 +5,12 @@ from sqlglot.typing import EXPRESSION_METADATA
 
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
+    **{
+        expr_type: {"returns": exp.DataType.Type.DOUBLE}
+        for expr_type in {
+            exp.Degrees,
+        }
+    },
     **{expr_type: {"returns": exp.DataType.Type.VARCHAR} for expr_type in (exp.Elt,)},
     exp.Localtime: {"returns": exp.DataType.Type.DATETIME},
     exp.DayOfWeek: {"returns": exp.DataType.Type.INT},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5571,6 +5571,14 @@ VARCHAR;
 --------------------------------------
 
 # dialect: mysql
+DEGREES(tbl.double_col);
+DOUBLE;
+
+# dialect: mysql
+DEGREES(tbl.int_col);
+DOUBLE;
+
+# dialect: mysql
 LOCALTIME;
 DATETIME;
 


### PR DESCRIPTION
**This PR annotate `DEGREES(expr)` for MySQL**

```sql
CREATE TEMPORARY TABLE test_type AS 
SELECT DEGREES(3.14), DEGREES(1);
DESCRIBE test_type;
```

```python
+---------------+--------+------+-----+---------+-------+
| Field         | Type   | Null | Key | Default | Extra |
+---------------+--------+------+-----+---------+-------+
| DEGREES(3.14) | double | NO   |     | 0       | NULL  |
| DEGREES(1)    | double | NO   |     | 0       | NULL  |
+---------------+--------+------+-----+---------+-------+
```

**Official documentation:**
https://dev.mysql.com/doc/refman/8.4/en/mathematical-functions.html#function_degrees