### PR TITLE
Fix: Make unit silently failing to move .so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ endif
 SO_BACKUP := /tmp/sqlglot_so_backup
 
 hidec:
-	rm -rf $(SO_BACKUP) && find sqlglot sqlglotc -name "*.so" | tar cf $(SO_BACKUP) -T - --remove-files 2>/dev/null; true
+	rm -rf $(SO_BACKUP) && find sqlglot sqlglotc -name "*.so" | tar cf $(SO_BACKUP) -T - 2>/dev/null && find sqlglot sqlglotc -name "*.so" -delete; true
 
 showc:
 	tar xf $(SO_BACKUP) 2>/dev/null; rm -f $(SO_BACKUP); true


### PR DESCRIPTION
The problem is macOS tar doesn't support `--remove-files`, so `hidec` archives the `.so` files but never removes them. The `2>/dev/null;` true masks the error.

The fix splits the non-portable `tar --remove-files` into two portable steps: `tar cf` + `find -delete`.