### PR TITLE
feat(snowflake)!: transpilation support MAP_DELETE

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -3616,6 +3616,39 @@ class DuckDB(Dialect):
                 "ARRAY_CONTAINS", exp.func("MAP_KEYS", expression.args["key"]), expression.this
             )
 
+        def mapdelete_sql(self, expression: exp.MapDelete) -> str:
+            map_arg = expression.this
+            keys_to_delete = expression.expressions
+
+            x_dot_key = exp.Dot(
+                this=exp.to_identifier("x", quoted=False),
+                expression=exp.to_identifier("key", quoted=False),
+            )
+
+            condition = exp.Not(
+                this=exp.In(
+                    this=x_dot_key,
+                    expressions=keys_to_delete,
+                )
+            )
+
+            lambda_expr = exp.Lambda(
+                this=condition,
+                expressions=[exp.to_identifier("x", quoted=False)],
+            )
+
+            filtered = exp.ArrayFilter(
+                this=exp.func("map_entries", map_arg),
+                expression=lambda_expr,
+            )
+
+            result = exp.func(
+                "map_from_entries",
+                filtered,
+            )
+
+            return self.sql(result)
+
         def startswith_sql(self, expression: exp.StartsWith) -> str:
             return self.func(
                 "STARTS_WITH",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -2502,3 +2502,23 @@ class TestDuckDB(Validator):
                 "snowflake": "SELECT CURRENT_SCHEMAS()",
             },
         )
+
+    def test_map_delete(self):
+        self.validate_all(
+            "SELECT MAP_FROM_ENTRIES(LIST_FILTER(MAP_ENTRIES(CAST({'a': 1, 'b': 2, 'c': 3} AS MAP(TEXT, DECIMAL(38, 0)))), x -> NOT x.key IN ('a', 'b')))",
+            read={
+                "snowflake": "SELECT MAP_DELETE({'a':1,'b':2,'c':3}::MAP(VARCHAR,NUMBER),'a','b')",
+            },
+            write={
+                "duckdb": "SELECT MAP_FROM_ENTRIES(LIST_FILTER(MAP_ENTRIES(CAST({'a': 1, 'b': 2, 'c': 3} AS MAP(TEXT, DECIMAL(38, 0)))), x -> NOT x.key IN ('a', 'b')))",
+            },
+        )
+        self.validate_all(
+            "SELECT id, MAP_FROM_ENTRIES(LIST_FILTER(MAP_ENTRIES(attrs), x -> NOT x.key IN (del_key1, del_key2))) AS attrs_after_delete FROM demo_maps",
+            read={
+                "snowflake": "SELECT id, MAP_DELETE(attrs, del_key1, del_key2) AS attrs_after_delete FROM demo_maps",
+            },
+            write={
+                "duckdb": "SELECT id, MAP_FROM_ENTRIES(LIST_FILTER(MAP_ENTRIES(attrs), x -> NOT x.key IN (del_key1, del_key2))) AS attrs_after_delete FROM demo_maps",
+            },
+        )


### PR DESCRIPTION
Implements MAP_DELETE transpilation by rewriting it to
map_from_entries(list_filter(map_entries(...))).