### PR TITLE
Refactor!: require original SQL in `Parser.parse`

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1744,16 +1744,14 @@ class Parser(metaclass=_Parser):
         self._chunks: t.List[t.List[Token]] = []
         self._chunk_index = 0
 
-    def parse(
-        self, raw_tokens: t.List[Token], sql: t.Optional[str] = None
-    ) -> t.List[t.Optional[exp.Expression]]:
+    def parse(self, raw_tokens: t.List[Token], sql: str) -> t.List[t.Optional[exp.Expression]]:
         """
         Parses a list of tokens and returns a list of syntax trees, one tree
         per parsed SQL statement.
 
         Args:
             raw_tokens: The list of tokens.
-            sql: The original SQL string, used to produce helpful debug messages.
+            sql: The original SQL string.
 
         Returns:
             The list of the produced syntax trees.

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -14,8 +14,9 @@ class TestGenerator(unittest.TestCase):
         class NewParser(Parser):
             FUNCTIONS = SpecialUDF.default_parser_mappings()
 
-        tokens = Tokenizer().tokenize("SELECT SPECIAL_UDF(a) FROM x")
-        expression = NewParser().parse(tokens)[0]
+        sql = "SELECT SPECIAL_UDF(a) FROM x"
+        tokens = Tokenizer().tokenize(sql)
+        expression = NewParser().parse(tokens, sql)[0]
         self.assertEqual(expression.sql(), "SELECT SPECIAL_UDF(a) FROM x")
 
     def test_fallback_function_var_args_sql(self):
@@ -26,9 +27,10 @@ class TestGenerator(unittest.TestCase):
         class NewParser(Parser):
             FUNCTIONS = SpecialUDF.default_parser_mappings()
 
-        tokens = Tokenizer().tokenize("SELECT SPECIAL_UDF(a, b, c, d + 1) FROM x")
-        expression = NewParser().parse(tokens)[0]
-        self.assertEqual(expression.sql(), "SELECT SPECIAL_UDF(a, b, c, d + 1) FROM x")
+        sql = "SELECT SPECIAL_UDF(a, b, c, d + 1) FROM x"
+        tokens = Tokenizer().tokenize(sql)
+        expression = NewParser().parse(tokens, sql)[0]
+        self.assertEqual(expression.sql(), sql)
 
         self.assertEqual(
             exp.DateTrunc(this=exp.to_column("event_date"), unit=exp.var("MONTH")).sql(),


### PR DESCRIPTION
  This fixes the issue documented in https://github.com/tobymao/sqlglot/issues/7031. Back in the day, we didn't "need" the `sql` argument to be present in `Parser.parse`, because it was mostly used to produce better error messages. However, at some point this changed, since we started relying on `_find_sql` in the parser itself. At this moment, I can see around 7 call sites that are unrelated to error messaging and which affect the control flow, meaning that the absence of `sql` can indeed result in different runtime behavior.

I took a stab at fixing the linked issue by reconstructing the input text from the tokens [here](https://github.com/tobymao/sqlglot/commit/d4649ce941c74094f273846b43b791d34e87e1fc), but unfortunately this is lacking in some scenarios. For example, an `IDENTIFIER` token does not preserve the identifier's delimiters in its `text` attribute, so we need to "guess" what the delimiters are, which still felt brittle and likely to result in different behavior compared to when `sql` is present.
