### PR TITLE
feat(snowflake)!: transpile `CURRENT_VERSION()` to ClickHouse, Postgres/Redshift, Trino

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -1162,6 +1162,7 @@ class ClickHouse(Dialect):
             exp.ComputedColumnConstraint: lambda self,
             e: f"{'MATERIALIZED' if e.args.get('persisted') else 'ALIAS'} {self.sql(e, 'this')}",
             exp.CurrentDate: lambda self, e: self.func("CURRENT_DATE"),
+            exp.CurrentVersion: rename_func("VERSION"),
             exp.DateAdd: _datetime_delta_sql("DATE_ADD"),
             exp.DateDiff: _datetime_delta_sql("DATE_DIFF"),
             exp.DateStrToDate: rename_func("toDate"),

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -737,6 +737,7 @@ class Postgres(Dialect):
             exp.CurrentDate: no_paren_current_date_sql,
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
             exp.CurrentUser: lambda *_: "CURRENT_USER",
+            exp.CurrentVersion: rename_func("VERSION"),
             exp.DateAdd: _date_add_sql("+"),
             exp.DateDiff: _date_diff_sql,
             exp.DateStrToDate: datestrtodate_sql,

--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -6,6 +6,7 @@ from sqlglot.dialects.dialect import (
     trim_sql,
     timestrtotime_sql,
     groupconcat_sql,
+    rename_func,
 )
 from sqlglot.dialects.presto import amend_exploded_column_table, Presto
 from sqlglot.tokens import TokenType
@@ -80,6 +81,7 @@ class Trino(Presto):
             exp.ArraySum: lambda self,
             e: f"REDUCE({self.sql(e, 'this')}, 0, (acc, x) -> acc + x, acc -> acc)",
             exp.ArrayUniqueAgg: lambda self, e: f"ARRAY_AGG(DISTINCT {self.sql(e, 'this')})",
+            exp.CurrentVersion: rename_func("VERSION"),
             exp.GroupConcat: lambda self, e: groupconcat_sql(self, e, on_overflow=True),
             exp.LocationProperty: lambda self, e: self.property_sql(e),
             exp.Merge: merge_without_target_sql,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2941,6 +2941,10 @@ class TestSnowflake(Validator):
                 "mysql": "SELECT VERSION()",
                 "singlestore": "SELECT VERSION()",
                 "starrocks": "SELECT CURRENT_VERSION()",
+                "postgres": "SELECT VERSION()",
+                "redshift": "SELECT VERSION()",
+                "clickhouse": "SELECT VERSION()",
+                "trino": "SELECT VERSION()",
             },
         )
 


### PR DESCRIPTION
This PR transpile `CURRENT_VERSION()` to **ClickHouse**, **Postgres**/**Redshift**, **Trino**

https://trino.io/docs/current/functions/system.html#version
https://www.postgresql.org/docs/current/functions-info.html#FUNCTIONS-INFO-VERSION
https://docs.aws.amazon.com/redshift/latest/dg/r_VERSION.html

**ClickHouse:**

<img width="322" height="340" alt="image" src="https://github.com/user-attachments/assets/576ce4dd-0102-4ed9-9ad6-ea7fa7e0511c" />
