### PR TITLE
fix: parse EXCLUDE column_list after non-star columns in Redshift

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -768,21 +768,22 @@ class TSQL(Dialect):
 
             return self._parse_csv(_parse_for_xml)
 
-        def _parse_projections(self) -> t.List[exp.Expression]:
+        def _parse_projections(self) -> t.Tuple[t.List[exp.Expression], t.Optional[t.List[exp.Expression]]]:
             """
             T-SQL supports the syntax alias = expression in the SELECT's projection list,
             so we transform all parsed Selects to convert their EQ projections into Aliases.
 
             See: https://learn.microsoft.com/en-us/sql/t-sql/queries/select-clause-transact-sql?view=sql-server-ver16#syntax
             """
+            projections, exclude = super()._parse_projections()
             return [
                 (
                     exp.alias_(projection.expression, projection.this.this, copy=False)
                     if isinstance(projection, exp.EQ) and isinstance(projection.this, exp.Column)
                     else projection
                 )
-                for projection in super()._parse_projections()
-            ]
+                for projection in projections
+            ], exclude
 
         def _parse_commit_or_rollback(self) -> exp.Commit | exp.Rollback:
             """Applies to SQL Server and Azure SQL Database

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -3957,6 +3957,7 @@ class Select(Query):
         "into": False,
         "from_": False,
         "operation_modifiers": False,
+        "exclude": False,
         **QUERY_MODIFIERS,
     }
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3356,8 +3356,10 @@ class Parser(metaclass=_Parser):
             return self.expression(exp.Tuple, expressions=[expression])
         return None
 
-    def _parse_projections(self) -> t.List[exp.Expression]:
-        return self._parse_expressions()
+    def _parse_projections(
+        self,
+    ) -> t.Tuple[t.List[exp.Expression], t.Optional[t.List[exp.Expression]]]:
+        return self._parse_expressions(), None
 
     def _parse_wrapped_select(self, table: bool = False) -> t.Optional[exp.Expression]:
         if self._match_set((TokenType.PIVOT, TokenType.UNPIVOT)):
@@ -3482,7 +3484,7 @@ class Parser(metaclass=_Parser):
                 operation_modifiers.append(exp.var(self._prev.text.upper()))
 
             limit = self._parse_limit(top=True)
-            projections = self._parse_projections()
+            projections, exclude = self._parse_projections()
 
             this = self.expression(
                 exp.Select,
@@ -3491,6 +3493,7 @@ class Parser(metaclass=_Parser):
                 distinct=distinct,
                 expressions=projections,
                 limit=limit,
+                exclude=exclude,
                 operation_modifiers=operation_modifiers or None,
             )
             this.comments = comments

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -6,6 +6,26 @@ class TestRedshift(Validator):
     dialect = "redshift"
 
     def test_redshift(self):
+        self.validate_identity(
+            "SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM (SELECT 1 AS col1, 2 AS col2, 3 AS col3)"
+        )
+        self.validate_identity(
+            "SELECT *, col1 EXCLUDE (col2) FROM t"
+        )
+        self.validate_all(
+            "SELECT *, 4 AS col4 EXCLUDE col2, col3 FROM t",
+            write={
+                "redshift": "SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM t",
+            },
+        )
+        self.validate_all(
+            "SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM t",
+            write={
+                "": "SELECT * EXCEPT (col2, col3) FROM (SELECT *, 4 AS col4 FROM t)",
+                "redshift": "SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM t",
+            },
+        )
+
         self.validate_identity("SELECT COSH(1.5)")
         self.validate_identity(
             "ROUND(CAST(a AS DOUBLE PRECISION) / CAST(b AS DOUBLE PRECISION), 2)"


### PR DESCRIPTION
## Summary

Fixes #6963

In Redshift, the `EXCLUDE` clause can appear at the end of the entire SELECT projection list, not just immediately after `*`. For example, this is valid Redshift SQL:

```sql
SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM (SELECT 1 AS col1, 2 AS col2, 3 AS col3);
```

Previously this raised `ParseError: Invalid expression / Unexpected token` because the parser only recognized `EXCLUDE` as part of the `Star` expression (i.e., `* EXCLUDE (...)`).

### Changes

- **`expressions.py`**: Added `exclude` field to `Select` to store the trailing EXCLUDE column list
- **`parser.py`**: Changed `_parse_projections` return type to include an optional exclude list
- **`redshift.py` (Parser)**: Override `_parse_projections` to detect and parse a trailing `EXCLUDE` clause after all projections
- **`redshift.py` (Generator)**: Set `STAR_EXCEPT = "EXCLUDE"` and `STAR_EXCLUDE_REQUIRES_DERIVED_TABLE = False` for correct Redshift output
- **`generator.py`**: Added `STAR_EXCLUDE_REQUIRES_DERIVED_TABLE` flag; when `True` (default), transpiles to a derived table with `* EXCEPT (...)`; when `False` (Redshift), emits `EXCLUDE` directly
- **`tsql.py`**: Updated `_parse_projections` override to match new return type
- **`test_redshift.py`**: Added test cases for identity, normalization, and cross-dialect transpilation

### Transpilation behavior

| Input (Redshift) | Output dialect | Result |
|---|---|---|
| `SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM t` | redshift | `SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM t` |
| `SELECT *, 4 AS col4 EXCLUDE (col2, col3) FROM t` | default | `SELECT * EXCEPT (col2, col3) FROM (SELECT *, 4 AS col4 FROM t)` |

## Test plan

- [x] All 926 existing tests pass (excluding `test_executor` and `test_optimizer` which require duckdb)
- [x] Added identity tests for `EXCLUDE` after non-star columns
- [x] Added normalization test (unparenthesized EXCLUDE)
- [x] Added cross-dialect transpilation test
- [x] Verified `* EXCLUDE (...)` (star-only) still works as before