### PR TITLE
Chore: Fix `uv sync` failing due to sqlglotc

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,9 @@ include = ["sqlglot", "sqlglot.*"]
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
 
+[tool.uv.sources]
+sqlglotc = { path = "./sqlglotc" }
+
 [tool.ruff]
 line-length = 100
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/7321

`uv sync` resolves all extras during lockfile creation, including `sqlglot[c]` which pins sqlglotc to a dynamic dev version; The dev version (e.g., `30.0.2.dev16`) is computed by `setuptools_scm` based on the number of commits since the last git tag so it only exists locally and not on PyPI. 

Adding `[tool.uv.sources]` tells uv to resolve sqlglotc from the local `./sqlglotc/` directory instead.