### PR TITLE
feat: fast path for tokenizer

### DIFF
--- a/benchmarks/parse.py
+++ b/benchmarks/parse.py
@@ -92,6 +92,10 @@ many_windows = (
 
 nested_functions = "SELECT " + "COALESCE(" * 50 + "x" + ", NULL)" * 50 + " FROM t"
 
+large_strings = "SELECT " + ", ".join(f"'{'x' * 100}'" for i in range(500)) + " FROM t"
+
+many_numbers = "SELECT " + ", ".join(str(i) for i in range(10000)) + " FROM t"
+
 tpch = """
 WITH "_e_0" AS (
   SELECT
@@ -231,6 +235,8 @@ QUERIES = {
     "many_ctes": many_ctes,
     "many_windows": many_windows,
     "nested_functions": nested_functions,
+    "large_strings": large_strings,
+    "many_numbers": many_numbers,
 }
 
 
@@ -242,7 +248,7 @@ def _can_parse(fn, sql):
         return False
 
 
-LARGE_QUERIES = {"large_in", "values", "many_unions"}
+LARGE_QUERIES = {"large_in", "values", "many_unions", "many_numbers"}
 
 
 def run_benchmarks():

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -910,7 +910,13 @@ class TokenizerCore:
 
         while True:
             if self._peek in _DIGIT_CHARS:
-                self._advance()
+                # Batch consecutive digits: scan ahead to find how many
+                sql = self.sql
+                end = self._current + 1
+                size = self.size
+                while end < size and sql[end] in _DIGIT_CHARS:
+                    end += 1
+                self._advance(end - self._current)
             elif self._peek == "." and not decimal:
                 if self.tokens and self.tokens[-1].token_type == TokenType.PARAMETER:
                     break
@@ -1095,6 +1101,33 @@ class TokenizerCore:
         escape_follow_chars = self.escape_follow_chars
         string_escapes_allowed_in_raw_strings = self.string_escapes_allowed_in_raw_strings
         quotes = self.quotes
+        sql = self.sql
+
+        # use str.find() when the string is simple... no \ or other escapes
+        if delim_size == 1:
+            pos = self._current - 1
+            end = sql.find(delimiter, pos)
+
+            if (
+                # the closing delimiter was found
+                end != -1
+                # there's no doubled delimiter (e.g. '' escape), or the delimiter isn't an escape char
+                and (end + 1 >= self.size or sql[end + 1] != delimiter or delimiter not in escapes)
+                # no backslash in the string that would need escape processing
+                and (not (unescaped_sequences or "\\" in escapes) or sql.find("\\", pos, end) == -1)
+            ):
+                newlines = sql.count("\n", pos, end)
+                if newlines:
+                    self._line += newlines
+                    self._col = end - sql.rfind("\n", pos, end)
+                else:
+                    self._col += end - pos
+
+                self._current = end + 1
+                self._end = self._current >= self.size
+                self._char = sql[end]
+                self._peek = "" if self._end else sql[self._current]
+                return sql[pos:end]
 
         while True:
             if not raw_string and unescaped_sequences and self._peek and self._char in escapes:
@@ -1139,6 +1172,6 @@ class TokenizerCore:
 
                 current = self._current - 1
                 self._advance(alnum=True)
-                text += self.sql[current : self._current - 1]
+                text += sql[current : self._current - 1]
 
         return text


### PR DESCRIPTION
┌───────────────┬─────────────────┬──────────────────┬─────────┬────────────────┬─────────────────┬─────────┐
│     Query     │ Python baseline │ Python optimized │ Speedup │ mypyc baseline │ mypyc optimized │ Speedup │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ large_strings │           6,608 │            2,149 │    +67% │          3,610 │             745 │    +79% │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ large_in      │         195,231 │          164,782 │    +16% │         71,567 │          60,598 │    +15% │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ long_numbers  │          27,551 │           23,256 │    +16% │         11,149 │          11,393 │     -2% │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ just_numbers  │          38,577 │           36,350 │     +6% │         13,899 │          14,351 │     -3% │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ many_joins    │           4,617 │            4,660 │      0% │          1,735 │           1,735 │      0% │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ many_columns  │           4,338 │            4,340 │      0% │          1,659 │           1,687 │      0% │
├───────────────┼─────────────────┼──────────────────┼─────────┼────────────────┼─────────────────┼─────────┤
│ short         │              51 │               51 │      0% │             20 │              20 │      0% │
└───────────────┴─────────────────┴──────────────────┴─────────┴────────────────┴─────────────────┴─────────┘