### PR TITLE
feat(duckdb): Add transpilation support for ILIKE ANY, LIKE ANY/ALL functions for ESCAPE pattern

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4052,6 +4052,13 @@ class Generator:
         return self.binary(expression, ":=")
 
     def escape_sql(self, expression: exp.Escape) -> str:
+        this = expression.this
+        if (
+            isinstance(this, (exp.Like, exp.ILike))
+            and isinstance(this.expression, (exp.All, exp.Any))
+            and not self.SUPPORTS_LIKE_QUANTIFIERS
+        ):
+            return self._like_sql(this, escape=expression)
         return self.binary(expression, "ESCAPE")
 
     def glob_sql(self, expression: exp.Glob) -> str:
@@ -4070,7 +4077,11 @@ class Generator:
             )
         return self.binary(expression, "IS")
 
-    def _like_sql(self, expression: exp.Like | exp.ILike) -> str:
+    def _like_sql(
+        self,
+        expression: exp.Like | exp.ILike,
+        escape: t.Optional[exp.Escape] = None,
+    ) -> str:
         this = expression.this
         rhs = expression.expression
 
@@ -4091,12 +4102,20 @@ class Generator:
 
             connective = exp.or_ if isinstance(rhs, exp.Any) else exp.and_
 
-            like_expr: exp.Expr = exp_class(this=this, expression=exprs[0])
-            for expr in exprs[1:]:
-                like_expr = connective(like_expr, exp_class(this=this, expression=expr))
+            def _make_like(expr: exp.Expression) -> exp.Expression:
+                like: exp.Expression = exp_class(this=this, expression=expr)
+                if escape:
+                    like = exp.Escape(this=like, expression=escape.expression.copy())
+                return like
 
-            parent = expression.parent
-            if not isinstance(parent, type(like_expr)) and isinstance(parent, exp.Condition):
+            like_expr: exp.Expr = _make_like(exprs[0])
+            for expr in exprs[1:]:
+                like_expr = connective(like_expr, _make_like(expr), copy=False)
+
+            parent = escape.parent if escape else expression.parent
+            if not isinstance(parent, (type(like_expr), exp.Paren)) and isinstance(
+                parent, exp.Condition
+            ):
                 like_expr = exp.paren(like_expr, copy=False)
 
             return self.sql(like_expr)

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4176,35 +4176,3 @@ class DuckDBGenerator(generator.Generator):
             corr_expr = expression  # make mypy happy
 
         return self.sql(exp.case().when(exp.IsNan(this=corr_expr), exp.null()).else_(corr_expr))
-
-    def escape_sql(self, expression: exp.Escape) -> str:
-        this = expression.this
-        if isinstance(this, (exp.Like, exp.ILike)) and isinstance(
-            this.expression, (exp.All, exp.Any)
-        ):
-            exp_class: t.Type[exp.Like | exp.ILike] = type(this)
-            quantifier = this.expression
-            escape_char = expression.expression
-
-            unnested = quantifier.this.unnest()
-            exprs = unnested.expressions if isinstance(unnested, exp.Tuple) else [unnested]
-
-            all_expanded = [
-                exp.Escape(
-                    this=exp_class(this=this.this, expression=e), expression=escape_char.copy()
-                )
-                for e in exprs
-            ]
-            expanded = (
-                exp.or_(*all_expanded, copy=False)
-                if isinstance(quantifier, exp.Any)
-                else exp.and_(*all_expanded, copy=False)
-            )
-
-            parent = expression.parent
-            if not isinstance(parent, type(expanded)) and isinstance(parent, exp.Condition):
-                expanded = exp.paren(expanded, copy=False)
-
-            return self.sql(expanded)
-
-        return self.binary(expression, "ESCAPE")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -3278,6 +3278,20 @@ class TestSnowflake(Validator):
                 "duckdb": "SELECT 'he%lo' ILIKE 'he#%lo' ESCAPE '#' OR 'he%lo' ILIKE 'hello' ESCAPE '#'",
             },
         )
