### PR TITLE
feat(optimizer)!: Annotate `POSITION` and `STRPOS` for Trino/Presto

### DIFF
--- a/sqlglot/typing/presto.py
+++ b/sqlglot/typing/presto.py
@@ -10,6 +10,7 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.Length,
             exp.Levenshtein,
+            exp.StrPosition,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5924,3 +5924,11 @@ BIGINT;
 # dialect: presto, trino
 LENGTH(tbl.str_col);
 BIGINT;
+
+# dialect: presto, trino
+POSITION(tbl.str_col IN tbl.str_col);
+BIGINT;
+
+# dialect: presto, trino
+STRPOS(tbl.str_col, tbl.str_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `POSITION` and `STRPOS` for Trino/Presto to `BIGINT`

https://trino.io/docs/current/functions/string.html#strpos
https://prestodb.io/docs/current/functions/string.html#position-substring-IN-string-bigint
https://trino.io/docs/current/functions/string.html#strpos
https://trino.io/docs/current/functions/string.html#position

```bash
trino> SELECT typeof(position('abhi' IN 'abhishek'));
 _col0  
--------
 bigint 
(1 row)

Query 20260203_180637_00022_u2nkw, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.08 [0 rows, 0B] [0 rows/s, 0B/s]

trino> SELECT typeof(strpos('abhi','abhishek'));
 _col0  
--------
 bigint 
(1 row)

Query 20260203_180648_00023_u2nkw, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.15 [0 rows, 0B] [0 rows/s, 0B/s]

```