### PR TITLE
feat(exasol)!: Custom transformation of JSON_OBJECT

### DIFF
--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -270,14 +270,13 @@ def _json_literal_part(self: ExasolGenerator, value: str) -> exp.Expr:
     return exp.Literal.string(f'"{escaped}"')
 
 
-def _json_literal_key_part(self: ExasolGenerator, value: str) -> exp.Expr:
-    escaped = self.escape_str(value, delimiter='"', escaped_delimiter='\\"')
-    return exp.Literal.string(f'"{escaped}": ')
+def _json_key_part(self: ExasolGenerator, key: exp.Expr) -> exp.Expr:
+    if key.is_string:
+        escaped = self.escape_str(key.name, delimiter='"', escaped_delimiter='\\"')
+        return exp.Literal.string(f'"{escaped}": ')
 
-
-def _json_key_part(key: exp.Expr) -> exp.Expr:
     key_expr: exp.Expr
-    if key.is_string or key.is_type(*exp.DataType.TEXT_TYPES):
+    if key.is_type(*exp.DataType.TEXT_TYPES):
         key_expr = exp.func("COALESCE", key.copy(), exp.Literal.string(""))
     else:
         key_expr = (
@@ -286,12 +285,7 @@ def _json_key_part(key: exp.Expr) -> exp.Expr:
             .else_(exp.DPipe(this=key.copy(), expression=exp.Literal.string("")))
         )
 
-    return exp.func(
-        "CONCAT",
-        exp.Literal.string('"'),
-        key_expr,
-        exp.Literal.string('": '),
-    )
+    return exp.DPipe(this=_json_string_part(key_expr), expression=exp.Literal.string(": "))
 
 
 def _json_string_part(value: exp.Expr) -> exp.Expr:
@@ -1042,16 +1036,8 @@ class ExasolGenerator(generator.Generator):
 
         return sql
 
-    @unsupported_args("null_handling", "return_type", "encoding")
+    @unsupported_args("null_handling", "return_type", "encoding", "unique_keys")
     def jsonobject_sql(self, expression: exp.JSONObject) -> str:
-        if expression.args.get("unique_keys") is not None:
-            self.unsupported(
-                "Argument 'unique_keys' is not supported for expression 'JSONObject' when targeting Exasol."
-            )
-
-        if not expression.expressions:
-            return self.sql(exp.Literal.string("{}"))
-
         parts: list[str | exp.Expr] = [exp.Literal.string("{")]
 
         for i, key_value in enumerate(expression.expressions):
@@ -1062,11 +1048,7 @@ class ExasolGenerator(generator.Generator):
                 self.unsupported("Only JSON key-value pairs are supported for Exasol JSON_OBJECT")
                 return self.function_fallback_sql(expression)
 
