### PR TITLE
feat(DuckDB)!: Enable transpilation for ARRAY_POSITION function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -1925,7 +1925,12 @@ class DuckDB(Dialect):
             exp.ArrayFilter: rename_func("LIST_FILTER"),
             exp.ArrayInsert: _array_insert_sql,
             exp.ArrayPosition: lambda self, e: (
-                f"{self.func('ARRAY_POSITION', e.this, e.expression)} - 1"
+                self.sql(
+                    exp.Sub(
+                        this=exp.ArrayPosition(this=e.this, expression=e.expression),
+                        expression=exp.Literal.number(1),
+                    )
+                )
                 if e.args.get("zero_based")
                 else self.func("ARRAY_POSITION", e.this, e.expression)
             ),

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -848,7 +848,6 @@ class Snowflake(Dialect):
                 this=seq_get(args, 1),
                 expression=seq_get(args, 0),
                 zero_based=True,
-                ensure_variant=False,
             ),
             "ARRAY_SORT": exp.SortArray.from_arg_list,
             "ARRAY_FLATTEN": exp.Flatten.from_arg_list,
@@ -1646,9 +1645,7 @@ class Snowflake(Dialect):
             ),
             exp.ArrayPosition: lambda self, e: self.func(
                 "ARRAY_POSITION",
-                e.expression
-                if e.args.get("ensure_variant") is False
-                else exp.cast(e.expression, exp.DataType.Type.VARIANT, copy=False),
+                e.expression,
                 e.this,
             ),
             exp.ArrayIntersect: rename_func("ARRAY_INTERSECTION"),

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -5597,7 +5597,7 @@ class ArrayLast(Func):
 
 
 class ArrayPosition(Binary, Func):
-    arg_types = {"this": True, "expression": True, "zero_based": False, "ensure_variant": False}
+    arg_types = {"this": True, "expression": True, "zero_based": False}
 
 
 class ArrayReverse(Func):

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1770,7 +1770,7 @@ class TestDialect(Validator):
                 "athena": "SELECT array_position(array[1, 2, 3], 2)",
             },
             write={
-                "snowflake": "SELECT ARRAY_POSITION(CAST(2 AS VARIANT), [1, 2, 3])",
+                "snowflake": "SELECT ARRAY_POSITION(2, [1, 2, 3])",
                 "spark": "SELECT ARRAY_POSITION(ARRAY(1, 2, 3), 2)",
                 "databricks": "SELECT ARRAY_POSITION(ARRAY(1, 2, 3), 2)",
                 "trino": "SELECT ARRAY_POSITION(ARRAY[1, 2, 3], 2)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -6221,10 +6221,10 @@ FROM SEMANTIC_VIEW(
 
     def test_array_position(self):
         self.validate_all(
-            "SELECT ARRAY_POSITION(2::VARIANT, ARRAY_CONSTRUCT(1, 2, 3))",
+            "SELECT ARRAY_POSITION(2, ARRAY_CONSTRUCT(1, 2, 3))",
             write={
-                "snowflake": "SELECT ARRAY_POSITION(CAST(2 AS VARIANT), [1, 2, 3])",
-                "duckdb": "SELECT ARRAY_POSITION([1, 2, 3], CAST(2 AS VARIANT)) - 1",
+                "snowflake": "SELECT ARRAY_POSITION(2, [1, 2, 3])",
+                "duckdb": "SELECT ARRAY_POSITION([1, 2, 3], 2) - 1",
             },
         )
 


### PR DESCRIPTION
There were 2 issues encountered while transpiling ARRAY_POSITION from Snowflake to Duckdb:

Issue 2: Parameter Order Mismatch
Snowflake: ARRAY_POSITION(element, array) - search element first
DuckDB: ARRAY_POSITION(array, element) - array first
Current transpilation preserves Snowflake order, which is incorrect for DuckDB

Issue 3: Index Base Mismatch
Snowflake: 0-based indexing (first element = 0)
DuckDB: 1-based indexing (first element = 1)
Direct transpilation will return wrong positions (off by 1)

Transpiled Query:
```
duckdb -c "SELECT ARRAY_POSITION(['hello', 'world', 'hello'], CAST('hello' AS VARIANT)) - 1 AS string_first_occurrence, ARRAY_POSITION(['hello', 'world', 'hello'], CAST('world' AS VARIANT)) - 1 AS string_middle, ARRAY_POSITION(['hello', 'world'], CAST('missing' AS VARIANT)) - 1 AS string_not_found, ARRAY_POSITION([1, 2, 3, 2], CAST(2 AS VARIANT)) - 1 AS int_first_occurrence, ARRAY_POSITION([1, 2, 3], CAST(5 AS VARIANT)) - 1 AS int_not_found, ARRAY_POSITION([1.5, 2.5, 3.5], CAST(2.5 AS VARIANT)) - 1 AS float_match, ARRAY_POSITION([1, NULL, 3], CAST(NULL AS VARIANT)) - 1 AS null_in_array, ARRAY_POSITION([NULL, 2, 3], CAST(1 AS VARIANT)) - 1 AS search_in_array_with_null, ARRAY_POSITION([0, 1, 2], CAST(0 AS VARIANT)) - 1 AS zero_value"  
┌─────────────────────────┬───────────────┬──────────────────┬──────────────────────┬───────────────┬─────────────┬───────────────┬───────────────────────────┬────────────┐
│ string_first_occurrence │ string_middle │ string_not_found │ int_first_occurrence │ int_not_found │ float_match │ null_in_array │ search_in_array_with_null │ zero_value │
│          int32          │     int32     │      int32       │        int32         │     int32     │    int32    │     int32     │           int32           │   int32    │
├─────────────────────────┼───────────────┼──────────────────┼──────────────────────┼───────────────┼─────────────┼───────────────┼───────────────────────────┼────────────┤
│            0            │       1       │       NULL       │          1           │     NULL      │      1      │       1       │           NULL            │     0      │
└─────────────────────────┴───────────────┴──────────────────┴──────────────────────┴───────────────┴─────────────┴───────────────┴───────────────────────────┴────────────┘
```