### PR TITLE
feat(oracle): Support WHERE in MERGE statement

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -320,6 +320,9 @@ class Generator:
     # Whether MERGE ... WHEN MATCHED BY SOURCE is allowed
     MATCHED_BY_SOURCE = True
 
+    # Whether MERGE ... WHEN MATCHED/NOT MATCHED THEN UPDATE/INSERT ... WHERE is supported
+    SUPPORTS_MERGE_WHERE = False
+
     # Whether the INTERVAL expression works only with values like '1 day'
     SINGLE_STRING_INTERVAL = False
 
@@ -4442,13 +4445,25 @@ class Generator:
             this = f"INSERT {this}" if this else "INSERT"
             then = self.sql(then_expression, "expression")
             then = f"{this} VALUES {then}" if then else this
+            where = self.sql(then_expression, "where")
+            if where and not self.SUPPORTS_MERGE_WHERE:
+                self.unsupported("WHERE clause in MERGE INSERT is not supported")
+                where = ""
+            then = f"{then}{where}"
         elif isinstance(then_expression, exp.Update):
             if isinstance(then_expression.args.get("expressions"), exp.Star):
                 then = f"UPDATE {self.sql(then_expression, 'expressions')}"
             else:
                 expressions_sql = self.expressions(then_expression)
-                then = f"UPDATE SET{self.sep()}{expressions_sql}" if expressions_sql else "UPDATE"
-
+                where = self.sql(then_expression, "where")
+                if where and not self.SUPPORTS_MERGE_WHERE:
+                    self.unsupported("WHERE clause in MERGE UPDATE is not supported")
+                    where = ""
+                then = (
+                    f"UPDATE SET{self.sep()}{expressions_sql}{where}"
+                    if expressions_sql
+                    else "UPDATE"
+                )
         else:
             then = self.sql(then_expression)
         return f"WHEN {matched}{source}{condition} THEN {then}"

--- a/sqlglot/generators/oracle.py
+++ b/sqlglot/generators/oracle.py
@@ -25,6 +25,7 @@ class OracleGenerator(generator.Generator):
     TRY_SUPPORTED = False
     SUPPORTS_UESCAPE = False
     LOCKING_READS_SUPPORTED = True
+    SUPPORTS_MERGE_WHERE = True
     JOIN_HINTS = False
     TABLE_HINTS = False
     DATA_TYPE_SPECIFIERS_ALLOWED = True

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8926,6 +8926,7 @@ class Parser:
                             if self._match_text_seq("ROW")
                             else self._parse_value(values=False),
                             expression=self._match_text_seq("VALUES") and self._parse_value(),
+                            where=self._parse_where(),
                         )
                     )
             elif self._match(TokenType.UPDATE):
@@ -8936,7 +8937,8 @@ class Parser:
                     then = self.expression(
                         exp.Update(
                             expressions=self._match(TokenType.SET)
-                            and self._parse_csv(self._parse_equality)
+                            and self._parse_csv(self._parse_equality),
+                            where=self._parse_where(),
                         )
                     )
             elif self._match(TokenType.DELETE):

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -881,6 +881,21 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
         self.validate_identity("UTC_TIMESTAMP()").assert_is(exp.UtcTimestamp)
         self.validate_identity("UTC_TIMESTAMP(6)").assert_is(exp.UtcTimestamp)
 
+    def test_merge(self):
+        self.validate_all(
+            "MERGE INTO target tgt USING (SELECT id, col1 FROM source_tbl) src ON tgt.id = src.id "
+            "WHEN MATCHED THEN UPDATE SET tgt.col1 = src.col1 WHERE tgt.some_column IS NULL "
+            "WHEN NOT MATCHED THEN INSERT (id, col1) VALUES (src.id, src.col1) WHERE NOT src.col1 IS NULL",
+            write={
+                "oracle": "MERGE INTO target tgt USING (SELECT id, col1 FROM source_tbl) src ON tgt.id = src.id "
+                "WHEN MATCHED THEN UPDATE SET tgt.col1 = src.col1 WHERE tgt.some_column IS NULL "
+                "WHEN NOT MATCHED THEN INSERT (id, col1) VALUES (src.id, src.col1) WHERE NOT src.col1 IS NULL",
+                "": "MERGE INTO target AS tgt USING (SELECT id, col1 FROM source_tbl) AS src ON tgt.id = src.id "
+                "WHEN MATCHED THEN UPDATE SET tgt.col1 = src.col1 "
+                "WHEN NOT MATCHED THEN INSERT (id, col1) VALUES (src.id, src.col1)",
+            },
+        )
+
     def test_merge_builder_alias(self):
         merge_stmt = exp.merge(
             "WHEN MATCHED THEN UPDATE SET my_table.col1 = source_table.col1",


### PR DESCRIPTION
Support WHERE clause in MERGE INSERT/UPDATE (See issue #6529)

Oracle supports optional WHERE clauses on both UPDATE and INSERT within MERGE statements.
Other dialects emit an unsupported warning and strip the WHERE clause during transpilation