### PR TITLE
Refactor!: use `IntEnum` instead of auto/string enums

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5948,7 +5948,7 @@ class Parser(metaclass=_Parser):
             if self._match_text_seq("UNSIGNED"):
                 unsigned_type_token = self.SIGNED_TO_UNSIGNED_TYPE_TOKEN.get(type_token)
                 if not unsigned_type_token:
-                    self.raise_error(f"Cannot convert {type_token.value} to unsigned.")
+                    self.raise_error(f"Cannot convert {type_token.name} to unsigned.")
 
                 type_token = unsigned_type_token or type_token
 
@@ -5958,7 +5958,7 @@ class Parser(metaclass=_Parser):
                 return None
 
             this = exp.DataType(
-                this=exp.DataType.Type[type_token.value],
+                this=exp.DataType.Type[type_token.name],
                 expressions=expressions,
                 nested=nested,
                 prefix=prefix,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import os
 import typing as t
-from enum import auto
+from enum import IntEnum, auto
 
 from sqlglot.errors import SqlglotError, TokenError
-from sqlglot.helper import AutoName
 from sqlglot.trie import TrieResult, in_trie, new_trie
 
 if t.TYPE_CHECKING:
@@ -25,7 +24,7 @@ except ImportError:
     USE_RS_TOKENIZER = False
 
 
-class TokenType(AutoName):
+class TokenType(IntEnum):
     L_PAREN = auto()
     R_PAREN = auto()
     L_BRACKET = auto()
@@ -465,6 +464,9 @@ class TokenType(AutoName):
     # sentinel
     HIVE_TOKEN_STREAM = auto()
 
+    def __str__(self) -> str:
+        return f"TokenType.{self.name}"
+
 
 _ALL_TOKEN_TYPES = list(TokenType)
 _TOKEN_TYPE_TO_INDEX = {token_type: i for i, token_type in enumerate(_ALL_TOKEN_TYPES)}
@@ -523,7 +525,12 @@ class Token:
         self.comments = [] if comments is None else comments
 
     def __repr__(self) -> str:
-        attributes = ", ".join(f"{k}: {getattr(self, k)}" for k in self.__slots__)
+        attributes = ", ".join(
+            f"{k}: TokenType.{self.token_type.name}"
+            if k == "token_type"
+            else f"{k}: {getattr(self, k)}"
+            for k in self.__slots__
+        )
         return f"<Token {attributes}>"
 
 


### PR DESCRIPTION
Small refactor to use `IntEnum` instead of `AutoName`.

```
(sqlglot) ➜  sqlglot git:(main) ✗ python benchmarks/parse.py # with intenum
.....................
parse_sqlglot_crazy: Mean +- std dev: 5.57 ms +- 0.22 ms
(sqlglot) ➜  sqlglot git:(main) ✗ python benchmarks/parse.py # without intenum
.....................
parse_sqlglot_crazy: Mean +- std dev: 6.09 ms +- 0.14 ms
```