### PR TITLE
Refactor!: Fully compile expressions

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -20,7 +20,6 @@ from sqlglot.errors import ParseError
 from sqlglot.helper import (
     camel_to_snake_case,
     ensure_list,
-    mypyc_attr,
     seq_get,
     to_bool,
     trait,
@@ -42,7 +41,6 @@ POSITION_META_KEYS: t.Tuple[str, ...] = ("line", "col", "start", "end")
 UNITTEST: bool = "unittest" in sys.modules or "pytest" in sys.modules
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, native_class=True)
 @trait
 class Expr:
     """
@@ -115,8 +113,6 @@ class Expr:
 
         for arg_key, value in self.args.items():
             self._set_parent(arg_key, value)
-        if hasattr(self, "_post_init"):
-            self._post_init()
 
     @property
     def this(self) -> t.Any:
@@ -481,7 +477,6 @@ class Expr:
         raise NotImplementedError
 
 
-@mypyc_attr(allow_interpreted_subclasses=True, native_class=True)
 class Expression(Expr):
     __slots__ = (
         "args",
@@ -670,10 +665,6 @@ class Expression(Expr):
         self._type = dtype  # type: ignore[assignment]
 
     def is_type(self, *dtypes: DATA_TYPE) -> bool:
-        # TODO (mypyc)
-        # Access _type directly (not via .type property) to avoid a mypyc shadow vtable bug
-        # where CPY_GET_ATTR(self, ..., 17, ...) incorrectly calls the setter on interpreted
-        # subclasses instead of the getter.
         t = self._type
         return t is not None and t.is_type(*dtypes)
 
@@ -761,7 +752,7 @@ class Expression(Expr):
             self.args[arg_key] = []
         self._set_parent(arg_key, value)
         values = self.args[arg_key]
-        if hasattr(value, "parent"):
+        if isinstance(value, Expr):
             value.index = len(values)
         values.append(value)
 
@@ -1149,16 +1140,18 @@ class Expression(Expr):
         Returns:
             A list of error messages for all possible errors that were found.
         """
-        errors: t.List[str] = []
-
         if UNITTEST:
             for k in self.args:
                 if k not in self.arg_types:
                     raise TypeError(f"Unexpected keyword: '{k}' for {self.__class__}")
 
+        errors: t.Optional[t.List[str]] = None
+
         for k in self.required_args:
             v = self.args.get(k)
             if v is None or (isinstance(v, list) and not v):
+                if errors is None:
+                    errors = []
                 errors.append(f"Required keyword: '{k}' missing for {self.__class__}")
 
         if (
@@ -1167,12 +1160,14 @@ class Expression(Expr):
             and len(args) > len(self.arg_types)
             and not self.is_var_len_args
         ):
+            if errors is None:
+                errors = []
             errors.append(
                 f"The number of provided arguments ({len(args)}) is greater than "
                 f"the maximum number of supported arguments ({len(self.arg_types)})"
             )
 
