### PR TITLE
refactor!: expression to not use **kwargs because it allocates multip…

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -55,7 +55,7 @@ def binary_range_parser(
         expression = self._parse_bitwise()
         if reverse_args:
             this, expression = expression, this
-        return self._parse_escape(self.expression(expr_type, this=this, expression=expression))
+        return self._parse_escape(self.expression(expr_type(this=this, expression=expression)))
 
     return _parse_binary_range
 
@@ -870,57 +870,48 @@ class Parser:
 
     LAMBDAS: t.ClassVar = {
         TokenType.ARROW: lambda self, expressions: self.expression(
-            exp.Lambda,
-            this=self._replace_lambda(
-                self._parse_disjunction(),
-                expressions,
-            ),
-            expressions=expressions,
+            exp.Lambda(
+                this=self._replace_lambda(
+                    self._parse_disjunction(),
+                    expressions,
+                ),
+                expressions=expressions,
+            )
         ),
         TokenType.FARROW: lambda self, expressions: self.expression(
-            exp.Kwarg,
-            this=exp.var(expressions[0].name),
-            expression=self._parse_disjunction(),
+            exp.Kwarg(this=exp.var(expressions[0].name), expression=self._parse_disjunction())
         ),
     }
 
     COLUMN_OPERATORS: t.ClassVar = {
         TokenType.DOT: None,
-        TokenType.DOTCOLON: lambda self, this, to: self.expression(
-            exp.JSONCast,
-            this=this,
-            to=to,
-        ),
+        TokenType.DOTCOLON: lambda self, this, to: self.expression(exp.JSONCast(this=this, to=to)),
         TokenType.DCOLON: lambda self, this, to: self.build_cast(
             strict=self.STRICT_CAST, this=this, to=to
         ),
         TokenType.ARROW: lambda self, this, path: self.expression(
-            exp.JSONExtract,
-            this=this,
-            expression=self.dialect.to_json_path(path),
-            only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+            exp.JSONExtract(
+                this=this,
+                expression=self.dialect.to_json_path(path),
+                only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+            )
         ),
         TokenType.DARROW: lambda self, this, path: self.expression(
-            exp.JSONExtractScalar,
-            this=this,
-            expression=self.dialect.to_json_path(path),
-            only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
-            scalar_only=self.dialect.JSON_EXTRACT_SCALAR_SCALAR_ONLY,
+            exp.JSONExtractScalar(
+                this=this,
+                expression=self.dialect.to_json_path(path),
+                only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+                scalar_only=self.dialect.JSON_EXTRACT_SCALAR_SCALAR_ONLY,
+            )
         ),
         TokenType.HASH_ARROW: lambda self, this, path: self.expression(
-            exp.JSONBExtract,
-            this=this,
-            expression=path,
+            exp.JSONBExtract(this=this, expression=path)
         ),
         TokenType.DHASH_ARROW: lambda self, this, path: self.expression(
-            exp.JSONBExtractScalar,
-            this=this,
-            expression=path,
+            exp.JSONBExtractScalar(this=this, expression=path)
         ),
         TokenType.PLACEHOLDER: lambda self, this, key: self.expression(
-            exp.JSONBContains,
-            this=this,
-            expression=key,
+            exp.JSONBContains(this=this, expression=key)
         ),
     }
 
@@ -985,7 +976,7 @@ class Parser:
         TokenType.LOAD: lambda self: self._parse_load(),
         TokenType.MERGE: lambda self: self._parse_merge(),
         TokenType.PIVOT: lambda self: self._parse_simplified_pivot(),
-        TokenType.PRAGMA: lambda self: self.expression(exp.Pragma, this=self._parse_expression()),
+        TokenType.PRAGMA: lambda self: self.expression(exp.Pragma(this=self._parse_expression())),
         TokenType.REFRESH: lambda self: self._parse_refresh(),
         TokenType.ROLLBACK: lambda self: self._parse_commit_or_rollback(),
         TokenType.SET: lambda self: self._parse_set(),
@@ -999,41 +990,52 @@ class Parser:
 
     UNARY_PARSERS: t.ClassVar = {
         TokenType.PLUS: lambda self: self._parse_unary(),  # Unary + is handled as a no-op
-        TokenType.NOT: lambda self: self.expression(exp.Not, this=self._parse_equality()),
-        TokenType.TILDE: lambda self: self.expression(exp.BitwiseNot, this=self._parse_unary()),
-        TokenType.DASH: lambda self: self.expression(exp.Neg, this=self._parse_unary()),
-        TokenType.PIPE_SLASH: lambda self: self.expression(exp.Sqrt, this=self._parse_unary()),
-        TokenType.DPIPE_SLASH: lambda self: self.expression(exp.Cbrt, this=self._parse_unary()),
+        TokenType.NOT: lambda self: self.expression(exp.Not(this=self._parse_equality())),
+        TokenType.TILDE: lambda self: self.expression(exp.BitwiseNot(this=self._parse_unary())),
+        TokenType.DASH: lambda self: self.expression(exp.Neg(this=self._parse_unary())),
+        TokenType.PIPE_SLASH: lambda self: self.expression(exp.Sqrt(this=self._parse_unary())),
+        TokenType.DPIPE_SLASH: lambda self: self.expression(exp.Cbrt(this=self._parse_unary())),
     }
 
     STRING_PARSERS: t.ClassVar = {
-        TokenType.HEREDOC_STRING: lambda self, token: self.expression(exp.RawString, token=token),
-        TokenType.NATIONAL_STRING: lambda self, token: self.expression(exp.National, token=token),
-        TokenType.RAW_STRING: lambda self, token: self.expression(exp.RawString, token=token),
+        TokenType.HEREDOC_STRING: lambda self, token: self.expression(
+            exp.RawString(this=token.text), token
+        ),
+        TokenType.NATIONAL_STRING: lambda self, token: self.expression(
+            exp.National(this=token.text), token
+        ),
+        TokenType.RAW_STRING: lambda self, token: self.expression(
+            exp.RawString(this=token.text), token
+        ),
         TokenType.STRING: lambda self, token: self.expression(
-            exp.Literal, token=token, is_string=True
+            exp.Literal(this=token.text, is_string=True), token
         ),
         TokenType.UNICODE_STRING: lambda self, token: self.expression(
-            exp.UnicodeString,
-            token=token,
-            escape=self._match_text_seq("UESCAPE") and self._parse_string(),
+            exp.UnicodeString(
+                this=token.text, escape=self._match_text_seq("UESCAPE") and self._parse_string()
+            ),
+            token,
         ),
     }
 
     NUMERIC_PARSERS: t.ClassVar = {
-        TokenType.BIT_STRING: lambda self, token: self.expression(exp.BitString, token=token),
+        TokenType.BIT_STRING: lambda self, token: self.expression(
+            exp.BitString(this=token.text), token
+        ),
         TokenType.BYTE_STRING: lambda self, token: self.expression(
-            exp.ByteString,
-            token=token,
-            is_bytes=self.dialect.BYTE_STRING_IS_BYTES_TYPE or None,
+            exp.ByteString(
+                this=token.text, is_bytes=self.dialect.BYTE_STRING_IS_BYTES_TYPE or None
+            ),
+            token,
         ),
         TokenType.HEX_STRING: lambda self, token: self.expression(
-            exp.HexString,
-            token=token,
-            is_integer=self.dialect.HEX_STRING_IS_INTEGER_TYPE or None,
+            exp.HexString(
+                this=token.text, is_integer=self.dialect.HEX_STRING_IS_INTEGER_TYPE or None
+            ),
+            token,
         ),
         TokenType.NUMBER: lambda self, token: self.expression(
-            exp.Literal, token=token, is_string=False
+            exp.Literal(this=token.text, is_string=False), token
         ),
     }
 
@@ -1041,18 +1043,18 @@ class Parser:
         **STRING_PARSERS,
         **NUMERIC_PARSERS,
         TokenType.INTRODUCER: lambda self, token: self._parse_introducer(token),
-        TokenType.NULL: lambda self, _: self.expression(exp.Null),
-        TokenType.TRUE: lambda self, _: self.expression(exp.Boolean, this=True),
-        TokenType.FALSE: lambda self, _: self.expression(exp.Boolean, this=False),
+        TokenType.NULL: lambda self, _: self.expression(exp.Null()),
+        TokenType.TRUE: lambda self, _: self.expression(exp.Boolean(this=True)),
+        TokenType.FALSE: lambda self, _: self.expression(exp.Boolean(this=False)),
         TokenType.SESSION_PARAMETER: lambda self, _: self._parse_session_parameter(),
         TokenType.STAR: lambda self, _: self._parse_star_ops(),
     }
 
     PLACEHOLDER_PARSERS: t.ClassVar = {
-        TokenType.PLACEHOLDER: lambda self: self.expression(exp.Placeholder),
+        TokenType.PLACEHOLDER: lambda self: self.expression(exp.Placeholder()),
         TokenType.PARAMETER: lambda self: self._parse_parameter(),
         TokenType.COLON: lambda self: (
-            self.expression(exp.Placeholder, this=self._prev.text)
+            self.expression(exp.Placeholder(this=self._prev.text))
             if self._match_set(self.COLON_PLACEHOLDER_TOKENS)
             else None
         ),
@@ -1100,13 +1102,13 @@ class Parser:
 
     PROPERTY_PARSERS: t.ClassVar[t.Dict[str, t.Callable]] = {
         "ALLOWED_VALUES": lambda self: self.expression(
-            exp.AllowedValuesProperty, expressions=self._parse_csv(self._parse_primary)
+            exp.AllowedValuesProperty(expressions=self._parse_csv(self._parse_primary))
         ),
         "ALGORITHM": lambda self: self._parse_property_assignment(exp.AlgorithmProperty),
         "AUTO": lambda self: self._parse_auto_property(),
         "AUTO_INCREMENT": lambda self: self._parse_property_assignment(exp.AutoIncrementProperty),
         "BACKUP": lambda self: self.expression(
-            exp.BackupProperty, this=self._parse_var(any_token=True)
+            exp.BackupProperty(this=self._parse_var(any_token=True))
         ),
         "BLOCKCOMPRESSION": lambda self: self._parse_blockcompression(),
         "CHARSET": lambda self, **kwargs: self._parse_character_set(**kwargs),
@@ -1124,34 +1126,34 @@ class Parser:
         "DATA_DELETION": lambda self: self._parse_data_deletion_property(),
         "DEFINER": lambda self: self._parse_definer(),
         "DETERMINISTIC": lambda self: self.expression(
-            exp.StabilityProperty, this=exp.Literal.string("IMMUTABLE")
+            exp.StabilityProperty(this=exp.Literal.string("IMMUTABLE"))
         ),
         "DISTRIBUTED": lambda self: self._parse_distributed_property(),
         "DUPLICATE": lambda self: self._parse_composite_key_property(exp.DuplicateKeyProperty),
-        "DYNAMIC": lambda self: self.expression(exp.DynamicProperty),
+        "DYNAMIC": lambda self: self.expression(exp.DynamicProperty()),
         "DISTKEY": lambda self: self._parse_distkey(),
         "DISTSTYLE": lambda self: self._parse_property_assignment(exp.DistStyleProperty),
-        "EMPTY": lambda self: self.expression(exp.EmptyProperty),
+        "EMPTY": lambda self: self.expression(exp.EmptyProperty()),
         "ENGINE": lambda self: self._parse_property_assignment(exp.EngineProperty),
         "ENVIRONMENT": lambda self: self.expression(
-            exp.EnviromentProperty, expressions=self._parse_wrapped_csv(self._parse_assignment)
+            exp.EnviromentProperty(expressions=self._parse_wrapped_csv(self._parse_assignment))
         ),
         "HANDLER": lambda self: self._parse_property_assignment(exp.HandlerProperty),
         "EXECUTE": lambda self: self._parse_property_assignment(exp.ExecuteAsProperty),
-        "EXTERNAL": lambda self: self.expression(exp.ExternalProperty),
+        "EXTERNAL": lambda self: self.expression(exp.ExternalProperty()),
         "FALLBACK": lambda self, **kwargs: self._parse_fallback(**kwargs),
         "FORMAT": lambda self: self._parse_property_assignment(exp.FileFormatProperty),
         "FREESPACE": lambda self: self._parse_freespace(),
-        "GLOBAL": lambda self: self.expression(exp.GlobalProperty),
-        "HEAP": lambda self: self.expression(exp.HeapProperty),
-        "ICEBERG": lambda self: self.expression(exp.IcebergProperty),
+        "GLOBAL": lambda self: self.expression(exp.GlobalProperty()),
+        "HEAP": lambda self: self.expression(exp.HeapProperty()),
+        "ICEBERG": lambda self: self.expression(exp.IcebergProperty()),
         "IMMUTABLE": lambda self: self.expression(
-            exp.StabilityProperty, this=exp.Literal.string("IMMUTABLE")
+            exp.StabilityProperty(this=exp.Literal.string("IMMUTABLE"))
         ),
         "INHERITS": lambda self: self.expression(
-            exp.InheritsProperty, expressions=self._parse_wrapped_csv(self._parse_table)
+            exp.InheritsProperty(expressions=self._parse_wrapped_csv(self._parse_table))
         ),
-        "INPUT": lambda self: self.expression(exp.InputModelProperty, this=self._parse_schema()),
+        "INPUT": lambda self: self.expression(exp.InputModelProperty(this=self._parse_schema())),
         "JOURNAL": lambda self, **kwargs: self._parse_journal(**kwargs),
         "LANGUAGE": lambda self: self._parse_property_assignment(exp.LanguageProperty),
         "LAYOUT": lambda self: self._parse_dict_property(this="LAYOUT"),
@@ -1161,14 +1163,14 @@ class Parser:
         "LOCK": lambda self: self._parse_locking(),
         "LOCKING": lambda self: self._parse_locking(),
         "LOG": lambda self, **kwargs: self._parse_log(**kwargs),
-        "MATERIALIZED": lambda self: self.expression(exp.MaterializedProperty),
+        "MATERIALIZED": lambda self: self.expression(exp.MaterializedProperty()),
         "MERGEBLOCKRATIO": lambda self, **kwargs: self._parse_mergeblockratio(**kwargs),
         "MODIFIES": lambda self: self._parse_modifies_property(),
-        "MULTISET": lambda self: self.expression(exp.SetProperty, multi=True),
+        "MULTISET": lambda self: self.expression(exp.SetProperty(multi=True)),
         "NO": lambda self: self._parse_no_property(),
         "ON": lambda self: self._parse_on_property(),
         "ORDER BY": lambda self: self._parse_order(skip_order_token=True),
-        "OUTPUT": lambda self: self.expression(exp.OutputModelProperty, this=self._parse_schema()),
+        "OUTPUT": lambda self: self.expression(exp.OutputModelProperty(this=self._parse_schema())),
         "PARTITION": lambda self: self._parse_partitioned_of(),
         "PARTITION BY": lambda self: self._parse_partitioned_by(),
         "PARTITIONED BY": lambda self: self._parse_partitioned_by(),
@@ -1178,37 +1180,37 @@ class Parser:
         "READS": lambda self: self._parse_reads_property(),
         "REMOTE": lambda self: self._parse_remote_with_connection(),
         "RETURNS": lambda self: self._parse_returns(),
-        "STRICT": lambda self: self.expression(exp.StrictProperty),
-        "STREAMING": lambda self: self.expression(exp.StreamingTableProperty),
+        "STRICT": lambda self: self.expression(exp.StrictProperty()),
+        "STREAMING": lambda self: self.expression(exp.StreamingTableProperty()),
         "ROW": lambda self: self._parse_row(),
         "ROW_FORMAT": lambda self: self._parse_property_assignment(exp.RowFormatProperty),
         "SAMPLE": lambda self: self.expression(
-            exp.SampleProperty, this=self._match_text_seq("BY") and self._parse_bitwise()
+            exp.SampleProperty(this=self._match_text_seq("BY") and self._parse_bitwise())
         ),
-        "SECURE": lambda self: self.expression(exp.SecureProperty),
+        "SECURE": lambda self: self.expression(exp.SecureProperty()),
         "SECURITY": lambda self: self._parse_sql_security(),
         "SQL SECURITY": lambda self: self._parse_sql_security(),
-        "SET": lambda self: self.expression(exp.SetProperty, multi=False),
+        "SET": lambda self: self.expression(exp.SetProperty(multi=False)),
         "SETTINGS": lambda self: self._parse_settings_property(),
         "SHARING": lambda self: self._parse_property_assignment(exp.SharingProperty),
         "SORTKEY": lambda self: self._parse_sortkey(),
         "SOURCE": lambda self: self._parse_dict_property(this="SOURCE"),
         "STABLE": lambda self: self.expression(
-            exp.StabilityProperty, this=exp.Literal.string("STABLE")
+            exp.StabilityProperty(this=exp.Literal.string("STABLE"))
         ),
         "STORED": lambda self: self._parse_stored(),
         "SYSTEM_VERSIONING": lambda self: self._parse_system_versioning_property(),
         "TBLPROPERTIES": lambda self: self._parse_wrapped_properties(),
-        "TEMP": lambda self: self.expression(exp.TemporaryProperty),
-        "TEMPORARY": lambda self: self.expression(exp.TemporaryProperty),
+        "TEMP": lambda self: self.expression(exp.TemporaryProperty()),
+        "TEMPORARY": lambda self: self.expression(exp.TemporaryProperty()),
         "TO": lambda self: self._parse_to_table(),
-        "TRANSIENT": lambda self: self.expression(exp.TransientProperty),
+        "TRANSIENT": lambda self: self.expression(exp.TransientProperty()),
         "TRANSFORM": lambda self: self.expression(
-            exp.TransformModelProperty, expressions=self._parse_wrapped_csv(self._parse_expression)
+            exp.TransformModelProperty(expressions=self._parse_wrapped_csv(self._parse_expression))
         ),
         "TTL": lambda self: self._parse_ttl(),
         "USING": lambda self: self._parse_property_assignment(exp.FileFormatProperty),
-        "UNLOGGED": lambda self: self.expression(exp.UnloggedProperty),
+        "UNLOGGED": lambda self: self.expression(exp.UnloggedProperty()),
         "VOLATILE": lambda self: self._parse_volatile_property(),
         "WITH": lambda self: self._parse_with_property(),
     }
@@ -1216,62 +1218,61 @@ class Parser:
     CONSTRAINT_PARSERS: t.ClassVar = {
         "AUTOINCREMENT": lambda self: self._parse_auto_increment(),
         "AUTO_INCREMENT": lambda self: self._parse_auto_increment(),
-        "CASESPECIFIC": lambda self: self.expression(exp.CaseSpecificColumnConstraint, not_=False),
+        "CASESPECIFIC": lambda self: self.expression(exp.CaseSpecificColumnConstraint(not_=False)),
         "CHARACTER SET": lambda self: self.expression(
-            exp.CharacterSetColumnConstraint, this=self._parse_var_or_string()
+            exp.CharacterSetColumnConstraint(this=self._parse_var_or_string())
         ),
         "CHECK": lambda self: self._parse_check_constraint(),
         "COLLATE": lambda self: self.expression(
-            exp.CollateColumnConstraint,
-            this=self._parse_identifier() or self._parse_column(),
+            exp.CollateColumnConstraint(this=self._parse_identifier() or self._parse_column())
         ),
         "COMMENT": lambda self: self.expression(
-            exp.CommentColumnConstraint, this=self._parse_string()
+            exp.CommentColumnConstraint(this=self._parse_string())
         ),
         "COMPRESS": lambda self: self._parse_compress(),
         "CLUSTERED": lambda self: self.expression(
-            exp.ClusteredColumnConstraint, this=self._parse_wrapped_csv(self._parse_ordered)
+            exp.ClusteredColumnConstraint(this=self._parse_wrapped_csv(self._parse_ordered))
         ),
         "NONCLUSTERED": lambda self: self.expression(
-            exp.NonClusteredColumnConstraint, this=self._parse_wrapped_csv(self._parse_ordered)
+            exp.NonClusteredColumnConstraint(this=self._parse_wrapped_csv(self._parse_ordered))
         ),
         "DEFAULT": lambda self: self.expression(
-            exp.DefaultColumnConstraint, this=self._parse_bitwise()
+            exp.DefaultColumnConstraint(this=self._parse_bitwise())
         ),
-        "ENCODE": lambda self: self.expression(exp.EncodeColumnConstraint, this=self._parse_var()),
+        "ENCODE": lambda self: self.expression(exp.EncodeColumnConstraint(this=self._parse_var())),
         "EPHEMERAL": lambda self: self.expression(
-            exp.EphemeralColumnConstraint, this=self._parse_bitwise()
+            exp.EphemeralColumnConstraint(this=self._parse_bitwise())
         ),
         "EXCLUDE": lambda self: self.expression(
-            exp.ExcludeColumnConstraint, this=self._parse_index_params()
+            exp.ExcludeColumnConstraint(this=self._parse_index_params())
         ),
         "FOREIGN KEY": lambda self: self._parse_foreign_key(),
         "FORMAT": lambda self: self.expression(
-            exp.DateFormatColumnConstraint, this=self._parse_var_or_string()
+            exp.DateFormatColumnConstraint(this=self._parse_var_or_string())
         ),
         "GENERATED": lambda self: self._parse_generated_as_identity(),
         "IDENTITY": lambda self: self._parse_auto_increment(),
         "INLINE": lambda self: self._parse_inline(),
         "LIKE": lambda self: self._parse_create_like(),
         "NOT": lambda self: self._parse_not_constraint(),
-        "NULL": lambda self: self.expression(exp.NotNullColumnConstraint, allow_null=True),
+        "NULL": lambda self: self.expression(exp.NotNullColumnConstraint(allow_null=True)),
         "ON": lambda self: (
             self._match(TokenType.UPDATE)
-            and self.expression(exp.OnUpdateColumnConstraint, this=self._parse_function())
+            and self.expression(exp.OnUpdateColumnConstraint(this=self._parse_function()))
         )
-        or self.expression(exp.OnProperty, this=self._parse_id_var()),
-        "PATH": lambda self: self.expression(exp.PathColumnConstraint, this=self._parse_string()),
+        or self.expression(exp.OnProperty(this=self._parse_id_var())),
+        "PATH": lambda self: self.expression(exp.PathColumnConstraint(this=self._parse_string())),
         "PERIOD": lambda self: self._parse_period_for_system_time(),
         "PRIMARY KEY": lambda self: self._parse_primary_key(),
         "REFERENCES": lambda self: self._parse_references(match=False),
         "TITLE": lambda self: self.expression(
-            exp.TitleColumnConstraint, this=self._parse_var_or_string()
+            exp.TitleColumnConstraint(this=self._parse_var_or_string())
         ),
-        "TTL": lambda self: self.expression(exp.MergeTreeTTL, expressions=[self._parse_bitwise()]),
+        "TTL": lambda self: self.expression(exp.MergeTreeTTL(expressions=[self._parse_bitwise()])),
         "UNIQUE": lambda self: self._parse_unique(),
-        "UPPERCASE": lambda self: self.expression(exp.UppercaseColumnConstraint),
+        "UPPERCASE": lambda self: self.expression(exp.UppercaseColumnConstraint()),
         "WITH": lambda self: self.expression(
-            exp.Properties, expressions=self._parse_wrapped_properties()
+            exp.Properties(expressions=self._parse_wrapped_properties())
         ),
         "BUCKET": lambda self: self._parse_partitioned_by_bucket_or_truncate(),
         "TRUNCATE": lambda self: self._parse_partitioned_by_bucket_or_truncate(),
@@ -1304,19 +1305,19 @@ class Parser:
             # Trino ref: https://docs.aws.amazon.com/athena/latest/ug/create-table-as.html#ctas-table-properties
             this, expression = expression, this
 
-        return self.expression(klass, this=this, expression=expression)
+        return self.expression(klass(this=this, expression=expression))
 
     ALTER_PARSERS: t.ClassVar = {
         "ADD": lambda self: self._parse_alter_table_add(),
         "AS": lambda self: self._parse_select(),
         "ALTER": lambda self: self._parse_alter_table_alter(),
         "CLUSTER BY": lambda self: self._parse_cluster(wrapped=True),
-        "DELETE": lambda self: self.expression(exp.Delete, where=self._parse_where()),
+        "DELETE": lambda self: self.expression(exp.Delete(where=self._parse_where())),
         "DROP": lambda self: self._parse_alter_table_drop(),
         "RENAME": lambda self: self._parse_alter_table_rename(),
         "SET": lambda self: self._parse_alter_table_set(),
         "SWAP": lambda self: self.expression(
-            exp.SwapTable, this=self._match(TokenType.WITH) and self._parse_table(schema=True)
+            exp.SwapTable(this=self._match(TokenType.WITH) and self._parse_table(schema=True))
         ),
     }
 
@@ -1340,10 +1341,10 @@ class Parser:
     }
 
     NO_PAREN_FUNCTION_PARSERS: t.ClassVar = {
-        "ANY": lambda self: self.expression(exp.Any, this=self._parse_bitwise()),
+        "ANY": lambda self: self.expression(exp.Any(this=self._parse_bitwise())),
         "CASE": lambda self: self._parse_case(),
         "CONNECT_BY_ROOT": lambda self: self.expression(
-            exp.ConnectByRoot, this=self._parse_column()
+            exp.ConnectByRoot(this=self._parse_column())
         ),
         "IF": lambda self: self._parse_if(),
     }
@@ -1432,7 +1433,7 @@ class Parser:
     SHOW_PARSERS: t.ClassVar[t.Dict[str, t.Callable]] = {}
 
     TYPE_LITERAL_PARSERS: t.ClassVar = {
-        exp.DType.JSON: lambda self, this, _: self.expression(exp.ParseJSON, this=this),
+        exp.DType.JSON: lambda self, this, _: self.expression(exp.ParseJSON(this=this)),
     }
 
     TYPE_CONVERTERS: t.ClassVar[t.Dict[exp.DType, t.Callable[[exp.DataType], exp.DataType]]] = {}
@@ -1882,16 +1883,12 @@ class Parser:
 
     def expression(
         self,
-        exp_class: t.Type[E],
+        instance: E,
         token: t.Optional[Token] = None,
         comments: t.Optional[t.List[str]] = None,
-        **kwargs,
     ) -> E:
         if token:
-            instance = exp_class(this=token.text, **kwargs)
             instance.update_positions(token)
-        else:
-            instance = exp_class(**kwargs)
         instance.add_comments(comments) if comments else self._add_comments(instance)
         return self.validate_expression(instance)
 
@@ -1967,11 +1964,10 @@ class Parser:
 
     def _parse_command(self) -> exp.Command:
         self._warn_unsupported()
+        comments = self._prev_comments
         return self.expression(
-            exp.Command,
-            comments=self._prev_comments,
-            this=self._prev.text.upper(),
-            expression=self._parse_string(),
+            exp.Command(this=self._prev.text.upper(), expression=self._parse_string()),
+            comments=comments,
         )
 
     def _parse_comment(self, allow_exists: bool = True) -> exp.Expr:
@@ -1997,19 +1993,20 @@ class Parser:
         self._match(TokenType.IS)
 
         return self.expression(
-            exp.Comment,
-            this=this,
-            kind=kind.text,
-            expression=self._parse_string(),
-            exists=exists,
-            materialized=materialized,
+            exp.Comment(
+                this=this,
+                kind=kind.text,
+                expression=self._parse_string(),
+                exists=exists,
+                materialized=materialized,
+            )
         )
 
     def _parse_to_table(
         self,
     ) -> exp.ToTableProperty:
         table = self._parse_table_parts(schema=True)
-        return self.expression(exp.ToTableProperty, this=table)
+        return self.expression(exp.ToTableProperty(this=table))
 
     # https://clickhouse.com/docs/en/engines/table-engines/mergetree-family/mergetree#mergetree-table-ttl
     def _parse_ttl(self) -> exp.Expr:
@@ -2017,18 +2014,18 @@ class Parser:
             this = self._parse_bitwise()
 
             if self._match_text_seq("DELETE"):
-                return self.expression(exp.MergeTreeTTLAction, this=this, delete=True)
+                return self.expression(exp.MergeTreeTTLAction(this=this, delete=True))
             if self._match_text_seq("RECOMPRESS"):
                 return self.expression(
-                    exp.MergeTreeTTLAction, this=this, recompress=self._parse_bitwise()
+                    exp.MergeTreeTTLAction(this=this, recompress=self._parse_bitwise())
                 )
             if self._match_text_seq("TO", "DISK"):
                 return self.expression(
-                    exp.MergeTreeTTLAction, this=this, to_disk=self._parse_string()
+                    exp.MergeTreeTTLAction(this=this, to_disk=self._parse_string())
                 )
             if self._match_text_seq("TO", "VOLUME"):
                 return self.expression(
-                    exp.MergeTreeTTLAction, this=this, to_volume=self._parse_string()
+                    exp.MergeTreeTTLAction(this=this, to_volume=self._parse_string())
                 )
 
             return this
@@ -2042,11 +2039,9 @@ class Parser:
             aggregates = self._parse_csv(self._parse_set_item)
 
         return self.expression(
-            exp.MergeTreeTTL,
-            expressions=expressions,
-            where=where,
-            group=group,
-            aggregates=aggregates,
+            exp.MergeTreeTTL(
+                expressions=expressions, where=where, group=group, aggregates=aggregates
+            )
         )
 
     def _parse_condition(self) -> t.Any:
@@ -2054,17 +2049,16 @@ class Parser:
 
     def _parse_block(self) -> exp.Block:
         return self.expression(
-            exp.Block,
-            expressions=self._parse_batch_statements(
-                parse_method=lambda self: self._parse_statement()
-            ),
+            exp.Block(
+                expressions=self._parse_batch_statements(
+                    parse_method=lambda self: self._parse_statement()
+                )
+            )
         )
 
     def _parse_whileblock(self) -> exp.WhileBlock:
         return self.expression(
-            exp.WhileBlock,
-            this=self._parse_condition(),
-            body=self._parse_block(),
+            exp.WhileBlock(this=self._parse_condition(), body=self._parse_block())
         )
 
     def _parse_statement(self) -> t.Optional[exp.Expr]:
@@ -2114,19 +2108,20 @@ class Parser:
             expressions = None
 
         return self.expression(
-            exp.Drop,
-            exists=if_exists,
-            this=this,
-            expressions=expressions,
-            kind=self.dialect.CREATABLE_KIND_MAPPING.get(kind) or kind,
-            temporary=temporary,
-            materialized=materialized,
-            cascade=self._match_text_seq("CASCADE"),
-            constraints=self._match_text_seq("CONSTRAINTS"),
-            purge=self._match_text_seq("PURGE"),
-            cluster=cluster,
-            concurrently=concurrently,
-            sync=self._match_text_seq("SYNC"),
+            exp.Drop(
+                exists=if_exists,
+                this=this,
+                expressions=expressions,
+                kind=self.dialect.CREATABLE_KIND_MAPPING.get(kind) or kind,
+                temporary=temporary,
+                materialized=materialized,
+                cascade=self._match_text_seq("CASCADE"),
+                constraints=self._match_text_seq("CONSTRAINTS"),
+                purge=self._match_text_seq("PURGE"),
+                cluster=cluster,
+                concurrently=concurrently,
+                sync=self._match_text_seq("SYNC"),
+            )
         )
 
     def _parse_exists(self, not_: bool = False) -> t.Optional[bool]:
@@ -2219,7 +2214,7 @@ class Parser:
                         )
 
                     if return_:
-                        expression = self.expression(exp.Return, this=expression)
+                        expression = self.expression(exp.Return(this=expression))
         elif create_token_type == TokenType.INDEX:
             # Postgres allows anonymous indexes, eg. CREATE INDEX IF NOT EXISTS ON t(c)
             if not self._match(TokenType.ON):
@@ -2263,18 +2258,19 @@ class Parser:
                 return self._parse_as_command(start)
 
             trigger_props = self.expression(
-                exp.TriggerProperties,
-                table=table,
-                timing=timing,
-                events=events,
-                execute=execute,
-                constraint=is_constraint,
-                referenced_table=referenced_table,
-                deferrable=deferrable,
-                initially=initially,
-                referencing=referencing,
-                for_each=for_each,
-                when=when,
+                exp.TriggerProperties(
+                    table=table,
+                    timing=timing,
+                    events=events,
+                    execute=execute,
+                    constraint=is_constraint,
+                    referenced_table=referenced_table,
+                    deferrable=deferrable,
+                    initially=initially,
+                    referencing=referencing,
+                    for_each=for_each,
+                    when=when,
+                )
             )
 
             this = trigger_name
