### PR TITLE
feat(snowflake)!: handle empty separator for SPLIT transpilation (Snowflake -> Duckdb)

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -3879,14 +3879,22 @@ class DuckDB(Dialect):
         def split_sql(self, expression: exp.Split) -> str:
             base_func = exp.func("STR_SPLIT", expression.this, expression.expression)
 
-            if expression.args.get("null_returns_null"):
-                return self.sql(
-                    exp.case()
-                    .when(expression.expression.is_(exp.null()), exp.null())
-                    .else_(base_func)
-                )
+            case_expr = exp.case().else_(base_func)
+            needs_case = False
 
-            return self.sql(base_func)
+            if expression.args.get("null_returns_null"):
+                case_expr = case_expr.when(expression.expression.is_(exp.null()), exp.null())
+                needs_case = True
+
+            if expression.args.get("empty_delimiter_returns_whole"):
+                # When delimiter is empty string, return input string as single array element
+                array_with_input = exp.array(expression.this)
+                case_expr = case_expr.when(
+                    expression.expression.eq(exp.Literal.string("")), array_with_input
+                )
+                needs_case = True
+
+            return self.sql(case_expr if needs_case else base_func)
 
         def respectnulls_sql(self, expression: exp.RespectNulls) -> str:
             if isinstance(expression.this, self.IGNORE_RESPECT_NULLS_WINDOW_FUNCTIONS):

--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -999,6 +999,7 @@ class Snowflake(Dialect):
                 this=seq_get(args, 0),
                 expression=seq_get(args, 1),
                 null_returns_null=True,
+                empty_delimiter_returns_whole=True,
             ),
             "SQUARE": lambda args: exp.Pow(this=seq_get(args, 0), expression=exp.Literal.number(2)),
             "STDDEV_SAMP": exp.Stddev.from_arg_list,

--- a/sqlglot/expressions/string.py
+++ b/sqlglot/expressions/string.py
@@ -158,7 +158,13 @@ class Space(Expression, Func):
 
 
 class Split(Expression, Func):
-    arg_types = {"this": True, "expression": True, "limit": False, "null_returns_null": False}
+    arg_types = {
+        "this": True,
+        "expression": True,
+        "limit": False,
+        "null_returns_null": False,
+        "empty_delimiter_returns_whole": False,
+    }
 
 
 class SplitPart(Expression, Func):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -223,7 +223,7 @@ class TestSnowflake(Validator):
             "SELECT SPLIT('127.0.0.1', '.')",
             write={
                 "snowflake": "SELECT SPLIT('127.0.0.1', '.')",
-                "duckdb": "SELECT CASE WHEN '.' IS NULL THEN NULL ELSE STR_SPLIT('127.0.0.1', '.') END",
+                "duckdb": "SELECT CASE WHEN '.' IS NULL THEN NULL WHEN '.' = '' THEN ['127.0.0.1'] ELSE STR_SPLIT('127.0.0.1', '.') END",
             },
         )
         self.validate_identity("SELECT PI()")


### PR DESCRIPTION
As it turns out, In Snowflake, SPLIT('1.2.3', '') returns ["1.2.3"] (the whole input string as the only element in the output array), while in DuckDB, str_split('1.2.3', '') returns [1, ., 2, ., 3]  (separate all the characters in the input string into an array). 

We also need to handle this discrepancy during transpilation, through the empty_delimiter_returns_whole flag