### PR TITLE
feat(snowflake)!: add support for JAROWINKLER_SIMILARITY

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -397,6 +397,7 @@ class ClickHouse(Dialect):
             "SUBSTRINGINDEX": exp.SubstringIndex.from_arg_list,
             "TOTYPENAME": exp.Typeof.from_arg_list,
             "EDITDISTANCE": exp.Levenshtein.from_arg_list,
+            "JAROWINKLERSIMILARITY": exp.JarowinklerSimilarity.from_arg_list,
             "LEVENSHTEINDISTANCE": exp.Levenshtein.from_arg_list,
         }
         FUNCTIONS.pop("TRANSFORM")
@@ -1231,6 +1232,7 @@ class ClickHouse(Dialect):
             exp.Lead: lambda self, e: self.func(
                 "leadInFrame", e.this, e.args.get("offset"), e.args.get("default")
             ),
+            exp.JarowinklerSimilarity: rename_func("jaroWinklerSimilarity"),
             exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
                 rename_func("editDistance")
             ),

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1534,6 +1534,7 @@ class DuckDB(Dialect):
                 this=seq_get(args, 0), charset=exp.Literal.string("utf-8")
             ),
             "EDITDIST3": exp.Levenshtein.from_arg_list,
+            "JARO_WINKLER_SIMILARITY": exp.JarowinklerSimilarity.from_arg_list,
             "ENCODE": lambda args: exp.Encode(
                 this=seq_get(args, 0), charset=exp.Literal.string("utf-8")
             ),
@@ -1923,6 +1924,7 @@ class DuckDB(Dialect):
             ),
             exp.Ceil: _ceil_floor,
             exp.Floor: _ceil_floor,
+            exp.JarowinklerSimilarity: rename_func("JARO_WINKLER_SIMILARITY"),
             exp.JSONBExists: rename_func("JSON_EXISTS"),
             exp.JSONExtract: _arrow_json_extract_sql,
             exp.JSONExtractArray: _json_extract_value_array_sql,

--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -33,6 +33,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
             exp.Atan2,
+            exp.JarowinklerSimilarity,
             exp.Rand,
             exp.TimeToUnix,
         }

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -93,6 +93,7 @@ class TestClickhouse(Validator):
         self.validate_identity("SELECT groupUniqArray(2)(a)")
         self.validate_identity("SELECT exponentialTimeDecayedAvg(60)(a, b)")
         self.validate_identity("levenshteinDistance(col1, col2)", "editDistance(col1, col2)")
+        self.validate_identity("jaroWinklerSimilarity('hello', 'world')")
         self.validate_identity("SELECT * FROM foo WHERE x GLOBAL IN (SELECT * FROM bar)")
         self.validate_identity("SELECT * FROM foo WHERE x GLOBAL NOT IN (SELECT * FROM bar)")
         self.validate_identity("POSITION(haystack, needle)")

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1152,6 +1152,7 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_identity("EDITDIST3(col1, col2)", "LEVENSHTEIN(col1, col2)")
+        self.validate_identity("JARO_WINKLER_SIMILARITY('hello', 'world')")
 
         self.validate_identity("SELECT LENGTH(foo)")
         self.validate_identity("SELECT ARRAY[1, 2, 3]", "SELECT [1, 2, 3]")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -187,7 +187,14 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT SIGN(x)")
         self.validate_identity("SELECT COSH(1.5)")
         self.validate_identity("SELECT TANH(0.5)")
-        self.validate_identity("SELECT JAROWINKLER_SIMILARITY('hello', 'world')")
+        self.validate_all(
+            "JAROWINKLER_SIMILARITY('hello', 'world')",
+            write={
+                "snowflake": "JAROWINKLER_SIMILARITY('hello', 'world')",
+                "duckdb": "JARO_WINKLER_SIMILARITY('hello', 'world')",
+                "clickhouse": "jaroWinklerSimilarity('hello', 'world')",
+            },
+        )
         self.validate_identity("SELECT TRANSLATE(column_name, 'abc', '123')")
         self.validate_identity("SELECT UNICODE(column_name)")
         self.validate_identity("SELECT WIDTH_BUCKET(col, 0, 100, 10)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -3421,6 +3421,10 @@ BOOLEAN;
 JAROWINKLER_SIMILARITY('hello', 'world');
 INT;
 
+# dialect: duckdb
+JARO_WINKLER_SIMILARITY('hello', 'world');
+DOUBLE;
+
 # dialect: snowflake
 INSERT('abc', 1, 2, 'Z');
 VARCHAR;


### PR DESCRIPTION
Add support for `JAROWINKLER_SIMILARITY(s, t)`

Docs:
[Snowflake](https://docs.snowflake.com/en/sql-reference/functions/jarowinkler_similarity)
[DuckDB](https://duckdb.org/docs/stable/sql/functions/text#jaro_winkler_similaritys1-s2-score_cutoff)
[ClickHouse](https://clickhouse.com/docs/sql-reference/functions/string-functions#jaroWinklerSimilarity)

Not supported in other dialects