### PR TITLE
feat(optimizer)!: annotate CURRENT_TIMESTAMP for TSQL

### DIFF
--- a/sqlglot/typing/tsql.py
+++ b/sqlglot/typing/tsql.py
@@ -33,4 +33,5 @@ EXPRESSION_METADATA = {
         }
     },
     exp.CurrentTimezone: {"returns": exp.DType.NVARCHAR},
+    exp.CurrentTimestamp: {"returns": exp.DType.DATETIME},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -5843,6 +5843,10 @@ FLOAT;
 DEGREES(tbl.bigint_col);
 BIGINT;
 
+# dialect: tsql 
+CURRENT_TIMESTAMP;
+DATETIME;
+
 --------------------------------------
 -- MySQL
 --------------------------------------


### PR DESCRIPTION
## This PR annotate CURRENT_TIMESTAMP for TSQL

https://learn.microsoft.com/en-us/sql/t-sql/functions/current-timestamp-transact-sql?view=sql-server-ver17#return-type

<img width="600" height="290" alt="image" src="https://github.com/user-attachments/assets/54578834-f037-466c-8d49-5c596585dae1" />
