### PR TITLE
WIP: Add initial Vertica dialect support for SELECT (requesting early feedback)

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -97,6 +97,7 @@ DIALECTS = [
     "Teradata",
     "Trino",
     "TSQL",
+    "Vertica",
 ]
 
 MODULE_BY_DIALECT = {name: name.lower() for name in DIALECTS}

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -108,6 +108,7 @@ class Dialects(str, Enum):
     TERADATA = "teradata"
     TRINO = "trino"
     TSQL = "tsql"
+    VERTICA = "vertica"
     EXASOL = "exasol"
 
 

--- a/sqlglot/dialects/vertica.py
+++ b/sqlglot/dialects/vertica.py
@@ -1,0 +1,579 @@
+from __future__ import annotations
+
+import typing as t
+from collections import defaultdict
+
+from sqlglot import exp
+from sqlglot.dialects.postgres import Postgres
+from sqlglot.helper import csv
+from sqlglot.tokens import TokenType
+
+
+class Vertica(Postgres):
+    class Tokenizer(Postgres.Tokenizer):
+        KEYWORDS = {
+            **Postgres.Tokenizer.KEYWORDS,
+            "MINUS": TokenType.EXCEPT,
+        }
+        TOKENS_PRECEDING_HINT = Postgres.Tokenizer.TOKENS_PRECEDING_HINT | {
+            TokenType.WITH,
+            TokenType.GROUP_BY,
+        }
+
+    class Parser(Postgres.Parser):
+        def _parse_hint(self) -> t.Optional[exp.Hint]:
+            hint = super()._parse_hint()
+            if hint:
+                return hint
+
+            comments = self._prev_comments
+            if not comments:
+                return None
+
+            for i, comment in enumerate(comments):
+                comment = comment.strip()
+                if not comment.startswith("+"):
+                    continue
+
+                comments.pop(i)
+                return exp.maybe_parse(comment[1:], into=exp.Hint, dialect=self.dialect)
+
+            return None
+
+        def _parse_table_alias(
+            self, alias_tokens: t.Optional[t.Collection[TokenType]] = None
+        ) -> t.Optional[exp.TableAlias]:
+            if self._curr and self._curr.text.upper() in {"MATCH", "TIMESERIES"}:
+                return None
+
+            return super()._parse_table_alias(alias_tokens=alias_tokens)
+
+        def _parse_statement(self) -> t.Optional[exp.Expression]:
+            if (
+                self._curr
+                and self._curr.text.upper() == "AT"
+                and self._next
+                and self._next.text.upper() in {"EPOCH", "TIME"}
+            ):
+                return self._parse_select()
+
+            return super()._parse_statement()
+
+        def _parse_historical_data(self) -> t.Optional[exp.HistoricalData]:
+            index = self._index
+
+            if not self._match_text_seq("AT"):
+                return None
+
+            if self._match_text_seq("EPOCH"):
+                kind = "EPOCH"
+                if self._curr and self._curr.text.upper() == "LATEST":
+                    self._advance()
+                    expression = exp.var("LATEST")
+                else:
+                    expression = self._parse_bitwise()
+            elif self._match_text_seq("TIME"):
+                kind = "TIME"
+                expression = self._parse_bitwise()
+            else:
+                self._retreat(index)
+                return None
+
+            if not expression:
+                self._retreat(index)
+                return None
+
+            return self.expression(
+                exp.HistoricalData,
+                this=exp.var("AT"),
+                kind=exp.var(kind),
+                expression=expression,
+            )
+
+        def _parse_limit(
+            self,
+            this: t.Optional[exp.Expression] = None,
+            top: bool = False,
+            skip_limit_token: bool = False,
+        ) -> t.Optional[exp.Expression]:
+            limit = super()._parse_limit(this=this, top=top, skip_limit_token=skip_limit_token)
+
+            if isinstance(limit, exp.Limit) and self._match(TokenType.OVER):
+                if isinstance(limit.expression, exp.Column) and limit.expression.name.upper() == "ALL":
+                    self.raise_error("LIMIT ALL cannot be used with OVER in Vertica")
+                self._match_l_paren()
+                limit.set("partition_by", self._parse_partition_by())
+                limit.set("order", self._parse_order())
+                self._match_r_paren()
+
+            return limit
+
+        @staticmethod
+        def _rightmost_set_operand(expression: exp.Expression) -> exp.Expression:
+            while isinstance(expression, exp.SetOperation) and expression.expression:
+                expression = expression.expression
+            return expression
+
+        def _reassociate_set_operations(
+            self, expression: exp.SetOperation
+        ) -> t.Optional[exp.Expression]:
+            operands: t.List[t.Optional[exp.Expression]] = []
+            operators: t.List[exp.SetOperation] = []
+
+            def collect(node: t.Optional[exp.Expression]) -> None:
+                if isinstance(node, exp.SetOperation):
+                    collect(node.this)
+                    operators.append(node)
+                    operands.append(node.expression)
+                else:
+                    operands.append(node)
+
+            collect(expression)
+
+            if not operators or len(operands) != len(operators) + 1:
+                return expression
+
+            reduced_operands: t.List[t.Optional[exp.Expression]] = [operands[0]]
+            reduced_operators: t.List[exp.SetOperation] = []
+
+            for operator, right in zip(operators, operands[1:]):
+                if isinstance(operator, exp.Intersect):
+                    left = reduced_operands.pop()
+                    operator.set("this", left)
+                    operator.set("expression", right)
+                    reduced_operands.append(operator)
+                else:
+                    reduced_operators.append(operator)
+                    reduced_operands.append(right)
+
+            result = reduced_operands[0]
+            for operator, right in zip(reduced_operators, reduced_operands[1:]):
+                operator.set("this", result)
+                operator.set("expression", right)
+                result = operator
+
+            return result
+
+        def parse_set_operation(
+            self, this: t.Optional[exp.Expression], consume_pipe: bool = False
+        ) -> t.Optional[exp.Expression]:
+            setop = super().parse_set_operation(this, consume_pipe=consume_pipe)
+
+            if isinstance(setop, (exp.Intersect, exp.Except)) and setop.args.get("distinct") is False:
+                self.raise_error(f"{setop.key.upper()} ALL is not supported in Vertica")
+
+            return setop
+
+        def _parse_set_operations(self, this: t.Optional[exp.Expression]) -> t.Optional[exp.Expression]:
+            while this:
+                setop = self.parse_set_operation(this)
+                if not setop:
+                    break
+                this = setop
+
+            if isinstance(this, exp.SetOperation):
+                this = self._reassociate_set_operations(this)
+
+            if isinstance(this, exp.SetOperation) and self.MODIFIERS_ATTACHED_TO_SET_OP:
+                rightmost_expression = self._rightmost_set_operand(this)
+
+                for arg in self.SET_OP_MODIFIERS:
+                    expr = rightmost_expression.args.get(arg)
+                    if expr:
+                        this.set(arg, expr.pop())
+
+            return this
+
+        def _parse_with(self, skip_with_token: bool = False) -> t.Optional[exp.With]:
+            if not skip_with_token and not self._match(TokenType.WITH):
+                return None
+
+            comments = self._prev_comments
+            hint = self._parse_hint()
+            recursive = self._match(TokenType.RECURSIVE)
+
+            last_comments = None
+            expressions = []
+            while True:
+                cte = self._parse_cte()
+                if isinstance(cte, exp.CTE):
+                    expressions.append(cte)
+                    if last_comments:
+                        cte.add_comments(last_comments)
+
+                if not self._match(TokenType.COMMA) and not self._match(TokenType.WITH):
+                    break
+                else:
+                    self._match(TokenType.WITH)
+
+                last_comments = self._prev_comments
+
+            return self.expression(
+                exp.With,
+                comments=comments,
+                hint=hint,
+                expressions=expressions,
+                recursive=recursive,
+                search=self._parse_recursive_with_search(),
+            )
+
+        def _parse_group(self, skip_group_by_token: bool = False) -> t.Optional[exp.Group]:
+            if not skip_group_by_token and not self._match(TokenType.GROUP_BY):
+                return None
+            comments = self._prev_comments
+            hint = self._parse_hint()
+
+            elements: t.Dict[str, t.Any] = defaultdict(list)
+
+            if self._match(TokenType.ALL):
+                elements["all"] = True
+            elif self._match(TokenType.DISTINCT):
+                elements["all"] = False
+
+            if self._match_set(self.QUERY_MODIFIER_TOKENS, advance=False):
+                return self.expression(exp.Group, comments=comments, hint=hint, **elements)
+
+            while True:
+                index = self._index
+
+                elements["expressions"].extend(
+                    self._parse_csv(
+                        lambda: None
+                        if self._match_set((TokenType.CUBE, TokenType.ROLLUP), advance=False)
+                        else self._parse_disjunction()
+                    )
+                )
+
+                before_with_index = self._index
+                with_prefix = self._match(TokenType.WITH)
+
+                if cube_or_rollup := self._parse_cube_or_rollup(with_prefix=with_prefix):
+                    key = "rollup" if isinstance(cube_or_rollup, exp.Rollup) else "cube"
+                    elements[key].append(cube_or_rollup)
+                elif grouping_sets := self._parse_grouping_sets():
+                    elements["grouping_sets"].append(grouping_sets)
+                elif self._match_text_seq("TOTALS"):
+                    elements["totals"] = True
+
+                if before_with_index <= self._index <= before_with_index + 1:
+                    self._retreat(before_with_index)
+                    break
+
+                if index == self._index:
+                    break
+
+            return self.expression(exp.Group, comments=comments, hint=hint, **elements)
+
+        def _parse_match_clause(self) -> t.Optional[exp.MatchRecognize]:
+            if not self._match_text_seq("MATCH"):
+                return None
+
+            self._match_l_paren()
+
+            partition_by = self._parse_partition_by()
+            order = self._parse_order()
+            if not order:
+                self.raise_error("Expecting ORDER BY")
+
+            if not self._match_text_seq("DEFINE"):
+                self.raise_error("Expecting DEFINE")
+
+            define = self._parse_csv(self._parse_name_as_expression)
+
+            if not self._match_text_seq("PATTERN"):
+                self.raise_error("Expecting PATTERN")
+
+            pattern_name = self._parse_id_var(any_token=False)
+            self._match_text_seq("AS")
+            self._match_l_paren()
+
+            if not self._curr:
+                self.raise_error("Expecting )", self._curr)
+
+            paren = 1
+            start = self._curr
+
+            while self._curr and paren > 0:
+                if self._curr.token_type == TokenType.L_PAREN:
+                    paren += 1
+                if self._curr.token_type == TokenType.R_PAREN:
+                    paren -= 1
+
+                end = self._prev
+                self._advance()
+
+            if paren > 0:
+                self.raise_error("Expecting )", self._curr)
+
+            pattern_expr = exp.var(self._find_sql(start, end))
+            pattern = (
+                exp.alias_(pattern_expr, pattern_name, copy=False) if pattern_name else pattern_expr
+            )
+
+            if self._match_text_seq("ROWS", "MATCH", "ALL", "EVENTS"):
+                rows = exp.var("ROWS MATCH ALL EVENTS")
+            elif self._match_text_seq("ROWS", "MATCH", "FIRST", "EVENT"):
+                rows = exp.var("ROWS MATCH FIRST EVENT")
+            else:
+                rows = None
+
+            self._match_r_paren()
+
+            return self.expression(
+                exp.MatchRecognize,
+                partition_by=partition_by,
+                order=order,
+                define=define,
+                pattern=pattern,
+                rows=rows,
+            )
+
+        def _parse_timeseries(self) -> t.Optional[exp.Timeseries]:
+            if not self._match_text_seq("TIMESERIES"):
+                return None
+
+            this = self._parse_id_var(any_token=False)
+            if not this:
+                self.raise_error("Expecting slice time alias")
+
+            self._match(TokenType.ALIAS)
+            expression = self._parse_bitwise()
+            if not expression:
+                self.raise_error("Expecting interval expression")
+
+            if not self._match(TokenType.OVER):
+                self.raise_error("Expecting OVER")
+
+            self._match_l_paren()
+            partition_by = self._parse_partition_by()
+            order = self._parse_order()
+            if not order:
+                self.raise_error("Expecting ORDER BY")
+            self._match_r_paren()
+
+            return self.expression(
+                exp.Timeseries,
+                this=this,
+                expression=expression,
+                partition_by=partition_by,
+                order=order,
+            )
+
+        def _parse_query_modifiers(self, this):
+            if isinstance(this, self.MODIFIABLES):
+                for join in self._parse_joins():
+                    this.append("joins", join)
+                for lateral in iter(self._parse_lateral, None):
+                    this.append("laterals", lateral)
+
+                while True:
+                    modifier_token = self._curr
+
+                    if self._match_text_seq("TIMESERIES", advance=False):
+                        key = "timeseries"
+                        expression = self._parse_timeseries()
+                    elif self._match_text_seq("MATCH", advance=False):
+                        key = "match"
+                        expression = self._parse_match_clause()
+                    elif self._match_set(self.QUERY_MODIFIER_PARSERS, advance=False):
+                        parser = self.QUERY_MODIFIER_PARSERS[modifier_token.token_type]
+                        key, expression = parser(self)
+                    else:
+                        break
+
+                    if not expression:
+                        break
+
+                    if this.args.get(key):
+                        self.raise_error(
+                            f"Found multiple '{key.upper()}' clauses",
+                            token=modifier_token,
+                        )
+
+                    this.set(key, expression)
+                    if key == "limit":
+                        offset = expression.args.get("offset")
+                        expression.set("offset", None)
+
+                        if offset:
+                            offset = exp.Offset(expression=offset)
+                            this.set("offset", offset)
+
+                            limit_by_expressions = expression.expressions
+                            expression.set("expressions", None)
+                            offset.set("expressions", limit_by_expressions)
+
+            if self.SUPPORTS_IMPLICIT_UNNEST and this and this.args.get("from_"):
+                this = self._implicit_unnests_to_explicit(this)
+
+            return this
+
+        def _parse_select(
+            self,
+            nested: bool = False,
+            table: bool = False,
+            parse_subquery_alias: bool = True,
+            parse_set_operation: bool = True,
+            consume_pipe: bool = True,
+            from_: t.Optional[exp.From] = None,
+        ) -> t.Optional[exp.Expression]:
+            historical_data = self._parse_historical_data()
+
+            query = super()._parse_select(
+                nested=nested,
+                table=table,
+                parse_subquery_alias=parse_subquery_alias,
+                parse_set_operation=parse_set_operation,
+                consume_pipe=consume_pipe,
+                from_=from_,
+            )
+
+            if historical_data and query and "when" in query.arg_types:
+                query.set("when", historical_data)
+
+            return query
+
+    class Generator(Postgres.Generator):
+        QUERY_HINTS = True
+        EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
+
+        def historicaldata_sql(self, expression: exp.HistoricalData) -> str:
+            if expression.text("this").upper() == "AT":
+                kind = expression.text("kind").upper()
+                if kind in {"EPOCH", "TIME"}:
+                    return f"AT {kind} {self.sql(expression, 'expression')}"
+
+            return super().historicaldata_sql(expression)
+
+        def select_sql(self, expression: exp.Select) -> str:
+            sql = super().select_sql(expression)
+            when = self.sql(expression, "when")
+            return f"{when} {sql}" if when else sql
+
+        def set_operations(self, expression: exp.SetOperation) -> str:
+            sql = super().set_operations(expression)
+            when = self.sql(expression, "when")
+            return f"{when} {sql}" if when else sql
+
+        def with_sql(self, expression: exp.With) -> str:
+            sql = self.expressions(expression, flat=True)
+            hint = self.sql(expression, "hint")
+            recursive = (
+                "RECURSIVE "
+                if self.CTE_RECURSIVE_KEYWORD_REQUIRED and expression.args.get("recursive")
+                else ""
+            )
+            search = self.sql(expression, "search")
+            search = f" {search}" if search else ""
+
+            return f"WITH{hint} {recursive}{sql}{search}"
+
+        def group_sql(self, expression: exp.Group) -> str:
+            group_by_all = expression.args.get("all")
+            if group_by_all is True:
+                modifier = " ALL"
+            elif group_by_all is False:
+                modifier = " DISTINCT"
+            else:
+                modifier = ""
+
+            hint = self.sql(expression, "hint")
+            group_by = self.op_expressions(f"GROUP BY{modifier}{hint}", expression)
+
+            grouping_sets = self.expressions(expression, key="grouping_sets")
+            cube = self.expressions(expression, key="cube")
+            rollup = self.expressions(expression, key="rollup")
+
+            groupings = csv(
+                self.seg(grouping_sets) if grouping_sets else "",
+                self.seg(cube) if cube else "",
+                self.seg(rollup) if rollup else "",
+                self.seg("WITH TOTALS") if expression.args.get("totals") else "",
+                sep=self.GROUPINGS_SEP,
+            )
+
+            if (
+                expression.expressions
+                and groupings
+                and groupings.strip() not in ("WITH CUBE", "WITH ROLLUP")
+            ):
+                group_by = f"{group_by}{self.GROUPINGS_SEP}"
+
+            return f"{group_by}{groupings}"
+
+        def limit_sql(self, expression: exp.Limit, top: bool = False) -> str:
+            sql = super().limit_sql(expression, top=top)
+            partition = self.expressions(expression, key="partition_by", flat=True)
+            partition = f"PARTITION BY {partition}" if partition else ""
+            order = self.sql(expression, "order").strip()
+
+            if partition or order:
+                if isinstance(expression.expression, exp.Column) and expression.expression.name.upper() == "ALL":
+                    self.unsupported("LIMIT ALL cannot be used with OVER in Vertica")
+                over = " ".join(part for part in (partition, order) if part)
+                sql = f"{sql} OVER ({over})"
+
+            return sql
+
+        def timeseries_sql(self, expression: exp.Timeseries) -> str:
+            partition = self.expressions(expression, key="partition_by", flat=True)
+            partition = f"PARTITION BY {partition} " if partition else ""
+            order = self.sql(expression, "order").strip()
+            return (
+                f" TIMESERIES {self.sql(expression, 'this')} AS {self.sql(expression, 'expression')} "
+                f"OVER ({partition}{order})"
+            )
+
+        def matchrecognize_sql(self, expression: exp.MatchRecognize) -> str:
+            partition = self.expressions(expression, key="partition_by", flat=True)
+            partition = f"PARTITION BY {partition}" if partition else ""
+            order = self.sql(expression, "order").strip()
+
+            definition_sqls = [
+                f"{self.sql(definition, 'alias')} AS {self.sql(definition, 'this')}"
+                for definition in expression.args.get("define", [])
+            ]
+            define = self.expressions(sqls=definition_sqls)
+            define = f"DEFINE {define}" if define else ""
+
+            pattern_expr = expression.args.get("pattern")
+            if isinstance(pattern_expr, exp.Alias):
+                pattern_name = self.sql(pattern_expr, "alias")
+                pattern_body = self.sql(pattern_expr, "this")
+                pattern = f"PATTERN {pattern_name} AS ({pattern_body})"
+            elif pattern_expr:
+                pattern = f"PATTERN ({self.sql(pattern_expr)})"
+            else:
+                pattern = ""
+
+            rows = self.sql(expression, "rows")
+            body = " ".join(part for part in (partition, order, define, pattern, rows) if part)
+            return f" MATCH ({body})"
+
+        def query_modifiers(self, expression: exp.Expression, *sqls: str) -> str:
+            limit = expression.args.get("limit")
+
+            if self.LIMIT_FETCH == "LIMIT" and isinstance(limit, exp.Fetch):
+                limit = exp.Limit(expression=exp.maybe_copy(limit.args.get("count")))
+            elif self.LIMIT_FETCH == "FETCH" and isinstance(limit, exp.Limit):
+                limit = exp.Fetch(direction="FIRST", count=exp.maybe_copy(limit.expression))
+
+            return csv(
+                *sqls,
+                *[self.sql(join) for join in expression.args.get("joins") or []],
+                *[self.sql(lateral) for lateral in expression.args.get("laterals") or []],
+                self.sql(expression, "prewhere"),
+                self.sql(expression, "where"),
+                self.sql(expression, "timeseries"),
+                self.sql(expression, "connect"),
+                self.sql(expression, "group"),
+                self.sql(expression, "having"),
+                *[gen(self, expression) for gen in self.AFTER_HAVING_MODIFIER_TRANSFORMS.values()],
+                self.sql(expression, "match"),
+                self.sql(expression, "order"),
+                *self.offset_limit_modifiers(expression, isinstance(limit, exp.Fetch), limit),
+                *self.after_limit_modifiers(expression),
+                self.options_modifier(expression),
+                self.for_modifiers(expression),
+                sep="",
+            )

