### PR TITLE
feat(optimizer)!: move `exp.Rand` to base

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -115,6 +115,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.Stddev,
             exp.StddevPop,
             exp.StddevSamp,
+            exp.Rand,
             exp.Tan,
             exp.Tanh,
             exp.ToDouble,

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -260,7 +260,6 @@ EXPRESSION_METADATA = {
             exp.Float64,
             exp.LaxFloat64,
             exp.PercentRank,
-            exp.Rand,
             exp.Sec,
             exp.Sech,
         }

--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -36,7 +36,6 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.Atan2,
             exp.JarowinklerSimilarity,
-            exp.Rand,
             exp.TimeToUnix,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -167,6 +167,9 @@ VARCHAR;
 SESSION_USER();
 VARCHAR;
 
+RAND();
+DOUBLE;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
## This PR move `exp.Rand` to base

**Spark:** https://spark.apache.org/docs/latest/api/sql/index.html#rand
**DBX:** https://docs.databricks.com/aws/en/sql/language-manual/functions/rand
**Exasol:** https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/random.htm
**BigQuery:** https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/mathematical_functions#rand
**MySQL:**

<img width="500" height="230" alt="image" src="https://github.com/user-attachments/assets/c78c2572-e207-4887-b144-296a698ff3ef" />

**Postgres:**

<img width="300" height="270" alt="image" src="https://github.com/user-attachments/assets/ba06b3c7-4265-4104-9d5d-692ba6cc3b2d" />

**ClickHouse:**

<img width="300" height="269" alt="image" src="https://github.com/user-attachments/assets/02b96a83-bed8-454e-9c68-104133f70411" />

