### PR TITLE
feat(optimizer)!: Annotate `WIDTH_BUCKET(expr)` for Presto/Trino

### DIFF
--- a/sqlglot/typing/presto.py
+++ b/sqlglot/typing/presto.py
@@ -11,6 +11,7 @@ EXPRESSION_METADATA = {
             exp.Length,
             exp.Levenshtein,
             exp.StrPosition,
+            exp.WidthBucket,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5932,3 +5932,7 @@ BIGINT;
 # dialect: presto, trino
 STRPOS(tbl.str_col, tbl.str_col);
 BIGINT;
+
+# dialect: presto, trino
+WIDTH_BUCKET(tbl.double_col, tbl.array_col);
+BIGINT;


### PR DESCRIPTION
This PR annotate `WIDTH_BUCKET(expr)` for Presto/Trino as `BIGINT`

https://trino.io/docs/current/functions/math.html#width_bucket
https://prestodb.io/docs/current/functions/math.html#width_bucket-x-bins-bigint

```bash
trino> SELECT typeof(width_bucket(1.1, ARRAY[10, 20, 30]));
 _col0  
--------
 bigint 
(1 row)

Query 20260203_182107_00035_u2nkw, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.10 [0 rows, 0B] [0 rows/s, 0B/s]

```