### PR TITLE
fix(expressions): wrap string alias in TableAlias in to_table()

### DIFF
--- a/sqlglot/expressions/builders.py
+++ b/sqlglot/expressions/builders.py
@@ -361,6 +361,8 @@ def to_table(
         table = table_(this, db=db, catalog=catalog)
 
     for k, v in kwargs.items():
+        if k == "alias" and isinstance(v, str):
+            v = TableAlias(this=to_identifier(v))
         table.set(k, v)
 
     return table

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1037,6 +1037,12 @@ FROM foo""",
         table_only_unsafe_identifier = exp.to_table("3e")
         self.assertEqual(table_only_unsafe_identifier.sql(), '"3e"')
 
+        # Alias passed as kwarg should be wrapped in TableAlias
+        table_with_alias = exp.to_table("foo", alias="bar")
+        self.assertIsInstance(table_with_alias.args.get("alias"), exp.TableAlias)
+        self.assertEqual(table_with_alias.args["alias"].name, "bar")
+        self.assertEqual(table_with_alias.sql(), "foo AS bar")
+
     def test_to_column(self):
         column_only = exp.to_column("column_name")
         self.assertEqual(column_only.name, "column_name")


### PR DESCRIPTION
## Problem

`to_table()` passes alias as a raw string via `table.set(k, v)`, but `qualify_columns` expects `TableAlias(this=Identifier(...))`. This causes `qualify_columns` to fail on AST-built queries with table aliases.

**Repro:**

```python
from sqlglot import exp
from sqlglot.optimizer.qualify_columns import qualify_columns

table = exp.to_table("foo", alias="bar")
select = exp.Select().select("*").from_(table)
qualify_columns(select, schema={"foo": {"id": "INT"}})
# TypeError — alias is str, not TableAlias
```

## Fix

Wraps string alias in `TableAlias(this=to_identifier(v))` before `table.set()` — same pattern already used in `table_()` (line 513).

2-line change, no behavior change for non-string aliases.