### PR TITLE
Fix(snowflake)!: refactor colon (extract) parsing precedence

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5595,7 +5595,12 @@ class Parser(metaclass=_Parser):
             return self._parse_id_var()
 
         this = self._parse_column()
-        return this and self._parse_column_ops(this)
+        if this:
+            this = self._parse_column_ops(this)
+        if this and self.COLON_IS_VARIANT_EXTRACT:
+            this = self._parse_colon_as_variant_extract(this)
+
+        return this
 
     def _parse_type_size(self) -> t.Optional[exp.DataTypeParam]:
         this = self._parse_type()
@@ -6044,7 +6049,7 @@ class Parser(metaclass=_Parser):
 
             this = self._parse_bracket(this)
 
-        return self._parse_colon_as_variant_extract(this) if self.COLON_IS_VARIANT_EXTRACT else this
+        return this
 
     def _parse_paren(self) -> t.Optional[exp.Expression]:
         if not self._match(TokenType.L_PAREN):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -13,6 +13,11 @@ class TestSnowflake(Validator):
 
     def test_snowflake(self):
         self.validate_identity(
+            """WITH t AS (SELECT PARSE_JSON('{"level1": {"level2": {"level3": "value"}}}') AS data) SELECT data:     level1  : level2 : level3::VARIANT FROM t""",
+            """WITH t AS (SELECT PARSE_JSON('{"level1": {"level2": {"level3": "value"}}}') AS data) SELECT CAST(GET_PATH(data, 'level1.level2.level3') AS VARIANT) FROM t""",
+        )
+
+        self.validate_identity(
             "SELECT * FROM x ASOF JOIN y OFFSET MATCH_CONDITION (x.a > y.a)",
             "SELECT * FROM x ASOF JOIN y AS OFFSET MATCH_CONDITION (x.a > y.a)",
         )


### PR DESCRIPTION
We used to have mutual recursion between `_parse_column_ops` and `_parse_colon_as_variant_extract`, which resulted in a couple of issues:

1. The added test failed because there's a stack frame where the start-end token range represents the text 'level1  : level2: level3'. This resulted in a `JSONPathKey` that included the redundant whitespace following `level1`.
2. The recursion would lead to a complexity class of O(n²), involving various costly steps like parsing JSON paths and various function calls. This becomes an issue for queries with deeply nested JSON constructs where `:` is used to access the corresponding fields.


