### PR TITLE
Add `INVISIBLE` column constraint for MySQL.

### DIFF
--- a/sqlglot/expressions/constraints.py
+++ b/sqlglot/expressions/constraints.py
@@ -33,6 +33,10 @@ class AutoIncrementColumnConstraint(Expression, ColumnConstraintKind):
     pass
 
 
+class InvisibleColumnConstraint(Expression, ColumnConstraintKind):
+    arg_types = {}
+
+
 class ZeroFillColumnConstraint(ColumnConstraint):
     arg_types = {}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -234,6 +234,7 @@ class Generator:
         exp.ProjectionPolicyColumnConstraint: lambda self, e: (
             f"PROJECTION POLICY {self.sql(e, 'this')}"
         ),
+        exp.InvisibleColumnConstraint: lambda self, e: "INVISIBLE",
         exp.ZeroFillColumnConstraint: lambda self, e: "ZEROFILL",
         exp.Put: lambda self, e: self.get_put_sql(e),
         exp.RemoteWithConnectionModelProperty: lambda self, e: (

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -247,6 +247,7 @@ class MySQLParser(parser.Parser):
         "KEY": lambda self: self._parse_index_constraint(),
         "SPATIAL": lambda self: self._parse_index_constraint(kind="SPATIAL"),
         "ZEROFILL": lambda self: self.expression(exp.ZeroFillColumnConstraint()),
+        "INVISIBLE": lambda self: self.expression(exp.InvisibleColumnConstraint()),
     }
 
     ALTER_PARSERS = {

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1685,13 +1685,11 @@ COMMENT='客户账户表'"""
 
     def test_invisible_column(self):
         expr = self.parse_one("CREATE TABLE t (c INT INVISIBLE)")
-        self.assertIsInstance(
-            expr.find(exp.InvisibleColumnConstraint),
-            exp.InvisibleColumnConstraint,
+        self.assertIsNotNone(
+            expr.find(exp.InvisibleColumnConstraint)
         )
 
         expr = self.parse_one("ALTER TABLE t ADD COLUMN c INT INVISIBLE")
         self.assertIsInstance(
-            expr.find(exp.InvisibleColumnConstraint),
-            exp.InvisibleColumnConstraint,
+            expr.find(exp.InvisibleColumnConstraint)
         )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -28,6 +28,8 @@ class TestMySQL(Validator):
         self.validate_identity("CREATE TABLE foo (a BIGINT, FULLTEXT INDEX (b))")
         self.validate_identity("CREATE TABLE foo (a BIGINT, SPATIAL INDEX (b))")
         self.validate_identity("CREATE TABLE foo (a INT UNSIGNED ZEROFILL)")
+        self.validate_identity("CREATE TABLE foo (a INT INVISIBLE)")
+        self.validate_identity("ALTER TABLE t ADD COLUMN c INT INVISIBLE")
         self.validate_identity("ALTER TABLE t1 ADD COLUMN x INT, ALGORITHM=INPLACE, LOCK=EXCLUSIVE")
         self.validate_identity("ALTER TABLE t ADD INDEX `i` (`c`)")
         self.validate_identity("ALTER TABLE t ADD UNIQUE `i` (`c`)")
@@ -1679,4 +1681,17 @@ COMMENT='客户账户表'"""
                 "oracle": "SELECT LEAD(col1, 1) RESPECT NULLS OVER (ORDER BY col2 NULLS FIRST) FROM table1",
                 "snowflake": "SELECT LEAD(col1, 1) RESPECT NULLS OVER (ORDER BY col2 NULLS FIRST) FROM table1",
             },
+        )
+
+    def test_invisible_column(self):
+        expr = self.parse_one("CREATE TABLE t (c INT INVISIBLE)")
+        self.assertIsInstance(
+            expr.find(exp.InvisibleColumnConstraint),
+            exp.InvisibleColumnConstraint,
+        )
+
+        expr = self.parse_one("ALTER TABLE t ADD COLUMN c INT INVISIBLE")
+        self.assertIsInstance(
+            expr.find(exp.InvisibleColumnConstraint),
+            exp.InvisibleColumnConstraint,
         )


### PR DESCRIPTION
MySQL 8.0.23 introduced invisible columns, declared with the `INVISIBLE` keyword in column definitions. Until now, sqlglot could parse `ALTER TABLE ... ALTER COLUMN ... SET INVISIBLE` (PR #4809) and `ALTER TABLE ... ALTER INDEX ... INVISIBLE` (PR #4800), but the keyword was not recognized in column definitions. This meant `CREATE TABLE t (c INT INVISIBLE)` and `ALTER TABLE t ADD COLUMN c INT INVISIBLE` both failed to parse.

This commit adds `InvisibleColumnConstraint`, following the same pattern as `AutoIncrementColumnConstraint` and `ZeroFillColumnConstraint`. The constraint is MySQL-specific and is registered in the MySQL dialect's `CONSTRAINT_PARSERS`. The generator emits the bare `INVISIBLE` keyword via an inline lambda in `TRANSFORMS`.

Note that `SHOW CREATE TABLE` emits invisible columns using MySQL's version-comment syntax (`/*!80023 INVISIBLE */`), which the tokenizer treats as a comment. This commit does not address that; it only supports the bare keyword in input DDL.