### PR TITLE
feat(optimizer)!: Annotate `RIGHT(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -51,12 +51,18 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.Randn,
         }
     },
+    **{
+        exp_type: {"returns": exp.DataType.Type.VARCHAR}
+        for exp_type in {
+            exp.Format,
+            exp.Right,
+        }
+    },
     exp.Concat: {
         "annotator": lambda self, e: _annotate_by_similar_args(
             self, e, "expressions", target_type=exp.DataType.Type.TEXT
         )
     },
-    exp.Format: {"returns": exp.DataType.Type.VARCHAR},
     exp.Pad: {
         "annotator": lambda self, e: _annotate_by_similar_args(
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -661,6 +661,10 @@ STRING;
 OVERLAY(tbl.bin_col PLACING tbl.bin_col FROM tbl.int_col FOR tbl.int_col);
 BINARY;
 
+# dialect: spark2, spark, databricks
+RIGHT(tbl.str_col, tbl.int_col);
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
This PR annotate `RIGHT(expr)` for `Spark`/`DBX`

https://docs.databricks.com/aws/en/sql/language-manual/functions/right
https://spark.apache.org/docs/latest/api/sql/index.html#right