### PR TITLE
feat(duckdb): Add transpilation support for INSERT function

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3427,6 +3427,29 @@ class DuckDBGenerator(generator.Generator):
         start = expression.args["start"]
         length = expression.args["length"]
         insertion = expression.expression
+
+        if _is_binary(base):
+            # DuckDB's SUBSTRING doesn't accept BLOB; operate on the HEX string instead
+            # (each byte = 2 hex chars), then UNHEX back to BLOB
+            left = exp.Substring(
+                this=exp.Hex(this=base.copy()),
+                start=exp.Literal.number(1),
+                length=(start.copy() - exp.Literal.number(1)) * exp.Literal.number(2),
+            )
+            right = exp.Substring(
+                this=exp.Hex(this=base.copy()),
+                start=(start.copy() + length.copy() - exp.Literal.number(1)) * exp.Literal.number(2)
+                + exp.Literal.number(1),
+            )
+            return self.sql(
+                exp.Unhex(
+                    this=exp.DPipe(
+                        this=exp.DPipe(this=left, expression=exp.Hex(this=insertion)),
+                        expression=right,
+                    )
+                )
+            )
+
         left = exp.Substring(
             this=base.copy(),
             start=exp.Literal.number(1),

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3427,28 +3427,14 @@ class DuckDBGenerator(generator.Generator):
         start = expression.args["start"]
         length = expression.args["length"]
         insertion = expression.expression
+        is_binary = _is_binary(base)
 
-        if _is_binary(base):
+        if is_binary:
             # DuckDB's SUBSTRING doesn't accept BLOB; operate on the HEX string instead
             # (each byte = 2 hex chars), then UNHEX back to BLOB
-            left = exp.Substring(
-                this=exp.Hex(this=base.copy()),
-                start=exp.Literal.number(1),
-                length=(start.copy() - exp.Literal.number(1)) * exp.Literal.number(2),
-            )
-            right = exp.Substring(
-                this=exp.Hex(this=base.copy()),
-                start=(start.copy() + length.copy() - exp.Literal.number(1)) * exp.Literal.number(2)
-                + exp.Literal.number(1),
-            )
-            return self.sql(
-                exp.Unhex(
-                    this=exp.DPipe(
-                        this=exp.DPipe(this=left, expression=exp.Hex(this=insertion)),
-                        expression=right,
-                    )
-                )
-            )
+            base = exp.Hex(this=base)
+            insertion = exp.Hex(this=insertion)
+            start = (start - exp.Literal.number(1)) * exp.Literal.number(2) + exp.Literal.number(1)
 
         left = exp.Substring(
             this=base.copy(),
@@ -3456,9 +3442,14 @@ class DuckDBGenerator(generator.Generator):
             length=start.copy() - exp.Literal.number(1),
         )
         right = exp.Substring(this=base.copy(), start=start.copy() + length.copy())
-        return self.sql(
-            exp.DPipe(this=exp.DPipe(this=left, expression=insertion), expression=right)
+        result: exp.Expr = exp.DPipe(
+            this=exp.DPipe(this=left, expression=insertion), expression=right
         )
+
+        if is_binary:
+            result = exp.Unhex(this=result)
+
+        return self.sql(result)
 
     def rand_sql(self, expression: exp.Rand) -> str:
         seed = expression.this

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3422,6 +3422,21 @@ class DuckDBGenerator(generator.Generator):
     def rtrimmedlength_sql(self, expression: exp.RtrimmedLength) -> str:
         return self.func("LENGTH", exp.Trim(this=expression.this, position="TRAILING"))
 
+    def stuff_sql(self, expression: exp.Stuff) -> str:
+        base = expression.this
+        start = expression.args["start"]
+        length = expression.args["length"]
+        insertion = expression.expression
+        left = exp.Substring(
+            this=base.copy(),
+            start=exp.Literal.number(1),
+            length=start.copy() - exp.Literal.number(1),
+        )
+        right = exp.Substring(this=base.copy(), start=start.copy() + length.copy())
+        return self.sql(
+            exp.DPipe(this=exp.DPipe(this=left, expression=insertion), expression=right)
+        )
+
     def rand_sql(self, expression: exp.Rand) -> str:
         seed = expression.this
         if seed is not None:


### PR DESCRIPTION
SQLGlot transpiles Snowflake `INSERT` to `STUFF (T-SQL)`, which does not exist in DuckDB. All cases fail with:` Catalog Error: Scalar Function with name stuff does not exist`

```
python3 -c "import sqlglot; print(sqlglot.transpile(\"SELECT INSERT('Hello World', 7, 5, 'SQLGlot') AS typical_replace, INSERT('Hello', 6, 0, '!') AS append_end, INSERT('Hello', 3, 0, 'XY') AS pure_insert, INSERT('Hello', 2, 3, '') AS delete_chars, INSERT('Hello', 0, 0, 'X') AS pos_zero, INSERT('Hello', 10, 0, 'X') AS pos_beyond\", read='snowflake', write='duckdb')[0])"         
-->
SELECT SUBSTRING('Hello World', 1, 7 - 1) || 'SQLGlot' || SUBSTRING('Hello World', 7 + 5) AS typical_replace, SUBSTRING('Hello', 1, 6 - 1) || '!' || SUBSTRING('Hello', 6 + 0) AS append_end, SUBSTRING('Hello', 1, 3 - 1) || 'XY' || SUBSTRING('Hello', 3 + 0) AS pure_insert, SUBSTRING('Hello', 1, 2 - 1) || '' || SUBSTRING('Hello', 2 + 3) AS delete_chars, SUBSTRING('Hello', 1, 0 - 1) || 'X' || SUBSTRING('Hello', 0 + 0) AS pos_zero, SUBSTRING('Hello', 1, 10 - 1) || 'X' || SUBSTRING('Hello', 10 + 0) AS pos_beyond

│ typical_replace │ append_end │ pure_insert │ delete_chars │ pos_zero │ pos_beyond │
│     varchar     │  varchar   │   varchar   │   varchar    │ varchar  │  varchar   │
├─────────────────┼────────────┼─────────────┼──────────────┼──────────┼────────────┤
│ Hello SQLGlot   │ Hello!     │ HeXYllo     │ Ho           │ XHello   │ HelloX     │
└─────────────────┴────────────┴─────────────┴──────────────┴──────────┴────────────┘
```