### PR TITLE
feat(duckdb): mark PARSE_IP as unsupported [CLAUDE]

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2281,6 +2281,10 @@ class DuckDBGenerator(generator.Generator):
         self.unsupported("PARSE_URL is not supported in DuckDB")
         return self.function_fallback_sql(expression)
 
+    def parseip_sql(self, expression: exp.ParseIp) -> str:
+        self.unsupported("PARSE_IP is not supported in DuckDB")
+        return self.function_fallback_sql(expression)
+
     def nthvalue_sql(self, expression: exp.NthValue) -> str:
         from_first = expression.args.get("from_first", True)
         if not from_first:


### PR DESCRIPTION
PARSE_IP is a Snowflake function that does not have a DuckDB equivalent. This change adds an unsupported warning when transpiling PARSE_IP from Snowflake to DuckDB, following the same pattern as ENCRYPT/DECRYPT functions.

- Added parseip_sql() method in duckdb.py to emit unsupported warning
- Added test in integration tests to verify UnsupportedError is raised