### PR TITLE
feat(optimizer)!: Annotate `MAKE_TIME(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -46,4 +46,5 @@ EXPRESSION_METADATA = {
         }
     },
     exp.ToDays: {"returns": exp.DataType.Type.INTERVAL},
+    exp.TimeFromParts: {"returns": exp.DataType.Type.TIME},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5869,3 +5869,7 @@ BIGINT;
 # dialect: duckdb
 TO_DAYS(tbl.int_col);
 INTERVAL;
+
+# dialect: duckdb
+MAKE_TIME(tbl.bigint_col, tbl.bigint_col, tbl.double_col);
+TIME;


### PR DESCRIPTION
This PR annotate `MAKE_TIME(expr)` for **`DuckDB`**

```python
duckdb> select typeof(make_time(13, 34, 27.123456));
┌──────────────────────────────────────┐
│ typeof(make_time(13, 34, 27.123456)) │
╞══════════════════════════════════════╡
│ TIME                                 │
└──────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/time#make_timebigint-bigint-double