### PR TITLE
feat(optimizer)!: Annotate `DAYOFWEEK(expr)`, `DAYOFYEAR(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -8,6 +8,8 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.BIGINT}
         for expr_type in {
+            exp.DayOfWeek,
+            exp.DayOfYear,
             exp.Minute,
             exp.Month,
             exp.Quarter,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5837,3 +5837,11 @@ BIGINT;
 # dialect: duckdb 
 MONTH(tbl.date_col);
 BIGINT;
+
+# dialect: duckdb 
+DAYOFWEEK(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb 
+DAYOFYEAR(tbl.date_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `DAYOFWEEK(expr)`, `DAYOFYEAR(expr)` for **`DuckDB`**

```python
duckdb> select typeof(dayofweek(DATE '1992-02-15'));
┌───────────────────────────────────────────────┐
│ typeof(dayofweek(CAST('1992-02-15' AS DATE))) │
╞═══════════════════════════════════════════════╡
│ BIGINT                                        │
└───────────────────────────────────────────────┘

duckdb> select typeof(dayofyear(DATE '1992-02-15'));
┌───────────────────────────────────────────────┐
│ typeof(dayofyear(CAST('1992-02-15' AS DATE))) │
╞═══════════════════════════════════════════════╡
│ BIGINT                                        │
└───────────────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/datepart#dayofweekdate
https://duckdb.org/docs/stable/sql/functions/datepart#dayofyeardate