### PR TITLE
fix(postgres): add missing TO_CHAR format tokens (Mon, Month, Day, Dy, AM/PM, HH)

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -21,12 +21,20 @@ class Postgres(Dialect):
     }
 
     TIME_MAPPING = {
+        "AM": "%p",  # AM/PM meridiem indicator
+        "A.M.": "%p",  # AM/PM with periods
         "d": "%u",  # 1-based day of week
         "D": "%u",  # 1-based day of week
+        "day": "%A",  # full weekday name (lowercase)
+        "Day": "%A",  # full weekday name (capitalized)
+        "DAY": "%A",  # full weekday name (uppercase)
         "dd": "%d",  # day of month
         "DD": "%d",  # day of month
         "ddd": "%j",  # zero padded day of year
         "DDD": "%j",  # zero padded day of year
+        "dy": "%a",  # abbreviated weekday name (lowercase)
+        "Dy": "%a",  # abbreviated weekday name (capitalized)
+        "DY": "%a",  # abbreviated weekday name (uppercase)
         "FMDD": "%-d",  # - is no leading zero for Python; same for FM in postgres
         "FMDDD": "%-j",  # day of year
         "FMHH12": "%-I",  # 9
@@ -34,13 +42,27 @@ class Postgres(Dialect):
         "FMMI": "%-M",  # Minute
         "FMMM": "%-m",  # 1
         "FMSS": "%-S",  # Second
+        "hh": "%I",  # 12-hour (HH defaults to 12-hour in PG)
+        "HH": "%I",  # 12-hour (HH defaults to 12-hour in PG)
         "HH12": "%I",  # 09
         "HH24": "%H",  # 09
         "mi": "%M",  # zero padded minute
         "MI": "%M",  # zero padded minute
         "mm": "%m",  # 01
         "MM": "%m",  # 01
+        "mon": "%b",  # abbreviated month name (lowercase)
+        "Mon": "%b",  # abbreviated month name (capitalized)
+        "MON": "%b",  # abbreviated month name (uppercase)
+        "month": "%B",  # full month name (lowercase)
+        "Month": "%B",  # full month name (capitalized)
+        "MONTH": "%B",  # full month name (uppercase)
         "OF": "%z",  # utc offset
+        "PM": "%p",  # PG treats AM/PM as synonymous; both print actual meridiem
+        "P.M.": "%p",
+        "am": "%p",
+        "a.m.": "%p",
+        "pm": "%p",
+        "p.m.": "%p",
         "ss": "%S",  # zero padded second
         "SS": "%S",  # zero padded second
         "TMDay": "%A",  # TM is locale dependent
@@ -55,6 +77,17 @@ class Postgres(Dialect):
         "YY": "%y",  # 15
         "yyyy": "%Y",  # 2015
         "YYYY": "%Y",  # 2015
+    }
+
+    # Prefer bare forms (Mon, Day, Dy, Month) over TM-prefixed forms when
+    # generating Postgres SQL from the internal strftime representation.
+    INVERSE_TIME_MAPPING = {
+        "%A": "Day",
+        "%a": "Dy",
+        "%b": "Mon",
+        "%B": "Month",
+        "%I": "HH12",
+        "%p": "AM",
     }
 
     class Tokenizer(tokens.Tokenizer):

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -464,7 +464,7 @@ class TestExasol(Validator):
             write={
                 "exasol": "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'DY')",
                 "oracle": "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'DY')",
-                "postgres": "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'TMDy')",
+                "postgres": "SELECT TO_CHAR(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'Dy')",
                 "databricks": "SELECT DATE_FORMAT(CAST('2024-07-08 13:45:00' AS TIMESTAMP), 'EEE')",
             },
         )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -152,10 +152,12 @@ class TestPostgres(Validator):
             "SELECT TO_TIMESTAMP(1284352323.5), TO_TIMESTAMP('05 Dec 2000', 'DD Mon YYYY')"
         )
         self.validate_identity(
-            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 AM', 'DD Mon YYYY HH:MI AM')"
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 AM', 'DD Mon YYYY HH:MI AM')",
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 AM', 'DD Mon YYYY HH12:MI AM')",
         )
         self.validate_identity(
-            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 PM', 'DD Mon YYYY HH:MI PM')"
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 PM', 'DD Mon YYYY HH:MI PM')",
+            "SELECT TO_TIMESTAMP('05 Dec 2000 10:00 PM', 'DD Mon YYYY HH12:MI AM')",
         )
         self.validate_identity(
             "SELECT * FROM foo, LATERAL (SELECT * FROM bar WHERE bar.id = foo.bar_id) AS ss"
@@ -1020,6 +1022,59 @@ FROM json_data, field_ids""",
                 "redshift": "SELECT TO_CHAR(foo, bar)",
             },
         )
+
+        # TO_CHAR format token conversions: month names, weekday names, AM/PM, HH
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'Mon YYYY')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%b %Y')",
+                "postgres": "SELECT TO_CHAR(dt, 'Mon YYYY')",
+            },
+        )
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'Month YYYY')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%B %Y')",
+                "postgres": "SELECT TO_CHAR(dt, 'Month YYYY')",
+            },
+        )
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'Day')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%A')",
+                "postgres": "SELECT TO_CHAR(dt, 'Day')",
+            },
+        )
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'Dy')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%a')",
+                "postgres": "SELECT TO_CHAR(dt, 'Dy')",
+            },
+        )
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'HH12:MI AM')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%I:%M %p')",
+                "postgres": "SELECT TO_CHAR(dt, 'HH12:MI AM')",
+            },
+        )
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'DD Mon YYYY HH24:MI')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%d %b %Y %H:%M')",
+                "postgres": "SELECT TO_CHAR(dt, 'DD Mon YYYY HH24:MI')",
+            },
+        )
+        # Bare HH (no 12/24 suffix) defaults to 12-hour in PostgreSQL
+        self.validate_all(
+            "SELECT TO_CHAR(dt, 'HH:MI')",
+            write={
+                "clickhouse": "SELECT formatDateTime(dt, '%I:%M')",
+                "postgres": "SELECT TO_CHAR(dt, 'HH12:MI')",
+            },
+        )
+
         self.validate_all(
             "CREATE TABLE table1 (a INT, b INT, PRIMARY KEY (a))",
             read={


### PR DESCRIPTION
## Summary

Adds bare (non-TM-prefixed) PostgreSQL `TO_CHAR` format tokens to `Postgres.TIME_MAPPING`:

- **Month names**: `Mon`/`mon`/`MON` → `%b`, `Month`/`month`/`MONTH` → `%B`
- **Weekday names**: `Day`/`day`/`DAY` → `%A`, `Dy`/`dy`/`DY` → `%a`
- **AM/PM**: `AM`/`PM`/`am`/`pm`/`A.M.`/`P.M.`/`a.m.`/`p.m.` → `%p`
- **Bare HH**: `HH`/`hh` → `%I` (PostgreSQL defaults to 12-hour when no suffix)

Also adds `INVERSE_TIME_MAPPING` to prefer canonical bare forms (`Mon`, `Day`, `Dy`, `Month`, `HH12`, `AM`) when generating Postgres SQL.

## Problem

Previously, these tokens were either left as unconverted literals or partially mangled:

| PG Token | Expected | Actual (before) | Issue |
|----------|----------|------------------|-------|
| `Mon` | `%b` | `Mon` (literal) | Not converted |
| `Month` | `%B` | `Month` (literal) | Not converted |
| `Day` | `%A` | `%uay` | `D` → `%u` matched first, `ay` left as literal |
| `Dy` | `%a` | `%uy` | `D` → `%u` matched first, `y` left as literal |
| `AM`/`PM` | `%p` | literal | Not converted |

The TM-prefixed versions (`TMDay`, `TMDy`, `TMMon`, `TMMonth`) were already mapped. This PR adds the standard bare forms which are far more commonly used in practice.

The trie-based `format_time()` correctly prioritizes longer matches, so `Day` → `%A` takes precedence over `D` → `%u` without affecting the existing single-character `D` mapping.

Note: Redshift already extended Postgres with `"MON": "%b"` (line 27 of `redshift.py`), which is now redundant but harmless.

Fixes #7476

## Test plan

- Added 7 new `validate_all` tests in `test_postgres.py` covering all new format tokens
- Updated 2 existing identity tests to account for HH/HH12 and PM/AM canonicalization
- Updated 1 Exasol test expectation (`TMDy` → `Dy` for postgres write target)
- All 862 existing tests pass (804 dialect + core tests, 58 bigquery tests)