### PR TITLE
Feat(mysql): support `ALTER TABLE ... RENAME INDEX`.

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -279,6 +279,10 @@ class AlterRename(Expression):
     pass
 
 
+class RenameIndex(Expression):
+    arg_types = {"this": True, "to": True}
+
+
 class AlterModifySqlSecurity(Expression):
     arg_types = {"expressions": True}
 

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -710,6 +710,11 @@ class MySQLGenerator(generator.Generator):
         """
         return super().alterrename_sql(expression, include_to=False)
 
+    def renameindex_sql(self, expression: exp.RenameIndex) -> str:
+        this = self.sql(expression, "this")
+        to = self.sql(expression, "to")
+        return f"RENAME INDEX {this} TO {to}"
+
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         dtype = self.sql(expression, "dtype")
         if not dtype:

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -300,6 +300,14 @@ class MySQLParser(parser.Parser):
     VALUES_FOLLOWED_BY_PAREN = False
     SUPPORTS_PARTITION_SELECTION = True
 
+    def _parse_alter_table_rename(self):
+        if self._match_texts(("INDEX", "KEY")):
+            old = self._parse_field(any_token=True)
+            self._match_text_seq("TO")
+            new = self._parse_field(any_token=True)
+            return self.expression(exp.RenameIndex(this=old, to=new))
+        return super()._parse_alter_table_rename()
+
     def _parse_generated_as_identity(
         self,
     ) -> (

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -194,6 +194,11 @@ class TestMySQL(Validator):
         self.validate_identity("ALTER TABLE t ALTER INDEX i VISIBLE")
         self.validate_identity("ALTER TABLE t ALTER COLUMN c SET INVISIBLE")
         self.validate_identity("ALTER TABLE t ALTER COLUMN c SET VISIBLE")
+        self.validate_identity("ALTER TABLE t RENAME INDEX a TO b")
+        self.validate_identity(
+            "ALTER TABLE t RENAME KEY a TO b",
+            "ALTER TABLE t RENAME INDEX a TO b",
+        )
         self.validate_identity(
             "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a WHERE foo.id = bar.id"
         )
@@ -1680,3 +1685,10 @@ COMMENT='客户账户表'"""
                 "snowflake": "SELECT LEAD(col1, 1) RESPECT NULLS OVER (ORDER BY col2 NULLS FIRST) FROM table1",
             },
         )
+
+    def test_rename_index(self):
+        expr = self.parse_one("ALTER TABLE t RENAME INDEX a TO b")
+        rename = expr.find(exp.RenameIndex)
+        self.assertIsInstance(rename, exp.RenameIndex)
+        self.assertEqual(rename.this.name, "a")
+        self.assertEqual(rename.args["to"].name, "b")

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1686,9 +1686,3 @@ COMMENT='客户账户表'"""
             },
         )
 
-    def test_rename_index(self):
-        expr = self.parse_one("ALTER TABLE t RENAME INDEX a TO b")
-        rename = expr.find(exp.RenameIndex)
-        self.assertIsInstance(rename, exp.RenameIndex)
-        self.assertEqual(rename.this.name, "a")
-        self.assertEqual(rename.args["to"].name, "b")


### PR DESCRIPTION
MySQL 5.7 introduced `ALTER TABLE ... RENAME INDEX old TO new` (and the `RENAME KEY` synonym) as a metadata-only operation that renames an index without rebuilding it.