### PR TITLE
feat(optimizer)!: Annotate `FORMAT_STRING(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -56,6 +56,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "expressions", target_type=exp.DataType.Type.TEXT
         )
     },
+    exp.Format: {"returns": exp.DataType.Type.VARCHAR},
     exp.Pad: {
         "annotator": lambda self, e: _annotate_by_similar_args(
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -637,6 +637,10 @@ BIGINT;
 COLLATION(tbl.str_col);
 STRING;
 
+# dialect: spark2, spark, databricks
+FORMAT_STRING(tbl.str_col, tbl.int_col, tbl.str_col);
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `FORMAT_STRING(expr)` for **Spark/DBX**

https://docs.databricks.com/aws/en/sql/language-manual/functions/format_string
https://spark.apache.org/docs/latest/api/sql/index.html#format_string