### PR TITLE
feat(clickhouse): support groupConcat parametric syntax

### DIFF
--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -416,6 +416,18 @@ class ClickHouseGenerator(generator.Generator):
         exp.DType.MULTIPOLYGON,
     }
 
+    def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
+        separator = expression.args.get("separator")
+        if separator:
+            return self.sql(
+                exp.ParameterizedAgg(
+                    this="groupConcat",
+                    params=[expression.this],
+                    expressions=[separator],
+                )
+            )
+        return self.func("groupConcat", expression.this)
+
     def offset_sql(self, expression: exp.Offset) -> str:
         offset = super().offset_sql(expression)
 

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -126,6 +126,7 @@ AGG_FUNCTIONS = {
     "deltaSumTimestamp",
     "groupArray",
     "groupArrayLast",
+    "groupConcat",
     "groupUniqArray",
     "groupArrayInsertAt",
     "groupArrayMovingAvg",
@@ -703,6 +704,27 @@ class ClickHouseParser(parser.Parser):
             instance = exp_class(this=anon_func.this, expressions=anon_func.expressions)
             if params:
                 instance.set("params", params)
+
+            if (
+                isinstance(instance, exp.ParameterizedAgg)
+                and instance.name == "groupConcat"
+                and len(instance.expressions) <= 1
+                and len(instance.args.get("params") or []) <= 1
+            ):
+                instance = exp.GroupConcat(
+                    this=seq_get(instance.args.get("params") or [], 0),
+                    separator=seq_get(instance.expressions, 0),
+                )
+            elif (
+                isinstance(instance, exp.AnonymousAggFunc)
+                and instance.name == "groupConcat"
+                and len(instance.expressions) <= 2
+            ):
+                instance = exp.GroupConcat(
+                    this=seq_get(instance.expressions, 0),
+                    separator=seq_get(instance.expressions, 1),
+                )
+
             func = self.expression(instance)
 
             if isinstance(expr, exp.Window):

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1719,6 +1719,45 @@ LIFETIME(MIN 0 MAX 0)""",
             "SELECT row_number() OVER (PARTITION BY column2 ORDER BY column3) FROM table"
         )
 
+    def test_groupconcat(self):
+        # groupConcat(sep)(col) - parametric form with separator
+        parsed = self.validate_identity("SELECT groupConcat(', ')(part_name) FROM system.parts")
+        gc = parsed.selects[0]
+        self.assertIsInstance(gc, exp.GroupConcat)
+        self.assertEqual(gc.this.name, "part_name")
+        self.assertEqual(gc.args["separator"].name, ", ")
+
+        # groupConcat(col) - no separator
+        parsed2 = self.validate_identity("SELECT groupConcat(part_name) FROM t")
+        gc2 = parsed2.selects[0]
+        self.assertIsInstance(gc2, exp.GroupConcat)
+        self.assertEqual(gc2.this.name, "part_name")
+        self.assertIsNone(gc2.args.get("separator"))
+
+        # groupConcat(sep, limit)(col) - not converted to GroupConcat; limit must be preserved
+        parsed3 = self.validate_identity("SELECT groupConcat(', ', 2)(part_name) FROM t")
+        self.assertIsInstance(parsed3.selects[0], exp.ParameterizedAgg)
+        self.assertEqual(parsed3.selects[0].name, "groupConcat")
+
+        # Combinators are preserved as CombinedAggFunc / CombinedParameterizedAgg
+        self.validate_identity("SELECT groupConcatIf(x, cond) FROM t").selects[0].assert_is(
+            exp.CombinedAggFunc
+        )
+        self.validate_identity("SELECT groupConcatIf(', ')(x, cond) FROM t").selects[0].assert_is(
+            exp.CombinedParameterizedAgg
+        )
+
+        # Cross-dialect transpilation
+        self.validate_all(
+            "SELECT groupConcat(', ')(part_name) FROM t",
+            read={"mysql": "SELECT GROUP_CONCAT(part_name SEPARATOR ', ') FROM t"},
+            write={
+                "clickhouse": "SELECT groupConcat(', ')(part_name) FROM t",
+                "mysql": "SELECT GROUP_CONCAT(part_name SEPARATOR ', ') FROM t",
+                "duckdb": "SELECT LISTAGG(part_name, ', ') FROM t",
+            },
+        )
+
     def test_functions(self):
         self.validate_identity("SELECT TRANSFORM(foo, [1, 2], ['first', 'second']) FROM table")
         self.validate_identity(


### PR DESCRIPTION
This PR fixes an issue reported in Superset (https://github.com/apache/superset/issues/37285), where this Clickhouse query fails to parse:

```sql
  select
    groupConcat(', ')(part_name) as concatenated
  from system.parts
```

In the `main` branch:

```python
>>> import sqlglot
>>> sqlglot.parse_one("""
...   select
...     groupConcat(', ')(part_name) as concatenated
...   from system.parts
... """, "clickhouse")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/beto/Projects/sqlglot/sqlglot/__init__.py", line 176, in parse_one
    result = dialect.parse(sql, **opts)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/beto/Projects/sqlglot/sqlglot/dialects/dialect.py", line 1116, in parse
    return self.parser(**opts).parse(self.tokenize(sql), sql)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/beto/Projects/sqlglot/sqlglot/parser.py", line 2008, in parse
    return self._parse(
           ^^^^^^^^^^^^
  File "/Users/beto/Projects/sqlglot/sqlglot/parser.py", line 2128, in _parse
    return self._parse_batch_statements(parse_method=parse_method, sep_first_statement=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/beto/Projects/sqlglot/sqlglot/parser.py", line 2098, in _parse_batch_statements
    self.raise_error("Invalid expression / Unexpected token")
  File "/Users/beto/Projects/sqlglot/sqlglot/parser.py", line 1969, in raise_error
    raise error
sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 3, Col: 35.

  select
    groupConcat(', ')(part_name) as concatenated
  from system.parts

>>>
```

With this PR:

```python
>>> import sqlglot
>>> sqlglot.parse_one("""
...   select
...     groupConcat(', ')(part_name) as concatenated
...   from system.parts
... """, "clickhouse")
Select(
  expressions=[
    Alias(
      this=GroupConcat(
        this=Column(
          this=Identifier(this=part_name, quoted=False)),
        separator=Literal(this=', ', is_string=True)),
      alias=Identifier(this=concatenated, quoted=False))],
  from_=From(
    this=Table(
      this=Identifier(this=parts, quoted=False),
      db=Identifier(this=system, quoted=False))))
>>> _.sql("clickhouse")
"SELECT groupConcat(', ')(part_name) AS concatenated FROM system.parts"
>>>
```