### PR TITLE
feat(duckdb): Add transpilation support for ARRAY_UNION_AGG function

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3229,6 +3229,9 @@ class DuckDBGenerator(generator.Generator):
             )
         )
 
+    def arrayunionagg_sql(self, expression: exp.ArrayUnionAgg) -> str:
+        return self.sql(exp.ArrayDistinct(this=exp.Flatten(this=exp.func("LIST", expression.this))))
+
     def arraydistinct_sql(self, expression: exp.ArrayDistinct) -> str:
         arr = expression.this
         func = self.func("LIST_DISTINCT", arr)
@@ -4272,6 +4275,10 @@ class DuckDBGenerator(generator.Generator):
 
     def window_sql(self, expression: exp.Window) -> str:
         this = expression.this
+        if isinstance(this, exp.ArrayUnionAgg):
+            new_window = expression.copy()
+            new_window.set("this", exp.func("LIST", this.this))
+            return self.sql(exp.ArrayDistinct(this=exp.Flatten(this=new_window)))
         if isinstance(this, exp.Corr) or (
             isinstance(this, exp.Filter) and isinstance(this.this, exp.Corr)
         ):


### PR DESCRIPTION
Snowflake's `ARRAY_UNION_AGG` computes the set-union of multiple input arrays across rows — returning one flat array of distinct elements. DuckDB has no equivalent function. SQLGlot was emitting it verbatim, causing DuckDB to raise a `Catalog Error` at runtime.

The window form added a second wrinkle: even if we replaced the inner function correctly, DuckDB requires the `OVER (...) `clause to wrap the innermost aggregate (LIST), not the outer transformation functions. Simply swapping the function name and appending OVER would produce structurally invalid SQL.

Fix

Two changes to the DuckDB generator:

1. Regular aggregate form — Added `arrayunionagg_sql`, which rewrites `ARRAY_UNION_AGG(col)` as `LIST_DISTINCT(FLATTEN(LIST(col)))`. `LIST` collects all input arrays into a list-of-lists, `FLATTEN` unwraps them into one flat list, and `LIST_DISTINCT` removes duplicates — together approximating the set-union semantics.

2. Window form — Extended the existing `window_sql` override to intercept `ARRAY_UNION_AGG(...) OVER (...)`. It deep-copies the Window node, swaps the inner function from `ArrayUnionAgg` to `LIST`, then wraps the restructured window in `FLATTEN` and `LIST_DISTINCT` — producing `LIST_DISTINCT(FLATTEN(LIST(col) OVER (PARTITION BY grp))) `where the `OVER` correctly wraps only the aggregate.

**Known limitation:** DuckDB `LIST_DISTINCT` uses strict set semantics. Snowflake's multiset semantics (where duplicates from a single input array are preserved) cannot be reproduced in DuckDB with built-in functions.