### PR TITLE
refactor(generators)!: Cleanup and fully compile all generators

### DIFF
--- a/sqlglot/dialects/athena.py
+++ b/sqlglot/dialects/athena.py
@@ -141,20 +141,6 @@ def _tokenize_as_hive(tokens: t.List[Token]) -> bool:
     return False
 
 
-# Athena extensions to Hive's generator
-class _HiveGenerator(Hive.Generator):
-    def alter_sql(self, expression: exp.Alter) -> str:
-        # Package any ALTER TABLE ADD actions into a Schema object, so it gets generated as
-        # `ALTER TABLE .. ADD COLUMNS(...)`, instead of `ALTER TABLE ... ADD COLUMN`, which
-        # is invalid syntax on Athena
-        if isinstance(expression, exp.Alter) and expression.kind == "TABLE":
-            if expression.actions and isinstance(expression.actions[0], exp.ColumnDef):
-                new_actions = exp.Schema(expressions=expression.actions)
-                expression.set("actions", [new_actions])
-
-        return super().alter_sql(expression)
-
-
 # Athena extensions to Trino's tokenizer
 class _TrinoTokenizer(Trino.Tokenizer):
     KEYWORDS = {

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -264,7 +264,7 @@ class _Dialect(type):
             "Parser", klass.__dict__.get("parser_class", base_parser[0])
         )
         klass.generator_class = klass.__dict__.get(
-            "Generator", type("Generator", base_generator, {})
+            "Generator", klass.__dict__.get("generator_class", base_generator[0])
         )
 
         # Remove transforms that correspond to unsupported JSONPathPart expressions
@@ -311,28 +311,6 @@ class _Dialect(type):
 
         if enum not in ("", "bigquery", "snowflake"):
             klass.INITCAP_SUPPORTS_CUSTOM_DELIMITERS = False