@@ -2352,7 +2348,7 @@ class Parser:
             if self._match_texts(self.CLONE_KEYWORDS):
                 copy = self._prev.text.lower() == "copy"
                 clone = self.expression(
-                    exp.Clone, this=self._parse_table(schema=True), shallow=shallow, copy=copy
+                    exp.Clone(this=self._parse_table(schema=True), shallow=shallow, copy=copy)
                 )
 
         if self._curr and not self._match_set((TokenType.R_PAREN, TokenType.COMMA), advance=False):
@@ -2360,21 +2356,22 @@ class Parser:
 
         create_kind_text = create_token.text.upper()
         return self.expression(
-            exp.Create,
-            this=this,
-            kind=self.dialect.CREATABLE_KIND_MAPPING.get(create_kind_text) or create_kind_text,
-            replace=replace,
-            refresh=refresh,
-            unique=unique,
-            expression=expression,
-            exists=exists,
-            properties=properties,
-            indexes=indexes,
-            no_schema_binding=no_schema_binding,
-            begin=begin,
-            clone=clone,
-            concurrently=concurrently,
-            clustered=clustered,
+            exp.Create(
+                this=this,
+                kind=self.dialect.CREATABLE_KIND_MAPPING.get(create_kind_text) or create_kind_text,
+                replace=replace,
+                refresh=refresh,
+                unique=unique,
+                expression=expression,
+                exists=exists,
+                properties=properties,
+                indexes=indexes,
+                no_schema_binding=no_schema_binding,
+                begin=begin,
+                clone=clone,
+                concurrently=concurrently,
+                clustered=clustered,
+            )
         )
 
     def _parse_sequence_properties(self) -> t.Optional[exp.SequenceProperties]:
@@ -2427,7 +2424,7 @@ class Parser:
                 else None
             )
 
-            events.append(self.expression(exp.TriggerEvent, this=event_type, columns=columns))
+            events.append(self.expression(exp.TriggerEvent(this=event_type, columns=columns)))
 
             if not self._match(TokenType.OR):
                 break
@@ -2480,11 +2477,7 @@ class Parser:
         if old_alias is None and new_alias is None:
             self.raise_error("REFERENCING clause requires at least OLD TABLE or NEW TABLE")
 
-        return self.expression(
-            exp.TriggerReferencing,
-            old=old_alias,
-            new=new_alias,
-        )
+        return self.expression(exp.TriggerReferencing(old=old_alias, new=new_alias))
 
     def _parse_trigger_for_each(self) -> t.Optional[str]:
         if not self._match_text_seq("FOR", "EACH"):
@@ -2500,7 +2493,7 @@ class Parser:
             self.raise_error("Expected FUNCTION or PROCEDURE after EXECUTE")
 
         func_call = self._parse_function(anonymous=True, optional_parens=False)
-        return self.expression(exp.TriggerExecute, this=func_call)
+        return self.expression(exp.TriggerExecute(this=func_call))
 
     def _parse_property_before(self) -> exp.Expr | t.List[exp.Expr] | None:
         # only used for teradata currently
@@ -2541,7 +2534,7 @@ class Parser:
             return self._parse_sortkey(compound=True)
 
         if self._match_text_seq("PARAMETER", "STYLE", "PANDAS"):
-            return self.expression(exp.ParameterStyleProperty, this="PANDAS")
+            return self.expression(exp.ParameterStyleProperty(this="PANDAS"))
 
         index = self._index
 
@@ -2566,28 +2559,29 @@ class Parser:
         if isinstance(value, exp.Column):
             value = exp.var(value.name)
 
-        return self.expression(exp.Property, this=key, value=value)
+        return self.expression(exp.Property(this=key, value=value))
 
     def _parse_stored(self) -> t.Union[exp.FileFormatProperty, exp.StorageHandlerProperty]:
         if self._match_text_seq("BY"):
-            return self.expression(exp.StorageHandlerProperty, this=self._parse_var_or_string())
+            return self.expression(exp.StorageHandlerProperty(this=self._parse_var_or_string()))
 
         self._match(TokenType.ALIAS)
         input_format = self._parse_string() if self._match_text_seq("INPUTFORMAT") else None
         output_format = self._parse_string() if self._match_text_seq("OUTPUTFORMAT") else None
 
         return self.expression(
-            exp.FileFormatProperty,
-            this=(
-                self.expression(
-                    exp.InputOutputFormat,
-                    input_format=input_format,
-                    output_format=output_format,
-                )
-                if input_format or output_format
-                else self._parse_var_or_string() or self._parse_number() or self._parse_id_var()
-            ),
-            hive_format=True,
+            exp.FileFormatProperty(
+                this=(
+                    self.expression(
+                        exp.InputOutputFormat(
+                            input_format=input_format, output_format=output_format
+                        )
+                    )
+                    if input_format or output_format
+                    else self._parse_var_or_string() or self._parse_number() or self._parse_id_var()
+                ),
+                hive_format=True,
+            )
         )
 
     def _parse_unquoted_field(self) -> t.Optional[exp.Expr]:
@@ -2601,7 +2595,7 @@ class Parser:
         self._match(TokenType.EQ)
         self._match(TokenType.ALIAS)
 
-        return self.expression(exp_class, this=self._parse_unquoted_field(), **kwargs)
+        return self.expression(exp_class(this=self._parse_unquoted_field(), **kwargs))
 
     def _parse_properties(self, before: t.Optional[bool] = None) -> t.Optional[exp.Properties]:
         properties = []
@@ -2616,24 +2610,25 @@ class Parser:
                 properties.append(p)
 
         if properties:
-            return self.expression(exp.Properties, expressions=properties)
+            return self.expression(exp.Properties(expressions=properties))
 
         return None
 
     def _parse_fallback(self, no: bool = False) -> exp.FallbackProperty:
         return self.expression(
-            exp.FallbackProperty, no=no, protection=self._match_text_seq("PROTECTION")
+            exp.FallbackProperty(no=no, protection=self._match_text_seq("PROTECTION"))
         )
 
     def _parse_sql_security(self) -> exp.SqlSecurityProperty:
         return self.expression(
-            exp.SqlSecurityProperty,
-            this=self._match_texts(self.SECURITY_PROPERTY_KEYWORDS) and self._prev.text.upper(),
+            exp.SqlSecurityProperty(
+                this=self._match_texts(self.SECURITY_PROPERTY_KEYWORDS) and self._prev.text.upper()
+            )
         )
 
     def _parse_settings_property(self) -> exp.SettingsProperty:
         return self.expression(
-            exp.SettingsProperty, expressions=self._parse_csv(self._parse_assignment)
+            exp.SettingsProperty(expressions=self._parse_csv(self._parse_assignment))
         )
 
     def _parse_volatile_property(self) -> exp.VolatileProperty | exp.StabilityProperty:
@@ -2645,7 +2640,7 @@ class Parser:
         if pre_volatile_token and pre_volatile_token.token_type in self.PRE_VOLATILE_TOKENS:
             return exp.VolatileProperty()
 
-        return self.expression(exp.StabilityProperty, this=exp.Literal.string("VOLATILE"))
+        return self.expression(exp.StabilityProperty(this=exp.Literal.string("VOLATILE")))
 
     def _parse_retention_period(self) -> exp.Var:
         # Parse TSQL's HISTORY_RETENTION_PERIOD: {INFINITE | <number> DAY | DAYS | MONTH ...}
@@ -2658,11 +2653,7 @@ class Parser:
         self, with_: bool = False
     ) -> exp.WithSystemVersioningProperty:
         self._match(TokenType.EQ)
-        prop = self.expression(
-            exp.WithSystemVersioningProperty,
-            on=True,
-            with_=with_,
-        )
+        prop = self.expression(exp.WithSystemVersioningProperty(on=True, with_=with_))
 
         if self._match_text_seq("OFF"):
             prop.set("on", False)
@@ -2685,7 +2676,7 @@ class Parser:
     def _parse_data_deletion_property(self) -> exp.DataDeletionProperty:
         self._match(TokenType.EQ)
         on = self._match_text_seq("ON") or not self._match_text_seq("OFF")
-        prop = self.expression(exp.DataDeletionProperty, on=on)
+        prop = self.expression(exp.DataDeletionProperty(on=on))
 
         if self._match(TokenType.L_PAREN):
             while self._curr and not self._match(TokenType.R_PAREN):
@@ -2712,17 +2703,15 @@ class Parser:
             buckets = self._parse_number()
 
         return self.expression(
-            exp.DistributedByProperty,
-            expressions=expressions,
-            kind=kind,
-            buckets=buckets,
-            order=self._parse_order(),
+            exp.DistributedByProperty(
+                expressions=expressions, kind=kind, buckets=buckets, order=self._parse_order()
+            )
         )
 
     def _parse_composite_key_property(self, expr_type: t.Type[E]) -> E:
         self._match_text_seq("KEY")
         expressions = self._parse_wrapped_id_vars()
-        return self.expression(expr_type, expressions=expressions)
+        return self.expression(expr_type(expressions=expressions))
 
     def _parse_with_property(self) -> t.Optional[exp.Expr] | t.List[exp.Expr]:
         if self._match_text_seq("(", "SYSTEM_VERSIONING"):
@@ -2737,7 +2726,7 @@ class Parser:
             return self._parse_withjournaltable()
 
         if self._match_texts(self.VIEW_ATTRIBUTES):
-            return self.expression(exp.ViewAttributeProperty, this=self._prev.text.upper())
+            return self.expression(exp.ViewAttributeProperty(this=self._prev.text.upper()))
 
         if self._match_text_seq("DATA"):
             return self._parse_withdata(no=False)
@@ -2749,13 +2738,14 @@ class Parser:
 
         if self._match(TokenType.SCHEMA):
             return self.expression(
-                exp.WithSchemaBindingProperty,
-                this=self._parse_var_from_options(self.SCHEMA_BINDING_OPTIONS),
+                exp.WithSchemaBindingProperty(
+                    this=self._parse_var_from_options(self.SCHEMA_BINDING_OPTIONS)
+                )
             )
 
         if self._match_texts(self.PROCEDURE_OPTIONS, advance=False):
             return self.expression(
-                exp.WithProcedureOptions, expressions=self._parse_csv(self._parse_procedure_option)
+                exp.WithProcedureOptions(expressions=self._parse_csv(self._parse_procedure_option))
             )
 
         if not self._next:
@@ -2766,9 +2756,12 @@ class Parser:
     def _parse_procedure_option(self) -> exp.Expr | None:
         if self._match_text_seq("EXECUTE", "AS"):
             return self.expression(
-                exp.ExecuteAsProperty,
-                this=self._parse_var_from_options(self.EXECUTE_AS_OPTIONS, raise_unmatched=False)
-                or self._parse_string(),
+                exp.ExecuteAsProperty(
+                    this=self._parse_var_from_options(
+                        self.EXECUTE_AS_OPTIONS, raise_unmatched=False
+                    )
+                    or self._parse_string()
+                )
             )
 
         return self._parse_var_from_options(self.PROCEDURE_OPTIONS)
@@ -2789,13 +2782,13 @@ class Parser:
     def _parse_withjournaltable(self) -> exp.WithJournalTableProperty:
         self._match(TokenType.TABLE)
         self._match(TokenType.EQ)
-        return self.expression(exp.WithJournalTableProperty, this=self._parse_table_parts())
+        return self.expression(exp.WithJournalTableProperty(this=self._parse_table_parts()))
 
     def _parse_log(self, no: bool = False) -> exp.LogProperty:
-        return self.expression(exp.LogProperty, no=no)
+        return self.expression(exp.LogProperty(no=no))
 
     def _parse_journal(self, **kwargs) -> exp.JournalProperty:
-        return self.expression(exp.JournalProperty, **kwargs)
+        return self.expression(exp.JournalProperty(**kwargs))
 
     def _parse_checksum(self) -> exp.ChecksumProperty:
         self._match(TokenType.EQ)
@@ -2806,16 +2799,17 @@ class Parser:
         elif self._match_text_seq("OFF"):
             on = False
 
-        return self.expression(exp.ChecksumProperty, on=on, default=self._match(TokenType.DEFAULT))
+        return self.expression(exp.ChecksumProperty(on=on, default=self._match(TokenType.DEFAULT)))
 
     def _parse_cluster(self, wrapped: bool = False) -> exp.Cluster:
         return self.expression(
-            exp.Cluster,
-            expressions=(
-                self._parse_wrapped_csv(self._parse_ordered)
-                if wrapped
-                else self._parse_csv(self._parse_ordered)
-            ),
+            exp.Cluster(
+                expressions=(
+                    self._parse_wrapped_csv(self._parse_ordered)
+                    if wrapped
+                    else self._parse_csv(self._parse_ordered)
+                )
+            )
         )
 
     def _parse_clustered_by(self) -> exp.ClusteredByProperty:
@@ -2837,10 +2831,7 @@ class Parser:
         self._match_text_seq("BUCKETS")
 
         return self.expression(
-            exp.ClusteredByProperty,
-            expressions=expressions,
-            sorted_by=sorted_by,
-            buckets=buckets,
+            exp.ClusteredByProperty(expressions=expressions, sorted_by=sorted_by, buckets=buckets)
         )
 
     def _parse_copy_property(self) -> t.Optional[exp.CopyGrantsProperty]:
@@ -2848,12 +2839,12 @@ class Parser:
             self._retreat(self._index - 1)
             return None
 
-        return self.expression(exp.CopyGrantsProperty)
+        return self.expression(exp.CopyGrantsProperty())
 
     def _parse_freespace(self) -> exp.FreespaceProperty:
         self._match(TokenType.EQ)
         return self.expression(
-            exp.FreespaceProperty, this=self._parse_number(), percent=self._match(TokenType.PERCENT)
+            exp.FreespaceProperty(this=self._parse_number(), percent=self._match(TokenType.PERCENT))
         )
 
     def _parse_mergeblockratio(
@@ -2861,12 +2852,12 @@ class Parser:
     ) -> exp.MergeBlockRatioProperty:
         if self._match(TokenType.EQ):
             return self.expression(
-                exp.MergeBlockRatioProperty,
-                this=self._parse_number(),
-                percent=self._match(TokenType.PERCENT),
+                exp.MergeBlockRatioProperty(
+                    this=self._parse_number(), percent=self._match(TokenType.PERCENT)
+                )
             )
 
