### PR TITLE
feat(optimizer)!: annotate `CURRENT_TIMESTAMP()` for MySQL

### DIFF
--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -13,6 +13,13 @@ EXPRESSION_METADATA = {
         }
     },
     **{
+        expr_type: {"returns": exp.DataType.Type.DATETIME}
+        for expr_type in {
+            exp.CurrentTimestamp,
+            exp.Localtime,
+        }
+    },
+    **{
         expr_type: {"returns": exp.DataType.Type.VARCHAR}
         for expr_type in {
             exp.CurrentVersion,
@@ -30,5 +37,4 @@ EXPRESSION_METADATA = {
             exp.Week,
         }
     },
-    exp.Localtime: {"returns": exp.DataType.Type.DATETIME},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5785,6 +5785,10 @@ DOUBLE;
 VERSION();
 VARCHAR;
 
+# dialect: mysql
+CURRENT_TIMESTAMP();
+DATETIME;
+
 --------------------------------------
 -- DuckDB
 --------------------------------------


### PR DESCRIPTION
### ✳️ This PR annotate `CURRENT_TIMESTAMP()` for MySQL

```sql
create table don as
select current_timestamp();
describe don;
```
```python
+---------------------+----------+------+-----+---------+-------+
| Field               | Type     | Null | Key | Default | Extra |
+---------------------+----------+------+-----+---------+-------+
| current_timestamp() | datetime | NO   |     | NULL    |       |
+---------------------+----------+------+-----+---------+-------+
```