### PR TITLE
feat(exasol): transpile FROM_UNIXTIME to FROM_POSIX_TIME

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -336,6 +336,7 @@ class Exasol(Dialect):
             "DIV": binary_from_function(exp.IntDiv),
             "EVERY": lambda args: exp.All(this=seq_get(args, 0)),
             "EDIT_DISTANCE": exp.Levenshtein.from_arg_list,
+            "FROM_POSIX_TIME": exp.UnixToTime.from_arg_list,
             "HASH_SHA": exp.SHA.from_arg_list,
             "HASH_SHA1": exp.SHA.from_arg_list,
             "HASH_MD5": exp.MD5.from_arg_list,
@@ -485,6 +486,8 @@ class Exasol(Dialect):
             ),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/mod.htm
             exp.Mod: rename_func("MOD"),
+            # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/from_posix_time.htm
+            exp.UnixToTime: lambda self, e: self.func("FROM_POSIX_TIME", e.this),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/rank.htm
             exp.Rank: unsupported_args("expressions")(lambda *_: "RANK()"),
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/dense_rank.htm

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -988,6 +988,7 @@ class TestDialect(Validator):
                 "presto": "FROM_UNIXTIME(x)",
                 "starrocks": "FROM_UNIXTIME(x)",
                 "doris": "FROM_UNIXTIME(x)",
+                "exasol": "FROM_POSIX_TIME(x)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -20,6 +20,17 @@ class TestExasol(Validator):
         self.validate_identity("SELECT CURRENT_USER", "SELECT CURRENT_USER")
         self.validate_identity("CURRENT_SCHEMA").assert_is(exp.CurrentSchema)
         self.validate_identity("SELECT NOW()", "SELECT CURRENT_TIMESTAMP()")
+        self.validate_identity("SELECT FROM_POSIX_TIME(1234567890)")
+        self.validate_all(
+            "SELECT FROM_POSIX_TIME(col)",
+            read={
+                "mysql": "SELECT FROM_UNIXTIME(col)",
+            },
+            write={
+                "exasol": "SELECT FROM_POSIX_TIME(col)",
+                "mysql": "SELECT FROM_UNIXTIME(col)",
+            },
+        )
 
     def test_exasol_keywords(self):
         keywords = ["CS", "ADD", "BOOLEAN", "CALL", "CONTROL"]


### PR DESCRIPTION
## Summary
Map MySQL/MariaDB FROM_UNIXTIME() to Exasol's FROM_POSIX_TIME() by adding parser and generator entries to the Exasol dialect:

- Add `FROM_POSIX_TIME` mapping to Exasol dialect so that MySQL/MariaDB `FROM_UNIXTIME()` transpiles correctly
- Add parser support for Exasol's native `FROM_POSIX_TIME` function
- Add cross-dialect and identity tests

## Test plan
- `self.validate_identity("SELECT FROM_POSIX_TIME(1234567890)")` round-trips
- `SELECT FROM_UNIXTIME(col)` read as MySQL writes `SELECT FROM_POSIX_TIME(col)` for Exasol
- `UNIX_TO_TIME(x)` cross-dialect test includes Exasol output
- `make test` passes (Python tokenizer)