### PR TITLE
fix(hive, spark)!: robust support for IGNORE NULLS

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -467,6 +467,15 @@ class Hive(Dialect):
             exp.Year,
         )
 
+        IGNORE_NULLS_FUNCS = (exp.First, exp.Last, exp.FirstValue, exp.LastValue)
+
+        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
+            this = expression.this
+            if isinstance(this, self.IGNORE_NULLS_FUNCS):
+                return self.func(this.sql_name(), this.this, exp.true())
+
+            return super().ignorenulls_sql(expression)
+
         def unnest_sql(self, expression: exp.Unnest) -> str:
             return rename_func("EXPLODE")(self, expression)
 

--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -12,6 +12,7 @@ from sqlglot.dialects.dialect import (
     groupconcat_sql,
 )
 from sqlglot.parsers.spark import SparkParser
+from sqlglot import generator
 from sqlglot.dialects.spark2 import Spark2, temporary_storage_provider
 from sqlglot.typing.spark import EXPRESSION_METADATA
 from sqlglot.helper import seq_get
@@ -159,6 +160,9 @@ class Spark(Spark2):
         TRANSFORMS.pop(exp.AnyValue)
         TRANSFORMS.pop(exp.DateDiff)
         TRANSFORMS.pop(exp.With)
+
+        def ignorenulls_sql(self, expression: exp.IgnoreNulls) -> str:
+            return generator.Generator.ignorenulls_sql(self, expression)
 
         def bracket_sql(self, expression: exp.Bracket) -> str:
             if expression.args.get("safe"):

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -951,17 +951,64 @@ class TestHive(Validator):
         )
 
         self.validate_all(
-            "SELECT FIRST(sample_col) IGNORE NULLS",
+            "SELECT FIRST(sample_col, TRUE)",
             read={
-                "hive": "SELECT FIRST(sample_col, TRUE)",
-                "spark2": "SELECT FIRST(sample_col, TRUE)",
                 "spark": "SELECT FIRST(sample_col, TRUE)",
                 "databricks": "SELECT FIRST(sample_col, TRUE)",
             },
             write={
+                "hive": "SELECT FIRST(sample_col, TRUE)",
+                "spark2": "SELECT FIRST(sample_col, TRUE)",
+                "spark": "SELECT FIRST(sample_col) IGNORE NULLS",
+                "databricks": "SELECT FIRST(sample_col) IGNORE NULLS",
                 "duckdb": "SELECT ANY_VALUE(sample_col)",
             },
         )
+
+        self.validate_all(
+            "SELECT FIRST_VALUE(sample_col, TRUE)",
+            read={
+                "spark": "SELECT FIRST_VALUE(sample_col, TRUE)",
+                "databricks": "SELECT FIRST_VALUE(sample_col, TRUE)",
+            },
+            write={
+                "hive": "SELECT FIRST_VALUE(sample_col, TRUE)",
+                "spark2": "SELECT FIRST_VALUE(sample_col, TRUE)",
+                "spark": "SELECT FIRST_VALUE(sample_col) IGNORE NULLS",
+                "databricks": "SELECT FIRST_VALUE(sample_col) IGNORE NULLS",
+                "duckdb": "SELECT FIRST_VALUE(sample_col IGNORE NULLS)",
+            },
+        )
+
+        self.validate_all(
+            "SELECT LAST_VALUE(sample_col, TRUE)",
+            read={
+                "spark": "SELECT LAST_VALUE(sample_col, TRUE)",
+                "databricks": "SELECT LAST_VALUE(sample_col, TRUE)",
+            },
+            write={
+                "hive": "SELECT LAST_VALUE(sample_col, TRUE)",
+                "spark2": "SELECT LAST_VALUE(sample_col, TRUE)",
+                "spark": "SELECT LAST_VALUE(sample_col) IGNORE NULLS",
+                "databricks": "SELECT LAST_VALUE(sample_col) IGNORE NULLS",
+                "duckdb": "SELECT LAST_VALUE(sample_col IGNORE NULLS)",
+            },
+        )
+
+        self.validate_all(
+            "SELECT LAST(sample_col, TRUE)",
+            read={
+                "spark": "SELECT LAST(sample_col, TRUE)",
+                "databricks": "SELECT LAST(sample_col, TRUE)",
+            },
+            write={
+                "hive": "SELECT LAST(sample_col, TRUE)",
+                "spark2": "SELECT LAST(sample_col, TRUE)",
+                "spark": "SELECT LAST(sample_col) IGNORE NULLS",
+                "databricks": "SELECT LAST(sample_col) IGNORE NULLS",
+            },
+        )
+
         self.validate_identity(
             "DATE_SUB(CURRENT_DATE, 1 + 1)", "DATE_ADD(CURRENT_DATE, (1 + 1) * -1)"
         )


### PR DESCRIPTION
Fixes #7282

**First issue**
```
Input: SELECT FIRST_VALUE(col, true) FROM (SELECT 1 AS col) t;

Output:
spark2 -> SELECT FIRST_VALUE(col) IGNORE NULLS FROM (SELECT 1 AS col) AS t
spark -> SELECT FIRST_VALUE(col) IGNORE NULLS FROM (SELECT 1 AS col) AS t
databricks -> SELECT FIRST_VALUE(col) IGNORE NULLS FROM (SELECT 1 AS col) AS t
```
For ^ spark2 this is invalid query, we must keep the argument inside the FIRST_VALUE.

**Second issue**
```
Hive:
SELECT FIRST_VALUE(value, TRUE) OVER (ORDER BY id) FROM (SELECT 1 AS id, NULL AS value UNION ALL SELECT 2, 20 UNION ALL SELECT 3, NULL) t;
+-----------------------+
| FIRST_VALUE_window_0  |
+-----------------------+
| NULL                  |
| 20                    |
| 20                    |
+-----------------------+

vs

SELECT FIRST_VALUE(value) IGNORE NULLS OVER (ORDER BY id) FROM (SELECT 1 AS id, NULL AS value UNION ALL SELECT 2, 20 UNION ALL SELECT 3, NULL) t;

+-----------------------+
| FIRST_VALUE_window_0  |
+-----------------------+
| NULL                  |
| NULL                  |
| NULL                  |
+-----------------------+
```
In the main when we had the `TRUE` argument we generated the `IGNORE NULLS` outside which results into wrong output.

