### PR TITLE
fix(optimizer)!: annotate ARRAY_CONTAINS

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -47,6 +47,7 @@ EXPRESSION_METADATA: ExpressionMetadataType = {
         for expr_type in {
             exp.All,
             exp.Any,
+            exp.ArrayContains,
             exp.Between,
             exp.Boolean,
             exp.Contains,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -184,6 +184,9 @@ BINARY;
 TO_BINARY('test', 'HEX');
 BINARY;
 
+ARRAY_CONTAINS(tbl.array_col, '1');
+BOOLEAN;
+
 --------------------------------------
 -- Spark2 / Spark3 / Databricks
 --------------------------------------


### PR DESCRIPTION
Fixes (partial) #7096
Add correct type annotation for `ARRAY_CONTAINS`

**DOCS**
[Hive](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=27362046#LanguageManualUDF-CollectionFunctions)
[Spark](https://spark.apache.org/docs/latest/api/sql/index.html#array_contains)
[Databricks](https://docs.databricks.com/aws/en/sql/language-manual/functions/array_contains)
[Duckdb](https://duckdb.org/docs/stable/sql/functions/list#list_containslist-element)
[Snowflake](https://docs.snowflake.com/en/sql-reference/functions/array_contains)
