### PR TITLE
feat(mysql)!: support `CURTIME()` for MySQL/SingleStore

### DIFF
--- a/sqlglot/dialects/mysql.py
+++ b/sqlglot/dialects/mysql.py
@@ -338,6 +338,7 @@ class MySQL(Dialect):
                 source_tz=seq_get(args, 1), target_tz=seq_get(args, 2), timestamp=seq_get(args, 0)
             ),
             "CURDATE": exp.CurrentDate.from_arg_list,
+            "CURTIME": exp.CurrentTime.from_arg_list,
             "DATE": lambda args: exp.TsOrDsToDate(this=seq_get(args, 0)),
             "DATE_ADD": build_date_delta_with_interval(exp.DateAdd),
             "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "mysql"),

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -243,6 +243,7 @@ class TestMySQL(Validator):
         self.validate_identity("""SELECT * FROM foo WHERE 'ab' MEMBER OF(content)""")
         self.validate_identity("SELECT CURRENT_TIMESTAMP(6)")
         self.validate_identity("SELECT CURRENT_ROLE()")
+        self.validate_identity("SELECT CURTIME()", "SELECT CURRENT_TIME()")
         self.validate_identity("x ->> '$.name'")
         self.validate_identity("SELECT CAST(`a`.`b` AS CHAR) FROM foo")
         self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ')")

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -25,6 +25,7 @@ class TestSingleStore(Validator):
 
         self.validate_identity("JSON_KEYS(json_doc, 'a', 'b', 'c', 2)")
         self.validate_identity("SELECT VERSION()")
+        self.validate_identity("SELECT CURTIME()", "SELECT CURRENT_TIME()")
 
     def test_byte_strings(self):
         self.validate_identity("SELECT e'text'")


### PR DESCRIPTION
### ✳️ This PR support `CURTIME()` for MySQL/SingleStore

```sql
select curtime(), current_time();
```

**MySQL:**

```python
+-----------+----------------+
| curtime() | current_time() |
+-----------+----------------+
| 12:53:23  | 12:53:23       |
+-----------+----------------+
```

**SingleStore:**

<img width="261" height="97" alt="image" src="https://github.com/user-attachments/assets/8a0557f0-37b3-4092-9344-3eafa97c302f" />

**Official documentation:**
https://docs.singlestore.com/cloud/reference/sql-reference/date-and-time-functions/current-time-and-curtime/
https://dev.mysql.com/doc/refman/8.4/en/date-and-time-functions.html#function_current-time