### PR TITLE
fix(bigquery): pipe syntax DISTINCT

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1189,6 +1189,7 @@ class Parser:
         "AS": lambda self, query: self._build_pipe_cte(
             query, [exp.Star()], self._parse_table_alias()
         ),
+        "DISTINCT": lambda self, query: self._advance() or query.distinct(copy=False),
         "EXTEND": lambda self, query: self._parse_pipe_syntax_extend(query),
         "LIMIT": lambda self, query: self._parse_pipe_syntax_limit(query),
         "ORDER BY": lambda self, query: query.order_by(

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -418,6 +418,24 @@ WHERE
             "WITH a AS (SELECT * FROM x JOIN y ON x.x1 = y.y1) SELECT * FROM a WHERE a.x2 > 1",
         )
 
+    def test_distinct(self):
+        self.validate_identity(
+            "SELECT 1 AS col1 UNION ALL SELECT 1 AS col1 |> DISTINCT",
+            "SELECT DISTINCT * FROM (SELECT 1 AS col1 UNION ALL SELECT 1 AS col1)",
+        )
+        self.validate_identity(
+            "FROM x |> DISTINCT",
+            "SELECT DISTINCT * FROM x",
+        )
+        self.validate_identity(
+            "FROM x |> DISTINCT |> WHERE x1 > 1",
+            "SELECT DISTINCT * FROM x WHERE x1 > 1",
+        )
+        self.validate_identity(
+            "FROM x |> SELECT x1, x2 |> DISTINCT",
+            "WITH __tmp1 AS (SELECT x1, x2 FROM x) SELECT DISTINCT * FROM __tmp1",
+        )
+
     def test_extend(self):
         self.validate_identity(
             "FROM x |> EXTEND id IN (1, 2) AS is_1_2, id + 1 as a_id",


### PR DESCRIPTION
Fixes #7449

**DOCS**
[BigQuery pipe syntax distinct](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/pipe-syntax#distinct_pipe_operator)