-            if key_value.this.is_string:
-                parts.append(_json_literal_key_part(self, key_value.this.name))
-            else:
-                parts.append(_json_key_part(key_value.this))
-
+            parts.append(_json_key_part(self, key_value.this))
             parts.append(_json_value_part(self, key_value.expression))
 
         parts.append(exp.Literal.string("}"))

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -328,14 +328,6 @@ def _json_runtime_value_part(value: exp.Expr) -> exp.Expr:
             exp.func("LOWER", stringified.copy()),
         )
         .when(
-            exp.EQ(this=value_type.copy(), expression=exp.Literal.string("DATE")),
-            quoted.copy(),
-        )
-        .when(
-            exp.Like(this=value_type.copy(), expression=exp.Literal.string("TIMESTAMP%")),
-            quoted.copy(),
-        )
-        .when(
             exp.or_(
                 exp.Like(this=value_type.copy(), expression=exp.Literal.string("DECIMAL%")),
                 exp.EQ(this=value_type.copy(), expression=exp.Literal.string("DOUBLE PRECISION")),

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -265,6 +265,142 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
+def _json_object_key_part(key: exp.Expr) -> exp.Expr:
+    key_expr: exp.Expr
+    if key.is_string or key.is_type(*exp.DataType.TEXT_TYPES):
+        key_expr = exp.func("COALESCE", key.copy(), exp.Literal.string(""))
+    else:
+        key_expr = (
+            exp.case()
+            .when(key.copy().is_(exp.null()), exp.Literal.string(""))
+            .else_(exp.DPipe(this=key.copy(), expression=exp.Literal.string("")))
+        )
+
+    return exp.func(
+        "CONCAT",
+        exp.Literal.string('"'),
+        key_expr,
+        exp.Literal.string('": '),
+    )
+
+
+def _json_string_part(value: exp.Expr) -> exp.Expr:
+    escaped = exp.Replace(
+        this=exp.Replace(
+            this=value,
+            expression=exp.Literal.string("\\"),
+            replacement=exp.Literal.string("\\\\"),
+        ),
+        expression=exp.Literal.string('"'),
+        replacement=exp.Literal.string('\\"'),
+    )
+    return exp.DPipe(
+        this=exp.DPipe(this=exp.Literal.string('"'), expression=escaped),
+        expression=exp.Literal.string('"'),
+    )
+
+
+def _json_null_safe_part(value: exp.Expr, rendered: exp.Expr) -> exp.Expr:
+    return exp.case().when(value.copy().is_(exp.null()), exp.Literal.string("null")).else_(rendered)
+
+
+def _json_formatted_temporal_part(value: exp.Expr, format_string: str) -> exp.Expr:
+    return _json_null_safe_part(
+        value,
+        _json_string_part(exp.ToChar(this=value.copy(), format=exp.Literal.string(format_string))),
+    )
+
+
+def _json_runtime_value_part(value: exp.Expr) -> exp.Expr:
+    value_type = exp.Typeof(this=value.copy())
+    stringified = exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))
+    quoted = _json_string_part(stringified)
+
+    return (
+        exp.case()
+        .when(value.copy().is_(exp.null()), exp.Literal.string("null"))
+        .when(
+            exp.EQ(this=value_type.copy(), expression=exp.Literal.string("BOOLEAN")),
+            exp.func("LOWER", stringified.copy()),
+        )
+        .when(
+            exp.EQ(this=value_type.copy(), expression=exp.Literal.string("DATE")),
+            quoted.copy(),
+        )
+        .when(
+            exp.Like(this=value_type.copy(), expression=exp.Literal.string("TIMESTAMP%")),
+            quoted.copy(),
+        )
+        .when(
+            exp.or_(
+                exp.Like(this=value_type.copy(), expression=exp.Literal.string("DECIMAL%")),
+                exp.EQ(this=value_type.copy(), expression=exp.Literal.string("DOUBLE PRECISION")),
+            ),
+            stringified,
+        )
+        .else_(quoted)
+    )
+
+
+def _json_object_value_part(value: exp.Expr) -> exp.Expr:
+    if isinstance(value, exp.Null):
+        return exp.Literal.string("null")
+
+    if isinstance(value, exp.Boolean):
+        return exp.Literal.string("true" if value.this else "false")
+
+    if value.is_number:
+        return value.copy()
+
+    if value.is_string:
+        escaped = value.name.replace("\\", "\\\\").replace('"', '\\"')
+        return exp.Literal.string(f'"{escaped}"')
+
+    if value.is_type(*exp.DataType.TEXT_TYPES):
+        return _json_string_part(exp.func("COALESCE", value.copy(), exp.Literal.string("")))
+
+    if isinstance(value, (exp.CurrentDate, exp.Date)):
+        return _json_formatted_temporal_part(value, "YYYY-MM-DD")
+
+    if isinstance(value, (exp.CurrentTimestamp,)):
+        return _json_formatted_temporal_part(value, "YYYY-MM-DD HH24:MI:SS")
+
+    if isinstance(value, (exp.CurrentTime, exp.Time)):
+        return _json_formatted_temporal_part(value, "HH24:MI:SS")
+
+    if value.is_type(exp.DType.DATE):
+        return _json_formatted_temporal_part(value, "YYYY-MM-DD")
+
+    if value.is_type(
+        exp.DType.DATETIME,
+        exp.DType.DATETIME2,
+        exp.DType.DATETIME64,
+        exp.DType.SMALLDATETIME,
+        exp.DType.TIMESTAMP,
+        exp.DType.TIMESTAMPTZ,
+        exp.DType.TIMESTAMPLTZ,
+        exp.DType.TIMESTAMPNTZ,
+        exp.DType.TIMESTAMP_S,
+        exp.DType.TIMESTAMP_MS,
+        exp.DType.TIMESTAMP_NS,
+    ):
+        return _json_formatted_temporal_part(value, "YYYY-MM-DD HH24:MI:SS")
+
+    if value.is_type(*exp.DataType.NUMERIC_TYPES):
+        return exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))
+
+    if value.is_type(exp.DType.BOOLEAN):
+        return (
+            exp.case()
+            .when(value.copy().is_(exp.null()), exp.Literal.string("null"))
+            .else_(
+                exp.func("LOWER", exp.DPipe(this=value.copy(), expression=exp.Literal.string("")))
+            )
+        )
+
+    return _json_runtime_value_part(value)
+
+
 class ExasolGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     TRY_SUPPORTED = False
@@ -312,7 +448,7 @@ class ExasolGenerator(generator.Generator):
         return super().datatype_sql(expression)
 
     TRANSFORMS = {
-        **generator.Generator.TRANSFORMS,
+        **{k: v for k, v in generator.Generator.TRANSFORMS.items() if k != exp.JSONObject},
         # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/every.htm
         exp.All: rename_func("EVERY"),
         # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/bit_and.htm
@@ -903,6 +1039,37 @@ class ExasolGenerator(generator.Generator):
             sql = f"{sql} EMITS {emits}"
 
         return sql
+
+    @unsupported_args("null_handling", "return_type", "encoding")
+    def jsonobject_sql(self, expression: exp.JSONObject) -> str:
+        if expression.args.get("unique_keys") is not None:
+            self.unsupported(
+                "Argument 'unique_keys' is not supported for expression 'JSONObject' when targeting Exasol."
+            )
+
+        if not expression.expressions:
+            return self.sql(exp.Literal.string("{}"))
+
+        parts: list[str | exp.Expr] = [exp.Literal.string("{")]
+
+        for i, key_value in enumerate(expression.expressions):
+            if i:
+                parts.append(exp.Literal.string(", "))
+
+            if not isinstance(key_value, exp.JSONKeyValue):
+                self.unsupported("Only JSON key-value pairs are supported for Exasol JSON_OBJECT")
+                return self.function_fallback_sql(expression)
+
+            if key_value.this.is_string:
+                escaped = key_value.this.name.replace("\\", "\\\\").replace('"', '\\"')
+                parts.append(exp.Literal.string(f'"{escaped}": '))
+            else:
+                parts.append(_json_object_key_part(key_value.this))
+
+            parts.append(_json_object_value_part(key_value.expression))
+
+        parts.append(exp.Literal.string("}"))
+        return self.func("CONCAT", *parts)
 
     @unsupported_args("flag")
     def regexplike_sql(self, expression: exp.RegexpLike) -> str:

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import typing as t
 
 from sqlglot import exp, generator, transforms
@@ -265,15 +266,32 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-def _json_literal_part(self: ExasolGenerator, value: str) -> exp.Expr:
-    escaped = self.escape_str(value, delimiter='"', escaped_delimiter='\\"')
-    return exp.Literal.string(f'"{escaped}"')
+_JSON_STRING_ESCAPE_SEQUENCES: tuple[tuple[str, str], ...] = (
+    ("\\", "\\\\"),
+    ('"', '\\"'),
+)
 
 
-def _json_key_part(self: ExasolGenerator, key: exp.Expr) -> exp.Expr:
+def _json_escape_part(value: exp.Expr) -> exp.Expr:
+    escaped = value
+
+    for raw, replacement in _JSON_STRING_ESCAPE_SEQUENCES:
+        escaped = exp.Replace(
+            this=escaped,
+            expression=exp.Literal.string(raw),
+            replacement=exp.Literal.string(replacement),
+        )
+
+    return escaped
+
+
+def _json_literal_part(value: str) -> exp.Expr:
+    return exp.Literal.string(json.dumps(value, ensure_ascii=False))
+
+
+def _json_key_part(key: exp.Expr) -> exp.Expr:
     if key.is_string:
-        escaped = self.escape_str(key.name, delimiter='"', escaped_delimiter='\\"')
-        return exp.Literal.string(f'"{escaped}": ')
+        return exp.Literal.string(f"{json.dumps(key.name, ensure_ascii=False)}: ")
 
     key_expr: exp.Expr
     if key.is_type(*exp.DataType.TEXT_TYPES):
@@ -285,19 +303,16 @@ def _json_key_part(self: ExasolGenerator, key: exp.Expr) -> exp.Expr:
             .else_(exp.DPipe(this=key.copy(), expression=exp.Literal.string("")))
         )
 
