### PR TITLE
feat(duckdb): Add transpilation support to TRY_PARSE_JSON

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2544,7 +2544,11 @@ class DuckDBGenerator(generator.Generator):
     def parsejson_sql(self, expression: exp.ParseJSON) -> str:
         arg = expression.this
         if expression.args.get("safe"):
-            return self.sql(exp.case().when(exp.func("json_valid", arg), arg).else_(exp.null()))
+            return self.sql(
+                exp.case()
+                .when(exp.func("json_valid", arg), exp.cast(arg.copy(), "JSON"))
+                .else_(exp.null())
+            )
         return self.func("JSON", arg)
 
     @unsupported_args("decimals")

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -100,9 +100,9 @@ class TestDuckDB(Validator):
         )
 
         self.validate_all(
-            """SELECT CASE WHEN JSON_VALID('{"x: 1}') THEN '{"x: 1}' ELSE NULL END""",
+            """SELECT CASE WHEN JSON_VALID('{"x: 1}') THEN CAST('{"x: 1}' AS JSON) ELSE NULL END""",
             read={
-                "duckdb": """SELECT CASE WHEN JSON_VALID('{"x: 1}') THEN '{"x: 1}' ELSE NULL END""",
+                "duckdb": """SELECT CASE WHEN JSON_VALID('{"x: 1}') THEN CAST('{"x: 1}' AS JSON) ELSE NULL END""",
                 "snowflake": """SELECT TRY_PARSE_JSON('{"x: 1}')""",
             },
         )

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -5402,6 +5402,15 @@ STORAGE_ALLOWED_LOCATIONS=('s3://mybucket1/path1/', 's3://mybucket2/path2/')""",
                     expression.sql(dialect="snowflake"), f"SELECT {func}(t.x AS VARCHAR) FROM t"
                 )
 
+    def test_try_parse_json(self):
+        self.validate_all(
+            "SELECT TRY_PARSE_JSON(x)",
+            write={
+                "snowflake": "SELECT TRY_PARSE_JSON(x)",
+                "duckdb": "SELECT CASE WHEN JSON_VALID(x) THEN CAST(x AS JSON) ELSE NULL END",
+            },
+        )
+
     def test_decfloat(self):
         self.validate_all(
             "SELECT CAST(1.5 AS DECFLOAT)",


### PR DESCRIPTION
`TRY_PARSE_JSON` returns `VARCHAR` instead of `JSON` in case of Duckdb while `TRY_PARSE_JSON` in Snowflake returns `JSON` type.

```
 python3 -c "
import sqlglot
q = \"SELECT TRY_PARSE_JSON('{\\\"a\\\": 1}') AS col_valid_obj, TRY_PARSE_JSON('[1, 2, 3]') AS col_valid_arr, TRY_PARSE_JSON('true') AS col_valid_bool, TRY_PARSE_JSON('42') AS col_valid_num, TRY_PARSE_JSON('{bad json}') AS col_invalid, TRY_PARSE_JSON(NULL) AS col_null\"
print(sqlglot.transpile(q, read='snowflake', write='duckdb')[0])
" | duckdb

┌───────────────┬───────────────┬────────────────┬───────────────┬─────────────┬──────────┐
│ col_valid_obj │ col_valid_arr │ col_valid_bool │ col_valid_num │ col_invalid │ col_null │
│     json      │     json      │      json      │     json      │    json     │   json   │
├───────────────┼───────────────┼────────────────┼───────────────┼─────────────┼──────────┤
│ {"a": 1}      │ [1, 2, 3]     │ true           │ 42            │ NULL        │ NULL     │
└───────────────┴───────────────┴────────────────┴───────────────┴─────────────┴──────────┘
```