### PR TITLE
add initial Netezza dialect support for DISTRIBUTE ON and ORGANIZE ON

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -80,6 +80,7 @@ DIALECTS = [
     "Hive",
     "Materialize",
     "MySQL",
+    "Netezza",
     "Oracle",
     "Postgres",
     "Presto",

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -95,6 +95,7 @@ class Dialects(str, Enum):
     HIVE = "hive"
     MATERIALIZE = "materialize"
     MYSQL = "mysql"
+    NETEZZA = "netezza"
     ORACLE = "oracle"
     POSTGRES = "postgres"
     PRESTO = "presto"

--- a/sqlglot/dialects/netezza.py
+++ b/sqlglot/dialects/netezza.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.dialects.postgres import Postgres
+from sqlglot.generators.postgres import PostgresGenerator
+from sqlglot.parsers.postgres import PostgresParser
+from sqlglot.tokens import TokenType
+
+
+class Netezza(Postgres):
+    class Parser(PostgresParser):
+        PROPERTY_PARSERS = {
+            **PostgresParser.PROPERTY_PARSERS,
+            "DISTRIBUTE": lambda self: self._parse_distribute_on(),
+            "ORGANIZE": lambda self: self._parse_organize_on(),
+        }
+
+        def _parse_distribute_on(self) -> exp.DistributeOnProperty:
+            self._match(TokenType.ON)
+
+            if self._match_text_seq("RANDOM"):
+                return self.expression(exp.DistributeOnProperty(this=exp.var("RANDOM")))
+
+            is_hash = self._match_text_seq("HASH")
+            return self.expression(
+                exp.DistributeOnProperty(
+                    this=exp.var("HASH") if is_hash else None,
+                    expressions=self._parse_wrapped_csv(self._parse_id_var),
+                )
+            )
+
+        def _parse_organize_on(self) -> exp.OrganizeOnProperty:
+            self._match(TokenType.ON)
+
+            if self._match_text_seq("NONE"):
+                return self.expression(exp.OrganizeOnProperty(none=True))
+
+            return self.expression(
+                exp.OrganizeOnProperty(expressions=self._parse_wrapped_csv(self._parse_id_var))
+            )
+
+    class Generator(PostgresGenerator):
+        PROPERTIES_LOCATION = {
+            **PostgresGenerator.PROPERTIES_LOCATION,
+            exp.DistributeOnProperty: exp.Properties.Location.POST_SCHEMA,
+            exp.OrganizeOnProperty: exp.Properties.Location.POST_SCHEMA,
+        }
+
+        def distributeonproperty_sql(self, expression: exp.DistributeOnProperty) -> str:
+            kind = expression.args.get("this")
+            if kind and kind.name.upper() == "RANDOM":
+                return "DISTRIBUTE ON RANDOM"
+
+            expressions = self.expressions(expression, flat=True)
+            if kind and kind.name.upper() == "HASH":
+                return f"DISTRIBUTE ON HASH({expressions})"
+
+            return f"DISTRIBUTE ON ({expressions})"
+
+        def organizeonproperty_sql(self, expression: exp.OrganizeOnProperty) -> str:
+            if expression.args.get("none"):
+                return "ORGANIZE ON NONE"
+
+            return f"ORGANIZE ON ({self.expressions(expression, flat=True)})"

--- a/sqlglot/expressions/properties.py
+++ b/sqlglot/expressions/properties.py
@@ -117,6 +117,10 @@ class DistributedByProperty(Property):
     arg_types = {"expressions": False, "kind": True, "buckets": False, "order": False}
 
 
+class DistributeOnProperty(Property):
+    arg_types = {"this": False, "expressions": False}
+
+
 class DistStyleProperty(Property):
     arg_types = {"this": True}
 
@@ -299,6 +303,10 @@ class OnProperty(Property):
 
 class OnCommitProperty(Property):
     arg_types = {"delete": False}
+
+
+class OrganizeOnProperty(Property):
+    arg_types = {"expressions": False, "none": False}
 
 
 class PartitionedByProperty(Property):
@@ -579,6 +587,7 @@ class Properties(Expression):
         "CREDENTIALS": CredentialsProperty,
         "DEFINER": DefinerProperty,
         "DISTKEY": DistKeyProperty,
+        "DISTRIBUTE ON": DistributeOnProperty,
         "DISTRIBUTED_BY": DistributedByProperty,
         "DISTSTYLE": DistStyleProperty,
         "ENGINE": EngineProperty,
@@ -587,6 +596,7 @@ class Properties(Expression):
         "LANGUAGE": LanguageProperty,
         "LOCATION": LocationProperty,
         "LOCK": LockProperty,
+        "ORGANIZE ON": OrganizeOnProperty,
         "PARTITIONED_BY": PartitionedByProperty,
         "RETURNS": ReturnsProperty,
         "ROW_FORMAT": RowFormatProperty,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -628,6 +628,7 @@ class Generator:
         exp.Cluster: exp.Properties.Location.POST_SCHEMA,
         exp.ClusteredByProperty: exp.Properties.Location.POST_SCHEMA,
         exp.DistributedByProperty: exp.Properties.Location.POST_SCHEMA,
+        exp.DistributeOnProperty: exp.Properties.Location.POST_SCHEMA,
         exp.DuplicateKeyProperty: exp.Properties.Location.POST_SCHEMA,
         exp.DataBlocksizeProperty: exp.Properties.Location.POST_NAME,
         exp.DatabaseProperty: exp.Properties.Location.POST_CREATE,
@@ -671,6 +672,7 @@ class Generator:
         exp.NoPrimaryIndexProperty: exp.Properties.Location.POST_EXPRESSION,
         exp.OnProperty: exp.Properties.Location.POST_SCHEMA,
         exp.OnCommitProperty: exp.Properties.Location.POST_EXPRESSION,
+        exp.OrganizeOnProperty: exp.Properties.Location.POST_SCHEMA,
         exp.Order: exp.Properties.Location.POST_SCHEMA,
         exp.OutputModelProperty: exp.Properties.Location.POST_SCHEMA,
         exp.PartitionedByProperty: exp.Properties.Location.POST_WITH,
@@ -1941,6 +1943,10 @@ class Generator:
     def uuidproperty_sql(self, expression: exp.UuidProperty) -> str:
         return f"UUID {self.sql(expression, 'this')}"
 
+    def distributeonproperty_sql(self, expression: exp.DistributeOnProperty) -> str:
+        self.unsupported("DISTRIBUTE ON is not supported in this dialect")
+        return ""
+
     def likeproperty_sql(self, expression: exp.LikeProperty) -> str:
         if self.SUPPORTS_CREATE_TABLE_LIKE:
             options = " ".join(f"{e.name} {self.sql(e, 'value')}" for e in expression.expressions)
@@ -1957,6 +1963,10 @@ class Generator:
 
         select = exp.select("*").from_(expression.this).limit(0)
         return f"AS {self.sql(select)}"
+
+    def organizeonproperty_sql(self, expression: exp.OrganizeOnProperty) -> str:
+        self.unsupported("ORGANIZE ON is not supported in this dialect")
+        return ""
 
     def fallbackproperty_sql(self, expression: exp.FallbackProperty) -> str:
         no = "NO " if expression.args.get("no") else ""

--- a/tests/dialects/test_netezza.py
+++ b/tests/dialects/test_netezza.py
@@ -1,0 +1,23 @@
+from sqlglot import Dialect, Dialects
+from tests.dialects.test_dialect import Validator
+
+
+class TestNetezza(Validator):
+    dialect = "netezza"
+
+    def test_identity(self):
+        self.validate_identity("SELECT CURRENT_DATE")
+        self.validate_identity("SELECT CAST(a AS VARCHAR(255)) FROM x")
+        self.validate_identity("SELECT * FROM t LIMIT 10")
+        self.validate_identity("CREATE TABLE t (id INT) DISTRIBUTE ON RANDOM")
+        self.validate_identity("CREATE TABLE t (id INT, name VARCHAR(10)) DISTRIBUTE ON (id)")
+        self.validate_identity("CREATE TABLE t (id INT, name VARCHAR(10)) DISTRIBUTE ON HASH(id)")
+        self.validate_identity("CREATE TABLE t (id INT, name VARCHAR(10)) ORGANIZE ON (id, name)")
+        self.validate_identity("CREATE TABLE t (id INT) ORGANIZE ON NONE")
+        self.validate_identity(
+            "CREATE TABLE t (id INT, name VARCHAR(10)) DISTRIBUTE ON HASH(id) ORGANIZE ON (name)"
+        )
+
+    def test_registry(self):
+        self.assertIsNotNone(Dialect.get_or_raise("netezza"))
+        self.assertEqual(Dialects.NETEZZA.value, "netezza")


### PR DESCRIPTION
## Summary

This PR adds initial `Netezza` dialect support to SQLGlot.

It introduces a new `netezza` dialect based on `Postgres`, registers it in the dialect registry, and implements support for Netezza-specific `CREATE TABLE` table properties:

- `DISTRIBUTE ON RANDOM`
- `DISTRIBUTE ON (col, ...)`
- `DISTRIBUTE ON HASH(col, ...)`
- `ORGANIZE ON (col, ...)`
- `ORGANIZE ON NONE`

## Changes

- registered the new `Netezza` dialect
- added a `sqlglot.dialects.netezza.Netezza` dialect
- added new property expressions for:
  - `DISTRIBUTE ON`
  - `ORGANIZE ON`
- added Netezza parser support for these clauses
- added Netezza SQL generation for these clauses
- added fallback generator handling so unsupported target dialects drop these properties with warnings instead of failing
- added dialect tests covering round-trip parsing / generation

## Examples

These now round-trip with `dialect="netezza"`:

```sql
CREATE TABLE t (id INT) DISTRIBUTE ON RANDOM
```

```sql
CREATE TABLE t (id INT, name VARCHAR(10)) DISTRIBUTE ON (id)
```

```sql
CREATE TABLE t (id INT, name VARCHAR(10)) DISTRIBUTE ON HASH(id)
```

```sql
CREATE TABLE t (id INT, name VARCHAR(10)) ORGANIZE ON (id, name)
```

```sql
CREATE TABLE t (id INT) ORGANIZE ON NONE
```

```sql
CREATE TABLE t (id INT, name VARCHAR(10)) DISTRIBUTE ON HASH(id) ORGANIZE ON (name)
```

## Notes

This is intended as an initial Netezza contribution rather than complete dialect coverage. The implementation focuses on core `CREATE TABLE` syntax that is specific to Netezza and fits cleanly into SQLGlot’s existing property-based DDL model.

## Tests

Ran:

```bash
python -m unittest tests.dialects.test_netezza tests.dialects.test_dialect.TestDialect.test_enum tests.test_dialect_imports
```