### PR TITLE
feat(optimizer)!: annotate `DEGREES(expr)` for T-SQL

### DIFF
--- a/sqlglot/typing/tsql.py
+++ b/sqlglot/typing/tsql.py
@@ -25,6 +25,12 @@ EXPRESSION_METADATA = {
             exp.Stuff,
         }
     },
+    **{
+        expr_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this")}
+        for expr_type in {
+            exp.Degrees,
+            exp.Radians,
+        }
+    },
     exp.CurrentTimezone: {"returns": exp.DataType.Type.NVARCHAR},
-    exp.Radians: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5713,6 +5713,18 @@ VARCHAR;
 STUFF(tbl.str_col, tbl.int_col, tbl.int_col, tbl.str_col);
 VARCHAR;
 
+# dialect: tsql
+DEGREES(tbl.int_col);
+INT;
+
+# dialect: tsql
+DEGREES(tbl.float_col);
+FLOAT;
+
+# dialect: tsql
+DEGREES(tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- MySQL
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `DEGREES(expr)` for T-SQL

follow-up to #7074 

https://learn.microsoft.com/en-us/sql/t-sql/functions/degrees-transact-sql?view=sql-server-ver17

@geooo109 should we annotate exactly or is this fine with "this"?