### PR TITLE
feat(optimizer)!: Annotate `MINUTE`, `MONTH` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -8,6 +8,8 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.BIGINT}
         for expr_type in {
+            exp.Minute,
+            exp.Month,
             exp.Quarter,
             exp.Week,
             exp.Year,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5829,3 +5829,11 @@ BIGINT;
 # dialect: duckdb
 QUARTER(tbl.timestamp_tz_col);
 BIGINT;
+
+# dialect: duckdb
+MINUTE(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb 
+MONTH(tbl.date_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `MINUTE`, `MONTH` for DuckDB as **`BIGINT`**

```python
duckdb> select typeof(month(DATE '1992-02-15'));
┌─────────────────────────────────────────────┐
│ typeof("month"(CAST('1992-02-15' AS DATE))) │
╞═════════════════════════════════════════════╡
│ BIGINT                                      │
└─────────────────────────────────────────────┘

duckdb> select typeof(minute(timestamp '2021-08-03 11:59:44.123456'));
┌───────────────────────────────────────────────────────────────────┐
│ typeof("minute"(CAST('2021-08-03 11:59:44.123456' AS TIMESTAMP))) │
╞═══════════════════════════════════════════════════════════════════╡
│ BIGINT                                                            │
└───────────────────────────────────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/datepart#monthdate
https://duckdb.org/docs/stable/sql/functions/datepart#minutedate