### PR TITLE
feat(optimizer)!: Annotate `FILTER(expr, func)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -69,4 +69,5 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
         )
     },
     exp.Substring: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
+    exp.ArrayFilter: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -689,6 +689,10 @@ ARRAY<STRING>;
 SPLIT(tbl.str_col, tbl.str_col);
 ARRAY<STRING>;
 
+# dialect: spark2, spark, databricks
+FILTER(tbl.array_col, x -> x > 2);
+ARRAY<STRING>;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
### This PR annotate `FILTER(expr, func)` for **`Spark/DBX`**

**Spark:**
```sql
SELECT typeof(filter(array('a','b'), x -> x % 2 == 1)) as sample
```

```python
+-------------+
|       sample|
+-------------+
|array<string>|
+-------------+
```

https://spark.apache.org/docs/latest/api/sql/index.html#filter
https://docs.databricks.com/aws/en/sql/language-manual/functions/filter