### PR TITLE
feat(optimizer)!: Annotate `DAY`, `HOUR`, `SECOND` and `DAYOFMONTH` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -8,11 +8,15 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.BIGINT}
         for expr_type in {
+            exp.Day,
+            exp.DayOfMonth,
             exp.DayOfWeek,
             exp.DayOfYear,
+            exp.Hour,
             exp.Minute,
             exp.Month,
             exp.Quarter,
+            exp.Second,
             exp.Week,
             exp.Year,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5845,3 +5845,19 @@ BIGINT;
 # dialect: duckdb 
 DAYOFYEAR(tbl.date_col);
 BIGINT;
+
+# dialect: duckdb
+DAYOFMONTH(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb
+DAY(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb
+HOUR(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb
+SECOND(tbl.date_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `DAY`, `HOUR`, `SECOND` and `DAYOFMONTH` for **`DuckDB`**

```python
duckdb> select typeof(hour(timestamp '2021-08-03 11:59:44.123456'));
┌─────────────────────────────────────────────────────────────────┐
│ typeof("hour"(CAST('2021-08-03 11:59:44.123456' AS TIMESTAMP))) │
╞═════════════════════════════════════════════════════════════════╡
│ BIGINT                                                          │
└─────────────────────────────────────────────────────────────────┘

duckdb> select typeof(second(timestamp '2021-08-03 11:59:44.123456'));
┌───────────────────────────────────────────────────────────────────┐
│ typeof("second"(CAST('2021-08-03 11:59:44.123456' AS TIMESTAMP))) │
╞═══════════════════════════════════════════════════════════════════╡
│ BIGINT                                                            │
└───────────────────────────────────────────────────────────────────┘

duckdb> select typeof(day(DATE '1992-02-15'));
┌───────────────────────────────────────────┐
│ typeof("day"(CAST('1992-02-15' AS DATE))) │
╞═══════════════════════════════════════════╡
│ BIGINT                                    │
└───────────────────────────────────────────┘

duckdb> select typeof(dayofmonth(DATE '1992-02-15'));
┌────────────────────────────────────────────────┐
│ typeof(dayofmonth(CAST('1992-02-15' AS DATE))) │
╞════════════════════════════════════════════════╡
│ BIGINT                                         │
└────────────────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/datepart#seconddate
https://duckdb.org/docs/stable/sql/functions/datepart#hourdate
https://duckdb.org/docs/stable/sql/functions/datepart#daydate
https://duckdb.org/docs/stable/sql/functions/datepart#dayofmonthdate