-
-        if enum not in ("", "bigquery"):
-            klass.generator_class.SELECT_KINDS = ()
-
-        if enum not in ("", "athena", "presto", "trino", "duckdb"):
-            klass.generator_class.TRY_SUPPORTED = False
-            klass.generator_class.SUPPORTS_UESCAPE = False
-
-        if enum not in ("", "databricks", "hive", "spark", "spark2"):
-            base = klass.generator_class.__dict__.get("AFTER_HAVING_MODIFIER_TRANSFORMS")
-            if not isinstance(base, dict):
-                from sqlglot.generator import Generator as _BaseGenerator
-
-                base = _BaseGenerator.AFTER_HAVING_MODIFIER_TRANSFORMS
-            modifier_transforms = base.copy()
-            for modifier in ("cluster", "distribute", "sort"):
-                modifier_transforms.pop(modifier, None)
-
-            klass.generator_class.AFTER_HAVING_MODIFIER_TRANSFORMS = modifier_transforms
-
-        if enum not in ("", "databricks", "oracle", "redshift", "snowflake", "spark"):
-            klass.generator_class.SUPPORTS_DECODE_CASE = False
 
         klass.VALID_INTERVAL_UNITS = {
             *klass.VALID_INTERVAL_UNITS,

--- a/sqlglot/dialects/prql.py
+++ b/sqlglot/dialects/prql.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 from sqlglot import tokens
 from sqlglot.dialects.dialect import Dialect
+from sqlglot.generators.prql import PRQLGenerator
 from sqlglot.parsers.prql import PRQLParser
 from sqlglot.tokens import TokenType
 
 
 class PRQL(Dialect):
     DPIPE_IS_STRING_CONCAT = False
+
+    Generator = PRQLGenerator
 
     class Tokenizer(tokens.Tokenizer):
         IDENTIFIERS = ["`"]

--- a/sqlglot/dialects/solr.py
+++ b/sqlglot/dialects/solr.py
@@ -1,5 +1,6 @@
 from sqlglot import tokens
 from sqlglot.dialects.dialect import Dialect, NormalizationStrategy
+from sqlglot.generators.solr import SolrGenerator
 from sqlglot.parsers.solr import SolrParser
 
 
@@ -9,6 +10,8 @@ from sqlglot.parsers.solr import SolrParser
 class Solr(Dialect):
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
     DPIPE_IS_STRING_CONCAT = False
+
+    Generator = SolrGenerator
 
     Parser = SolrParser
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -9,7 +9,7 @@ from functools import reduce, wraps
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel, UnsupportedError, concat_messages
 from sqlglot.expressions import apply_index_offset
-from sqlglot.helper import csv, mypyc_attr, name_sequence, seq_get
+from sqlglot.helper import csv, name_sequence, seq_get
 from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSON_PATH_PART_TRANSFORMS
 from sqlglot.time import format_time
 from sqlglot.tokens import TokenType
@@ -61,7 +61,16 @@ def unsupported_args(
     return decorator
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
+AFTER_HAVING_MODIFIER_TRANSFORMS: t.Dict[str, t.Any] = {
+    "windows": lambda self, e: (
+        self.seg("WINDOW ") + self.expressions(e, key="windows", flat=True)
+        if e.args.get("windows")
+        else ""
+    ),
+    "qualify": lambda self, e: self.sql(e, "qualify"),
+}
+
+
 class Generator:
     """
     Generator converts a given syntax tree to the corresponding SQL string.
@@ -350,7 +359,7 @@ class Generator:
     NVL2_SUPPORTED = True
 
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax
-    SELECT_KINDS: t.ClassVar[t.Tuple[str, ...]] = ("STRUCT", "VALUE")
+    SELECT_KINDS: t.Tuple[str, ...] = ("STRUCT", "VALUE")
 
     # Whether VALUES statements can be used as derived tables.
     # MySQL 5 and Redshift do not allow this, so when False, it will convert
@@ -472,10 +481,10 @@ class Generator:
     COPY_HAS_INTO_KEYWORD = True
 
     # Whether the conditional TRY(expression) function is supported
-    TRY_SUPPORTED: t.ClassVar = True
+    TRY_SUPPORTED = True
 
     # Whether the UESCAPE syntax in unicode strings is supported
-    SUPPORTS_UESCAPE: t.ClassVar = True
+    SUPPORTS_UESCAPE = True
 
     # Function used to replace escaped unicode codes in unicode strings
     UNICODE_SUBSTITUTE: t.ClassVar[t.Any] = None
@@ -534,7 +543,7 @@ class Generator:
     ARRAY_SIZE_DIM_REQUIRED: t.Optional[bool] = None
 
     # Whether a multi-argument DECODE(...) function is supported. If not, a CASE expression is generated
-    SUPPORTS_DECODE_CASE: t.ClassVar = True
+    SUPPORTS_DECODE_CASE = True
 
     # Whether SYMMETRIC and ASYMMETRIC flags are supported with BETWEEN expression
     SUPPORTS_BETWEEN_FLAGS = False
@@ -593,12 +602,7 @@ class Generator:
         "cluster": lambda self, e: self.sql(e, "cluster"),
         "distribute": lambda self, e: self.sql(e, "distribute"),
         "sort": lambda self, e: self.sql(e, "sort"),
-        "windows": lambda self, e: (
-            self.seg("WINDOW ") + self.expressions(e, key="windows", flat=True)
-            if e.args.get("windows")
-            else ""
-        ),
-        "qualify": lambda self, e: self.sql(e, "qualify"),
+        **AFTER_HAVING_MODIFIER_TRANSFORMS,
     }
 
     TOKEN_MAPPING: t.ClassVar[t.Dict[TokenType, str]] = {}

--- a/sqlglot/generators/athena.py
+++ b/sqlglot/generators/athena.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp, generator
-from sqlglot.generators.trino import TrinoGenerator, _POST_WITH
+from sqlglot.generators.hive import HiveGenerator
+from sqlglot.generators.trino import TrinoGenerator
 
 
 def _is_iceberg_table(properties: exp.Properties) -> bool:
@@ -98,10 +99,20 @@ def _generator_kwargs(
     return kwargs
 
 
+class _HiveGenerator(HiveGenerator):
+    def alter_sql(self, expression: exp.Alter) -> str:
+        if isinstance(expression, exp.Alter) and expression.kind == "TABLE":
+            if expression.actions and isinstance(expression.actions[0], exp.ColumnDef):
+                new_actions = exp.Schema(expressions=expression.actions)
+                expression.set("actions", [new_actions])
+
+        return super().alter_sql(expression)
+
+
 class AthenaTrinoGenerator(TrinoGenerator):
-    PROPERTIES_LOCATION: t.ClassVar[t.Dict[t.Any, t.Any]] = {
+    PROPERTIES_LOCATION = {
         **TrinoGenerator.PROPERTIES_LOCATION,
-        exp.LocationProperty: _POST_WITH,
+        exp.LocationProperty: exp.Properties.Location.POST_WITH,
     }
 
     TRANSFORMS = {
@@ -112,6 +123,11 @@ class AthenaTrinoGenerator(TrinoGenerator):
 
 
 class AthenaGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     __slots__ = ("_hive_generator", "_trino_generator")
 
     def __init__(
@@ -131,7 +147,6 @@ class AthenaGenerator(generator.Generator):
         hive: t.Any = None,
         trino: t.Any = None,
     ) -> None:
-        import sqlglot.dialects.athena as athena_mod
         import sqlglot.dialects.hive as hive_mod
         import sqlglot.dialects.trino as trino_mod
 
@@ -153,9 +168,7 @@ class AthenaGenerator(generator.Generator):
         )
 
         generator.Generator.__init__(self, dialect=dialect, **kwargs)
-        self._hive_generator: generator.Generator = athena_mod._HiveGenerator(
-            dialect=hive_dialect, **kwargs
-        )
+        self._hive_generator: generator.Generator = _HiveGenerator(dialect=hive_dialect, **kwargs)
         self._trino_generator: generator.Generator = AthenaTrinoGenerator(
             dialect=trino_dialect, **kwargs
         )

--- a/sqlglot/generators/bigquery.py
+++ b/sqlglot/generators/bigquery.py
@@ -218,6 +218,9 @@ def _json_extract_sql(self: BigQueryGenerator, expression: JSON_EXTRACT_TYPE) ->
 
 
 class BigQueryGenerator(generator.Generator):
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
     INTERVAL_ALLOWS_PLURAL_FORM = False
     JOIN_HINTS = False
     QUERY_HINTS = False
@@ -437,9 +440,10 @@ class BigQueryGenerator(generator.Generator):
 
     # WINDOW comes after QUALIFY
     # https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#window_clause
+    # BigQuery requires QUALIFY before WINDOW
     AFTER_HAVING_MODIFIER_TRANSFORMS = {
-        "qualify": generator.Generator.AFTER_HAVING_MODIFIER_TRANSFORMS["qualify"],
-        "windows": generator.Generator.AFTER_HAVING_MODIFIER_TRANSFORMS["windows"],
+        "qualify": generator.AFTER_HAVING_MODIFIER_TRANSFORMS["qualify"],
+        "windows": generator.AFTER_HAVING_MODIFIER_TRANSFORMS["windows"],
     }
 
     # from: https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#reserved_keywords

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -164,6 +164,13 @@ def _json_cast_sql(self: ClickHouseGenerator, expression: exp.JSONCast) -> str:
 
 
 class ClickHouseGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     QUERY_HINTS = False
     STRUCT_DELIMITER = ("(", ")")
     NVL2_SUPPORTED = False

--- a/sqlglot/generators/dremio.py
+++ b/sqlglot/generators/dremio.py
@@ -30,6 +30,13 @@ def _date_delta_sql(name: str) -> t.Callable[[DremioGenerator, DATE_DELTA], str]
 
 
 class DremioGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     NVL2_SUPPORTED = False
     SUPPORTS_CONVERT_TIMEZONE = True
     INTERVAL_ALLOWS_PLURAL_FORM = False

--- a/sqlglot/generators/drill.py
+++ b/sqlglot/generators/drill.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp, generator, transforms
 from sqlglot.dialects.dialect import (
     datestrtodate_sql,
@@ -24,6 +26,13 @@ def _str_to_date(self: DrillGenerator, expression: exp.StrToDate) -> str:
 
 
 class DrillGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     JOIN_HINTS = False
     TABLE_HINTS = False
     QUERY_HINTS = False

--- a/sqlglot/generators/druid.py
+++ b/sqlglot/generators/druid.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp, generator
 from sqlglot.dialects.dialect import rename_func
 
 
 class DruidGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     # https://druid.apache.org/docs/latest/querying/sql-data-types/
     TYPE_MAPPING = {
         **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1470,16 +1470,10 @@ class DuckDBGenerator(generator.Generator):
     MULTI_ARG_DISTINCT = False
     CAN_IMPLEMENT_ARRAY_ANY = True
     SUPPORTS_TO_NUMBER = False
-    SELECT_KINDS: t.ClassVar[t.Tuple[str, ...]] = ()
+    SELECT_KINDS: t.Tuple[str, ...] = ()
     SUPPORTS_DECODE_CASE = False
-    AFTER_HAVING_MODIFIER_TRANSFORMS: t.ClassVar = {
-        "windows": lambda self, e: (
-            self.seg("WINDOW ") + self.expressions(e, key="windows", flat=True)
-            if e.args.get("windows")
-            else ""
-        ),
-        "qualify": lambda self, e: self.sql(e, "qualify"),
-    }
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
     SUPPORTS_WINDOW_EXCLUDE = True
     COPY_HAS_INTO_KEYWORD = False
     STAR_EXCEPT = "EXCLUDE"

--- a/sqlglot/generators/dune.py
+++ b/sqlglot/generators/dune.py
@@ -5,6 +5,9 @@ from sqlglot.generators.trino import TrinoGenerator
 
 
 class DuneGenerator(TrinoGenerator):
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+
     TRANSFORMS = {
         **TrinoGenerator.TRANSFORMS,
         exp.HexString: lambda self, e: f"0x{e.this}",

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -266,6 +266,13 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
 
 
 class ExasolGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     # https://docs.exasol.com/db/latest/sql_references/data_types/datatypedetails.htm#StringDataType
     STRING_TYPE_MAPPING: t.ClassVar = {
         exp.DType.BLOB: "VARCHAR",

--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -4,8 +4,6 @@ import re
 import typing as t
 from functools import partial
 
-from sqlglot.helper import mypyc_attr
-
 from sqlglot import exp, generator, transforms
 from sqlglot.dialects.dialect import (
     DATE_ADD_OR_SUB,
@@ -184,8 +182,11 @@ def _to_date_sql(self: HiveGenerator, expression: exp.TsOrDsToDate) -> str:
     return self.func("TO_DATE", expression.this)
 
 
-@mypyc_attr(allow_interpreted_subclasses=True)
 class HiveGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
     LIMIT_FETCH = "LIMIT"
     TABLESAMPLE_WITH_METHOD = False
     JOIN_HINTS = False

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -106,6 +106,13 @@ def _remove_ts_or_ds_to_date(
 
 
 class MySQLGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     INTERVAL_ALLOWS_PLURAL_FORM = False
     LOCKING_READS_SUPPORTED = True
     NULL_ORDERING_SUPPORTED: t.Optional[bool] = None

--- a/sqlglot/generators/oracle.py
+++ b/sqlglot/generators/oracle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp, generator, transforms
 from sqlglot.dialects.dialect import (
     no_ilike_sql,
@@ -20,6 +22,9 @@ def _trim_sql(self: OracleGenerator, expression: exp.Trim) -> str:
 
 
 class OracleGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
     LOCKING_READS_SUPPORTED = True
     JOIN_HINTS = False
     TABLE_HINTS = False
@@ -33,6 +38,8 @@ class OracleGenerator(generator.Generator):
     SUPPORTS_WINDOW_EXCLUDE = True
     QUERY_HINT_SEP = " "
     SUPPORTS_DECODE_CASE = True
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
 
     TYPE_MAPPING = {
         **generator.Generator.TYPE_MAPPING,

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -221,6 +221,13 @@ def _round_sql(self: PostgresGenerator, expression: exp.Round) -> str:
 
 
 class PostgresGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     SINGLE_STRING_INTERVAL = True
     RENAME_TABLE_WITH_DB = False
     LOCKING_READS_SUPPORTED = True

--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -34,9 +34,6 @@ from sqlglot.transforms import unqualify_columns
 
 DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TimestampAdd, exp.DateSub]
 
-_UNSUPPORTED: t.Any = getattr(exp.Properties.Location, "UNSUPPORTED")
-_DType: t.Any = exp.DType
-
 
 def _initcap_sql(self: PrestoGenerator, expression: exp.Initcap) -> str:
     delimiters = expression.expression
@@ -211,6 +208,11 @@ def amend_exploded_column_table(expression: exp.Expr) -> exp.Expr:
 
 
 class PrestoGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     INTERVAL_ALLOWS_PLURAL_FORM = False
     JOIN_HINTS = False
     TABLE_HINTS = False
@@ -231,26 +233,26 @@ class PrestoGenerator(generator.Generator):
     SUPPORTS_MEDIAN = False
     ARRAY_SIZE_NAME = "CARDINALITY"
 
-    PROPERTIES_LOCATION: t.ClassVar[t.Dict[t.Any, t.Any]] = {
+    PROPERTIES_LOCATION = {
         **generator.Generator.PROPERTIES_LOCATION,
-        exp.LocationProperty: _UNSUPPORTED,
-        exp.VolatileProperty: _UNSUPPORTED,
+        exp.LocationProperty: exp.Properties.Location.UNSUPPORTED,
+        exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
     }
 
     TYPE_MAPPING = {
         **generator.Generator.TYPE_MAPPING,
-        _DType.BINARY: "VARBINARY",
-        _DType.BIT: "BOOLEAN",
-        _DType.DATETIME: "TIMESTAMP",
-        _DType.DATETIME64: "TIMESTAMP",
-        _DType.FLOAT: "REAL",
-        _DType.HLLSKETCH: "HYPERLOGLOG",
-        _DType.INT: "INTEGER",
-        _DType.STRUCT: "ROW",
-        _DType.TEXT: "VARCHAR",
-        _DType.TIMESTAMPTZ: "TIMESTAMP",
-        _DType.TIMESTAMPNTZ: "TIMESTAMP",
-        _DType.TIMETZ: "TIME",
+        exp.DType.BINARY: "VARBINARY",
+        exp.DType.BIT: "BOOLEAN",
+        exp.DType.DATETIME: "TIMESTAMP",
+        exp.DType.DATETIME64: "TIMESTAMP",
+        exp.DType.FLOAT: "REAL",
+        exp.DType.HLLSKETCH: "HYPERLOGLOG",
+        exp.DType.INT: "INTEGER",
+        exp.DType.STRUCT: "ROW",
+        exp.DType.TEXT: "VARCHAR",
+        exp.DType.TIMESTAMPTZ: "TIMESTAMP",
+        exp.DType.TIMESTAMPNTZ: "TIMESTAMP",
+        exp.DType.TIMETZ: "TIME",
     }
 
     TRANSFORMS = {

--- a/sqlglot/generators/prql.py
+++ b/sqlglot/generators/prql.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sqlglot import generator
+
+
+class PRQLGenerator(generator.Generator):
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -30,6 +30,7 @@ from sqlglot.optimizer.scope import build_scope, find_all_in_scope
 from sqlglot.parsers.snowflake import (
     RANKING_WINDOW_FUNCTIONS_WITH_FRAME,
     TIMESTAMP_TYPES,
+    SnowflakeParser,
     build_object_construct,
 )
 from sqlglot.tokens import TokenType
@@ -114,8 +115,6 @@ def _flatten_structured_types_unless_iceberg(expression: exp.Expr) -> exp.Expr:
 
 
 def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
-    from sqlglot.parsers.snowflake import SnowflakeParser
-
     generate_date_array = unnest.expressions[0]
     start = generate_date_array.args.get("start")
     end = generate_date_array.args.get("end")
@@ -373,6 +372,7 @@ def _eliminate_dot_variant_lookup(expression: exp.Expr) -> exp.Expr:
 
 
 class SnowflakeGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
     PARAMETER_TOKEN = "$"
     MATCHED_BY_SOURCE = False
     SINGLE_STRING_INTERVAL = True
@@ -396,6 +396,9 @@ class SnowflakeGenerator(generator.Generator):
     SUPPORTS_MEDIAN = True
     ARRAY_SIZE_NAME = "ARRAY_SIZE"
     SUPPORTS_DECODE_CASE = True
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     IS_BOOL_ALLOWED = False
     DIRECTED_JOINS = True
     SUPPORTS_UESCAPE = False

--- a/sqlglot/generators/solr.py
+++ b/sqlglot/generators/solr.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from sqlglot import generator
+
+
+class SolrGenerator(generator.Generator):
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -9,7 +9,7 @@ from sqlglot.dialects.dialect import (
     rename_func,
     unit_to_str,
 )
-from sqlglot.generators.hive import HiveGenerator, HIVE_TS_OR_DS_EXPRESSIONS
+from sqlglot.generators.hive import HIVE_DATE_FORMAT, HiveGenerator, HIVE_TS_OR_DS_EXPRESSIONS
 from sqlglot.transforms import (
     preprocess,
     remove_unique_constraints,
@@ -30,10 +30,7 @@ def _map_sql(self: Spark2Generator, expression: exp.Map) -> str:
 
 def _str_to_date(self: Spark2Generator, expression: exp.StrToDate) -> str:
     time_format = self.format_time(expression)
-
-    from sqlglot.dialects.hive import Hive
-
-    if time_format == Hive.DATE_FORMAT:
+    if time_format == HIVE_DATE_FORMAT:
         return self.func("TO_DATE", expression.this)
     return self.func("TO_DATE", expression.this, time_format)
 

--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -74,6 +74,13 @@ def _generated_to_auto_increment(expression: exp.Expr) -> exp.Expr:
 
 
 class SQLiteGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     JOIN_HINTS = False
     TABLE_HINTS = False
     QUERY_HINTS = False

--- a/sqlglot/generators/tableau.py
+++ b/sqlglot/generators/tableau.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp, generator, transforms
 from sqlglot.dialects.dialect import rename_func, strposition_sql as _strposition_sql
 
 
 class TableauGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     JOIN_HINTS = False
     TABLE_HINTS = False
     QUERY_HINTS = False

--- a/sqlglot/generators/teradata.py
+++ b/sqlglot/generators/teradata.py
@@ -36,6 +36,13 @@ def _date_add_sql(
 
 
 class TeradataGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     LIMIT_IS_TOP = True
     JOIN_HINTS = False
     TABLE_HINTS = False

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import typing as t
-
 from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
     merge_without_target_sql,
@@ -12,14 +10,12 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.generators.presto import PrestoGenerator, amend_exploded_column_table
 
-_POST_WITH: t.Any = getattr(exp.Properties.Location, "POST_WITH")
-
 
 class TrinoGenerator(PrestoGenerator):
     EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = True
-    PROPERTIES_LOCATION: t.ClassVar[t.Dict[t.Any, t.Any]] = {
+    PROPERTIES_LOCATION = {
         **PrestoGenerator.PROPERTIES_LOCATION,
-        exp.LocationProperty: _POST_WITH,
+        exp.LocationProperty: exp.Properties.Location.POST_WITH,
     }
 
     TRANSFORMS = {

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
     trim_sql,
 )
 from sqlglot.helper import seq_get
+from sqlglot.parsers.tsql import OPTIONS_THAT_REQUIRE_EQUAL
 from sqlglot.time import format_time
 
 DATE_PART_UNMAPPING = {
@@ -115,6 +116,13 @@ def _timestrtotime_sql(self: TSQLGenerator, expression: exp.TimeStrToTime):
 
 
 class TSQLGenerator(generator.Generator):
+    SELECT_KINDS: t.Tuple[str, ...] = ()
+    TRY_SUPPORTED = False
+    SUPPORTS_UESCAPE = False
+    SUPPORTS_DECODE_CASE = False
+
+    AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
+
     LIMIT_IS_TOP = True
     QUERY_HINTS = False
     RETURNING_END = False
@@ -277,8 +285,6 @@ class TSQLGenerator(generator.Generator):
         return self.func(name, expression.this, expression.expression, expression.args.get("style"))
 
     def queryoption_sql(self, expression: exp.QueryOption) -> str:
-        from sqlglot.parsers.tsql import OPTIONS_THAT_REQUIRE_EQUAL
-
         option = self.sql(expression, "this")
         value = self.sql(expression, "expression")
         if value:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -10,6 +10,7 @@ import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
+import sqlglot.generator as _generator_module
 from sqlglot import exp, find_tables, parse_one, transpile
 from sqlglot.errors import ExecuteError
 from sqlglot.executor import execute
@@ -24,6 +25,8 @@ from tests.helpers import (
     TPCDS_SCHEMA,
     load_sql_fixture_pairs,
 )
+
+_GENERATOR_IS_COMPILED = getattr(_generator_module, "__file__", "").endswith(".so")
 
 DIR_TPCH = FIXTURES_DIR + "/optimizer/tpc-h/"
 DIR_TPCDS = FIXTURES_DIR + "/optimizer/tpc-ds/"
@@ -66,6 +69,7 @@ def mp_execute(expression, meta):
 
 
 @unittest.skipIf(SKIP_INTEGRATION, "Skipping Integration Tests since `SKIP_INTEGRATION` is set")
+@unittest.skipIf(_GENERATOR_IS_COMPILED, "executor requires interpreted Generator subclass")
 class TestExecutor(unittest.TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
- Remove `@mypyc_attr(allow_interpreted_subclasses=True)` from base `Generator` and `HiveGenerator`
- Remove metaclass setattr logic from `_Dialect.__new__`, add explicit attrs to each `Generator` 
- Change generator_class assignment in `_Dialect.__new__` to match parser pattern (no dynamic interpreted subclasses)
- Extract `AFTER_HAVING_MODIFIER_TRANSFORMS` base dict to module level in generator.py; each non-Hive generator references it, BigQuery overrides for custom order (qualify before windows)
- Move `_HiveGenerator` from `dialects/athena.py` to `generators/athena.py` (now compiled)
- Create `generators/prql.py` and `generators/solr.py`
- Remove `_DType, _UNSUPPORTED`,` _POST_WITH` aliases in presto/trino/athena
- Move deferred imports to top-level in snowflake/tsql/spark2