### PR TITLE
feat(optimizer)!: annotate EXTRACT(expr) for DuckDB

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -15,6 +15,7 @@ EXPRESSION_METADATA = {
             exp.DayOfWeek,
             exp.DayOfWeekIso,
             exp.DayOfYear,
+            exp.Extract,
             exp.Hour,
             exp.Length,
             exp.Minute,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6251,6 +6251,14 @@ HUGEINT;
 DATE_DIFF('year', tbl.timestamp_col, tbl.timestamp_col);
 BIGINT;
 
+# dialect: duckdb
+EXTRACT('hour' FROM tbl.timestamp_col);
+BIGINT;
+
+# dialect: duckdb
+EXTRACT('month' FROM tbl.timestamp_col);
+BIGINT;
+
 --------------------------------------
 -- Presto / Trino
 --------------------------------------


### PR DESCRIPTION
### This PR annotate EXTRACT(expr) for [DuckDB](https://duckdb.org/docs/stable/sql/functions/timestamp#extractfield-from-timestamp)

```python
duckdb> select typeof(extract('day' FROM TIMESTAMP '1992-09-20 20:38:48'));
┌─────────────────────────────────────────────────────────────────────────┐
│ typeof(main.date_part('day', CAST('1992-09-20 20:38:48' AS TIMESTAMP))) │
╞═════════════════════════════════════════════════════════════════════════╡
│ BIGINT                                                                  │
└─────────────────────────────────────────────────────────────────────────┘

duckdb> select typeof(extract('month' FROM TIMESTAMP '1992-09-20 20:38:48'));
┌───────────────────────────────────────────────────────────────────────────┐
│ typeof(main.date_part('month', CAST('1992-09-20 20:38:48' AS TIMESTAMP))) │
╞═══════════════════════════════════════════════════════════════════════════╡
│ BIGINT                                                                    │
└───────────────────────────────────────────────────────────────────────────┘

duckdb> select typeof(extract('hour' FROM TIMESTAMP '1992-09-20 20:38:48'));
┌──────────────────────────────────────────────────────────────────────────┐
│ typeof(main.date_part('hour', CAST('1992-09-20 20:38:48' AS TIMESTAMP))) │
╞══════════════════════════════════════════════════════════════════════════╡
│ BIGINT                                                                   │
└──────────────────────────────────────────────────────────────────────────┘
```