### PR TITLE
Fix(snowflake)!: parse single-arg TO_{GEOMETRY/GEOGRAPHY} as Cast

### DIFF
--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -622,6 +622,12 @@ class SnowflakeParser(parser.Parser):
         "TO_TIMESTAMP_LTZ": _build_datetime("TO_TIMESTAMP_LTZ", exp.DType.TIMESTAMPLTZ),
         "TO_TIMESTAMP_NTZ": _build_datetime("TO_TIMESTAMP_NTZ", exp.DType.TIMESTAMPNTZ),
         "TO_TIMESTAMP_TZ": _build_datetime("TO_TIMESTAMP_TZ", exp.DType.TIMESTAMPTZ),
+        "TO_GEOGRAPHY": lambda args: exp.cast(args[0], exp.DType.GEOGRAPHY)
+        if len(args) == 1
+        else exp.Anonymous(this="TO_GEOGRAPHY", expressions=args),
+        "TO_GEOMETRY": lambda args: exp.cast(args[0], exp.DType.GEOMETRY)
+        if len(args) == 1
+        else exp.Anonymous(this="TO_GEOMETRY", expressions=args),
         "TO_VARCHAR": build_timetostr_or_tochar,
         "TO_JSON": exp.JSONFormat.from_arg_list,
         "VECTOR_COSINE_SIMILARITY": exp.CosineDistance.from_arg_list,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -772,6 +772,10 @@ class TestSnowflake(Validator):
             "CAST(x AS GEOMETRY)",
             "TO_GEOMETRY(x)",
         )
+        self.validate_identity("TO_GEOGRAPHY(x)")
+        self.validate_identity("TO_GEOMETRY(x)")
+        self.validate_identity("TO_GEOGRAPHY(x, y)")
+        self.validate_identity("TO_GEOMETRY(x, y)")
         self.validate_identity(
             "transform(x, a int -> a + a + 1)",
             "TRANSFORM(x, a -> CAST(a AS INT) + CAST(a AS INT) + 1)",


### PR DESCRIPTION
When we have a `CAST(x AS GEOMETRY/GEOGRAPHY)` today, we generate `TO_GEOMETRY/GEOGRAPHY(...)`. If we re-parse this, it creates a different AST node (anonymous) vs the input. This PR makes is so that we produce a `Cast` node to have a consistent AST representation.

Context for the `CAST` generation logic: https://github.com/tobymao/sqlglot/commit/47cee36b70d032cda8bdef1f415c1f30c02d955a.