### PR TITLE
fix(parser): Do not consume constraints following `UNIQUE`

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7068,6 +7068,8 @@ class Parser:
         return result
 
     def _parse_unique_key(self) -> t.Optional[exp.Expr]:
+        if self._curr and self._curr.text.upper() in self.CONSTRAINT_PARSERS:
+            return None
         return self._parse_id_var(any_token=False)
 
     def _parse_unique(self) -> exp.UniqueColumnConstraint:

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -17,6 +17,7 @@ class TestMySQL(Validator):
         self.validate_identity("CREATE TABLE bar (abacate DOUBLE(10, 2) UNSIGNED)")
         self.validate_identity("CREATE TABLE t (id DECIMAL(20, 4) UNSIGNED)")
         self.validate_identity("CREATE TABLE foo (a BIGINT, UNIQUE (b) USING BTREE)")
+        self.validate_identity("CREATE TABLE foo (a VARCHAR(32) NOT NULL UNIQUE COMMENT 'test')")
         self.validate_identity("CREATE TABLE foo (id BIGINT)")
         self.validate_identity("CREATE TABLE 00f (1d BIGINT)")
         self.validate_identity("CREATE TABLE temp (id SERIAL PRIMARY KEY)")


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/7327

Added a guard so that `self._parse_id_var(any_token=False)` does not preemptively consume the next token 