### PR TITLE
feat(spark)!: Map `BIT_GET` to `GETBIT` for Spark/DBX

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -137,6 +137,7 @@ class Spark(Spark2):
                 offset=1,
             ),
             "BIT_AND": exp.BitwiseAndAgg.from_arg_list,
+            "BIT_GET": exp.Getbit.from_arg_list,
             "BIT_OR": exp.BitwiseOrAgg.from_arg_list,
             "BIT_XOR": exp.BitwiseXorAgg.from_arg_list,
             "BIT_COUNT": exp.BitwiseCount.from_arg_list,

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -251,6 +251,7 @@ class TestDatabricks(Validator):
         self.validate_identity("CURDATE", "CURRENT_DATE")
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
         self.validate_identity("SELECT name, GROUPING_ID() FROM customer GROUP BY ROLLUP (name)")
+        self.validate_identity("BIT_GET(11, 0)", "GETBIT(11, 0)")
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -954,6 +954,7 @@ TBLPROPERTIES (
                 "databricks": "foo ILIKE 'pattern' ESCAPE '!'",
             },
         )
+        self.validate_identity("BIT_GET(11, 0)", "GETBIT(11, 0)")
         self.validate_identity("BITMAP_OR_AGG(x)")
         self.validate_identity("SELECT ELT(2, 'foo', 'bar', 'baz') AS Result")
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")


### PR DESCRIPTION
## This PR Map `BIT_GET` to `GETBIT` for Spark/DBX

https://spark.apache.org/docs/latest/api/sql/index.html#bit_get
https://spark.apache.org/docs/latest/api/sql/index.html#getbit
https://docs.databricks.com/aws/en/sql/language-manual/functions/getbit
https://docs.databricks.com/aws/en/sql/language-manual/functions/bit_get

**Spark:**
```sql
select BIT_GET(11, 0), GETBIT(11, 0), version()
```

```python
+--------------+-------------+--------------------+
|bit_get(11, 0)|getbit(11, 0)|           version()|
+--------------+-------------+--------------------+
|             1|            1|3.5.5 7c29c664cdc...|
+--------------+-------------+--------------------+
```

**Databricks:**

<img width="402" height="258" alt="image" src="https://github.com/user-attachments/assets/710efd92-2d76-43f1-855b-d84587b9b717" />
