### PR TITLE
feat(optimizer)!: annotate `ISODOW(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -12,6 +12,7 @@ EXPRESSION_METADATA = {
             exp.Day,
             exp.DayOfMonth,
             exp.DayOfWeek,
+            exp.DayOfWeekIso,
             exp.DayOfYear,
             exp.Hour,
             exp.Length,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5990,6 +5990,10 @@ TO_DAYS(tbl.int_col);
 INTERVAL;
 
 # dialect: duckdb
+ISODOW(tbl.date_col);
+BIGINT;
+
+# dialect: duckdb
 BIT_LENGTH(tbl.str_col);
 BIGINT;
 


### PR DESCRIPTION
## This PR annotate `ISODOW(expr)` for [DuckDB](https://duckdb.org/docs/stable/sql/functions/datepart#isodowdate)

```python
duckdb> select typeof(isodow(DATE '1992-02-15'));
┌────────────────────────────────────────────┐
│ typeof(isodow(CAST('1992-02-15' AS DATE))) │
╞════════════════════════════════════════════╡
│ BIGINT                                     │
└────────────────────────────────────────────┘
```