### PR TITLE
feat(snowflake): mark ENCRYPT_RAW as unsupported in DuckDB

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2273,6 +2273,10 @@ class DuckDBGenerator(generator.Generator):
         self.unsupported(f"{func_name} is not supported in DuckDB")
         return self.function_fallback_sql(expression)
 
+    def encryptraw_sql(self, expression: exp.EncryptRaw) -> str:
+        self.unsupported("ENCRYPT_RAW is not supported in DuckDB")
+        return self.function_fallback_sql(expression)
+
     def nthvalue_sql(self, expression: exp.NthValue) -> str:
         from_first = expression.args.get("from_first", True)
         if not from_first:


### PR DESCRIPTION
## Summary
Mark ENCRYPT_RAW as unsupported in DuckDB transpilation.

## Changes
- Add encryptraw_sql method to DuckDB generator
- Mark ENCRYPT_RAW as unsupported with appropriate warning
- Add test case validating UnsupportedError is raised

## Test Example
```sql
-- Snowflake
SELECT ENCRYPT_RAW('data', 'key', 'iv') AS encrypted

-- DuckDB (with warning)
SELECT ENCRYPT_RAW('data', 'key', 'iv') AS encrypted
-- Warning: ENCRYPT_RAW is not supported in DuckDB
```

Resolves RD-1069384