### PR TITLE
Drop the mutable default in subclasses

### DIFF
--- a/sqlglot/helper.py
+++ b/sqlglot/helper.py
@@ -141,7 +141,7 @@ def csv(*args: str, sep: str = ", ") -> str:
 def subclasses(
     module_name: str,
     classes: t.Type | t.Tuple[t.Type, ...],
-    exclude: t.Set[t.Type] = set(),
+    exclude: t.Set[t.Type] = None,
 ) -> t.List[t.Type]:
     """
     Returns all subclasses for a collection of classes, possibly excluding some of them.
@@ -154,6 +154,8 @@ def subclasses(
     Returns:
         The target subclasses.
     """
+    if exclude is None:
+        exclude = set()
     return [
         obj
         for _, obj in inspect.getmembers(


### PR DESCRIPTION
Eliminates shared mutable default in subclasses() within helper.py to prevent state leaks.

Mutable defaults are shared across calls and usually turn into state leaks.

Ran: `/Users/tejasattarde/Downloads/gh-patchbot/.venv/bin/python3.14 -m py_compile sqlglot/helper.py`.

This changes a public function signature by replacing mutable defaults with None guards. Call sites stay source-compatible, but callers introspecting defaults will see None now.

`helper.py` line 141.