### PR TITLE
fix(optimizer):  fix correlated subquery miscategorized as non-correlated when outer table name collides with CTE name

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -426,10 +426,11 @@ class Scope:
                 left, right = self.union_scopes
                 self._external_columns = left.external_columns + right.external_columns
             else:
+                local_source_names = {name for name, _ in self.references}
                 self._external_columns = [
                     c
                     for c in self.columns
-                    if c.text("table") not in self.sources
+                    if c.text("table") not in local_source_names
                     and c.text("table") not in self.semi_or_anti_join_tables
                 ]
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1075,6 +1075,13 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         scope = build_scope(parse_one(sql, read="bigquery"))
         self.assertEqual(set(scope.selected_sources), {"t", "a1", "a2"})
 
+        # Correlated subquery must be detected even when the outer table name collides with a CTE name
+        sql = "WITH x AS (SELECT 1 AS id) SELECT x.id, (SELECT MAX(x2.id) FROM x AS x2 WHERE x2.id = x.id) AS mx FROM x"
+        scopes = traverse_scope(parse_one(sql))
+        subquery_scope = next(s for s in scopes if s.is_subquery)
+        self.assertTrue(subquery_scope.is_correlated_subquery)
+        self.assertIn("x.id", [c.sql() for c in subquery_scope.external_columns])
+
     @patch("sqlglot.optimizer.scope.logger")
     def test_scope_warning(self, logger):
         self.assertEqual(len(traverse_scope(parse_one("WITH q AS (@y) SELECT * FROM q"))), 1)


### PR DESCRIPTION
Fixes  #7308

When a correlated subquery's outer table reference shares a name with a visible CTE, SQLGlot incorrectly classifies the subquery as non-correlated `(is_correlated_subquery = False)`.
Reason being, `Scope.external_columns checks c.text("table")` not in `self.sources`, but `sources` includes inherited `CTE` names — so when the outer table has the same name as a `CTE`, the outer reference is misclassified as local.

Verification:
```
Before:
 python3 -c "
import sqlglot
from sqlglot.optimizer.scope import traverse_scope

sql = 'WITH x AS (SELECT 1 AS id) SELECT (SELECT x.id FROM x AS x2) FROM x'
for scope in traverse_scope(sqlglot.parse_one(sql)):
    print(scope.scope_type, scope.is_correlated_subquery, [c.sql() for c in scope.external_columns])
"
ScopeType.CTE False []
ScopeType.SUBQUERY False []
ScopeType.ROOT False []

After:
sqlglot % python3 -c "
import sqlglot
from sqlglot.optimizer.scope import traverse_scope

sql = 'WITH x AS (SELECT 1 AS id) SELECT (SELECT x.id FROM x AS x2) FROM x'
for scope in traverse_scope(sqlglot.parse_one(sql)):
    print(scope.scope_type, scope.is_correlated_subquery, [c.sql() for c in scope.external_columns])
"
ScopeType.CTE False []
ScopeType.SUBQUERY True ['x.id']
ScopeType.ROOT False []
```