### PR TITLE
feat(optimizer)!: Annotate TO_DAYS(expr) for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -45,4 +45,5 @@ EXPRESSION_METADATA = {
             exp.TimeToUnix,
         }
     },
+    exp.ToDays: {"returns": exp.DataType.Type.INTERVAL},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5865,3 +5865,7 @@ BIGINT;
 # dialect: duckdb
 SECOND(tbl.date_col);
 BIGINT;
+
+# dialect: duckdb
+TO_DAYS(tbl.int_col);
+INTERVAL;


### PR DESCRIPTION
This PR annotate `TO_DAYS(expr)` for **`DuckDB`**

```python
duckdb> select typeof(to_days(5));
┌────────────────────┐
│ typeof(to_days(5)) │
╞════════════════════╡
│ INTERVAL           │
└────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/interval#to_daysinteger