### PR TITLE
feat(optimizer)!: annotate `BIT_AND(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -32,6 +32,7 @@ EXPRESSION_METADATA = {
             exp.ArrayCompact,
             exp.ArrayInsert,
             exp.BitwiseOrAgg,
+            exp.BitwiseAndAgg,
             exp.Overlay,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -831,6 +831,14 @@ INT;
 BIT_OR(tbl.bigint_col);
 BIGINT;
 
+# dialect: spark, databricks
+BIT_AND(tbl.int_col);
+INT;
+
+# dialect: spark, databricks
+BIT_AND(tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `BIT_AND(expr)` for Spark/DBX

**DBX:**
```sql
SELECT typeof(bit_and(10000000000000)), typeof(bit_and(1));
```

|typeof(bit_and(10000000000000))|typeof(bit_and(1))|
|---|---|
|bigint|int|

https://docs.databricks.com/aws/en/sql/language-manual/functions/bit_and