### PR TITLE
Chore: remove `classproperty` as it is dead code

### DIFF
--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -36,15 +36,6 @@ class AutoName(Enum):
         return name
 
 
-class classproperty(property):
-    """
-    Similar to a normal property but works for class methods
-    """
-
-    def __get__(self, obj: t.Any, owner: t.Any = None) -> t.Any:
-        return classmethod(self.fget).__get__(None, owner)()  # type: ignore
-
-
 def suggest_closest_match_and_fail(
     kind: str,
     word: str,


### PR DESCRIPTION
This was used as part of sqlframe-related logic, which is now [in a different repo](https://github.com/eakmanrq/sqlframe/blob/bdde1cb5b3f4f8bfb55c9756062b9df526dc2e62/sqlframe/spark/session.py#L118). Thus, it's dead code as far as sqlglot is concerned, since it's not a helper used within itself.