### PR TITLE
feat(exasol): support REGEXP_LIKE binary predicate

### DIFF
--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -298,6 +298,7 @@ class Exasol(Dialect):
             # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/if.htm
             "ENDIF": TokenType.END,
             "LONG VARCHAR": TokenType.TEXT,
+            "REGEXP_LIKE": TokenType.RLIKE,
             "SEPARATOR": TokenType.SEPARATOR,
             "SYSTIMESTAMP": TokenType.SYSTIMESTAMP,
         }
@@ -348,6 +349,12 @@ class Exasol(Dialect):
             ),
             "NOW": exp.CurrentTimestamp.from_arg_list,
             "NULLIFZERO": _build_nullifzero,
+            "REGEXP_LIKE": lambda args: exp.RegexpLike(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                flag=seq_get(args, 2),
+                full_match=True,
+            ),
             "REGEXP_SUBSTR": exp.RegexpExtract.from_arg_list,
             "REGEXP_REPLACE": lambda args: exp.RegexpReplace(
                 this=seq_get(args, 0),
@@ -369,6 +376,16 @@ class Exasol(Dialect):
             "COMMENT": lambda self: self.expression(
                 exp.CommentColumnConstraint,
                 this=self._match(TokenType.IS) and self._parse_string(),
+            ),
+        }
+
+        RANGE_PARSERS = {
+            **parser.Parser.RANGE_PARSERS,
+            TokenType.RLIKE: lambda self, this: self.expression(
+                exp.RegexpLike,
+                this=this,
+                expression=self._parse_bitwise(),
+                full_match=True,
             ),
         }
 
@@ -1033,3 +1050,25 @@ class Exasol(Dialect):
 
         def collate_sql(self, expression: exp.Collate) -> str:
             return self.sql(expression.this)
+
+        @unsupported_args("flag")
+        def regexplike_sql(self, expression: exp.RegexpLike) -> str:
+            if not expression.args.get("full_match"):
+                expression = expression.copy()
+                pattern = expression.expression
+                if pattern.is_string:
+                    expression.set("expression", exp.Literal.string(f".*{pattern.name}.*"))
+                else:
+                    expression.set(
+                        "expression",
+                        exp.Paren(
+                            this=exp.Concat(
+                                expressions=[
+                                    exp.Literal.string(".*"),
+                                    pattern,
+                                    exp.Literal.string(".*"),
+                                ]
+                            )
+                        ),
+                    )
+            return self.binary(expression, "REGEXP_LIKE")

--- a/sqlglot/dialects/exasol.py
+++ b/sqlglot/dialects/exasol.py
@@ -1054,7 +1054,6 @@ class Exasol(Dialect):
         @unsupported_args("flag")
         def regexplike_sql(self, expression: exp.RegexpLike) -> str:
             if not expression.args.get("full_match"):
-                expression = expression.copy()
                 pattern = expression.expression
                 if pattern.is_string:
                     expression.set("expression", exp.Literal.string(f".*{pattern.name}.*"))

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -839,6 +839,24 @@ class TestExasol(Validator):
                     write={"exasol": exasol_sql, "databricks": dbx_sql},
                 )
 
+    def test_regexp_like(self):
+        # Exasol uses binary predicate syntax: col REGEXP_LIKE pattern
+        self.validate_identity("SELECT x REGEXP_LIKE '.*pattern.*'")
+
+        # Cross-dialect: partial match semantics from other dialects get .* wrapping
+        self.validate_all(
+            "SELECT a REGEXP_LIKE '.*x.*'",
+            read={
+                "hive": "SELECT a RLIKE 'x'",
+                "presto": "SELECT REGEXP_LIKE(a, 'x')",
+            },
+            write={
+                "exasol": "SELECT a REGEXP_LIKE '.*x.*'",
+                "hive": "SELECT a RLIKE '.*x.*'",
+                "presto": "SELECT REGEXP_LIKE(a, '.*x.*')",
+            },
+        )
+
     def test_json(self):
         self.validate_identity("""SELECT JSON_VALUE('{"d":"a"}', '$.d' NULL ON ERROR) AS x""")
         self.validate_all(

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -365,6 +365,7 @@ class TestHive(Validator):
             "a RLIKE 'x'",
             write={
                 "duckdb": "REGEXP_MATCHES(a, 'x')",
+                "exasol": "a REGEXP_LIKE '.*x.*'",
                 "presto": "REGEXP_LIKE(a, 'x')",
                 "hive": "a RLIKE 'x'",
                 "spark": "a RLIKE 'x'",
@@ -375,6 +376,7 @@ class TestHive(Validator):
             "a REGEXP 'x'",
             write={
                 "duckdb": "REGEXP_MATCHES(a, 'x')",
+                "exasol": "a REGEXP_LIKE '.*x.*'",
                 "presto": "REGEXP_LIKE(a, 'x')",
                 "hive": "a RLIKE 'x'",
                 "spark": "a RLIKE 'x'",


### PR DESCRIPTION
Exasol uses `REGEXP_LIKE` as a binary predicate (`col REGEXP_LIKE pattern`) rather than a function call. Additionally, Exasol's REGEXP_LIKE performs full-string matching, so partial-match patterns from other dialects (REGEXP, RLIKE) are wrapped with `.*` on both sides.