### PR TITLE
feat(optimizer)!: annotate `REVERSE(str)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -38,6 +38,7 @@ EXPRESSION_METADATA = {
             exp.TimeToUnix,
         }
     },
+    exp.Reverse: {"returns": exp.DataType.Type.VARCHAR},
     exp.ToDays: {"returns": exp.DataType.Type.INTERVAL},
     exp.TimeFromParts: {"returns": exp.DataType.Type.TIME},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5930,6 +5930,10 @@ ISINF(tbl.float_col);
 BOOLEAN;
 
 # dialect: duckdb
+REVERSE(tbl.str_col);
+VARCHAR;
+
+# dialect: duckdb
 RANDOM();
 DOUBLE;
 


### PR DESCRIPTION
## This PR annotate `REVERSE(str)` for [DuckDB ➚](https://duckdb.org/docs/stable/sql/functions/text#reversestring)

```python
duckdb> select typeof(reverse('hello'));
┌──────────────────────────┐
│ typeof(reverse('hello')) │
╞══════════════════════════╡
│ VARCHAR                  │
└──────────────────────────┘
```