### PR TITLE
feat(clickhouse)!: support `arrayExcept` for ClickHouse

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -358,6 +358,7 @@ class ClickHouse(Dialect):
             "ARRAYCOMPACT": exp.ArrayCompact.from_arg_list,
             "ARRAYCONCAT": exp.ArrayConcat.from_arg_list,
             "ARRAYDISTINCT": exp.ArrayDistinct.from_arg_list,
+            "ARRAYEXCEPT": exp.ArrayExcept.from_arg_list,
             "ARRAYSUM": exp.ArraySum.from_arg_list,
             "ARRAYMAX": exp.ArrayMax.from_arg_list,
             "ARRAYMIN": exp.ArrayMin.from_arg_list,

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -706,6 +706,7 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("arrayConcat([1, 2], [3, 4])").assert_is(exp.ArrayConcat)
         self.validate_identity("arrayDistinct([1, 2, 2, 3, 1])").assert_is(exp.ArrayDistinct)
+        self.validate_identity("arrayExcept([1, 2, 3, 2, 4], [3, 5])").assert_is(exp.ArrayExcept)
         self.validate_identity("SELECT UTCTimestamp()", "SELECT CURRENT_TIMESTAMP('UTC')")
 
         for global_ in ["", "GLOBAL "]:


### PR DESCRIPTION
### This PR support `arrayExcept` for ClickHouse

https://clickhouse.com/docs/sql-reference/functions/array-functions#arrayExcept

<img width="300" height="248" alt="image" src="https://github.com/user-attachments/assets/f84cb5d4-eb21-4ca4-aa62-9e433158cf74" />