### PR TITLE
fix(redshift): avoid warning for IGNORE/RESPECT NULLS

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
     map_date_part,
 )
 from sqlglot.dialects.postgres import Postgres
+from sqlglot.generator import Generator
 from sqlglot.helper import seq_get
 from sqlglot.tokens import TokenType
 from sqlglot.parser import build_convert_timezone
@@ -493,6 +494,12 @@ class Redshift(Postgres):
                 return super().array_sql(expression)
 
             return rename_func("ARRAY")(self, expression)
+
+        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
+            return Generator.ignorenulls_sql(self, expression)
+
+        def respectnulls_sql(self, expression: exp.RespectNulls) -> str:
+            return Generator.respectnulls_sql(self, expression)
 
         def explode_sql(self, expression: exp.Explode) -> str:
             self.unsupported("Unsupported EXPLODE() function")

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -771,6 +771,17 @@ FROM (
         )
         self.assertEqual(expr.expressions[0].type.this, exp.DataType.Type.TIMESTAMPTZ)
 
+        self.validate_identity("SELECT LAG(x) IGNORE NULLS OVER (PARTITION BY y ORDER BY z)")
+        self.validate_identity("SELECT LAG(x) RESPECT NULLS OVER (PARTITION BY y ORDER BY z)")
+        self.validate_identity(
+            "SELECT LAG(x IGNORE NULLS) OVER (PARTITION BY y ORDER BY z)",
+            "SELECT LAG(x) IGNORE NULLS OVER (PARTITION BY y ORDER BY z)",
+        )
+        self.validate_identity(
+            "SELECT LAG(x RESPECT NULLS) OVER (PARTITION BY y ORDER BY z)",
+            "SELECT LAG(x) RESPECT NULLS OVER (PARTITION BY y ORDER BY z)",
+        )
+
     def test_regexp_extract(self):
         self.validate_all(
             "SELECT REGEXP_SUBSTR(abc, 'pattern(group)', 2) FROM table",


### PR DESCRIPTION
Redshift inherited from Postgres the unsupported warning for IGNORE/RESPECT NULLS.

**DOCS**
[Redshift IGNORE/RESPECT NULLS example](https://docs.aws.amazon.com/redshift/latest/dg/r_WF_LAG.html)