### PR TITLE
feat(optimizer)!: Annotate `SPLIT(expr)` for Hive/Spark/DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -49,5 +49,6 @@ EXPRESSION_METADATA = {
         "annotator": lambda self, e: self._annotate_by_args(e, "this", "expressions", promote=True)
     },
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
+    exp.RegexpSplit: {"returns": exp.DataType.build("ARRAY<STRING>")},
     exp.Reverse: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -677,6 +677,14 @@ ARRAY<STRING>;
 RIGHT(tbl.str_col, tbl.int_col);
 STRING;
 
+# dialect: hive, spark2, spark, databricks
+SPLIT(tbl.str_col, tbl.str_col, tbl.int_col);
+ARRAY<STRING>;
+
+# dialect: hive, spark2, spark, databricks
+SPLIT(tbl.str_col, tbl.str_col);
+ARRAY<STRING>;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
### This PR annotate `SPLIT(expr)` for **`Hive/Spark/DBX`**

https://spark.apache.org/docs/latest/api/sql/index.html#split
https://docs.databricks.com/aws/en/sql/language-manual/functions/split

```python
Hive Version: 4.1.0
+----------------+--+
|      _c0       |
+----------------+--+
| array<string>  |
+----------------+--+
```