### PR TITLE
Chore: generate API docs before checking out api-docs branch

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -154,9 +154,12 @@ jobs:
         file_pattern: "CHANGELOG.md"
     - name: Update API docs
       run: |
-        git checkout api-docs
         source ./.venv/bin/activate
         make docs
+        mv docs /tmp/generated-docs
+        git checkout api-docs
+        rm -rf docs
+        mv /tmp/generated-docs docs
     - name: Commit API docs
       uses: stefanzweifel/git-auto-commit-action@v4
       with:


### PR DESCRIPTION
The workflow was checking out api-docs before running make docs, causing a mismatch between the stale Python code on api-docs and the Rust tokenizer installed from the current tag. Now docs are generated first, then api-docs is checked out and the old docs directory is removed to ensure freshness before copying the new docs.