-    return exp.DPipe(this=_json_string_part(key_expr), expression=exp.Literal.string(": "))
+    return exp.func(
+        "CONCAT",
+        exp.Literal.string('"'),
+        _json_escape_part(key_expr),
+        exp.Literal.string('": '),
+    )
 
 
 def _json_string_part(value: exp.Expr) -> exp.Expr:
-    escaped = exp.Replace(
-        this=exp.Replace(
-            this=value,
-            expression=exp.Literal.string("\\"),
-            replacement=exp.Literal.string("\\\\"),
-        ),
-        expression=exp.Literal.string('"'),
-        replacement=exp.Literal.string('\\"'),
-    )
+    escaped = _json_escape_part(value)
     return exp.DPipe(
         this=exp.DPipe(this=exp.Literal.string('"'), expression=escaped),
         expression=exp.Literal.string('"'),
@@ -350,7 +365,7 @@ def _json_temporal_format(value: exp.Expr) -> str:
     return "YYYY-MM-DD HH24:MI:SS"
 
 
-def _json_value_part(self: ExasolGenerator, value: exp.Expr) -> exp.Expr:
+def _json_value_part(value: exp.Expr) -> exp.Expr:
     if isinstance(value, exp.Null):
         return exp.Literal.string("null")
 
@@ -361,29 +376,23 @@ def _json_value_part(self: ExasolGenerator, value: exp.Expr) -> exp.Expr:
         return value.copy()
 
     if value.is_string:
-        return _json_literal_part(self, value.name)
+        return _json_literal_part(value.name)
 
     if value.is_type(*exp.DataType.TEXT_TYPES):
         return _json_string_part(exp.func("COALESCE", value.copy(), exp.Literal.string("")))
 
     if isinstance(
         value, (exp.CurrentDate, exp.CurrentTime, exp.CurrentTimestamp, exp.Date, exp.Time)
-    ):
-        return _json_formatted_temporal_part(value, _json_temporal_format(value))
-
-    if value.is_type(*exp.DataType.TEMPORAL_TYPES):
+    ) or value.is_type(*exp.DataType.TEMPORAL_TYPES):
         return _json_formatted_temporal_part(value, _json_temporal_format(value))
 
     if value.is_type(*exp.DataType.NUMERIC_TYPES):
         return exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))
 
     if value.is_type(exp.DType.BOOLEAN):
-        return (
-            exp.case()
-            .when(value.copy().is_(exp.null()), exp.Literal.string("null"))
-            .else_(
-                exp.func("LOWER", exp.DPipe(this=value.copy(), expression=exp.Literal.string("")))
-            )
+        return _json_null_safe_part(
+            value,
+            exp.func("LOWER", exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))),
         )
 
     return _json_runtime_value_part(value)
@@ -1040,8 +1049,8 @@ class ExasolGenerator(generator.Generator):
                 self.unsupported("Only JSON key-value pairs are supported for Exasol JSON_OBJECT")
                 return self.function_fallback_sql(expression)
 
-            parts.append(_json_key_part(self, key_value.this))
-            parts.append(_json_value_part(self, key_value.expression))
+            parts.append(_json_key_part(key_value.this))
+            parts.append(_json_value_part(key_value.expression))
 
         parts.append(exp.Literal.string("}"))
         return self.func("CONCAT", *parts)

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -265,7 +265,17 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-def _json_object_key_part(key: exp.Expr) -> exp.Expr:
+def _json_literal_part(self: ExasolGenerator, value: str) -> exp.Expr:
+    escaped = self.escape_str(value, delimiter='"', escaped_delimiter='\\"')
+    return exp.Literal.string(f'"{escaped}"')
+
+
+def _json_literal_key_part(self: ExasolGenerator, value: str) -> exp.Expr:
+    escaped = self.escape_str(value, delimiter='"', escaped_delimiter='\\"')
+    return exp.Literal.string(f'"{escaped}": ')
+
+
+def _json_key_part(key: exp.Expr) -> exp.Expr:
     key_expr: exp.Expr
     if key.is_string or key.is_type(*exp.DataType.TEXT_TYPES):
         key_expr = exp.func("COALESCE", key.copy(), exp.Literal.string(""))
