### PR TITLE
test(databricks): add explicit tests for SET VAR / SET VARIABLE [CLAUDE]

### DIFF
--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -491,6 +491,15 @@ class TestDatabricks(Validator):
             "SELECT OVERLAY('Spark SQL' PLACING 'ANSI ' FROM 7 FOR 0)",
         )
 
+    def test_set_variable(self):
+        # Both SET VAR and SET VARIABLE are synonyms; both normalize to SET VARIABLE on output
+        self.validate_identity("SET VAR v = 5", "SET VARIABLE v = 5")
+        self.validate_identity("SET VARIABLE v = 5")
+        self.validate_identity("SET VARIABLE v1 = 1, v2 = '2'")
+        self.validate_identity("SET VARIABLE (v1, v2) = (SELECT 1, 2)")
+        self.validate_identity("SET VARIABLE v = (SELECT MAX(c1) FROM VALUES (1), (2) AS T(c1))")
+        self.validate_identity("SET VARIABLE v = DEFAULT")
+
     def test_declare(self):
         self.validate_identity("DECLARE VAR x INT", "DECLARE x INT")
         self.validate_identity("DECLARE x INT")


### PR DESCRIPTION
## Summary

`SET VAR` and `SET VARIABLE` were already working in Databricks (fixed as a side effect of #7235), but had no Databricks-specific test coverage — only the Spark tests covered the Databricks write output.

This PR adds explicit round-trip identity tests in `tests/dialects/test_databricks.py` covering all main variants:
- `SET VAR v = 5` → normalizes to `SET VARIABLE v = 5`
- `SET VARIABLE v = 5` (identity)
- Multi-variable: `SET VARIABLE v1 = 1, v2 = '2'`
- Tuple assignment: `SET VARIABLE (v1, v2) = (SELECT 1, 2)`
- Subquery: `SET VARIABLE v = (SELECT MAX(c1) FROM ...)`
- Default: `SET VARIABLE v = DEFAULT`

Closes #7358

## Test plan

- [ ] `test_set_variable` in `tests/dialects/test_databricks.py` passes
- [ ] Full Databricks test suite passes