### PR TITLE
Fix(snowflake): parse GET_DDL #unknown_policy in ROW ACCESS POLICY [CLAUDE]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -865,7 +865,11 @@ class SnowflakeGenerator(generator.Generator):
             return "ROW ACCESS"
         policy = expression.this
         # GET_DDL outputs #unknown_policy when privileges are insufficient; never quote it
-        policy_sql = policy.name if isinstance(policy, exp.Identifier) and policy.name.startswith("#") else self.sql(policy)
+        policy_sql = (
+            policy.name
+            if isinstance(policy, exp.Identifier) and policy.name.startswith("#")
+            else self.sql(policy)
+        )
         on = f" ON ({self.expressions(expression, flat=True)})" if expression.expressions else ""
         return f"WITH ROW ACCESS POLICY {policy_sql}{on}"
 

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -863,8 +863,11 @@ class SnowflakeGenerator(generator.Generator):
     def rowaccessproperty_sql(self, expression: exp.RowAccessProperty) -> str:
         if not expression.this:
             return "ROW ACCESS"
-        on = f" ON ({self.expressions(expression, flat=True)})"
-        return f"WITH ROW ACCESS POLICY {self.sql(expression, 'this')}{on}"
+        policy = expression.this
+        # GET_DDL outputs #unknown_policy when privileges are insufficient; never quote it
+        policy_sql = policy.name if isinstance(policy, exp.Identifier) and policy.name.startswith("#") else self.sql(policy)
+        on = f" ON ({self.expressions(expression, flat=True)})" if expression.expressions else ""
+        return f"WITH ROW ACCESS POLICY {policy_sql}{on}"
 
     def describe_sql(self, expression: exp.Describe) -> str:
         kind_value = expression.args.get("kind") or "TABLE"

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -863,15 +863,8 @@ class SnowflakeGenerator(generator.Generator):
     def rowaccessproperty_sql(self, expression: exp.RowAccessProperty) -> str:
         if not expression.this:
             return "ROW ACCESS"
-        policy = expression.this
-        # GET_DDL outputs #unknown_policy when privileges are insufficient; never quote it
-        policy_sql = (
-            policy.name
-            if isinstance(policy, exp.Identifier) and policy.name.startswith("#")
-            else self.sql(policy)
-        )
         on = f" ON ({self.expressions(expression, flat=True)})" if expression.expressions else ""
-        return f"WITH ROW ACCESS POLICY {policy_sql}{on}"
+        return f"WITH ROW ACCESS POLICY {self.sql(expression, 'this')}{on}"
 
     def describe_sql(self, expression: exp.Describe) -> str:
         kind_value = expression.args.get("kind") or "TABLE"

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -980,10 +980,8 @@ class SnowflakeParser(parser.Parser):
     def _parse_row_access_policy(self) -> exp.RowAccessProperty:
         # GET_DDL outputs #unknown_policy when the user lacks privileges to see the policy name
         if self._match(TokenType.HASH):
-            id_var = self._parse_id_var()
-            policy: exp.Expr | None = exp.to_identifier(
-                f"#{id_var.name}" if id_var else "#", quoted=False
-            )
+            id_var = self._parse_var(any_token=True)
+            policy: exp.Expr | None = exp.Var(this=f"#{id_var.name}" if id_var else "#")
             expressions = None
         else:
             policy = self._parse_column()

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -978,14 +978,20 @@ class SnowflakeParser(parser.Parser):
         return super()._parse_with_property()
 
     def _parse_row_access_policy(self) -> exp.RowAccessProperty:
-        policy = self._parse_column()
-        if not self._match(TokenType.ON):
-            self.raise_error("Expected ON after ROW ACCESS POLICY name")
+        # GET_DDL outputs #unknown_policy when the user lacks privileges to see the policy name
+        if self._match(TokenType.HASH):
+            policy = exp.to_identifier(f"#{self._parse_id_var().name}", quoted=False)
+            expressions = None
+        else:
+            policy = self._parse_column()
+            if isinstance(policy, exp.Column):
+                policy = policy.to_dot()
+            if not self._match(TokenType.ON):
+                self.raise_error("Expected ON after ROW ACCESS POLICY name")
+            expressions = self._parse_wrapped_csv(self._parse_id_var)
+
         return self.expression(
-            exp.RowAccessProperty(
-                this=policy.to_dot() if isinstance(policy, exp.Column) else policy,
-                expressions=self._parse_wrapped_csv(self._parse_id_var),
-            )
+            exp.RowAccessProperty(this=policy, expressions=expressions)
         )
 
     def _parse_create(self) -> exp.Create | exp.Command:

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -980,7 +980,10 @@ class SnowflakeParser(parser.Parser):
     def _parse_row_access_policy(self) -> exp.RowAccessProperty:
         # GET_DDL outputs #unknown_policy when the user lacks privileges to see the policy name
         if self._match(TokenType.HASH):