@@ -342,7 +352,19 @@ def _json_runtime_value_part(value: exp.Expr) -> exp.Expr:
     )
 
 
-def _json_object_value_part(value: exp.Expr) -> exp.Expr:
+def _json_temporal_format(value: exp.Expr) -> str:
+    if isinstance(value, (exp.CurrentDate, exp.Date)) or value.is_type(exp.DType.DATE):
+        return "YYYY-MM-DD"
+
+    if isinstance(value, (exp.CurrentTime, exp.Time)) or value.is_type(
+        exp.DType.TIME, exp.DType.TIMETZ, exp.DType.TIME_NS
+    ):
+        return "HH24:MI:SS"
+
+    return "YYYY-MM-DD HH24:MI:SS"
+
+
+def _json_value_part(self: ExasolGenerator, value: exp.Expr) -> exp.Expr:
     if isinstance(value, exp.Null):
         return exp.Literal.string("null")
 
@@ -353,38 +375,18 @@ def _json_object_value_part(value: exp.Expr) -> exp.Expr:
         return value.copy()
 
     if value.is_string:
-        escaped = value.name.replace("\\", "\\\\").replace('"', '\\"')
-        return exp.Literal.string(f'"{escaped}"')
+        return _json_literal_part(self, value.name)
 
     if value.is_type(*exp.DataType.TEXT_TYPES):
         return _json_string_part(exp.func("COALESCE", value.copy(), exp.Literal.string("")))
 
-    if isinstance(value, (exp.CurrentDate, exp.Date)):
-        return _json_formatted_temporal_part(value, "YYYY-MM-DD")
-
-    if isinstance(value, (exp.CurrentTimestamp,)):
-        return _json_formatted_temporal_part(value, "YYYY-MM-DD HH24:MI:SS")
-
-    if isinstance(value, (exp.CurrentTime, exp.Time)):
-        return _json_formatted_temporal_part(value, "HH24:MI:SS")
-
-    if value.is_type(exp.DType.DATE):
-        return _json_formatted_temporal_part(value, "YYYY-MM-DD")
-
-    if value.is_type(
-        exp.DType.DATETIME,
-        exp.DType.DATETIME2,
-        exp.DType.DATETIME64,
-        exp.DType.SMALLDATETIME,
-        exp.DType.TIMESTAMP,
-        exp.DType.TIMESTAMPTZ,
-        exp.DType.TIMESTAMPLTZ,
-        exp.DType.TIMESTAMPNTZ,
-        exp.DType.TIMESTAMP_S,
-        exp.DType.TIMESTAMP_MS,
-        exp.DType.TIMESTAMP_NS,
+    if isinstance(
+        value, (exp.CurrentDate, exp.CurrentTime, exp.CurrentTimestamp, exp.Date, exp.Time)
     ):
-        return _json_formatted_temporal_part(value, "YYYY-MM-DD HH24:MI:SS")
+        return _json_formatted_temporal_part(value, _json_temporal_format(value))
+
+    if value.is_type(*exp.DataType.TEMPORAL_TYPES):
+        return _json_formatted_temporal_part(value, _json_temporal_format(value))
 
     if value.is_type(*exp.DataType.NUMERIC_TYPES):
         return exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))
@@ -1061,12 +1063,11 @@ class ExasolGenerator(generator.Generator):
                 return self.function_fallback_sql(expression)
 
             if key_value.this.is_string:
-                escaped = key_value.this.name.replace("\\", "\\\\").replace('"', '\\"')
-                parts.append(exp.Literal.string(f'"{escaped}": '))
+                parts.append(_json_literal_key_part(self, key_value.this.name))
             else:
-                parts.append(_json_object_key_part(key_value.this))
+                parts.append(_json_key_part(key_value.this))
 
-            parts.append(_json_object_value_part(key_value.expression))
+            parts.append(_json_value_part(self, key_value.expression))
 
         parts.append(exp.Literal.string("}"))
         return self.func("CONCAT", *parts)

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -266,74 +266,35 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-_JSON_STRING_ESCAPE_SEQUENCES: tuple[tuple[str, str], ...] = (
-    ("\\", "\\\\"),
-    ('"', '\\"'),
-)
+def _json_long_varchar_cast(value: exp.Expr) -> exp.Expr:
+    if isinstance(value, exp.Cast) and value.to.is_type(*exp.DataType.TEXT_TYPES):
+        value = value.this
+
+    return exp.cast(value.copy(), exp.DType.TEXT)
 
 
-def _json_escape_part(value: exp.Expr) -> exp.Expr:
-    escaped = value
-
-    for raw, replacement in _JSON_STRING_ESCAPE_SEQUENCES:
-        escaped = exp.Replace(
-            this=escaped,
-            expression=exp.Literal.string(raw),
-            replacement=exp.Literal.string(replacement),
-        )
-
-    return escaped
-
-
-def _json_literal_part(value: str) -> exp.Expr:
-    return exp.Literal.string(json.dumps(value, ensure_ascii=False))
+def _json_quoted(value: exp.Expr) -> exp.Expr:
+    return exp.DPipe(
+        this=exp.DPipe(this=exp.Literal.string('"'), expression=value),
+        expression=exp.Literal.string('"'),
+    )
 
 
 def _json_key_part(key: exp.Expr) -> exp.Expr:
     if key.is_string:
         return exp.Literal.string(f"{json.dumps(key.name, ensure_ascii=False)}: ")
 