-        return errors
+        return errors or []
 
     def and_(
         self,
@@ -1272,19 +1267,24 @@ class Expression(Expr):
             The updated expression.
         """
         if other is None:
-            self.meta["line"] = line
-            self.meta["col"] = col
-            self.meta["start"] = start
-            self.meta["end"] = end
+            meta = self.meta
+            meta["line"] = line
+            meta["col"] = col
+            meta["start"] = start
+            meta["end"] = end
         elif isinstance(other, Expr):
-            for k in POSITION_META_KEYS:
-                if k in other.meta:
-                    self.meta[k] = other.meta[k]
+            other_meta = other._meta
+            if other_meta:
+                meta = self.meta
+                for k in POSITION_META_KEYS:
+                    if k in other_meta:
+                        meta[k] = other_meta[k]
         else:
-            self.meta["line"] = other.line
-            self.meta["col"] = other.col
-            self.meta["start"] = other.start
-            self.meta["end"] = other.end
+            meta = self.meta
+            meta["line"] = other.line
+            meta["col"] = other.col
+            meta["start"] = other.start
+            meta["end"] = other.end
         return self
 
     def as_(
@@ -1937,9 +1937,7 @@ class TimeUnit(Expr):
         ):
             unit = Var(this=(self.UNABBREVIATED_UNIT_NAME.get(unit.name) or unit.name).upper())
             self.args["unit"] = unit
-            # TODO (mypyc): change back to self._set_parent("unit", unit)
-            unit.parent = self
-            unit.arg_key = "unit"
+            self._set_parent("unit", unit)
         elif type(unit).__name__ == "Week":
             unit.set("this", Var(this=unit.this.name.upper()))  # type: ignore[union-attr]
 
@@ -1959,11 +1957,7 @@ class IntervalOp(TimeUnit):
     def interval(self) -> "Interval":
         from sqlglot.expressions.datatypes import Interval
 
-        # TODO (mypyc):
-        # Access self.args directly instead of self.expression to avoid mypyc
-        # dispatching to ExpressionCore.expression (which raises NotImplementedError)
-        # rather than the concrete Expr.expression implementation.
-        expr = self.args.get("expression")
+        expr = self.expression
         return Interval(
             this=expr.copy() if expr is not None else None,
             unit=self.unit.copy() if self.unit else None,
@@ -2461,16 +2455,8 @@ def _to_s(node: t.Any, verbose: bool = False, level: int = 0, repr_str: bool = F
     if isinstance(node, Expr):
         args = {k: v for k, v in node.args.items() if (v is not None and v != []) or verbose}
 
-        # TODO (mypyc):
-        # Access _type directly (not via .type property) to avoid a mypyc shadow vtable bug
-        # where CPY_GET_ATTR_TRAIT(node, CPyType_core___Expr, 16, ...) calls the setter
-        # instead of the getter on interpreted subclasses. Replicate the type property logic:
-        # for Cast nodes, fall back to the `to` argument when _type is not set.
-        _node_type = node._type
-        if _node_type is None and node.is_cast:
-            _node_type = node.args.get("to")
-        if (_node_type or verbose) and type(node).__name__ != "DataType":
-            args["_type"] = _node_type
+        if (node.type or verbose) and type(node).__name__ != "DataType":
+            args["_type"] = node.type
         if node.comments or verbose:
             args["_comments"] = node.comments
 

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -23,8 +23,7 @@ class DDL(Selectable):
     @property
     def selects(self) -> t.List[Expr]:
         """If this statement contains a query (e.g. a CTAS), this returns the query's projections."""
-        # TODO (mypyc): make this self.expression
-        expression = self.args.get("expression")
+        expression = self.expression
         return expression.selects if isinstance(expression, Query) else []
 
     @property
@@ -33,8 +32,7 @@ class DDL(Selectable):
         If this statement contains a query (e.g. a CTAS), this returns the output
         names of the query's projections.
         """
-        # TODO (mypyc): make this self.expression
-        expression = self.args.get("expression")
+        expression = self.expression
         return expression.named_selects if isinstance(expression, Query) else []
 
 

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -85,17 +85,16 @@ class Selectable(Expr):
         return _named_selects(self)
 
 
-# TODO (mypyc): t.Any needed so compiled code uses Python attribute dispatch, not trait vtable
-def _named_selects(self: t.Any) -> t.List[str]:
-    return [select.output_name for select in self.selects]
+def _named_selects(self: Expr) -> t.List[str]:
+    selectable = t.cast(Selectable, self)
+    return [select.output_name for select in selectable.selects]
 
 
 @trait
 class DerivedTable(Selectable):
     @property
     def selects(self) -> t.List[Expr]:
-        # TODO (mypyc): make this self.this
-        this = self.args.get("this")
+        this = self.this
         return this.selects if isinstance(this, Query) else []
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -4,8 +4,13 @@ from sqlglot import exp, parse_one
 from sqlglot.expressions import Expression, Func
 from sqlglot.parsers.snowflake import SnowflakeParser
 
+import sqlglot.expressions.core as _core_module
+
+_EXPRESSION_IS_COMPILED = getattr(_core_module, "__file__", "").endswith(".so")
+
 
 class TestGenerator(unittest.TestCase):
+    @unittest.skipIf(_EXPRESSION_IS_COMPILED, "mypyc compiled expressions cannot be subclassed")
     def test_fallback_function_sql(self):
         class SpecialUdf(Expression, Func):
             arg_types = {"a": True, "b": False}
@@ -18,6 +23,7 @@ class TestGenerator(unittest.TestCase):
         finally:
             del SnowflakeParser.FUNCTIONS["SPECIAL_UDF"]
 
+    @unittest.skipIf(_EXPRESSION_IS_COMPILED, "mypyc compiled expressions cannot be subclassed")
     def test_fallback_function_var_args_sql(self):
         class SpecialUdf(Expression, Func):
             arg_types = {"a": True, "expressions": False}

--- a/tests/test_serde.py
+++ b/tests/test_serde.py
@@ -6,8 +6,14 @@ from sqlglot import exp, parse_one
 from sqlglot.optimizer.annotate_types import annotate_types
 from tests.helpers import load_sql_fixtures
 
+import sqlglot.expressions.core as _core_module
 
-class CustomExpression(exp.Expression): ...
+_EXPRESSION_IS_COMPILED = getattr(_core_module, "__file__", "").endswith(".so")
+
+
+if not _EXPRESSION_IS_COMPILED:
+
+    class CustomExpression(exp.Expression): ...
 
 
 class TestSerde(unittest.TestCase):
@@ -21,6 +27,7 @@ class TestSerde(unittest.TestCase):
                 after = self.dump_load(before)
                 self.assertEqual(repr(before), repr(after))
 
+    @unittest.skipIf(_EXPRESSION_IS_COMPILED, "mypyc compiled expressions cannot be subclassed")
     def test_custom_expression(self):
         before = CustomExpression()
         after = self.dump_load(before)


### PR DESCRIPTION
- Removed `@mypyc_attr` decorators                                                                                                                                                                                                                                            
- Removed dead `_post_init` check from `Expr.__init__`                                                                                                                                                                                                                                                                                     
- `hasattr(value, "parent")` -> `isinstance(value, Expr)`, I think this is faster on compiled classes                                                                                                                                                                            
- Cleaned up is_type(), the vtable bug should be fixed on `sqlglot-mypy`    
- `error_messages()` ->  deferred list allocation given that the function is very hot                                                                                                                                                                     
- update_positions()` ->  reduced property calls and added early exit                                                                                                                                                                           as each self.meta["key"] went through the meta property.                                                                                                                                                                        
                                                                  
  Test changes:                                                                                                                                                                                                                                
  - `test_generator.py`: Skip 2 tests that subclass Expression when .so is present
  - `test_serde.py:` Skip `test_custom_expression`