### PR TITLE
feat(optimizer)!: annotate `UNIX_DATE(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -30,7 +30,6 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.ArraySize,
             exp.CountIf,
             exp.Int64,
-            exp.UnixDate,
             exp.UnixSeconds,
             exp.UnixMicros,
             exp.UnixMillis,
@@ -143,6 +142,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.StrPosition,
             exp.TsOrDiToDi,
             exp.Quarter,
+            exp.UnixDate,
         }
     },
     **{

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -214,6 +214,7 @@ EXPRESSION_METADATA = {
             exp.RangeBucket,
             exp.RegexpInstr,
             exp.RowNumber,
+            exp.UnixDate,
         }
     },
     **{

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -16,7 +16,6 @@ EXPRESSION_METADATA = {
         exp_type: {"returns": exp.DataType.Type.INT}
         for exp_type in {
             exp.ArraySize,
-            exp.UnixDate,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -91,9 +91,6 @@ VARCHAR;
 TO_BASE64(tbl.bytes_col);
 VARCHAR;
 
-UNIX_DATE(tbl.date_col);
-BIGINT;
-
 UNIX_SECONDS(tbl.timestamp_col);
 BIGINT;
 
@@ -2176,6 +2173,10 @@ DATETIME;
 # dialect: bigquery
 DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 30 MINUTE);
 DATETIME;
+
+# dialect: bigquery
+UNIX_DATE(tbl.date_col);
+BIGINT;
 
 --------------------------------------
 -- Snowflake


### PR DESCRIPTION
### ✳️ This PR annotate `UNIX_DATE(expr)` for `Spark`/`DBX` as `INT`

```sql
SELECT typeof(unix_date(DATE('1970-01-02'))), version()
```

**Spark:**

```python
+-----------------------------+--------------------+
|typeof(unix_date(1970-01-02))|           version()|
+-----------------------------+--------------------+
|                          int|3.5.5 7c29c664cdc...|
+-----------------------------+--------------------+
```

**Databricks:**

<img width="411" height="241" alt="image" src="https://github.com/user-attachments/assets/d33e9b8d-d92e-40c1-a8bc-d225a756b79e" />


**Official documentation:**
https://docs.databricks.com/aws/en/sql/language-manual/functions/unix_date
https://spark.apache.org/docs/latest/api/sql/index.html#unix_date