### PR TITLE
fix(presto): iterate over copy in eliminate_semi_and_anti_joins

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -606,7 +606,7 @@ def epoch_cast_to_ts(expression: exp.Expr) -> exp.Expr:
 def eliminate_semi_and_anti_joins(expression: exp.Expr) -> exp.Expr:
     """Convert SEMI and ANTI joins into equivalent forms that use EXIST instead."""
     if isinstance(expression, exp.Select):
-        for join in expression.args.get("joins") or []:
+        for join in list(expression.args.get("joins") or []):
             on = join.args.get("on")
             if on and join.kind in ("SEMI", "ANTI"):
                 subquery = exp.select("1").from_(join.this).where(on)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -5,6 +5,7 @@ from sqlglot.transforms import (
     eliminate_distinct_on,
     eliminate_join_marks,
     eliminate_qualify,
+    eliminate_semi_and_anti_joins,
     eliminate_window_clause,
     inherit_struct_field_names,
     remove_precision_parameterized_types,
@@ -278,6 +279,33 @@ class TestTransforms(unittest.TestCase):
             self.assertRaises(
                 AssertionError, eliminate_join_marks, parse_one(script, dialect=dialect)
             )
+
+    def test_eliminate_semi_and_anti_joins(self):
+        self.validate(
+            eliminate_semi_and_anti_joins,
+            "SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id ANTI JOIN t3 ON t1.id = t3.id",
+            "SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id WHERE NOT EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)",
+        )
+        self.validate(
+            eliminate_semi_and_anti_joins,
+            "SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id SEMI JOIN t3 ON t1.id = t3.id",
+            "SELECT t1.id FROM t1 JOIN t2 ON t1.id = t2.id WHERE EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)",
+        )
+        self.validate(
+            eliminate_semi_and_anti_joins,
+            "SELECT t1.id FROM t1 ANTI JOIN t2 ON t1.id = t2.id ANTI JOIN t3 ON t1.id = t3.id",
+            "SELECT t1.id FROM t1 WHERE NOT EXISTS(SELECT 1 FROM t2 WHERE t1.id = t2.id) AND NOT EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)",
+        )
+        self.validate(
+            eliminate_semi_and_anti_joins,
+            "SELECT t1.id FROM t1 ANTI JOIN t2 ON t1.id = t2.id ANTI JOIN t3 ON t1.id = t3.id ANTI JOIN t4 ON t1.id = t4.id",
+            "SELECT t1.id FROM t1 WHERE (NOT EXISTS(SELECT 1 FROM t2 WHERE t1.id = t2.id) AND NOT EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)) AND NOT EXISTS(SELECT 1 FROM t4 WHERE t1.id = t4.id)",
+        )
+        self.validate(
+            eliminate_semi_and_anti_joins,
+            "SELECT t1.id FROM t1 SEMI JOIN t2 ON t1.id = t2.id SEMI JOIN t3 ON t1.id = t3.id",
+            "SELECT t1.id FROM t1 WHERE EXISTS(SELECT 1 FROM t2 WHERE t1.id = t2.id) AND EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)",
+        )
 
     def test_eliminate_window_clause(self):
         self.validate(


### PR DESCRIPTION
## Summary

When a `SELECT` has multiple `SEMI` or `ANTI` joins, `eliminate_semi_and_anti_joins` only rewrites every other one. The remaining joins leak into the generated SQL as bare `ANTI JOIN` / `SEMI JOIN` — invalid syntax for dialects like Presto/Trino.

**Root cause:** the transform iterates over `expression.args.get("joins")` while calling `join.pop()` inside the loop. After popping index *i*, the next element shifts into position *i*, but the iterator has already advanced to *i+1* — so that element is never visited.

**Fix:** iterate over `list(...)` so removals don't shift unvisited elements. Same approach as #4364 which fixed the identical pattern in `unnest_to_explode`.

## Minimal reproduction

```python
from sqlglot import exp

select = (
    exp.Select()
    .select(exp.column("id", table="t1"))
    .from_("t1")
    .join("t2", on=exp.EQ(this=exp.column("id", table="t1"),
                           expression=exp.column("id", table="t2")))
    .join("t3", join_type="anti",
          on=exp.EQ(this=exp.column("id", table="t1"),
                    expression=exp.column("id", table="t3")))
    .join("t4", join_type="anti",
          on=exp.EQ(this=exp.column("id", table="t1"),
                    expression=exp.column("id", table="t4")))
)

print(select.sql(dialect="presto", pretty=True))
```

**Before (bug):** `t4` leaks as bare `ANTI JOIN`

```sql
SELECT
  t1.id
FROM t1
JOIN t2
  ON t1.id = t2.id
ANTI JOIN t4
  ON t1.id = t4.id
WHERE
  NOT EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)
```

**After (fix):** both rewritten to `NOT EXISTS`

```sql
SELECT
  t1.id
FROM t1
JOIN t2
  ON t1.id = t2.id
WHERE
  NOT EXISTS(SELECT 1 FROM t3 WHERE t1.id = t3.id)
  AND NOT EXISTS(SELECT 1 FROM t4 WHERE t1.id = t4.id)
```

## Changes

- `sqlglot/transforms.py`: iterate over `list(expression.args.get("joins") or [])` instead of the original list
- `tests/test_transforms.py`: add tests for single, double, and triple ANTI/SEMI joins

Made with [Cursor](https://cursor.com)