### PR TITLE
fix: transpile Spark LATERAL VIEW INLINE to DuckDB UNNEST

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1386,6 +1386,13 @@ def _sha_sql(
     return self.func("UNHEX", result) if is_binary else result
 
 
+def _explode_to_unnest_sql(self: DuckDB.Generator, expression: exp.Lateral) -> str:
+    if isinstance(expression.this, exp.Inline):
+        expression.this.replace(exp.Explode(this=expression.this.this.copy()))
+
+    return explode_to_unnest_sql(self, expression)
+
+
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = True
@@ -1932,7 +1939,7 @@ class DuckDB(Dialect):
             exp.JSONExtractArray: _json_extract_value_array_sql,
             exp.JSONFormat: _json_format_sql,
             exp.JSONValueArray: _json_extract_value_array_sql,
-            exp.Lateral: explode_to_unnest_sql,
+            exp.Lateral: _explode_to_unnest_sql,
             exp.LogicalOr: lambda self, e: self.func("BOOL_OR", _cast_to_boolean(e.this)),
             exp.LogicalAnd: lambda self, e: self.func("BOOL_AND", _cast_to_boolean(e.this)),
             exp.Seq1: lambda self, e: _seq_sql(self, e, 1),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -917,6 +917,18 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
+            "SELECT h.id, cost.amount FROM hourlycostagg AS h CROSS JOIN UNNEST(h.costs) AS exploded(cost)",
+            read={
+                "spark": "SELECT h.id, cost.amount FROM hourlycostagg h LATERAL VIEW INLINE(h.costs) exploded AS cost",
+            },
+        )
+        self.validate_all(
+            "SELECT id_column, name, age FROM test_table CROSS JOIN UNNEST(struc_column) AS explode_view(name, age)",
+            read={
+                "spark": "SELECT id_column, name, age FROM test_table LATERAL VIEW INLINE(struc_column) explode_view AS name, age",
+            },
+        )
+        self.validate_all(
             "1d",
             write={
                 "duckdb": "1 AS d",


### PR DESCRIPTION
## Summary
- Adds support for transpiling Spark's `LATERAL VIEW INLINE` syntax to DuckDB's `UNNEST`
- Follows the same pattern as PR #4905 which added this support for Presto/Trino
- Creates a custom `_explode_to_unnest_sql` function for DuckDB that converts `INLINE` to `EXPLODE` before calling the base `explode_to_unnest_sql` function
- Adds test cases validating the transpilation

## Fixes
Closes #6969

## Test Results

### Manual Test
```python
import sqlglot

sql = """
SELECT h.id, cost.amount
FROM hourlycostagg h
LATERAL VIEW inline(h.costs) exploded AS cost
"""

result = sqlglot.transpile(sql, read='spark', write='duckdb')[0]
print(result)
```

**Output:**
```sql
SELECT h.id, cost.amount FROM hourlycostagg AS h CROSS JOIN UNNEST(h.costs) AS exploded(cost)
```

### Unit Tests
```bash
$ python3 -m pytest tests/dialects/test_duckdb.py::TestDuckDB::test_duckdb -x -q
. [100%]
1 passed, 344 subtests passed in 0.25s
```

All tests pass successfully.