### PR TITLE
Fix Oracle dialect crash on parenthesized LIKE expression

### DIFF
--- a/sqlglot/dialects/oracle.py
+++ b/sqlglot/dialects/oracle.py
@@ -293,8 +293,8 @@ class Oracle(Dialect):
             index = self._index
 
             # https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/Interval-Expressions.html
-            interval_span = self._parse_interval_span(this)
-            if isinstance(interval_span.args.get("unit"), exp.IntervalSpan):
+            interval_span = self._try_parse(lambda: self._parse_interval_span(this))
+            if interval_span and isinstance(interval_span.args.get("unit"), exp.IntervalSpan):
                 return interval_span
 
             self._retreat(index)

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -87,6 +87,9 @@ class TestOracle(Validator):
             "SELECT COUNT(1) INTO V_Temp FROM TABLE(CAST(somelist AS data_list)) WHERE col LIKE '%contact'"
         )
         self.validate_identity(
+            "SELECT * FROM t WHERE c LIKE (:v)",
+        )
+        self.validate_identity(
             "SELECT department_id INTO v_department_id FROM departments FETCH FIRST 1 ROWS ONLY"
         )
         self.validate_identity(


### PR DESCRIPTION
## Summary

Fixes #7118. `SELECT * FROM t WHERE c LIKE (:var)` crashes with `ParseError: Required keyword: 'this' missing for <class 'sqlglot.expressions.Like'>` in the Oracle dialect.

**Root cause:** Oracle's `_parse_column_ops` speculatively calls `_parse_interval_span`, which internally calls `_parse_function()`. When the current token is `LIKE` followed by parenthesized arguments, `_parse_function` consumes `LIKE` and tries to validate `LIKE(:var)` as a function call — but `Like` requires a `this` argument that isn't present, so it raises a `ParseError`. The existing retreat logic on line 300 never executes because the error is thrown first.

**Fix:** Wrap the speculative `_parse_interval_span` call in `_try_parse`, which catches `ParseError` and properly restores the parser state. This follows the same pattern used elsewhere in the parser for speculative parsing.

```python
# Before (buggy):
interval_span = self._parse_interval_span(this)

# After (fixed):
interval_span = self._try_parse(lambda: self._parse_interval_span(this))
```

All 23 Oracle dialect tests pass (211 subtests). General parser tests also pass.