### PR TITLE
refactor(generator)!: Compile base Generator with mypyc

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -22,7 +22,7 @@ from sqlglot.helper import (
     to_bool,
     ensure_list,
 )
-from sqlglot.jsonpath import JSONPathTokenizer, parse as parse_json_path
+from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSONPathTokenizer, parse as parse_json_path
 from sqlglot.parser import Parser
 from sqlglot.parsers.base import BaseParser
 from sqlglot.time import TIMEZONES, format_time, subsecond_precision
@@ -266,6 +266,13 @@ class _Dialect(type):
             "Generator", type("Generator", base_generator, {})
         )
 
+        # Remove transforms that correspond to unsupported JSONPathPart expressions
+        gen_cls = klass.generator_class
+        supported = getattr(gen_cls, "SUPPORTED_JSON_PATH_PARTS", None)
+        if isinstance(supported, set):
+            for part in ALL_JSON_PATH_PARTS - supported:
+                gen_cls.TRANSFORMS.pop(part, None)
+
         klass.QUOTE_START, klass.QUOTE_END = list(klass.tokenizer_class._QUOTES.items())[0]
         klass.IDENTIFIER_START, klass.IDENTIFIER_END = list(
             klass.tokenizer_class._IDENTIFIERS.items()
@@ -312,7 +319,12 @@ class _Dialect(type):
             klass.generator_class.SUPPORTS_UESCAPE = False
 
         if enum not in ("", "databricks", "hive", "spark", "spark2"):
-            modifier_transforms = klass.generator_class.AFTER_HAVING_MODIFIER_TRANSFORMS.copy()
+            base = klass.generator_class.__dict__.get("AFTER_HAVING_MODIFIER_TRANSFORMS")
+            if not isinstance(base, dict):
+                from sqlglot.generator import Generator as _BaseGenerator
+
+                base = _BaseGenerator.AFTER_HAVING_MODIFIER_TRANSFORMS
+            modifier_transforms = base.copy()
             for modifier in ("cluster", "distribute", "sort"):
                 modifier_transforms.pop(modifier, None)
 
@@ -428,6 +440,15 @@ class Dialect(metaclass=_Dialect):
 
     UNESCAPED_SEQUENCES: t.Dict[str, str] = {}
     """Mapping of an escaped sequence (`\\n`) to its unescaped version (`\n`)."""
+
+    STRINGS_SUPPORT_ESCAPED_SEQUENCES: bool = False
+    """Whether string literals support escape sequences (e.g. `\\n`). Set by the metaclass based on the tokenizer's STRING_ESCAPES."""
+
+    BYTE_STRINGS_SUPPORT_ESCAPED_SEQUENCES: bool = False
+    """Whether byte string literals support escape sequences. Set by the metaclass based on the tokenizer's BYTE_STRING_ESCAPES."""
+
+    INVERSE_VECTOR_TYPE_ALIASES: t.Dict[str, str] = {}
+    """Mapping of vector type aliases back to their canonical names. Overridden by dialects like SingleStore."""
 
     PSEUDOCOLUMNS: t.Set[str] = set()
     """

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -9,7 +9,7 @@ from functools import reduce, wraps
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel, UnsupportedError, concat_messages
 from sqlglot.expressions import apply_index_offset
-from sqlglot.helper import csv, name_sequence, seq_get
+from sqlglot.helper import csv, mypyc_attr, name_sequence, seq_get
 from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSON_PATH_PART_TRANSFORMS
 from sqlglot.time import format_time
 from sqlglot.tokens import TokenType
@@ -61,18 +61,8 @@ def unsupported_args(
     return decorator
 
 
-class _Generator(type):
-    def __new__(cls, clsname, bases, attrs):
-        klass = super().__new__(cls, clsname, bases, attrs)
-
-        # Remove transforms that correspond to unsupported JSONPathPart expressions
-        for part in ALL_JSON_PATH_PARTS - klass.SUPPORTED_JSON_PATH_PARTS:
-            klass.TRANSFORMS.pop(part, None)
-
-        return klass
-
-
-class Generator(metaclass=_Generator):
+@mypyc_attr(allow_interpreted_subclasses=True)
+class Generator:
     """
     Generator converts a given syntax tree to the corresponding SQL string.
 
@@ -111,7 +101,7 @@ class Generator(metaclass=_Generator):
             Default: True
     """
 
-    TRANSFORMS: t.Dict[t.Type[exp.Expr], t.Callable[..., str]] = {
+    TRANSFORMS: t.ClassVar[t.Dict[t.Type[exp.Expr], t.Callable[..., str]]] = {
         **JSON_PATH_PART_TRANSFORMS,
         exp.Adjacent: lambda self, e: self.binary(e, "-|-"),
         exp.AllowedValuesProperty: lambda self, e: (
@@ -360,7 +350,7 @@ class Generator(metaclass=_Generator):
     NVL2_SUPPORTED = True
 
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
-    SELECT_KINDS: t.Tuple[str, ...] = ("STRUCT", "VALUE")
+    SELECT_KINDS: t.ClassVar[t.Tuple[str, ...]] = ("STRUCT", "VALUE")
 
     # Whether VALUES statements can be used as derived tables.
     # MySQL 5 and Redshift do not allow this, so when False, it will convert
@@ -456,7 +446,7 @@ class Generator(metaclass=_Generator):
     JSON_PATH_SINGLE_QUOTE_ESCAPE = False
 
     # The JSONPathPart expressions supported by this dialect
-    SUPPORTED_JSON_PATH_PARTS = ALL_JSON_PATH_PARTS.copy()
+    SUPPORTED_JSON_PATH_PARTS: t.ClassVar = ALL_JSON_PATH_PARTS.copy()
 
     # Whether any(f(x) for x in array) can be implemented by this dialect
     CAN_IMPLEMENT_ARRAY_ANY = False
@@ -569,7 +559,7 @@ class Generator(metaclass=_Generator):
     # Whether SELECT *, ... EXCLUDE requires wrapping in a subquery for transpilation.
     STAR_EXCLUDE_REQUIRES_DERIVED_TABLE = True
 
-    TYPE_MAPPING = {
+    TYPE_MAPPING: t.ClassVar = {
         exp.DType.DATETIME2: "TIMESTAMP",
         exp.DType.NCHAR: "CHAR",
         exp.DType.NVARCHAR: "VARCHAR",
@@ -585,9 +575,9 @@ class Generator(metaclass=_Generator):
         exp.DType.SMALLDATETIME: "TIMESTAMP",
     }
 
-    UNSUPPORTED_TYPES: set[exp.DType] = set()
+    UNSUPPORTED_TYPES: t.ClassVar[set[exp.DType]] = set()
 
-    TIME_PART_SINGULARS = {
+    TIME_PART_SINGULARS: t.ClassVar = {
         "MICROSECONDS": "MICROSECOND",
         "SECONDS": "SECOND",
         "MINUTES": "MINUTE",
@@ -599,7 +589,7 @@ class Generator(metaclass=_Generator):
         "YEARS": "YEAR",
     }
 
-    AFTER_HAVING_MODIFIER_TRANSFORMS = {
+    AFTER_HAVING_MODIFIER_TRANSFORMS: t.ClassVar = {
         "cluster": lambda self, e: self.sql(e, "cluster"),
         "distribute": lambda self, e: self.sql(e, "distribute"),
         "sort": lambda self, e: self.sql(e, "sort"),
@@ -611,16 +601,16 @@ class Generator(metaclass=_Generator):
         "qualify": lambda self, e: self.sql(e, "qualify"),
     }
 
-    TOKEN_MAPPING: t.Dict[TokenType, str] = {}
+    TOKEN_MAPPING: t.ClassVar[t.Dict[TokenType, str]] = {}
 
-    STRUCT_DELIMITER = ("<", ">")
+    STRUCT_DELIMITER: t.ClassVar = ("<", ">")
 
     PARAMETER_TOKEN = "@"
     NAMED_PLACEHOLDER_TOKEN = ":"
 
-    EXPRESSION_PRECEDES_PROPERTIES_CREATABLES: t.Set[str] = set()
+    EXPRESSION_PRECEDES_PROPERTIES_CREATABLES: t.ClassVar[t.Set[str]] = set()
 
-    PROPERTIES_LOCATION = {
+    PROPERTIES_LOCATION: t.ClassVar = {
         exp.AllowedValuesProperty: exp.Properties.Location.POST_SCHEMA,
         exp.AlgorithmProperty: exp.Properties.Location.POST_CREATE,
         exp.ApiProperty: exp.Properties.Location.POST_CREATE,
@@ -733,10 +723,10 @@ class Generator(metaclass=_Generator):
     }
 
     # Keywords that can't be used as unquoted identifier names
-    RESERVED_KEYWORDS: t.Set[str] = set()
+    RESERVED_KEYWORDS: t.ClassVar[t.Set[str]] = set()
 
     # Exprs whose comments are separated from them for better formatting
-    WITH_SEPARATED_COMMENTS: t.Tuple[t.Type[exp.Expr], ...] = (
+    WITH_SEPARATED_COMMENTS: t.ClassVar[t.Tuple[t.Type[exp.Expr], ...]] = (
         exp.Command,
         exp.Create,
         exp.Describe,
@@ -757,20 +747,20 @@ class Generator(metaclass=_Generator):
     )
 
     # Exprs that should not have their comments generated in maybe_comment
-    EXCLUDE_COMMENTS: t.Tuple[t.Type[exp.Expr], ...] = (
+    EXCLUDE_COMMENTS: t.ClassVar[t.Tuple[t.Type[exp.Expr], ...]] = (
         exp.Binary,
         exp.SetOperation,
     )
 
     # Exprs that can remain unwrapped when appearing in the context of an INTERVAL
-    UNWRAPPED_INTERVAL_VALUES: t.Tuple[t.Type[exp.Expr], ...] = (
+    UNWRAPPED_INTERVAL_VALUES: t.ClassVar[t.Tuple[t.Type[exp.Expr], ...]] = (
         exp.Column,
         exp.Literal,
         exp.Neg,
         exp.Paren,
     )
 
-    PARAMETERIZABLE_TEXT_TYPES = {
+    PARAMETERIZABLE_TEXT_TYPES: t.ClassVar = {
         exp.DType.NVARCHAR,
         exp.DType.VARCHAR,
         exp.DType.CHAR,
@@ -778,11 +768,11 @@ class Generator(metaclass=_Generator):
     }
 
     # Exprs that need to have all CTEs under them bubbled up to them
-    EXPRESSIONS_WITHOUT_NESTED_CTES: t.Set[t.Type[exp.Expr]] = set()
+    EXPRESSIONS_WITHOUT_NESTED_CTES: t.ClassVar[t.Set[t.Type[exp.Expr]]] = set()
 
-    RESPECT_IGNORE_NULLS_UNSUPPORTED_EXPRESSIONS: t.Tuple[t.Type[exp.Expr], ...] = ()
+    RESPECT_IGNORE_NULLS_UNSUPPORTED_EXPRESSIONS: t.ClassVar[t.Tuple[t.Type[exp.Expr], ...]] = ()
 
-    SAFE_JSON_PATH_KEY_RE = exp.SAFE_IDENTIFIER_RE
+    SAFE_JSON_PATH_KEY_RE: t.ClassVar = exp.SAFE_IDENTIFIER_RE
 
     SENTINEL_LINE_BREAK = "__SQLGLOT__LB__"
 
@@ -811,7 +801,7 @@ class Generator(metaclass=_Generator):
 
     def __init__(
         self,
-        pretty: t.Optional[bool] = None,
+        pretty: t.Optional[bool | int] = None,
         identify: str | bool = False,
         normalize: bool = False,
         pad: int = 2,
@@ -825,7 +815,7 @@ class Generator(metaclass=_Generator):
         dialect: DialectType = None,
     ):
         import sqlglot
-        from sqlglot.dialects import Dialect
+        import sqlglot.dialects.dialect
 
         self.pretty = pretty if pretty is not None else sqlglot.pretty
         self.identify = identify
@@ -837,7 +827,7 @@ class Generator(metaclass=_Generator):
         self.leading_comma = leading_comma
         self.max_text_width = max_text_width
         self.comments = comments
-        self.dialect = Dialect.get_or_raise(dialect)
+        self.dialect = sqlglot.dialects.dialect.Dialect.get_or_raise(dialect)
 
         # This is both a Dialect property and a Generator argument, so we prioritize the latter
         self.normalize_functions = (
@@ -901,9 +891,9 @@ class Generator(metaclass=_Generator):
         expression = self._move_ctes_to_top_level(expression)
 
         if self.ENSURE_BOOLS:
-            from sqlglot.transforms import ensure_bools
+            import sqlglot.transforms
 
-            expression = ensure_bools(expression)
+            expression = sqlglot.transforms.ensure_bools(expression)
 
         return expression
 
@@ -913,9 +903,9 @@ class Generator(metaclass=_Generator):
             and type(expression) in self.EXPRESSIONS_WITHOUT_NESTED_CTES
             and any(node.parent is not expression for node in expression.find_all(exp.With))
         ):
-            from sqlglot.transforms import move_ctes_to_top_level
+            import sqlglot.transforms
 
-            expression = move_ctes_to_top_level(expression)
+            expression = sqlglot.transforms.move_ctes_to_top_level(expression)
         return expression
 
     def unsupported(self, message: str) -> None:
@@ -1614,6 +1604,7 @@ class Generator(metaclass=_Generator):
                 f"Data type {type_value.value} is not supported when targeting {self.dialect.__class__.__name__}"
             )
 
+        type_sql: t.Any = ""
         if type_value == exp.DType.USERDEFINED and expression.args.get("kind"):
             type_sql = self.sql(expression, "kind")
         elif type_value == exp.DType.CHARACTER_SET:
@@ -2797,7 +2788,7 @@ class Generator(metaclass=_Generator):
         this = self.sql(expression, "this")
         this = f"{this} " if this else this
         siblings = "SIBLINGS " if expression.args.get("siblings") else ""
-        return self.op_expressions(f"{this}ORDER {siblings}BY", expression, flat=this or flat)  # type: ignore
+        return self.op_expressions(f"{this}ORDER {siblings}BY", expression, flat=bool(this) or flat)
 
     def withfill_sql(self, expression: exp.WithFill) -> str:
         from_sql = self.sql(expression, "from_")
@@ -3086,7 +3077,7 @@ class Generator(metaclass=_Generator):
         sql = self.schema_columns_sql(expression)
         return f"{this} {sql}" if this and sql else this or sql
 
-    def schema_columns_sql(self, expression: exp.Schema) -> str:
+    def schema_columns_sql(self, expression: exp.Expr) -> str:
         if expression.expressions:
             return f"({self.sep('')}{self.expressions(expression)}{self.seg(')', sep='')}"
         return ""
@@ -3302,10 +3293,10 @@ class Generator(metaclass=_Generator):
         return f"NEXT VALUE FOR {self.sql(expression, 'this')}{order}"
 
     def extract_sql(self, expression: exp.Extract) -> str:
-        from sqlglot.dialects.dialect import map_date_part
+        import sqlglot.dialects.dialect
 
         this = (
-            map_date_part(expression.this, self.dialect)
+            sqlglot.dialects.dialect.map_date_part(expression.this, self.dialect)
             if self.NORMALIZE_EXTRACT_DATE_PARTS
             else expression.this
         )
@@ -3326,7 +3317,7 @@ class Generator(metaclass=_Generator):
 
         return self.func(func_name, expression.this, expression.expression)
 
-    def convert_concat_args(self, expression: exp.Concat | exp.ConcatWs) -> t.List[exp.Expr]:
+    def convert_concat_args(self, expression: exp.Func) -> t.List[exp.Expr]:
         args = expression.expressions
         if isinstance(expression, exp.ConcatWs):
             args = args[1:]  # Skip the delimiter
@@ -3338,9 +3329,9 @@ class Generator(metaclass=_Generator):
 
             def _wrap_with_coalesce(e: exp.Expr) -> exp.Expr:
                 if not e.type:
-                    from sqlglot.optimizer.annotate_types import annotate_types
+                    import sqlglot.optimizer.annotate_types
 
-                    e = annotate_types(e, dialect=self.dialect)
+                    e = sqlglot.optimizer.annotate_types.annotate_types(e, dialect=self.dialect)
 
                 if e.is_string or e.is_type(exp.DType.ARRAY):
                     return e
@@ -3356,9 +3347,9 @@ class Generator(metaclass=_Generator):
             # Dialect's CONCAT function coalesces NULLs to empty strings, but the expression does not.
             # Transpile to double pipe operators, which typically returns NULL if any args are NULL
             # instead of coalescing them to empty string.
-            from sqlglot.dialects.dialect import concat_to_dpipe_sql
+            import sqlglot.dialects.dialect
 
-            return concat_to_dpipe_sql(self, expression)
+            return sqlglot.dialects.dialect.concat_to_dpipe_sql(self, expression)
 
         expressions = self.convert_concat_args(expression)
 
@@ -3665,7 +3656,7 @@ class Generator(metaclass=_Generator):
     def aliases_sql(self, expression: exp.Aliases) -> str:
         return f"{self.sql(expression, 'this')} AS ({self.expressions(expression, flat=True)})"
 
-    def atindex_sql(self, expression: exp.AtTimeZone) -> str:
+    def atindex_sql(self, expression: exp.AtIndex) -> str:
         this = self.sql(expression, "this")
         index = self.sql(expression, "expression")
         return f"{this} AT {index}"
@@ -4224,7 +4215,7 @@ class Generator(metaclass=_Generator):
     def func(
         self,
         name: str,
-        *args: t.Optional[exp.Expr | str],
+        *args: t.Any,
         prefix: str = "(",
         suffix: str = ")",
         normalize: bool = True,
@@ -4232,7 +4223,7 @@ class Generator(metaclass=_Generator):
         name = self.normalize_func(name) if normalize else name
         return f"{name}{prefix}{self.format_args(*args)}{suffix}"
 
-    def format_args(self, *args: t.Optional[str | exp.Expr], sep: str = ", ") -> str:
+    def format_args(self, *args: t.Any, sep: str = ", ") -> str:
         arg_sqls = tuple(
             self.sql(arg) for arg in args if arg is not None and not isinstance(arg, bool)
         )
@@ -4643,9 +4634,9 @@ class Generator(metaclass=_Generator):
     def toarray_sql(self, expression: exp.ToArray) -> str:
         arg = expression.this
         if not arg.type:
-            from sqlglot.optimizer.annotate_types import annotate_types
+            import sqlglot.optimizer.annotate_types
 
-            arg = annotate_types(arg, dialect=self.dialect)
+            arg = sqlglot.optimizer.annotate_types.annotate_types(arg, dialect=self.dialect)
 
         if arg.is_type(exp.DType.ARRAY):
             return self.sql(arg)
@@ -4725,10 +4716,13 @@ class Generator(metaclass=_Generator):
         return self.func("LAST_DAY", expression.this)
 
     def dateadd_sql(self, expression: exp.DateAdd) -> str:
-        from sqlglot.dialects.dialect import unit_to_str
+        import sqlglot.dialects.dialect
 
         return self.func(
-            "DATE_ADD", expression.this, expression.expression, unit_to_str(expression)
+            "DATE_ADD",
+            expression.this,
+            expression.expression,
+            sqlglot.dialects.dialect.unit_to_str(expression),
         )
 
     def arrayany_sql(self, expression: exp.ArrayAny) -> str:
@@ -4738,10 +4732,10 @@ class Generator(metaclass=_Generator):
             original_is_empty = exp.ArraySize(this=expression.this).eq(0)
             return self.sql(exp.paren(original_is_empty.or_(filtered_not_empty)))
 
-        from sqlglot.dialects import Dialect
+        import sqlglot.dialects.dialect
 
         # SQLGlot's executor supports ARRAY_ANY, so we don't wanna warn for the SQLGlot dialect
-        if self.dialect.__class__ != Dialect:
+        if self.dialect.__class__ != sqlglot.dialects.dialect.Dialect:
             self.unsupported("ARRAY_ANY is unsupported")
 
         return self.function_fallback_sql(expression)
@@ -4806,10 +4800,10 @@ class Generator(metaclass=_Generator):
 
         # Check whether a conversion with format (T-SQL calls this 'style') is applicable
         if isinstance(style, exp.Literal) and style.is_int:
-            from sqlglot.dialects.tsql import TSQL
+            import sqlglot.dialects.tsql
 
             style_value = style.name
-            converted_style = TSQL.CONVERT_FORMAT_MAPPING.get(style_value)
+            converted_style = sqlglot.dialects.tsql.TSQL.CONVERT_FORMAT_MAPPING.get(style_value)
             if not converted_style:
                 self.unsupported(f"Unsupported T-SQL 'style' value: {style_value}")
 
@@ -4851,9 +4845,9 @@ class Generator(metaclass=_Generator):
 
     def _simplify_unless_literal(self, expression: E) -> E:
         if not isinstance(expression, exp.Literal):
-            from sqlglot.optimizer.simplify import simplify
+            import sqlglot.optimizer.simplify
 
-            expression = simplify(expression, dialect=self.dialect)
+            expression = sqlglot.optimizer.simplify.simplify(expression, dialect=self.dialect)
 
         return expression
 
@@ -5612,21 +5606,21 @@ class Generator(metaclass=_Generator):
         if self.SUPPORTS_DECODE_CASE:
             return self.func("DECODE", *expression.expressions)
 
-        expression, *expressions = expression.expressions
+        decode_expr, *expressions = expression.expressions
 
         ifs = []
         for search, result in zip(expressions[::2], expressions[1::2]):
             if isinstance(search, exp.Literal):
-                ifs.append(exp.If(this=expression.eq(search), true=result))
+                ifs.append(exp.If(this=decode_expr.eq(search), true=result))
             elif isinstance(search, exp.Null):
-                ifs.append(exp.If(this=expression.is_(exp.Null()), true=result))
+                ifs.append(exp.If(this=decode_expr.is_(exp.Null()), true=result))
             else:
                 if isinstance(search, exp.Binary):
                     search = exp.paren(search)
 
                 cond = exp.or_(
-                    expression.eq(search),
-                    exp.and_(expression.is_(exp.Null()), search.is_(exp.Null()), copy=False),
+                    decode_expr.eq(search),
+                    exp.and_(decode_expr.is_(exp.Null()), search.is_(exp.Null()), copy=False),
                     copy=False,
                 )
                 ifs.append(exp.If(this=cond, true=result))
@@ -5657,9 +5651,9 @@ class Generator(metaclass=_Generator):
         expr = expression.expression
 
         if not this.type or not expression.type:
-            from sqlglot.optimizer.annotate_types import annotate_types
+            import sqlglot.optimizer.annotate_types
 
-            this = annotate_types(this, dialect=self.dialect)
+            this = sqlglot.optimizer.annotate_types.annotate_types(this, dialect=self.dialect)
 
         if this.is_type(*(exp.DType.ARRAY, exp.DType.MAP)):
             return self.sql(exp.Bracket(this=this, expressions=[expr]))
@@ -5731,7 +5725,7 @@ class Generator(metaclass=_Generator):
         this = expression.this
         return self.func("LOCALTIME", this) if this else "LOCALTIME"
 
-    def localtimestamp_sql(self, expression: exp.Localtime) -> str:
+    def localtimestamp_sql(self, expression: exp.Localtimestamp) -> str:
         this = expression.this
         return self.func("LOCALTIMESTAMP", this) if this else "LOCALTIMESTAMP"
 

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -44,6 +44,7 @@ def _subpkg_files(src_dir, subpkg, files=None):
 def _source_files(src_dir):
     return [
         "errors.py",
+        "generator.py",
         "helper.py",
         "parser.py",
         "schema.py",


### PR DESCRIPTION
- Remove `_Generator` metaclass:
   - Move JSON path cleanup logic into `_Dialect.__new__`
   - Add `STRINGS_SUPPORT_ESCAPED_SEQUENCES` / `BYTE_STRINGS_SUPPORT_ESCAPED_SEQUENCES` declarations to `Dialect` (set by metaclass, needed for mypyc type resolution)
   - Fix `AFTER_HAVING_MODIFIER_TRANSFORMS` in `_Dialect.__new__` to respect dialect overrides
- Add `@mypyc_attr(allow_interpreted_subclasses=True)` until all generators are moved out
- Add `t.ClassVar` annotations to all container class attributes (dicts, sets, tuples) so mypyc keeps them as plain dicts instead of getset descriptors
- Convert all lazy `from X import Y` imports in methods to `import X` + qualified access (mypyc doesn't support `from` imports inside compiled functions)
- Fix incorrect type annotations exposed by mypyc strict checking:
  - `localtimestamp_sql`: `exp.Localtime` → `exp.Localtimestamp`
  - `atindex_sql`: `exp.AtTimeZone` → `exp.AtIndex`
  - `convert_concat_args`: `exp.Concat | exp.ConcatWs` → `exp.Func` (avoids mypyc recursion)
  - `schema_columns_sql`: `exp.Schema` → `exp.Expr`
  - `decodecase_sql`: rename shadowed `expression` variable to `decode_expr`
  - `order_sql`: `flat=this or flat` → `flat=bool(this) or flat`
  - `func`/`format_args`: widen `*args` to `t.Any`
  - `datatype_sql`: declare `type_sql: t.Any` before branching
  - `__init__` `pretty` param: accept `int` alongside `bool`