### PR TITLE
feat(postgres)!: support parsing `VERSION()` for Postgres/Redshift

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -434,6 +434,7 @@ class Postgres(Dialect):
             "BIT_AND": exp.BitwiseAndAgg.from_arg_list,
             "BIT_OR": exp.BitwiseOrAgg.from_arg_list,
             "BIT_XOR": exp.BitwiseXorAgg.from_arg_list,
+            "VERSION": exp.CurrentVersion.from_arg_list,
             "DATE_TRUNC": build_timestamp_trunc,
             "DIV": lambda args: exp.cast(
                 binary_from_function(exp.IntDiv)(args), exp.DataType.Type.DECIMAL

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -82,6 +82,7 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT CURRENT_SCHEMA")
         self.validate_identity("SELECT CURRENT_USER")
         self.validate_identity("SELECT CURRENT_ROLE")
+        self.validate_identity("SELECT VERSION()")
         self.validate_identity("SELECT * FROM ONLY t1")
         self.validate_identity("SELECT INTERVAL '-1 MONTH'")
         self.validate_identity("SELECT INTERVAL '4.1 DAY'")

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -329,6 +329,8 @@ class TestRedshift(Validator):
             },
         )
 
+        self.validate_identity("SELECT VERSION()")
+
     def test_identity(self):
         self.validate_identity("SELECT GETBIT(FROM_HEX('4d'), 2)")
         self.validate_identity("SELECT EXP(1)")


### PR DESCRIPTION
### This PR add support for `VERSION()` for `Postgres`/`Redshift`