### PR TITLE
feat(duckdb)!: Fix [NOT] REGEXP / REGEXP_LIKE transpilation from Snowflake to DuckDB

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -3158,24 +3158,12 @@ class DuckDB(Dialect):
             pattern = expression.expression
             flag = expression.args.get("flag")
 
-            if not expression.args.get("full_match"):
-                return self.func("REGEXP_MATCHES", this, pattern, flag)
+            if expression.args.get("full_match"):
+                validated_flags = self._validate_regexp_flags(flag, supported_flags="cims")
+                flag = exp.Literal.string(validated_flags) if validated_flags else None
+                return self.func("REGEXP_FULL_MATCH", this, pattern, flag)
 
-            # DuckDB REGEXP_MATCHES supports: c, i, m, s (but not 'e')
-            validated_flags = self._validate_regexp_flags(flag, supported_flags="cims")
-
-            anchored_pattern = exp.Concat(
-                expressions=[
-                    exp.Literal.string("^("),
-                    exp.Paren(this=pattern),
-                    exp.Literal.string(")$"),
-                ]
-            )
-
-            if validated_flags:
-                flag = exp.Literal.string(validated_flags)
-
-            return self.func("REGEXP_MATCHES", this, anchored_pattern, flag)
+            return self.func("REGEXP_MATCHES", this, pattern, flag)
 
         @unsupported_args("ins_cost", "del_cost", "sub_cost")
         def levenshtein_sql(self, expression: exp.Levenshtein) -> str:

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -373,6 +373,13 @@ class SnowflakeParser(parser.Parser):
         TokenType.CURRENT_TIME: exp.Localtime,
     }
 
+    RANGE_PARSERS = {
+        **parser.Parser.RANGE_PARSERS,
+        TokenType.RLIKE: lambda self, this: self.expression(
+            exp.RegexpLike(this=this, expression=self._parse_bitwise(), full_match=True)
+        ),
+    }
+
     FUNCTIONS = {
         **parser.Parser.FUNCTIONS,
         "CHARINDEX": lambda args: exp.StrPosition(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1938,7 +1938,7 @@ class TestSnowflake(Validator):
         self.validate_all(
             "SELECT RLIKE(a, b)",
             write={
-                "duckdb": "SELECT REGEXP_MATCHES(a, '^(' || (b) || ')$')",
+                "duckdb": "SELECT REGEXP_FULL_MATCH(a, b)",
                 "hive": "SELECT a RLIKE b",
                 "snowflake": "SELECT REGEXP_LIKE(a, b)",
                 "spark": "SELECT a RLIKE b",
@@ -1947,13 +1947,14 @@ class TestSnowflake(Validator):
         self.validate_all(
             "SELECT RLIKE(a, b, 'i')",
             write={
-                "duckdb": "SELECT REGEXP_MATCHES(a, '^(' || (b) || ')$', 'i')",
+                "duckdb": "SELECT REGEXP_FULL_MATCH(a, b, 'i')",
                 "snowflake": "SELECT REGEXP_LIKE(a, b, 'i')",
             },
         )
         self.validate_all(
             "'foo' REGEXP 'bar'",
             write={
+                "duckdb": "REGEXP_FULL_MATCH('foo', 'bar')",
                 "snowflake": "REGEXP_LIKE('foo', 'bar')",
                 "postgres": "'foo' ~ 'bar'",
                 "mysql": "REGEXP_LIKE('foo', 'bar')",
@@ -1963,6 +1964,7 @@ class TestSnowflake(Validator):
         self.validate_all(
             "'foo' NOT REGEXP 'bar'",
             write={
+                "duckdb": "NOT REGEXP_FULL_MATCH('foo', 'bar')",
                 "snowflake": "NOT REGEXP_LIKE('foo', 'bar')",
                 "postgres": "NOT 'foo' ~ 'bar'",
                 "mysql": "NOT REGEXP_LIKE('foo', 'bar')",


### PR DESCRIPTION
Snowflake's `REGEXP / RLIKE / REGEXP_LIKE` use full-match semantics — the pattern must match the entire string. Two bugs caused incorrect DuckDB output:

**Bug 1 —** Binary operator not handled: The `REGEXP / RLIKE` binary operator form was parsed without `full_match=True`, so it generated DuckDB's partial-match `REGEXP_MATCHES` with no anchoring — silently returning wrong results.

```
-- Snowflake: FALSE  (full match: 'hello' ≠ entire string 'hello world')
SELECT 'hello world' REGEXP 'hello'

-- Old DuckDB output: TRUE  ← WRONG (partial match)
SELECT REGEXP_MATCHES('hello world', 'hello')

-- Fixed DuckDB output: FALSE  ← CORRECT
SELECT REGEXP_FULL_MATCH('hello world', 'hello')
```

**Bug 2 —** Anchoring workaround replaced with native function: PR #7030 introduced a ^(...)$ string-concatenation workaround for the function call forms (REGEXP_LIKE, RLIKE()). This has been replaced with DuckDB's native REGEXP_FULL_MATCH, to avoid per-row string construction, and handles edge cases like pre-anchored patterns, e-flag stripping.

```
-- Old DuckDB output (anchoring workaround):
SELECT REGEXP_MATCHES(a, '^(' || (b) || ')$')

-- Fixed DuckDB output (native full-match):
SELECT REGEXP_FULL_MATCH(a, b)
```