### PR TITLE
Fix: Drop schema with if exists displacing catalog

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2162,9 +2162,7 @@ class Parser:
         if kind == "COLUMN":
             this = self._parse_column()
         else:
-            this = self._parse_table_parts(
-                schema=True, is_db_reference=self._prev.token_type == TokenType.SCHEMA
-            )
+            this = self._parse_table_parts(schema=True, is_db_reference=kind == "SCHEMA")
 
         cluster = self._parse_on_property() if self._match(TokenType.ON) else None
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -836,7 +836,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(ast[0].sql(), "CONCAT_WS()")
 
     def test_parse_drop_schema(self):
-        for dialect in [None, "bigquery", "snowflake"]:
+        for dialect in [None, "bigquery", "snowflake", "duckdb"]:
             with self.subTest(dialect):
                 ast = parse_one("DROP SCHEMA catalog.schema", dialect=dialect)
                 self.assertEqual(
@@ -851,6 +851,40 @@ class TestParser(unittest.TestCase):
                     ),
                 )
                 self.assertEqual(ast.sql(dialect=dialect), "DROP SCHEMA catalog.schema")
+
+        # when there is IF EXISTS it must not displace catalog mapping
+        for dialect in [None, "bigquery", "snowflake", "duckdb"]:
+            with self.subTest(f"{dialect} IF EXISTS"):
+                ast = parse_one("DROP SCHEMA IF EXISTS catalog.schema", dialect=dialect)
+                self.assertEqual(
+                    ast,
+                    exp.Drop(
+                        this=exp.Table(
+                            this=None,
+                            db=exp.Identifier(this="schema", quoted=False),
+                            catalog=exp.Identifier(this="catalog", quoted=False),
+                        ),
+                        kind="SCHEMA",
+                        exists=True,
+                    ),
+                )
+                self.assertEqual(ast.sql(dialect=dialect), "DROP SCHEMA IF EXISTS catalog.schema")
+
+        # single part name no catalog and schema name in db
+        for dialect in [None, "bigquery", "snowflake", "duckdb"]:
+            ast = parse_one("DROP SCHEMA IF EXISTS myschema")
+            self.assertEqual(
+                ast,
+                exp.Drop(
+                    this=exp.Table(
+                        this=None,
+                        db=exp.Identifier(this="myschema", quoted=False),
+                    ),
+                    kind="SCHEMA",
+                    exists=True,
+                ),
+            )
+            self.assertEqual(ast.sql(), "DROP SCHEMA IF EXISTS myschema")
 
     def test_parse_create_schema(self):
         for dialect in [None, "bigquery", "snowflake"]:


### PR DESCRIPTION
when drop schema contains if exists the catalog is mapped as db:
```
>>> parse_one("DROP SCHEMA IF EXISTS polaris.test_schema").find(exp.Table)
Table(
  this=Identifier(this=test_schema),
  db=Identifier(this=polaris),        # <- catalog misplaced
)
```

because `_parse_drop` is using `self._prev.token_type == TokenType.SCHEMA` to set `is_db_reference`, but with `_parse_exists()` the cursor will be past it, so `self._prev` is `EXISTS` instead of `SCHEMA` so this is to instead use `kind`, so with this update:

```
>>> parse_one("DROP SCHEMA IF EXISTS polaris.test_schema").find(exp.Table)
Table(
  db=Identifier(this=test_schema),
  catalog=Identifier(this=polaris),   # <- catalog
)
```