### PR TITLE
chore(exasol): add MySQL DATEDIFF <-> Exasol DAYS_BETWEEN cross-dialect coverage

### DIFF
--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -729,10 +729,12 @@ class TestMySQL(Validator):
         self.validate_all(
             "SELECT DATEDIFF(x, y)",
             read={
+                "exasol": "SELECT DAYS_BETWEEN(x, y)",
                 "presto": "SELECT DATE_DIFF('DAY', y, x)",
                 "redshift": "SELECT DATEDIFF(DAY, y, x)",
             },
             write={
+                "exasol": "SELECT DAYS_BETWEEN(x, y)",
                 "mysql": "SELECT DATEDIFF(x, y)",
                 "presto": "SELECT DATE_DIFF('DAY', y, x)",
                 "redshift": "SELECT DATEDIFF(DAY, y, x)",


### PR DESCRIPTION
Added "exasol": "SELECT DAYS_BETWEEN(x, y)" to both the read and write dicts in the existing DATEDIFF validate_all block in tests/dialects/test_mysql.py.