### PR TITLE
fix(databricks): support IFF as a synonym for IF [CLAUDE]

### DIFF
--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -14,6 +14,7 @@ class DatabricksParser(SparkParser):
 
     FUNCTIONS = {
         **SparkParser.FUNCTIONS,
+        "IFF": exp.If.from_arg_list,
         "GETDATE": exp.CurrentTimestamp.from_arg_list,
         "DATEADD": build_date_delta(exp.DateAdd),
         "DATE_ADD": build_date_delta(exp.DateAdd),

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -491,6 +491,17 @@ class TestDatabricks(Validator):
             "SELECT OVERLAY('Spark SQL' PLACING 'ANSI ' FROM 7 FOR 0)",
         )
 
+    def test_iff(self):
+        # IFF is a synonym for IF in Databricks; it normalizes to IF on output
+        self.validate_all(
+            "SELECT IF(x > 0, 'positive', 'non-positive')",
+            read={"databricks": "SELECT IFF(x > 0, 'positive', 'non-positive')"},
+            write={
+                "databricks": "SELECT IF(x > 0, 'positive', 'non-positive')",
+                "snowflake": "SELECT IFF(x > 0, 'positive', 'non-positive')",
+            },
+        )
+
     def test_declare(self):
         self.validate_identity("DECLARE VAR x INT", "DECLARE x INT")
         self.validate_identity("DECLARE x INT")


### PR DESCRIPTION
## Summary

- Databricks supports [`IFF`](https://docs.databricks.com/gcp/en/sql/language-manual/functions/iff) as a synonym for `IF`
- Adds `"IFF": exp.If.from_arg_list` to `DatabricksParser.FUNCTIONS`, so `IFF(cond, true, false)` is parsed to `exp.If` and transpiles correctly to all target dialects
- Follows the same pattern already used by the Snowflake parser

Fixes #7347

## Test plan

- [ ] `test_iff` in `tests/dialects/test_databricks.py` — verifies `IFF` parses from Databricks and transpiles to `IF` (Databricks) and `IFF` (Snowflake)
- [ ] Full Databricks test suite passes (`python -m unittest tests.dialects.test_databricks`)