### PR TITLE
bug(tsql): fix datepart handling when part is quoted

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -704,7 +704,7 @@ class TSQL(Dialect):
         }
 
         def _parse_datepart(self) -> exp.Extract:
-            this = self._parse_var()
+            this = self._parse_var(tokens=[TokenType.IDENTIFIER])
             expression = self._match(TokenType.COMMA) and self._parse_bitwise()
             name = map_date_part(this, self.dialect)
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1570,6 +1570,10 @@ WHERE
                 "tsql": "SELECT DATEPART(day, CAST('2017-01-02' AS DATE))",
             },
         )
+        self.validate_identity(
+            'SELECT DATEPART("dd", x)',
+            "SELECT DATEPART(DAY, x)",
+        )
 
     def test_convert(self):
         self.validate_all(


### PR DESCRIPTION
Previous discussion [here](https://github.com/tobymao/sqlglot/pull/6933#discussion_r2755637694)
Summary - while this doesn't seem valid, this is a legitimate TSQL syntax (escaping date parts).
It's already supported in `dateadd` & `datediff`, but was missing from `datepart`.

Validated [here](https://runsql.com/r) as well with `select datepart("dd",'2025-12-13')` on SQL Server 2022

-- more details
trust me, I don't like this being a valid syntax neither, but it is :)
```sql
select @reportdate = datepart("dd",getdate())
```
the above is a valid TSQL syntax.
Also - note that you guys already support this syntax in other date functions:
```sql
select dateadd("dd", -DAY(getdate()), DATEADD("mm", 0, detdate()))
```
is parsed into:
```python
[Select(
   expressions=[
     DateAdd(
       this=DateAdd(
         this=Anonymous(this=detdate),
         expression=Literal(this=0, is_string=False),
         unit=Var(this=MONTH)),
       expression=Neg(
         this=Day(
           this=CurrentTimestamp())),
       unit=Var(this=DAY))])]
```