--- a/sqlglot/expressions.py
+++ b/sqlglot/expressions.py
@@ -1755,7 +1755,7 @@ class RecursiveWithSearch(Expression):
 
 
 class With(Expression):
-    arg_types = {"expressions": True, "recursive": False, "search": False}
+    arg_types = {"expressions": True, "recursive": False, "search": False, "hint": False}
 
     @property
     def recursive(self) -> bool:
@@ -2591,6 +2591,7 @@ class Revoke(Expression):
 
 class Group(Expression):
     arg_types = {
+        "hint": False,
         "expressions": False,
         "grouping_sets": False,
         "cube": False,
@@ -2622,6 +2623,8 @@ class Limit(Expression):
         "expression": True,
         "offset": False,
         "limit_options": False,
+        "partition_by": False,
+        "order": False,
         "expressions": False,
     }
 
@@ -2837,6 +2840,15 @@ class MatchRecognize(Expression):
         "pattern": False,
         "define": False,
         "alias": False,
+    }
+
+
+class Timeseries(Expression):
+    arg_types = {
+        "this": True,
+        "expression": True,
+        "partition_by": False,
+        "order": False,
     }
 
 
@@ -3520,6 +3532,8 @@ class Tuple(Expression):
 
 
 QUERY_MODIFIERS = {
+    "when": False,
+    "timeseries": False,
     "match": False,
     "laterals": False,
     "joins": False,

--- a/tests/dialects/test_vertica.py
+++ b/tests/dialects/test_vertica.py
@@ -1,0 +1,155 @@
+from sqlglot import ErrorLevel, ParseError, UnsupportedError, exp, parse_one
+from tests.dialects.test_dialect import Validator
+
+
+class TestVertica(Validator):
+    dialect = "vertica"
+
+    def test_select_baseline(self):
+        self.validate_identity("SELECT a FROM tbl")
+        self.validate_identity("WITH cte AS (SELECT 1 AS a) SELECT a FROM cte")
+        self.validate_identity("SELECT * FROM tbl ORDER BY a LIMIT 10 OFFSET 5")
+        self.validate_identity("SELECT * FROM tbl FOR UPDATE")
+
+    def test_minus(self):
+        self.validate_all(
+            "SELECT 1 EXCEPT SELECT 2",
+            read={"vertica": "SELECT 1 MINUS SELECT 2"},
+            write={"vertica": "SELECT 1 EXCEPT SELECT 2"},
+        )
+
+    def test_at_epoch_query(self):
+        self.validate_identity("AT EPOCH LATEST SELECT 1")
+        self.validate_identity("AT EPOCH 42 SELECT 1")
+        self.validate_identity("AT TIME '2024-01-01 00:00:00' SELECT 1")
+        self.validate_identity("AT EPOCH LATEST WITH cte AS (SELECT 1) SELECT * FROM cte")
+        self.validate_identity("AT TIME '2024-01-01 00:00:00' WITH cte AS (SELECT 1) SELECT * FROM cte")
+        self.validate_identity("AT EPOCH LATEST SELECT 1 UNION SELECT 2")
+        self.validate_identity("AT TIME '2024-01-01 00:00:00' SELECT 1 UNION SELECT 2")
+        self.validate_identity("SELECT * FROM (AT TIME '2024-01-01 00:00:00' SELECT 1 AS a) AS t")
+
+    def test_at_epoch_table(self):
+        self.validate_identity("SELECT * FROM x AT EPOCH LATEST")
+        self.validate_identity("SELECT * FROM x AT EPOCH 42")
+        self.validate_identity("SELECT * FROM x AT TIME '2024-01-01 00:00:00'")
+
+    def test_limit_over(self):
+        self.validate_identity(
+            "SELECT store_region, store_name FROM store.store_dimension LIMIT 2 OVER (PARTITION BY store_region ORDER BY number_of_employees)"
+        )
+        self.validate_identity(
+            "SELECT a, b FROM t LIMIT 3 OVER (PARTITION BY a ORDER BY b DESC NULLS LAST)"
+        )
+        self.validate_identity("SELECT * FROM t LIMIT ALL")
+
+    def test_limit_all_over_not_supported(self):
+        with self.assertRaises(ParseError):
+            self.parse_one("SELECT * FROM t LIMIT ALL OVER (ORDER BY x)")
+
+        expression = exp.select("*").from_("t")
+        expression.set(
+            "limit",
+            exp.Limit(
+                expression=exp.column("ALL"),
+                order=exp.Order(expressions=[exp.Ordered(this=exp.column("x"))]),
+            ),
+        )
+
+        with self.assertRaises(UnsupportedError):
+            expression.sql(dialect="vertica", unsupported_level=ErrorLevel.RAISE)
+
+    def test_match_clause(self):
+        self.validate_identity(
+            "SELECT * FROM clicks MATCH (PARTITION BY user_id ORDER BY ts DEFINE A AS action = 'A', B AS action = 'B' PATTERN P AS (A B) ROWS MATCH FIRST EVENT)"
+        )
+        self.validate_identity(
+            "SELECT * FROM clicks MATCH (ORDER BY ts DEFINE A AS action = 'A' PATTERN P AS (A+) ROWS MATCH ALL EVENTS)"
+        )
+
+    def test_timeseries_clause(self):
+        self.validate_identity(
+            "SELECT slice_time, symbol, TS_FIRST_VALUE(bid) FROM Tickstore TIMESERIES slice_time AS '5 seconds' OVER (PARTITION BY symbol ORDER BY ts)"
+        )
+        self.validate_identity(
+            "SELECT slice_time, TS_FIRST_VALUE(bid) FROM Tickstore TIMESERIES slice_time AS '1 second' OVER (ORDER BY ts) ORDER BY slice_time"
+        )
+
+    def test_set_operation_precedence(self):
+        expression = parse_one(
+            "SELECT 1 AS x UNION SELECT 2 AS x INTERSECT SELECT 3 AS x", read="vertica"
+        )
+        self.assertIsInstance(expression, exp.Union)
+        self.assertIsInstance(expression.args["expression"], exp.Intersect)
+
+        expression = parse_one(
+            "SELECT 1 AS x EXCEPT SELECT 2 AS x INTERSECT SELECT 3 AS x", read="vertica"
+        )
+        self.assertIsInstance(expression, exp.Except)
+        self.assertIsInstance(expression.args["expression"], exp.Intersect)
+
+        expression = parse_one(
+            "(SELECT 1 AS x UNION SELECT 2 AS x) INTERSECT SELECT 3 AS x", read="vertica"
+        )
+        self.assertIsInstance(expression, exp.Intersect)
+        self.assertIsInstance(expression.args["this"], exp.Subquery)
+
+        expression = parse_one(
+            "SELECT 1 AS x EXCEPT SELECT 2 AS x EXCEPT SELECT 3 AS x", read="vertica"
+        )
+        self.assertIsInstance(expression, exp.Except)
+        self.assertIsInstance(expression.args["this"], exp.Except)
+
+        expression = parse_one(
+            "SELECT 1 AS x UNION SELECT 2 AS x INTERSECT SELECT 3 AS x LIMIT 1",
+            read="vertica",
+        )
+        self.assertIsInstance(expression, exp.Union)
+        self.assertIsInstance(expression.args.get("limit"), exp.Limit)
+        self.assertIsNone(expression.args["expression"].args.get("limit"))
+
+        expression = parse_one("SELECT 1 MINUS SELECT 2 INTERSECT SELECT 3", read="vertica")
+        self.assertIsInstance(expression, exp.Except)
+        self.assertIsInstance(expression.args["expression"], exp.Intersect)
+
+    def test_set_operation_all_not_supported(self):
+        with self.assertRaises(ParseError):
+            self.parse_one("SELECT 1 INTERSECT ALL SELECT 1")
+
+        with self.assertRaises(ParseError):
+            self.parse_one("SELECT 1 EXCEPT ALL SELECT 1")
+
+        with self.assertRaises(UnsupportedError):
+            parse_one("SELECT 1 INTERSECT ALL SELECT 1").sql(
+                dialect="vertica", unsupported_level=ErrorLevel.RAISE
+            )
+
+        with self.assertRaises(UnsupportedError):
+            parse_one("SELECT 1 EXCEPT ALL SELECT 1").sql(
+                dialect="vertica", unsupported_level=ErrorLevel.RAISE
+            )
+
+    def test_hints(self):
+        self.validate_all(
+            "WITH /*+ ENABLE_WITH_CLAUSE_MATERIALIZATION */ cte AS (SELECT 1) SELECT * FROM cte",
+            read={"vertica": "WITH /*+ENABLE_WITH_CLAUSE_MATERIALIZATION*/ cte AS (SELECT 1) SELECT * FROM cte"},
+            write={"vertica": "WITH /*+ ENABLE_WITH_CLAUSE_MATERIALIZATION */ cte AS (SELECT 1) SELECT * FROM cte"},
+        )
+        self.validate_all(
+            "SELECT a, SUM(b) FROM t GROUP BY /*+ GBYTYPE(HASH) */ a",
+            read={"vertica": "SELECT a, SUM(b) FROM t GROUP BY /*+GBYTYPE(HASH)*/ a"},
+            write={"vertica": "SELECT a, SUM(b) FROM t GROUP BY /*+ GBYTYPE(HASH) */ a"},
+        )
+        self.validate_all(
+            "WITH /*+ ENABLE_WITH_CLAUSE_MATERIALIZATION */ RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3) SELECT * FROM t",
+            read={
+                "vertica": "WITH /*+ENABLE_WITH_CLAUSE_MATERIALIZATION*/ RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3) SELECT * FROM t"
+            },
+            write={
+                "vertica": "WITH /*+ ENABLE_WITH_CLAUSE_MATERIALIZATION */ RECURSIVE t(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM t WHERE n < 3) SELECT * FROM t"
+            },
+        )
+        self.validate_all(
+            "SELECT a, SUM(b) FROM t GROUP BY /*+ GBYTYPE(PIPELINED) */ a",
+            read={"vertica": "SELECT a, SUM(b) FROM t GROUP BY /*+GBYTYPE(PIPELINED)*/ a"},
+            write={"vertica": "SELECT a, SUM(b) FROM t GROUP BY /*+ GBYTYPE(PIPELINED) */ a"},
+        )


### PR DESCRIPTION
## Summary

We use Vertica in production at our company and want to contribute dialect support upstream.  
This PR is an initial **WIP** focused on `SELECT` syntax, opened early to get maintainer feedback on scope, AST choices, and parser/generator direction before expanding further.

## What’s Included (Initial Scope)

- Added built-in `vertica` dialect registration and base implementation.
- Added `MINUS` support as alias of `EXCEPT`.
- Added historical query support:
  - `AT EPOCH ...`
  - `AT TIME '...'`
- Added `LIMIT ... OVER (PARTITION BY ... ORDER BY ...)`.
- Added Vertica `MATCH (...)` clause support.
- Added Vertica `TIMESERIES ... OVER (...)` support.
- Added Vertica-specific set-op handling:
  - mixed precedence handling for `INTERSECT` vs `UNION/EXCEPT`
  - rejection of `INTERSECT ALL` / `EXCEPT ALL`
- Added Vertica hint fidelity for:
  - `WITH /*+ENABLE_WITH_CLAUSE_MATERIALIZATION*/`
  - `GROUP BY /*+GBYTYPE(...)*/`
- Added additional hardening:
  - rejection of `LIMIT ALL OVER (...)` per Vertica LIMIT grammar.
- Added new dialect coverage in `tests/dialects/test_vertica.py`.

## Validation

- `python3 -m unittest tests.dialects.test_vertica`
- `python3 -m unittest tests.dialects.test_dialect.TestDialect.test_limit`
- `python3 -m unittest tests.dialects.test_dialect.TestDialect.test_enum`
- `python3 -m unittest tests.test_serde`
- `python3 -m unittest tests.test_parser.TestParser.test_union`
- `python3 -m unittest tests.test_parser.TestParser.test_select`

## Feedback Requested

- Is this initial scope reasonable for a first Vertica contribution?
- Are AST additions (`Timeseries`, query modifiers, hint args on `With`/`Group`, limit-over args) acceptable?
- Is the current set-op precedence/restriction handling direction acceptable for Vertica?
- What should be the preferred next incremental scope after this PR (broader `SELECT` parity vs non-`SELECT` statements)?