### PR TITLE
feat(duckdb)!: Implement transpilation for ARRAYS_TO_OBJECT function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -2131,6 +2131,15 @@ class DuckDB(Dialect):
             """,
         )
 
+        # Snowflake: NULL array input -> NULL result; NULL key -> pair omitted.
+        # LIST_ZIP(NULL, ...) returns [] in DuckDB (not NULL), so an explicit NULL guard is required.
+        # LIST_FILTER strips NULL-keyed pairs to avoid "Map keys can not be NULL" error.
+        # Returns MAP type, not OBJECT.
+        ARRAYS_TO_OBJECT_TEMPLATE: exp.Expr = exp.maybe_parse(
+            "CASE WHEN :arr1 IS NULL OR :arr2 IS NULL THEN NULL"
+            " ELSE MAP_FROM_ENTRIES(LIST_FILTER(LIST_ZIP(:arr1, :arr2), __p -> __p[0] IS NOT NULL)) END"
+        )
+
         # Template for ARRAYS_ZIP transpilation
         # Snowflake pads to longest array; DuckDB LIST_ZIP truncates to shortest
         # Uses RANGE + indexing to match Snowflake behavior
@@ -3266,6 +3275,18 @@ class DuckDB(Dialect):
                 transform_struct=transform_struct,
             )
             return self.sql(result)
+
+        def arraystoobject_sql(self, expression: exp.ArraysToObject) -> str:
+            self.unsupported(
+                "ARRAYS_TO_OBJECT returns OBJECT type; DuckDB equivalent returns MAP type"
+            )
+            return self.sql(
+                exp.replace_placeholders(
+                    self.ARRAYS_TO_OBJECT_TEMPLATE.copy(),
+                    arr1=expression.this,
+                    arr2=expression.expression,
+                )
+            )
 
         def lower_sql(self, expression: exp.Lower) -> str:
             result_sql = self.func("LOWER", _cast_to_varchar(expression.this))

--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -168,6 +168,10 @@ class ArraySum(Expression, Func):
 # Array conversion / utility
 
 
+class ArraysToObject(Expression, Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class ArraysZip(Expression, Func):
     arg_types = {"expressions": False}
     is_var_len_args = True

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -394,6 +394,7 @@ class SnowflakeParser(parser.Parser):
         ),
         "ARRAY_SORT": exp.SortArray.from_arg_list,
         "ARRAY_FLATTEN": exp.Flatten.from_arg_list,
+        "ARRAYS_TO_OBJECT": exp.ArraysToObject.from_arg_list,
         "ARRAYS_OVERLAP": lambda args: exp.ArrayOverlaps(
             this=seq_get(args, 0), expression=seq_get(args, 1), null_safe=True
         ),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1069,6 +1069,16 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
+            "SELECT ARRAYS_TO_OBJECT(['a', 'b'], [1, 2])",
+            read={
+                "snowflake": "SELECT ARRAYS_TO_OBJECT(['a', 'b'], [1, 2])",
+            },
+            write={
+                "snowflake": "SELECT ARRAYS_TO_OBJECT(['a', 'b'], [1, 2])",
+                "duckdb": "SELECT CASE WHEN ['a', 'b'] IS NULL OR [1, 2] IS NULL THEN NULL ELSE MAP_FROM_ENTRIES(LIST_FILTER(LIST_ZIP(['a', 'b'], [1, 2]), __p -> NOT __p[1] IS NULL)) END",
+            },
+        )
+        self.validate_all(
             "SELECT ARRAYS_OVERLAP(col1, col2)",
             read={
                 "snowflake": "SELECT ARRAYS_OVERLAP(col1, col2)",


### PR DESCRIPTION
The following issues were fixed in this PR:

1. `ARRAYS_TO_OBJECT` not recognized by SQLGlot → Anonymous expression → DuckDB runtime error.
2. No native DuckDB equivalent: DuckDB uses MAP type `(map_from_entries(list_zip(keys, values))),` not `OBJECT`. These are semantically different types — `OBJECT` is a JSON semi-structured type; MAP is a typed key-value structure.
3. NULL key filtering: Snowflake omits entries where the key is `NULL` `(['a',NULL,'c'] → {"a":1,"c":3})`. DuckDB's `list_zip` does not automatically filter `NULL` keys.

Trnaspilation:
```
 python -m sqlglot --read snowflake --write duckdb "SELECT ARRAYS_TO_OBJECT(['a','b','c'], [1,2,3]) AS obj_basic, ARRAYS_TO_OBJECT(['key1','key2'], ['v1','v2']) AS obj_strings, ARRAYS_TO_OBJECT(['a',NULL,'c'], [1,2,3]) AS obj_null_key, ARRAYS_TO_OBJECT(['a','b'], [1,NULL]) AS obj_null_val, ARRAYS_TO_OBJECT(NULL, [1,2]) AS obj_null_input"

  warnings.warn(
ARRAYS_TO_OBJECT returns OBJECT type; DuckDB equivalent returns MAP type
ARRAYS_TO_OBJECT returns OBJECT type; DuckDB equivalent returns MAP type
ARRAYS_TO_OBJECT returns OBJECT type; DuckDB equivalent returns MAP type
ARRAYS_TO_OBJECT returns OBJECT type; DuckDB equivalent returns MAP type
ARRAYS_TO_OBJECT returns OBJECT type; DuckDB equivalent returns MAP type
SELECT
  CASE
    WHEN ['a', 'b', 'c'] IS NULL OR [1, 2, 3] IS NULL
    THEN NULL
    ELSE MAP_FROM_ENTRIES(LIST_FILTER(LIST_ZIP(['a', 'b', 'c'], [1, 2, 3]), "__p" -> NOT "__p"[1] IS NULL))
  END AS "obj_basic",
  CASE
    WHEN ['key1', 'key2'] IS NULL OR ['v1', 'v2'] IS NULL
    THEN NULL
    ELSE MAP_FROM_ENTRIES(
      LIST_FILTER(LIST_ZIP(['key1', 'key2'], ['v1', 'v2']), "__p" -> NOT "__p"[1] IS NULL)
    )
  END AS "obj_strings",
  CASE
    WHEN ['a', NULL, 'c'] IS NULL OR [1, 2, 3] IS NULL
    THEN NULL
    ELSE MAP_FROM_ENTRIES(
      LIST_FILTER(LIST_ZIP(['a', NULL, 'c'], [1, 2, 3]), "__p" -> NOT "__p"[1] IS NULL)
    )
  END AS "obj_null_key",
  CASE
    WHEN ['a', 'b'] IS NULL OR [1, NULL] IS NULL
    THEN NULL
    ELSE MAP_FROM_ENTRIES(LIST_FILTER(LIST_ZIP(['a', 'b'], [1, NULL]), "__p" -> NOT "__p"[1] IS NULL))
  END AS "obj_null_val",
  CASE
    WHEN NULL IS NULL OR [1, 2] IS NULL
    THEN NULL
    ELSE MAP_FROM_ENTRIES(LIST_FILTER(LIST_ZIP(NULL, [1, 2]), "__p" -> NOT "__p"[1] IS NULL))
  END AS "obj_null_input"
```

```
Duckdb:
│       obj_basic       │      obj_strings      │     obj_null_key      │     obj_null_val      │    obj_null_input     │
│ map(varchar, integer) │ map(varchar, varchar) │ map(varchar, integer) │ map(varchar, integer) │ map(integer, integer) │
├───────────────────────┼───────────────────────┼───────────────────────┼───────────────────────┼───────────────────────┤
│ {a=1, b=2, c=3}       │ {key1=v1, key2=v2}    │ {a=1, c=3}            │ {a=1, b=NULL}         │ NULL                  │
└───────────────────────┴───────────────────────┴───────────────────────┴───────────────────────┴───────────────────────┘
```