### PR TITLE
feat(duckdb)!: Implement transpilation for ARRAYS_OVERLAP function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -570,13 +570,20 @@ def _array_overlaps_sql(self: DuckDB.Generator, expression: exp.ArrayOverlaps) -
     ARRAY_LENGTH counts all elements (including NULLs); LIST_COUNT counts only non-NULLs.
     When they differ, the array contains at least one NULL, matching Snowflake's NULL-safe semantics.
     """
+    if not expression.args.get("nullsafe"):
+        return self.binary(expression, "&&")
     arr1 = expression.this
     arr2 = expression.expression
-
-    def has_null(arr: exp.Expression) -> exp.Expression:
-        return exp.NEQ(this=exp.ArraySize(this=arr), expression=exp.func("LIST_COUNT", arr))
-
-    null_safe = self.sql(exp.and_(has_null(arr1.copy()), has_null(arr2.copy())))
+    null_safe = self.sql(
+        exp.and_(
+            exp.NEQ(
+                this=exp.ArraySize(this=arr1.copy()), expression=exp.func("LIST_COUNT", arr1.copy())
+            ),
+            exp.NEQ(
+                this=exp.ArraySize(this=arr2.copy()), expression=exp.func("LIST_COUNT", arr2.copy())
+            ),
+        )
+    )
     return f"({self.binary(expression, '&&')}) OR ({null_safe})"
 
 

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -880,7 +880,9 @@ class Snowflake(Dialect):
             ),
             "ARRAY_SORT": exp.SortArray.from_arg_list,
             "ARRAY_FLATTEN": exp.Flatten.from_arg_list,
-            "ARRAYS_OVERLAP": exp.ArrayOverlaps.from_arg_list,
+            "ARRAYS_OVERLAP": lambda args: exp.ArrayOverlaps(
+                this=seq_get(args, 0), expression=seq_get(args, 1), nullsafe=True
+            ),
             "BITAND": _build_bitwise(exp.BitwiseAnd, "BITAND"),
             "BIT_AND": _build_bitwise(exp.BitwiseAnd, "BITAND"),
             "BITNOT": lambda args: exp.BitwiseNot(this=seq_get(args, 0)),

--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -126,7 +126,7 @@ class ArrayIntersect(Expression, Func):
 
 
 class ArrayOverlaps(Expression, Binary, Func):
-    pass
+    arg_types = {"this": True, "expression": True, "nullsafe": False}
 
 
 class ArrayPosition(Expression, Binary, Func):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1213,10 +1213,7 @@ class TestDuckDB(Validator):
         self.validate_identity("a ~~ b", "a LIKE b")
         self.validate_identity("a @> b")
         self.validate_identity("a <@ b", "b @> a")
-        self.validate_identity(
-            "a && b",
-            "(a && b) OR (ARRAY_LENGTH(a) <> LIST_COUNT(a) AND ARRAY_LENGTH(b) <> LIST_COUNT(b))",
-        ).assert_is(exp.ArrayOverlaps)
+        self.validate_identity("a && b").assert_is(exp.ArrayOverlaps)
         self.validate_identity("a ^@ b", "STARTS_WITH(a, b)")
         self.validate_identity(
             "a !~~ b",
@@ -1267,7 +1264,7 @@ class TestDuckDB(Validator):
         self.validate_all(
             "LIST_HAS_ANY([1, 2, 3], [1,2])",
             write={
-                "duckdb": "([1, 2, 3] && [1, 2]) OR (ARRAY_LENGTH([1, 2, 3]) <> LIST_COUNT([1, 2, 3]) AND ARRAY_LENGTH([1, 2]) <> LIST_COUNT([1, 2]))",
+                "duckdb": "[1, 2, 3] && [1, 2]",
                 "postgres": "ARRAY[1, 2, 3] && ARRAY[1, 2]",
             },
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1063,7 +1063,9 @@ class TestSnowflake(Validator):
         )
         self.validate_all(
             "SELECT ARRAYS_OVERLAP(col1, col2)",
-            read={"snowflake": "SELECT ARRAYS_OVERLAP(col1, col2)"},
+            read={
+                "snowflake": "SELECT ARRAYS_OVERLAP(col1, col2)",
+            },
             write={
                 "snowflake": "SELECT ARRAYS_OVERLAP(col1, col2)",
                 "duckdb": "SELECT (col1 && col2) OR (ARRAY_LENGTH(col1) <> LIST_COUNT(col1) AND ARRAY_LENGTH(col2) <> LIST_COUNT(col2))",
@@ -1071,7 +1073,9 @@ class TestSnowflake(Validator):
         )
         self.validate_all(
             "SELECT ARRAYS_OVERLAP([1, NULL, 3], [NULL, 4, 5])",
-            read={"snowflake": "SELECT ARRAYS_OVERLAP([1, NULL, 3], [NULL, 4, 5])"},
+            read={
+                "snowflake": "SELECT ARRAYS_OVERLAP([1, NULL, 3], [NULL, 4, 5])",
+            },
             write={
                 "snowflake": "SELECT ARRAYS_OVERLAP([1, NULL, 3], [NULL, 4, 5])",
                 "duckdb": "SELECT ([1, NULL, 3] && [NULL, 4, 5]) OR (ARRAY_LENGTH([1, NULL, 3]) <> LIST_COUNT([1, NULL, 3]) AND ARRAY_LENGTH([NULL, 4, 5]) <> LIST_COUNT([NULL, 4, 5]))",


### PR DESCRIPTION

The following issues were encountered while transpiling `ARRAYS_OVERLAP` from Snowflake to DuckDB:

1. ARRAYS_OVERLAP is not in Snowflake's Parser.FUNCTIONS dict. It parses as Anonymous(`ARRAYS_OVERLAP`, ...) and      emits unchanged. DuckDB has no `ARRAYS_OVERLAP` function → runtime Catalog Error.
2. Snowflake `ARRAYS_OVERLAP` is NULL-safe (NULLs treated as known values).
   `[1,NULL,3] && [NULL,4,5] returns TRUE in Snowflake.`
   DuckDB's equivalent && operator is NOT NULL-safe:
  ` [1,NULL,3] && [NULL,4,5] returns FALSE in DuckDB.`
 
 
 Snowflake Results:
```
  | OVERLAP_TRUE | OVERLAP_FALSE | OVERLAP_NULL | OVERLAP_EMPTY | OVERLAP_NULL_INPUT |
  |--------------|---------------|--------------|---------------|--------------------|
  | True         | False         | True         | False         | NULL               |

```
 
Transpilation:
```
python -m sqlglot --read snowflake --write duckdb "SELECT ARRAYS_OVERLAP([1,2,3], [2,3,4]) AS overlap_true, ARRAYS_OVERLAP([1,2,3], [4,5,6]) AS overlap_false, ARRAYS_OVERLAP([1,NULL,3], [NULL,4,5]) AS overlap_null, ARRAYS_OVERLAP([], [1,2]) AS overlap_empty, ARRAYS_OVERLAP(NULL, [1,2]) AS overlap_null_input"
-->
SELECT
  ([1, 2, 3] && [2, 3, 4]) OR (ARRAY_LENGTH([1, 2, 3]) <> LIST_COUNT([1, 2, 3])
  AND ARRAY_LENGTH([2, 3, 4]) <> LIST_COUNT([2, 3, 4])) AS "overlap_true",
  ([1, 2, 3] && [4, 5, 6]) OR (ARRAY_LENGTH([1, 2, 3]) <> LIST_COUNT([1, 2, 3])
  AND ARRAY_LENGTH([4, 5, 6]) <> LIST_COUNT([4, 5, 6])) AS "overlap_false",
  ([1, NULL, 3] && [NULL, 4, 5]) OR (ARRAY_LENGTH([1, NULL, 3]) <> LIST_COUNT([1, NULL, 3])
  AND ARRAY_LENGTH([NULL, 4, 5]) <> LIST_COUNT([NULL, 4, 5])) AS "overlap_null",
  ([] && [1, 2]) OR (ARRAY_LENGTH([]) <> LIST_COUNT([]) AND ARRAY_LENGTH([1, 2]) <> LIST_COUNT([1, 2])) AS "overlap_empty",
  (NULL && [1, 2]) OR (ARRAY_LENGTH(NULL) <> LIST_COUNT(NULL)
  AND ARRAY_LENGTH([1, 2]) <> LIST_COUNT([1, 2])) AS "overlap_null_input"
```

Duckdb:
```
 overlap_true │ overlap_false │ overlap_null │ overlap_empty │ overlap_null_input │
│   boolean    │    boolean    │   boolean    │    boolean    │      boolean       │
├──────────────┼───────────────┼──────────────┼───────────────┼────────────────────┤
│ true         │ false         │ true         │ false         │ NULL               │
```