### PR TITLE
feat(sqlite)!: Map `SQLITE_VERSION()` to exp.CurrentVersion expression

### DIFF
--- a/sqlglot/dialects/sqlite.py
+++ b/sqlglot/dialects/sqlite.py
@@ -122,6 +122,7 @@ class SQLite(Dialect):
             "STRFTIME": _build_strftime,
             "DATETIME": lambda args: exp.Anonymous(this="DATETIME", expressions=args),
             "TIME": lambda args: exp.Anonymous(this="TIME", expressions=args),
+            "SQLITE_VERSION": exp.CurrentVersion.from_arg_list,
         }
 
         STATEMENT_PARSERS = {
@@ -208,6 +209,7 @@ class SQLite(Dialect):
             exp.CurrentDate: lambda *_: "CURRENT_DATE",
             exp.CurrentTime: lambda *_: "CURRENT_TIME",
             exp.CurrentTimestamp: lambda *_: "CURRENT_TIMESTAMP",
+            exp.CurrentVersion: lambda *_: "SQLITE_VERSION()",
             exp.ColumnDef: transforms.preprocess([_generated_to_auto_increment]),
             exp.DateStrToDate: lambda self, e: self.sql(e, "this"),
             exp.If: rename_func("IIF"),

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -160,6 +160,7 @@ class TestSQLite(Validator):
         self.validate_identity(
             "SELECT * FROM t WHERE NULL IS NOT y", "SELECT * FROM t WHERE NOT NULL IS y"
         )
+        self.validate_identity("SELECT SQLITE_VERSION()")
 
     def test_strftime(self):
         self.validate_identity("SELECT STRFTIME('%Y/%m/%d', 'now')")


### PR DESCRIPTION
**Map `SQLITE_VERSION()` to `exp.CurrentVersion` expression initially it was `Anonymous`**

https://sqlite.org/lang_corefunc.html#sqlite_version