### PR TITLE
feat(optimizer)!: Annotate `COLLATION(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -14,6 +14,7 @@ EXPRESSION_METADATA = {
     **{
         exp_type: {"returns": exp.DataType.Type.VARCHAR}
         for exp_type in {
+            exp.Collation,
             exp.CurrentTimezone,
             exp.Monthname,
             exp.SessionUser,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -629,6 +629,10 @@ STRING;
 HOUR(tbl.timestamp_col);
 INT;
 
+# dialect: spark, databricks
+COLLATION(tbl.str_col);
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
https://spark.apache.org/docs/latest/api/sql/index.html#collation
https://docs.databricks.com/aws/en/sql/language-manual/functions/collate

```sql
SELECT typeof(collation('Spark SQL')), version()
```

**Databricks:**
```python
|typeof(collation(Spark SQL))|version()|
|---|---|
|string|4.0.0 0000000000000000000000000000000000000000|
```