### PR TITLE
feat(spark)!: Map `curdate` to `current_date` for Spark/DBX

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -141,6 +141,7 @@ class Spark(Spark2):
             "BIT_OR": exp.BitwiseOrAgg.from_arg_list,
             "BIT_XOR": exp.BitwiseXorAgg.from_arg_list,
             "BIT_COUNT": exp.BitwiseCount.from_arg_list,
+            "CURDATE": exp.CurrentDate.from_arg_list,
             "DATE_ADD": _build_dateadd,
             "DATEADD": _build_dateadd,
             "MAKE_TIMESTAMP": exp.TimestampFromParts.from_arg_list,

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -252,6 +252,7 @@ class TestDatabricks(Validator):
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
         self.validate_identity("SELECT name, GROUPING_ID() FROM customer GROUP BY ROLLUP (name)")
         self.validate_identity("BIT_GET(11, 0)", "GETBIT(11, 0)")
+        self.validate_identity("SELECT CURDATE()", "SELECT CURRENT_DATE")
 
     # https://docs.databricks.com/sql/language-manual/functions/colonsign.html
     def test_json(self):

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1013,6 +1013,7 @@ TBLPROPERTIES (
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 12, 13, 14, 14, 15)")
         self.validate_identity("SELECT name, GROUPING_ID() FROM customer GROUP BY ROLLUP (name)")
         self.validate_identity("SELECT MAKE_TIMESTAMP(2014, 12, 28, 6, 30, 45.887)")
+        self.validate_identity("SELECT CURDATE()", "SELECT CURRENT_DATE")
 
         self.validate_all(
             "SELECT BIT_COUNT(0)",


### PR DESCRIPTION
## This PR Map `curdate` to `current_date` for Spark/DBX

https://docs.databricks.com/aws/en/sql/language-manual/functions/curdate
https://spark.apache.org/docs/latest/api/sql/index.html#curdate