### PR TITLE
fix: sqlglotc sdist install fails when ../sqlglot dir doesn't exist

### DIFF
--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -12,8 +12,11 @@ sqlglot_src = os.path.join(here, "..", "sqlglot")
 
 def _subpkg_files(subpkg, files=None):
     """List source files from a sqlglot subpackage. Compiles all .py files if `files` is None."""
-    subpkg_dir = os.path.join(sqlglot_src, subpkg)
     if files is None:
+        # Try repo source first, fall back to sdist-bundled copy.
+        subpkg_dir = os.path.join(sqlglot_src, subpkg)
+        if not os.path.isdir(subpkg_dir):
+            subpkg_dir = os.path.join(here, "sqlglot", subpkg)
         files = sorted(
             f for f in os.listdir(subpkg_dir) if f.endswith(".py") and f != "__init__.py"
         )


### PR DESCRIPTION
_subpkg_files always used ../sqlglot to discover .py files, which doesn't exist when installing from a PyPI sdist. Fall back to the bundled ./sqlglot/ copy, matching _source_paths() behavior.

Fixes #7333