### PR TITLE
fix(parser): Limit named PK parsing to MySQL only

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -918,10 +918,15 @@ class ClickHouse(Dialect):
             return super()._parse_wrapped_id_vars(optional=True)
 
         def _parse_primary_key(
-            self, wrapped_optional: bool = False, in_props: bool = False
+            self,
+            wrapped_optional: bool = False,
+            in_props: bool = False,
+            named_primary_key: bool = False,
         ) -> exp.PrimaryKeyColumnConstraint | exp.PrimaryKey:
             return super()._parse_primary_key(
-                wrapped_optional=wrapped_optional or in_props, in_props=in_props
+                wrapped_optional=wrapped_optional or in_props,
+                in_props=in_props,
+                named_primary_key=named_primary_key,
             )
 
         def _parse_on_property(self) -> t.Optional[exp.Expression]:

--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -791,6 +791,16 @@ class MySQL(Dialect):
             part_list = self.expression(exp.PartitionList, this=name, expressions=values)
             return self.expression(exp.Partition, expressions=[part_list])
 
+        def _parse_primary_key(
+            self,
+            wrapped_optional: bool = False,
+            in_props: bool = False,
+            named_primary_key: bool = False,
+        ) -> exp.PrimaryKeyColumnConstraint | exp.PrimaryKey:
+            return super()._parse_primary_key(
+                wrapped_optional=wrapped_optional, in_props=in_props, named_primary_key=True
+            )
+
     class Generator(generator.Generator):
         INTERVAL_ALLOWS_PLURAL_FORM = False
         LOCKING_READS_SUPPORTED = True

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6678,7 +6678,10 @@ class Parser(metaclass=_Parser):
         )
 
     def _parse_primary_key(
-        self, wrapped_optional: bool = False, in_props: bool = False
+        self,
+        wrapped_optional: bool = False,
+        in_props: bool = False,
+        named_primary_key: bool = False,
     ) -> exp.PrimaryKeyColumnConstraint | exp.PrimaryKey:
         desc = (
             self._match_set((TokenType.ASC, TokenType.DESC))
@@ -6687,7 +6690,8 @@ class Parser(metaclass=_Parser):
 
         this = None
         if (
-            self._curr.text.upper() not in self.CONSTRAINT_PARSERS
+            named_primary_key
+            and self._curr.text.upper() not in self.CONSTRAINT_PARSERS
             and self._next
             and self._next.token_type == TokenType.L_PAREN
         ):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -941,6 +941,14 @@ ORDER BY (
         self.validate_identity(
             'CREATE TABLE t1 ("x" UInt32, "y" Dynamic, "z" Dynamic(max_types = 10)) ENGINE=MergeTree ORDER BY x'
         )
+        self.validate_identity(
+            "CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY id",
+            "CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY (id)",
+        )
+        self.validate_identity(
+            "CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY tuple()",
+            "CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY (tuple())",
+        )
 
         self.validate_all(
             "CREATE DATABASE x",


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/6989

The regression is due to https://github.com/tobymao/sqlglot/pull/6389 as it tried to parse MySQL's named primary keys such as `PRIMARY KEY name (...)`, which now trips up for Clickhouse's `PRIMARY KEY tuple (...)`.

I don't think named primary keys exist outside of MySQL (it itself seems to discard the name anyways) so I opted out of using a parser flag to generalize the behavior.

```SQL
# Naming the PK does not work
:) CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY "foo" (id);
Code: 46. DB::Exception: Unknown function foo: While processing foo(id). (UNKNOWN_FUNCTION)

# tuple() works
:) CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY tuple();
OK

# wrapped tuple() also works
:) CREATE TABLE test_table (id Int32, name String) ENGINE=MergeTree PRIMARY KEY (tuple());
OK
```


Docs
--------
[Clickhouse PK](https://clickhouse.com/docs/guides/best-practices/sparse-primary-indexes#a-table-with-a-primary-key)
