### PR TITLE
feat(optimizer)!: annotate `ARRAY_COMPACT(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -28,9 +28,15 @@ EXPRESSION_METADATA = {
             exp.SessionUser,
         }
     },
+    **{
+        exp_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this")}
+        for exp_type in {
+            exp.ArrayCompact,
+            exp.Overlay,
+        }
+    },
     exp.BitmapCount: {"returns": exp.DataType.Type.BIGINT},
     exp.Localtimestamp: {"returns": exp.DataType.Type.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DataType.Type.BINARY},
     exp.DateFromUnixDate: {"returns": exp.DataType.Type.DATE},
-    exp.Overlay: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -704,6 +704,14 @@ INT;
 TRANSLATE(tbl.str_col, tbl.str_col, tbl.str_col);
 STRING; 
 
+# dialect: spark, databricks
+ARRAY_COMPACT(tbl.array_col);
+ARRAY<STRING>;
+
+# dialect: spark, databricks
+ARRAY_COMPACT(array(1, 2, 3));
+ARRAY<INT>;
+
 # dialect: hive, spark2, spark, databricks
 SPLIT(tbl.str_col, tbl.str_col, tbl.int_col);
 ARRAY<STRING>;


### PR DESCRIPTION
## This PR annotate `ARRAY_COMPACT(expr)` for [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#array_compact) / [DBX](https://docs.databricks.com/aws/en/sql/language-manual/functions/array_compact)

```sql
SELECT typeof(array_compact(array('a', NULL))), typeof(array_compact(array(1, NULL))), version()
```

```python
+-------------------------------------+-------------------------------------+--------------------+
|typeof(array_compact(array(a, NULL)))|typeof(array_compact(array(1, NULL)))|           version()|
+-------------------------------------+-------------------------------------+--------------------+
|                        array<string>|                           array<int>|3.5.5 7c29c664cdc...|
+-------------------------------------+-------------------------------------+--------------------+
```