### PR TITLE
fix(parser): INTERVAL units with DCOLON

### DIFF
--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -5186,3 +5186,13 @@ FROM subquery2""",
                 "doris": "JSON_KEYS(foo, '$.a')",
             },
         )
+
+    def test_interval_with_units_dcolon(self):
+        self.validate_identity(
+            "SELECT interval '00:00:01'::interval AS foo",
+            "SELECT CAST(INTERVAL '00:00:01' AS INTERVAL) AS foo",
+        )
+        self.validate_identity(
+            "SELECT ROW_NUMBER() OVER(PARTITION BY event_time + interval '00:00:01'::interval) AS foo FROM t",
+            "SELECT ROW_NUMBER() OVER (PARTITION BY event_time + CAST(INTERVAL '00:00:01' AS INTERVAL)) AS foo FROM t",
+        )

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -503,15 +503,6 @@ ORDER BY
         self.validate_identity("SELECT * FROM (SELECT 1 AS EXCLUDE) AS t")
         self.validate_identity("SELECT 1 AS EXCLUDE, 2 AS foo")
 
-        self.validate_identity(
-            "SELECT interval '00:00:01'::interval AS foo",
-            "SELECT CAST(INTERVAL '00:00:01' AS INTERVAL) AS foo",
-        )
-        self.validate_identity(
-            "SELECT ROW_NUMBER() OVER(PARTITION BY event_time + interval '00:00:01'::interval) AS foo FROM t",
-            "SELECT ROW_NUMBER() OVER (PARTITION BY event_time + CAST(INTERVAL '00:00:01' AS INTERVAL)) AS foo FROM t",
-        )
-
     def test_values(self):
         # Test crazy-sized VALUES clause to UNION ALL conversion to ensure we don't get RecursionError
         values = [str(v) for v in range(0, 10000)]


### PR DESCRIPTION
Fixes #7072

The issue mentions redshift, but the bug affects other dialects such as postgres and duckdb.