### PR TITLE
feat(spark)!: transpile `BIT_COUNT` to DuckDB

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1860,6 +1860,7 @@ class DuckDB(Dialect):
             exp.Base64DecodeString: lambda self, e: _base64_decode_sql(self, e, to_string=True),
             exp.BitwiseAnd: lambda self, e: self._bitwise_op(e, "&"),
             exp.BitwiseAndAgg: _bitwise_agg_sql,
+            exp.BitwiseCount: rename_func("BIT_COUNT"),
             exp.BitwiseLeftShift: _bitshift_sql,
             exp.BitwiseOr: lambda self, e: self._bitwise_op(e, "|"),
             exp.BitwiseOrAgg: _bitwise_agg_sql,

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -960,6 +960,15 @@ TBLPROPERTIES (
         self.validate_identity("SELECT name, GROUPING_ID() FROM customer GROUP BY ROLLUP (name)")
         self.validate_identity("SELECT MAKE_TIMESTAMP(2014, 12, 28, 6, 30, 45.887)")
 
+        self.validate_all(
+            "SELECT BIT_COUNT(0)",
+            write={
+                "spark": "SELECT BIT_COUNT(0)",
+                "databricks": "SELECT BIT_COUNT(0)",
+                "duckdb": "SELECT BIT_COUNT(0)",
+            },
+        )
+
     def test_bool_or(self):
         self.validate_all(
             "SELECT a, LOGICAL_OR(b) FROM table GROUP BY a",


### PR DESCRIPTION
## This PR transpile `BIT_COUNT` function from [Spark](https://spark.apache.org/docs/latest/api/sql/index.html#bit_count)/[DBX](https://docs.databricks.com/aws/en/sql/language-manual/functions/bit_count) -> [DuckDB](https://duckdb.org/docs/stable/sql/functions/bitstring#bit_countbitstring)

```python
duckdb> SELECT BIT_COUNT(0);
┌──────────────┐
│ bit_count(0) │
╞══════════════╡
│            0 │
└──────────────┘
```

```python
from sqlglot import parse_one, exp
from sqlglot.optimizer.annotate_types import annotate_types

sql = """
SELECT bit_count(0);
"""

expression = parse_one(sql, dialect='databricks')
print(repr(expression))
print(expression.sql(dialect='duckdb'))
```

**Before:**
```python
Select(
  expressions=[
    BitwiseCount(
      this=Literal(this=0, is_string=False))])
SELECT BITWISE_COUNT(0)
```

**After:**
```python
Select(
  expressions=[
    BitwiseCount(
      this=Literal(this=0, is_string=False))])
SELECT BIT_COUNT(0)
```