### PR TITLE
feat(duckdb): Add transpilation support to CONTAINS.

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3082,6 +3082,14 @@ class DuckDBGenerator(generator.Generator):
         levenshtein = exp.Levenshtein(this=this, expression=expr)
         return self.sql(exp.Least(this=levenshtein, expressions=[max_dist]))
 
+    def contains_sql(self, expression: exp.Contains) -> str:
+        expr = expression.expression
+        return self.func(
+            "CONTAINS",
+            expression.this,
+            exp.cast(expr.copy(), "VARCHAR") if isinstance(expr, exp.Null) else expr,
+        )
+
     def pad_sql(self, expression: exp.Pad) -> str:
         """
         Handle RPAD/LPAD for VARCHAR and BINARY types.

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -6644,6 +6644,15 @@ FROM SEMANTIC_VIEW(
             },
         )
 
+    def test_contains(self):
+        self.validate_all(
+            "SELECT CONTAINS(col1, col2)",
+            write={
+                "snowflake": "SELECT CONTAINS(col1, col2)",
+                "duckdb": "SELECT CONTAINS(col1, col2)",
+            },
+        )
+
     def test_directed_joins(self):
         self.validate_identity("SELECT * FROM a CROSS DIRECTED JOIN b USING (id)")
         self.validate_identity("SELECT * FROM a INNER DIRECTED JOIN b USING (id)")


### PR DESCRIPTION
Adds `contains_sql` to `DuckDBGenerator` to cast untyped `NULL` literals to `VARCHAR`, resolving DuckDB's overload ambiguity between `contains(MAP,K)` and `contains(T[],T) `when `NULL` is passed as an argument.
```
 python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT CONTAINS('hello', NULL) AS hello_null, CONTAINS(NULL, NULL) AS null_null\", read='snowflake', write='duckdb')[0])"

SELECT CONTAINS('hello', CAST(NULL AS TEXT)) AS hello_null, CONTAINS(NULL, CAST(NULL AS TEXT)) AS null_null
┌────────────┬───────────┐
│ hello_null │ null_null │
│  boolean   │  boolean  │
├────────────┼───────────┤
│ NULL       │ NULL      │
└────────────┴───────────┘
```