### PR TITLE
feat(optimizer)!: Annotate `DAYOFWEEK(expr)`, `DAYOFMONTH(expr)` for Hive/Spark/DBX

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -131,6 +131,9 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.BitLength,
             exp.Ceil,
             exp.DatetimeDiff,
+            exp.DayOfMonth,
+            exp.DayOfWeek,
+            exp.DayOfYear,
             exp.Getbit,
             exp.Hour,
             exp.TimestampDiff,
@@ -189,10 +192,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
         expr_type: {"returns": exp.DataType.Type.TINYINT}
         for expr_type in {
             exp.Day,
-            exp.DayOfMonth,
-            exp.DayOfWeek,
             exp.DayOfWeekIso,
-            exp.DayOfYear,
             exp.Month,
             exp.Week,
             exp.WeekOfYear,

--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -43,8 +43,6 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.INT}
         for expr_type in {
-            exp.DayOfMonth,
-            exp.DayOfWeek,
             exp.Month,
             exp.Second,
         }

--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -29,9 +29,6 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.INT}
         for expr_type in {
-            exp.DayOfMonth,
-            exp.DayOfWeek,
-            exp.DayOfYear,
             exp.Month,
             exp.Second,
             exp.Week,

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -470,6 +470,9 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.TINYINT}
         for expr_type in {
+            exp.DayOfMonth,
+            exp.DayOfWeek,
+            exp.DayOfYear,
             exp.Quarter,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -692,6 +692,14 @@ NEXT_DAY(tbl.date_col, tbl.str_col);
 VARCHAR;
 
 # dialect: hive, spark2, spark, databricks
+DAYOFWEEK(tbl.date_col);
+INT;
+
+# dialect: hive, spark2, spark, databricks
+DAYOFMONTH(tbl.date_col);
+INT;
+
+# dialect: hive, spark2, spark, databricks
 TRANSLATE(tbl.str_col, tbl.str_col, tbl.str_col);
 STRING; 
 


### PR DESCRIPTION
### 📌 This PR annotate `DAYOFWEEK(expr)`, `DAYOFMONTH(expr)` for Hive/Spark/DBX


```sql
SELECT typeof(dayofmonth('2009-07-30')), typeof(dayofweek('2009-07-30')), version()
```

**Spark:**

```python
+------------------------------+-----------------------------+--------------------+
|typeof(dayofmonth(2009-07-30))|typeof(dayofweek(2009-07-30))|           version()|
+------------------------------+-----------------------------+--------------------+
|                           int|                          int|3.5.5 7c29c664cdc...|
+------------------------------+-----------------------------+--------------------+
```

**Hive:**
```python
Hive Version: 4.1.0
+------+------+--------------------------------------------------+--+
| _c0  | _c1  |                       _c2                        |
+------+------+--------------------------------------------------+--+
| int  | int  | 4.1.0 r75e40b7537c91a70ccaa31c397d21823c7528eeb  |
+------+------+--------------------------------------------------+--+
```

for hive -> dayofyear(expr) is not supported, so should we add in spark2 annotator?
```sql
SELECT dayofyear('2009-07-30')
```

```python
Hive Version: 4.1.0
log4j:WARN No appenders could be found for logger (org.apache.hive.jdbc.Utils).
log4j:WARN Please initialize the log4j system properly.
log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
Error: Error while compiling statement: FAILED: SemanticException [Error 10011]: Invalid function dayofyear; Query ID: hive_20260206173453_460fda2a-82dc-479d-833c-bc5cf81ca03d (state=42000,code=10011)
```