### PR TITLE
fix(exasol)!: fix dense rank function by ignoring parameters

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -1030,8 +1030,15 @@ class Exasol(Dialect):
         def collate_sql(self, expression: exp.Collate) -> str:
             return self.sql(expression.this)
 
+        def _no_arg_window_func(self, expression: exp.Expression, name: str) -> str:
+            if expression.args.get("expressions"):
+                self.unsupported(f"Exasol does not support arguments in {name}")
+            return self.func(name)
+
         # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/rank.htm
         def rank_sql(self, expression: exp.Rank) -> str:
-            if expression.args.get("expressions"):
-                self.unsupported("Exasol does not support arguments in RANK")
-            return self.func("RANK")
+            return self._no_arg_window_func(expression, "RANK")
+
+        # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/dense_rank.htm
+        def denserank_sql(self, expression: exp.DenseRank) -> str:
+            return self._no_arg_window_func(expression, "DENSE_RANK")

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -273,14 +273,16 @@ class TestExasol(Validator):
             },
         )
 
-        self.validate_all(
-            "SELECT a, b, rank(b) OVER (ORDER BY b) FROM (VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1)) AS tab(a, b)",
-            write={
-                "exasol": "SELECT a, b, RANK() OVER (ORDER BY b) FROM (VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1)) AS tab(a, b)",
-                "databricks": "SELECT a, b, RANK(b) OVER (ORDER BY b NULLS LAST) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) AS tab(a, b)",
-                "spark": "SELECT a, b, RANK(b) OVER (ORDER BY b NULLS LAST) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) AS tab(a, b)",
-            },
-        )
+        for func in ("RANK", "DENSE_RANK"):
+            with self.subTest(func=func):
+                self.validate_all(
+                    f"SELECT a, b, {func}(b) OVER (ORDER BY b) FROM (VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1)) AS tab(a, b)",
+                    write={
+                        "exasol": f"SELECT a, b, {func}() OVER (ORDER BY b) FROM (VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1)) AS tab(a, b)",
+                        "databricks": f"SELECT a, b, {func}(b) OVER (ORDER BY b NULLS LAST) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) AS tab(a, b)",
+                        "spark": f"SELECT a, b, {func}(b) OVER (ORDER BY b NULLS LAST) FROM VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1) AS tab(a, b)",
+                    },
+                )
 
     def test_stringFunctions(self):
         self.validate_identity(


### PR DESCRIPTION
**What motivated this PR?**
Exasol doesn't support passing parameters to the [`DENSE_RANK`](https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/dense_rank.htm), which is supported by some dialects such as [spark](https://spark.apache.org/docs/latest/api/sql/index.html#dense_rank) and Databricks.

**How is the existing logic in main incorrect?**
For example when transpiling from databricks or spark to exasol `SELECT a, b, dense_rank(b) OVER (ORDER BY b) FROM (VALUES ('A1', 2), ('A1', 1), ('A2', 3), ('A1', 1)) AS tab(a, b)` This would fail in exasol because passing parameters to rank is not supported.

**How does the PR address the aforementioned issues?**
The PR ignores the parameter passed to the `DENSE_RANK` function.

**Provide documentation for the SQL functions involved in the implementation & explain whether semantics change / are preserved**
The links to documentation - https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/dense_rank.htm. There are no  semantics changes in the generator, only the parameter is ignored