### PR TITLE
fix(expressions): restore Expression.alias for non-Identifier alias nodes (Placeholder regression)

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -618,8 +618,8 @@ class Expression(Expr):
         Returns the alias of the expression, or an empty string if it's not aliased.
         """
         alias = self.args.get("alias")
-        if type(alias).__name__ == "TableAlias":
-            return alias.name  # type: ignore[union-attr]
+        if isinstance(alias, Expression):
+            return alias.name
         return self.text("alias")
 
     @property

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -835,6 +835,16 @@ class TestExprs(unittest.TestCase):
         self.assertEqual(alias('"foo"', "_bar").sql(), '"foo" AS _bar')
         self.assertEqual(alias("foo", "bar", quoted=True).sql(), 'foo AS "bar"')
 
+    def test_alias_with_placeholder(self):
+        # Snowflake's `AS :name` syntax parses the alias as a Placeholder node.
+        # Regression test: Expression.alias should return the placeholder name, not "".
+        expr = parse_one("SELECT PARSE_JSON(col) AS :userInfo FROM t", dialect="snowflake")
+        select = expr.selects[0]
+        self.assertIsInstance(select.args.get("alias"), exp.Placeholder)
+        self.assertEqual(select.alias, "userInfo")
+        self.assertEqual(select.alias_or_name, "userInfo")
+        self.assertEqual(select.output_name, "userInfo")
+
     def test_unit(self):
         unit = parse_one("timestamp_trunc(current_timestamp, week(thursday))")
         self.assertIsNotNone(unit.find(exp.CurrentTimestamp))


### PR DESCRIPTION
## Summary

In v29, `ExpressionCore.alias` delegated to `alias.name` for **any** `Expression` in the alias slot:

```python
# v29 expression_core.py
@property
def alias(self) -> str:
    alias = self.args.get("alias")
    if isinstance(alias, ExpressionCore):
        return alias.name   # handles TableAlias, Placeholder, etc.
    return self.text("alias")
```

The v30 refactor (#7160) narrowed this to only special-case `TableAlias`:

```python
# v30 expressions/core.py
@property
def alias(self) -> str:
    alias = self.args.get("alias")
    if type(alias).__name__ == "TableAlias":
        return alias.name   # only TableAlias
    return self.text("alias")  # Placeholder → ""
```

`text()` only handles `Identifier`, `Literal`, `Var`, `Star`, `Null` — not `Placeholder`. So any `Expression` subtype other than `TableAlias` now returns `""` from `.alias`, `.alias_or_name`, and `.output_name`.

## Broken case

Snowflake's `AS :name` syntax (e.g. `PARSE_JSON(col) AS :userInfo`) is parsed as `Alias(alias=Placeholder("userInfo"))`. After the v30 refactor:

```python
parse_one("SELECT PARSE_JSON(col) AS :userInfo FROM t", dialect="snowflake").selects[0].alias
# v29: "userInfo"
# v30: ""   ← regression
```

## Fix

Replace the type-name string check with `isinstance(alias, Expression)`, restoring the original v29 behaviour:

```python
if isinstance(alias, Expression):
    return alias.name
```

A regression test for the `Placeholder` alias case is included.