### PR TITLE
fix(duckdb): support TRUNC with decimal arg

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2558,10 +2558,6 @@ class DuckDBGenerator(generator.Generator):
             .else_(expression.this)
         )
 
-    @unsupported_args("decimals")
-    def trunc_sql(self, expression: exp.Trunc) -> str:
-        return self.func("TRUNC", expression.this)
-
     def normal_sql(self, expression: exp.Normal) -> str:
         """
         Transpile Snowflake's NORMAL(mean, stddev, gen) to DuckDB.

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -11,11 +11,13 @@ class TestDuckDB(Validator):
     dialect = "duckdb"
 
     def test_duckdb(self):
-        # Numeric TRUNC - DuckDB only supports TRUNC(x), no decimals parameter
         self.validate_identity("TRUNC(3.14)").assert_is(exp.Trunc)
         self.validate_all(
-            "TRUNC(3.14159)",
-            read={"postgres": "TRUNC(3.14159, 2)"},
+            "TRUNC(3.14159, 2)",
+            read={
+                "postgres": "TRUNC(3.14159, 2)",
+                "duckdb": "TRUNC(3.14159, 2)",
+            },
         )
 
         self.validate_identity("SELECT ([1,2,3])[:-:-1]", "SELECT ([1, 2, 3])[:-1:-1]")

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -805,7 +805,7 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
                 "tsql": "ROUND(3.14159, 2, 1)",
                 "snowflake": "TRUNC(3.14159, 2)",
                 "bigquery": "TRUNC(3.14159, 2)",
-                "duckdb": "TRUNC(3.14159)",
+                "duckdb": "TRUNC(3.14159, 2)",
                 "presto": "TRUNCATE(3.14159, 2)",
                 "clickhouse": "trunc(3.14159, 2)",
                 "spark": "CAST(3.14159 AS BIGINT)",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -3939,7 +3939,7 @@ class TestSnowflake(Validator):
                 "mysql": "TRUNCATE(3.14159, 2)",
                 "tsql": "ROUND(3.14159, 2, 1)",
                 "bigquery": "TRUNC(3.14159, 2)",
-                "duckdb": "TRUNC(3.14159)",
+                "duckdb": "TRUNC(3.14159, 2)",
                 "presto": "TRUNCATE(3.14159, 2)",
                 "clickhouse": "trunc(3.14159, 2)",
                 "spark": "CAST(3.14159 AS BIGINT)",


### PR DESCRIPTION
Fixes #7413

```
memory D select trunc(17.1234);
┌────────────────┐
│ trunc(17.1234) │
│  decimal(6,0)  │
├────────────────┤
│             17 │
└────────────────┘
memory D select trunc(17.1234, 1);
┌───────────────────┐
│ trunc(17.1234, 1) │
│   decimal(6,1)    │
├───────────────────┤
│              17.1 │
└───────────────────┘
memory D select trunc(17.1234, 2);
┌───────────────────┐
│ trunc(17.1234, 2) │
│   decimal(6,2)    │
├───────────────────┤
│             17.12 │
└───────────────────┘
```