### PR TITLE
fix(snowflake): Parse `MODIFY` as `ALTER` in `ALTER TABLE`

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -1045,6 +1045,7 @@ class Snowflake(Dialect):
 
         ALTER_PARSERS = {
             **parser.Parser.ALTER_PARSERS,
+            "MODIFY": lambda self: self._parse_alter_table_alter(),
             "SESSION": lambda self: self._parse_alter_session(),
             "UNSET": lambda self: self.expression(
                 exp.Set,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -2972,6 +2972,9 @@ class TestSnowflake(Validator):
             },
         )
 
+        self.validate_identity("SELECT CURRENT_DATABASE()")
+        self.validate_identity("SELECT CURRENT_SCHEMA()")
+
     def test_null_treatment(self):
         self.validate_all(
             r"SELECT FIRST_VALUE(TABLE1.COLUMN1) OVER (PARTITION BY RANDOM_COLUMN1, RANDOM_COLUMN2 ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS MY_ALIAS FROM TABLE1",
@@ -3982,10 +3985,10 @@ class TestSnowflake(Validator):
         for action in ("SET", "DROP"):
             with self.subTest(f"ALTER COLUMN {action} NOT NULL"):
                 self.validate_all(
-                    f"""
-                        ALTER TABLE a
-                        ALTER COLUMN my_column {action} NOT NULL;
-                    """,
+                    f"ALTER TABLE a ALTER COLUMN my_column {action} NOT NULL",
+                    read={
+                        "snowflake": f"ALTER TABLE a MODIFY COLUMN my_column {action} NOT NULL",
+                    },
                     write={
                         "snowflake": f"ALTER TABLE a ALTER COLUMN my_column {action} NOT NULL",
                         "duckdb": f"ALTER TABLE a ALTER COLUMN my_column {action} NOT NULL",
@@ -5945,9 +5948,3 @@ FROM SEMANTIC_VIEW(
                     prefix = natural + join_side + outer + " DIRECTED"
                     with self.subTest(f"Testing {prefix} JOIN"):
                         self.validate_identity(f"SELECT * FROM a {prefix} JOIN b USING (id)")
-
-    def test_current_database(self):
-        self.validate_identity("SELECT CURRENT_DATABASE()")
-
-    def test_current_schema(self):
-        self.validate_identity("SELECT CURRENT_SCHEMA()")


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/7023


Docs
------
[Snowflake ALTER COLUMN](https://docs.snowflake.com/en/sql-reference/sql/alter-table-column#syntax)