-            policy = exp.to_identifier(f"#{self._parse_id_var().name}", quoted=False)
+            id_var = self._parse_id_var()
+            policy: t.Optional[exp.Expr] = exp.to_identifier(
+                f"#{id_var.name}" if id_var else "#", quoted=False
+            )
             expressions = None
         else:
             policy = self._parse_column()
@@ -990,9 +993,7 @@ class SnowflakeParser(parser.Parser):
                 self.raise_error("Expected ON after ROW ACCESS POLICY name")
             expressions = self._parse_wrapped_csv(self._parse_id_var)
 
-        return self.expression(
-            exp.RowAccessProperty(this=policy, expressions=expressions)
-        )
+        return self.expression(exp.RowAccessProperty(this=policy, expressions=expressions))
 
     def _parse_create(self) -> exp.Create | exp.Command:
         expression = super()._parse_create()

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -980,8 +980,9 @@ class SnowflakeParser(parser.Parser):
     def _parse_row_access_policy(self) -> exp.RowAccessProperty:
         # GET_DDL outputs #unknown_policy when the user lacks privileges to see the policy name
         if self._match(TokenType.HASH):
-            id_var = self._parse_var(any_token=True)
-            policy: exp.Expr | None = exp.Var(this=f"#{id_var.name}" if id_var else "#")
+            policy: exp.Expr | None = self._parse_var(any_token=True)
+            if policy:
+                policy = exp.Var(this=f"#{policy.name}")
             expressions = None
         else:
             policy = self._parse_column()

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -981,7 +981,7 @@ class SnowflakeParser(parser.Parser):
         # GET_DDL outputs #unknown_policy when the user lacks privileges to see the policy name
         if self._match(TokenType.HASH):
             id_var = self._parse_id_var()
-            policy: t.Optional[exp.Expr] = exp.to_identifier(
+            policy: exp.Expr | None = exp.to_identifier(
                 f"#{id_var.name}" if id_var else "#", quoted=False
             )
             expressions = None

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -5973,6 +5973,16 @@ SINGLE = TRUE""",
                 "CREATE VIEW v WITH ROW ACCESS POLICY p AS SELECT 1",
                 dialect="snowflake",
             )
+        self.validate_identity(
+            "CREATE VIEW v WITH ROW ACCESS POLICY #unknown_policy AS SELECT 1",
+        )
+        self.assertEqual(
+            parse_one(
+                "CREATE VIEW v WITH ROW ACCESS POLICY #unknown_policy AS SELECT 1",
+                dialect="snowflake",
+            ).sql(dialect="snowflake", identify=True),
+            'CREATE VIEW "v" WITH ROW ACCESS POLICY #unknown_policy AS SELECT 1',
+        )
 
     def test_semantic_view(self):
         for dimensions, metrics, where, facts in [


### PR DESCRIPTION
## Summary
- Snowflake's `GET_DDL` outputs `#unknown_policy` (without an `ON` clause) when the user lacks privileges to see the actual row access policy name
- Handle the `#` token prefix in the Snowflake parser so this syntax is parsed into a proper `Create` AST node instead of falling back to `Command`
- Ensure `#unknown_policy` is never quoted in generated output, even with `identify=True`
- The `ON` clause remains required for normal (non-`#`) policy names

## Test plan
- [x] Round-trip test for `#unknown_policy` via `validate_identity`
- [x] Test that `identify=True` does not quote `#unknown_policy`
- [x] Existing test retained: `ParseError` still raised for normal policy names missing `ON`
- [x] Full Snowflake test suite passes (95 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)