### PR TITLE
feat(optimizer)!: annotate `COUNTIF(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -26,6 +26,7 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DataType.Type.INT128}
         for expr_type in {
+            exp.CountIf,
             exp.Factorial,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6005,6 +6005,10 @@ BIGINT;
 TRANSLATE(tbl.str_col, tbl.str_col, tbl.str_col);
 VARCHAR;
 
+# dialect: duckdb
+COUNTIF(tbl.int_col > tbl.int_col);
+HUGEINT;
+
 --------------------------------------
 -- Presto / Trino
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `COUNTIF(expr)` for DuckDB as `HUGEINT`

**DuckDB:**
```python
duckdb> SELECT typeof(COUNTIF(2 > 5));
┌──────────────────────────┐
│ typeof(countif((2 > 5))) │
╞══════════════════════════╡
│ HUGEINT                  │
└──────────────────────────┘
```

https://duckdb.org/docs/stable/sql/functions/aggregates#countifarg