### PR TITLE
test(Snowflake):add transpilation tests for LAG from snowflake to duckdb

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1388,6 +1388,30 @@ class TestSnowflake(Validator):
         )
 
         self.validate_all(
+            "SELECT LAG(amount) OVER (ORDER BY seq) AS basic_lag",
+            write={
+                "snowflake": "SELECT LAG(amount) OVER (ORDER BY seq) AS basic_lag",
+                "duckdb": "SELECT LAG(amount) OVER (ORDER BY seq) AS basic_lag",
+            },
+        )
+
+        self.validate_all(
+            "SELECT LAG(amount, 2) IGNORE NULLS OVER (PARTITION BY category ORDER BY seq) AS lag_offset_ignore_nulls",
+            write={
+                "snowflake": "SELECT LAG(amount, 2) IGNORE NULLS OVER (PARTITION BY category ORDER BY seq) AS lag_offset_ignore_nulls",
+                "duckdb": "SELECT LAG(amount, 2 IGNORE NULLS) OVER (PARTITION BY category ORDER BY seq) AS lag_offset_ignore_nulls",
+            },
+        )
+
+        self.validate_all(
+            "SELECT LAG(amount, 2, -777) RESPECT NULLS OVER (PARTITION BY category ORDER BY seq ASC) AS lag_full_ignore_nulls",
+            write={
+                "snowflake": "SELECT LAG(amount, 2, -777) RESPECT NULLS OVER (PARTITION BY category ORDER BY seq ASC) AS lag_full_ignore_nulls",
+                "duckdb": "SELECT LAG(amount, 2, -777 RESPECT NULLS) OVER (PARTITION BY category ORDER BY seq ASC) AS lag_full_ignore_nulls",
+            },
+        )
+
+        self.validate_all(
             "SELECT BOOLOR_AGG(c1), BOOLOR_AGG(c2) FROM test",
             write={
                 "": "SELECT LOGICAL_OR(c1), LOGICAL_OR(c2) FROM test",


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/functions/lag

LAG can be transpiled from Snowflake to DuckDB already (besides the issue with NULLS FIRST/LAST which will need to be fixed for transpiling for window ranking functions in snowflake). This PR just adds some transpilation tests