### PR TITLE
test(snowflake): add test for SPLIT transpilation from Snowflake to DuckDB

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -219,6 +219,13 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT UNICODE(column_name)")
         self.validate_identity("SELECT WIDTH_BUCKET(col, 0, 100, 10)")
         self.validate_identity("SELECT SPLIT_PART('11.22.33', '.', 1)")
+        self.validate_all(
+            "SELECT SPLIT('127.0.0.1', '.')",
+            write={
+                "snowflake": "SELECT SPLIT('127.0.0.1', '.')",
+                "duckdb": "SELECT STR_SPLIT('127.0.0.1', '.')",
+            },
+        )
         self.validate_identity("SELECT PI()")
         self.validate_identity("SELECT DEGREES(PI() / 3)")
         self.validate_identity("SELECT DEGREES(1)")


### PR DESCRIPTION
https://docs.snowflake.com/en/sql-reference/functions/split

The transpilation of SPLIT from Snowflake to DuckDB works already. This PR just adds a test for it.


There is one discrepancy though. With Snowflake, if the separator is NULL, any the result is also null (SPLIT('|a||', NULL) returns NULL). But in DuckDB, if the separator is NULL it just returns the whole input string (STR_SPLIT('|a||', NULL) returns [|a||] ).