### PR TITLE
chore(duckdb): Add tests for NOT RLIKE to check the full match semantics

### DIFF
--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1944,6 +1944,24 @@ class TestSnowflake(Validator):
             },
         )
         self.validate_all(
+            "SELECT a RLIKE b",
+            write={
+                "duckdb": "SELECT REGEXP_FULL_MATCH(a, b)",
+                "hive": "SELECT a RLIKE b",
+                "snowflake": "SELECT REGEXP_LIKE(a, b)",
+                "spark": "SELECT a RLIKE b",
+            },
+        )
+        self.validate_all(
+            "SELECT a NOT RLIKE b",
+            write={
+                "duckdb": "SELECT NOT REGEXP_FULL_MATCH(a, b)",
+                "hive": "SELECT NOT a RLIKE b",
+                "snowflake": "SELECT NOT REGEXP_LIKE(a, b)",
+                "spark": "SELECT NOT a RLIKE b",
+            },
+        )
+        self.validate_all(
             "SELECT RLIKE(a, b)",
             write={
                 "duckdb": "SELECT REGEXP_FULL_MATCH(a, b)",


### PR DESCRIPTION
`RLIKE` is a Snowflake alias for `REGEXP`, which uses full-match semantics. 
DuckDB's `REGEXP_MATCHES` uses partial-match semantics. 
The fix - use `REGEXP_FULL_MATCH` in DuckDB instead of `REGEXP_MATCHES`. This was already taken care of in #7354 .


```
python3 -m sqlglot --read snowflake --write duckdb "SELECT 'hello world' RLIKE 'hello'"                         
SELECT
  REGEXP_FULL_MATCH('hello world', 'hello')
   regexp_full_match('hello world', 'hello') │
│                  boolean                  │
├───────────────────────────────────────────┤
│ false                                     │
└───────────────────────────────────────────┘
```