### PR TITLE
Chore: Fix mypyc setup

### DIFF
--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -67,7 +67,6 @@ def _source_files(src_dir):
                 "qualify_columns.py",
             ],
         ),
-        *_subpkg_files(src_dir, "generators"),
         *_subpkg_files(src_dir, "parsers"),
         *_subpkg_files(src_dir, "executor", ["table.py"]),
     ]


### PR DESCRIPTION
The generator extractions PR  added `*_subpkg_files(src_dir, "generators")` twice 