### PR TITLE
fix(parser): Add builder for `ARRAY_INTERSECT`

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -3694,14 +3694,14 @@ class DuckDB(Dialect):
                 """
                 Output looks something like this:
 
-                CASE 
-                WHEN delimiter is '' THEN 
+                CASE
+                WHEN delimiter is '' THEN
                     (
-                        CASE 
+                        CASE
                         WHEN adjusted_part_index = 1 OR adjusted_part_index = -1 THEN input
                         ELSE '' END
-                    ) 
-                ELSE SPLIT_PART(input, delimiter, adjusted_part_index) 
+                    )
+                ELSE SPLIT_PART(input, delimiter, adjusted_part_index)
                 END
 
                 """

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -317,6 +317,8 @@ class Parser:
         "ARRAY_APPEND": build_array_append,
         "ARRAY_CAT": build_array_concat,
         "ARRAY_CONCAT": build_array_concat,
+        "ARRAY_INTERSECT": lambda args: exp.ArrayIntersect(expressions=args),
+        "ARRAY_INTERSECTION": lambda args: exp.ArrayIntersect(expressions=args),
         "ARRAY_PREPEND": build_array_prepend,
         "ARRAY_REMOVE": build_array_remove,
         "COUNT": lambda args: exp.Count(this=seq_get(args, 0), expressions=args[1:], big_int=True),

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1417,6 +1417,7 @@ class TestDialect(Validator):
                 "trino": "ARRAY_INTERSECT(x, y)",
                 "snowflake": "ARRAY_INTERSECTION(x, y)",
                 "starrocks": "ARRAY_INTERSECT(x, y)",
+                "duckdb": "ARRAY_INTERSECT(x, y)",
             },
             write={
                 "hive": "ARRAY_INTERSECT(x, y)",
@@ -1427,6 +1428,7 @@ class TestDialect(Validator):
                 "trino": "ARRAY_INTERSECT(x, y)",
                 "snowflake": "ARRAY_INTERSECTION(x, y)",
                 "starrocks": "ARRAY_INTERSECT(x, y)",
+                "duckdb": "ARRAY_INTERSECT(x, y)",
             },
         )
 


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/7326

https://github.com/tobymao/sqlglot/pull/7145 added `is_multiset` arg which caused varlen args to spill to that arg instead of `expressions`. 

This PR fixes this by overriding the construction to store all `args` into `expressions`.