### PR TITLE
feat(duckdb)!: support transpilation of ARRAY_REMOVE_AT

### DIFF
--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -6112,6 +6112,10 @@ class ArrayInsert(Func):
     arg_types = {"this": True, "position": True, "expression": True, "offset": False}
 
 
+class ArrayRemoveAt(Func):
+    arg_types = {"this": True, "position": True}
+
+
 class ArrayConstructCompact(Func):
     arg_types = {"expressions": False}
     is_var_len_args = True


### PR DESCRIPTION
Implements transpilation of Snowflake's `ARRAY_REMOVE_AT(array, position)` to DuckDB using `LIST_CONCAT` and array slicing.

### Transpilation patterns
- Position 0: `arr[2:]`
- Positive position: `LIST_CONCAT(arr[1:p], arr[p+2:])`
- Position -1: `arr[1:LEN(arr)-1]`
- Negative position: `LIST_CONCAT(arr[1:LEN(arr)+p], arr[LEN(arr)+p+2:])`

All expressions wrapped in `CASE WHEN arr IS NULL THEN NULL ELSE ... END` for proper `NULL` propagation.

### Limitations
- Only supports literal integer positions
- Non-literal positions remain untranspiled with unsupported warning

### Changes
- Added `ArrayRemoveAt` expression class
- Implemented `_array_remove_at_sql` in DuckDB generator
- Added test cases covering positive/negative positions, edge cases, and non-literal handling