### PR TITLE
feat(duckdb)!: Add transpilation support for ARRAY_UNIQUE_AGG function

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1527,7 +1527,6 @@ class DuckDBGenerator(generator.Generator):
         exp.ArraySum: rename_func("LIST_SUM"),
         exp.ArrayMax: rename_func("LIST_MAX"),
         exp.ArrayMin: rename_func("LIST_MIN"),
-        exp.ArrayUniqueAgg: lambda self, e: self.func("LIST", exp.Distinct(expressions=[e.this])),
         exp.Base64DecodeBinary: lambda self, e: _base64_decode_sql(self, e, to_string=False),
         exp.Base64DecodeString: lambda self, e: _base64_decode_sql(self, e, to_string=True),
         exp.BitwiseAnd: lambda self, e: self._bitwise_op(e, "&"),
@@ -3125,6 +3124,14 @@ class DuckDBGenerator(generator.Generator):
         expr = expression.this
         result = exp.replace_placeholders(self.APPROXIMATE_SIMILARITY_TEMPLATE.copy(), expr=expr)
         return f"({self.sql(result)})"
+
+    def arrayuniqueagg_sql(self, expression: exp.ArrayUniqueAgg) -> str:
+        return self.sql(
+            exp.Filter(
+                this=exp.func("LIST", exp.Distinct(expressions=[expression.this])),
+                expression=exp.Where(this=expression.this.copy().is_(exp.null()).not_()),
+            )
+        )
 
     def arraydistinct_sql(self, expression: exp.ArrayDistinct) -> str:
         arr = expression.this

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -642,11 +642,8 @@ class TestDuckDB(Validator):
         self.validate_identity("REGEXP_FULL_MATCH(x, y, 'i')")
         self.validate_all("SELECT * FROM 'x.y'", write={"duckdb": 'SELECT * FROM "x.y"'})
         self.validate_all(
-            "SELECT LIST(DISTINCT sample_col) FROM sample_table",
-            read={
-                "duckdb": "SELECT LIST(DISTINCT sample_col) FROM sample_table",
-                "spark": "SELECT COLLECT_SET(sample_col) FROM sample_table",
-            },
+            "SELECT LIST(DISTINCT sample_col) FILTER(WHERE NOT sample_col IS NULL) FROM sample_table",
+            read={"spark": "SELECT COLLECT_SET(sample_col) FROM sample_table"},
         )
         self.validate_all(
             "SELECT LIST_TRANSFORM(STR_SPLIT_REGEX('abc , dfg ', ','), x -> TRIM(x))",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -596,6 +596,16 @@ class TestSnowflake(Validator):
         self.validate_identity("SELECT TO_ARRAY(CAST(x AS ARRAY))")
         self.validate_identity("SELECT TO_ARRAY(CAST(['test'] AS VARIANT))")
         self.validate_identity("SELECT ARRAY_UNIQUE_AGG(x)")
+        self.validate_all(
+            "SELECT ARRAY_UNIQUE_AGG(col) FROM t",
+            write={"duckdb": "SELECT LIST(DISTINCT col) FILTER(WHERE NOT col IS NULL) FROM t"},
+        )
+        self.validate_all(
+            "SELECT ARRAY_UNIQUE_AGG(col) OVER (PARTITION BY grp) FROM t",
+            write={
+                "duckdb": "SELECT LIST(DISTINCT col) FILTER(WHERE NOT col IS NULL) OVER (PARTITION BY grp) FROM t"
+            },
+        )
         self.validate_identity("SELECT ARRAY_APPEND([1, 2, 3], 4)")
         self.validate_identity("SELECT ARRAY_CAT([1, 2], [3, 4])")
         self.validate_identity("SELECT ARRAY_PREPEND([2, 3, 4], 1)")


### PR DESCRIPTION
Issue: DuckDB's `LIST(DISTINCT col)` includes `NULL` values while Snowflake's `ARRAY_UNIQUE_AGG` ignores `NULLs` per documentation.

Fix: Added a `FILTER` clause - `LIST(DISTINCT col) FILTER (WHERE NOT col IS NULL)`.

```
Aggregate:
python3 -c "import sqlglot; print(sqlglot.transpile('SELECT ARRAY_UNIQUE_AGG(col) AS basic_agg FROM (VALUES (1), (2), (2), (3), (NULL)) AS t(col)', read='snowflake', write='duckdb')[0])"
"SELECT LIST(DISTINCT col) FILTER(WHERE NOT col IS NULL) AS basic_agg FROM (VALUES (1), (2), (2), (3), (NULL)) AS t(col)"

┌───────────┐
│ basic_agg │
│  int32[]  │
├───────────┤
│ [3, 2, 1] │
└───────────┘

Window:
python3 -c "import sqlglot; print(sqlglot.transpile('SELECT ARRAY_UNIQUE_AGG(col) OVER (PARTITION BY grp) AS window_agg FROM (VALUES (1, \'A\'), (2, \'A\'), (2, \'A\'), (3, \'A\'), (NULL, \'A\')) AS t(col, grp)', read='snowflake', write='duckdb')[0])"
"SELECT LIST(DISTINCT col) FILTER(WHERE NOT col IS NULL) OVER (PARTITION BY grp) AS window_agg FROM (VALUES (1, 'A'), (2, 'A'), (2, 'A'), (3, 'A'), (NULL, 'A')) AS t(col, grp)"

┌────────────┐
│ window_agg │
│  int32[]   │
├────────────┤
│ [3, 1, 2]  │
│ [3, 1, 2]  │
│ [3, 1, 2]  │
│ [3, 1, 2]  │
│ [3, 1, 2]  │
└────────────┘
```
NOTE: Order is non-deterministic for `ARRAY_UNIQUE_AGG`, which is expected behavior documented in Snowflake's docs.