### PR TITLE
feat(optimizer)!: annotate `TIME_BUCKET(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -40,7 +40,6 @@ EXPRESSION_METADATA = {
             exp.TimeToUnix,
         }
     },
-    exp.DateBin: {"returns": exp.DataType.Type.DATE},
     **{
         expr_type: {"returns": exp.DataType.Type.VARCHAR}
         for expr_type in {
@@ -48,6 +47,7 @@ EXPRESSION_METADATA = {
             exp.Reverse,
         }
     },
+    exp.DateBin: {"annotator": lambda self, e: self._annotate_by_args(e, "expression")},
     exp.ToDays: {"returns": exp.DataType.Type.INTERVAL},
     exp.TimeFromParts: {"returns": exp.DataType.Type.TIME},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6056,6 +6056,14 @@ TIME_BUCKET(tbl.interval_col, tbl.date_col);
 DATE;
 
 # dialect: duckdb
+TIME_BUCKET(tbl.interval_col, tbl.timestamp_col, tbl.interval_col);
+TIMESTAMP;
+
+# dialect: duckdb
+TIME_BUCKET(tbl.interval_col, tbl.timestamp_col);
+TIMESTAMP;
+
+# dialect: duckdb
 TRANSLATE(tbl.str_col, tbl.str_col, tbl.str_col);
 VARCHAR;
 


### PR DESCRIPTION
## This PR annotate `TIME_BUCKET(expr)` for DuckDB 🦢

```python
duckdb> select typeof(time_bucket(INTERVAL '2 months', DATE '1992-04-20', INTERVAL '1 month'));
┌────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ typeof(time_bucket(CAST('2 months' AS INTERVAL), CAST('1992-04-20' AS DATE), CAST('1 month' AS INTERVAL))) │
╞════════════════════════════════════════════════════════════════════════════════════════════════════════════╡
│ DATE                                                                                                       │
└────────────────────────────────────────────────────────────────────────────────────────────────────────────┘

duckdb> select typeof(time_bucket(INTERVAL '2 months', DATE '1992-04-20'));
┌───────────────────────────────────────────────────────────────────────────────┐
│ typeof(time_bucket(CAST('2 months' AS INTERVAL), CAST('1992-04-20' AS DATE))) │
╞═══════════════════════════════════════════════════════════════════════════════╡
│ DATE                                                                          │
└───────────────────────────────────────────────────────────────────────────────┘
```

```
D select time_bucket(INTERVAL '2 months', TIMESTAMP '1992-04-20', INTERVAL '1 month')
  ;
┌─────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ time_bucket(CAST('2 months' AS INTERVAL), CAST('1992-04-20' AS TIMESTAMP), CAST('1 month' AS INTERVAL)) │
│                                                timestamp                                                │
├─────────────────────────────────────────────────────────────────────────────────────────────────────────┤
│ 1992-04-01 00:00:00                                                                                     │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

**Official documentation:**
https://duckdb.org/docs/stable/sql/functions/date#time_bucketbucket_width-date-offset