### PR TITLE
feat(optimizer)!: Annotate `HOUR(expr)` for MySQL, Hive, Spark, DBX through Base

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -123,6 +123,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.Ceil,
             exp.DatetimeDiff,
             exp.Getbit,
+            exp.Hour,
             exp.TimestampDiff,
             exp.TimeDiff,
             exp.Unicode,

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -418,7 +418,6 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.ByteLength,
             exp.Grouping,
-            exp.Hour,
             exp.JarowinklerSimilarity,
             exp.MapSize,
             exp.Minute,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -625,6 +625,10 @@ INT;
 MD5(tbl.str_col);
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+HOUR(tbl.timestamp_col);
+INT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------
@@ -5607,6 +5611,10 @@ INT;
 
 # dialect: mysql
 QUARTER(tbl.date_col);
+INT;
+
+# dialect: mysql
+HOUR(tbl.time_col);
 INT;
 
 # dialect: mysql


### PR DESCRIPTION
**Official documentation:**
Spark - https://spark.apache.org/docs/latest/api/sql/index.html#hour
DBX - https://docs.databricks.com/aws/en/sql/language-manual/functions/hour
MySQL - https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_hour

**Spark:**
```sql
SELECT typeof(hour('2018-02-14 12:58:59')), version()
```

```python
+---------------------------------+--------------------+
|typeof(hour(2018-02-14 12:58:59))|           version()|
+---------------------------------+--------------------+
|                              int|3.5.5 7c29c664cdc...|
+---------------------------------+--------------------+
```

**MySQL:**
```sql
CREATE TEMPORARY TABLE test_type AS 
SELECT HOUR('10:05:03');
DESCRIBE test_type;
```

```python
+------------------+------+------+-----+---------+-------+
| Field            | Type | Null | Key | Default | Extra |
+------------------+------+------+-----+---------+-------+
| HOUR('10:05:03') | int  | YES  |     | NULL    | NULL  |
+------------------+------+------+-----+---------+-------+
```