-    key_expr: exp.Expr
-    if key.is_type(*exp.DataType.TEXT_TYPES):
-        key_expr = exp.func("COALESCE", key.copy(), exp.Literal.string(""))
-    else:
-        key_expr = (
-            exp.case()
-            .when(key.copy().is_(exp.null()), exp.Literal.string(""))
-            .else_(exp.DPipe(this=key.copy(), expression=exp.Literal.string("")))
-        )
+    key = exp.func("COALESCE", _json_long_varchar_cast(key), exp.Literal.string(""))
 
-    return exp.func(
-        "CONCAT",
-        exp.Literal.string('"'),
-        _json_escape_part(key_expr),
-        exp.Literal.string('": '),
-    )
-
-
-def _json_string_part(value: exp.Expr) -> exp.Expr:
-    escaped = _json_escape_part(value)
     return exp.DPipe(
-        this=exp.DPipe(this=exp.Literal.string('"'), expression=escaped),
-        expression=exp.Literal.string('"'),
-    )
-
-
-def _json_null_safe_part(value: exp.Expr, rendered: exp.Expr) -> exp.Expr:
-    return exp.case().when(value.copy().is_(exp.null()), exp.Literal.string("null")).else_(rendered)
-
-
-def _json_formatted_temporal_part(value: exp.Expr, format_string: str) -> exp.Expr:
-    return _json_null_safe_part(
-        value,
-        _json_string_part(exp.ToChar(this=value.copy(), format=exp.Literal.string(format_string))),
+        this=exp.DPipe(this=exp.Literal.string('"'), expression=key),
+        expression=exp.Literal.string('": '),
     )
 
 
 def _json_runtime_value_part(value: exp.Expr) -> exp.Expr:
     value_type = exp.Typeof(this=value.copy())
-    stringified = exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))
-    quoted = _json_string_part(stringified)
+    stringified = _json_long_varchar_cast(value)
 
     return (
         exp.case()
@@ -349,51 +310,44 @@ def _json_runtime_value_part(value: exp.Expr) -> exp.Expr:
             ),
             stringified,
         )
-        .else_(quoted)
+        .else_(_json_quoted(stringified))
     )
-
-
-def _json_temporal_format(value: exp.Expr) -> str:
-    if isinstance(value, (exp.CurrentDate, exp.Date)) or value.is_type(exp.DType.DATE):
-        return "YYYY-MM-DD"
-
-    if isinstance(value, (exp.CurrentTime, exp.Time)) or value.is_type(
-        exp.DType.TIME, exp.DType.TIMETZ, exp.DType.TIME_NS
-    ):
-        return "HH24:MI:SS"
-
-    return "YYYY-MM-DD HH24:MI:SS"
 
 
 def _json_value_part(value: exp.Expr) -> exp.Expr:
     if isinstance(value, exp.Null):
-        return exp.Literal.string("null")
+        return exp.func("COALESCE", _json_long_varchar_cast(value), exp.Literal.string("null"))
 
-    if isinstance(value, exp.Boolean):
-        return exp.Literal.string("true" if value.this else "false")
+    if isinstance(value, exp.Boolean) or value.is_type(exp.DType.BOOLEAN):
+        stringified = _json_long_varchar_cast(value)
+
+        if not isinstance(value, exp.Boolean):
+            stringified = exp.func("COALESCE", stringified, exp.Literal.string("null"))
+
+        return exp.func("LOWER", stringified)
 
     if value.is_number:
-        return value.copy()
+        return _json_long_varchar_cast(value)
 
     if value.is_string:
-        return _json_literal_part(value.name)
+        return exp.Literal.string(json.dumps(value.name, ensure_ascii=False))
 
     if value.is_type(*exp.DataType.TEXT_TYPES):
-        return _json_string_part(exp.func("COALESCE", value.copy(), exp.Literal.string("")))
+        return _json_quoted(
+            exp.func("COALESCE", _json_long_varchar_cast(value), exp.Literal.string(""))
+        )
 
     if isinstance(
         value, (exp.CurrentDate, exp.CurrentTime, exp.CurrentTimestamp, exp.Date, exp.Time)
     ) or value.is_type(*exp.DataType.TEMPORAL_TYPES):
-        return _json_formatted_temporal_part(value, _json_temporal_format(value))
+        return exp.func(
+            "COALESCE",
+            _json_quoted(_json_long_varchar_cast(value)),
+            exp.Literal.string("null"),
+        )
 
     if value.is_type(*exp.DataType.NUMERIC_TYPES):
