### PR TITLE
feat(optimizer)!: annotate `NEXT_DAY(expr)` for Hive/Spark/DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -26,6 +26,7 @@ EXPRESSION_METADATA = {
             exp.CurrentSchema,
             exp.CurrentUser,
             exp.Hex,
+            exp.NextDay,
             exp.Repeat,
             exp.Replace,
             exp.Soundex,

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -63,6 +63,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             self, e, "expressions", target_type=exp.DataType.Type.TEXT
         )
     },
+    exp.NextDay: {"returns": exp.DataType.Type.DATE},
     exp.Pad: {
         "annotator": lambda self, e: _annotate_by_similar_args(
             self, e, "this", "fill_pattern", target_type=exp.DataType.Type.TEXT

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -677,6 +677,14 @@ ARRAY<STRING>;
 RIGHT(tbl.str_col, tbl.int_col);
 STRING;
 
+# dialect: spark2, spark, databricks
+NEXT_DAY(tbl.date_col, tbl.str_col);
+DATE;
+
+# dialect: hive
+NEXT_DAY(tbl.date_col, tbl.str_col);
+VARCHAR;
+
 # dialect: hive, spark2, spark, databricks
 TRANSLATE(tbl.str_col, tbl.str_col, tbl.str_col);
 STRING; 


### PR DESCRIPTION
### This PR annotate `NEXT_DAY(expr)` for Hive/Spark/DBX as `DATE`

```sql
SELECT typeof(next_day('2015-01-14', 'TU'))
```

**DBX:**

<img width="332" height="107" alt="image" src="https://github.com/user-attachments/assets/9db118e1-cadc-46fe-afb0-2b42d7f29fb1" />

**Spark:**
```python
+--------------------------------+--------------------+
|typeof(next_day(2015-01-14, TU))|           version()|
+--------------------------------+--------------------+
|                            date|3.5.5 7c29c664cdc...|
+--------------------------------+--------------------+
```

**Hive:**
```python
Hive Version: 4.1.0
+---------+--+
|   _c0   |
+---------+--+
| string  |
+---------+--+
```