### PR TITLE
feat(generator): Add numeric TRUNC output for additional dialects

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1186,6 +1186,7 @@ class ClickHouse(Dialect):
             exp.Rand: rename_func("randCanonical"),
             exp.StartsWith: rename_func("startsWith"),
             exp.Struct: rename_func("tuple"),
+            exp.Trunc: rename_func("trunc"),
             exp.EndsWith: rename_func("endsWith"),
             exp.EuclideanDistance: rename_func("L2Distance"),
             exp.StrPosition: lambda self, e: strposition_sql(

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -2728,6 +2728,10 @@ class DuckDB(Dialect):
                 return self.sql(exp.case().when(exp.func("json_valid", arg), arg).else_(exp.null()))
             return self.func("JSON", arg)
 
+        @unsupported_args("decimals")
+        def trunc_sql(self, expression: exp.Trunc) -> str:
+            return self.func("TRUNC", expression.this)
+
         def normal_sql(self, expression: exp.Normal) -> str:
             """
             Transpile Snowflake's NORMAL(mean, stddev, gen) to DuckDB.

--- a/sqlglot/dialects/presto.py
+++ b/sqlglot/dialects/presto.py
@@ -545,6 +545,12 @@ class Presto(Dialect):
             exp.WithinGroup: transforms.preprocess(
                 [transforms.remove_within_group_for_percentiles]
             ),
+            # Note: Presto's TRUNCATE always returns DOUBLE, even with decimals=0, whereas
+            # most dialects return INT (SQLite also returns REAL, see sqlite.py). This creates
+            # a bidirectional transpilation gap: Presto→Other may change float division to int
+            # division, and vice versa. Modeling precisely would require exp.FloatTrunc or
+            # similar, deemed overengineering for this subtle semantic difference.
+            exp.Trunc: rename_func("TRUNCATE"),
             exp.Xor: bool_xor_sql,
             exp.MD5Digest: rename_func("MD5"),
             exp.SHA: rename_func("SHA1"),

--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -267,6 +267,10 @@ class SQLite(Dialect):
 
             return super().cast_sql(expression)
 
+        # Note: SQLite's TRUNC always returns REAL (e.g., trunc(10.99) -> 10.0), not INTEGER.
+        # This creates a transpilation gap affecting division semantics, similar to Presto.
+        # Unlike Presto where this only affects decimals=0, SQLite has no decimals parameter
+        # so every use of TRUNC is affected. Modeling precisely would require exp.FloatTrunc.
         @unsupported_args("decimals")
         def trunc_sql(self, expression: exp.Trunc) -> str:
             return self.func("TRUNC", expression.this)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -110,6 +110,15 @@ class TestClickhouse(Validator):
         self.validate_identity("TRUNCATE DATABASE db")
         self.validate_identity("TRUNCATE DATABASE db ON CLUSTER test_cluster")
         self.validate_identity("TRUNCATE DATABASE db ON CLUSTER '{cluster}'")
+
+        # Numeric trunc
+        self.validate_identity("trunc(3.14159, 2)").assert_is(exp.Trunc)
+        self.validate_identity("trunc(3.14159)").assert_is(exp.Trunc)
+        self.validate_all(
+            "trunc(3.14159, 2)",
+            read={"postgres": "TRUNC(3.14159, 2)"},
+        )
+
         self.validate_identity("EXCHANGE TABLES x.a AND y.b", check_command_warning=True)
         self.validate_identity("CREATE TABLE test (id UInt8) ENGINE=Null()")
         self.validate_identity(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -9,6 +9,14 @@ class TestDuckDB(Validator):
     dialect = "duckdb"
 
     def test_duckdb(self):
+        # Numeric TRUNC - DuckDB only supports TRUNC(x), no decimals parameter
+        self.validate_identity("TRUNC(3.14)").assert_is(exp.Trunc)
+        self.validate_identity("TRUNC(3.14, 2)", "TRUNC(3.14)").assert_is(exp.Trunc)
+        self.validate_all(
+            "TRUNC(3.14159)",
+            read={"postgres": "TRUNC(3.14159, 2)"},
+        )
+
         self.validate_identity("SELECT ([1,2,3])[:-:-1]", "SELECT ([1, 2, 3])[:-1:-1]")
         self.validate_identity(
             "SELECT INTERVAL '1 hour'::VARCHAR", "SELECT CAST(INTERVAL '1' HOUR AS TEXT)"

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -888,6 +888,13 @@ class TestHive(Validator):
 
         # Hive TRUNC is date-only, should parse to TimestampTrunc (not numeric Trunc)
         self.validate_identity("TRUNC(date_col, 'MM')").assert_is(exp.TimestampTrunc)
+
+        # Numeric TRUNC from other dialects - Hive has no native support, uses CAST to BIGINT
+        self.validate_all(
+            "CAST(3.14159 AS BIGINT)",
+            read={"postgres": "TRUNC(3.14159, 2)"},
+        )
+
         self.validate_all(
             "REGEXP_EXTRACT('abc', '(a)(b)(c)')",
             read={

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -802,7 +802,10 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
                 "tsql": "ROUND(3.14159, 2, 1)",
                 "snowflake": "TRUNC(3.14159, 2)",
                 "bigquery": "TRUNC(3.14159, 2)",
-                "duckdb": "TRUNC(3.14159, 2)",
+                "duckdb": "TRUNC(3.14159)",
+                "presto": "TRUNCATE(3.14159, 2)",
+                "clickhouse": "trunc(3.14159, 2)",
+                "spark": "CAST(3.14159 AS BIGINT)",
             },
         )
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -718,6 +718,14 @@ class TestPresto(Validator):
         self.validate_identity("SELECT * FROM x OFFSET 1 LIMIT 1")
         self.validate_identity("SELECT * FROM x OFFSET 1 FETCH FIRST 1 ROWS ONLY")
         self.validate_identity("SELECT BOOL_OR(a > 10) FROM asd AS T(a)")
+
+        # Numeric TRUNCATE
+        self.validate_identity("TRUNCATE(3.14159, 2)").assert_is(exp.Trunc)
+        self.validate_identity("TRUNCATE(3.14159)").assert_is(exp.Trunc)
+        self.validate_all(
+            "TRUNCATE(3.14159, 2)",
+            read={"postgres": "TRUNC(3.14159, 2)"},
+        )
         self.validate_identity("SELECT * FROM (VALUES (1))")
         self.validate_identity("START TRANSACTION READ WRITE, ISOLATION LEVEL SERIALIZABLE")
         self.validate_identity("START TRANSACTION ISOLATION LEVEL REPEATABLE READ")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -3577,7 +3577,10 @@ class TestSnowflake(Validator):
                 "mysql": "TRUNCATE(3.14159, 2)",
                 "tsql": "ROUND(3.14159, 2, 1)",
                 "bigquery": "TRUNC(3.14159, 2)",
-                "duckdb": "TRUNC(3.14159, 2)",
+                "duckdb": "TRUNC(3.14159)",
+                "presto": "TRUNCATE(3.14159, 2)",
+                "clickhouse": "trunc(3.14159, 2)",
+                "spark": "CAST(3.14159 AS BIGINT)",
             },
         )
 

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -279,6 +279,12 @@ TBLPROPERTIES (
         # Spark TRUNC is date-only, should parse to DateTrunc (not numeric Trunc)
         self.validate_identity("TRUNC(date_col, 'MM')").assert_is(exp.DateTrunc)
 
+        # Numeric TRUNC from other dialects - Spark has no native support, uses CAST to BIGINT
+        self.validate_all(
+            "CAST(3.14159 AS BIGINT)",
+            read={"postgres": "TRUNC(3.14159, 2)"},
+        )
+
         self.validate_identity("SELECT APPROX_TOP_K_ACCUMULATE(col, 10)")
         self.validate_identity("SELECT APPROX_TOP_K_ACCUMULATE(col)")
         self.validate_identity("SELECT BITMAP_BIT_POSITION(10)")


### PR DESCRIPTION
Follow-up to #6923 (numeric TRUNC support)

Add dialect-specific generators for numeric TRUNC (exp.Trunc):

- **Presto/Trino**: Use TRUNCATE (Presto's function name)
- **ClickHouse**: Use lowercase `trunc` (ClickHouse convention)
- **DuckDB**: Strip decimals arg (DuckDB only supports TRUNC(x))
- **Hive/Spark**: Use CAST(x AS BIGINT) since no native numeric TRUNC

For Hive/Spark, CAST to integral types truncates toward zero (does not round), matching TRUNC semantics: CAST(3.7 AS BIGINT) → 3, not 4. The decimals parameter is marked unsupported since the cast only produces integer output.

Known limitations documented in code comments:

- Presto/SQLite return DOUBLE/REAL from TRUNC even for integer truncation, creating a bidirectional transpilation gap affecting division semantics. Modeling precisely would require exp.FloatTrunc, deemed overengineering.

- Hive/Spark could use a TRUNC_TEMPLATE with FLOOR/CEIL (Spark 3.3+) to preserve decimals, but current CAST approach is simpler.

- A future `unsupported_args_unless_default` decorator could suppress warnings when decimals=0, the common case for DuckDB/SQLite/Hive/Spark.