### PR TITLE
Chore: improve schema module perf by caching normalized tables/names

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -306,7 +306,7 @@ class MappingSchema(AbstractMappingSchema, Schema):
         self.normalize = normalize
         self._dialect = Dialect.get_or_raise(dialect)
         self._type_mapping_cache: t.Dict[str, exp.DataType] = {}
-        self._normalized_table_cache: t.Dict[t.Tuple[int, DialectType, bool], exp.Table] = {}
+        self._normalized_table_cache: t.Dict[t.Tuple[exp.Table, DialectType, bool], exp.Table] = {}
         self._normalized_name_cache: t.Dict[t.Tuple[str, DialectType, bool, bool], str] = {}
         self._depth = 0
         schema = {} if schema is None else schema
@@ -599,7 +599,7 @@ class MappingSchema(AbstractMappingSchema, Schema):
         # Cache normalized tables by object id for exp.Table inputs
         # This is effective when the same Table object is looked up multiple times
         if isinstance(table, exp.Table) and (
-            cached := self._normalized_table_cache.get((id(table), dialect, normalize))
+            cached := self._normalized_table_cache.get((table, dialect, normalize))
         ):
             return cached
 
@@ -612,7 +612,9 @@ class MappingSchema(AbstractMappingSchema, Schema):
                         normalize_name(part, dialect=dialect, is_table=True, normalize=normalize)
                     )
 
-        self._normalized_table_cache[(id(table), dialect, normalize)] = normalized_table
+        self._normalized_table_cache[(t.cast(exp.Table, table), dialect, normalize)] = (
+            normalized_table
+        )
         return normalized_table
 
     def _normalize_name(


### PR DESCRIPTION
Using this [script](https://github.com/user-attachments/files/25268819/profiler.py) to profile `annotate_types` on a relatively complicated query, I got the following execution times:

Main:

```
      100    0.001    0.000    2.694    0.027 annotate_types.py:43(annotate_types)
```

This branch:

```
      100    0.001    0.000    2.174    0.022 annotate_types.py:43(annotate_types)
```