### PR TITLE
feat(mysql)!: support `user()` for mysql

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -368,6 +368,7 @@ class MySQL(Dialect):
                 )
                 + 1
             ),
+            "USER": exp.CurrentUser.from_arg_list,
             "VERSION": exp.CurrentVersion.from_arg_list,
             "WEEK": lambda args: exp.Week(
                 this=exp.TsOrDsToDate(this=seq_get(args, 0)), mode=seq_get(args, 1)

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -243,6 +243,7 @@ class TestMySQL(Validator):
         self.validate_identity("""SELECT * FROM foo WHERE 'ab' MEMBER OF(content)""")
         self.validate_identity("SELECT CURRENT_TIMESTAMP(6)")
         self.validate_identity("SELECT CURRENT_ROLE()")
+        self.validate_identity("SELECT USER()", "SELECT CURRENT_USER()")
         self.validate_identity("x ->> '$.name'")
         self.validate_identity("SELECT CAST(`a`.`b` AS CHAR) FROM foo")
         self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ')")


### PR DESCRIPTION
### ✳️ This PR map `exp.CurrentUser` to USER for `MySQL`

```sql
select current_user(), user();
```

```python
+----------------------------+--------------------------------------+
| current_user()             | user()                               |
+----------------------------+--------------------------------------+
| user_44ctrvzeh_44cvj2esn@% | user_44ctrvzeh_44cvj2esn@172.17.0.10 |
+----------------------------+--------------------------------------+
```