### PR TITLE
feat(duckdb): mark PARSE_URL as unsupported 

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2277,6 +2277,10 @@ class DuckDBGenerator(generator.Generator):
         self.unsupported("ENCRYPT_RAW is not supported in DuckDB")
         return self.function_fallback_sql(expression)
 
+    def parseurl_sql(self, expression: exp.ParseUrl) -> str:
+        self.unsupported("PARSE_URL is not supported in DuckDB")
+        return self.function_fallback_sql(expression)
+
     def nthvalue_sql(self, expression: exp.NthValue) -> str:
         from_first = expression.args.get("from_first", True)
         if not from_first:


### PR DESCRIPTION
PARSE_URL is a Snowflake function that does not have a DuckDB equivalent. This change adds an unsupported warning when transpiling PARSE_URL from Snowflake to DuckDB, following the same pattern as ENCRYPT/DECRYPT functions.

- Added parseurl_sql() method in duckdb.py to emit unsupported warning
- Added test in integration tests to verify UnsupportedError is raised