### PR TITLE
Chore: use ProcessPoolExecutor in test_executor

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -3,7 +3,7 @@ import csv
 import datetime
 import unittest
 from datetime import date, time
-from multiprocessing import Pool
+from concurrent.futures import ProcessPoolExecutor
 
 import duckdb
 import numpy as np
@@ -158,16 +158,13 @@ class TestExecutor(unittest.TestCase):
             assert_frame_equal(a, b, check_dtype=False, check_index_type=False)
 
     def _mp_execute(self, schema, tables, sqls, tpch):
-        with Pool(
+        with ProcessPoolExecutor(
             initializer=initializer,
             initargs=(schema, tables),
         ) as pool:
-            for i, table in enumerate(
-                pool.starmap(
-                    mp_execute,
-                    ((parse_one(sql), args) for args, sql, _ in sqls),
-                )
-            ):
+            futures = [pool.submit(mp_execute, parse_one(sql), args) for args, sql, _ in sqls]
+            for i, future in enumerate(futures):
+                table = future.result()
                 if table is not None:
                     self.subtestHelper(i, table, tpch=tpch)
 


### PR DESCRIPTION
Aims to fix some warnings we see in CICD for Python 3.12:

```
/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=2301) is multi-threaded, use of
 fork() may lead to deadlocks in the child.
```

This is now consistent with `test_optimizer.py`.