### PR TITLE
feat(optimizer)!: move `SessionUser` to base

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -234,6 +234,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.UnixToTimeStr,
             exp.Upper,
             exp.RawString,
+            exp.SessionUser,
             exp.Space,
         }
     },

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -25,7 +25,6 @@ EXPRESSION_METADATA = {
             exp.CurrentTimezone,
             exp.Monthname,
             exp.Randstr,
-            exp.SessionUser,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -164,6 +164,9 @@ VARCHAR;
 CURRENT_USER();
 VARCHAR;
 
+SESSION_USER();
+VARCHAR;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
## This PR moves `SessionUser` to base

[BigQuery](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/security_functions#session_user)
**DuckDB:**
```python
duckdb> select typeof(session_user);
┌──────────────────────┐
│ typeof(session_user) │
╞══════════════════════╡
│ VARCHAR              │
└──────────────────────┘
```
[MySQL](https://dev.mysql.com/doc/refman/8.4/en/information-functions.html#function_session-user)