-        return self.expression(exp.MergeBlockRatioProperty, no=no, default=default)
+        return self.expression(exp.MergeBlockRatioProperty(no=no, default=default))
 
     def _parse_datablocksize(
         self,
@@ -2882,12 +2873,9 @@ class Parser:
             units = self._prev.text
 
         return self.expression(
-            exp.DataBlocksizeProperty,
-            size=size,
-            units=units,
-            default=default,
-            minimum=minimum,
-            maximum=maximum,
+            exp.DataBlocksizeProperty(
+                size=size, units=units, default=default, minimum=minimum, maximum=maximum
+            )
         )
 
     def _parse_blockcompression(self) -> exp.BlockCompressionProperty:
@@ -2902,12 +2890,9 @@ class Parser:
             autotemp = self._parse_schema()
 
         return self.expression(
-            exp.BlockCompressionProperty,
-            always=always,
-            manual=manual,
-            never=never,
-            default=default,
-            autotemp=autotemp,
+            exp.BlockCompressionProperty(
+                always=always, manual=manual, never=never, default=default, autotemp=autotemp
+            )
         )
 
     def _parse_withisolatedloading(self) -> t.Optional[exp.IsolatedLoadingProperty]:
@@ -2921,7 +2906,7 @@ class Parser:
 
         target = self._parse_var_from_options(self.ISOLATED_LOADING_OPTIONS, raise_unmatched=False)
         return self.expression(
-            exp.IsolatedLoadingProperty, no=no, concurrent=concurrent, target=target
+            exp.IsolatedLoadingProperty(no=no, concurrent=concurrent, target=target)
         )
 
     def _parse_locking(self) -> exp.LockingProperty:
@@ -2966,12 +2951,9 @@ class Parser:
         override = self._match_text_seq("OVERRIDE")
 
         return self.expression(
-            exp.LockingProperty,
-            this=this,
-            kind=kind,
-            for_or_in=for_or_in,
-            lock_type=lock_type,
-            override=override,
+            exp.LockingProperty(
+                this=this, kind=kind, for_or_in=for_or_in, lock_type=lock_type, override=override
+            )
         )
 
     def _parse_partition_by(self) -> t.List[exp.Expr]:
@@ -3007,11 +2989,12 @@ class Parser:
             self.raise_error("Failed to parse partition bound spec.")
 
         return self.expression(
-            exp.PartitionBoundSpec,
-            this=this,
-            expression=expression,
-            from_expressions=from_expressions,
-            to_expressions=to_expressions,
+            exp.PartitionBoundSpec(
+                this=this,
+                expression=expression,
+                from_expressions=from_expressions,
+                to_expressions=to_expressions,
+            )
         )
 
     # https://www.postgresql.org/docs/current/sql-createtable.html
@@ -3029,13 +3012,14 @@ class Parser:
         else:
             self.raise_error("Expecting either DEFAULT or FOR VALUES clause.")
 
-        return self.expression(exp.PartitionedOfProperty, this=this, expression=expression)
+        return self.expression(exp.PartitionedOfProperty(this=this, expression=expression))
 
     def _parse_partitioned_by(self) -> exp.PartitionedByProperty:
         self._match(TokenType.EQ)
         return self.expression(
-            exp.PartitionedByProperty,
-            this=self._parse_schema() or self._parse_bracket(self._parse_field()),
+            exp.PartitionedByProperty(
+                this=self._parse_schema() or self._parse_bracket(self._parse_field())
+            )
         )
 
     def _parse_withdata(self, no: bool = False) -> exp.WithDataProperty:
@@ -3046,23 +3030,23 @@ class Parser:
         else:
             statistics = None
 
-        return self.expression(exp.WithDataProperty, no=no, statistics=statistics)
+        return self.expression(exp.WithDataProperty(no=no, statistics=statistics))
 
     def _parse_contains_property(self) -> t.Optional[exp.SqlReadWriteProperty]:
         if self._match_text_seq("SQL"):
-            return self.expression(exp.SqlReadWriteProperty, this="CONTAINS SQL")
+            return self.expression(exp.SqlReadWriteProperty(this="CONTAINS SQL"))
         return None
 
     def _parse_modifies_property(self) -> t.Optional[exp.SqlReadWriteProperty]:
         if self._match_text_seq("SQL", "DATA"):
-            return self.expression(exp.SqlReadWriteProperty, this="MODIFIES SQL DATA")
+            return self.expression(exp.SqlReadWriteProperty(this="MODIFIES SQL DATA"))
         return None
 
     def _parse_no_property(self) -> t.Optional[exp.Expr]:
         if self._match_text_seq("PRIMARY", "INDEX"):
             return exp.NoPrimaryIndexProperty()
         if self._match_text_seq("SQL"):
-            return self.expression(exp.SqlReadWriteProperty, this="NO SQL")
+            return self.expression(exp.SqlReadWriteProperty(this="NO SQL"))
         return None
 
     def _parse_on_property(self) -> t.Optional[exp.Expr]:
@@ -3070,15 +3054,15 @@ class Parser:
             return exp.OnCommitProperty()
         if self._match_text_seq("COMMIT", "DELETE", "ROWS"):
             return exp.OnCommitProperty(delete=True)
-        return self.expression(exp.OnProperty, this=self._parse_schema(self._parse_id_var()))
+        return self.expression(exp.OnProperty(this=self._parse_schema(self._parse_id_var())))
 
     def _parse_reads_property(self) -> t.Optional[exp.SqlReadWriteProperty]:
         if self._match_text_seq("SQL", "DATA"):
-            return self.expression(exp.SqlReadWriteProperty, this="READS SQL DATA")
+            return self.expression(exp.SqlReadWriteProperty(this="READS SQL DATA"))
         return None
 
     def _parse_distkey(self) -> exp.DistKeyProperty:
-        return self.expression(exp.DistKeyProperty, this=self._parse_wrapped(self._parse_id_var))
+        return self.expression(exp.DistKeyProperty(this=self._parse_wrapped(self._parse_id_var)))
 
     def _parse_create_like(self) -> t.Optional[exp.LikeProperty]:
         table = self._parse_table(schema=True)
@@ -3092,26 +3076,26 @@ class Parser:
                 return None
 
             options.append(
-                self.expression(exp.Property, this=this, value=exp.var(id_var.this.upper()))
+                self.expression(exp.Property(this=this, value=exp.var(id_var.this.upper())))
             )
 
-        return self.expression(exp.LikeProperty, this=table, expressions=options)
+        return self.expression(exp.LikeProperty(this=table, expressions=options))
 
     def _parse_sortkey(self, compound: bool = False) -> exp.SortKeyProperty:
         return self.expression(
-            exp.SortKeyProperty, this=self._parse_wrapped_id_vars(), compound=compound
+            exp.SortKeyProperty(this=self._parse_wrapped_id_vars(), compound=compound)
         )
 
     def _parse_character_set(self, default: bool = False) -> exp.CharacterSetProperty:
         self._match(TokenType.EQ)
         return self.expression(
-            exp.CharacterSetProperty, this=self._parse_var_or_string(), default=default
+            exp.CharacterSetProperty(this=self._parse_var_or_string(), default=default)
         )
 
     def _parse_remote_with_connection(self) -> exp.RemoteWithConnectionModelProperty:
         self._match_text_seq("WITH", "CONNECTION")
         return self.expression(
-            exp.RemoteWithConnectionModelProperty, this=self._parse_table_parts()
+            exp.RemoteWithConnectionModelProperty(this=self._parse_table_parts())
         )
 
     def _parse_returns(self) -> exp.ReturnsProperty:
@@ -3122,9 +3106,7 @@ class Parser:
         if is_table:
             if self._match(TokenType.LT):
                 value = self.expression(
-                    exp.Schema,
-                    this="TABLE",
-                    expressions=self._parse_csv(self._parse_struct_types),
+                    exp.Schema(this="TABLE", expressions=self._parse_csv(self._parse_struct_types))
                 )
                 if not self._match(TokenType.GT):
                     self.raise_error("Expecting >")
@@ -3136,7 +3118,7 @@ class Parser:
         else:
             value = self._parse_types()
 
-        return self.expression(exp.ReturnsProperty, this=value, is_table=is_table, null=null)
+        return self.expression(exp.ReturnsProperty(this=value, is_table=is_table, null=null))
 
     def _parse_describe(self) -> exp.Describe:
         kind = self._match_set(self.CREATABLES) and self._prev.text
@@ -3156,14 +3138,15 @@ class Parser:
         expressions = properties.expressions if properties else None
         partition = self._parse_partition()
         return self.expression(
-            exp.Describe,
-            this=this,
-            style=style,
-            kind=kind,
-            expressions=expressions,
-            partition=partition,
-            format=format,
-            as_json=self._match_text_seq("AS", "JSON"),
+            exp.Describe(
+                this=this,
+                style=style,
+                kind=kind,
+                expressions=expressions,
+                partition=partition,
+                format=format,
+                as_json=self._match_text_seq("AS", "JSON"),
+            )
         )
 
     def _parse_multitable_inserts(self, comments: t.Optional[t.List[str]]) -> exp.MultitableInserts:
@@ -3183,14 +3166,16 @@ class Parser:
                 return None
 
             return self.expression(
-                exp.ConditionalInsert,
-                this=self.expression(
-                    exp.Insert,
-                    this=self._parse_table(schema=True),
-                    expression=self._parse_derived_table_values(),
-                ),
-                expression=expression,
-                else_=else_,
+                exp.ConditionalInsert(
+                    this=self.expression(
+                        exp.Insert(
+                            this=self._parse_table(schema=True),
+                            expression=self._parse_derived_table_values(),
+                        )
+                    ),
+                    expression=expression,
+                    else_=else_,
+                )
             )
 
         expression = parse_conditional_insert()
@@ -3199,11 +3184,8 @@ class Parser:
             expression = parse_conditional_insert()
 
         return self.expression(
-            exp.MultitableInserts,
-            kind=kind,
+            exp.MultitableInserts(kind=kind, expressions=expressions, source=self._parse_table()),
             comments=comments,
-            expressions=expressions,
-            source=self._parse_table(),
         )
 
     def _parse_insert(self) -> t.Union[exp.Insert, exp.MultitableInserts]:
@@ -3217,10 +3199,11 @@ class Parser:
 
         if self._match_text_seq("DIRECTORY"):
             this: t.Optional[exp.Expr] = self.expression(
-                exp.Directory,
-                this=self._parse_var_or_string(),
-                local=local,
-                row_format=self._parse_row_format(match_row=True),
+                exp.Directory(
+                    this=self._parse_var_or_string(),
+                    local=local,
+                    row_format=self._parse_row_format(match_row=True),
+                )
             )
         else:
             if self._match_set((TokenType.FIRST, TokenType.ALL)):
@@ -3240,26 +3223,27 @@ class Parser:
         returning = self._parse_returning()  # TSQL allows RETURNING before source
 
         return self.expression(
-            exp.Insert,
+            exp.Insert(
+                hint=hint,
+                is_function=is_function,
+                this=this,
+                stored=self._match_text_seq("STORED") and self._parse_stored(),
+                by_name=self._match_text_seq("BY", "NAME"),
+                exists=self._parse_exists(),
+                where=self._match_pair(TokenType.REPLACE, TokenType.WHERE)
+                and self._parse_disjunction(),
+                partition=self._match(TokenType.PARTITION_BY) and self._parse_partitioned_by(),
+                settings=self._match_text_seq("SETTINGS") and self._parse_settings_property(),
+                default=self._match_text_seq("DEFAULT", "VALUES"),
+                expression=self._parse_derived_table_values() or self._parse_ddl_select(),
+                conflict=self._parse_on_conflict(),
+                returning=returning or self._parse_returning(),
+                overwrite=overwrite,
+                alternative=alternative,
+                ignore=ignore,
+                source=self._match(TokenType.TABLE) and self._parse_table(),
+            ),
             comments=comments,
-            hint=hint,
-            is_function=is_function,
-            this=this,
-            stored=self._match_text_seq("STORED") and self._parse_stored(),
-            by_name=self._match_text_seq("BY", "NAME"),
-            exists=self._parse_exists(),
-            where=self._match_pair(TokenType.REPLACE, TokenType.WHERE)
-            and self._parse_disjunction(),
-            partition=self._match(TokenType.PARTITION_BY) and self._parse_partitioned_by(),
-            settings=self._match_text_seq("SETTINGS") and self._parse_settings_property(),
-            default=self._match_text_seq("DEFAULT", "VALUES"),
-            expression=self._parse_derived_table_values() or self._parse_ddl_select(),
-            conflict=self._parse_on_conflict(),
-            returning=returning or self._parse_returning(),
-            overwrite=overwrite,
-            alternative=alternative,
-            ignore=ignore,
-            source=self._match(TokenType.TABLE) and self._parse_table(),
         )
 
     def _parse_insert_table(self) -> t.Optional[exp.Expr]:
@@ -3271,11 +3255,7 @@ class Parser:
     def _parse_kill(self) -> exp.Kill:
         kind = exp.var(self._prev.text) if self._match_texts(("CONNECTION", "QUERY")) else None
 
-        return self.expression(
-            exp.Kill,
-            this=self._parse_primary(),
-            kind=kind,
-        )
+        return self.expression(exp.Kill(this=self._parse_primary(), kind=kind))
 
     def _parse_on_conflict(self) -> t.Optional[exp.OnConflict]:
         conflict = self._match_text_seq("ON", "CONFLICT")
@@ -3304,23 +3284,25 @@ class Parser:
             expressions = None
 
         return self.expression(
-            exp.OnConflict,
-            duplicate=duplicate,
-            expressions=expressions,
-            action=action,
-            conflict_keys=conflict_keys,
-            index_predicate=index_predicate,
-            constraint=constraint,
-            where=self._parse_where(),
+            exp.OnConflict(
+                duplicate=duplicate,
+                expressions=expressions,
+                action=action,
+                conflict_keys=conflict_keys,
+                index_predicate=index_predicate,
+                constraint=constraint,
+                where=self._parse_where(),
+            )
         )
 
     def _parse_returning(self) -> t.Optional[exp.Returning]:
         if not self._match(TokenType.RETURNING):
             return None
         return self.expression(
-            exp.Returning,
-            expressions=self._parse_csv(self._parse_expression),
-            into=self._match(TokenType.INTO) and self._parse_table_part(),
+            exp.Returning(
+                expressions=self._parse_csv(self._parse_expression),
+                into=self._match(TokenType.INTO) and self._parse_table_part(),
+            )
         )
 
     def _parse_row(self) -> t.Optional[exp.RowFormatSerdeProperty | exp.RowFormatDelimitedProperty]:
@@ -3336,9 +3318,7 @@ class Parser:
             self._retreat(index)
             return None
         return self.expression(
-            exp.SerdeProperties,
-            expressions=self._parse_wrapped_properties(),
-            with_=with_,
+            exp.SerdeProperties(expressions=self._parse_wrapped_properties(), with_=with_)
         )
 
     def _parse_row_format(
@@ -3353,7 +3333,7 @@ class Parser:
             serde_properties = self._parse_serde_properties()
 
             return self.expression(
-                exp.RowFormatSerdeProperty, this=this, serde_properties=serde_properties
+                exp.RowFormatSerdeProperty(this=this, serde_properties=serde_properties)
             )
 
         self._match_text_seq("DELIMITED")
@@ -3373,7 +3353,7 @@ class Parser:
         if self._match_text_seq("NULL", "DEFINED", "AS"):
             kwargs["null"] = self._parse_string()
 
-        return self.expression(exp.RowFormatDelimitedProperty, **kwargs)  # type: ignore
+        return self.expression(exp.RowFormatDelimitedProperty(**kwargs))  # type: ignore
 
     def _parse_load(self) -> exp.LoadData | exp.Command:
         if self._match_text_seq("DATA"):
@@ -3384,14 +3364,15 @@ class Parser:
             self._match_pair(TokenType.INTO, TokenType.TABLE)
 
             return self.expression(
-                exp.LoadData,
-                this=self._parse_table(schema=True),
-                local=local,
-                overwrite=overwrite,
-                inpath=inpath,
-                partition=self._parse_partition(),
-                input_format=self._match_text_seq("INPUTFORMAT") and self._parse_string(),
-                serde=self._match_text_seq("SERDE") and self._parse_string(),
+                exp.LoadData(
+                    this=self._parse_table(schema=True),
+                    local=local,
+                    overwrite=overwrite,
+                    inpath=inpath,
+                    partition=self._parse_partition(),
+                    input_format=self._match_text_seq("INPUTFORMAT") and self._parse_string(),
+                    serde=self._match_text_seq("SERDE") and self._parse_string(),
+                )
             )
         return self._parse_as_command(self._prev)
 
@@ -3405,16 +3386,17 @@ class Parser:
         returning = self._parse_returning()
 
         return self.expression(
-            exp.Delete,
-            tables=tables,
-            this=self._match(TokenType.FROM) and self._parse_table(joins=True),
-            using=self._match(TokenType.USING)
-            and self._parse_csv(lambda: self._parse_table(joins=True)),
-            cluster=self._match(TokenType.ON) and self._parse_on_property(),
-            where=self._parse_where(),
-            returning=returning or self._parse_returning(),
-            order=self._parse_order(),
-            limit=self._parse_limit(),
+            exp.Delete(
+                tables=tables,
+                this=self._match(TokenType.FROM) and self._parse_table(joins=True),
+                using=self._match(TokenType.USING)
+                and self._parse_csv(lambda: self._parse_table(joins=True)),
+                cluster=self._match(TokenType.ON) and self._parse_on_property(),
+                where=self._parse_where(),
+                returning=returning or self._parse_returning(),
+                order=self._parse_order(),
+                limit=self._parse_limit(),
+            )
         )
 
     def _parse_update(self) -> exp.Update:
@@ -3442,13 +3424,14 @@ class Parser:
             else:
                 break
 
-        return self.expression(exp.Update, **kwargs)
+        return self.expression(exp.Update(**kwargs))
 
     def _parse_use(self) -> exp.Use:
         return self.expression(
-            exp.Use,
-            kind=self._parse_var_from_options(self.USABLES, raise_unmatched=False),
-            this=self._parse_table(schema=False),
+            exp.Use(
+                kind=self._parse_var_from_options(self.USABLES, raise_unmatched=False),
+                this=self._parse_table(schema=False),
+            )
         )
 
     def _parse_uncache(self) -> exp.Uncache:
@@ -3456,7 +3439,7 @@ class Parser:
             self.raise_error("Expecting TABLE after UNCACHE")
 
         return self.expression(
-            exp.Uncache, exists=self._parse_exists(), this=self._parse_table(schema=True)
+            exp.Uncache(exists=self._parse_exists(), this=self._parse_table(schema=True))
         )
 
     def _parse_cache(self) -> exp.Cache:
@@ -3475,11 +3458,9 @@ class Parser:
 
         self._match(TokenType.ALIAS)
         return self.expression(
-            exp.Cache,
-            this=table,
-            lazy=lazy,
-            options=options,
-            expression=self._parse_select(nested=True),
+            exp.Cache(
+                this=table, lazy=lazy, options=options, expression=self._parse_select(nested=True)
+            )
         )
 
     def _parse_partition(self) -> t.Optional[exp.Partition]:
@@ -3487,9 +3468,10 @@ class Parser:
             return None
 
         return self.expression(
-            exp.Partition,
-            subpartition=self._prev.text.upper() == "SUBPARTITION",
-            expressions=self._parse_wrapped_csv(self._parse_disjunction),
+            exp.Partition(
+                subpartition=self._prev.text.upper() == "SUBPARTITION",
+                expressions=self._parse_wrapped_csv(self._parse_disjunction),
+            )
         )
 
     def _parse_value(self, values: bool = True) -> t.Optional[exp.Tuple]:
@@ -3501,12 +3483,12 @@ class Parser:
         if self._match(TokenType.L_PAREN):
             expressions = self._parse_csv(_parse_value_expression)
             self._match_r_paren()
-            return self.expression(exp.Tuple, expressions=expressions)
+            return self.expression(exp.Tuple(expressions=expressions))
 
         # In some dialects we can have VALUES 1, 2 which results in 1 column & 2 rows.
         expression = self._parse_expression()
         if expression:
-            return self.expression(exp.Tuple, expressions=[expression])
+            return self.expression(exp.Tuple(expressions=[expression]))
         return None
 
     def _parse_projections(
@@ -3626,8 +3608,9 @@ class Parser:
 
             distinct: t.Optional[exp.Expr] = (
                 self.expression(
-                    exp.Distinct,
-                    on=self._parse_value(values=False) if self._match(TokenType.ON) else None,
+                    exp.Distinct(
+                        on=self._parse_value(values=False) if self._match(TokenType.ON) else None
+                    )
                 )
                 if matched_distinct
                 else None
@@ -3644,14 +3627,15 @@ class Parser:
             projections, exclude = self._parse_projections()
 
             this = self.expression(
-                exp.Select,
-                kind=kind,
-                hint=hint,
-                distinct=distinct,
-                expressions=projections,
-                limit=limit,
-                exclude=exclude,
-                operation_modifiers=operation_modifiers or None,
+                exp.Select(
+                    kind=kind,
+                    hint=hint,
+                    distinct=distinct,
+                    expressions=projections,
+                    limit=limit,
+                    exclude=exclude,
+                    operation_modifiers=operation_modifiers or None,
+                )
             )
             this.comments = comments
 
@@ -3684,7 +3668,7 @@ class Parser:
         elif self._match(TokenType.SUMMARIZE):
             table = self._match(TokenType.TABLE)
             this = self._parse_select() or self._parse_string() or self._parse_table()
-            return self.expression(exp.Summarize, this=this, table=table)
+            return self.expression(exp.Summarize(this=this, table=table))
         elif self._match(TokenType.DESCRIBE):
             this = self._parse_describe()
         else:
@@ -3703,11 +3687,12 @@ class Parser:
         self._match_text_seq("FIRST", "BY")
 
         return self.expression(
-            exp.RecursiveWithSearch,
-            kind=kind,
-            this=self._parse_id_var(),
-            expression=self._match_text_seq("SET") and self._parse_id_var(),
-            using=self._match_text_seq("USING") and self._parse_id_var(),
+            exp.RecursiveWithSearch(
+                kind=kind,
+                this=self._parse_id_var(),
+                expression=self._match_text_seq("SET") and self._parse_id_var(),
+                using=self._match_text_seq("USING") and self._parse_id_var(),
+            )
         )
 
     def _parse_with(self, skip_with_token: bool = False) -> t.Optional[exp.With]:
@@ -3734,11 +3719,12 @@ class Parser:
             last_comments = self._prev_comments
 
         return self.expression(
-            exp.With,
+            exp.With(
+                expressions=expressions,
+                recursive=recursive or None,
+                search=self._parse_recursive_with_search(),
+            ),
             comments=comments,
-            expressions=expressions,
-            recursive=recursive or None,
-            search=self._parse_recursive_with_search(),
         )
 
     def _parse_cte(self) -> t.Optional[exp.CTE]:
@@ -3766,11 +3752,12 @@ class Parser:
             materialized = None
 
         cte = self.expression(
-            exp.CTE,
-            this=self._parse_wrapped(self._parse_statement),
-            alias=alias,
-            materialized=materialized,
-            key_expressions=key_expressions,
+            exp.CTE(
+                this=self._parse_wrapped(self._parse_statement),
+                alias=alias,
+                materialized=materialized,
+                key_expressions=key_expressions,
+            ),
             comments=comments,
         )
 
@@ -3808,7 +3795,7 @@ class Parser:
         if not alias and not columns:
             return None
 
-        table_alias = self.expression(exp.TableAlias, this=alias, columns=columns)
+        table_alias = self.expression(exp.TableAlias(this=alias, columns=columns))
 
         # We bubble up comments from the Identifier to the TableAlias
         if isinstance(alias, exp.Identifier):
@@ -3823,11 +3810,12 @@ class Parser:
             return None
 
         return self.expression(
-            exp.Subquery,
-            this=this,
-            pivots=self._parse_pivots(),
-            alias=self._parse_table_alias() if parse_alias else None,
-            sample=self._parse_table_sample(),
+            exp.Subquery(
+                this=this,
+                pivots=self._parse_pivots(),
+                alias=self._parse_table_alias() if parse_alias else None,
+                sample=self._parse_table_sample(),
+            )
         )
 
     def _implicit_unnests_to_explicit(self, this: E) -> E:
@@ -3934,7 +3922,7 @@ class Parser:
             self._retreat(start_index)
             return self._parse_hint_fallback_to_string()
 
-        return self.expression(exp.Hint, expressions=hints)
+        return self.expression(exp.Hint(expressions=hints))
 
     def _parse_hint(self) -> t.Optional[exp.Hint]:
         if self._match(TokenType.HINT) and self._prev_comments:
@@ -3951,7 +3939,7 @@ class Parser:
         self._match(TokenType.TABLE)
 
         return self.expression(
-            exp.Into, this=self._parse_table(schema=True), temporary=temp, unlogged=unlogged
+            exp.Into(this=self._parse_table(schema=True), temporary=temp, unlogged=unlogged)
         )
 
     def _parse_from(
@@ -3963,17 +3951,18 @@ class Parser:
         if not skip_from_token and not self._match(TokenType.FROM):
             return None
 
+        comments = self._prev_comments
         return self.expression(
-            exp.From,
-            comments=self._prev_comments,
-            this=self._parse_table(joins=joins, consume_pipe=consume_pipe),
+            exp.From(this=self._parse_table(joins=joins, consume_pipe=consume_pipe)),
+            comments=comments,
         )
 
     def _parse_match_recognize_measure(self) -> exp.MatchRecognizeMeasure:
         return self.expression(
-            exp.MatchRecognizeMeasure,
-            window_frame=self._match_texts(("FINAL", "RUNNING")) and self._prev.text.upper(),
-            this=self._parse_expression(),
+            exp.MatchRecognizeMeasure(
+                window_frame=self._match_texts(("FINAL", "RUNNING")) and self._prev.text.upper(),
+                this=self._parse_expression(),
+            )
         )
 
     def _parse_match_recognize(self) -> t.Optional[exp.MatchRecognize]:
@@ -4053,15 +4042,16 @@ class Parser:
         self._match_r_paren()
 
         return self.expression(
-            exp.MatchRecognize,
-            partition_by=partition,
-            order=order,
-            measures=measures,
-            rows=rows,
-            after=after,
-            pattern=pattern,
-            define=define,
-            alias=self._parse_table_alias(),
+            exp.MatchRecognize(
+                partition_by=partition,
+                order=order,
+                measures=measures,
+                rows=rows,
+                after=after,
+                pattern=pattern,
+                define=define,
+                alias=self._parse_table_alias(),
+            )
         )
 
     def _parse_lateral(self) -> t.Optional[exp.Lateral]:
@@ -4101,7 +4091,7 @@ class Parser:
             table = self._parse_id_var(any_token=False)
             columns = self._parse_csv(self._parse_id_var) if self._match(TokenType.ALIAS) else []
             table_alias: t.Optional[exp.TableAlias] = self.expression(
-                exp.TableAlias, this=table, columns=columns
+                exp.TableAlias(this=table, columns=columns)
             )
         elif isinstance(this, (exp.Subquery, exp.Unnest)) and this.alias:
             # We move the alias from the lateral's child node to the lateral itself
@@ -4111,13 +4101,14 @@ class Parser:
             table_alias = self._parse_table_alias()
 
         return self.expression(
-            exp.Lateral,
-            this=this,
-            view=view,
-            outer=outer,
-            alias=table_alias,
-            cross_apply=cross_apply,
-            ordinality=ordinality,
+            exp.Lateral(
+                this=this,
+                view=view,
+                outer=outer,
+                alias=table_alias,
+                cross_apply=cross_apply,
+                ordinality=ordinality,
+            )
         )
 
     def _parse_stream(self) -> t.Optional[exp.Stream]:
@@ -4125,7 +4116,7 @@ class Parser:
         if self._match_text_seq("STREAM"):
             this = self._try_parse(self._parse_table)
             if this:
-                return self.expression(exp.Stream, this=this)
+                return self.expression(exp.Stream(this=this))
 
         self._retreat(index)
         return None
@@ -4153,7 +4144,7 @@ class Parser:
     ) -> t.Optional[exp.Join]:
         if self._match(TokenType.COMMA):
             table = self._try_parse(self._parse_table)
-            cross_join = self.expression(exp.Join, this=table) if table else None
+            cross_join = self.expression(exp.Join(this=table)) if table else None
 
             if cross_join and self.JOINS_HAVE_EQUAL_PRECEDENCE:
                 cross_join.set("kind", "CROSS")
@@ -4237,7 +4228,7 @@ class Parser:
         if directed:
             kwargs["directed"] = directed
 
-        return self.expression(exp.Join, comments=comments, **kwargs)
+        return self.expression(exp.Join(**kwargs), comments=comments)
 
     def _parse_opclass(self) -> t.Optional[exp.Expr]:
         this = self._parse_disjunction()
@@ -4246,7 +4237,7 @@ class Parser:
             return this
 
         if not self._match_set(self.OPTYPE_FOLLOW_TOKENS, advance=False):
-            return self.expression(exp.Opclass, this=this, expression=self._parse_table_parts())
+            return self.expression(exp.Opclass(this=this, expression=self._parse_table_parts()))
 
         return this
 
@@ -4271,15 +4262,16 @@ class Parser:
         on = self._parse_field() if self._match(TokenType.ON) else None
 
         return self.expression(
-            exp.IndexParameters,
-            using=using,
-            columns=columns,
-            include=include,
-            partition_by=partition_by,
-            where=where,
-            with_storage=with_storage,
-            tablespace=tablespace,
-            on=on,
+            exp.IndexParameters(
+                using=using,
+                columns=columns,
+                include=include,
+                partition_by=partition_by,
+                where=where,
+                with_storage=with_storage,
+                tablespace=tablespace,
+                on=on,
+            )
         )
 
     def _parse_index(
@@ -4307,13 +4299,9 @@ class Parser:
         params = self._parse_index_params()
 
         return self.expression(
-            exp.Index,
-            this=index,
-            table=table,
-            unique=unique,
-            primary=primary,
-            amp=amp,
-            params=params,
+            exp.Index(
+                this=index, table=table, unique=unique, primary=primary, amp=amp, params=params
+            )
         )
 
     def _parse_table_hints(self) -> t.Optional[t.List[exp.Expr]]:
@@ -4322,10 +4310,11 @@ class Parser:
             # https://learn.microsoft.com/en-us/sql/t-sql/queries/hints-transact-sql-table?view=sql-server-ver16
             hints.append(
                 self.expression(
-                    exp.WithTableHint,
-                    expressions=self._parse_csv(
-                        lambda: self._parse_function() or self._parse_var(any_token=True)
-                    ),
+                    exp.WithTableHint(
+                        expressions=self._parse_csv(
+                            lambda: self._parse_function() or self._parse_var(any_token=True)
+                        )
+                    )
                 )
             )
             self._match_r_paren()
@@ -4362,7 +4351,7 @@ class Parser:
             if catalog:
                 # This allows nesting the table in arbitrarily many dot expressions if needed
                 table = self.expression(
-                    exp.Dot, this=table, expression=self._parse_table_part(schema=schema)
+                    exp.Dot(this=table, expression=self._parse_table_part(schema=schema))
                 )
             else:
                 catalog = db
@@ -4394,13 +4383,7 @@ class Parser:
         if not db and is_db_reference:
             self.raise_error(f"Expected database name but got {self._curr}")
 
-        table = self.expression(
-            exp.Table,
-            comments=comments,
-            this=table,
-            db=db,
-            catalog=catalog,
-        )
+        table = self.expression(exp.Table(this=table, db=db, catalog=catalog), comments=comments)
 
         changes = self._parse_changes()
         if changes:
@@ -4449,7 +4432,7 @@ class Parser:
             return subquery
 
         bracket = parse_bracket and self._parse_bracket(None)
-        bracket = self.expression(exp.Table, this=bracket) if bracket else None
+        bracket = self.expression(exp.Table(this=bracket)) if bracket else None
 
         rows_from_tables = (
             self._parse_wrapped_csv(self._parse_table)
@@ -4457,7 +4440,7 @@ class Parser:
             else None
         )
         rows_from = (
-            self.expression(exp.Table, rows_from=rows_from_tables) if rows_from_tables else None
+            self.expression(exp.Table(rows_from=rows_from_tables)) if rows_from_tables else None
         )
 
         only = self._match(TokenType.ONLY)
@@ -4501,7 +4484,7 @@ class Parser:
 
         if isinstance(this, exp.Table) and self._match_text_seq("AT"):
             return self.expression(
-                exp.AtIndex, this=this.to_column(copy=False), expression=self._parse_id_var()
+                exp.AtIndex(this=this.to_column(copy=False), expression=self._parse_id_var())
             )
 
         this.set("hints", self._parse_table_hints())
@@ -4538,11 +4521,11 @@ class Parser:
             start = self._parse_bitwise()
             self._match_texts(("TO", "AND"))
             end = self._parse_bitwise()
-            expression: t.Optional[exp.Expr] = self.expression(exp.Tuple, expressions=[start, end])
+            expression: t.Optional[exp.Expr] = self.expression(exp.Tuple(expressions=[start, end]))
         elif self._match_text_seq("CONTAINED", "IN"):
             kind = "CONTAINED IN"
             expression = self.expression(
-                exp.Tuple, expressions=self._parse_wrapped_csv(self._parse_bitwise)
+                exp.Tuple(expressions=self._parse_wrapped_csv(self._parse_bitwise))
             )
         elif self._match(TokenType.ALL):
             kind = "ALL"
@@ -4552,7 +4535,7 @@ class Parser:
             kind = "AS OF"
             expression = self._parse_type()
 
-        return self.expression(exp.Version, this=this, expression=expression, kind=kind)
+        return self.expression(exp.Version(this=this, expression=expression, kind=kind))
 
     def _parse_historical_data(self) -> t.Optional[exp.HistoricalData]:
         # https://docs.snowflake.com/en/sql-reference/constructs/at-before
@@ -4570,7 +4553,7 @@ class Parser:
             if expression:
                 self._match_r_paren()
                 historical_data = self.expression(
-                    exp.HistoricalData, this=this, kind=kind, expression=expression
+                    exp.HistoricalData(this=this, kind=kind, expression=expression)
                 )
             else:
                 self._retreat(index)
@@ -4585,10 +4568,11 @@ class Parser:
         self._match_r_paren()
 
         return self.expression(
-            exp.Changes,
-            information=information,
-            at_before=self._parse_historical_data(),
-            end=self._parse_historical_data(),
+            exp.Changes(
+                information=information,
+                at_before=self._parse_historical_data(),
+                end=self._parse_historical_data(),
+            )
         )
 
     def _parse_unnest(self, with_alias: bool = True) -> t.Optional[exp.Unnest]:
@@ -4620,7 +4604,7 @@ class Parser:
                 any_token=False, tokens=self.UNNEST_OFFSET_ALIAS_TOKENS
             ) or exp.to_identifier("offset")
 
-        return self.expression(exp.Unnest, expressions=expressions, alias=alias, offset=offset)
+        return self.expression(exp.Unnest(expressions=expressions, alias=alias, offset=offset))
 
     def _parse_derived_table_values(self) -> t.Optional[exp.Values]:
         is_derived = self._match_pair(TokenType.L_PAREN, TokenType.VALUES)
@@ -4637,7 +4621,7 @@ class Parser:
             self._match_r_paren()
 
         return self.expression(
-            exp.Values, expressions=expressions, alias=alias or self._parse_table_alias()
+            exp.Values(expressions=expressions, alias=alias or self._parse_table_alias())
         )
 
     def _parse_table_sample(self, as_modifier: bool = False) -> t.Optional[exp.TableSample]:
@@ -4694,15 +4678,16 @@ class Parser:
             method = exp.var(self.DEFAULT_SAMPLING_METHOD)
 
         return self.expression(
-            exp.TableSample,
-            expressions=expressions,
-            method=method,
-            bucket_numerator=bucket_numerator,
-            bucket_denominator=bucket_denominator,
-            bucket_field=bucket_field,
-            percent=percent,
-            size=size,
-            seed=seed,
+            exp.TableSample(
+                expressions=expressions,
+                method=method,
+                bucket_numerator=bucket_numerator,
+                bucket_denominator=bucket_denominator,
+                bucket_field=bucket_field,
+                percent=percent,
+                size=size,
+                seed=seed,
+            )
         )
 
     def _parse_pivots(self) -> t.Optional[t.List[exp.Pivot]]:
@@ -4716,9 +4701,10 @@ class Parser:
             return None
 
         return self.expression(
-            exp.UnpivotColumns,
-            this=self._match_text_seq("NAME") and self._parse_column(),
-            expressions=self._match_text_seq("VALUE") and self._parse_csv(self._parse_column),
+            exp.UnpivotColumns(
+                this=self._match_text_seq("NAME") and self._parse_column(),
+                expressions=self._match_text_seq("VALUE") and self._parse_csv(self._parse_column),
+            )
         )
 
     # https://duckdb.org/docs/sql/statements/pivot
@@ -4744,13 +4730,14 @@ class Parser:
         group = self._parse_group()
 
         return self.expression(
-            exp.Pivot,
-            this=this,
-            expressions=expressions,
-            using=using,
-            group=group,
-            unpivot=is_unpivot,
-            into=into,
+            exp.Pivot(
+                this=this,
+                expressions=expressions,
+                using=using,
+                group=group,
+                unpivot=is_unpivot,
+                into=into,
+            )
         )
 
     def _parse_pivot_in(self) -> exp.In:
@@ -4762,7 +4749,7 @@ class Parser:
             if alias:
                 if isinstance(alias, exp.Column) and not alias.db:
                     alias = alias.this
-                return self.expression(exp.PivotAlias, this=this, alias=alias)
+                return self.expression(exp.PivotAlias(this=this, alias=alias))
 
             return this
 
@@ -4777,9 +4764,9 @@ class Parser:
             else:
                 exprs = self._parse_csv(_parse_aliased_expression)
             self._match_r_paren()
-            return self.expression(exp.In, this=value, expressions=exprs)
+            return self.expression(exp.In(this=value, expressions=exprs))
 
-        return self.expression(exp.In, this=value, field=self._parse_id_var())
+        return self.expression(exp.In(this=value, field=self._parse_id_var()))
 
     def _parse_pivot_aggregation(self) -> t.Optional[exp.Expr]:
         func = self._parse_function()
@@ -4840,13 +4827,14 @@ class Parser:
         self._match_r_paren()
 
         pivot = self.expression(
-            exp.Pivot,
-            expressions=expressions,
-            fields=fields,
-            unpivot=unpivot,
-            include_nulls=include_nulls,
-            default_on_null=default_on_null,
-            group=group,
+            exp.Pivot(
+                expressions=expressions,
+                fields=fields,
+                unpivot=unpivot,
+                include_nulls=include_nulls,
+                default_on_null=default_on_null,
+                group=group,
+            )
         )
 
         if not self._match_set((TokenType.PIVOT, TokenType.UNPIVOT), advance=False):
@@ -4898,16 +4886,20 @@ class Parser:
         if not skip_where_token and not self._match(TokenType.PREWHERE):
             return None
 
+        comments = self._prev_comments
         return self.expression(
-            exp.PreWhere, comments=self._prev_comments, this=self._parse_disjunction()
+            exp.PreWhere(this=self._parse_disjunction()),
+            comments=comments,
         )
 
     def _parse_where(self, skip_where_token: bool = False) -> t.Optional[exp.Where]:
         if not skip_where_token and not self._match(TokenType.WHERE):
             return None
 
+        comments = self._prev_comments
         return self.expression(
-            exp.Where, comments=self._prev_comments, this=self._parse_disjunction()
+            exp.Where(this=self._parse_disjunction()),
+            comments=comments,
         )
 
     def _parse_group(self, skip_group_by_token: bool = False) -> t.Optional[exp.Group]:
@@ -4923,7 +4915,7 @@ class Parser:
             elements["all"] = False
 
         if self._match_set(self.QUERY_MODIFIER_TOKENS, advance=False):
-            return self.expression(exp.Group, comments=comments, **elements)  # type: ignore
+            return self.expression(exp.Group(**elements), comments=comments)  # type: ignore
 
         while True:
             index = self._index
@@ -4954,7 +4946,7 @@ class Parser:
             if index == self._index:
                 break
 
-        return self.expression(exp.Group, comments=comments, **elements)  # type: ignore
+        return self.expression(exp.Group(**elements), comments=comments)  # type: ignore
 
     def _parse_cube_or_rollup(self, with_prefix: bool = False) -> t.Optional[exp.Cube | exp.Rollup]:
         if self._match(TokenType.CUBE):
@@ -4965,13 +4957,13 @@ class Parser:
             return None
 
         return self.expression(
-            kind, expressions=[] if with_prefix else self._parse_wrapped_csv(self._parse_bitwise)
+            kind(expressions=[] if with_prefix else self._parse_wrapped_csv(self._parse_bitwise))
         )
 
     def _parse_grouping_sets(self) -> t.Optional[exp.GroupingSets]:
         if self._match(TokenType.GROUPING_SETS):
             return self.expression(
-                exp.GroupingSets, expressions=self._parse_wrapped_csv(self._parse_grouping_set)
+                exp.GroupingSets(expressions=self._parse_wrapped_csv(self._parse_grouping_set))
             )
         return None
 
@@ -4981,18 +4973,20 @@ class Parser:
     def _parse_having(self, skip_having_token: bool = False) -> t.Optional[exp.Having]:
         if not skip_having_token and not self._match(TokenType.HAVING):
             return None
+        comments = self._prev_comments
         return self.expression(
-            exp.Having, comments=self._prev_comments, this=self._parse_disjunction()
+            exp.Having(this=self._parse_disjunction()),
+            comments=comments,
         )
 
     def _parse_qualify(self) -> t.Optional[exp.Qualify]:
         if not self._match(TokenType.QUALIFY):
             return None
-        return self.expression(exp.Qualify, this=self._parse_disjunction())
+        return self.expression(exp.Qualify(this=self._parse_disjunction()))
 
     def _parse_connect_with_prior(self) -> t.Optional[exp.Expr]:
         self.NO_PAREN_FUNCTION_PARSERS["PRIOR"] = lambda self: self.expression(
-            exp.Prior, this=self._parse_bitwise()
+            exp.Prior(this=self._parse_bitwise())
         )
         connect = self._parse_disjunction()
         self.NO_PAREN_FUNCTION_PARSERS.pop("PRIOR")
@@ -5013,12 +5007,12 @@ class Parser:
         if not start and self._match(TokenType.START_WITH):
             start = self._parse_disjunction()
 
-        return self.expression(exp.Connect, start=start, connect=connect, nocycle=nocycle)
+        return self.expression(exp.Connect(start=start, connect=connect, nocycle=nocycle))
 
     def _parse_name_as_expression(self) -> t.Optional[exp.Expr]:
         this = self._parse_id_var(any_token=True)
         if self._match(TokenType.ALIAS):
-            this = self.expression(exp.Alias, alias=this, this=self._parse_disjunction())
+            this = self.expression(exp.Alias(alias=this, this=self._parse_disjunction()))
         return this
 
     def _parse_interpolate(self) -> t.Optional[t.List[exp.Expr]]:
@@ -5036,18 +5030,20 @@ class Parser:
 
             siblings = True
 
+        comments = self._prev_comments
         return self.expression(
-            exp.Order,
-            comments=self._prev_comments,
-            this=this,
-            expressions=self._parse_csv(self._parse_ordered),
-            siblings=siblings,
+            exp.Order(
+                this=this,
+                expressions=self._parse_csv(self._parse_ordered),
+                siblings=siblings,
+            ),
+            comments=comments,
         )
 
     def _parse_sort(self, exp_class: t.Type[E], token: TokenType) -> t.Optional[E]:
         if not self._match(token):
             return None
-        return self.expression(exp_class, expressions=self._parse_csv(self._parse_ordered))
+        return self.expression(exp_class(expressions=self._parse_csv(self._parse_ordered)))
 
     def _parse_ordered(
         self, parse_method: t.Optional[t.Callable] = None
@@ -5080,17 +5076,18 @@ class Parser:
 
         if self._match_text_seq("WITH", "FILL"):
             with_fill = self.expression(
-                exp.WithFill,
-                from_=self._match(TokenType.FROM) and self._parse_bitwise(),
-                to=self._match_text_seq("TO") and self._parse_bitwise(),
-                step=self._match_text_seq("STEP") and self._parse_bitwise(),
-                interpolate=self._parse_interpolate(),
+                exp.WithFill(
+                    from_=self._match(TokenType.FROM) and self._parse_bitwise(),
+                    to=self._match_text_seq("TO") and self._parse_bitwise(),
+                    step=self._match_text_seq("STEP") and self._parse_bitwise(),
+                    interpolate=self._parse_interpolate(),
+                )
             )
         else:
             with_fill = None
 
         return self.expression(
-            exp.Ordered, this=this, desc=desc, nulls_first=nulls_first, with_fill=with_fill
+            exp.Ordered(this=this, desc=desc, nulls_first=nulls_first, with_fill=with_fill)
         )
 
     def _parse_limit_options(self) -> t.Optional[exp.LimitOptions]:
@@ -5102,7 +5099,7 @@ class Parser:
         if not (percent or rows or with_ties):
             return None
 
-        return self.expression(exp.LimitOptions, percent=percent, rows=rows, with_ties=with_ties)
+        return self.expression(exp.LimitOptions(percent=percent, rows=rows, with_ties=with_ties))
 
     def _parse_limit(
         self,
@@ -5139,13 +5136,14 @@ class Parser:
                 offset = None
 
             limit_exp = self.expression(
-                exp.Limit,
-                this=this,
-                expression=expression,
-                offset=offset,
+                exp.Limit(
+                    this=this,
+                    expression=expression,
+                    offset=offset,
+                    limit_options=limit_options,
+                    expressions=self._parse_limit_by(),
+                ),
                 comments=comments,
-                limit_options=limit_options,
-                expressions=self._parse_limit_by(),
             )
 
             return limit_exp
@@ -5160,10 +5158,9 @@ class Parser:
             count = self._parse_field(tokens=self.FETCH_TOKENS)
 
             return self.expression(
-                exp.Fetch,
-                direction=direction,
-                count=count,
-                limit_options=self._parse_limit_options(),
+                exp.Fetch(
+                    direction=direction, count=count, limit_options=self._parse_limit_options()
+                )
             )
 
         return this
@@ -5176,7 +5173,7 @@ class Parser:
         self._match_set((TokenType.ROW, TokenType.ROWS))
 
         return self.expression(
-            exp.Offset, this=this, expression=count, expressions=self._parse_limit_by()
+            exp.Offset(this=this, expression=count, expressions=self._parse_limit_by())
         )
 
     def _can_parse_limit_or_offset(self) -> bool:
@@ -5230,7 +5227,7 @@ class Parser:
 
             locks.append(
                 self.expression(
-                    exp.Lock, update=update, expressions=expressions, wait=wait, key=key
+                    exp.Lock(update=update, expressions=expressions, wait=wait, key=key)
                 )
             )
 
@@ -5288,15 +5285,16 @@ class Parser:
         )
 
         return self.expression(
-            operation,
+            operation(
+                this=this,
+                distinct=distinct,
+                by_name=by_name,
+                expression=expression,
+                side=side,
+                kind=kind,
+                on=on_column_list,
+            ),
             comments=comments,
-            this=this,
-            distinct=distinct,
-            by_name=by_name,
-            expression=expression,
-            side=side,
-            kind=kind,
-            on=on_column_list,
         )
 
     def _parse_set_operations(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
@@ -5332,11 +5330,12 @@ class Parser:
             if isinstance(this, exp.Column) and len(this.parts) == 1:
                 this = this.this
 
+            comments = self._prev_comments
             this = self.expression(
-                self.ASSIGNMENT[self._prev.token_type],
-                this=this,
-                comments=self._prev_comments,
-                expression=self._parse_assignment(),
+                self.ASSIGNMENT[self._prev.token_type](
+                    this=this, expression=self._parse_assignment()
+                ),
+                comments=comments,
             )
 
         return this
@@ -5364,13 +5363,13 @@ class Parser:
 
             this = expression
         elif self._match(TokenType.ISNULL) or (negate and self._match(TokenType.NULL)):
-            this = self.expression(exp.Is, this=this, expression=exp.Null())
+            this = self.expression(exp.Is(this=this, expression=exp.Null()))
 
         # Postgres supports ISNULL and NOTNULL for conditions.
         # https://blog.andreiavram.ro/postgresql-null-composite-type/
         if self._match(TokenType.NOTNULL):
-            this = self.expression(exp.Is, this=this, expression=exp.Null())
-            this = self.expression(exp.Not, this=this)
+            this = self.expression(exp.Is(this=this, expression=exp.Null()))
+            this = self.expression(exp.Not(this=this))
 
         if negate:
             this = self._negate_range(this)
@@ -5384,7 +5383,7 @@ class Parser:
         if not this:
             return this
 
-        return self.expression(exp.Not, this=this)
+        return self.expression(exp.Not(this=this))
 
     def _parse_is(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
         index = self._index - 1
@@ -5392,7 +5391,7 @@ class Parser:
 
         if self._match_text_seq("DISTINCT", "FROM"):
             klass = exp.NullSafeEQ if negate else exp.NullSafeNEQ
-            return self.expression(klass, this=this, expression=self._parse_bitwise())
+            return self.expression(klass(this=this, expression=self._parse_bitwise()))
 
         if self._match(TokenType.JSON):
             kind = self._match_texts(self.IS_JSON_PREDICATE_KIND) and self._prev.text.upper()
@@ -5407,10 +5406,7 @@ class Parser:
             unique = self._match(TokenType.UNIQUE)
             self._match_text_seq("KEYS")
             expression: t.Optional[exp.Expr] = self.expression(
-                exp.JSON,
-                this=kind,
-                with_=_with,
-                unique=unique,
+                exp.JSON(this=kind, with_=_with, unique=unique)
             )
         else:
             expression = self._parse_null() or self._parse_bitwise()
@@ -5418,33 +5414,31 @@ class Parser:
                 self._retreat(index)
                 return None
 
-        this = self.expression(exp.Is, this=this, expression=expression)
-        this = self.expression(exp.Not, this=this) if negate else this
+        this = self.expression(exp.Is(this=this, expression=expression))
+        this = self.expression(exp.Not(this=this)) if negate else this
         return self._parse_column_ops(this)
 
     def _parse_in(self, this: t.Optional[exp.Expr], alias: bool = False) -> exp.In:
         unnest = self._parse_unnest(with_alias=False)
         if unnest:
-            this = self.expression(exp.In, this=this, unnest=unnest)
+            this = self.expression(exp.In(this=this, unnest=unnest))
         elif self._match_set((TokenType.L_PAREN, TokenType.L_BRACKET)):
             matched_l_paren = self._prev.token_type == TokenType.L_PAREN
             expressions = self._parse_csv(lambda: self._parse_select_or_expression(alias=alias))
 
             if len(expressions) == 1 and isinstance(query := expressions[0], exp.Query):
                 this = self.expression(
-                    exp.In,
-                    this=this,
-                    query=self._parse_query_modifiers(query).subquery(copy=False),
+                    exp.In(this=this, query=self._parse_query_modifiers(query).subquery(copy=False))
                 )
             else:
-                this = self.expression(exp.In, this=this, expressions=expressions)
+                this = self.expression(exp.In(this=this, expressions=expressions))
 
             if matched_l_paren:
                 self._match_r_paren(this)
             elif not self._match(TokenType.R_BRACKET, expression=this):
                 self.raise_error("Expecting ]")
         else:
-            this = self.expression(exp.In, this=this, field=self._parse_column())
+            this = self.expression(exp.In(this=this, field=self._parse_column()))
 
         return this
 
@@ -5459,19 +5453,13 @@ class Parser:
         self._match(TokenType.AND)
         high = self._parse_bitwise()
 
-        return self.expression(
-            exp.Between,
-            this=this,
-            low=low,
-            high=high,
-            symmetric=symmetric,
-        )
+        return self.expression(exp.Between(this=this, low=low, high=high, symmetric=symmetric))
 
     def _parse_escape(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
         if not self._match(TokenType.ESCAPE):
             return this
         return self.expression(
-            exp.Escape, this=this, expression=self._parse_string() or self._parse_null()
+            exp.Escape(this=this, expression=self._parse_string() or self._parse_null())
         )
 
     def _parse_interval_span(self, this: exp.Expr) -> exp.Interval:
@@ -5521,16 +5509,18 @@ class Parser:
 
             if len(parts) == 1:
                 this = exp.Literal.string(parts[0][0])
-                unit = self.expression(exp.Var, this=parts[0][1].upper())
+                unit = self.expression(exp.Var(this=parts[0][1].upper()))
 
         if self.INTERVAL_SPANS and self._match_text_seq("TO"):
             unit = self.expression(
-                exp.IntervalSpan,
-                this=unit,
-                expression=self._parse_function() or self._parse_var(any_token=True, upper=True),
+                exp.IntervalSpan(
+                    this=unit,
+                    expression=self._parse_function()
+                    or self._parse_var(any_token=True, upper=True),
+                )
             )
 
-        return self.expression(exp.Interval, this=this, unit=unit)
+        return self.expression(exp.Interval(this=this, unit=unit))
 
     def _parse_interval(self, require_interval: bool = True) -> t.Optional[exp.Add | exp.Interval]:
         index = self._index
@@ -5560,7 +5550,7 @@ class Parser:
 
         # Convert INTERVAL 'val_1' unit_1 [+] ... [+] 'val_n' unit_n into a sum of intervals
         if self._match_set((TokenType.STRING, TokenType.NUMBER), advance=False):
-            return self.expression(exp.Add, this=interval, expression=self._parse_interval(False))
+            return self.expression(exp.Add(this=interval, expression=self._parse_interval(False)))
 
         self._retreat(index)
         return interval
@@ -5571,28 +5561,27 @@ class Parser:
         while True:
             if self._match_set(self.BITWISE):
                 this = self.expression(
-                    self.BITWISE[self._prev.token_type],
-                    this=this,
-                    expression=self._parse_term(),
+                    self.BITWISE[self._prev.token_type](this=this, expression=self._parse_term())
                 )
             elif self.dialect.DPIPE_IS_STRING_CONCAT and self._match(TokenType.DPIPE):
                 this = self.expression(
-                    exp.DPipe,
-                    this=this,
-                    expression=self._parse_term(),
-                    safe=not self.dialect.STRICT_STRING_CONCAT,
+                    exp.DPipe(
+                        this=this,
+                        expression=self._parse_term(),
+                        safe=not self.dialect.STRICT_STRING_CONCAT,
+                    )
                 )
             elif self._match(TokenType.DQMARK):
                 this = self.expression(
-                    exp.Coalesce, this=this, expressions=ensure_list(self._parse_term())
+                    exp.Coalesce(this=this, expressions=ensure_list(self._parse_term()))
                 )
             elif self._match_pair(TokenType.LT, TokenType.LT):
                 this = self.expression(
-                    exp.BitwiseLeftShift, this=this, expression=self._parse_term()
+                    exp.BitwiseLeftShift(this=this, expression=self._parse_term())
                 )
             elif self._match_pair(TokenType.GT, TokenType.GT):
                 this = self.expression(
-                    exp.BitwiseRightShift, this=this, expression=self._parse_term()
+                    exp.BitwiseRightShift(this=this, expression=self._parse_term())
                 )
             else:
                 break
@@ -5607,7 +5596,7 @@ class Parser:
             comments = self._prev_comments
             expression = self._parse_factor()
 
-            this = self.expression(klass, this=this, comments=comments, expression=expression)
+            this = self.expression(klass(this=this, expression=expression), comments=comments)
 
             if isinstance(this, exp.Collate):
                 expr = this.expression
@@ -5634,7 +5623,7 @@ class Parser:
                 self._retreat(self._index - 1)
                 return this
 
-            this = self.expression(klass, this=this, comments=comments, expression=expression)
+            this = self.expression(klass(this=this, expression=expression), comments=comments)
 
             if isinstance(this, exp.Div):
                 this.set("typed", self.dialect.TYPED_DIVISION)
@@ -5685,7 +5674,7 @@ class Parser:
                 ):
                     data_type = exp.DataType.build("TIMESTAMPTZ")
 
-                return self.expression(exp.Cast, this=this, to=data_type)
+                return self.expression(exp.Cast(this=this, to=data_type))
 
             # The expressions arg gets set by the parser when we have something like DECIMAL(38, 0)
             # in the input SQL. In that case, we'll produce these tokens: DECIMAL ( 38 , 0 )
@@ -5726,7 +5715,7 @@ class Parser:
             this = exp.var(this.name.upper())
 
         return self.expression(
-            exp.DataTypeParam, this=this, expression=self._parse_var(any_token=True)
+            exp.DataTypeParam(this=this, expression=self._parse_var(any_token=True))
         )
 
     def _parse_user_defined_type(self, identifier: exp.Identifier) -> t.Optional[exp.Expr]:
@@ -5768,10 +5757,10 @@ class Parser:
                 return None
 
         if type_token == TokenType.PSEUDO_TYPE:
-            return self.expression(exp.PseudoType, this=self._prev.text.upper())
+            return self.expression(exp.PseudoType(this=self._prev.text.upper()))
 
         if type_token == TokenType.OBJECT_IDENTIFIER:
-            return self.expression(exp.ObjectIdentifier, this=self._prev.text.upper())
+            return self.expression(exp.ObjectIdentifier(this=self._prev.text.upper()))
 
         # https://materialize.com/docs/sql/types/map/
         if type_token == TokenType.MAP and self._match(TokenType.L_BRACKET):
@@ -5890,9 +5879,9 @@ class Parser:
                 if self._match_text_seq("TO"):
                     unit = exp.IntervalSpan(this=unit, expression=self._parse_var(upper=True))
 
-                this = self.expression(exp.DataType, this=self.expression(exp.Interval, unit=unit))
+                this = self.expression(exp.DataType(this=self.expression(exp.Interval(unit=unit))))
             else:
-                this = self.expression(exp.DataType, this=exp.DType.INTERVAL)
+                this = self.expression(exp.DataType(this=exp.DType.INTERVAL))
         elif type_token == TokenType.VOID:
             this = exp.DataType(this=exp.DType.NULL)
 
@@ -5990,7 +5979,7 @@ class Parser:
             arg = self._parse_column()
             if isinstance(arg, exp.Column):
                 arg = arg.to_dot()
-            return self.expression(exp.SkipJSONColumn, regexp=regexp, expression=arg)
+            return self.expression(exp.SkipJSONColumn(regexp=regexp, expression=arg))
 
         param_or_col = self._parse_column()
         if not isinstance(param_or_col, exp.Column):
@@ -6000,12 +5989,12 @@ class Parser:
         if len(param_or_col.parts) == 1 and self._match(TokenType.EQ):
             param = param_or_col.name
             value = self._parse_primary()
-            return self.expression(exp.EQ, this=exp.var(param), expression=value)
+            return self.expression(exp.EQ(this=exp.var(param), expression=value))
 
         # Column type hint: col_name Type
         col = param_or_col.to_dot()
         kind = self._parse_types(check_func=False, allow_identifiers=False)
-        return self.expression(exp.ColumnDef, this=col, kind=kind)
+        return self.expression(exp.ColumnDef(this=col, kind=kind))
 
     def _parse_vector_expressions(self, expressions: t.List[exp.Expr]) -> t.List[exp.Expr]:
         return [exp.DataType.build(expressions[0].name, dialect=self.dialect), *expressions[1:]]
@@ -6044,7 +6033,7 @@ class Parser:
         if not self._match_text_seq("AT", "TIME", "ZONE"):
             return this
         return self._parse_at_time_zone(
-            self.expression(exp.AtTimeZone, this=this, zone=self._parse_unary())
+            self.expression(exp.AtTimeZone(this=this, zone=self._parse_unary()))
         )
 
     def _parse_column(self) -> t.Optional[exp.Expr]:
@@ -6068,7 +6057,7 @@ class Parser:
 
         if isinstance(this, exp.Identifier):
             # We bubble up comments from the Identifier to the Column
-            this = self.expression(exp.Column, comments=this.pop_comments(), this=this)
+            this = self.expression(exp.Column(this=this), comments=this.pop_comments())
 
         return this
 
@@ -6118,15 +6107,16 @@ class Parser:
                 json_path_expr.set("escape", escape)
 
             this = self.expression(
-                exp.JSONExtract,
-                this=this,
-                expression=json_path_expr,
-                variant_extract=True,
-                requires_json=self.JSON_EXTRACT_REQUIRES_JSON_EXPRESSION,
+                exp.JSONExtract(
+                    this=this,
+                    expression=json_path_expr,
+                    variant_extract=True,
+                    requires_json=self.JSON_EXTRACT_REQUIRES_JSON_EXPRESSION,
+                )
             )
 
             while casts:
-                this = self.expression(exp.Cast, this=this, to=casts.pop())
+                this = self.expression(exp.Cast(this=this, to=casts.pop()))
 
         return this
 
@@ -6169,20 +6159,21 @@ class Parser:
                 this = op(self, this, field)
             elif isinstance(this, exp.Column) and not this.args.get("catalog"):
                 this = self.expression(
-                    exp.Column,
+                    exp.Column(
+                        this=field,
+                        table=this.this,
+                        db=this.args.get("table"),
+                        catalog=this.args.get("db"),
+                    ),
                     comments=this.comments,
-                    this=field,
-                    table=this.this,
-                    db=this.args.get("table"),
-                    catalog=this.args.get("db"),
                 )
             elif isinstance(field, exp.Window):
                 # Move the exp.Dot's to the window's function
-                window_func = self.expression(exp.Dot, this=this, expression=field.this)
+                window_func = self.expression(exp.Dot(this=this, expression=field.this))
                 field.set("this", window_func)
                 this = field
             else:
-                this = self.expression(exp.Dot, this=this, expression=field)
+                this = self.expression(exp.Dot(this=this, expression=field))
 
             if field and field.comments:
                 t.cast(exp.Expr, this).add_comments(field.pop_comments())
@@ -6206,7 +6197,7 @@ class Parser:
         this = seq_get(expressions, 0)
 
         if not this and self._match(TokenType.R_PAREN, advance=False):
-            this = self.expression(exp.Tuple)
+            this = self.expression(exp.Tuple())
         elif isinstance(this, exp.UNWRAPPED_QUERIES):
             this = self._parse_subquery(this=this, parse_alias=False)
         elif isinstance(this, (exp.Subquery, exp.Values)):
@@ -6215,9 +6206,9 @@ class Parser:
                 parse_alias=False,
             )
         elif len(expressions) > 1 or self._prev.token_type == TokenType.COMMA:
-            this = self.expression(exp.Tuple, expressions=expressions)
+            this = self.expression(exp.Tuple(expressions=expressions))
         else:
-            this = self.expression(exp.Paren, this=this)
+            this = self.expression(exp.Paren(this=this))
 
         if this:
             this.add_comments(comments)
@@ -6241,7 +6232,7 @@ class Parser:
 
                 if len(expressions) > 1:
                     return self.expression(
-                        exp.Concat, expressions=expressions, coalesce=self.dialect.CONCAT_COALESCE
+                        exp.Concat(expressions=expressions, coalesce=self.dialect.CONCAT_COALESCE)
                     )
 
             return primary
@@ -6326,7 +6317,7 @@ class Parser:
         if not self._next or self._next.token_type != TokenType.L_PAREN:
             if optional_parens and token_type in self.NO_PAREN_FUNCTIONS:
                 self._advance()
-                return self.expression(self.NO_PAREN_FUNCTIONS[token_type])
+                return self.expression(self.NO_PAREN_FUNCTIONS[token_type]())
 
             return None
 
@@ -6356,7 +6347,7 @@ class Parser:
                     expr = self._parse_bitwise()
 
                 if expr:
-                    return self.expression(subquery_predicate, comments=comments, this=expr)
+                    return self.expression(subquery_predicate(this=expr), comments=comments)
 
             if functions is None:
                 functions = self.FUNCTIONS
@@ -6399,7 +6390,7 @@ class Parser:
                 if token_type == TokenType.IDENTIFIER:
                     this = exp.Identifier(this=this, quoted=True).update_positions(token)
 
-                this = self.expression(exp.Anonymous, this=this, expressions=args)
+                this = self.expression(exp.Anonymous(this=this, expressions=args))
 
             this = this.update_positions(token)
 
@@ -6423,13 +6414,14 @@ class Parser:
         for index, e in enumerate(expressions):
             if isinstance(e, self.KEY_VALUE_DEFINITIONS):
                 if isinstance(e, exp.Alias):
-                    e = self.expression(exp.PropertyEQ, this=e.args.get("alias"), expression=e.this)
+                    e = self.expression(exp.PropertyEQ(this=e.args.get("alias"), expression=e.this))
 
                 if not isinstance(e, exp.PropertyEQ):
                     e = self.expression(
-                        exp.PropertyEQ,
-                        this=e.this if parse_map else exp.to_identifier(e.this.name),
-                        expression=e.expression,
+                        exp.PropertyEQ(
+                            this=e.this if parse_map else exp.to_identifier(e.this.name),
+                            expression=e.expression,
+                        )
                     )
 
                 if isinstance(e.this, exp.Column):
@@ -6458,13 +6450,13 @@ class Parser:
         expressions = self._parse_csv(self._parse_function_parameter)
         self._match_r_paren()
         return self.expression(
-            exp.UserDefinedFunction, this=this, expressions=expressions, wrapped=True
+            exp.UserDefinedFunction(this=this, expressions=expressions, wrapped=True)
         )
 
     def _parse_introducer(self, token: Token) -> exp.Introducer | exp.Identifier:
         literal = self._parse_primary()
         if literal:
-            return self.expression(exp.Introducer, token=token, expression=literal)
+            return self.expression(exp.Introducer(this=token.text, expression=literal), token)
 
         return self._identifier_expression(token)
 
@@ -6476,7 +6468,7 @@ class Parser:
             kind = this.name
             this = self._parse_var() or self._parse_primary()
 
-        return self.expression(exp.SessionParameter, this=this, kind=kind)
+        return self.expression(exp.SessionParameter(this=this, kind=kind))
 
     def _parse_lambda_arg(self) -> t.Optional[exp.Expr]:
         return self._parse_id_var()
@@ -6503,7 +6495,7 @@ class Parser:
 
         if self._match(TokenType.DISTINCT):
             this = self.expression(
-                exp.Distinct, expressions=self._parse_csv(self._parse_disjunction)
+                exp.Distinct(expressions=self._parse_csv(self._parse_disjunction))
             )
         else:
             this = self._parse_select_or_expression(alias=alias)
@@ -6526,7 +6518,7 @@ class Parser:
             return this
         args = self._parse_csv(lambda: self._parse_constraint() or self._parse_field_def())
         self._match_r_paren()
-        return self.expression(exp.Schema, this=this, expressions=args)
+        return self.expression(exp.Schema(this=this, expressions=args))
 
     def _parse_field_def(self) -> t.Optional[exp.Expr]:
         return self._parse_column_def(self._parse_field(any_token=True))
@@ -6544,7 +6536,7 @@ class Parser:
         kind = self._parse_types(schema=True)
 
         if self._match_text_seq("FOR", "ORDINALITY"):
-            return self.expression(exp.ColumnDef, this=this, ordinality=True)
+            return self.expression(exp.ColumnDef(this=this, ordinality=True))
 
         constraints: t.List[exp.Expr] = []
 
@@ -6560,12 +6552,12 @@ class Parser:
                 else self._parse_types(),
                 not_null=self._match_pair(TokenType.NOT, TokenType.NULL),
             )
-            constraints.append(self.expression(exp.ColumnConstraint, kind=constraint_kind))
+            constraints.append(self.expression(exp.ColumnConstraint(kind=constraint_kind)))
         elif not kind and self._match_set({TokenType.IN, TokenType.OUT}, advance=False):
             in_out_constraint = self.expression(
-                exp.InOutColumnConstraint,
-                input_=self._match(TokenType.IN),
-                output=self._match(TokenType.OUT),
+                exp.InOutColumnConstraint(
+                    input_=self._match(TokenType.IN), output=self._match(TokenType.OUT)
+                )
             )
             constraints.append(in_out_constraint)
             kind = self._parse_types()
@@ -6580,12 +6572,13 @@ class Parser:
             self._advance()
             constraints.append(
                 self.expression(
-                    exp.ColumnConstraint,
-                    kind=exp.ComputedColumnConstraint(
-                        this=self._parse_disjunction(),
-                        persisted=self._match_texts(("STORED", "VIRTUAL"))
-                        and self._prev.text.upper() == "STORED",
-                    ),
+                    exp.ColumnConstraint(
+                        kind=exp.ComputedColumnConstraint(
+                            this=self._parse_disjunction(),
+                            persisted=self._match_texts(("STORED", "VIRTUAL"))
+                            and self._prev.text.upper() == "STORED",
+                        )
+                    )
                 )
             )
 
@@ -6598,7 +6591,7 @@ class Parser:
         if not kind and not constraints:
             return this
 
-        return self.expression(exp.ColumnDef, this=this, kind=kind, constraints=constraints)
+        return self.expression(exp.ColumnDef(this=this, kind=kind, constraints=constraints))
 
     def _parse_auto_increment(
         self,
@@ -6632,24 +6625,25 @@ class Parser:
             return None
 
         return self.expression(
-            exp.CheckColumnConstraint,
-            this=self._parse_wrapped(self._parse_assignment),
-            enforced=self._match_text_seq("ENFORCED"),
+            exp.CheckColumnConstraint(
+                this=self._parse_wrapped(self._parse_assignment),
+                enforced=self._match_text_seq("ENFORCED"),
+            )
         )
 
     def _parse_auto_property(self) -> t.Optional[exp.AutoRefreshProperty]:
         if not self._match_text_seq("REFRESH"):
             self._retreat(self._index - 1)
             return None
-        return self.expression(exp.AutoRefreshProperty, this=self._parse_var(upper=True))
+        return self.expression(exp.AutoRefreshProperty(this=self._parse_var(upper=True)))
 
     def _parse_compress(self) -> exp.CompressColumnConstraint:
         if self._match(TokenType.L_PAREN, advance=False):
             return self.expression(
-                exp.CompressColumnConstraint, this=self._parse_wrapped_csv(self._parse_bitwise)
+                exp.CompressColumnConstraint(this=self._parse_wrapped_csv(self._parse_bitwise))
             )
 
-        return self.expression(exp.CompressColumnConstraint, this=self._parse_bitwise())
+        return self.expression(exp.CompressColumnConstraint(this=self._parse_bitwise()))
 
     def _parse_generated_as_identity(
         self,
@@ -6661,11 +6655,11 @@ class Parser:
         if self._match_text_seq("BY", "DEFAULT"):
             on_null = self._match_pair(TokenType.ON, TokenType.NULL)
             this = self.expression(
-                exp.GeneratedAsIdentityColumnConstraint, this=False, on_null=on_null
+                exp.GeneratedAsIdentityColumnConstraint(this=False, on_null=on_null)
             )
         else:
             self._match_text_seq("ALWAYS")
-            this = self.expression(exp.GeneratedAsIdentityColumnConstraint, this=True)
+            this = self.expression(exp.GeneratedAsIdentityColumnConstraint(this=True))
 
         self._match(TokenType.ALIAS)
 
@@ -6674,7 +6668,7 @@ class Parser:
             if not start:
                 self._match(TokenType.END)
             hidden = self._match_text_seq("HIDDEN")
-            return self.expression(exp.GeneratedAsRowColumnConstraint, start=start, hidden=hidden)
+            return self.expression(exp.GeneratedAsRowColumnConstraint(start=start, hidden=hidden))
 
         identity = self._match_text_seq("IDENTITY")
 
@@ -6706,15 +6700,15 @@ class Parser:
 
     def _parse_inline(self) -> exp.InlineLengthColumnConstraint:
         self._match_text_seq("LENGTH")
-        return self.expression(exp.InlineLengthColumnConstraint, this=self._parse_bitwise())
+        return self.expression(exp.InlineLengthColumnConstraint(this=self._parse_bitwise()))
 
     def _parse_not_constraint(self) -> t.Optional[exp.Expr]:
         if self._match_text_seq("NULL"):
-            return self.expression(exp.NotNullColumnConstraint)
+            return self.expression(exp.NotNullColumnConstraint())
         if self._match_text_seq("CASESPECIFIC"):
-            return self.expression(exp.CaseSpecificColumnConstraint, not_=True)
+            return self.expression(exp.CaseSpecificColumnConstraint(not_=True))
         if self._match_text_seq("FOR", "REPLICATION"):
-            return self.expression(exp.NotForReplicationColumnConstraint)
+            return self.expression(exp.NotForReplicationColumnConstraint())
 
         # Unconsume the `NOT` token
         self._retreat(self._index - 1)
@@ -6735,7 +6729,7 @@ class Parser:
                 self._retreat(self._index - 1)
                 return None
 
-            return self.expression(exp.ColumnConstraint, this=this, kind=constraint)
+            return self.expression(exp.ColumnConstraint(this=this, kind=constraint))
 
         return this
 
@@ -6744,9 +6738,7 @@ class Parser:
             return self._parse_unnamed_constraint(constraints=self.SCHEMA_UNNAMED_CONSTRAINTS)
 
         return self.expression(
-            exp.Constraint,
-            this=self._parse_id_var(),
-            expressions=self._parse_unnamed_constraints(),
+            exp.Constraint(this=self._parse_id_var(), expressions=self._parse_unnamed_constraints())
         )
 
     def _parse_unnamed_constraints(self) -> t.List[exp.Expr]:
@@ -6785,12 +6777,13 @@ class Parser:
     def _parse_unique(self) -> exp.UniqueColumnConstraint:
         self._match_texts(("KEY", "INDEX"))
         return self.expression(
-            exp.UniqueColumnConstraint,
-            nulls=self._match_text_seq("NULLS", "NOT", "DISTINCT"),
-            this=self._parse_schema(self._parse_unique_key()),
-            index_type=self._match(TokenType.USING) and self._advance_any() and self._prev.text,
-            on_conflict=self._parse_on_conflict(),
-            options=self._parse_key_constraint_options(),
+            exp.UniqueColumnConstraint(
+                nulls=self._match_text_seq("NULLS", "NOT", "DISTINCT"),
+                this=self._parse_schema(self._parse_unique_key()),
+                index_type=self._match(TokenType.USING) and self._advance_any() and self._prev.text,
+                on_conflict=self._parse_on_conflict(),
+                options=self._parse_key_constraint_options(),
+            )
         )
 
     def _parse_key_constraint_options(self) -> t.List[str]:
@@ -6834,7 +6827,7 @@ class Parser:
         expressions: t.Optional[t.List] = None
         this = self._parse_table(schema=True)
         options = self._parse_key_constraint_options()
-        return self.expression(exp.Reference, this=this, expressions=expressions, options=options)
+        return self.expression(exp.Reference(this=this, expressions=expressions, options=options))
 
     def _parse_foreign_key(self) -> exp.ForeignKey:
         expressions = (
@@ -6863,11 +6856,12 @@ class Parser:
             on_options[kind] = action
 
         return self.expression(
-            exp.ForeignKey,
-            expressions=expressions,
-            reference=reference,
-            options=self._parse_key_constraint_options(),
-            **on_options,  # type: ignore
+            exp.ForeignKey(
+                expressions=expressions,
+                reference=reference,
+                options=self._parse_key_constraint_options(),
+                **on_options,
+            )
         )
 
     def _parse_primary_key_part(self) -> t.Optional[exp.Expr]:
@@ -6880,9 +6874,9 @@ class Parser:
 
         id_vars = self._parse_wrapped_id_vars()
         return self.expression(
-            exp.PeriodForSystemTimeConstraint,
-            this=seq_get(id_vars, 0),
-            expression=seq_get(id_vars, 1),
+            exp.PeriodForSystemTimeConstraint(
+                this=seq_get(id_vars, 0), expression=seq_get(id_vars, 1)
+            )
         )
 
     def _parse_primary_key(
@@ -6908,9 +6902,9 @@ class Parser:
 
         if not in_props and not self._match(TokenType.L_PAREN, advance=False):
             return self.expression(
-                exp.PrimaryKeyColumnConstraint,
-                desc=desc,
-                options=self._parse_key_constraint_options(),
+                exp.PrimaryKeyColumnConstraint(
+                    desc=desc, options=self._parse_key_constraint_options()
+                )
             )
 
         expressions = self._parse_wrapped_csv(
@@ -6918,11 +6912,12 @@ class Parser:
         )
 
         return self.expression(
-            exp.PrimaryKey,
-            this=this,
-            expressions=expressions,
-            include=self._parse_index_params(),
-            options=self._parse_key_constraint_options(),
+            exp.PrimaryKey(
+                this=this,
+                expressions=expressions,
+                include=self._parse_index_params(),
+                options=self._parse_key_constraint_options(),
+            )
         )
 
     def _parse_bracket_key_value(self, is_map: bool = False) -> t.Optional[exp.Expr]:
@@ -6939,7 +6934,7 @@ class Parser:
         """
         self._match(TokenType.VAR)
         exp_class = self.ODBC_DATETIME_LITERALS[self._prev.text.lower()]
-        expression = self.expression(exp_class=exp_class, this=self._parse_string())
+        expression = self.expression(exp_class(this=self._parse_string()))
         if not self._match(TokenType.R_BRACE):
             self.raise_error("Expected }")
         return expression
@@ -6975,8 +6970,9 @@ class Parser:
         # https://duckdb.org/docs/sql/data_types/struct.html#creating-structs
         if bracket_kind == TokenType.L_BRACE:
             this = self.expression(
-                exp.Struct,
-                expressions=self._kv_to_prop_eq(expressions=expressions, parse_map=parse_map),
+                exp.Struct(
+                    expressions=self._kv_to_prop_eq(expressions=expressions, parse_map=parse_map)
+                )
             )
         elif not this:
             this = build_array_constructor(
@@ -6996,10 +6992,7 @@ class Parser:
                 this, expressions, -self.dialect.INDEX_OFFSET, dialect=self.dialect
             )
             this = self.expression(
-                exp.Bracket,
-                this=this,
-                expressions=expressions,
-                comments=this.pop_comments(),
+                exp.Bracket(this=this, expressions=expressions), comments=this.pop_comments()
             )
 
         self._add_comments(this)
@@ -7015,7 +7008,7 @@ class Parser:
         else:
             end = self._parse_assignment()
         step = self._parse_unary() if self._match(TokenType.COLON) else None
-        return self.expression(exp.Slice, this=this, expression=end, step=step)
+        return self.expression(exp.Slice(this=this, expression=end, step=step))
 
     def _parse_case(self) -> t.Optional[exp.Expr]:
         if self._match(TokenType.DOT, advance=False):
@@ -7033,7 +7026,7 @@ class Parser:
             this = self._parse_disjunction()
             self._match(TokenType.THEN)
             then = self._parse_disjunction()
-            ifs.append(self.expression(exp.If, this=this, true=then))
+            ifs.append(self.expression(exp.If(this=this, true=then)))
 
         if self._match(TokenType.ELSE):
             default = self._parse_disjunction()
@@ -7045,7 +7038,7 @@ class Parser:
                 self.raise_error("Expected END after CASE", self._prev)
 
         return self.expression(
-            exp.Case, comments=comments, this=expression, ifs=ifs, default=default
+            exp.Case(this=expression, ifs=ifs, default=default), comments=comments
         )
 
     def _parse_if(self) -> t.Optional[exp.Expr]:
@@ -7071,7 +7064,7 @@ class Parser:
             true = self._parse_disjunction()
             false = self._parse_disjunction() if self._match(TokenType.ELSE) else None
             self._match(TokenType.END)
-            this = self.expression(exp.If, this=condition, true=true, false=false)
+            this = self.expression(exp.If(this=condition, true=true, false=false))
 
         return this
 
@@ -7081,21 +7074,22 @@ class Parser:
             return None
 
         return self.expression(
-            exp.NextValueFor,
-            this=self._parse_column(),
-            order=self._match(TokenType.OVER) and self._parse_wrapped(self._parse_order),
+            exp.NextValueFor(
+                this=self._parse_column(),
+                order=self._match(TokenType.OVER) and self._parse_wrapped(self._parse_order),
+            )
         )
 
     def _parse_extract(self) -> exp.Extract | exp.Anonymous:
         this = self._parse_function() or self._parse_var_or_string(upper=True)
 
         if self._match(TokenType.FROM):
-            return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
+            return self.expression(exp.Extract(this=this, expression=self._parse_bitwise()))
 
         if not self._match(TokenType.COMMA):
             self.raise_error("Expected FROM or comma after EXTRACT", self._prev)
 
-        return self.expression(exp.Extract, this=this, expression=self._parse_bitwise())
+        return self.expression(exp.Extract(this=this, expression=self._parse_bitwise()))
 
     def _parse_gap_fill(self) -> exp.GapFill:
         self._match(TokenType.TABLE)
@@ -7109,9 +7103,10 @@ class Parser:
 
     def _parse_char(self) -> exp.Chr:
         return self.expression(
-            exp.Chr,
-            expressions=self._parse_csv(self._parse_assignment),
-            charset=self._match(TokenType.USING) and self._parse_var(),
+            exp.Chr(
+                expressions=self._parse_csv(self._parse_assignment),
+                charset=self._match(TokenType.USING) and self._parse_var(),
+            )
         )
 
     def _parse_cast(self, strict: bool, safe: t.Optional[bool] = None) -> exp.Expr:
@@ -7119,7 +7114,7 @@ class Parser:
 
         if not self._match(TokenType.ALIAS):
             if self._match(TokenType.COMMA):
-                return self.expression(exp.CastToStrType, this=this, to=self._parse_string())
+                return self.expression(exp.CastToStrType(this=this, to=self._parse_string()))
 
             self.raise_error("Expected AS after CAST")
 
@@ -7139,16 +7134,17 @@ class Parser:
                 to = exp.DataType.build(exp.DType.UNKNOWN)
             if to.this in exp.DataType.TEMPORAL_TYPES:
                 this = self.expression(
-                    exp.StrToDate if to.this == exp.DType.DATE else exp.StrToTime,
-                    this=this,
-                    format=exp.Literal.string(
-                        format_time(
-                            fmt_string.this if fmt_string else "",
-                            self.dialect.FORMAT_MAPPING or self.dialect.TIME_MAPPING,
-                            self.dialect.FORMAT_TRIE or self.dialect.TIME_TRIE,
-                        )
-                    ),
-                    safe=safe,
+                    (exp.StrToDate if to.this == exp.DType.DATE else exp.StrToTime)(
+                        this=this,
+                        format=exp.Literal.string(
+                            format_time(
+                                fmt_string.this if fmt_string else "",
+                                self.dialect.FORMAT_MAPPING or self.dialect.TIME_MAPPING,
+                                self.dialect.FORMAT_TRIE or self.dialect.TIME_TRIE,
+                            )
+                        ),
+                        safe=safe,
+                    )
                 )
 
                 if isinstance(fmt, exp.AtTimeZone) and isinstance(this, exp.StrToTime):
@@ -7174,7 +7170,7 @@ class Parser:
     def _parse_string_agg(self) -> exp.GroupConcat:
         if self._match(TokenType.DISTINCT):
             args: t.List[t.Optional[exp.Expr]] = [
-                self.expression(exp.Distinct, expressions=[self._parse_disjunction()])
+                self.expression(exp.Distinct(expressions=[self._parse_disjunction()]))
             ]
             if self._match(TokenType.COMMA):
                 args.extend(self._parse_csv(self._parse_disjunction))
@@ -7188,12 +7184,13 @@ class Parser:
             else:
                 self._match_text_seq("TRUNCATE")
                 on_overflow = self.expression(
-                    exp.OverflowTruncateBehavior,
-                    this=self._parse_string(),
-                    with_count=(
-                        self._match_text_seq("WITH", "COUNT")
-                        or not self._match_text_seq("WITHOUT", "COUNT")
-                    ),
+                    exp.OverflowTruncateBehavior(
+                        this=self._parse_string(),
+                        with_count=(
+                            self._match_text_seq("WITH", "COUNT")
+                            or not self._match_text_seq("WITHOUT", "COUNT")
+                        ),
+                    )
                 )
         else:
             on_overflow = None
@@ -7204,7 +7201,7 @@ class Parser:
             # bigquery: STRING_AGG([DISTINCT] expression [, separator] [ORDER BY key [{ASC | DESC}] [, ... ]] [LIMIT n])
             # The order is parsed through `this` as a canonicalization for WITHIN GROUPs
             args[0] = self._parse_limit(this=self._parse_order(this=args[0]))
-            return self.expression(exp.GroupConcat, this=args[0], separator=seq_get(args, 1))
+            return self.expression(exp.GroupConcat(this=args[0], separator=seq_get(args, 1)))
 
         # Checks if we can parse an order clause: WITHIN GROUP (ORDER BY <order_by_expression_list> [ASC | DESC]).
         # This is done "manually", instead of letting _parse_window parse it into an exp.WithinGroup node, so that
@@ -7217,10 +7214,11 @@ class Parser:
         self._match_l_paren()
 
         return self.expression(
-            exp.GroupConcat,
-            this=self._parse_order(this=seq_get(args, 0)),
-            separator=seq_get(args, 1),
-            on_overflow=on_overflow,
+            exp.GroupConcat(
+                this=self._parse_order(this=seq_get(args, 0)),
+                separator=seq_get(args, 1),
+                on_overflow=on_overflow,
+            )
         )
 
     def _parse_convert(self, strict: bool, safe: t.Optional[bool] = None) -> t.Optional[exp.Expr]:
@@ -7248,10 +7246,11 @@ class Parser:
             this = self._parse_id_var()
 
         return self.expression(
-            exp.XMLElement,
-            this=this,
-            expressions=self._match(TokenType.COMMA) and self._parse_csv(self._parse_bitwise),
-            evalname=evalname,
+            exp.XMLElement(
+                this=this,
+                expressions=self._match(TokenType.COMMA) and self._parse_csv(self._parse_bitwise),
+                evalname=evalname,
+            )
         )
 
     def _parse_xml_table(self) -> exp.XMLTable:
@@ -7276,12 +7275,9 @@ class Parser:
             columns = self._parse_csv(self._parse_field_def)
 
         return self.expression(
-            exp.XMLTable,
-            this=this,
-            namespaces=namespaces,
-            passing=passing,
-            columns=columns,
-            by_ref=by_ref,
+            exp.XMLTable(
+                this=this, namespaces=namespaces, passing=passing, columns=columns, by_ref=by_ref
+            )
         )
 
     def _parse_xml_namespace(self) -> t.List[exp.XMLNamespace]:
@@ -7292,7 +7288,7 @@ class Parser:
                 uri = self._parse_string()
             else:
                 uri = self._parse_alias(self._parse_string())
-            namespaces.append(self.expression(exp.XMLNamespace, this=uri))
+            namespaces.append(self.expression(exp.XMLNamespace(this=uri)))
             if not self._match(TokenType.COMMA):
                 break
 
@@ -7302,9 +7298,9 @@ class Parser:
         args = self._parse_csv(self._parse_disjunction)
 
         if len(args) < 3:
-            return self.expression(exp.Decode, this=seq_get(args, 0), charset=seq_get(args, 1))
+            return self.expression(exp.Decode(this=seq_get(args, 0), charset=seq_get(args, 1)))
 
-        return self.expression(exp.DecodeCase, expressions=args)
+        return self.expression(exp.DecodeCase(expressions=args))
 
     def _parse_json_key_value(self) -> t.Optional[exp.JSONKeyValue]:
         self._match_text_seq("KEY")
@@ -7315,13 +7311,13 @@ class Parser:
 
         if not key and not value:
             return None
-        return self.expression(exp.JSONKeyValue, this=key, expression=value)
+        return self.expression(exp.JSONKeyValue(this=key, expression=value))
 
     def _parse_format_json(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
         if not this or not self._match_text_seq("FORMAT", "JSON"):
             return this
 
-        return self.expression(exp.FormatJson, this=this)
+        return self.expression(exp.FormatJson(this=this))
 
     def _parse_on_condition(self) -> t.Optional[exp.OnCondition]:
         # MySQL uses "X ON EMPTY Y ON ERROR" (e.g. JSON_VALUE) while Oracle uses the opposite (e.g. JSON_EXISTS)
@@ -7337,12 +7333,7 @@ class Parser:
         if not empty and not error and not null:
             return None
 
-        return self.expression(
-            exp.OnCondition,
-            empty=empty,
-            error=error,
-            null=null,
-        )
+        return self.expression(exp.OnCondition(empty=empty, error=error, null=null))
 
     def _parse_on_handling(self, on: str, *values: str) -> t.Optional[str] | t.Optional[exp.Expr]:
         # Parses the "X ON Y" or "DEFAULT <expr> ON Y syntax, e.g. NULL ON NULL (Oracle, T-SQL, MySQL)
@@ -7389,12 +7380,13 @@ class Parser:
         encoding = self._match_text_seq("ENCODING") and self._parse_var()
 
         return self.expression(
-            exp.JSONObjectAgg if agg else exp.JSONObject,
-            expressions=expressions,
-            null_handling=null_handling,
-            unique_keys=unique_keys,
-            return_type=return_type,
-            encoding=encoding,
+            (exp.JSONObjectAgg if agg else exp.JSONObject)(
+                expressions=expressions,
+                null_handling=null_handling,
+                unique_keys=unique_keys,
+                return_type=return_type,
+                encoding=encoding,
+            )
         )
 
     # Note: this is currently incomplete; it only implements the "JSON_value_column" part
@@ -7414,19 +7406,17 @@ class Parser:
         nested_schema = nested and self._parse_json_schema()
 
         return self.expression(
-            exp.JSONColumnDef,
-            this=this,
-            kind=kind,
-            path=path,
-            nested_schema=nested_schema,
-            ordinality=ordinality,
+            exp.JSONColumnDef(
+                this=this, kind=kind, path=path, nested_schema=nested_schema, ordinality=ordinality
+            )
         )
 
     def _parse_json_schema(self) -> exp.JSONSchema:
         self._match_text_seq("COLUMNS")
         return self.expression(
-            exp.JSONSchema,
-            expressions=self._parse_wrapped_csv(self._parse_json_column_def, optional=True),
+            exp.JSONSchema(
+                expressions=self._parse_wrapped_csv(self._parse_json_column_def, optional=True)
+            )
         )
 
     def _parse_json_table(self) -> exp.JSONTable:
@@ -7471,7 +7461,7 @@ class Parser:
             modifier = None
 
         return self.expression(
-            exp.MatchAgainst, this=this, expressions=expressions, modifier=modifier
+            exp.MatchAgainst(this=this, expressions=expressions, modifier=modifier)
         )
 
     # https://learn.microsoft.com/en-us/sql/t-sql/functions/openjson-transact-sql?view=sql-server-ver16
@@ -7486,7 +7476,7 @@ class Parser:
             as_json = self._match_pair(TokenType.ALIAS, TokenType.JSON)
 
             return self.expression(
-                exp.OpenJSONColumnDef, this=this, kind=kind, path=path, as_json=as_json
+                exp.OpenJSONColumnDef(this=this, kind=kind, path=path, as_json=as_json)
             )
 
         expressions = None
@@ -7494,14 +7484,14 @@ class Parser:
             self._match_l_paren()
             expressions = self._parse_csv(_parse_open_json_column_def)
 
-        return self.expression(exp.OpenJSON, this=this, path=path, expressions=expressions)
+        return self.expression(exp.OpenJSON(this=this, path=path, expressions=expressions))
 
     def _parse_position(self, haystack_first: bool = False) -> exp.StrPosition:
         args = self._parse_csv(self._parse_bitwise)
 
         if self._match(TokenType.IN):
             return self.expression(
-                exp.StrPosition, this=self._parse_bitwise(), substr=seq_get(args, 0)
+                exp.StrPosition(this=self._parse_bitwise(), substr=seq_get(args, 0))
             )
 
         if haystack_first:
@@ -7512,7 +7502,7 @@ class Parser:
             needle = seq_get(args, 0)
 
         return self.expression(
-            exp.StrPosition, this=haystack, substr=needle, position=seq_get(args, 2)
+            exp.StrPosition(this=haystack, substr=needle, position=seq_get(args, 2))
         )
 
     def _parse_join_hint(self, func_name: str) -> exp.JoinHint:
@@ -7568,7 +7558,7 @@ class Parser:
             collation = self._parse_bitwise()
 
         return self.expression(
-            exp.Trim, this=this, position=position, expression=expression, collation=collation
+            exp.Trim(this=this, position=position, expression=expression, collation=collation)
         )
 
     def _parse_window_clause(self) -> t.Optional[t.List[exp.Expr]]:
@@ -7579,9 +7569,9 @@ class Parser:
 
     def _parse_respect_or_ignore_nulls(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
         if self._match_text_seq("IGNORE", "NULLS"):
-            return self.expression(exp.IgnoreNulls, this=this)
+            return self.expression(exp.IgnoreNulls(this=this))
         if self._match_text_seq("RESPECT", "NULLS"):
-            return self.expression(exp.RespectNulls, this=this)
+            return self.expression(exp.RespectNulls(this=this))
         return this
 
     def _parse_having_max(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
@@ -7589,7 +7579,7 @@ class Parser:
             self._match_texts(("MAX", "MIN"))
             max = self._prev.text.upper() != "MIN"
             return self.expression(
-                exp.HavingMax, this=this, expression=self._parse_column(), max=max
+                exp.HavingMax(this=this, expression=self._parse_column(), max=max)
             )
 
         return this
@@ -7604,12 +7594,12 @@ class Parser:
         # https://learn.microsoft.com/en-us/sql/t-sql/functions/percentile-disc-transact-sql?view=sql-server-ver16
         if self._match_text_seq("WITHIN", "GROUP"):
             order = self._parse_wrapped(self._parse_order)
-            this = self.expression(exp.WithinGroup, this=this, expression=order)
+            this = self.expression(exp.WithinGroup(this=this, expression=order))
 
         if self._match_pair(TokenType.FILTER, TokenType.L_PAREN):
             self._match(TokenType.WHERE)
             this = self.expression(
-                exp.Filter, this=this, expression=self._parse_where(skip_where_token=True)
+                exp.Filter(this=this, expression=self._parse_where(skip_where_token=True))
             )
             self._match_r_paren()
 
@@ -7632,7 +7622,7 @@ class Parser:
 
             if ignore_respect and ignore_respect is not this:
                 ignore_respect.replace(ignore_respect.this)
-                this = self.expression(ignore_respect.__class__, this=this)
+                this = self.expression(ignore_respect.__class__(this=this))
 
         this = self._parse_respect_or_ignore_nulls(this)
 
@@ -7650,11 +7640,7 @@ class Parser:
 
         if not self._match(TokenType.L_PAREN):
             return self.expression(
-                exp.Window,
-                comments=comments,
-                this=this,
-                alias=self._parse_id_var(False),
-                over=over,
+                exp.Window(this=this, alias=self._parse_id_var(False), over=over), comments=comments
             )
 
         window_alias = self._parse_id_var(any_token=False, tokens=self.WINDOW_ALIAS_TOKENS)
@@ -7680,13 +7666,14 @@ class Parser:
             )
 
             spec = self.expression(
-                exp.WindowSpec,
-                kind=kind,
-                start=start["value"],
-                start_side=start["side"],
-                end=end.get("value"),
-                end_side=end.get("side"),
-                exclude=exclude,
+                exp.WindowSpec(
+                    kind=kind,
+                    start=start["value"],
+                    start_side=start["side"],
+                    end=end.get("value"),
+                    end_side=end.get("side"),
+                    exclude=exclude,
+                )
             )
         else:
             spec = None
@@ -7694,15 +7681,16 @@ class Parser:
         self._match_r_paren()
 
         window = self.expression(
-            exp.Window,
+            exp.Window(
+                this=this,
+                partition_by=partition,
+                order=order,
+                spec=spec,
+                alias=window_alias,
+                over=over,
+                first=first,
+            ),
             comments=comments,
-            this=this,
-            partition_by=partition,
-            order=order,
-            spec=spec,
-            alias=window_alias,
-            over=over,
-            first=first,
         )
 
         # This covers Oracle's FIRST/LAST syntax: aggregate KEEP (...) OVER (...)
@@ -7745,10 +7733,10 @@ class Parser:
 
         if self._match(TokenType.L_PAREN):
             aliases = self.expression(
-                exp.Aliases,
+                exp.Aliases(
+                    this=this, expressions=self._parse_csv(lambda: self._parse_id_var(any_token))
+                ),
                 comments=comments,
-                this=this,
-                expressions=self._parse_csv(lambda: self._parse_id_var(any_token)),
             )
             self._match_r_paren(aliases)
             return aliases
@@ -7759,7 +7747,7 @@ class Parser:
 
         if alias:
             comments.extend(alias.pop_comments())
-            this = self.expression(exp.Alias, comments=comments, this=this, alias=alias)
+            this = self.expression(exp.Alias(this=this, alias=alias), comments=comments)
             column = this.this
 
             # Moves the comment next to the alias in `expr /* comment */ AS alias`
@@ -7816,7 +7804,7 @@ class Parser:
             or (self._match_set(tokens) if tokens else False)
         ):
             return self.expression(
-                exp.Var, this=self._prev.text.upper() if upper else self._prev.text
+                exp.Var(this=self._prev.text.upper() if upper else self._prev.text)
             )
         return self._parse_placeholder()
 
@@ -7851,7 +7839,7 @@ class Parser:
 
     def _parse_parameter(self) -> exp.Parameter:
         this = self._parse_identifier() or self._parse_primary_or_var()
-        return self.expression(exp.Parameter, this=this)
+        return self.expression(exp.Parameter(this=this))
 
     def _parse_placeholder(self) -> t.Optional[exp.Expr]:
         if self._match_set(self.PLACEHOLDER_PARSERS):
@@ -7888,11 +7876,10 @@ class Parser:
         this = parse_method()
 
         while self._match_set(expressions):
+            comments = self._prev_comments
             this = self.expression(
-                expressions[self._prev.token_type],
-                this=this,
-                comments=self._prev_comments,
-                expression=parse_method(),
+                expressions[self._prev.token_type](this=this, expression=parse_method()),
+                comments=comments,
             )
 
         return this
@@ -7952,7 +7939,7 @@ class Parser:
             if not self._match(TokenType.COMMA):
                 break
 
-        return self.expression(exp.Transaction, this=this, modes=modes)
+        return self.expression(exp.Transaction(this=this, modes=modes))
 
     def _parse_commit_or_rollback(self) -> exp.Commit | exp.Rollback:
         chain = None
@@ -7970,9 +7957,9 @@ class Parser:
             self._match_text_seq("CHAIN")
 
         if is_rollback:
-            return self.expression(exp.Rollback, savepoint=savepoint)
+            return self.expression(exp.Rollback(savepoint=savepoint))
 
-        return self.expression(exp.Commit, chain=chain)
+        return self.expression(exp.Commit(chain=chain))
 
     def _parse_refresh(self) -> exp.Refresh | exp.Command:
         if self._match(TokenType.TABLE):
@@ -7986,7 +7973,7 @@ class Parser:
         if not kind and not isinstance(this, exp.Literal):
             return self._parse_as_command(self._prev)
 
-        return self.expression(exp.Refresh, this=this, kind=kind)
+        return self.expression(exp.Refresh(this=this, kind=kind))
 
     def _parse_column_def_with_exists(self):
         start = self._index
@@ -8015,7 +8002,7 @@ class Parser:
         if self._match_texts(("FIRST", "AFTER")):
             position = self._prev.text
             column_position = self.expression(
-                exp.ColumnPosition, this=self._parse_column(), position=position
+                exp.ColumnPosition(this=self._parse_column(), position=position)
             )
             expression.set("position", column_position)
 
@@ -8030,7 +8017,7 @@ class Parser:
     # https://docs.aws.amazon.com/athena/latest/ug/alter-table-drop-partition.html
     def _parse_drop_partition(self, exists: t.Optional[bool] = None) -> exp.DropPartition:
         return self.expression(
-            exp.DropPartition, expressions=self._parse_csv(self._parse_partition), exists=exists
+            exp.DropPartition(expressions=self._parse_csv(self._parse_partition), exists=exists)
         )
 
     def _parse_alter_table_add(self) -> t.List[exp.Expr]:
@@ -8038,7 +8025,7 @@ class Parser:
             self._match_text_seq("ADD")
             if self._match_set(self.ADD_CONSTRAINT_TOKENS, advance=False):
                 return self.expression(
-                    exp.AddConstraint, expressions=self._parse_csv(self._parse_constraint)
+                    exp.AddConstraint(expressions=self._parse_csv(self._parse_constraint))
                 )
 
             column_def = self._parse_add_column()
@@ -8048,11 +8035,12 @@ class Parser:
             exists = self._parse_exists(not_=True)
             if self._match_pair(TokenType.PARTITION, TokenType.L_PAREN, advance=False):
                 return self.expression(
-                    exp.AddPartition,
-                    exists=exists,
-                    this=self._parse_field(any_token=True),
-                    location=self._match_text_seq("LOCATION", advance=False)
-                    and self._parse_property(),
+                    exp.AddPartition(
+                        exists=exists,
+                        this=self._parse_field(any_token=True),
+                        location=self._match_text_seq("LOCATION", advance=False)
+                        and self._parse_property(),
+                    )
                 )
 
             return None
@@ -8081,46 +8069,38 @@ class Parser:
         column = self._parse_field(any_token=True)
 
         if self._match_pair(TokenType.DROP, TokenType.DEFAULT):
-            return self.expression(exp.AlterColumn, this=column, drop=True)
+            return self.expression(exp.AlterColumn(this=column, drop=True))
         if self._match_pair(TokenType.SET, TokenType.DEFAULT):
-            return self.expression(exp.AlterColumn, this=column, default=self._parse_disjunction())
+            return self.expression(exp.AlterColumn(this=column, default=self._parse_disjunction()))
         if self._match(TokenType.COMMENT):
-            return self.expression(exp.AlterColumn, this=column, comment=self._parse_string())
+            return self.expression(exp.AlterColumn(this=column, comment=self._parse_string()))
         if self._match_text_seq("DROP", "NOT", "NULL"):
-            return self.expression(
-                exp.AlterColumn,
-                this=column,
-                drop=True,
-                allow_null=True,
-            )
+            return self.expression(exp.AlterColumn(this=column, drop=True, allow_null=True))
         if self._match_text_seq("SET", "NOT", "NULL"):
-            return self.expression(
-                exp.AlterColumn,
-                this=column,
-                allow_null=False,
-            )
+            return self.expression(exp.AlterColumn(this=column, allow_null=False))
 
         if self._match_text_seq("SET", "VISIBLE"):
-            return self.expression(exp.AlterColumn, this=column, visible="VISIBLE")
+            return self.expression(exp.AlterColumn(this=column, visible="VISIBLE"))
         if self._match_text_seq("SET", "INVISIBLE"):
-            return self.expression(exp.AlterColumn, this=column, visible="INVISIBLE")
+            return self.expression(exp.AlterColumn(this=column, visible="INVISIBLE"))
 
         self._match_text_seq("SET", "DATA")
         self._match_text_seq("TYPE")
         return self.expression(
-            exp.AlterColumn,
-            this=column,
-            dtype=self._parse_types(),
-            collate=self._match(TokenType.COLLATE) and self._parse_term(),
-            using=self._match(TokenType.USING) and self._parse_disjunction(),
+            exp.AlterColumn(
+                this=column,
+                dtype=self._parse_types(),
+                collate=self._match(TokenType.COLLATE) and self._parse_term(),
+                using=self._match(TokenType.USING) and self._parse_disjunction(),
+            )
         )
 
     def _parse_alter_diststyle(self) -> exp.AlterDistStyle:
         if self._match_texts(("ALL", "EVEN", "AUTO")):
-            return self.expression(exp.AlterDistStyle, this=exp.var(self._prev.text.upper()))
+            return self.expression(exp.AlterDistStyle(this=exp.var(self._prev.text.upper())))
 
         self._match_text_seq("KEY", "DISTKEY")
-        return self.expression(exp.AlterDistStyle, this=self._parse_column())
+        return self.expression(exp.AlterDistStyle(this=self._parse_column()))
 
     def _parse_alter_sortkey(self, compound: t.Optional[bool] = None) -> exp.AlterSortKey:
         if compound:
@@ -8128,12 +8108,12 @@ class Parser:
 
         if self._match(TokenType.L_PAREN, advance=False):
             return self.expression(
-                exp.AlterSortKey, expressions=self._parse_wrapped_id_vars(), compound=compound
+                exp.AlterSortKey(expressions=self._parse_wrapped_id_vars(), compound=compound)
             )
 
         self._match_texts(("AUTO", "NONE"))
         return self.expression(
-            exp.AlterSortKey, this=exp.var(self._prev.text.upper()), compound=compound
+            exp.AlterSortKey(this=exp.var(self._prev.text.upper()), compound=compound)
         )
 
     def _parse_alter_table_drop(self) -> t.List[exp.Expr]:
@@ -8156,13 +8136,13 @@ class Parser:
             if old_column is None or not to or new_column is None:
                 return None
 
-            return self.expression(exp.RenameColumn, this=old_column, to=new_column, exists=exists)
+            return self.expression(exp.RenameColumn(this=old_column, to=new_column, exists=exists))
 
         self._match_text_seq("TO")
-        return self.expression(exp.AlterRename, this=self._parse_table(schema=True))
+        return self.expression(exp.AlterRename(this=self._parse_table(schema=True)))
 
     def _parse_alter_table_set(self) -> exp.AlterSet:
-        alter_set = self.expression(exp.AlterSet)
+        alter_set = self.expression(exp.AlterSet())
 
         if self._match(TokenType.L_PAREN, advance=False) or self._match_text_seq(
             "TABLE", "PROPERTIES"
@@ -8201,13 +8181,13 @@ class Parser:
         """Parse ALTER SESSION SET/UNSET statements."""
         if self._match(TokenType.SET):
             expressions = self._parse_csv(lambda: self._parse_set_item_assignment())
-            return self.expression(exp.AlterSession, expressions=expressions, unset=False)
+            return self.expression(exp.AlterSession(expressions=expressions, unset=False))
 
         self._match_text_seq("UNSET")
         expressions = self._parse_csv(
-            lambda: self.expression(exp.SetItem, this=self._parse_id_var(any_token=True))
+            lambda: self.expression(exp.SetItem(this=self._parse_id_var(any_token=True)))
         )
-        return self.expression(exp.AlterSession, expressions=expressions, unset=True)
+        return self.expression(exp.AlterSession(expressions=expressions, unset=True))
 
     def _parse_alter(self) -> exp.Alter | exp.Command:
         start = self._prev
@@ -8240,17 +8220,18 @@ class Parser:
 
             if not self._curr and actions:
                 return self.expression(
-                    exp.Alter,
-                    this=this,
-                    kind=alter_token.text.upper(),
-                    exists=exists,
-                    actions=actions,
-                    only=only,
-                    options=options,
-                    cluster=cluster,
-                    not_valid=not_valid,
-                    check=check,
-                    cascade=cascade,
+                    exp.Alter(
+                        this=this,
+                        kind=alter_token.text.upper(),
+                        exists=exists,
+                        actions=actions,
+                        only=only,
+                        options=options,
+                        cluster=cluster,
+                        not_valid=not_valid,
+                        check=check,
+                        cascade=cascade,
+                    )
                 )
 
         return self._parse_as_command(start)
@@ -8259,7 +8240,7 @@ class Parser:
         start = self._prev
         # https://duckdb.org/docs/sql/statements/analyze
         if not self._curr:
-            return self.expression(exp.Analyze)
+            return self.expression(exp.Analyze())
 
         options = []
         while self._match_texts(self.ANALYZE_STYLES):
@@ -8309,14 +8290,15 @@ class Parser:
 
         properties = self._parse_properties()
         return self.expression(
-            exp.Analyze,
-            kind=kind,
-            this=this,
-            mode=mode,
-            partition=partition,
-            properties=properties,
-            expression=inner_expression,
-            options=options,
+            exp.Analyze(
+                kind=kind,
+                this=this,
+                mode=mode,
+                partition=partition,
+                properties=properties,
+                expression=inner_expression,
+                options=options,
+            )
         )
 
     # https://spark.apache.org/docs/3.5.1/sql-ref-syntax-aux-analyze-table.html
@@ -8341,14 +8323,15 @@ class Parser:
             sample = self._parse_number()
             expressions = [
                 self.expression(
-                    exp.AnalyzeSample,
-                    sample=sample,
-                    kind=self._prev.text.upper() if self._match(TokenType.PERCENT) else None,
+                    exp.AnalyzeSample(
+                        sample=sample,
+                        kind=self._prev.text.upper() if self._match(TokenType.PERCENT) else None,
+                    )
                 )
             ]
 
         return self.expression(
-            exp.AnalyzeStatistics, kind=kind, option=option, this=this, expressions=expressions
+            exp.AnalyzeStatistics(kind=kind, option=option, this=this, expressions=expressions)
         )
 
     # https://docs.oracle.com/en/database/oracle/oracle-database/21/sqlrf/ANALYZE.html
@@ -8371,23 +8354,23 @@ class Parser:
                 this = f"CASCADE COMPLETE {self._prev.text.upper()}"
                 expression = self._parse_into()
 
-        return self.expression(exp.AnalyzeValidate, kind=kind, this=this, expression=expression)
+        return self.expression(exp.AnalyzeValidate(kind=kind, this=this, expression=expression))
 
     def _parse_analyze_columns(self) -> t.Optional[exp.AnalyzeColumns]:
         this = self._prev.text.upper()
         if self._match_text_seq("COLUMNS"):
-            return self.expression(exp.AnalyzeColumns, this=f"{this} {self._prev.text.upper()}")
+            return self.expression(exp.AnalyzeColumns(this=f"{this} {self._prev.text.upper()}"))
         return None
 
     def _parse_analyze_delete(self) -> t.Optional[exp.AnalyzeDelete]:
         kind = self._prev.text.upper() if self._match_text_seq("SYSTEM") else None
         if self._match_text_seq("STATISTICS"):
-            return self.expression(exp.AnalyzeDelete, kind=kind)
+            return self.expression(exp.AnalyzeDelete(kind=kind))
         return None
 
     def _parse_analyze_list(self) -> t.Optional[exp.AnalyzeListChainedRows]:
         if self._match_text_seq("CHAINED", "ROWS"):
-            return self.expression(exp.AnalyzeListChainedRows, expression=self._parse_into())
+            return self.expression(exp.AnalyzeListChainedRows(expression=self._parse_into()))
         return None
 
     # https://dev.mysql.com/doc/refman/8.4/en/analyze-table.html
@@ -8411,7 +8394,7 @@ class Parser:
                     if self._match_text_seq("BUCKETS"):
                         with_expressions.append(f"{buckets} BUCKETS")
             if with_expressions:
-                expression = self.expression(exp.AnalyzeWith, expressions=with_expressions)
+                expression = self.expression(exp.AnalyzeWith(expressions=with_expressions))
 
             if self._match_texts(("MANUAL", "AUTO")) and self._match(
                 TokenType.UPDATE, advance=False
@@ -8419,14 +8402,15 @@ class Parser:
                 update_options = self._prev.text.upper()
                 self._advance()
             elif self._match_text_seq("USING", "DATA"):
-                expression = self.expression(exp.UsingData, this=self._parse_string())
+                expression = self.expression(exp.UsingData(this=self._parse_string()))
 
         return self.expression(
-            exp.AnalyzeHistogram,
-            this=this,
-            expressions=expressions,
-            expression=expression,
-            update_options=update_options,
+            exp.AnalyzeHistogram(
+                this=this,
+                expressions=expressions,
+                expression=expression,
+                update_options=update_options,
+            )
         )
 
     def _parse_merge(self) -> exp.Merge:
@@ -8440,13 +8424,14 @@ class Parser:
         using = self._parse_table()
 
         return self.expression(
-            exp.Merge,
-            this=target,
-            using=using,
-            on=self._match(TokenType.ON) and self._parse_disjunction(),
-            using_cond=self._match(TokenType.USING) and self._parse_using_identifiers(),
-            whens=self._parse_when_matched(),
-            returning=self._parse_returning(),
+            exp.Merge(
+                this=target,
+                using=using,
+                on=self._match(TokenType.ON) and self._parse_disjunction(),
+                using_cond=self._match(TokenType.USING) and self._parse_using_identifiers(),
+                whens=self._parse_when_matched(),
+                returning=self._parse_returning(),
+            )
         )
 
     def _parse_when_matched(self) -> exp.Whens:
@@ -8467,40 +8452,38 @@ class Parser:
             if self._match(TokenType.INSERT):
                 this = self._parse_star()
                 if this:
-                    then: t.Optional[exp.Expr] = self.expression(exp.Insert, this=this)
+                    then: t.Optional[exp.Expr] = self.expression(exp.Insert(this=this))
                 else:
                     then = self.expression(
-                        exp.Insert,
-                        this=exp.var("ROW")
-                        if self._match_text_seq("ROW")
-                        else self._parse_value(values=False),
-                        expression=self._match_text_seq("VALUES") and self._parse_value(),
+                        exp.Insert(
+                            this=exp.var("ROW")
+                            if self._match_text_seq("ROW")
+                            else self._parse_value(values=False),
+                            expression=self._match_text_seq("VALUES") and self._parse_value(),
+                        )
                     )
             elif self._match(TokenType.UPDATE):
                 expressions = self._parse_star()
                 if expressions:
-                    then = self.expression(exp.Update, expressions=expressions)
+                    then = self.expression(exp.Update(expressions=expressions))
                 else:
                     then = self.expression(
-                        exp.Update,
-                        expressions=self._match(TokenType.SET)
-                        and self._parse_csv(self._parse_equality),
+                        exp.Update(
+                            expressions=self._match(TokenType.SET)
+                            and self._parse_csv(self._parse_equality)
+                        )
                     )
             elif self._match(TokenType.DELETE):
-                then = self.expression(exp.Var, this=self._prev.text)
+                then = self.expression(exp.Var(this=self._prev.text))
             else:
                 then = self._parse_var_from_options(self.CONFLICT_ACTIONS)
 
             whens.append(
                 self.expression(
-                    exp.When,
-                    matched=matched,
-                    source=source,
-                    condition=condition,
-                    then=then,
+                    exp.When(matched=matched, source=source, condition=condition, then=then)
                 )
             )
-        return self.expression(exp.Whens, expressions=whens)
+        return self.expression(exp.Whens(expressions=whens))
 
     def _parse_show(self) -> t.Optional[exp.Expr]:
         parser = self._find_parser(self.SHOW_PARSERS, self.SHOW_TRIE)
@@ -8525,8 +8508,8 @@ class Parser:
         if isinstance(right, (exp.Column, exp.Identifier)):
             right = exp.var(right.name)
 
-        this = self.expression(exp.EQ, this=left, expression=right)
-        return self.expression(exp.SetItem, this=this, kind=kind)
+        this = self.expression(exp.EQ(this=left, expression=right))
+        return self.expression(exp.SetItem(this=this, kind=kind))
 
     def _parse_set_transaction(self, global_: bool = False) -> exp.Expr:
         self._match_text_seq("TRANSACTION")
@@ -8534,10 +8517,7 @@ class Parser:
             lambda: self._parse_var_from_options(self.TRANSACTION_CHARACTERISTICS)
         )
         return self.expression(
-            exp.SetItem,
-            expressions=characteristics,
-            kind="TRANSACTION",
-            global_=global_,
+            exp.SetItem(expressions=characteristics, kind="TRANSACTION", global_=global_)
         )
 
     def _parse_set_item(self) -> t.Optional[exp.Expr]:
@@ -8547,7 +8527,7 @@ class Parser:
     def _parse_set(self, unset: bool = False, tag: bool = False) -> exp.Set | exp.Command:
         index = self._index
         set_ = self.expression(
-            exp.Set, expressions=self._parse_csv(self._parse_set_item), unset=unset, tag=tag
+            exp.Set(expressions=self._parse_csv(self._parse_set_item), unset=unset, tag=tag)
         )
 
         if self._curr:
@@ -8605,16 +8585,13 @@ class Parser:
                 value = self._parse_function() or self._parse_primary_or_var()
                 if not key and value is None:
                     break
-                settings.append(self.expression(exp.DictSubProperty, this=key, value=value))
+                settings.append(self.expression(exp.DictSubProperty(this=key, value=value)))
             self._match(TokenType.R_PAREN)
 
         self._match_r_paren()
 
         return self.expression(
-            exp.DictProperty,
-            this=this,
-            kind=kind.this if kind else None,
-            settings=settings,
+            exp.DictProperty(this=this, kind=kind.this if kind else None, settings=settings)
         )
 
     def _parse_dict_range(self, this: str) -> exp.DictRange:
@@ -8628,7 +8605,7 @@ class Parser:
             max = self._parse_var() or self._parse_primary()
             min = exp.Literal.number(0)
         self._match_r_paren()
-        return self.expression(exp.DictRange, this=this, min=min, max=max)
+        return self.expression(exp.DictRange(this=this, min=min, max=max))
 
     def _parse_comprehension(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Comprehension]:
         index = self._index
@@ -8641,17 +8618,18 @@ class Parser:
         iterator = self._parse_column()
         condition = self._parse_disjunction() if self._match_text_seq("IF") else None
         return self.expression(
-            exp.Comprehension,
-            this=this,
-            expression=expression,
-            position=position,
-            iterator=iterator,
-            condition=condition,
+            exp.Comprehension(
+                this=this,
+                expression=expression,
+                position=position,
+                iterator=iterator,
+                condition=condition,
+            )
         )
 
     def _parse_heredoc(self) -> t.Optional[exp.Heredoc]:
         if self._match(TokenType.HEREDOC_STRING):
-            return self.expression(exp.Heredoc, this=self._prev.text)
+            return self.expression(exp.Heredoc(this=self._prev.text))
 
         if not self._match_text_seq("$"):
             return None
@@ -8678,7 +8656,7 @@ class Parser:
             if self._match_text_seq(*tags, advance=False):
                 this = self._find_sql(heredoc_start, self._prev)
                 self._advance(len(tags))
-                return self.expression(exp.Heredoc, this=this, tag=tag_text)
+                return self.expression(exp.Heredoc(this=this, tag=tag_text))
 
             self._advance()
 
@@ -8733,11 +8711,7 @@ class Parser:
                 dot_or_id = column.to_dot() if column.table else column.this
 
                 if typ:
-                    dot_or_id = self.expression(
-                        exp.Cast,
-                        this=dot_or_id,
-                        to=typ,
-                    )
+                    dot_or_id = self.expression(exp.Cast(this=dot_or_id, to=typ))
 
                 parent = column.parent
 
@@ -8793,14 +8767,15 @@ class Parser:
             return self._parse_as_command(start)
 
         return self.expression(
-            exp.TruncateTable,
-            expressions=expressions,
-            is_database=is_database,
-            exists=exists,
-            cluster=cluster,
-            identity=identity,
-            option=option,
-            partition=partition,
+            exp.TruncateTable(
+                expressions=expressions,
+                is_database=is_database,
+                exists=exists,
+                cluster=cluster,
+                identity=identity,
+                option=option,
+                partition=partition,
+            )
         )
 
     def _parse_with_operator(self) -> t.Optional[exp.Expr]:
@@ -8811,7 +8786,7 @@ class Parser:
 
         op = self._parse_var(any_token=True, tokens=self.RESERVED_TOKENS)
 
-        return self.expression(exp.WithOperator, this=this, op=op)
+        return self.expression(exp.WithOperator(this=this, op=op))
 
     def _parse_wrapped_options(self) -> t.List[t.Optional[exp.Expr]]:
         self._match(TokenType.EQ)
@@ -8846,7 +8821,7 @@ class Parser:
             self._match(TokenType.EQ)
             self._match(TokenType.ALIAS)
 
-            param = self.expression(exp.CopyParameter, this=option)
+            param = self.expression(exp.CopyParameter(this=option))
 
             if prev in self.COPY_INTO_VARLEN_OPTIONS and self._match(
                 TokenType.L_PAREN, advance=False
@@ -8874,7 +8849,7 @@ class Parser:
         return options
 
     def _parse_credentials(self) -> t.Optional[exp.Credentials]:
-        expr = self.expression(exp.Credentials)
+        expr = self.expression(exp.Credentials())
 
         if self._match_text_seq("STORAGE_INTEGRATION", "="):
             expr.set("storage", self._parse_field())
@@ -8931,19 +8906,14 @@ class Parser:
             return self._parse_as_command(start)
 
         return self.expression(
-            exp.Copy,
-            this=this,
-            kind=kind,
-            credentials=credentials,
-            files=files,
-            params=params,
+            exp.Copy(this=this, kind=kind, credentials=credentials, files=files, params=params)
         )
 
     def _parse_normalize(self) -> exp.Normalize:
         return self.expression(
-            exp.Normalize,
-            this=self._parse_bitwise(),
-            form=self._match(TokenType.COMMA) and self._parse_var(),
+            exp.Normalize(
+                this=self._parse_bitwise(), form=self._match(TokenType.COMMA) and self._parse_var()
+            )
         )
 
     def _parse_ceil_floor(self, expr_type: t.Type[TCeilFloor]) -> TCeilFloor:
@@ -8968,10 +8938,11 @@ class Parser:
             return this
 
         return self.expression(
-            exp.Star,
-            except_=self._parse_star_op("EXCEPT", "EXCLUDE"),
-            replace=self._parse_star_op("REPLACE"),
-            rename=self._parse_star_op("RENAME"),
+            exp.Star(
+                except_=self._parse_star_op("EXCEPT", "EXCLUDE"),
+                replace=self._parse_star_op("REPLACE"),
+                rename=self._parse_star_op("RENAME"),
+            )
         ).update_positions(star_token)
 
     def _parse_grant_privilege(self) -> t.Optional[exp.GrantPrivilege]:
@@ -8990,7 +8961,7 @@ class Parser:
             else None
         )
 
-        return self.expression(exp.GrantPrivilege, this=this, expressions=expressions)
+        return self.expression(exp.GrantPrivilege(this=this, expressions=expressions))
 
     def _parse_grant_principal(self) -> t.Optional[exp.GrantPrincipal]:
         kind = self._match_texts(("ROLE", "GROUP")) and self._prev.text.upper()
@@ -8999,7 +8970,7 @@ class Parser:
         if not principal:
             return None
 
-        return self.expression(exp.GrantPrincipal, this=principal, kind=kind)
+        return self.expression(exp.GrantPrincipal(this=principal, kind=kind))
 
     def _parse_grant_revoke_common(
         self,
@@ -9031,12 +9002,13 @@ class Parser:
             return self._parse_as_command(start)
 
         return self.expression(
-            exp.Grant,
-            privileges=privileges,
-            kind=kind,
-            securable=securable,
-            principals=principals,
-            grant_option=grant_option,
+            exp.Grant(
+                privileges=privileges,
+                kind=kind,
+                securable=securable,
+                principals=principals,
+                grant_option=grant_option,
+            )
         )
 
     def _parse_revoke(self) -> exp.Revoke | exp.Command:
@@ -9059,13 +9031,14 @@ class Parser:
             return self._parse_as_command(start)
 
         return self.expression(
-            exp.Revoke,
-            privileges=privileges,
-            kind=kind,
-            securable=securable,
-            principals=principals,
-            grant_option=grant_option,
-            cascade=cascade,
+            exp.Revoke(
+                privileges=privileges,
+                kind=kind,
+                securable=securable,
+                principals=principals,
+                grant_option=grant_option,
+                cascade=cascade,
+            )
         )
 
     def _parse_overlay(self) -> exp.Overlay:
@@ -9077,39 +9050,41 @@ class Parser:
             )
 
         return self.expression(
-            exp.Overlay,
-            this=self._parse_bitwise(),
-            expression=_parse_overlay_arg("PLACING"),
-            from_=_parse_overlay_arg("FROM"),
-            for_=_parse_overlay_arg("FOR"),
+            exp.Overlay(
+                this=self._parse_bitwise(),
+                expression=_parse_overlay_arg("PLACING"),
+                from_=_parse_overlay_arg("FROM"),
+                for_=_parse_overlay_arg("FOR"),
+            )
         )
 
     def _parse_format_name(self) -> exp.Property:
         # Note: Although not specified in the docs, Snowflake does accept a string/identifier
         # for FILE_FORMAT = <format_name>
         return self.expression(
-            exp.Property,
-            this=exp.var("FORMAT_NAME"),
-            value=self._parse_string() or self._parse_table_parts(),
+            exp.Property(
+                this=exp.var("FORMAT_NAME"), value=self._parse_string() or self._parse_table_parts()
+            )
         )
 
     def _parse_max_min_by(self, expr_type: t.Type[exp.AggFunc]) -> exp.AggFunc:
         args: t.List[exp.Expr] = []
 
         if self._match(TokenType.DISTINCT):
-            args.append(self.expression(exp.Distinct, expressions=[self._parse_lambda()]))
+            args.append(self.expression(exp.Distinct(expressions=[self._parse_lambda()])))
             self._match(TokenType.COMMA)
 
         args.extend(self._parse_function_args())
 
         return self.expression(
-            expr_type, this=seq_get(args, 0), expression=seq_get(args, 1), count=seq_get(args, 2)
+            expr_type(this=seq_get(args, 0), expression=seq_get(args, 1), count=seq_get(args, 2))
         )
 
     def _identifier_expression(
-        self, token: t.Optional[Token] = None, **kwargs: t.Any
+        self, token: t.Optional[Token] = None, quoted: t.Optional[bool] = None
     ) -> exp.Identifier:
-        return self.expression(exp.Identifier, token=token or self._prev, **kwargs)
+        token = token or self._prev
+        return self.expression(exp.Identifier(this=token.text, quoted=quoted), token)
 
     def _build_pipe_cte(
         self,
@@ -9315,7 +9290,7 @@ class Parser:
             self._match(TokenType.DEFAULT) or self._match(TokenType.EQ)
         ) and self._parse_bitwise()
 
-        return self.expression(exp.DeclareItem, this=vars, kind=kind, default=default)
+        return self.expression(exp.DeclareItem(this=vars, kind=kind, default=default))
 
     def _parse_declare(self) -> exp.Declare | exp.Command:
         start = self._prev
@@ -9325,7 +9300,7 @@ class Parser:
         if not expressions or self._curr:
             return self._parse_as_command(start)
 
-        return self.expression(exp.Declare, expressions=expressions, replace=replace)
+        return self.expression(exp.Declare(expressions=expressions, replace=replace))
 
     def build_cast(self, strict: bool, **kwargs) -> exp.Cast:
         exp_class = exp.Cast if strict else exp.TryCast
@@ -9333,7 +9308,7 @@ class Parser:
         if exp_class == exp.TryCast:
             kwargs["requires_string"] = self.dialect.TRY_CAST_REQUIRES_STRING
 
-        return self.expression(exp_class, **kwargs)
+        return self.expression(exp_class(**kwargs))
 
     def _parse_json_value(self) -> exp.JSONValue:
         this = self._parse_bitwise()
@@ -9343,11 +9318,12 @@ class Parser:
         returning = self._match(TokenType.RETURNING) and self._parse_type()
 
         return self.expression(
-            exp.JSONValue,
-            this=this,
-            path=self.dialect.to_json_path(path),
-            returning=returning,
-            on_condition=self._parse_on_condition(),
+            exp.JSONValue(
+                this=this,
+                path=self.dialect.to_json_path(path),
+                returning=returning,
+                on_condition=self._parse_on_condition(),
+            )
         )
 
     def _parse_group_concat(self) -> t.Optional[exp.Expr]:
@@ -9355,10 +9331,11 @@ class Parser:
             if isinstance(node, exp.Distinct) and len(node.expressions) > 1:
                 concat_exprs = [
                     self.expression(
-                        exp.Concat,
-                        expressions=node.expressions,
-                        safe=True,
-                        coalesce=self.dialect.CONCAT_COALESCE,
+                        exp.Concat(
+                            expressions=node.expressions,
+                            safe=True,
+                            coalesce=self.dialect.CONCAT_COALESCE,
+                        )
                     )
                 ]
                 node.set("expressions", concat_exprs)
@@ -9366,7 +9343,7 @@ class Parser:
             if len(exprs) == 1:
                 return exprs[0]
             return self.expression(
-                exp.Concat, expressions=args, safe=True, coalesce=self.dialect.CONCAT_COALESCE
+                exp.Concat(expressions=args, safe=True, coalesce=self.dialect.CONCAT_COALESCE)
             )
 
         args = self._parse_csv(self._parse_lambda)
@@ -9386,7 +9363,7 @@ class Parser:
 
         separator = self._parse_field() if self._match(TokenType.SEPARATOR) else None
 
-        return self.expression(exp.GroupConcat, this=this, separator=separator)
+        return self.expression(exp.GroupConcat(this=this, separator=separator))
 
     def _parse_initcap(self) -> exp.Initcap:
         expr = exp.Initcap.from_arg_list(self._parse_function_args())
@@ -9407,12 +9384,10 @@ class Parser:
                 op += self._curr.text
                 self._advance()
 
+            comments = self._prev_comments
             this = self.expression(
-                exp.Operator,
-                comments=self._prev_comments,
-                this=this,
-                operator=op,
-                expression=self._parse_bitwise(),
+                exp.Operator(this=this, operator=op, expression=self._parse_bitwise()),
+                comments=comments,
             )
 
             if not self._match(TokenType.OPERATOR):

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -271,12 +271,10 @@ class BigQueryParser(parser.Parser):
     FUNCTION_PARSERS = {
         **{k: v for k, v in parser.Parser.FUNCTION_PARSERS.items() if k != "TRIM"},
         "ARRAY": lambda self: self.expression(
-            exp.Array,
-            expressions=[self._parse_statement()],
-            struct_name_inheritance=True,
+            exp.Array(expressions=[self._parse_statement()], struct_name_inheritance=True)
         ),
         "JSON_ARRAY": lambda self: self.expression(
-            exp.JSONArray, expressions=self._parse_csv(self._parse_bitwise)
+            exp.JSONArray(expressions=self._parse_csv(self._parse_bitwise))
         ),
         "MAKE_INTERVAL": lambda self: self._parse_make_interval(),
         "PREDICT": lambda self: self._parse_ml(exp.Predict),
@@ -301,7 +299,7 @@ class BigQueryParser(parser.Parser):
     PROPERTY_PARSERS: t.ClassVar = {
         **parser.Parser.PROPERTY_PARSERS,
         "NOT DETERMINISTIC": lambda self: self.expression(
-            exp.StabilityProperty, this=exp.Literal.string("VOLATILE")
+            exp.StabilityProperty(this=exp.Literal.string("VOLATILE"))
         ),
         "OPTIONS": lambda self: self._parse_with_property(),
     }
@@ -344,7 +342,7 @@ class BigQueryParser(parser.Parser):
         if self._match(TokenType.COMMAND):
             self._retreat(index)
             return self._parse_as_command(self._prev)
-        return self.expression(exp.ForIn, this=this, expression=self._parse_statement())
+        return self.expression(exp.ForIn(this=this, expression=self._parse_statement()))
 
     def _parse_table_part(self, schema: bool = False) -> t.Optional[exp.Expr]:
         this = super()._parse_table_part(schema=schema) or self._parse_number()
@@ -581,11 +579,9 @@ class BigQueryParser(parser.Parser):
         self._match(TokenType.COMMA)
 
         return self.expression(
-            expr_type,
-            this=this,
-            expression=expression,
-            params_struct=self._parse_bitwise(),
-            **kwargs,
+            expr_type(
+                this=this, expression=expression, params_struct=self._parse_bitwise(), **kwargs
+            )
         )
 
     def _parse_translate(self) -> exp.Translate | exp.MLTranslate:
@@ -600,7 +596,7 @@ class BigQueryParser(parser.Parser):
         self._match(TokenType.TABLE)
         this = self._parse_table()
 
-        expr = self.expression(exp.FeaturesAtTime, this=this)
+        expr = self.expression(exp.FeaturesAtTime(this=this))
 
         while self._match(TokenType.COMMA):
             arg = self._parse_lambda()
@@ -625,10 +621,9 @@ class BigQueryParser(parser.Parser):
         query_table = self._parse_table()
 
         expr = self.expression(
-            exp.VectorSearch,
-            this=base_table,
-            column_to_search=column_to_search,
-            query_table=query_table,
+            exp.VectorSearch(
+                this=base_table, column_to_search=column_to_search, query_table=query_table
+            )
         )
 
         while self._match(TokenType.COMMA):
@@ -647,10 +642,11 @@ class BigQueryParser(parser.Parser):
         self._match_text_seq("DATA")
 
         return self.expression(
-            exp.Export,
-            connection=self._match_text_seq("WITH", "CONNECTION") and self._parse_table_parts(),
-            options=self._parse_properties(),
-            this=self._match_text_seq("AS") and self._parse_select(),
+            exp.Export(
+                connection=self._match_text_seq("WITH", "CONNECTION") and self._parse_table_parts(),
+                options=self._parse_properties(),
+                this=self._match_text_seq("AS") and self._parse_select(),
+            )
         )
 
     def _parse_column_ops(self, this: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -360,7 +360,7 @@ class ClickHouseParser(parser.Parser):
 
     FUNCTION_PARSERS = {
         **{k: v for k, v in parser.Parser.FUNCTION_PARSERS.items() if k != "MATCH"},
-        "ARRAYJOIN": lambda self: self.expression(exp.Explode, this=self._parse_expression()),
+        "ARRAYJOIN": lambda self: self.expression(exp.Explode(this=self._parse_expression())),
         "QUANTILE": lambda self: self._parse_quantile(),
         "MEDIAN": lambda self: self._parse_quantile(),
         "COLUMNS": lambda self: self._parse_columns(),
@@ -392,7 +392,7 @@ class ClickHouseParser(parser.Parser):
     COLUMN_OPERATORS = {
         **{k: v for k, v in parser.Parser.COLUMN_OPERATORS.items() if k != TokenType.PLACEHOLDER},
         TokenType.DOTCARET: lambda self, this, field: self.expression(
-            exp.NestedJSONSelect, this=this, expression=field
+            exp.NestedJSONSelect(this=this, expression=field)
         ),
     }
 
@@ -464,19 +464,18 @@ class ClickHouseParser(parser.Parser):
 
     def _parse_check_constraint(self) -> t.Optional[exp.CheckColumnConstraint]:
         return self.expression(
-            exp.CheckColumnConstraint, this=self._parse_wrapped_select_or_assignment()
+            exp.CheckColumnConstraint(this=self._parse_wrapped_select_or_assignment())
         )
 
     def _parse_assume_constraint(self) -> t.Optional[exp.AssumeColumnConstraint]:
         return self.expression(
-            exp.AssumeColumnConstraint, this=self._parse_wrapped_select_or_assignment()
+            exp.AssumeColumnConstraint(this=self._parse_wrapped_select_or_assignment())
         )
 
     def _parse_engine_property(self) -> exp.EngineProperty:
         self._match(TokenType.EQ)
         return self.expression(
-            exp.EngineProperty,
-            this=self._parse_field(any_token=True, anonymous_func=True),
+            exp.EngineProperty(this=self._parse_field(any_token=True, anonymous_func=True))
         )
 
     # https://clickhouse.com/docs/en/sql-reference/statements/create/function
@@ -513,7 +512,7 @@ class ClickHouseParser(parser.Parser):
         # TODO: can we somehow convert the former into an equivalent `regexpExtract` call?
         self._match(TokenType.COMMA)
         return self.expression(
-            exp.Anonymous, this="extract", expressions=[this, self._parse_bitwise()]
+            exp.Anonymous(this="extract", expressions=[this, self._parse_bitwise()])
         )
 
     def _parse_assignment(self) -> t.Optional[exp.Expr]:
@@ -521,10 +520,11 @@ class ClickHouseParser(parser.Parser):
 
         if self._match(TokenType.PLACEHOLDER):
             return self.expression(
-                exp.If,
-                this=this,
-                true=self._parse_assignment(),
-                false=self._match(TokenType.COLON) and self._parse_assignment(),
+                exp.If(
+                    this=this,
+                    true=self._parse_assignment(),
+                    false=self._match(TokenType.COLON) and self._parse_assignment(),
+                )
             )
 
         return this
@@ -551,7 +551,7 @@ class ClickHouseParser(parser.Parser):
         if isinstance(this, exp.Identifier) and not this.quoted:
             this = exp.var(this.name)
 
-        return self.expression(exp.Placeholder, this=this, kind=kind)
+        return self.expression(exp.Placeholder(this=this, kind=kind))
 
     def _parse_bracket(self, this: t.Optional[exp.Expr] = None) -> t.Optional[exp.Expr]:
         if this:
@@ -570,7 +570,7 @@ class ClickHouseParser(parser.Parser):
                 )
 
             if bracket_json_type:
-                return self.expression(exp.JSONCast, this=this, to=bracket_json_type)
+                return self.expression(exp.JSONCast(this=this, to=bracket_json_type))
 
         l_brace = self._match(TokenType.L_BRACE, advance=False)
         bracket = super()._parse_bracket(this)
@@ -594,7 +594,7 @@ class ClickHouseParser(parser.Parser):
         if self._match(TokenType.IN):
             in_expr = self._parse_in(this)
             in_expr.set("is_global", True)
-        return self.expression(exp.Not, this=in_expr) if is_negated else t.cast(exp.In, in_expr)
+        return self.expression(exp.Not(this=in_expr)) if is_negated else t.cast(exp.In, in_expr)
 
     def _parse_table(
         self,
@@ -622,7 +622,7 @@ class ClickHouseParser(parser.Parser):
                 alias.set("columns", [exp.to_identifier("generate_series")])
 
         if self._match(TokenType.FINAL):
-            this = self.expression(exp.Final, this=this)
+            this = self.expression(exp.Final(this=this))
 
         return this
 
@@ -637,10 +637,7 @@ class ClickHouseParser(parser.Parser):
         if not cte:
             # WITH <expression> AS <identifier>
             cte = self.expression(
-                exp.CTE,
-                this=self._parse_assignment(),
-                alias=self._parse_table_alias(),
-                scalar=True,
+                exp.CTE(this=self._parse_assignment(), alias=self._parse_table_alias(), scalar=True)
             )
 
         return cte
@@ -696,10 +693,6 @@ class ClickHouseParser(parser.Parser):
             anon_func: exp.Anonymous = t.cast(exp.Anonymous, func)
             params = self._parse_func_params(anon_func)
 
-            kwargs = {
-                "this": anon_func.this,
-                "expressions": anon_func.expressions,
-            }
             if len(parts[1]) > 0:
                 exp_class: t.Type[exp.Expr] = (
                     exp.CombinedParameterizedAgg if params else exp.CombinedAggFunc
@@ -707,11 +700,10 @@ class ClickHouseParser(parser.Parser):
             else:
                 exp_class = exp.ParameterizedAgg if params else exp.AnonymousAggFunc
 
-            kwargs["exp_class"] = exp_class
+            instance = exp_class(this=anon_func.this, expressions=anon_func.expressions)
             if params:
-                kwargs["params"] = params
-
-            func = self.expression(**kwargs)
+                instance.set("params", params)
+            func = self.expression(instance)
 
             if isinstance(expr, exp.Window):
                 # The window's func was parsed as Anonymous in base parser, fix its
@@ -741,8 +733,8 @@ class ClickHouseParser(parser.Parser):
         this = self._parse_lambda()
         params = self._parse_func_params()
         if params:
-            return self.expression(exp.Quantile, this=params[0], quantile=this)
-        return self.expression(exp.Quantile, this=this, quantile=exp.Literal.number(0.5))
+            return self.expression(exp.Quantile(this=params[0], quantile=this))
+        return self.expression(exp.Quantile(this=this, quantile=exp.Literal.number(0.5)))
 
     def _parse_wrapped_id_vars(self, optional: bool = False) -> t.List[exp.Expr]:
         return super()._parse_wrapped_id_vars(optional=True)
@@ -772,7 +764,7 @@ class ClickHouseParser(parser.Parser):
         if self._match_text_seq("CLUSTER"):
             this = self._parse_string() or self._parse_id_var()
             if this:
-                return self.expression(exp.OnCluster, this=this)
+                return self.expression(exp.OnCluster(this=this))
             else:
                 self._retreat(index)
         return None
@@ -787,11 +779,9 @@ class ClickHouseParser(parser.Parser):
         granularity = self._match_text_seq("GRANULARITY") and self._parse_term()
 
         return self.expression(
-            exp.IndexColumnConstraint,
-            this=this,
-            expression=expression,
-            index_type=index_type,
-            granularity=granularity,
+            exp.IndexColumnConstraint(
+                this=this, expression=expression, index_type=index_type, granularity=granularity
+            )
         )
 
     def _parse_partition(self) -> t.Optional[exp.Partition]:
@@ -802,12 +792,12 @@ class ClickHouseParser(parser.Parser):
         if self._match_text_seq("ID"):
             # Corresponds to the PARTITION ID <string_value> syntax
             expressions: t.List[exp.Expr] = [
-                self.expression(exp.PartitionId, this=self._parse_string())
+                self.expression(exp.PartitionId(this=self._parse_string()))
             ]
         else:
             expressions = self._parse_expressions()
 
-        return self.expression(exp.Partition, expressions=expressions)
+        return self.expression(exp.Partition(expressions=expressions))
 
     def _parse_alter_table_replace(self) -> t.Optional[exp.Expr]:
         partition = self._parse_partition()
@@ -816,12 +806,12 @@ class ClickHouseParser(parser.Parser):
             return None
 
         return self.expression(
-            exp.ReplacePartition, expression=partition, source=self._parse_table_parts()
+            exp.ReplacePartition(expression=partition, source=self._parse_table_parts())
         )
 
     def _parse_alter_table_modify(self) -> t.Optional[exp.Expr]:
         if properties := self._parse_properties():
-            return self.expression(exp.AlterModifySqlSecurity, expressions=properties.expressions)
+            return self.expression(exp.AlterModifySqlSecurity(expressions=properties.expressions))
         return None
 
     def _parse_definer(self) -> t.Optional[exp.DefinerProperty]:
@@ -835,9 +825,9 @@ class ClickHouseParser(parser.Parser):
             return None
 
         return self.expression(
-            exp.ProjectionDef,
-            this=self._parse_id_var(),
-            expression=self._parse_wrapped(self._parse_statement),
+            exp.ProjectionDef(
+                this=self._parse_id_var(), expression=self._parse_wrapped(self._parse_statement)
+            )
         )
 
     def _parse_constraint(self) -> t.Optional[exp.Expr]:
@@ -864,7 +854,7 @@ class ClickHouseParser(parser.Parser):
         return this
 
     def _parse_columns(self) -> exp.Expr:
-        this: exp.Expr = self.expression(exp.Columns, this=self._parse_lambda())
+        this: exp.Expr = self.expression(exp.Columns(this=self._parse_lambda()))
 
         while self._next and self._match_text_seq(")", "APPLY", "("):
             self._match(TokenType.R_PAREN)
@@ -885,7 +875,7 @@ class ClickHouseParser(parser.Parser):
         if values and not isinstance(expressions[-1], exp.Tuple):
             value.set(
                 "expressions",
-                [self.expression(exp.Tuple, expressions=[expr]) for expr in expressions],
+                [self.expression(exp.Tuple(expressions=[expr])) for expr in expressions],
             )
 
         return value
@@ -893,10 +883,7 @@ class ClickHouseParser(parser.Parser):
     def _parse_partitioned_by(self) -> exp.PartitionedByProperty:
         # ClickHouse allows custom expressions as partition key
         # https://clickhouse.com/docs/engines/table-engines/mergetree-family/custom-partitioning-key
-        return self.expression(
-            exp.PartitionedByProperty,
-            this=self._parse_assignment(),
-        )
+        return self.expression(exp.PartitionedByProperty(this=self._parse_assignment()))
 
     def _parse_detach(self) -> exp.Detach:
         kind = self._match_set(self.DB_CREATABLES) and self._prev.text.upper()
@@ -904,11 +891,12 @@ class ClickHouseParser(parser.Parser):
         this = self._parse_table_parts()
 
         return self.expression(
-            exp.Detach,
-            this=this,
-            kind=kind,
-            exists=exists,
-            cluster=self._parse_on_property() if self._match(TokenType.ON) else None,
-            permanent=self._match_text_seq("PERMANENTLY"),
-            sync=self._match_text_seq("SYNC"),
+            exp.Detach(
+                this=this,
+                kind=kind,
+                exists=exists,
+                cluster=self._parse_on_property() if self._match(TokenType.ON) else None,
+                permanent=self._match_text_seq("PERMANENTLY"),
+                sync=self._match_text_seq("SYNC"),
+            )
         )

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -54,4 +54,4 @@ class DatabricksParser(SparkParser):
         # CURDATE, an alias for CURRENT_DATE, has optional parentheses
         if self._match(TokenType.L_PAREN):
             self._match_r_paren()
-        return self.expression(exp.CurrentDate)
+        return self.expression(exp.CurrentDate())

--- a/sqlglot/parsers/doris.py
+++ b/sqlglot/parsers/doris.py
@@ -75,9 +75,9 @@ class DorisParser(MySQLParser):
         self._match_r_paren()
 
         return self.expression(
-            exp.PartitionByRangeProperty,
-            partition_expressions=expr,
-            create_expressions=create_expressions,
+            exp.PartitionByRangeProperty(
+                partition_expressions=expr, create_expressions=create_expressions
+            )
         )
 
     def _parse_partitioning_granularity_dynamic(self) -> exp.PartitionByRangePropertyDynamic:
@@ -88,9 +88,9 @@ class DorisParser(MySQLParser):
         self._match_text_seq("INTERVAL")
         number = self._parse_number()
         unit = self._parse_var(any_token=True)
-        every = self.expression(exp.Interval, this=number, unit=unit)
+        every = self.expression(exp.Interval(this=number, unit=unit))
         return self.expression(
-            exp.PartitionByRangePropertyDynamic, start=start, end=end, every=every
+            exp.PartitionByRangePropertyDynamic(start=start, end=end, every=every)
         )
 
     def _parse_partition_range_value(self) -> t.Optional[exp.Expr]:
@@ -109,11 +109,11 @@ class DorisParser(MySQLParser):
         self._match(TokenType.R_BRACKET)
         self._match(TokenType.R_PAREN)
 
-        part_range = self.expression(exp.PartitionRange, this=name, expressions=values)
-        return self.expression(exp.Partition, expressions=[part_range])
+        part_range = self.expression(exp.PartitionRange(this=name, expressions=values))
+        return self.expression(exp.Partition(expressions=[part_range]))
 
     def _parse_build_property(self) -> exp.BuildProperty:
-        return self.expression(exp.BuildProperty, this=self._parse_var(upper=True))
+        return self.expression(exp.BuildProperty(this=self._parse_var(upper=True)))
 
     def _parse_refresh_property(self) -> exp.RefreshTriggerProperty:
         method = self._parse_var(upper=True)
@@ -126,10 +126,7 @@ class DorisParser(MySQLParser):
         starts = self._match_text_seq("STARTS") and self._parse_string()
 
         return self.expression(
-            exp.RefreshTriggerProperty,
-            method=method,
-            kind=kind,
-            every=every,
-            unit=unit,
-            starts=starts,
+            exp.RefreshTriggerProperty(
+                method=method, kind=kind, every=every, unit=unit, starts=starts
+            )
         )

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -192,7 +192,7 @@ class DuckDBParser(parser.Parser):
     PLACEHOLDER_PARSERS = {
         **parser.Parser.PLACEHOLDER_PARSERS,
         TokenType.PARAMETER: lambda self: (
-            self.expression(exp.Placeholder, this=self._prev.text)
+            self.expression(exp.Placeholder(this=self._prev.text))
             if self._match(TokenType.NUMBER) or self._match_set(self.ID_VAR_TOKENS)
             else None
         ),
@@ -230,7 +230,7 @@ class DuckDBParser(parser.Parser):
             return None
 
         this = self._replace_lambda(self._parse_assignment(), expressions)
-        return self.expression(exp.Lambda, this=this, expressions=expressions, colon=True)
+        return self.expression(exp.Lambda(this=this, expressions=expressions, colon=True))
 
     def _parse_expression(self) -> t.Optional[exp.Expr]:
         # DuckDB supports prefix aliases, e.g. foo: 1
@@ -244,7 +244,7 @@ class DuckDBParser(parser.Parser):
                 # Moves the comment next to the alias in `alias: expr /* comment */`
                 comments += this.pop_comments() or []
 
-            return self.expression(exp.Alias, comments=comments, this=this, alias=alias)
+            return self.expression(exp.Alias(this=this, alias=alias), comments=comments)
 
         return super()._parse_expression()
 
@@ -305,10 +305,10 @@ class DuckDBParser(parser.Parser):
 
     def _parse_map(self) -> exp.ToMap | exp.Map:
         if self._match(TokenType.L_BRACE, advance=False):
-            return self.expression(exp.ToMap, this=self._parse_bracket())
+            return self.expression(exp.ToMap(this=self._parse_bracket()))
 
         args = self._parse_wrapped_csv(self._parse_assignment)
-        return self.expression(exp.Map, keys=seq_get(args, 0), values=seq_get(args, 1))
+        return self.expression(exp.Map(keys=seq_get(args, 0), values=seq_get(args, 1)))
 
     def _parse_struct_types(self, type_required: bool = False) -> t.Optional[exp.Expr]:
         return self._parse_field_def()
@@ -321,9 +321,10 @@ class DuckDBParser(parser.Parser):
     def _parse_attach_detach(self, is_attach: bool = True) -> exp.Attach | exp.Detach:
         def _parse_attach_option() -> exp.AttachOption:
             return self.expression(
-                exp.AttachOption,
-                this=self._parse_var(any_token=True),
-                expression=self._parse_field(any_token=True),
+                exp.AttachOption(
+                    this=self._parse_var(any_token=True),
+                    expression=self._parse_field(any_token=True),
+                )
             )
 
         self._match(TokenType.DATABASE)
@@ -336,13 +337,13 @@ class DuckDBParser(parser.Parser):
             expressions = None
 
         return (
-            self.expression(exp.Attach, this=this, exists=exists, expressions=expressions)
+            self.expression(exp.Attach(this=this, exists=exists, expressions=expressions))
             if is_attach
-            else self.expression(exp.Detach, this=this, exists=exists)
+            else self.expression(exp.Detach(this=this, exists=exists))
         )
 
     def _parse_show_duckdb(self, this: str) -> exp.Show:
-        return self.expression(exp.Show, this=this)
+        return self.expression(exp.Show(this=this))
 
     def _parse_force(self) -> exp.Install | exp.Command:
         # FORCE can only be followed by INSTALL or CHECKPOINT
@@ -354,10 +355,11 @@ class DuckDBParser(parser.Parser):
 
     def _parse_install(self, force: bool = False) -> exp.Install:
         return self.expression(
-            exp.Install,
-            this=self._parse_id_var(),
-            from_=self._parse_var_or_string() if self._match(TokenType.FROM) else None,
-            force=force,
+            exp.Install(
+                this=self._parse_id_var(),
+                from_=self._parse_var_or_string() if self._match(TokenType.FROM) else None,
+                force=force,
+            )
         )
 
     def _parse_primary(self) -> t.Optional[exp.Expr]:

--- a/sqlglot/parsers/exasol.py
+++ b/sqlglot/parsers/exasol.py
@@ -91,18 +91,14 @@ class ExasolParser(parser.Parser):
     CONSTRAINT_PARSERS = {
         **parser.Parser.CONSTRAINT_PARSERS,
         "COMMENT": lambda self: self.expression(
-            exp.CommentColumnConstraint,
-            this=self._match(TokenType.IS) and self._parse_string(),
+            exp.CommentColumnConstraint(this=self._match(TokenType.IS) and self._parse_string())
         ),
     }
 
     RANGE_PARSERS = {
         **parser.Parser.RANGE_PARSERS,
         TokenType.RLIKE: lambda self, this: self.expression(
-            exp.RegexpLike,
-            this=this,
-            expression=self._parse_bitwise(),
-            full_match=True,
+            exp.RegexpLike(this=this, expression=self._parse_bitwise(), full_match=True)
         ),
     }
 

--- a/sqlglot/parsers/hive.py
+++ b/sqlglot/parsers/hive.py
@@ -154,20 +154,21 @@ class HiveParser(parser.Parser):
             record_reader = self._parse_string()
 
         return self.expression(
-            exp.QueryTransform,
-            expressions=args,
-            command_script=command_script,
-            schema=schema,
-            row_format_before=row_format_before,
-            record_writer=record_writer,
-            row_format_after=row_format_after,
-            record_reader=record_reader,
+            exp.QueryTransform(
+                expressions=args,
+                command_script=command_script,
+                schema=schema,
+                row_format_before=row_format_before,
+                record_writer=record_writer,
+                row_format_after=row_format_after,
+                record_reader=record_reader,
+            )
         )
 
     def _parse_quantile_function(self, func: t.Type[F]) -> F:
         if self._match(TokenType.DISTINCT):
             first_arg: t.Optional[exp.Expr] = self.expression(
-                exp.Distinct, expressions=[self._parse_lambda()]
+                exp.Distinct(expressions=[self._parse_lambda()])
             )
         else:
             self._match(TokenType.ALL)
@@ -221,11 +222,7 @@ class HiveParser(parser.Parser):
         this = self._parse_field(any_token=True)
 
         if self.CHANGE_COLUMN_ALTER_SYNTAX and self._match_text_seq("TYPE"):
-            return self.expression(
-                exp.AlterColumn,
-                this=this,
-                dtype=self._parse_types(schema=True),
-            )
+            return self.expression(exp.AlterColumn(this=this, dtype=self._parse_types(schema=True)))
 
         column_new = self._parse_field(any_token=True)
         dtype = self._parse_types(schema=True)
@@ -238,11 +235,7 @@ class HiveParser(parser.Parser):
             )
 
         return self.expression(
-            exp.AlterColumn,
-            this=this,
-            rename_to=column_new,
-            dtype=dtype,
-            comment=comment,
+            exp.AlterColumn(this=this, rename_to=column_new, dtype=dtype, comment=comment)
         )
 
     def _parse_partition_and_order(
@@ -264,7 +257,7 @@ class HiveParser(parser.Parser):
             self._parse_identifier() or self._parse_primary_or_var()
         )
         self._match(TokenType.R_BRACE)
-        return self.expression(exp.Parameter, this=this, expression=expression)
+        return self.expression(exp.Parameter(this=this, expression=expression))
 
     def _to_prop_eq(self, expression: exp.Expr, index: int) -> exp.Expr:
         if expression.is_star:
@@ -275,4 +268,4 @@ class HiveParser(parser.Parser):
         else:
             key = exp.to_identifier(f"col{index + 1}")
 
-        return self.expression(exp.PropertyEQ, this=key, expression=expression)
+        return self.expression(exp.PropertyEQ(this=key, expression=expression))

--- a/sqlglot/parsers/materialize.py
+++ b/sqlglot/parsers/materialize.py
@@ -18,7 +18,7 @@ class MaterializeParser(PostgresParser):
     LAMBDAS = {
         **PostgresParser.LAMBDAS,
         TokenType.FARROW: lambda self, expressions: self.expression(
-            exp.Kwarg, this=seq_get(expressions, 0), expression=self._parse_assignment()
+            exp.Kwarg(this=seq_get(expressions, 0), expression=self._parse_assignment())
         ),
     }
 
@@ -27,7 +27,7 @@ class MaterializeParser(PostgresParser):
 
     def _parse_map(self) -> exp.ToMap:
         if self._match(TokenType.L_PAREN):
-            to_map = self.expression(exp.ToMap, this=self._parse_select())
+            to_map = self.expression(exp.ToMap(this=self._parse_select()))
             self._match_r_paren()
             return to_map
 
@@ -42,4 +42,4 @@ class MaterializeParser(PostgresParser):
         if not self._match(TokenType.R_BRACKET):
             self.raise_error("Expecting ]")
 
-        return self.expression(exp.ToMap, this=self.expression(exp.Struct, expressions=entries))
+        return self.expression(exp.ToMap(this=self.expression(exp.Struct(expressions=entries))))

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -77,14 +77,13 @@ class MySQLParser(parser.Parser):
     RANGE_PARSERS = {
         **parser.Parser.RANGE_PARSERS,
         TokenType.SOUNDS_LIKE: lambda self, this: self.expression(
-            exp.EQ,
-            this=self.expression(exp.Soundex, this=this),
-            expression=self.expression(exp.Soundex, this=self._parse_term()),
+            exp.EQ(
+                this=self.expression(exp.Soundex(this=this)),
+                expression=self.expression(exp.Soundex(this=self._parse_term())),
+            )
         ),
         TokenType.MEMBER_OF: lambda self, this: self.expression(
-            exp.JSONArrayContains,
-            this=this,
-            expression=self._parse_wrapped(self._parse_expression),
+            exp.JSONArrayContains(this=this, expression=self._parse_wrapped(self._parse_expression))
         ),
     }
 
@@ -145,7 +144,7 @@ class MySQLParser(parser.Parser):
         "GROUP_CONCAT": lambda self: self._parse_group_concat(),
         # https://dev.mysql.com/doc/refman/5.7/en/miscellaneous-functions.html#function_values
         "VALUES": lambda self: self.expression(
-            exp.Anonymous, this="VALUES", expressions=[self._parse_id_var()]
+            exp.Anonymous(this="VALUES", expressions=[self._parse_id_var()])
         ),
         "JSON_VALUE": lambda self: self._parse_json_value(),
         "SUBSTR": lambda self: self._parse_substring(),
@@ -232,7 +231,7 @@ class MySQLParser(parser.Parser):
         "INDEX": lambda self: self._parse_index_constraint(),
         "KEY": lambda self: self._parse_index_constraint(),
         "SPATIAL": lambda self: self._parse_index_constraint(kind="SPATIAL"),
-        "ZEROFILL": lambda self: self.expression(exp.ZeroFillColumnConstraint),
+        "ZEROFILL": lambda self: self.expression(exp.ZeroFillColumnConstraint()),
     }
 
     ALTER_PARSERS = {
@@ -302,7 +301,7 @@ class MySQLParser(parser.Parser):
                 this.set("persisted", persisted)
             elif isinstance(this, exp.GeneratedAsIdentityColumnConstraint):
                 this = self.expression(
-                    exp.ComputedColumnConstraint, this=this.expression, persisted=persisted
+                    exp.ComputedColumnConstraint(this=this.expression, persisted=persisted)
                 )
 
         return this
@@ -314,7 +313,7 @@ class MySQLParser(parser.Parser):
 
         expression = self._parse_number()
         self._match_r_paren()
-        return self.expression(exp.ColumnPrefix, this=this, expression=expression)
+        return self.expression(exp.ColumnPrefix(this=this, expression=expression))
 
     def _parse_index_constraint(self, kind: t.Optional[str] = None) -> exp.IndexColumnConstraint:
         if kind:
@@ -354,12 +353,13 @@ class MySQLParser(parser.Parser):
             options.append(opt)
 
         return self.expression(
-            exp.IndexColumnConstraint,
-            this=this,
-            expressions=expressions,
-            kind=kind,
-            index_type=index_type,
-            options=options,
+            exp.IndexColumnConstraint(
+                this=this,
+                expressions=expressions,
+                kind=kind,
+                index_type=index_type,
+                options=options,
+            )
         )
 
     def _parse_show_mysql(
@@ -417,28 +417,29 @@ class MySQLParser(parser.Parser):
         into_outfile = self._parse_string() if self._match_text_seq("INTO", "OUTFILE") else None
 
         return self.expression(
-            exp.Show,
-            this=this,
-            target=target_id,
-            full=full,
-            log=log,
-            position=position,
-            db=db,
-            channel=channel,
-            like=like,
-            where=where,
-            types=types,
-            query=query,
-            offset=offset,
-            limit=limit,
-            mutex=mutex,
-            for_table=for_table,
-            for_group=for_group,
-            for_user=for_user,
-            for_role=for_role,
-            into_outfile=into_outfile,
-            json=json,
-            global_=global_,
+            exp.Show(
+                this=this,
+                target=target_id,
+                full=full,
+                log=log,
+                position=position,
+                db=db,
+                channel=channel,
+                like=like,
+                where=where,
+                types=types,
+                query=query,
+                offset=offset,
+                limit=limit,
+                mutex=mutex,
+                for_table=for_table,
+                for_group=for_group,
+                for_user=for_user,
+                for_role=for_role,
+                into_outfile=into_outfile,
+                json=json,
+                global_=global_,
+            )
         )
 
     def _parse_oldstyle_limit(
@@ -458,7 +459,7 @@ class MySQLParser(parser.Parser):
 
     def _parse_set_item_charset(self, kind: str) -> exp.Expr:
         this = self._parse_string() or self._parse_unquoted_field()
-        return self.expression(exp.SetItem, this=this, kind=kind)
+        return self.expression(exp.SetItem(this=this, kind=kind))
 
     def _parse_set_item_names(self) -> exp.Expr:
         charset = self._parse_string() or self._parse_unquoted_field()
@@ -467,7 +468,7 @@ class MySQLParser(parser.Parser):
         else:
             collate = None
 
-        return self.expression(exp.SetItem, this=charset, collate=collate, kind="NAMES")
+        return self.expression(exp.SetItem(this=charset, collate=collate, kind="NAMES"))
 
     def _parse_type(
         self, parse_interval: bool = True, fallback_to_identifier: bool = False
@@ -478,7 +479,7 @@ class MySQLParser(parser.Parser):
             data_type = self._parse_types(check_func=True, allow_identifiers=False)
 
             if isinstance(data_type, exp.DataType):
-                return self.expression(exp.Cast, this=self._parse_column(), to=data_type)
+                return self.expression(exp.Cast(this=self._parse_column(), to=data_type))
 
         return super()._parse_type(
             parse_interval=parse_interval, fallback_to_identifier=fallback_to_identifier
@@ -494,7 +495,7 @@ class MySQLParser(parser.Parser):
         else:
             visible = None
 
-        return self.expression(exp.AlterIndex, this=index, visible=visible)
+        return self.expression(exp.AlterIndex(this=index, visible=visible))
 
     def _parse_partition_property(
         self,
@@ -521,9 +522,9 @@ class MySQLParser(parser.Parser):
         create_expressions = self._parse_wrapped_csv(value_parser)
 
         return self.expression(
-            partition_cls,
-            partition_expressions=partition_expressions,
-            create_expressions=create_expressions,
+            partition_cls(
+                partition_expressions=partition_expressions, create_expressions=create_expressions
+            )
         )
 
     def _parse_partition_range_value(self) -> t.Optional[exp.Expr]:
@@ -542,16 +543,16 @@ class MySQLParser(parser.Parser):
         ):
             values = [exp.var("MAXVALUE")]
 
-        part_range = self.expression(exp.PartitionRange, this=name, expressions=values)
-        return self.expression(exp.Partition, expressions=[part_range])
+        part_range = self.expression(exp.PartitionRange(this=name, expressions=values))
+        return self.expression(exp.Partition(expressions=[part_range]))
 
     def _parse_partition_list_value(self) -> exp.Partition:
         self._match_text_seq("PARTITION")
         name = self._parse_id_var()
         self._match_text_seq("VALUES", "IN")
         values = self._parse_wrapped_csv(self._parse_expression)
-        part_list = self.expression(exp.PartitionList, this=name, expressions=values)
-        return self.expression(exp.Partition, expressions=[part_list])
+        part_list = self.expression(exp.PartitionList(this=name, expressions=values))
+        return self.expression(exp.Partition(expressions=[part_list]))
 
     def _parse_primary_key(
         self,

--- a/sqlglot/parsers/oracle.py
+++ b/sqlglot/parsers/oracle.py
@@ -41,8 +41,8 @@ class OracleParser(parser.Parser):
     NO_PAREN_FUNCTION_PARSERS = {
         **parser.Parser.NO_PAREN_FUNCTION_PARSERS,
         "NEXT": lambda self: self._parse_next_value_for(),
-        "PRIOR": lambda self: self.expression(exp.Prior, this=self._parse_bitwise()),
-        "SYSDATE": lambda self: self.expression(exp.CurrentTimestamp, sysdate=True),
+        "PRIOR": lambda self: self.expression(exp.Prior(this=self._parse_bitwise())),
+        "SYSDATE": lambda self: self.expression(exp.CurrentTimestamp(sysdate=True)),
         "DBMS_RANDOM": lambda self: self._parse_dbms_random(),
     }
 
@@ -61,10 +61,10 @@ class OracleParser(parser.Parser):
     PROPERTY_PARSERS = {
         **parser.Parser.PROPERTY_PARSERS,
         "GLOBAL": lambda self: self._match_text_seq("TEMPORARY")
-        and self.expression(exp.TemporaryProperty, this="GLOBAL"),
+        and self.expression(exp.TemporaryProperty(this="GLOBAL")),
         "PRIVATE": lambda self: self._match_text_seq("TEMPORARY")
-        and self.expression(exp.TemporaryProperty, this="PRIVATE"),
-        "FORCE": lambda self: self.expression(exp.ForceProperty),
+        and self.expression(exp.TemporaryProperty(this="PRIVATE")),
+        "FORCE": lambda self: self.expression(exp.ForceProperty()),
     }
 
     QUERY_MODIFIER_PARSERS = {
@@ -74,7 +74,7 @@ class OracleParser(parser.Parser):
     }
 
     TYPE_LITERAL_PARSERS = {
-        exp.DType.DATE: lambda self, this, _: self.expression(exp.DateStrToDate, this=this),
+        exp.DType.DATE: lambda self, this, _: self.expression(exp.DateStrToDate(this=this)),
         # https://docs.oracle.com/en/database/oracle/oracle-database/19/refrn/NLS_TIMESTAMP_FORMAT.html
         exp.DType.TIMESTAMP: lambda self, this, _: _build_to_timestamp(
             [this, '"%Y-%m-%d %H:%M:%S.%f"']
@@ -120,11 +120,12 @@ class OracleParser(parser.Parser):
 
     def _parse_json_array(self, expr_type: t.Type[E], **kwargs) -> E:
         return self.expression(
-            expr_type,
-            null_handling=self._parse_on_handling("NULL", "NULL", "ABSENT"),
-            return_type=self._match_text_seq("RETURNING") and self._parse_type(),
-            strict=self._match_text_seq("STRICT"),
-            **kwargs,
+            expr_type(
+                null_handling=self._parse_on_handling("NULL", "NULL", "ABSENT"),
+                return_type=self._match_text_seq("RETURNING") and self._parse_type(),
+                strict=self._match_text_seq("STRICT"),
+                **kwargs,
+            )
         )
 
     def _parse_hint_function_call(self) -> t.Optional[exp.Expr]:
@@ -135,7 +136,7 @@ class OracleParser(parser.Parser):
 
         self._advance(2)
         args = self._parse_hint_args()
-        this = self.expression(exp.Anonymous, this=this, expressions=args)
+        this = self.expression(exp.Anonymous(this=this, expressions=args))
         self._match_r_paren(this)
         return this
 
@@ -156,21 +157,22 @@ class OracleParser(parser.Parser):
             return None
 
         return self.expression(
-            exp.QueryOption,
-            this=kind,
-            expression=self._match(TokenType.CONSTRAINT) and self._parse_field(),
+            exp.QueryOption(
+                this=kind, expression=self._match(TokenType.CONSTRAINT) and self._parse_field()
+            )
         )
 
     def _parse_json_exists(self) -> exp.JSONExists:
         this = self._parse_format_json(self._parse_bitwise())
         self._match(TokenType.COMMA)
         return self.expression(
-            exp.JSONExists,
-            this=this,
-            path=self.dialect.to_json_path(self._parse_bitwise()),
-            passing=self._match_text_seq("PASSING")
-            and self._parse_csv(lambda: self._parse_alias(self._parse_bitwise())),
-            on_condition=self._parse_on_condition(),
+            exp.JSONExists(
+                this=this,
+                path=self.dialect.to_json_path(self._parse_bitwise()),
+                passing=self._match_text_seq("PASSING")
+                and self._parse_csv(lambda: self._parse_alias(self._parse_bitwise())),
+                on_condition=self._parse_on_condition(),
+            )
         )
 
     def _parse_into(self) -> t.Optional[exp.Into]:
@@ -186,10 +188,10 @@ class OracleParser(parser.Parser):
             self._retreat(index)
             self._match(TokenType.TABLE)
             return self.expression(
-                exp.Into, this=self._parse_table(schema=True), bulk_collect=bulk_collect
+                exp.Into(this=self._parse_table(schema=True), bulk_collect=bulk_collect)
             )
 
-        return self.expression(exp.Into, bulk_collect=bulk_collect, expressions=expressions)
+        return self.expression(exp.Into(bulk_collect=bulk_collect, expressions=expressions))
 
     def _parse_connect_with_prior(self):
         return self._parse_assignment()

--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -86,12 +86,12 @@ class PostgresParser(parser.Parser):
 
     PROPERTY_PARSERS = {
         **{k: v for k, v in parser.Parser.PROPERTY_PARSERS.items() if k != "INPUT"},
-        "SET": lambda self: self.expression(exp.SetConfigProperty, this=self._parse_set()),
+        "SET": lambda self: self.expression(exp.SetConfigProperty(this=self._parse_set())),
     }
 
     PLACEHOLDER_PARSERS = {
         **parser.Parser.PLACEHOLDER_PARSERS,
-        TokenType.PLACEHOLDER: lambda self: self.expression(exp.Placeholder, jdbc=True),
+        TokenType.PLACEHOLDER: lambda self: self.expression(exp.Placeholder(jdbc=True)),
         TokenType.MOD: lambda self: self._parse_query_parameter(),
     }
 
@@ -136,7 +136,7 @@ class PostgresParser(parser.Parser):
 
     NO_PAREN_FUNCTION_PARSERS = {
         **parser.Parser.NO_PAREN_FUNCTION_PARSERS,
-        "VARIADIC": lambda self: self.expression(exp.Variadic, this=self._parse_bitwise()),
+        "VARIADIC": lambda self: self.expression(exp.Variadic(this=self._parse_bitwise())),
     }
 
     NO_PAREN_FUNCTIONS = {
@@ -148,9 +148,7 @@ class PostgresParser(parser.Parser):
         **parser.Parser.FUNCTION_PARSERS,
         "DATE_PART": lambda self: self._parse_date_part(),
         "JSON_AGG": lambda self: self.expression(
-            exp.JSONArrayAgg,
-            this=self._parse_lambda(),
-            order=self._parse_order(),
+            exp.JSONArrayAgg(this=self._parse_lambda(), order=self._parse_order())
         ),
         "JSONB_EXISTS": lambda self: self._parse_jsonb_exists(),
     }
@@ -168,7 +166,7 @@ class PostgresParser(parser.Parser):
         **parser.Parser.RANGE_PARSERS,
         TokenType.DAMP: binary_range_parser(exp.ArrayOverlaps),
         TokenType.DAT: lambda self, this: self.expression(
-            exp.MatchAgainst, this=self._parse_bitwise(), expressions=[this]
+            exp.MatchAgainst(this=self._parse_bitwise(), expressions=[this])
         ),
     }
 
@@ -180,7 +178,7 @@ class PostgresParser(parser.Parser):
     UNARY_PARSERS = {
         **parser.Parser.UNARY_PARSERS,
         # The `~` token is remapped from TILDE to RLIKE in Postgres due to the binary REGEXP LIKE operator
-        TokenType.RLIKE: lambda self: self.expression(exp.BitwiseNot, this=self._parse_unary()),
+        TokenType.RLIKE: lambda self: self.expression(exp.BitwiseNot(this=self._parse_unary())),
     }
 
     JSON_ARROWS_REQUIRE_JSON_TYPE = True
@@ -256,10 +254,11 @@ class PostgresParser(parser.Parser):
             InOutColumnConstraint expression representing the parameter mode.
         """
         return self.expression(
-            exp.InOutColumnConstraint,
-            input_=(param_mode in {TokenType.IN, TokenType.INOUT}),
-            output=(param_mode in {TokenType.OUT, TokenType.INOUT}),
-            variadic=(param_mode == TokenType.VARIADIC),
+            exp.InOutColumnConstraint(
+                input_=(param_mode in {TokenType.IN, TokenType.INOUT}),
+                output=(param_mode in {TokenType.OUT, TokenType.INOUT}),
+                variadic=(param_mode == TokenType.VARIADIC),
+            )
         )
 
     def _parse_function_parameter(self) -> t.Optional[exp.Expr]:
@@ -288,7 +287,7 @@ class PostgresParser(parser.Parser):
             else None
         )
         self._match_text_seq("S")
-        return self.expression(exp.Placeholder, this=this)
+        return self.expression(exp.Placeholder(this=this))
 
     def _parse_date_part(self) -> exp.Expr:
         part = self._parse_type()
@@ -298,16 +297,18 @@ class PostgresParser(parser.Parser):
         if part and isinstance(part, (exp.Column, exp.Literal)):
             part = exp.var(part.name)
 
-        return self.expression(exp.Extract, this=part, expression=value)
+        return self.expression(exp.Extract(this=part, expression=value))
 
     def _parse_unique_key(self) -> t.Optional[exp.Expr]:
         return None
 
     def _parse_jsonb_exists(self) -> exp.JSONBExists:
         return self.expression(
-            exp.JSONBExists,
-            this=self._parse_bitwise(),
-            path=self._match(TokenType.COMMA) and self.dialect.to_json_path(self._parse_bitwise()),
+            exp.JSONBExists(
+                this=self._parse_bitwise(),
+                path=self._match(TokenType.COMMA)
+                and self.dialect.to_json_path(self._parse_bitwise()),
+            )
         )
 
     def _parse_generated_as_identity(
@@ -320,7 +321,7 @@ class PostgresParser(parser.Parser):
         this = super()._parse_generated_as_identity()
 
         if self._match_text_seq("STORED"):
-            this = self.expression(exp.ComputedColumnConstraint, this=this.expression)
+            this = self.expression(exp.ComputedColumnConstraint(this=this.expression))
 
         return this
 

--- a/sqlglot/parsers/prql.py
+++ b/sqlglot/parsers/prql.py
@@ -135,7 +135,7 @@ class PRQLParser(parser.Parser):
         expressions = self._parse_csv(self._parse_ordered)
         if l_brace and not self._match(TokenType.R_BRACE):
             self.raise_error("Expecting }")
-        return query.order_by(self.expression(exp.Order, expressions=expressions), copy=False)
+        return query.order_by(self.expression(exp.Order(expressions=expressions)), copy=False)
 
     def _parse_aggregate(self) -> t.Optional[exp.Expr]:
         alias = None
@@ -152,14 +152,14 @@ class PRQLParser(parser.Parser):
         else:
             self.raise_error(f"Unsupported aggregation function {name}")
         if alias:
-            return self.expression(exp.Alias, this=func, alias=alias)
+            return self.expression(exp.Alias(this=func, alias=alias))
         return func
 
     def _parse_expression(self) -> t.Optional[exp.Expr]:
         if self._next and self._next.token_type == TokenType.ALIAS:
             alias = self._parse_id_var(True)
             self._match(TokenType.ALIAS)
-            return self.expression(exp.Alias, this=self._parse_assignment(), alias=alias)
+            return self.expression(exp.Alias(this=self._parse_assignment(), alias=alias))
         return self._parse_assignment()
 
     def _parse_table(
@@ -183,6 +183,8 @@ class PRQLParser(parser.Parser):
         if not skip_from_token and not self._match(TokenType.FROM):
             return None
 
+        comments = self._prev_comments
         return self.expression(
-            exp.From, comments=self._prev_comments, this=self._parse_table(joins=joins)
+            exp.From(this=self._parse_table(joins=joins)),
+            comments=comments,
         )

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -61,7 +61,7 @@ class RedshiftParser(PostgresParser):
     NO_PAREN_FUNCTION_PARSERS = {
         **PostgresParser.NO_PAREN_FUNCTION_PARSERS,
         "APPROXIMATE": lambda self: self._parse_approximate_count(),
-        "SYSDATE": lambda self: self.expression(exp.CurrentTimestamp, sysdate=True),
+        "SYSDATE": lambda self: self.expression(exp.CurrentTimestamp(sysdate=True)),
     }
 
     SUPPORTS_IMPLICIT_UNNEST = True
@@ -86,20 +86,20 @@ class RedshiftParser(PostgresParser):
             is_db_reference=is_db_reference,
         )
 
-        return self.expression(exp.Pivot, this=table, unpivot=True) if unpivot else table
+        return self.expression(exp.Pivot(this=table, unpivot=True)) if unpivot else table
 
     def _parse_convert(self, strict: bool, safe: t.Optional[bool] = None) -> t.Optional[exp.Expr]:
         to = self._parse_types()
         self._match(TokenType.COMMA)
         this = self._parse_bitwise()
-        return self.expression(exp.TryCast, this=this, to=to, safe=safe)
+        return self.expression(exp.TryCast(this=this, to=to, safe=safe))
 
     def _parse_approximate_count(self) -> t.Optional[exp.ApproxDistinct]:
         index = self._index - 1
         func = self._parse_function()
 
         if isinstance(func, exp.Count) and isinstance(func.this, exp.Distinct):
-            return self.expression(exp.ApproxDistinct, this=seq_get(func.this.expressions, 0))
+            return self.expression(exp.ApproxDistinct(this=seq_get(func.this.expressions, 0)))
         self._retreat(index)
         return None
 

--- a/sqlglot/parsers/risingwave.py
+++ b/sqlglot/parsers/risingwave.py
@@ -22,9 +22,10 @@ class RisingWaveParser(PostgresParser):
     CONSTRAINT_PARSERS = {
         **PostgresParser.CONSTRAINT_PARSERS,
         "WATERMARK": lambda self: self.expression(
-            exp.WatermarkColumnConstraint,
-            this=self._match(TokenType.FOR) and self._parse_column(),
-            expression=self._match(TokenType.ALIAS) and self._parse_disjunction(),
+            exp.WatermarkColumnConstraint(
+                this=self._match(TokenType.FOR) and self._parse_column(),
+                expression=self._match(TokenType.ALIAS) and self._parse_disjunction(),
+            )
         ),
     }
 
@@ -47,12 +48,12 @@ class RisingWaveParser(PostgresParser):
         if not self._match(TokenType.ALIAS):
             header = self._parse_field()
             if header:
-                coldef = self.expression(exp.ColumnDef, this=header, kind=self._parse_types())
+                coldef = self.expression(exp.ColumnDef(this=header, kind=self._parse_types()))
 
         self._match(TokenType.ALIAS)
         alias = self._parse_id_var(tokens=self.ALIAS_TOKENS)
 
-        return self.expression(exp.IncludeProperty, this=this, alias=alias, column_def=coldef)
+        return self.expression(exp.IncludeProperty(this=this, alias=alias, column_def=coldef))
 
     def _parse_encode_property(self, key: t.Optional[bool] = None) -> exp.EncodeProperty:
         self._match_text_seq("ENCODE")
@@ -60,9 +61,9 @@ class RisingWaveParser(PostgresParser):
 
         if self._match(TokenType.L_PAREN, advance=False):
             properties = self.expression(
-                exp.Properties, expressions=self._parse_wrapped_properties()
+                exp.Properties(expressions=self._parse_wrapped_properties())
             )
         else:
             properties = None
 
-        return self.expression(exp.EncodeProperty, this=this, properties=properties, key=key)
+        return self.expression(exp.EncodeProperty(this=this, properties=properties, key=key))

--- a/sqlglot/parsers/singlestore.py
+++ b/sqlglot/parsers/singlestore.py
@@ -168,16 +168,8 @@ class SingleStoreParser(MySQLParser):
 
     COLUMN_OPERATORS = {
         **MySQLParser.COLUMN_OPERATORS,
-        TokenType.COLON_GT: lambda self, this, to: self.expression(
-            exp.Cast,
-            this=this,
-            to=to,
-        ),
-        TokenType.NCOLON_GT: lambda self, this, to: self.expression(
-            exp.TryCast,
-            this=this,
-            to=to,
-        ),
+        TokenType.COLON_GT: lambda self, this, to: self.expression(exp.Cast(this=this, to=to)),
+        TokenType.NCOLON_GT: lambda self, this, to: self.expression(exp.TryCast(this=this, to=to)),
         TokenType.DCOLON: lambda self, this, path: build_json_extract_path(exp.JSONExtract)(
             [this, exp.Literal.string(path.name)]
         ),
@@ -188,10 +180,7 @@ class SingleStoreParser(MySQLParser):
             exp.JSONExtractScalar, json_type="DOUBLE"
         )([this, exp.Literal.string(path.name)]),
         TokenType.DCOLONQMARK: lambda self, this, path: self.expression(
-            exp.JSONExists,
-            this=this,
-            path=path.name,
-            from_dcolonqmark=True,
+            exp.JSONExists(this=this, path=path.name, from_dcolonqmark=True)
         ),
     }
     COLUMN_OPERATORS = {
@@ -251,7 +240,7 @@ class SingleStoreParser(MySQLParser):
     ALTER_PARSERS = {
         **MySQLParser.ALTER_PARSERS,
         "CHANGE": lambda self: self.expression(
-            exp.RenameColumn, this=self._parse_column(), to=self._parse_column()
+            exp.RenameColumn(this=self._parse_column(), to=self._parse_column())
         ),
     }
 

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -654,10 +654,11 @@ class SnowflakeParser(parser.Parser):
         "MODIFY": lambda self: self._parse_alter_table_alter(),
         "SESSION": lambda self: self._parse_alter_session(),
         "UNSET": lambda self: self.expression(
-            exp.Set,
-            tag=self._match_text_seq("TAG"),
-            expressions=self._parse_csv(self._parse_id_var),
-            unset=True,
+            exp.Set(
+                tag=self._match_text_seq("TAG"),
+                expressions=self._parse_csv(self._parse_id_var),
+                unset=True,
+            )
         ),
     }
 
@@ -675,7 +676,7 @@ class SnowflakeParser(parser.Parser):
         "LOCATION": lambda self: self._parse_location_property(),
         "TAG": lambda self: self._parse_tag(),
         "USING": lambda self: self._match_text_seq("TEMPLATE")
-        and self.expression(exp.UsingTemplateProperty, this=self._parse_statement()),
+        and self.expression(exp.UsingTemplateProperty(this=self._parse_statement())),
     }
 
     TYPE_CONVERTERS = {
@@ -735,32 +736,33 @@ class SnowflakeParser(parser.Parser):
     LAMBDAS = {
         **parser.Parser.LAMBDAS,
         TokenType.ARROW: lambda self, expressions: self.expression(
-            exp.Lambda,
-            this=self._replace_lambda(
-                self._parse_assignment(),
-                expressions,
-            ),
-            expressions=[e.this if isinstance(e, exp.Cast) else e for e in expressions],
+            exp.Lambda(
+                this=self._replace_lambda(
+                    self._parse_assignment(),
+                    expressions,
+                ),
+                expressions=[e.this if isinstance(e, exp.Cast) else e for e in expressions],
+            )
         ),
     }
 
     COLUMN_OPERATORS = {
         **parser.Parser.COLUMN_OPERATORS,
         TokenType.EXCLAMATION: lambda self, this, attr: self.expression(
-            exp.ModelAttribute, this=this, expression=attr
+            exp.ModelAttribute(this=this, expression=attr)
         ),
     }
 
     def _parse_directory(self) -> exp.DirectoryStage:
         table = self._parse_table_parts()
         this: exp.Expr = table.this if isinstance(table, exp.Table) else table
-        return self.expression(exp.DirectoryStage, this=this)
+        return self.expression(exp.DirectoryStage(this=this))
 
     def _parse_use(self) -> exp.Use:
         if self._match_text_seq("SECONDARY", "ROLES"):
             this = self._match_texts(("ALL", "NONE")) and exp.var(self._prev.text.upper())
             roles = None if this else self._parse_csv(lambda: self._parse_table(schema=False))
-            return self.expression(exp.Use, kind="SECONDARY ROLES", this=this, expressions=roles)
+            return self.expression(exp.Use(kind="SECONDARY ROLES", this=this, expressions=roles))
 
         return super()._parse_use()
 
@@ -776,15 +778,12 @@ class SnowflakeParser(parser.Parser):
             #
             # https://docs.snowflake.com/en/sql-reference/functions/in
             # Context: https://github.com/tobymao/sqlglot/issues/3890
-            return self.expression(exp.NEQ, this=this.this, expression=exp.All(this=query.unnest()))
+            return self.expression(exp.NEQ(this=this.this, expression=exp.All(this=query.unnest())))
 
-        return self.expression(exp.Not, this=this)
+        return self.expression(exp.Not(this=this))
 
     def _parse_tag(self) -> exp.Tags:
-        return self.expression(
-            exp.Tags,
-            expressions=self._parse_wrapped_csv(self._parse_property),
-        )
+        return self.expression(exp.Tags(expressions=self._parse_wrapped_csv(self._parse_property)))
 
     def _parse_with_constraint(self) -> t.Optional[exp.Expr]:
         if self._prev.token_type != TokenType.WITH:
@@ -793,16 +792,18 @@ class SnowflakeParser(parser.Parser):
         if self._match_text_seq("MASKING", "POLICY"):
             policy = self._parse_column()
             return self.expression(
-                exp.MaskingPolicyColumnConstraint,
-                this=policy.to_dot() if isinstance(policy, exp.Column) else policy,
-                expressions=self._match(TokenType.USING)
-                and self._parse_wrapped_csv(self._parse_id_var),
+                exp.MaskingPolicyColumnConstraint(
+                    this=policy.to_dot() if isinstance(policy, exp.Column) else policy,
+                    expressions=self._match(TokenType.USING)
+                    and self._parse_wrapped_csv(self._parse_id_var),
+                )
             )
         if self._match_text_seq("PROJECTION", "POLICY"):
             policy = self._parse_column()
             return self.expression(
-                exp.ProjectionPolicyColumnConstraint,
-                this=policy.to_dot() if isinstance(policy, exp.Column) else policy,
+                exp.ProjectionPolicyColumnConstraint(
+                    this=policy.to_dot() if isinstance(policy, exp.Column) else policy
+                )
             )
         if self._match(TokenType.TAG):
             return self._parse_tag()
@@ -834,7 +835,7 @@ class SnowflakeParser(parser.Parser):
         # Handle both syntaxes: DATE_PART(part, expr) and DATE_PART(part FROM expr)
         expression = self._match_set((TokenType.FROM, TokenType.COMMA)) and self._parse_bitwise()
         return self.expression(
-            exp.Extract, this=map_date_part(this, self.dialect), expression=expression
+            exp.Extract(this=map_date_part(this, self.dialect), expression=expression)
         )
 
     def _parse_bracket_key_value(self, is_map: bool = False) -> t.Optional[exp.Expr]:
@@ -889,7 +890,7 @@ class SnowflakeParser(parser.Parser):
 
                 self._match(TokenType.COMMA)
 
-            table = self.expression(exp.Table, this=table, format=file_format, pattern=pattern)
+            table = self.expression(exp.Table(this=table, format=file_format, pattern=pattern))
         else:
             table = super()._parse_table_parts(schema=schema, is_db_reference=is_db_reference)
 
@@ -933,7 +934,7 @@ class SnowflakeParser(parser.Parser):
                 super()._parse_id_var(any_token=any_token, tokens=tokens) or self._parse_string()
             )
             self._match_r_paren()
-            return self.expression(exp.Anonymous, this="IDENTIFIER", expressions=[identifier])
+            return self.expression(exp.Anonymous(this="IDENTIFIER", expressions=[identifier]))
 
         return super()._parse_id_var(any_token=any_token, tokens=tokens)
 
@@ -969,18 +970,19 @@ class SnowflakeParser(parser.Parser):
                 scope = self._parse_table_parts()
 
         return self.expression(
-            exp.Show,
-            terse=terse,
-            this=this,
-            history=history,
-            like=like,
-            scope=scope,
-            scope_kind=scope_kind,
-            starts_with=self._match_text_seq("STARTS", "WITH") and self._parse_string(),
-            limit=self._parse_limit(),
-            from_=self._parse_string() if self._match(TokenType.FROM) else None,
-            privileges=self._match_text_seq("WITH", "PRIVILEGES")
-            and self._parse_csv(lambda: self._parse_var(any_token=True, upper=True)),
+            exp.Show(
+                terse=terse,
+                this=this,
+                history=history,
+                like=like,
+                scope=scope,
+                scope_kind=scope_kind,
+                starts_with=self._match_text_seq("STARTS", "WITH") and self._parse_string(),
+                limit=self._parse_limit(),
+                from_=self._parse_string() if self._match(TokenType.FROM) else None,
+                privileges=self._match_text_seq("WITH", "PRIVILEGES")
+                and self._parse_csv(lambda: self._parse_var(any_token=True, upper=True)),
+            )
         )
 
     def _parse_put(self) -> exp.Put | exp.Command:
@@ -988,10 +990,11 @@ class SnowflakeParser(parser.Parser):
             return self._parse_as_command(self._prev)
 
         return self.expression(
-            exp.Put,
-            this=self._parse_string(),
-            target=self._parse_location_path(),
-            properties=self._parse_properties(),
+            exp.Put(
+                this=self._parse_string(),
+                target=self._parse_location_path(),
+                properties=self._parse_properties(),
+            )
         )
 
     def _parse_get(self) -> t.Optional[exp.Expr]:
@@ -1009,15 +1012,12 @@ class SnowflakeParser(parser.Parser):
             return self._parse_as_command(start)
 
         return self.expression(
-            exp.Get,
-            this=self._parse_string(),
-            target=target,
-            properties=self._parse_properties(),
+            exp.Get(this=self._parse_string(), target=target, properties=self._parse_properties())
         )
 
     def _parse_location_property(self) -> exp.LocationProperty:
         self._match(TokenType.EQ)
-        return self.expression(exp.LocationProperty, this=self._parse_location_path())
+        return self.expression(exp.LocationProperty(this=self._parse_location_path()))
 
     def _parse_file_location(self) -> t.Optional[exp.Expr]:
         # Parse either a subquery or a staged file
@@ -1050,14 +1050,14 @@ class SnowflakeParser(parser.Parser):
         typ = self._parse_types()
 
         if typ:
-            return self.expression(exp.Cast, this=this, to=typ)
+            return self.expression(exp.Cast(this=this, to=typ))
 
         return this
 
     def _parse_foreign_key(self) -> exp.ForeignKey:
         # inlineFK, the REFERENCES columns are implied
         if self._match(TokenType.REFERENCES, advance=False):
-            return self.expression(exp.ForeignKey)
+            return self.expression(exp.ForeignKey())
 
         # outoflineFK, explicitly names the columns
         return super()._parse_foreign_key()
@@ -1069,16 +1069,10 @@ class SnowflakeParser(parser.Parser):
         else:
             expressions = [self._parse_format_name()]
 
-        return self.expression(
-            exp.FileFormatProperty,
-            expressions=expressions,
-        )
+        return self.expression(exp.FileFormatProperty(expressions=expressions))
 
     def _parse_credentials_property(self) -> exp.CredentialsProperty:
-        return self.expression(
-            exp.CredentialsProperty,
-            expressions=self._parse_wrapped_options(),
-        )
+        return self.expression(exp.CredentialsProperty(expressions=self._parse_wrapped_options()))
 
     def _parse_semantic_view(self) -> exp.SemanticView:
         kwargs: t.Dict[str, t.Any] = {"this": self._parse_table_parts()}
@@ -1095,7 +1089,7 @@ class SnowflakeParser(parser.Parser):
                 self.raise_error("Expecting ) or encountered unexpected keyword")
                 break
 
-        return self.expression(exp.SemanticView, **kwargs)
+        return self.expression(exp.SemanticView(**kwargs))
 
     def _parse_set(self, unset: bool = False, tag: bool = False) -> exp.Set | exp.Command:
         set = super()._parse_set(unset=unset, tag=tag)

--- a/sqlglot/parsers/spark.py
+++ b/sqlglot/parsers/spark.py
@@ -106,7 +106,7 @@ class SparkParser(Spark2Parser):
     def _parse_query_parameter(self) -> t.Optional[exp.Expr]:
         this = self._parse_id_var()
         self._match(TokenType.R_BRACE)
-        return self.expression(exp.Placeholder, this=this, widget=True)
+        return self.expression(exp.Placeholder(this=this, widget=True))
 
     FUNCTION_PARSERS = {
         **Spark2Parser.FUNCTION_PARSERS,
@@ -127,7 +127,7 @@ class SparkParser(Spark2Parser):
     ):
         this = super()._parse_generated_as_identity()
         if this.expression:
-            return self.expression(exp.ComputedColumnConstraint, this=this.expression)
+            return self.expression(exp.ComputedColumnConstraint(this=this.expression))
         return this
 
     def _parse_pivot_aggregation(self) -> t.Optional[exp.Expr]:

--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -93,7 +93,7 @@ class Spark2Parser(HiveParser):
 
     def _parse_drop_column(self) -> t.Optional[exp.Drop | exp.Command]:
         return (
-            self.expression(exp.Drop, this=self._parse_schema(), kind="COLUMNS")
+            self.expression(exp.Drop(this=self._parse_schema(), kind="COLUMNS"))
             if self._match_text_seq("DROP", "COLUMNS")
             else None
         )

--- a/sqlglot/parsers/sqlite.py
+++ b/sqlglot/parsers/sqlite.py
@@ -50,7 +50,7 @@ class SQLiteParser(parser.Parser):
         # Do not consume more tokens if UNIQUE is used as a standalone constraint, e.g:
         # CREATE TABLE foo (bar TEXT UNIQUE REFERENCES baz ...)
         if self._curr.text.upper() in self.CONSTRAINT_PARSERS:
-            return self.expression(exp.UniqueColumnConstraint)
+            return self.expression(exp.UniqueColumnConstraint())
 
         return super()._parse_unique()
 
@@ -59,7 +59,7 @@ class SQLiteParser(parser.Parser):
         this = self._parse_expression()
 
         return (
-            self.expression(exp.Attach, this=this)
+            self.expression(exp.Attach(this=this))
             if is_attach
-            else self.expression(exp.Detach, this=this)
+            else self.expression(exp.Detach(this=this))
         )

--- a/sqlglot/parsers/starrocks.py
+++ b/sqlglot/parsers/starrocks.py
@@ -35,19 +35,20 @@ class StarRocksParser(MySQLParser):
         # ROLLUP (rollup_name (col1, col2) [FROM from_index] [PROPERTIES (...)], ...)
         def parse_rollup_index() -> exp.RollupIndex:
             return self.expression(
-                exp.RollupIndex,
-                this=self._parse_id_var(),
-                expressions=self._parse_wrapped_id_vars(),
-                from_index=self._parse_id_var() if self._match_text_seq("FROM") else None,
-                properties=self.expression(
-                    exp.Properties, expressions=self._parse_wrapped_properties()
+                exp.RollupIndex(
+                    this=self._parse_id_var(),
+                    expressions=self._parse_wrapped_id_vars(),
+                    from_index=self._parse_id_var() if self._match_text_seq("FROM") else None,
+                    properties=self.expression(
+                        exp.Properties(expressions=self._parse_wrapped_properties())
+                    )
+                    if self._match_text_seq("PROPERTIES")
+                    else None,
                 )
-                if self._match_text_seq("PROPERTIES")
-                else None,
             )
 
         return self.expression(
-            exp.RollupProperty, expressions=self._parse_wrapped_csv(parse_rollup_index)
+            exp.RollupProperty(expressions=self._parse_wrapped_csv(parse_rollup_index))
         )
 
     def _parse_create(self) -> exp.Create | exp.Command:
@@ -85,10 +86,11 @@ class StarRocksParser(MySQLParser):
 
     def _parse_partitioned_by(self) -> exp.PartitionedByProperty:
         return self.expression(
-            exp.PartitionedByProperty,
-            this=exp.Schema(
-                expressions=self._parse_wrapped_csv(self._parse_assignment, optional=True)
-            ),
+            exp.PartitionedByProperty(
+                this=exp.Schema(
+                    expressions=self._parse_wrapped_csv(self._parse_assignment, optional=True)
+                )
+            )
         )
 
     def _parse_partition_property(
@@ -112,9 +114,9 @@ class StarRocksParser(MySQLParser):
         self._match_r_paren()
 
         return self.expression(
-            exp.PartitionByRangeProperty,
-            partition_expressions=expr,
-            create_expressions=create_expressions,
+            exp.PartitionByRangeProperty(
+                partition_expressions=expr, create_expressions=create_expressions
+            )
         )
 
     def _parse_partitioning_granularity_dynamic(self) -> exp.PartitionByRangePropertyDynamic:
@@ -125,7 +127,7 @@ class StarRocksParser(MySQLParser):
         self._match_text_seq("EVERY")
         every = self._parse_wrapped(lambda: self._parse_interval() or self._parse_number())
         return self.expression(
-            exp.PartitionByRangePropertyDynamic, start=start, end=end, every=every
+            exp.PartitionByRangePropertyDynamic(start=start, end=end, every=every)
         )
 
     def _parse_refresh_property(self) -> exp.RefreshTriggerProperty:
@@ -148,10 +150,7 @@ class StarRocksParser(MySQLParser):
             unit = None
 
         return self.expression(
-            exp.RefreshTriggerProperty,
-            method=method,
-            kind=kind,
-            starts=start,
-            every=every,
-            unit=unit,
+            exp.RefreshTriggerProperty(
+                method=method, kind=kind, starts=start, every=every, unit=unit
+            )
         )

--- a/sqlglot/parsers/teradata.py
+++ b/sqlglot/parsers/teradata.py
@@ -52,7 +52,7 @@ class TeradataParser(parser.Parser):
     STATEMENT_PARSERS = {
         **parser.Parser.STATEMENT_PARSERS,
         TokenType.DATABASE: lambda self: self.expression(
-            exp.Use, this=self._parse_table(schema=False)
+            exp.Use(this=self._parse_table(schema=False))
         ),
         TokenType.REPLACE: lambda self: self._parse_create(),
         TokenType.LOCK: lambda self: self._parse_locking_statement(),
@@ -67,9 +67,7 @@ class TeradataParser(parser.Parser):
             self.raise_error("Expected SELECT statement after LOCKING clause")
 
         return self.expression(
-            exp.LockingStatement,
-            this=locking_property,
-            expression=wrapped_query,
+            exp.LockingStatement(this=locking_property, expression=wrapped_query)
         )
 
     SET_PARSERS = {
@@ -101,21 +99,23 @@ class TeradataParser(parser.Parser):
         self._match_texts(self.CHARSET_TRANSLATORS)
 
         return self.expression(
-            exp.TranslateCharacters,
-            this=this,
-            expression=self._prev.text.upper(),
-            with_error=self._match_text_seq("WITH", "ERROR"),
+            exp.TranslateCharacters(
+                this=this,
+                expression=self._prev.text.upper(),
+                with_error=self._match_text_seq("WITH", "ERROR"),
+            )
         )
 
     # FROM before SET in Teradata UPDATE syntax
     # https://docs.teradata.com/r/Enterprise_IntelliFlex_VMware/Teradata-VantageTM-SQL-Data-Manipulation-Language-17.20/Statement-Syntax/UPDATE/UPDATE-Syntax-Basic-Form-FROM-Clause
     def _parse_update(self) -> exp.Update:
         return self.expression(
-            exp.Update,
-            this=self._parse_table(alias_tokens=self.UPDATE_ALIAS_TOKENS),
-            from_=self._parse_from(joins=True),
-            expressions=self._match(TokenType.SET) and self._parse_csv(self._parse_equality),
-            where=self._parse_where(),
+            exp.Update(
+                this=self._parse_table(alias_tokens=self.UPDATE_ALIAS_TOKENS),
+                from_=self._parse_from(joins=True),
+                expressions=self._match(TokenType.SET) and self._parse_csv(self._parse_equality),
+                where=self._parse_where(),
+            )
         )
 
     def _parse_rangen(self):
@@ -125,7 +125,7 @@ class TeradataParser(parser.Parser):
         expressions = self._parse_csv(self._parse_assignment)
         each = self._match_text_seq("EACH") and self._parse_assignment()
 
-        return self.expression(exp.RangeN, this=this, expressions=expressions, each=each)
+        return self.expression(exp.RangeN(this=this, expressions=expressions, each=each))
 
     def _parse_query_band(self) -> exp.QueryBand:
         # Parse: SET QUERY_BAND = 'key=value;key2=value2;' FOR SESSION|TRANSACTION
@@ -150,12 +150,7 @@ class TeradataParser(parser.Parser):
         else:
             scope = None
 
-        return self.expression(
-            exp.QueryBand,
-            this=query_band_string,
-            scope=scope,
-            update=update,
-        )
+        return self.expression(exp.QueryBand(this=query_band_string, scope=scope, update=update))
 
     def _parse_index_params(self) -> exp.IndexParameters:
         this = super()._parse_index_params()
@@ -200,6 +195,6 @@ class TeradataParser(parser.Parser):
             fmt_string = self._parse_string()
             self._match_r_paren()
 
-            this = self.expression(exp.FormatPhrase, this=this, format=fmt_string)
+            this = self.expression(exp.FormatPhrase(this=this, format=fmt_string))
 
         return this

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -42,18 +42,20 @@ class TrinoParser(PrestoParser):
             return None
 
         return self.expression(
-            exp.JSONExtractQuote,
-            option=self._tokens[self._index - 2].text.upper(),
-            scalar=self._match_text_seq("ON", "SCALAR", "STRING"),
+            exp.JSONExtractQuote(
+                option=self._tokens[self._index - 2].text.upper(),
+                scalar=self._match_text_seq("ON", "SCALAR", "STRING"),
+            )
         )
 
     def _parse_json_query(self) -> exp.JSONExtract:
         return self.expression(
-            exp.JSONExtract,
-            this=self._parse_bitwise(),
-            expression=self._match(TokenType.COMMA) and self._parse_bitwise(),
-            option=self._parse_var_from_options(self.JSON_QUERY_OPTIONS, raise_unmatched=False),
-            json_query=True,
-            quote=self._parse_json_query_quote(),
-            on_condition=self._parse_on_condition(),
+            exp.JSONExtract(
+                this=self._parse_bitwise(),
+                expression=self._match(TokenType.COMMA) and self._parse_bitwise(),
+                option=self._parse_var_from_options(self.JSON_QUERY_OPTIONS, raise_unmatched=False),
+                json_query=True,
+                quote=self._parse_json_query_quote(),
+                on_condition=self._parse_on_condition(),
+            )
         )

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -388,9 +388,9 @@ class TSQLParser(parser.Parser):
     RANGE_PARSERS = {
         **parser.Parser.RANGE_PARSERS,
         TokenType.DCOLON: lambda self, this: self.expression(
-            exp.ScopeResolution,
-            this=this,
-            expression=self._parse_function() or self._parse_var(any_token=True),
+            exp.ScopeResolution(
+                this=this, expression=self._parse_function() or self._parse_var(any_token=True)
+            )
         ),
     }
 
@@ -402,10 +402,11 @@ class TSQLParser(parser.Parser):
     FUNCTION_PARSERS = {
         **parser.Parser.FUNCTION_PARSERS,
         "JSON_ARRAYAGG": lambda self: self.expression(
-            exp.JSONArrayAgg,
-            this=self._parse_bitwise(),
-            order=self._parse_order(),
-            null_handling=self._parse_on_handling("NULL", "NULL", "ABSENT"),
+            exp.JSONArrayAgg(
+                this=self._parse_bitwise(),
+                order=self._parse_order(),
+                null_handling=self._parse_on_handling("NULL", "NULL", "ABSENT"),
+            )
         ),
         "DATEPART": lambda self: self._parse_datepart(),
     }
@@ -413,9 +414,9 @@ class TSQLParser(parser.Parser):
     # The DCOLON (::) operator serves as a scope resolution (exp.ScopeResolution) operator in T-SQL
     COLUMN_OPERATORS = {
         **parser.Parser.COLUMN_OPERATORS,
-        TokenType.DCOLON: lambda self, this, to: self.expression(exp.Cast, this=this, to=to)
+        TokenType.DCOLON: lambda self, this, to: self.expression(exp.Cast(this=this, to=to))
         if isinstance(to, exp.DataType) and to.this != exp.DType.USERDEFINED
-        else self.expression(exp.ScopeResolution, this=this, expression=to),
+        else self.expression(exp.ScopeResolution(this=this, expression=to)),
     }
 
     SET_OP_MODIFIERS = {"offset"}
@@ -428,13 +429,14 @@ class TSQLParser(parser.Parser):
 
     def _parse_execute(self) -> exp.Execute:
         execute = self.expression(
-            exp.Execute,
-            this=self._parse_table(schema=True),
-            expressions=self._parse_csv(self._parse_expression),
+            exp.Execute(
+                this=self._parse_table(schema=True),
+                expressions=self._parse_csv(self._parse_expression),
+            )
         )
 
         if execute.name.lower() == "sp_executesql":
-            execute = self.expression(exp.ExecuteSql, **execute.args)
+            execute = self.expression(exp.ExecuteSql(**execute.args))
 
         return execute
 
@@ -443,7 +445,7 @@ class TSQLParser(parser.Parser):
         expression = self._match(TokenType.COMMA) and self._parse_bitwise()
         name = map_date_part(this, self.dialect)
 
-        return self.expression(exp.Extract, this=name, expression=expression)
+        return self.expression(exp.Extract(this=name, expression=expression))
 
     def _parse_alter_table_set(self) -> exp.AlterSet:
         return self._parse_wrapped(super()._parse_alter_table_set)
@@ -476,7 +478,7 @@ class TSQLParser(parser.Parser):
 
             self._match(TokenType.EQ)
             return self.expression(
-                exp.QueryOption, this=option, expression=self._parse_primary_or_var()
+                exp.QueryOption(this=option, expression=self._parse_primary_or_var())
             )
 
         return self._parse_wrapped_csv(_parse_option)
@@ -496,9 +498,10 @@ class TSQLParser(parser.Parser):
 
         def _parse_for_xml() -> t.Optional[exp.Expr]:
             return self.expression(
-                exp.QueryOption,
-                this=self._parse_var_from_options(XML_OPTIONS, raise_unmatched=False)
-                or self._parse_xml_key_value_option(),
+                exp.QueryOption(
+                    this=self._parse_var_from_options(XML_OPTIONS, raise_unmatched=False)
+                    or self._parse_xml_key_value_option()
+                )
             )
 
         return self._parse_csv(_parse_for_xml)
@@ -538,7 +541,7 @@ class TSQLParser(parser.Parser):
         this = self._parse_id_var()
 
         if rollback:
-            return self.expression(exp.Rollback, this=this)
+            return self.expression(exp.Rollback(this=this))
 
         durability = None
         if self._match_pair(TokenType.WITH, TokenType.L_PAREN):
@@ -553,7 +556,7 @@ class TSQLParser(parser.Parser):
 
             self._match_r_paren()
 
-        return self.expression(exp.Commit, this=this, durability=durability)
+        return self.expression(exp.Commit(this=this, durability=durability))
 
     def _parse_transaction(self) -> exp.Transaction | exp.Command:
         """Applies to SQL Server and Azure SQL Database
@@ -563,7 +566,7 @@ class TSQLParser(parser.Parser):
         ]
         """
         if self._match_texts(("TRAN", "TRANSACTION")):
-            transaction = self.expression(exp.Transaction, this=self._parse_id_var())
+            transaction = self.expression(exp.Transaction(this=self._parse_id_var()))
             if self._match_text_seq("WITH", "MARK"):
                 transaction.set("mark", self._parse_string())
 
@@ -613,13 +616,14 @@ class TSQLParser(parser.Parser):
                 expressions = self._parse_csv(self._parse_function_parameter)
 
             return self.expression(
-                exp.StoredProcedure,
-                this=this if isinstance(this, exp.Table) else this.this,
-                expressions=expressions,
-                wrapped=this.args.get("wrapped"),
+                exp.StoredProcedure(
+                    this=this if isinstance(this, exp.Table) else this.this,
+                    expressions=expressions,
+                    wrapped=this.args.get("wrapped"),
+                )
             )
 
-        return self.expression(exp.UserDefinedFunction, this=this)
+        return self.expression(exp.UserDefinedFunction(this=this))
 
     def _parse_into(self) -> t.Optional[exp.Into]:
         into = super()._parse_into()
@@ -669,7 +673,7 @@ class TSQLParser(parser.Parser):
 
         false = self._match(TokenType.ELSE) and self._parse_block()
 
-        return self.expression(exp.IfBlock, this=this, true=true, false=false)
+        return self.expression(exp.IfBlock(this=this, true=true, false=false))
 
     def _parse_unique(self) -> exp.UniqueColumnConstraint:
         if self._match_texts(("CLUSTERED", "NONCLUSTERED")):
@@ -677,7 +681,7 @@ class TSQLParser(parser.Parser):
         else:
             this = self._parse_schema(self._parse_id_var(any_token=False))
 
-        return self.expression(exp.UniqueColumnConstraint, this=this)
+        return self.expression(exp.UniqueColumnConstraint(this=this))
 
     def _parse_update(self) -> exp.Update:
         expression = super()._parse_update()
@@ -692,9 +696,9 @@ class TSQLParser(parser.Parser):
             low = self._parse_bitwise()
             high = self._parse_bitwise() if self._match_text_seq("TO") else None
 
-            return self.expression(exp.PartitionRange, this=low, expression=high) if high else low
+            return self.expression(exp.PartitionRange(this=low, expression=high)) if high else low
 
-        partition = self.expression(exp.Partition, expressions=self._parse_wrapped_csv(parse_range))
+        partition = self.expression(exp.Partition(expressions=self._parse_wrapped_csv(parse_range)))
 
         self._match_r_paren()
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -255,19 +255,19 @@ class TestParser(unittest.TestCase):
 
     def test_expression(self):
         ignore = Parser(error_level=ErrorLevel.IGNORE)
-        self.assertIsInstance(ignore.expression(exp.Hint, expressions=[]), exp.Hint)
-        self.assertIsInstance(ignore.expression(exp.Hint, y=""), exp.Hint)
-        self.assertIsInstance(ignore.expression(exp.Hint), exp.Hint)
+        self.assertIsInstance(ignore.expression(exp.Hint(expressions=[])), exp.Hint)
+        self.assertIsInstance(ignore.expression(exp.Hint(y="")), exp.Hint)
+        self.assertIsInstance(ignore.expression(exp.Hint()), exp.Hint)
 
         default = Parser(error_level=ErrorLevel.RAISE)
         with self.assertRaises(TypeError):
-            default.expression(exp.Hint, y="")
-        self.assertIsInstance(default.expression(exp.Hint, expressions=[]), exp.Hint)
-        default.expression(exp.Hint)
+            default.expression(exp.Hint(y=""))
+        self.assertIsInstance(default.expression(exp.Hint(expressions=[])), exp.Hint)
+        default.expression(exp.Hint())
         self.assertEqual(len(default.errors), 2)
 
         warn = Parser(error_level=ErrorLevel.WARN)
-        warn.expression(exp.Hint)
+        warn.expression(exp.Hint())
         self.assertEqual(len(warn.errors), 1)
 
     def test_parse_errors(self):


### PR DESCRIPTION
…le dicts

● Benchmark              Baseline    Refactor    Change
  ------------------------------------------------------
  tpch                     3.94ms      3.73ms    +5.4%
  many_unions             62.00ms     58.78ms    +5.2%
  nested_subqueries        3.64ms      3.46ms    +5.0%
  deep_arithmetic         11.15ms     10.62ms    +4.8%
  short                    0.30ms      0.29ms    +4.6%
  many_columns            19.72ms     18.91ms    +4.1%
  many_joins              21.85ms     20.98ms    +4.0%
  complex_where           39.70ms     38.17ms    +3.9%
  large_in               573.48ms    556.48ms    +3.0%
  large_strings            7.61ms      7.39ms    +2.9%
  many_ctes               24.78ms     24.08ms    +2.8%
  values                 634.23ms    618.59ms    +2.5%
  large_case              54.04ms     52.80ms    +2.3%
  many_windows            29.78ms     29.16ms    +2.1%
  many_numbers           139.36ms    136.50ms    +2.1%
  nested_functions         3.59ms      3.86ms    -7.4%
  ------------------------------------------------------
  Average                                        +2.9%