### PR TITLE
feat(optimizer)!: annotate `BIT_XOR(expr)` for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -31,8 +31,9 @@ EXPRESSION_METADATA = {
         for exp_type in {
             exp.ArrayCompact,
             exp.ArrayInsert,
-            exp.BitwiseOrAgg,
             exp.BitwiseAndAgg,
+            exp.BitwiseOrAgg,
+            exp.BitwiseXorAgg,
             exp.Overlay,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -839,6 +839,14 @@ INT;
 BIT_AND(tbl.bigint_col);
 BIGINT;
 
+# dialect: spark, databricks
+BIT_XOR(tbl.int_col);
+INT;
+
+# dialect: spark, databricks
+BIT_XOR(tbl.bigint_col);
+BIGINT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `BIT_XOR(expr)` for Spark/DBX

**Databricks:**

```sql
SELECT typeof(bit_xor(10000000000000)), typeof(bit_xor(1));
```

|typeof(bit_xor(10000000000000))|typeof(bit_xor(1))|
|---|---|
|bigint|int|

https://spark.apache.org/docs/latest/api/sql/index.html#bit_xor