-        return exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))
-
-    if value.is_type(exp.DType.BOOLEAN):
-        return _json_null_safe_part(
-            value,
-            exp.func("LOWER", exp.DPipe(this=value.copy(), expression=exp.Literal.string(""))),
-        )
+        return exp.func("COALESCE", _json_long_varchar_cast(value), exp.Literal.string("null"))
 
     return _json_runtime_value_part(value)
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -893,7 +893,7 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"user": ', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"', ', ', '"balance": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) = 'DATE' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            r"""SELECT CONCAT('{', '"user": ', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"', ', ', '"balance": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
             read={
                 "mysql": """SELECT JSON_OBJECT('user', CAST(user_name AS CHAR), 'balance', account_balance) AS jsonData FROM t""",
             },
@@ -911,13 +911,13 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"' || ': ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) = 'DATE' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            r"""SELECT CONCAT('{', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"' || ': ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
             read={
                 "mysql": """SELECT JSON_OBJECT(CAST(user_name AS CHAR), account_balance) AS jsonData FROM t""",
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"col1": ', CASE WHEN t.col1 IS NULL THEN 'null' WHEN TYPEOF(t.col1) = 'BOOLEAN' THEN LOWER(t.col1 || '') WHEN TYPEOF(t.col1) = 'DATE' THEN '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col1) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col1) LIKE 'DECIMAL%' OR TYPEOF(t.col1) = 'DOUBLE PRECISION' THEN t.col1 || '' ELSE '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' END, ', ', '"col2": ', CASE WHEN t.col2 IS NULL THEN 'null' WHEN TYPEOF(t.col2) = 'BOOLEAN' THEN LOWER(t.col2 || '') WHEN TYPEOF(t.col2) = 'DATE' THEN '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col2) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col2) LIKE 'DECIMAL%' OR TYPEOF(t.col2) = 'DOUBLE PRECISION' THEN t.col2 || '' ELSE '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' END, '}') FROM x AS t""",
+            r"""SELECT CONCAT('{', '"col1": ', CASE WHEN t.col1 IS NULL THEN 'null' WHEN TYPEOF(t.col1) = 'BOOLEAN' THEN LOWER(t.col1 || '') WHEN TYPEOF(t.col1) LIKE 'DECIMAL%' OR TYPEOF(t.col1) = 'DOUBLE PRECISION' THEN t.col1 || '' ELSE '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' END, ', ', '"col2": ', CASE WHEN t.col2 IS NULL THEN 'null' WHEN TYPEOF(t.col2) = 'BOOLEAN' THEN LOWER(t.col2 || '') WHEN TYPEOF(t.col2) LIKE 'DECIMAL%' OR TYPEOF(t.col2) = 'DOUBLE PRECISION' THEN t.col2 || '' ELSE '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' END, '}') FROM x AS t""",
             read={
                 "mysql": """SELECT JSON_OBJECT('col1', t.col1, 'col2', t.col2) FROM x AS t""",
             },

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -886,6 +886,54 @@ class TestExasol(Validator):
         self.validate_identity(
             """SELECT JSON_EXTRACT('{"firstname" : "Ann", "surname" : "Smith", "age" : 29}', '$.firstname', '$.surname', '$.age') EMITS (firstname VARCHAR(100), surname VARCHAR(100), age INT)"""
         )
