### PR TITLE
fix(optimizer)!: Annotate `DAYOFMONTH(expr)`, `DAYOFYEAR(expr)` for MySQL

### DIFF
--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -19,7 +19,9 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.INT}
         for expr_type in {
+            exp.DayOfMonth,
             exp.DayOfWeek,
+            exp.DayOfYear,
             exp.Month,
             exp.Second,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5591,6 +5591,14 @@ DAYOFWEEK(tbl.date_col);
 INT;
 
 # dialect: mysql
+DAYOFMONTH(tbl.date_col);
+INT;
+
+# dialect: mysql
+DAYOFYEAR(tbl.date_col);
+INT;
+
+# dialect: mysql
 MONTH(tbl.date_col);
 INT;
 


### PR DESCRIPTION
This PR annotate `DAYOFMONTH(expr)`, `DAYOFYEAR(expr)` for MySQL before it was `TINYINT`

```python
CREATE TEMPORARY TABLE test_type AS 
SELECT DAYOFMONTH('2007-02-03');
DESCRIBE test_type;
```

```sql
+--------------------------+------+------+-----+---------+-------+
| Field                    | Type | Null | Key | Default | Extra |
+--------------------------+------+------+-----+---------+-------+
| DAYOFMONTH('2007-02-03') | int  | YES  |     | NULL    | NULL  |
+--------------------------+------+------+-----+---------+-------+
```

```sql
CREATE TEMPORARY TABLE test_type AS 
SELECT DAYOFYEAR('2007-02-03');
DESCRIBE test_type;
```

```python
+-------------------------+------+------+-----+---------+-------+
| Field                   | Type | Null | Key | Default | Extra |
+-------------------------+------+------+-----+---------+-------+
| DAYOFYEAR('2007-02-03') | int  | YES  |     | NULL    | NULL  |
+-------------------------+------+------+-----+---------+-------+
```

**Official documentation:**
https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_dayofmonth
https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_dayofyear