### PR TITLE
Fix/lineage cte memoization

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -80,7 +80,7 @@ def lineage(
     scope: t.Optional[Scope] = None,
     trim_selects: bool = True,
     copy: bool = True,
-    memoize: bool = False,
+    read_only: bool = False,
     **kwargs,
 ) -> Node:
     """Build the lineage graph for a column of a SQL query.
@@ -94,8 +94,10 @@ def lineage(
         scope: A pre-created scope to use instead.
         trim_selects: Whether to clean up selects by trimming to only relevant columns.
         copy: Whether to copy the Expr arguments.
-        memoize: Whether to memoize CTE node traversal. When True, shared CTE references
-            produce a DAG instead of a tree, improving performance for self-joining CTEs.
+        read_only: Whether the returned node graph is read-only. Enables optimizations
+            such as sharing cached nodes across CTE references, producing a DAG instead
+            of a tree. When False (default), cached nodes are copied to ensure each
+            reference is independent and safely mutable.
         **kwargs: Qualification optimizer kwargs.
 
     Returns:
@@ -136,8 +138,32 @@ def lineage(
         raise SqlglotError(f"Cannot find column '{column}' in query.")
 
     return to_node(
-        column, scope, dialect, trim_selects=trim_selects, _cache={} if memoize else None
+        column, scope, dialect, trim_selects=trim_selects, _cache={}, _read_only=read_only
     )
+
+
+def _copy_node(node: Node) -> Node:
+    """Deep copy a Node graph while sharing AST expression objects."""
+    copied: t.Dict[int, Node] = {}
+
+    def _copy(n: Node) -> Node:
+        node_id = id(n)
+        if node_id in copied:
+            return copied[node_id]
+
+        new_node = Node(
+            name=n.name,
+            expression=n.expression,
+            source=n.source,
+            source_name=n.source_name,
+            reference_node_name=n.reference_node_name,
+        )
+        copied[node_id] = new_node
+        for d in n.downstream:
+            new_node.downstream.append(_copy(d))
+        return new_node
+
+    return _copy(node)
 
 
 def to_node(
@@ -150,11 +176,14 @@ def to_node(
     reference_node_name: t.Optional[str] = None,
     trim_selects: bool = True,
     _cache: t.Optional[t.Dict[t.Tuple, Node]] = None,
+    _read_only: bool = False,
 ) -> Node:
     cache_key = (column, id(scope), scope_name, source_name, reference_node_name)
 
     if _cache is not None and cache_key in _cache:
         cached_node = _cache[cache_key]
+        if not _read_only:
+            cached_node = _copy_node(cached_node)
         if upstream:
             upstream.downstream.append(cached_node)
         return cached_node
@@ -182,6 +211,7 @@ def to_node(
                 reference_node_name=reference_node_name,
                 trim_selects=trim_selects,
                 _cache=_cache,
+                _read_only=_read_only,
             )
             if _cache is not None:
                 _cache[cache_key] = result
@@ -216,6 +246,7 @@ def to_node(
                 reference_node_name=reference_node_name,
                 trim_selects=trim_selects,
                 _cache=_cache,
+                _read_only=_read_only,
             )
 
         if _cache is not None:
@@ -261,6 +292,7 @@ def to_node(
                 upstream=node,
                 trim_selects=trim_selects,
                 _cache=_cache,
+                _read_only=_read_only,
             )
 
     # if the select is a star add all scope sources as downstreams
@@ -335,6 +367,7 @@ def to_node(
                 reference_node_name=reference_node_name,
                 trim_selects=trim_selects,
                 _cache=_cache,
+                _read_only=_read_only,
             )
         elif pivot and pivot.alias_or_name == c.table:
             downstream_columns = []

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -788,19 +788,15 @@ class TestLineage(unittest.TestCase):
             )
         sql = "WITH " + ",\n     ".join(ctes) + f"\nSELECT a FROM cte_{n_levels - 1}"
 
-        for memoize in (False, True):
-            with self.subTest(memoize=memoize):
-                node = lineage("a", sql, schema={"base_table": {"a": "int"}}, memoize=memoize)
+        for read_only in (False, True):
+            with self.subTest(read_only=read_only):
+                node = lineage("a", sql, schema={"base_table": {"a": "int"}}, read_only=read_only)
 
                 # Walk the DAG and verify structure.
                 all_nodes = list(node.walk())
 
-                if not memoize:
-                    # Without memoization, nodes are fully independent.
-                    # Node count should be O(2^N) — verify it's large to confirm no caching.
-                    self.assertGreater(len(all_nodes), 200)
-                else:
-                    # With memoization, shared references keep node count small (O(N), not O(2^N)).
+                if read_only:
+                    # With read_only=True, shared references keep node count small (O(N), not O(2^N)).
                     self.assertLess(
                         len(all_nodes),
                         200,
@@ -810,6 +806,9 @@ class TestLineage(unittest.TestCase):
                     # walk() should yield each node exactly once.
                     all_ids = [id(n) for n in all_nodes]
                     self.assertEqual(len(all_ids), len(set(all_ids)))
+                else:
+                    # With read_only=False, cached nodes are copied so each reference is independent.
+                    self.assertGreater(len(all_nodes), 200)
 
                 # Leaf nodes should reference base_table.
                 leaves = [n for n in all_nodes if not n.downstream]
@@ -817,13 +816,13 @@ class TestLineage(unittest.TestCase):
                 self.assertTrue(all("base_table" in n.source.sql() for n in leaves))
 
     def test_lineage_cte_self_join_distinct_aliases(self) -> None:
-        for memoize in (False, True):
-            with self.subTest(memoize=memoize):
+        for read_only in (False, True):
+            with self.subTest(read_only=read_only):
                 node = lineage(
                     "combined",
                     "WITH shared AS (SELECT a FROM x) SELECT s1.a + s2.a AS combined FROM shared s1, shared s2",
                     schema={"x": {"a": "int"}},
-                    memoize=memoize,
+                    read_only=read_only,
                 )
                 downstream_names = sorted(d.name for d in node.downstream)
                 self.assertEqual(downstream_names, ["s1.a", "s2.a"])


### PR DESCRIPTION
## Summary

- When a CTE is referenced multiple times (e.g., self-joins), `to_node()` re-expands the same scope for each reference, causing O(2^N) growth in nodes and computation time
- Add a memoization cache to `to_node()` keyed on `(column, scope_id, scope_name, source_name, reference_node_name)` that returns previously computed nodes instead of re-expanding
- Make `Node.walk()` DAG-aware with a visited set, since memoization can turn the lineage tree into a DAG with shared nodes
- Add `read_only` parameter to `lineage()` (default `False`) that enables read-only optimizations such as sharing cached nodes across CTE references. When `False`, cached nodes are copied on cache hit to preserve mutability safety.

### Mutability safety

- **`read_only=False` (default):** cached nodes are copied on cache hit via `_copy_node()`, so each reference gets an independent node graph. Safe to mutate.
- **`read_only=True`:** cached nodes are shared across references, producing a DAG. Faster and uses less memory, but callers must not mutate the returned nodes.

### Benchmark

Query pattern: N chained CTEs, each self-joining the previous one (`SELECT t1.a + t2.a AS a FROM cte_{k-1} t1 JOIN cte_{k-1} t2`).

| N | No memoization | | `read_only=False` (copy on hit) | | `read_only=True` (shared DAG) | |
|--:|--:|--:|--:|--:|--:|--:|
| | Nodes | Time | Nodes | Time | Nodes | Time |
| 2 | 6 | 0.4ms | 6 | 1.6ms | 6 | 1.5ms |
| 4 | 24 | 1.4ms | 24 | 2.8ms | 10 | 2.9ms |
| 6 | 96 | 5.3ms | 96 | 4.4ms | 14 | 4.7ms |
| 8 | 384 | 19.2ms | 384 | 6.3ms | 18 | 5.8ms |
| 10 | 1,536 | 73.2ms | 1,536 | 9.1ms | 22 | 7.1ms |
| 12 | 6,144 | 339.8ms | 6,144 | 15.3ms | 26 | 8.7ms |
| 14 | 24,576 | 1.5s | 24,576 | 38.4ms | 30 | 12.5ms |
| 16 | 98,304 | 7.0s | 98,304 | 130.4ms | 34 | 11.5ms |

- `read_only=False` produces the same node count as before (independent copies) but is significantly faster because `_copy_node()` is cheaper than re-traversing scopes (54x faster at N=16)
- `read_only=True` at N=16: 2,891x fewer nodes, 609x faster than no memoization