### PR TITLE
feat(optimizer)!: annotate `BIT_OR(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -31,6 +31,7 @@ EXPRESSION_METADATA = {
         for exp_type in {
             exp.ArrayCompact,
             exp.ArrayInsert,
+            exp.BitwiseOrAgg,
             exp.Overlay,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -823,6 +823,14 @@ ARRAY<DOUBLE>;
 APPROX_PERCENTILE(3, array(0.2, 0.3));
 ARRAY<INT>;
 
+# dialect: spark, databricks
+BIT_OR(tbl.int_col);
+INT;
+
+# dialect: spark, databricks
+BIT_OR(tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `BIT_OR(expr)` for `Spark`/`DBX`

**DBX:**
```sql
SELECT typeof(bit_or(10000000000000)), typeof(bit_or(1));
```

```python
|typeof(bit_or(10000000000000))|typeof(bit_or(1))|
|---|---|
|bigint|int|
```

https://spark.apache.org/docs/latest/api/sql/index.html#bit_or