### PR TITLE
feat(optimizer)!: annotate `ARRAY_EXCEPT` for Hive/Spark/DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -51,6 +51,7 @@ EXPRESSION_METADATA = {
         expr_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this")}
         for expr_type in {
             exp.ArrayDistinct,
+            exp.ArrayExcept,
             exp.Reverse,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -871,6 +871,14 @@ ARRAY<STRING>;
 ARRAY_DISTINCT(array(1, 2, 3, null, 3));
 ARRAY<INT>;
 
+# dialect: hive, spark2, spark, databricks
+ARRAY_EXCEPT(array(1, 2, 3), array(1, 3, 5));
+ARRAY<INT>;
+
+# dialect: hive, spark2, spark, databricks
+ARRAY_EXCEPT(tbl.array_col, tbl.array_col);
+ARRAY<STRING>;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `ARRAY_EXCEPT` for Hive/Spark/DBX

```sql
SELECT typeof(array_except(array(1, 2, 3), array(1, 3, 5)))
```

**Hive:**

```python
Hive Version: 4.1.0
+-------------+--+
|     _c0     |
+-------------+--+
| array<int>  |
+-------------+--+
```
**DBX:**

```sql
SELECT typeof(array_except(array(1, 2, 3), array(1, 3, 5))), version();
```

|typeof(array_except(array(1, 2, 3), array(1, 3, 5)))|version()|
|---|---|
|array<int>|4.0.0 0000000000000000000000000000000000000000|

https://spark.apache.org/docs/latest/api/sql/index.html#array_except