### PR TITLE
fix(bigquery): parse FOR SYSTEM TIME AS OF (with spaces) [CLAUDE]

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -183,6 +183,7 @@ class BigQuery(Dialect):
             "EXCEPTION": TokenType.COMMAND,
             "EXPORT": TokenType.EXPORT,
             "FLOAT64": TokenType.DOUBLE,
+            "FOR SYSTEM TIME": TokenType.TIMESTAMP_SNAPSHOT,
             "FOR SYSTEM_TIME": TokenType.TIMESTAMP_SNAPSHOT,
             "LOOP": TokenType.COMMAND,
             "MODEL": TokenType.MODEL,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -134,6 +134,10 @@ class TestBigQuery(Validator):
         self.validate_identity("TIME('2008-12-25 15:30:00+08', 'America/Los_Angeles')")
         self.validate_identity(r"SELECT '\n\r\a\v\f\t'")
         self.validate_identity("SELECT * FROM tbl FOR SYSTEM_TIME AS OF z")
+        self.validate_identity(
+            "SELECT * FROM tbl FOR SYSTEM TIME AS OF z",
+            "SELECT * FROM tbl FOR SYSTEM_TIME AS OF z",
+        )
         self.validate_identity("SELECT PARSE_TIMESTAMP('%c', 'Thu Dec 25 07:30:00 2008', 'UTC')")
         self.validate_identity("SELECT ANY_VALUE(fruit HAVING MAX sold) FROM fruits")
         self.validate_identity("SELECT ANY_VALUE(fruit HAVING MIN sold) FROM fruits")


### PR DESCRIPTION
Closes #7481

BigQuery accepts both `FOR SYSTEM_TIME AS OF` and `FOR SYSTEM TIME AS OF` (with spaces instead of underscore). The parser only recognized the underscore form, raising `ParseError: Invalid expression / Unexpected token` for the space form.

**Before:** `SELECT * FROM tbl FOR SYSTEM TIME AS OF z` → ParseError
**After:** `SELECT * FROM tbl FOR SYSTEM TIME AS OF z` → parses correctly, normalizes to `FOR SYSTEM_TIME AS OF` in output

The fix adds `"FOR SYSTEM TIME"` as an additional keyword mapping to `TIMESTAMP_SNAPSHOT` in the BigQuery tokenizer, alongside the existing `"FOR SYSTEM_TIME"` entry.

**Validation:** BigQuery dialect tests pass (`python -m pytest tests/dialects/test_bigquery.py`).