+        self.validate_all(
+            "SELECT 1 WHERE 'he%lo' LIKE ANY ('he#%lo', 'hello') ESCAPE '#' AND x = 1",
+            write={
+                "snowflake": "SELECT 1 WHERE 'he%lo' LIKE ANY ('he#%lo', 'hello') ESCAPE '#' AND x = 1",
+                "duckdb": "SELECT 1 WHERE ('he%lo' LIKE 'he#%lo' ESCAPE '#' OR 'he%lo' LIKE 'hello' ESCAPE '#') AND x = 1",
+            },
+        )
+        self.validate_all(
+            "SELECT 1 WHERE 'he%lo' LIKE ALL ('he#%lo', 'he#%lo2') ESCAPE '#' OR x = 1",
+            write={
+                "snowflake": "SELECT 1 WHERE 'he%lo' LIKE ALL ('he#%lo', 'he#%lo2') ESCAPE '#' OR x = 1",
+                "duckdb": "SELECT 1 WHERE ('he%lo' LIKE 'he#%lo' ESCAPE '#' AND 'he%lo' LIKE 'he#%lo2' ESCAPE '#') OR x = 1",
+            },
+        )
 
     def test_null_treatment(self):
         self.validate_all(


### PR DESCRIPTION
Issue: `ESCAPE` mis-expansion — `'he%lo' LIKE ANY ('he#%lo', 'hello') ESCAPE '#'` transpiles to `('he%lo' LIKE 'he#%lo' OR 'he%lo' LIKE 'hello') ESCAPE '#' `— invalid DuckDB SQL. 
Fix: The `ESCAPE` clause must be distributed to each individual LIKE pattern, not the entire `OR` expression.

Duckdb:
```

"SELECT 'hello' LIKE '%he%' OR 'hello' LIKE '%lo%' AS multi_no_escape, 'hello' LIKE '%xyz%' AS single_no_escape, 'he%lo' LIKE 'he#%lo' ESCAPE '#' OR 'he%lo' LIKE 'hello' ESCAPE '#' AS multi_escape, 'he%lo' LIKE 'he#%lo' ESCAPE '#' AS single_escape, ('hello' LIKE '%a%' OR 'hello' LIKE '%b%') OR 'hello' LIKE '%c%' AS three_patterns"
┌─────────────────┬──────────────────┬──────────────┬───────────────┬────────────────┐
│ multi_no_escape │ single_no_escape │ multi_escape │ single_escape │ three_patterns │
│     boolean     │     boolean      │   boolean    │    boolean    │    boolean     │
├─────────────────┼──────────────────┼──────────────┼───────────────┼────────────────┤
│ true            │ false            │ true         │ true          │ false          │
└─────────────────┴──────────────────┴──────────────┴───────────────┴────────────────┘

"SELECT 'hello' LIKE '%he%' AND 'hello' LIKE '%hello%' AS multi_no_escape, 'he%lo' LIKE 'he#%lo' ESCAPE '#' AND 'he%lo' LIKE 'he#%' ESCAPE '#' AS multi_escape, 'he%lo' LIKE 'he#%lo' ESCAPE '#' AS single_escape"
┌─────────────────┬──────────────┬───────────────┐
│ multi_no_escape │ multi_escape │ single_escape │
│     boolean     │   boolean    │    boolean    │
├─────────────────┼──────────────┼───────────────┤
│ true            │ false        │ true          │
└─────────────────┴──────────────┴───────────────┘

"SELECT 'HELLO' ILIKE '%he%' OR 'HELLO' ILIKE '%lo%' AS multi_no_escape, 'he%lo' ILIKE 'he#%lo' ESCAPE '#' OR 'he%lo' ILIKE 'hello' ESCAPE '#' AS multi_escape, 'he%lo' ILIKE 'he#%lo' ESCAPE '#' AS single_escape"
┌─────────────────┬──────────────┬───────────────┐
│ multi_no_escape │ multi_escape │ single_escape │
│     boolean     │   boolean    │    boolean    │
├─────────────────┼──────────────┼───────────────┤
│ true            │ true         │ true          │
└─────────────────┴──────────────┴───────────────┘
```