### PR TITLE
fix(snowflake): transpile DuckDB JSON_ARRAY to ARRAY_CONSTRUCT [CLAUDE]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -498,8 +498,7 @@ class SnowflakeGenerator(generator.Generator):
         exp.GroupConcat: lambda self, e: groupconcat_sql(self, e, sep=""),
         exp.If: if_sql(name="IFF", false_value="NULL"),
         exp.JSONArray: lambda self, e: self.func(
-            "ARRAY_CONSTRUCT",
-            *(e.expressions if isinstance(e.expressions, list) else [e.expressions]),
+            "TO_JSON", self.func("ARRAY_CONSTRUCT", *e.expressions)
         ),
         exp.JSONExtractArray: _json_extract_value_array_sql,
         exp.JSONExtractScalar: lambda self, e: self.func(

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -497,6 +497,10 @@ class SnowflakeGenerator(generator.Generator):
         exp.GetExtract: rename_func("GET"),
         exp.GroupConcat: lambda self, e: groupconcat_sql(self, e, sep=""),
         exp.If: if_sql(name="IFF", false_value="NULL"),
+        exp.JSONArray: lambda self, e: self.func(
+            "ARRAY_CONSTRUCT",
+            *(e.expressions if isinstance(e.expressions, list) else [e.expressions]),
+        ),
         exp.JSONExtractArray: _json_extract_value_array_sql,
         exp.JSONExtractScalar: lambda self, e: self.func(
             "JSON_EXTRACT_PATH_TEXT", e.this, e.expression

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -130,6 +130,7 @@ class DuckDBParser(parser.Parser):
         ),
         "JARO_WINKLER_SIMILARITY": exp.JarowinklerSimilarity.from_arg_list,
         "JSON": exp.ParseJSON.from_arg_list,
+        "JSON_ARRAY": lambda args: exp.JSONArray(expressions=args),
         "JSON_EXTRACT_PATH": parser.build_extract_json_with_path(exp.JSONExtract),
         "JSON_EXTRACT_STRING": parser.build_extract_json_with_path(exp.JSONExtractScalar),
         "LIST_APPEND": exp.ArrayAppend.from_arg_list,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -552,7 +552,28 @@ class TestDuckDB(Validator):
             "SELECT JSON_ARRAY('a', 'b', 'c')",
             write={
                 "duckdb": "SELECT JSON_ARRAY('a', 'b', 'c')",
-                "snowflake": "SELECT ARRAY_CONSTRUCT('a', 'b', 'c')",
+                "snowflake": "SELECT TO_JSON(ARRAY_CONSTRUCT('a', 'b', 'c'))",
+            },
+        )
+        self.validate_all(
+            "SELECT JSON_ARRAY(NULL, 'a', 1)",
+            write={
+                "duckdb": "SELECT JSON_ARRAY(NULL, 'a', 1)",
+                "snowflake": "SELECT TO_JSON(ARRAY_CONSTRUCT(NULL, 'a', 1))",
+            },
+        )
+        self.validate_all(
+            "SELECT JSON_ARRAY(NULL)",
+            write={
+                "duckdb": "SELECT JSON_ARRAY(NULL)",
+                "snowflake": "SELECT TO_JSON(ARRAY_CONSTRUCT(NULL))",
+            },
+        )
+        self.validate_all(
+            "SELECT JSON_ARRAY()",
+            write={
+                "duckdb": "SELECT JSON_ARRAY()",
+                "snowflake": "SELECT TO_JSON(ARRAY_CONSTRUCT())",
             },
         )
         self.validate_identity(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -548,6 +548,13 @@ class TestDuckDB(Validator):
             """SELECT JSON_EXTRACT_STRING('{ "family": "anatidae", "species": [ "duck", "goose", "swan", null ] }', ['$.family', '$.species'])""",
             """SELECT '{ "family": "anatidae", "species": [ "duck", "goose", "swan", null ] }' ->> ['$.family', '$.species']""",
         )
+        self.validate_all(
+            "SELECT JSON_ARRAY('a', 'b', 'c')",
+            write={
+                "duckdb": "SELECT JSON_ARRAY('a', 'b', 'c')",
+                "snowflake": "SELECT ARRAY_CONSTRUCT('a', 'b', 'c')",
+            },
+        )
         self.validate_identity(
             "SELECT col FROM t WHERE JSON_EXTRACT_STRING(col, '$.id') NOT IN ('b')",
             "SELECT col FROM t WHERE NOT (col ->> '$.id') IN ('b')",


### PR DESCRIPTION
## Summary

DuckDB's `JSON_ARRAY` function has no Snowflake equivalent — Snowflake uses `ARRAY_CONSTRUCT` instead (`JSON_ARRAY` is not a recognized Snowflake function).

Currently, `JSON_ARRAY(...)` falls through to `Anonymous` in the DuckDB parser and passes through unchanged to Snowflake output, producing invalid SQL.

**Changes:**
- Add `JSON_ARRAY` → `exp.JSONArray` mapping in DuckDB parser `FUNCTIONS` dict (follows the SingleStore pattern at `parsers/singlestore.py:107`)
- Add `exp.JSONArray` → `ARRAY_CONSTRUCT` transform in Snowflake generator `TRANSFORMS` dict

**Before:**
```sql
-- DuckDB input
SELECT JSON_ARRAY('a', 'b', 'c')

-- Snowflake output (broken)
SELECT JSON_ARRAY('a', 'b', 'c')
```

**After:**
```sql
-- Snowflake output (correct)
SELECT ARRAY_CONSTRUCT('a', 'b', 'c')
```

**Reference:** [Snowflake ARRAY_CONSTRUCT docs](https://docs.snowflake.com/en/sql-reference/functions/array_construct)

## Test plan

- Added `validate_all` test for `JSON_ARRAY` → `ARRAY_CONSTRUCT` cross-dialect transpilation in `test_duckdb.py`
- All existing DuckDB tests pass (44 passed, 585 subtests)
- All existing Snowflake tests pass (95 passed, 1567 subtests)