### PR TITLE
feat(bigquery): add typed handling for AI scalar functions

### DIFF
--- a/sqlglot/expressions/functions.py
+++ b/sqlglot/expressions/functions.py
@@ -321,6 +321,24 @@ class AIClassify(Expression, Func):
     _sql_names = ["AI_CLASSIFY"]
 
 
+class AIEmbed(Expression, Func):
+    arg_types = {"expressions": False}
+    is_var_len_args = True
+    _sql_names = ["EMBED"]
+
+
+class AISimilarity(Expression, Func):
+    arg_types = {"expressions": False}
+    is_var_len_args = True
+    _sql_names = ["SIMILARITY"]
+
+
+class AIGenerate(Expression, Func):
+    arg_types = {"expressions": False}
+    is_var_len_args = True
+    _sql_names = ["GENERATE"]
+
+
 class FeaturesAtTime(Expression, Func):
     arg_types = {"this": True, "time": False, "num_rows": False, "ignore_feature_nulls": False}
 

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -730,6 +730,16 @@ class BigQueryParser(parser.Parser):
                 self._retreat(func_index)
                 parsed = self._parse_function(any_token=True)
                 if parsed:
+                    if prefix == "AI" and isinstance(parsed, exp.Anonymous):
+                        ai_scalars: dict[str, type[exp.Func]] = {
+                            "EMBED": exp.AIEmbed,
+                            "SIMILARITY": exp.AISimilarity,
+                            "GENERATE": exp.AIGenerate,
+                        }
+                        expr_type = ai_scalars.get(parsed.name.upper())
+                        if expr_type:
+                            parsed = expr_type(expressions=parsed.expressions)
+
                     this = self.expression(exp.Dot(this=this.this, expression=parsed))
 
         return this

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2445,6 +2445,18 @@ OPTIONS (
             "SELECT AI.GENERATE_BOOL(MODEL `mydataset.gemini_model`, 'Is sky blue?')"
         )
 
+        ast = self.validate_identity("SELECT AI.EMBED('hello')")
+        assert isinstance(ast.expressions[0], exp.Dot)
+        assert isinstance(ast.expressions[0].expression, exp.AIEmbed)
+
+        ast = self.validate_identity("SELECT AI.SIMILARITY('a', 'b')")
+        assert isinstance(ast.expressions[0], exp.Dot)
+        assert isinstance(ast.expressions[0].expression, exp.AISimilarity)
+
+        ast = self.validate_identity("SELECT AI.GENERATE('Write a haiku')")
+        assert isinstance(ast.expressions[0], exp.Dot)
+        assert isinstance(ast.expressions[0].expression, exp.AIGenerate)
+
     def test_merge(self):
         self.validate_all(
             """


### PR DESCRIPTION
## Description:

- add typed expression nodes for BigQuery AI scalar calls:
  - AI.EMBED -> AIEmbed
  - AI.SIMILARITY -> AISimilarity
  - AI.GENERATE -> AIGenerate
- keep SQL output backward compatible through explicit SQL names (EMBED, SIMILARITY, GENERATE)
- preserve generic behavior for unqualified scalar names; typed conversion is applied to dotted AI.* calls in BigQuery parser column-op handling
- add BigQuery dialect tests asserting both identity round-trip and typed AST nodes

Closes #7478.

## Validation:

- python -m pytest -q tests/dialects/test_bigquery.py -k ml_functions -vv
- python -m pytest -q tests/dialects/test_bigquery.py -vv
- python -m pytest -q

Results:
- focused BigQuery ml_functions: passed.
- full BigQuery dialect module: passed (58 passed).
- full suite: passed (1076 passed).

#### The validation screenshots of the tests run, locally on WSL:

<img width="2023" height="466" alt="image" src="https://github.com/user-attachments/assets/9d51b5c5-7248-4e22-96fc-7c73f087e63a" />


<img width="2020" height="1281" alt="image" src="https://github.com/user-attachments/assets/92fe2638-5502-4d9e-9c8a-3468eef2eda3" />


<img width="2020" height="995" alt="image" src="https://github.com/user-attachments/assets/661c140b-01a0-4081-9ff9-bbac802ee815" />

Additionally, verified direct parses now produce typed function nodes under AI.* dot calls while preserving round-trip SQL.