### PR TITLE
fix(optimizer)!: Annotate `WEEK(expr)` for MySQL

### DIFF
--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -24,6 +24,7 @@ EXPRESSION_METADATA = {
             exp.DayOfYear,
             exp.Month,
             exp.Second,
+            exp.Week,
         }
     },
     exp.Localtime: {"returns": exp.DataType.Type.DATETIME},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5606,6 +5606,14 @@ MONTH(tbl.date_col);
 INT;
 
 # dialect: mysql
+WEEK(tbl.date_col);
+INT;
+
+# dialect: mysql
+WEEK(tbl.date_col, int_col);
+INT;
+
+# dialect: mysql
 QUARTER(tbl.date_col);
 INT;
 


### PR DESCRIPTION
This PR qnnotate `WEEK(expr)` for MySQL before it was `TINYINT`

```sql
CREATE TEMPORARY TABLE test_type AS 
SELECT WEEK('2008-02-20', 1);
DESCRIBE test_type;
```

```python
+-----------------------+------+------+-----+---------+-------+
| Field                 | Type | Null | Key | Default | Extra |
+-----------------------+------+------+-----+---------+-------+
| WEEK('2008-02-20', 1) | int  | YES  |     | NULL    | NULL  |
+-----------------------+------+------+-----+---------+-------+
```

```sql
CREATE TEMPORARY TABLE test_type AS 
SELECT WEEK('2008-02-20');
DESCRIBE test_type;
```

```python
+--------------------+------+------+-----+---------+-------+
| Field              | Type | Null | Key | Default | Extra |
+--------------------+------+------+-----+---------+-------+
| WEEK('2008-02-20') | int  | YES  |     | NULL    | NULL  |
+--------------------+------+------+-----+---------+-------+
```

**Official documentation:**
https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_week