+        self.validate_all(
+            """SELECT CONCAT('{', '"id": ', 87, ', ', '"active": ', 'true', ', ', '"name": ', '"carrot"', '}')""",
+            read={
+                "mysql": """SELECT JSON_OBJECT('id', 87, 'active', TRUE, 'name', 'carrot')""",
+            },
+        )
+        self.validate_all(
+            r"""SELECT CONCAT('{', '"user": ', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"', ', ', '"balance": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) = 'DATE' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            read={
+                "mysql": """SELECT JSON_OBJECT('user', CAST(user_name AS CHAR), 'balance', account_balance) AS jsonData FROM t""",
+            },
+        )
+        self.validate_all(
+            """SELECT '{}'""",
+            read={
+                "mysql": """SELECT JSON_OBJECT()""",
+            },
+        )
+        self.validate_all(
+            """SELECT CONCAT('{', '"na\\"me": ', 1, '}')""",
+            read={
+                "mysql": """SELECT JSON_OBJECT('na"me', 1)""",
+            },
+        )
+        self.validate_all(
+            r"""SELECT CONCAT('{', '"' || COALESCE(CAST(user_name AS CHAR), '') || '": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) = 'DATE' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            read={
+                "mysql": """SELECT JSON_OBJECT(CAST(user_name AS CHAR), account_balance) AS jsonData FROM t""",
+            },
+        )
+        self.validate_all(
+            r"""SELECT CONCAT('{', '"col1": ', CASE WHEN t.col1 IS NULL THEN 'null' WHEN TYPEOF(t.col1) = 'BOOLEAN' THEN LOWER(t.col1 || '') WHEN TYPEOF(t.col1) = 'DATE' THEN '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col1) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col1) LIKE 'DECIMAL%' OR TYPEOF(t.col1) = 'DOUBLE PRECISION' THEN t.col1 || '' ELSE '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' END, ', ', '"col2": ', CASE WHEN t.col2 IS NULL THEN 'null' WHEN TYPEOF(t.col2) = 'BOOLEAN' THEN LOWER(t.col2 || '') WHEN TYPEOF(t.col2) = 'DATE' THEN '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col2) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(t.col2) LIKE 'DECIMAL%' OR TYPEOF(t.col2) = 'DOUBLE PRECISION' THEN t.col2 || '' ELSE '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' END, '}') FROM x AS t""",
+            read={
+                "mysql": """SELECT JSON_OBJECT('col1', t.col1, 'col2', t.col2) FROM x AS t""",
+            },
+        )
+        self.validate_all(
+            r"""SELECT CONCAT('{', '"name": ', '"' || REPLACE(REPLACE(COALESCE(CAST(NULL AS CHAR), ''), '\', '\\'), '"', '\"') || '"', ', ', '"count": ', 'null', '}')""",
+            read={
+                "mysql": """SELECT JSON_OBJECT('name', CAST(NULL AS CHAR), 'count', NULL)""",
+            },
+        )
+        self.validate_all(
+            r"""SELECT CONCAT('{', '"name": ', '"Alice"', ', ', '"age": ', 25, ', ', '"time": ', CASE WHEN CURRENT_TIMESTAMP() IS NULL THEN 'null' ELSE '"' || REPLACE(REPLACE(TO_CHAR(CURRENT_TIMESTAMP(), 'YYYY-MM-DD HH24:MI:SS'), '\', '\\'), '"', '\"') || '"' END, ', ', '"date": ', CASE WHEN CURRENT_DATE IS NULL THEN 'null' ELSE '"' || REPLACE(REPLACE(TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD'), '\', '\\'), '"', '\"') || '"' END, ', ', '"other": ', 'null', ', ', '"average": ', 3.5455, '}')""",
+            read={
+                "mysql": """SELECT JSON_OBJECT('name', 'Alice', 'age', 25, 'time', CURRENT_TIMESTAMP(), 'date', CURRENT_DATE(), 'other', NULL, 'average', 3.5455)""",
+            },
+        )
 
     def test_group_by_all(self):
         self.validate_all(

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -899,7 +899,7 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            """SELECT '{}'""",
+            """SELECT CONCAT('{', '}')""",
             read={
                 "mysql": """SELECT JSON_OBJECT()""",
             },
@@ -911,7 +911,7 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"' || COALESCE(CAST(user_name AS CHAR), '') || '": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) = 'DATE' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            r"""SELECT CONCAT('{', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"' || ': ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) = 'DATE' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'TIMESTAMP%' THEN '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
             read={
                 "mysql": """SELECT JSON_OBJECT(CAST(user_name AS CHAR), account_balance) AS jsonData FROM t""",
             },

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -911,7 +911,13 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"' || ': ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            r"""SELECT CONCAT('{', '"path": ', '"C:\\tmp\\file.txt"', '}')""",
+            read={
+                "mysql": r"""SELECT JSON_OBJECT('path', 'C:\\tmp\\file.txt')""",
+            },
+        )
+        self.validate_all(
+            r"""SELECT CONCAT('{', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
             read={
                 "mysql": """SELECT JSON_OBJECT(CAST(user_name AS CHAR), account_balance) AS jsonData FROM t""",
             },

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -887,13 +887,13 @@ class TestExasol(Validator):
             """SELECT JSON_EXTRACT('{"firstname" : "Ann", "surname" : "Smith", "age" : 29}', '$.firstname', '$.surname', '$.age') EMITS (firstname VARCHAR(100), surname VARCHAR(100), age INT)"""
         )
         self.validate_all(
-            """SELECT CONCAT('{', '"id": ', 87, ', ', '"active": ', 'true', ', ', '"name": ', '"carrot"', '}')""",
+            """SELECT CONCAT('{', '"id": ', CAST(87 AS LONG VARCHAR), ', ', '"active": ', LOWER(CAST(TRUE AS LONG VARCHAR)), ', ', '"name": ', '"carrot"', '}')""",
             read={
                 "mysql": """SELECT JSON_OBJECT('id', 87, 'active', TRUE, 'name', 'carrot')""",
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"user": ', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '"', ', ', '"balance": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            r"""SELECT CONCAT('{', '"user": ', '"' || COALESCE(CAST(user_name AS LONG VARCHAR), '') || '"', ', ', '"balance": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(CAST(account_balance AS LONG VARCHAR)) WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN CAST(account_balance AS LONG VARCHAR) ELSE '"' || CAST(account_balance AS LONG VARCHAR) || '"' END, '}') AS jsonData FROM t""",
             read={
                 "mysql": """SELECT JSON_OBJECT('user', CAST(user_name AS CHAR), 'balance', account_balance) AS jsonData FROM t""",
             },
@@ -905,7 +905,7 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            """SELECT CONCAT('{', '"na\\"me": ', 1, '}')""",
+            """SELECT CONCAT('{', '"na\\"me": ', CAST(1 AS LONG VARCHAR), '}')""",
             read={
                 "mysql": """SELECT JSON_OBJECT('na"me', 1)""",
             },
@@ -917,25 +917,25 @@ class TestExasol(Validator):
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"' || REPLACE(REPLACE(COALESCE(CAST(user_name AS CHAR), ''), '\', '\\'), '"', '\"') || '": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(account_balance || '') WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN account_balance || '' ELSE '"' || REPLACE(REPLACE(account_balance || '', '\', '\\'), '"', '\"') || '"' END, '}') AS jsonData FROM t""",
+            r"""SELECT CONCAT('{', '"' || COALESCE(CAST(user_name AS LONG VARCHAR), '') || '": ', CASE WHEN account_balance IS NULL THEN 'null' WHEN TYPEOF(account_balance) = 'BOOLEAN' THEN LOWER(CAST(account_balance AS LONG VARCHAR)) WHEN TYPEOF(account_balance) LIKE 'DECIMAL%' OR TYPEOF(account_balance) = 'DOUBLE PRECISION' THEN CAST(account_balance AS LONG VARCHAR) ELSE '"' || CAST(account_balance AS LONG VARCHAR) || '"' END, '}') AS jsonData FROM t""",
             read={
                 "mysql": """SELECT JSON_OBJECT(CAST(user_name AS CHAR), account_balance) AS jsonData FROM t""",
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"col1": ', CASE WHEN t.col1 IS NULL THEN 'null' WHEN TYPEOF(t.col1) = 'BOOLEAN' THEN LOWER(t.col1 || '') WHEN TYPEOF(t.col1) LIKE 'DECIMAL%' OR TYPEOF(t.col1) = 'DOUBLE PRECISION' THEN t.col1 || '' ELSE '"' || REPLACE(REPLACE(t.col1 || '', '\', '\\'), '"', '\"') || '"' END, ', ', '"col2": ', CASE WHEN t.col2 IS NULL THEN 'null' WHEN TYPEOF(t.col2) = 'BOOLEAN' THEN LOWER(t.col2 || '') WHEN TYPEOF(t.col2) LIKE 'DECIMAL%' OR TYPEOF(t.col2) = 'DOUBLE PRECISION' THEN t.col2 || '' ELSE '"' || REPLACE(REPLACE(t.col2 || '', '\', '\\'), '"', '\"') || '"' END, '}') FROM x AS t""",
+            r"""SELECT CONCAT('{', '"col1": ', CASE WHEN t.col1 IS NULL THEN 'null' WHEN TYPEOF(t.col1) = 'BOOLEAN' THEN LOWER(CAST(t.col1 AS LONG VARCHAR)) WHEN TYPEOF(t.col1) LIKE 'DECIMAL%' OR TYPEOF(t.col1) = 'DOUBLE PRECISION' THEN CAST(t.col1 AS LONG VARCHAR) ELSE '"' || CAST(t.col1 AS LONG VARCHAR) || '"' END, ', ', '"col2": ', CASE WHEN t.col2 IS NULL THEN 'null' WHEN TYPEOF(t.col2) = 'BOOLEAN' THEN LOWER(CAST(t.col2 AS LONG VARCHAR)) WHEN TYPEOF(t.col2) LIKE 'DECIMAL%' OR TYPEOF(t.col2) = 'DOUBLE PRECISION' THEN CAST(t.col2 AS LONG VARCHAR) ELSE '"' || CAST(t.col2 AS LONG VARCHAR) || '"' END, '}') FROM x AS t""",
             read={
                 "mysql": """SELECT JSON_OBJECT('col1', t.col1, 'col2', t.col2) FROM x AS t""",
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"name": ', '"' || REPLACE(REPLACE(COALESCE(CAST(NULL AS CHAR), ''), '\', '\\'), '"', '\"') || '"', ', ', '"count": ', 'null', '}')""",
+            r"""SELECT CONCAT('{', '"name": ', '"' || COALESCE(CAST(NULL AS LONG VARCHAR), '') || '"', ', ', '"count": ', COALESCE(CAST(NULL AS LONG VARCHAR), 'null'), '}')""",
             read={
                 "mysql": """SELECT JSON_OBJECT('name', CAST(NULL AS CHAR), 'count', NULL)""",
             },
         )
         self.validate_all(
-            r"""SELECT CONCAT('{', '"name": ', '"Alice"', ', ', '"age": ', 25, ', ', '"time": ', CASE WHEN CURRENT_TIMESTAMP() IS NULL THEN 'null' ELSE '"' || REPLACE(REPLACE(TO_CHAR(CURRENT_TIMESTAMP(), 'YYYY-MM-DD HH24:MI:SS'), '\', '\\'), '"', '\"') || '"' END, ', ', '"date": ', CASE WHEN CURRENT_DATE IS NULL THEN 'null' ELSE '"' || REPLACE(REPLACE(TO_CHAR(CURRENT_DATE, 'YYYY-MM-DD'), '\', '\\'), '"', '\"') || '"' END, ', ', '"other": ', 'null', ', ', '"average": ', 3.5455, '}')""",
+            r"""SELECT CONCAT('{', '"name": ', '"Alice"', ', ', '"age": ', CAST(25 AS LONG VARCHAR), ', ', '"time": ', COALESCE('"' || CAST(CURRENT_TIMESTAMP() AS LONG VARCHAR) || '"', 'null'), ', ', '"date": ', COALESCE('"' || CAST(CURRENT_DATE AS LONG VARCHAR) || '"', 'null'), ', ', '"other": ', COALESCE(CAST(NULL AS LONG VARCHAR), 'null'), ', ', '"average": ', CAST(3.5455 AS LONG VARCHAR), '}')""",
             read={
                 "mysql": """SELECT JSON_OBJECT('name', 'Alice', 'age', 25, 'time', CURRENT_TIMESTAMP(), 'date', CURRENT_DATE(), 'other', NULL, 'average', 3.5455)""",
             },


### PR DESCRIPTION
### **What motivated this PR?**

When transpiling MySQL `JSON_OBJECT(...)` calls to Exasol, SQLGlot would emit `JSON_OBJECT(...)` directly, even though Exasol doesn't support JSON_OBJECT.

As a result, queries such as:

```sql
SELECT JSON_OBJECT('user', user_name, 'balance', account_balance, 'active', is_active)
```

did not transpile into valid Exasol SQL.

---

### **What was incorrect in the existing logic?**

The Exasol generator did not provide a custom `JSON_OBJECT` transformation.

That meant:
- `JSON_OBJECT(...)` was preserved instead of being rewritten into Exasol-compatible SQL
- mixed value types were not handled correctly for JSON output
- unknown runtime values such as columns or function calls could generate invalid Exasol SQL when type-specific formatting was attempted too aggressively

---

### **How does this PR resolve the issue?**

This PR adds a custom Exasol `JSON_OBJECT` transformation that rewrites JSON construction into `CONCAT(...)` with JSON-safe value rendering.

The implementation now:
- emits JSON object text explicitly for Exasol
- preserves JSON quoting for string values
- keeps numeric values unquoted
- renders booleans as `true` / `false`
- handles `NULL` as `null`
- supports typed and runtime-unknown expressions, including columns and function calls
- adds explicit runtime handling for `DATE` and `TIMESTAMP` values without hardcoding arbitrary string lengths

---

### **Documentation and semantic notes**

* Only affects `JSON_OBJECT` generation for the Exasol dialect.
* Unsupported `JSON_OBJECT` options such as `null_handling`, `unique_keys`, `return_type`, and `encoding` are surfaced explicitly.
* Improves correctness and compatibility for MySQL to Exasol JSON transpilation in SQLGlot.