### PR TITLE
fix(optimizer)!: annotate `date_diff(expr)` for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -9,6 +9,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DataType.Type.BIGINT}
         for expr_type in {
             exp.BitLength,
+            exp.DateDiff,
             exp.Day,
             exp.DayOfMonth,
             exp.DayOfWeek,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6239,6 +6239,10 @@ VARCHAR;
 COUNTIF(tbl.int_col > tbl.int_col);
 HUGEINT;
 
+# dialect: duckdb
+DATE_DIFF('year', tbl.timestamp_col, tbl.timestamp_col);
+BIGINT;
+
 --------------------------------------
 -- Presto / Trino
 --------------------------------------


### PR DESCRIPTION
## This PR annotate `date_diff(expr)` for [DuckDB](https://duckdb.org/docs/stable/sql/functions/time#date_diffpart-starttime-endtime)

```python
duckdb> select typeof(date_diff('hour', TIME '01:02:03', TIME '06:01:03'));
┌───────────────────────────────────────────────────────────────────────────────┐
│ typeof(date_diff('hour', CAST('01:02:03' AS TIME), CAST('06:01:03' AS TIME))) │
╞═══════════════════════════════════════════════════════════════════════════════╡
│ BIGINT                                                                        │
└───────────────────────────────────────────────────────────────────────────────┘

duckdb> select typeof(date_diff('hour', TIME '01:02:03', TIME '06:01:03',0));
Binder Error: No function matches the given name and argument types 'date_diff(STRING_LITERAL, TIME, TIME, INTEGER_LITERAL)'. You might need to add explicit type casts.
        Candidate functions:
        date_diff(VARCHAR, DATE, DATE) -> BIGINT
        date_diff(VARCHAR, TIME, TIME) -> BIGINT
        date_diff(VARCHAR, TIMESTAMP, TIMESTAMP) -> BIGINT
        date_diff(VARCHAR, TIMESTAMP WITH TIME ZONE, TIMESTAMP WITH TIME ZONE) -> BIGINT


LINE 1: select typeof(date_diff('hour', TIME '01:02:03', TIME '06:01:03',0));
```