### PR TITLE
feat(optimizer)!: Annotate `LENGTH(expr)`, `LEVENSHTEIN_DISTANCE(expr)` for Presto/Trino

### DIFF
--- a/sqlglot/typing/presto.py
+++ b/sqlglot/typing/presto.py
@@ -6,6 +6,13 @@ from sqlglot.typing import EXPRESSION_METADATA
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
+        expr_type: {"returns": exp.DataType.Type.BIGINT}
+        for expr_type in {
+            exp.Length,
+            exp.Levenshtein,
+        }
+    },
+    **{
         expr_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this")}
         for expr_type in {
             exp.Ceil,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5916,3 +5916,11 @@ BIGINT;
 # dialect: presto, trino
 MD5(tbl.bin_col);
 VARBINARY;
+
+# dialect: presto, trino
+LEVENSHTEIN_DISTANCE(tbl.str_col, tbl.str_col);
+BIGINT;
+
+# dialect: presto, trino
+LENGTH(tbl.str_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `LENGTH(expr)`, `LEVENSHTEIN_DISTANCE(expr)` for Presto/Trino to `BIGINT`

**Trino:**
```bash
trino> select typeof(levenshtein_distance('abhishek','jo'));
 _col0  
--------
 bigint 
(1 row)

Query 20260203_172900_00014_u2nkw, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.16 [0 rows, 0B] [0 rows/s, 0B/s]
```

```bash
trino> select typeof(length('aslk'));
 _col0  
--------
 bigint 
(1 row)

Query 20260203_172608_00012_u2nkw, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.17 [0 rows, 0B] [0 rows/s, 0B/s]
```

**Official documentation:**
https://trino.io/docs/current/functions/string.html#length
https://trino.io/docs/current/functions/string.html#levenshtein_distance
https://prestodb.io/docs/current/functions/string.html#length-string-bigint
https://prestodb.io/docs/current/functions/string.html#levenshtein_distance-string1-string2-bigint