### PR TITLE
fix(clickhouse): lowercase dateTrunc units for versions before 23.12

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -759,16 +759,9 @@ class ClickHouse(Dialect):
 
             return super().values_sql(expression, values_as_table=values_as_table)
 
-        def _lowered_unit(self, unit: t.Optional[exp.Expr]) -> t.Optional[exp.Expr]:
-            # https://github.com/ClickHouse/ClickHouse/pull/57624
-            if self.dialect.version < (23, 12) and unit and unit.is_string:
-                return exp.Literal.string(unit.name.lower())
-            return unit
-
-        def datetrunc_sql(self, expression: exp.DateTrunc) -> str:
-            unit = self._lowered_unit(expression.args.get("unit"))
-            return self.func("DATE_TRUNC", unit, expression.this, expression.args.get("zone"))
-
         def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
-            unit = self._lowered_unit(unit_to_str(expression))
+            unit = unit_to_str(expression)
+            # https://clickhouse.com/docs/whats-new/changelog/2023#improvement
+            if self.dialect.version < (23, 12) and unit and unit.is_string:
+                unit = exp.Literal.string(unit.name.lower())
             return self.func("dateTrunc", unit, expression.this, expression.args.get("zone"))

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1759,13 +1759,6 @@ LIFETIME(MIN 0 MAX 0)""",
                     "spark": f"DATE_TRUNC('{unit}', x)",
                 },
             )
-            self.validate_all(
-                f"DATE_TRUNC('{unit}', x)",
-                write={
-                    "clickhouse, version=23.8": f"DATE_TRUNC('{unit.lower()}', x)",
-                    "clickhouse, version=24.1": f"DATE_TRUNC('{unit}', x)",
-                },
-            )
 
         self.validate_all(
             "toMonday(x)",


### PR DESCRIPTION
  Older versions of ClickHouse require the unit argument of dateTrunc to be lowercase (e.g. 'month'), but sqlglot was generating  
  uppercase ('MONTH'), causing failures on those versions. Additionally, dateTrunc(...) written directly in SQL was being parsed
  as an Anonymous node instead of TimestampTrunc.                                                                                 
                                                            
  Changes

  - parsers/clickhouse.py: Register DATETRUNC in FUNCTIONS so dateTrunc(unit, date[, tz]) is correctly parsed as TimestampTrunc   
  - dialects/clickhouse.py: Override timestamptrunc_sql to lowercase the unit when generating dateTrunc
                                                                                                                                  
  Result                                                    

  -- before
  dateTrunc('MONTH', today())
                                                                                                                                  
  -- after
  dateTrunc('month', today()) 