### PR TITLE
feat(exasol)!: support `NOW()` for exasol

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -345,6 +345,7 @@ class Exasol(Dialect):
             "HASH_SHA512": lambda args: exp.SHA2(
                 this=seq_get(args, 0), length=exp.Literal.number(512)
             ),
+            "NOW": exp.CurrentTimestamp.from_arg_list,
             "TRUNC": build_trunc,
             "TRUNCATE": build_trunc,
             "VAR_POP": exp.VariancePop.from_arg_list,

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -14,6 +14,7 @@ class TestExasol(Validator):
         self.validate_identity("SYSTIMESTAMP", "SYSTIMESTAMP()")
         self.validate_identity("SELECT SYSTIMESTAMP()")
         self.validate_identity("SELECT SYSTIMESTAMP(6)")
+        self.validate_identity("SELECT NOW()", "SELECT CURRENT_TIMESTAMP()")
 
     def test_qualify_unscoped_star(self):
         self.validate_all(


### PR DESCRIPTION
### ✳️ This PR support `NOW()` for exasol

```python
SQL_EXA> select now(), current_timestamp();
EXA: select now(), current_timestamp();

CURRENT_TIMESTAMP(3)       CURRENT_TIMESTAMP(3)      
-------------------------- --------------------------
2026-02-07 14:17:40.169000 2026-02-07 14:17:40.169000

1 row in resultset.
```

https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/now.htm