### PR TITLE
feat(optimizer)!: move `DEGREES(expr)` to base

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -99,6 +99,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
             exp.Cos,
             exp.Cosh,
             exp.Cot,
+            exp.Degrees,
             exp.Exp,
             exp.Kurtosis,
             exp.Ln,

--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -9,7 +9,6 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.DOUBLE}
         for expr_type in {
             exp.Atan2,
-            exp.Degrees,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -170,6 +170,9 @@ VARCHAR;
 RAND();
 DOUBLE;
 
+DEGREES(tbl.double_col);
+DOUBLE;
+
 # dialect: snowflake
 TO_BINARY('test');
 BINARY;


### PR DESCRIPTION
## This PR move `DEGREES(expr)` to base

**Spark:** https://spark.apache.org/docs/latest/api/sql/index.html#degrees

**DuckDB:**
```python
duckdb> select typeof(Degrees(1.3333));
┌─────────────────────────┐
│ typeof(degrees(1.3333)) │
╞═════════════════════════╡
│ DOUBLE                  │
└─────────────────────────┘
```

**ClickHouse:**

<img width="300" height="230" alt="image" src="https://github.com/user-attachments/assets/e12a421c-70f5-41dd-9258-fc6411b06a6d" />


**Postgres:**

<img width="300" height="150" alt="image" src="https://github.com/user-attachments/assets/c18e1512-e92f-49c4-8286-4af5a28cef5c" />

**MySQL:**

<img width="400" height="272" alt="image" src="https://github.com/user-attachments/assets/508fd0e3-d544-4c38-8e6f-2fb44bcdd710" />
