### PR TITLE
fix(snowflake): map JSON type to VARIANT in Snowflake generator [CLAUDE]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -640,6 +640,7 @@ class SnowflakeGenerator(generator.Generator):
     TYPE_MAPPING = {
         **generator.Generator.TYPE_MAPPING,
         exp.DType.BIGDECIMAL: "DOUBLE",
+        exp.DType.JSON: "VARIANT",
         exp.DType.NESTED: "OBJECT",
         exp.DType.STRUCT: "OBJECT",
         exp.DType.TEXT: "VARCHAR",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -760,6 +760,10 @@ class TestDuckDB(Validator):
                 "duckdb": """SELECT '{"x": 1}'::JSON""",
                 "postgres": """SELECT '{"x": 1}'::JSONB""",
             },
+            write={
+                "duckdb": """SELECT CAST('{"x": 1}' AS JSON)""",
+                "snowflake": """SELECT CAST('{"x": 1}' AS VARIANT)""",
+            },
         )
         self.validate_all(
             "SELECT * FROM produce PIVOT(SUM(sales) FOR quarter IN ('Q1', 'Q2'))",


### PR DESCRIPTION
## Summary

Snowflake has no native JSON data type — `VARIANT` is the equivalent. When transpiling `CAST(x AS JSON)` from DuckDB (or other dialects) to Snowflake, the JSON type was passed through unchanged, producing invalid SQL.

- Add `exp.DType.JSON: "VARIANT"` to the Snowflake generator's `TYPE_MAPPING`
- Add cross-dialect write test in `test_duckdb.py` verifying `CAST(x AS JSON)` → `CAST(x AS VARIANT)` for Snowflake

Follows the same pattern as Fabric's `JSON → VARCHAR` mapping in `generators/fabric.py`.

## References

- [Snowflake Semi-structured Data Types](https://docs.snowflake.com/en/sql-reference/data-types-semistructured): *"Snowflake can convert data from JSON format to an internal hierarchy of ARRAY, OBJECT, and VARIANT data and store that hierarchical data directly in a VARIANT value."*