### PR TITLE
fix(presto): transpile PARSE_DATETIME like DATE_PARSE

### DIFF
--- a/sqlglot/parsers/presto.py
+++ b/sqlglot/parsers/presto.py
@@ -88,6 +88,7 @@ class PrestoParser(parser.Parser):
         "DATE_FORMAT": build_formatted_time(exp.TimeToStr, "presto"),
         "DATE_PARSE": build_formatted_time(exp.StrToTime, "presto"),
         "DATE_TRUNC": date_trunc_to_time,
+        "PARSE_DATETIME": build_formatted_time(exp.StrToTime, "presto"),
         "DAY_OF_WEEK": exp.DayOfWeekIso.from_arg_list,
         "DOW": exp.DayOfWeekIso.from_arg_list,
         "DOY": exp.DayOfYear.from_arg_list,

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -343,6 +343,24 @@ class TestPresto(Validator):
             },
         )
         self.validate_all(
+            "PARSE_DATETIME(x, '%Y-%m-%d %H:%i:%S')",
+            write={
+                "duckdb": "STRPTIME(x, '%Y-%m-%d %H:%M:%S')",
+                "presto": "DATE_PARSE(x, '%Y-%m-%d %T')",
+                "hive": "CAST(x AS TIMESTAMP)",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd HH:mm:ss')",
+            },
+        )
+        self.validate_all(
+            "PARSE_DATETIME(x, '%Y-%m-%d')",
+            write={
+                "duckdb": "STRPTIME(x, '%Y-%m-%d')",
+                "presto": "DATE_PARSE(x, '%Y-%m-%d')",
+                "hive": "CAST(x AS TIMESTAMP)",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd')",
+            },
+        )
+        self.validate_all(
             "FROM_UNIXTIME(x)",
             write={
                 "duckdb": "TO_TIMESTAMP(x)",


### PR DESCRIPTION
## Summary

- Presto's `PARSE_DATETIME` was not being mapped to an internal expression in the parser, so it passed through untranspiled to target dialects (e.g. Spark, DuckDB, Hive).
- Added `PARSE_DATETIME` → `exp.StrToTime` mapping in the Presto parser, matching the existing `DATE_PARSE` behavior.
- This enables correct transpilation: `TO_TIMESTAMP` in Spark, `STRPTIME` in DuckDB, `CAST(x AS TIMESTAMP)` in Hive, etc.

## Test plan

- Added two `validate_all` test cases in `tests/dialects/test_presto.py` covering `PARSE_DATETIME` with different format strings.
- All 1174 unit tests pass.
- Linter (`ruff`, `ruff-format`, `mypy`) passes cleanly.

Made with [Cursor](https://cursor.com)