### PR TITLE
Chore: Revert setup for sqlglot-mypy

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        python: ["cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
         platform:
           - os: ubuntu-latest
             archs: x86_64

--- a/.github/workflows/package-test.yml
+++ b/.github/workflows/package-test.yml
@@ -30,8 +30,4 @@ jobs:
     - name: Run tests and linter checks
       run: |
         source ./.venv/bin/activate
-        if [ "${{ matrix.python-version }}" = "3.9" ]; then
-          make style test
-        else
-          make check
-        fi
+        make check

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     extras_require={
         "dev": [
             "duckdb>=0.6",
-            "mypy",
+            "sqlglot-mypy",
             "setuptools_scm",
             "pandas",
             "pandas-stubs",
@@ -22,8 +22,8 @@ setup(
             "pyperf",
         ],
         # Compiles from source on the user's machine.
-        "c": [f"sqlglotc=={version}; python_version >= '3.10'"],
+        "c": [f"sqlglotc=={version}"],
         # Deprecated: the Rust tokenizer has been replaced by sqlglotc.
-        "rs": ["sqlglotrs==0.13.0", f"sqlglotc=={version}; python_version >= '3.10'"],
+        "rs": ["sqlglotrs==0.13.0", f"sqlglotc=={version}"],
     },
 )

--- a/sqlglotc/pyproject.toml
+++ b/sqlglotc/pyproject.toml
@@ -4,17 +4,17 @@ dynamic = ["version"]
 description = "mypyc-compiled extensions for sqlglot"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
 license = "MIT"
-requires-python = ">= 3.10"
+requires-python = ">= 3.9"
 
 [project.optional-dependencies]
-dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy>=1.20.0.post1"]
+dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy"]
 
 [project.urls]
 Homepage = "https://sqlglot.com/"
 Repository = "https://github.com/tobymao/sqlglot"
 
 [build-system]
-requires = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy>=1.20.0.post1", "types-python-dateutil", "sqlglot"]
+requires = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy", "types-python-dateutil", "sqlglot"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
My [previous PR](https://github.com/tobymao/sqlglot/pull/7439) was based on the stale assumption that `make install-devc` was building with _isolation_ i.e seperating `mypy` from `sqlglot-mypy` which we used to do with `cd sqlglotc && pip install .`.

However, that was changed by https://github.com/tobymao/sqlglot/pull/7303 which optimized compilation time by using `python3 setup.py --inplace`; This way we **do not** isolate the sqlglotc build env from the root venv.

So, to avoid adding build isolation back which would 3x the compilation time (1m -> 3m), I've reverted that change.

Note: Given that mypy 1.20 dropped Python 3.9 support, I verified that on Python 3.12 we pull in `sqlglot-mypy=1.20.0.post1` whereas for Python 3.9 we install `sqlglot-mypy=1.19.1.post7`