### PR TITLE
feat(optimizer)!: Annotate `REPEAT(expr)` for Hive, Spark, DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -26,6 +26,7 @@ EXPRESSION_METADATA = {
             exp.CurrentSchema,
             exp.CurrentUser,
             exp.Hex,
+            exp.Repeat,
             exp.Soundex,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -637,6 +637,10 @@ BIGINT;
 COLLATION(tbl.str_col);
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+REPEAT(tbl.str_col, tbl.int_col);
+STRING;
+
 # dialect: spark2, spark, databricks
 FORMAT_STRING(tbl.str_col, tbl.int_col, tbl.str_col);
 STRING;


### PR DESCRIPTION
This PR annotate `REPEAT(expr)` for **Hive**, **Spark**, **DBX**

https://docs.databricks.com/aws/en/sql/language-manual/functions/repeat
https://spark.apache.org/docs/latest/api/sql/index.html#repeat

**Hive:**
```
Hive Version: 4.1.0
+---------+--+
|   _c0   |
+---------+--+
| string  |
+---------+--+
```