### PR TITLE
feat(trino)!: support for `version()` for trino

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -24,6 +24,11 @@ class Trino(Presto):
         }
 
     class Parser(Presto.Parser):
+        FUNCTIONS = {
+            **Presto.Parser.FUNCTIONS,
+            "VERSION": exp.CurrentVersion.from_arg_list,
+        }
+
         FUNCTION_PARSERS = {
             **Presto.Parser.FUNCTION_PARSERS,
             "TRIM": lambda self: self._parse_trim(),

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -49,6 +49,8 @@ class TestTrino(Validator):
             "SELECT * FROM tbl MATCH_RECOGNIZE (PARTITION BY id ORDER BY col MEASURES FIRST(col, 2) AS col1, LAST(col, 2) AS col2 PATTERN (B* A) DEFINE A AS col = 1)"
         )
 
+        self.validate_identity("SELECT VERSION()")
+
     def test_listagg(self):
         self.validate_identity(
             "SELECT LISTAGG(DISTINCT col, ',') WITHIN GROUP (ORDER BY col ASC) FROM tbl"


### PR DESCRIPTION
This PR map `exp.CurrentVersion` to `VERSION` Function for **`Trino`**


```python
trino> select version();
 _col0 
-------
 478   
(1 row)

Query 20260204_092232_00001_u2nkw, FINISHED, 1 node
Splits: 1 total, 1 done (100.00%)
0.05 [0 rows, 0B] [0 rows/s, 0B/s]

```