### PR TITLE
feat(optimizer)!: annotate `CURRENT_USER` to base

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -209,6 +209,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.ConcatWs,
             exp.Chr,
             exp.CurrentCatalog,
+            exp.CurrentUser,
             exp.Dayname,
             exp.DateToDateStr,
             exp.DPipe,

--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -24,7 +24,6 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.CurrentDatabase,
             exp.CurrentSchema,
-            exp.CurrentUser,
             exp.Hex,
             exp.Repeat,
             exp.Replace,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -161,6 +161,9 @@ BOOLEAN;
 CURRENT_CATALOG();
 VARCHAR;
 
+CURRENT_USER();
+VARCHAR;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
### ✳️  This PR annotate `CURRENT_USER` to base

**Hive, Spark, DBX:** 
https://github.com/tobymao/sqlglot/pull/6790

**MySQL:**
```sql
create table don as
select current_user();
describe don;
```

```python
+----------------+--------------+------+-----+---------+-------+
| Field          | Type         | Null | Key | Default | Extra |
+----------------+--------------+------+-----+---------+-------+
| current_user() | varchar(288) | YES  |     | NULL    |       |
+----------------+--------------+------+-----+---------+-------+
```


**DuckDB:**
```sql
duckdb> select typeof(current_user);
┌──────────────────────┐
│ typeof(current_user) │
╞══════════════════════╡
│ VARCHAR              │
└──────────────────────┘

duckdb> 
```

**Exasol:**
```sql
SQL_EXA> SELECT typeof(CURRENT_USER);
EXA: SELECT typeof(CURRENT_USER);

TYPEOF(CURRENT_USER)                    
----------------------------------------
VARCHAR(128) UTF8                       

1 row in resultset.
```