### PR TITLE
feat(duckdb): Add transpilation support for check_json function

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -2640,6 +2640,17 @@ class DuckDB(Dialect):
             )
             return self.sql(expr)
 
+        def checkjson_sql(self, expression: exp.CheckJson) -> str:
+            arg = expression.this
+            return self.sql(
+                exp.case()
+                .when(
+                    exp.or_(arg.is_(exp.Null()), arg.eq(""), exp.func("json_valid", arg)),
+                    exp.null(),
+                )
+                .else_(exp.Literal.string("Invalid JSON"))
+            )
+
         def parsejson_sql(self, expression: exp.ParseJSON) -> str:
             arg = expression.this
             if expression.args.get("safe"):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -146,6 +146,14 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT NVL2(col1, col2, col3)")
         self.validate_identity("SELECT NVL(col1, col2)", "SELECT COALESCE(col1, col2)")
         self.validate_identity("SELECT CHR(8364)")
+        self.validate_all(
+            "SELECT CHECK_JSON(x)",
+            read={"snowflake": "SELECT CHECK_JSON(x)"},
+            write={
+                "snowflake": "SELECT CHECK_JSON(x)",
+                "duckdb": "SELECT CASE WHEN x IS NULL OR x = '' OR JSON_VALID(x) THEN NULL ELSE 'Invalid JSON' END",
+            },
+        )
         self.validate_identity('SELECT CHECK_JSON(\'{"key": "value"}\')')
         self.validate_identity(
             "SELECT CHECK_XML('<root><key attribute=\"attr\">value</key></root>')"


### PR DESCRIPTION
`CHECK_JSON` is not transformed by SQLGlot; DuckDB has no native `CHECK_JSON` function and the query fails at runtime.

The following is a known semantic difference which is not addressed by this PR as the fix rather seems infeasible. 
For non-standard json inputs, the results of Snowflake and Duckdb differ.

  | {a: 1} | {"a": 1}
-- | -- | --
JSON spec | ❌ Invalid | ✓ Valid
Snowflake | ✓ Treated as valid (lenient parser) → NULL | ✓ Valid → NULL
DuckDB json_valid | ❌ Strict → FALSE → 'Invalid JSON' | ✓ Strict → TRUE → NULL

<br class="Apple-interchange-newline">

Reason: 
Snowflake's semi-structured data engine (VARIANT) uses a lenient JSON parser that accepts non-standard formats like unquoted keys and trailing commas. DuckDB's json_valid is a strict RFC-compliant validator.

DuckDb after transpilation:
```
"SELECT CASE WHEN '{"a": 1}' IS NULL OR '{"a": 1}' = '' OR JSON_VALID('{"a": 1}') THEN NULL ELSE 'Invalid JSON' END AS col_valid_obj, CASE WHEN '[1, 2, 3]' IS NULL OR '[1, 2, 3]' = '' OR JSON_VALID('[1, 2, 3]') THEN NULL ELSE 'Invalid JSON' END AS col_valid_arr, CASE WHEN 'true' IS NULL OR 'true' = '' OR JSON_VALID('true') THEN NULL ELSE 'Invalid JSON' END AS col_valid_bool, CASE WHEN '{bad: json}' IS NULL OR '{bad: json}' = '' OR JSON_VALID('{bad: json}') THEN NULL ELSE 'Invalid JSON' END AS col_invalid_colon, CASE WHEN '[1, 2,]' IS NULL OR '[1, 2,]' = '' OR JSON_VALID('[1, 2,]') THEN NULL ELSE 'Invalid JSON' END AS col_invalid_comma, CASE WHEN NULL IS NULL OR NULL = '' OR JSON_VALID(NULL) THEN NULL ELSE 'Invalid JSON' END AS col_null, CASE WHEN '' IS NULL OR '' = '' OR JSON_VALID('') THEN NULL ELSE 'Invalid JSON' END AS col_empty"
┌───────────────┬───────────────┬────────────────┬───────────────────┬───────────────────┬──────────┬───────────┐
│ col_valid_obj │ col_valid_arr │ col_valid_bool │ col_invalid_colon │ col_invalid_comma │ col_null │ col_empty │
│    varchar    │    varchar    │    varchar     │      varchar      │      varchar      │ varchar  │  varchar  │
├───────────────┼───────────────┼────────────────┼───────────────────┼───────────────────┼──────────┼───────────┤
│ Invalid JSON  │ NULL          │ NULL           │ Invalid JSON      │ NULL              │ NULL     │ NULL      │
```