### PR TITLE
feat(optimizer)!: Annotate `LENGTH(expr)` for `DuckDB`

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -14,6 +14,7 @@ EXPRESSION_METADATA = {
             exp.DayOfWeek,
             exp.DayOfYear,
             exp.Hour,
+            exp.Length,
             exp.Minute,
             exp.Month,
             exp.Quarter,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5877,3 +5877,7 @@ BIGINT;
 # dialect: duckdb
 MAKE_TIME(tbl.bigint_col, tbl.bigint_col, tbl.double_col);
 TIME;
+
+# dialect: duckdb
+LENGTH(tbl.str_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `LENGTH(expr)` for `DuckDB`

```python
duckdb> select typeof(length('aslk'));
┌────────────────────────┐
│ typeof(length('aslk')) │
╞════════════════════════╡
│ BIGINT                 │
└────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/text#lengthstring