### PR TITLE
feat(doris, starrocks): support two-argument DATE_ADD/DATE_SUB

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1598,6 +1598,7 @@ def build_date_delta(
 
 def build_date_delta_with_interval(
     expression_class: Type[E],
+    default_unit: str | None = None,
 ) -> t.Callable[[BuilderArgs], E | None]:
     def _builder(args: BuilderArgs) -> E | None:
         if len(args) < 2:
@@ -1606,7 +1607,13 @@ def build_date_delta_with_interval(
         interval = args[1]
 
         if not isinstance(interval, exp.Interval):
-            raise ParseError(f"INTERVAL expression expected but got '{interval}'")
+            if default_unit is None:
+                raise ParseError(f"INTERVAL expression expected but got '{interval}'")
+            return expression_class(
+                this=args[0],
+                expression=interval,
+                unit=exp.Literal.string(default_unit),
+            )
 
         return expression_class(this=args[0], expression=interval.this, unit=unit_to_str(interval))
 

--- a/sqlglot/parsers/doris.py
+++ b/sqlglot/parsers/doris.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 
 from sqlglot import exp
+from sqlglot.dialects.dialect import build_date_delta_with_interval
 from sqlglot.helper import seq_get
 from sqlglot.parsers.mysql import MySQLParser
 from sqlglot.tokens import TokenType
@@ -26,11 +27,15 @@ def _build_date_trunc(args: list[exp.Expr]) -> exp.Expr:
 class DorisParser(MySQLParser):
     FUNCTIONS = {
         **MySQLParser.FUNCTIONS,
+        "ADDDATE": build_date_delta_with_interval(exp.DateAdd, default_unit="DAY"),
         "COLLECT_SET": exp.ArrayUniqueAgg.from_arg_list,
+        "DATE_ADD": build_date_delta_with_interval(exp.DateAdd, default_unit="DAY"),
+        "DATE_SUB": build_date_delta_with_interval(exp.DateSub, default_unit="DAY"),
         "DATE_TRUNC": _build_date_trunc,
         "L2_DISTANCE": exp.EuclideanDistance.from_arg_list,
         "MONTHS_ADD": exp.AddMonths.from_arg_list,
         "REGEXP": exp.RegexpLike.from_arg_list,
+        "SUBDATE": build_date_delta_with_interval(exp.DateSub, default_unit="DAY"),
         "TO_DATE": exp.TsOrDsToDate.from_arg_list,
     }
 

--- a/sqlglot/parsers/starrocks.py
+++ b/sqlglot/parsers/starrocks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 
 from sqlglot import exp
-from sqlglot.dialects.dialect import build_timestamp_trunc
+from sqlglot.dialects.dialect import build_date_delta_with_interval, build_timestamp_trunc
 from sqlglot.helper import seq_get
 from sqlglot.parsers.mysql import MySQLParser
 
@@ -10,6 +10,10 @@ from sqlglot.parsers.mysql import MySQLParser
 class StarRocksParser(MySQLParser):
     FUNCTIONS = {
         **MySQLParser.FUNCTIONS,
+        "ADDDATE": build_date_delta_with_interval(exp.DateAdd, default_unit="DAY"),
+        "DATE_ADD": build_date_delta_with_interval(exp.DateAdd, default_unit="DAY"),
+        "DATE_SUB": build_date_delta_with_interval(exp.DateSub, default_unit="DAY"),
+        "SUBDATE": build_date_delta_with_interval(exp.DateSub, default_unit="DAY"),
         "DATE_TRUNC": build_timestamp_trunc,
         "DATEDIFF": lambda args: exp.DateDiff(
             this=seq_get(args, 0), expression=seq_get(args, 1), unit=exp.Literal.string("DAY")

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -105,6 +105,31 @@ class TestDoris(Validator):
         self.validate_identity("DATE_TRUNC('2010-12-02 19:28:30', 'HOUR')")
         self.validate_identity("CURRENT_DATE()")
 
+    def test_date_add_sub(self):
+        # Standard INTERVAL form
+        self.validate_identity("SELECT DATE_ADD(x, INTERVAL '3' DAY)")
+        self.validate_identity("SELECT DATE_SUB(x, INTERVAL '3' MONTH)")
+
+        # Two-argument shorthand - default unit DAY
+        self.validate_all(
+            "SELECT DATE_SUB(x, 3)",
+            write={"doris": "SELECT DATE_SUB(x, INTERVAL 3 DAY)"},
+        )
+        self.validate_all(
+            "SELECT DATE_ADD(x, 7)",
+            write={"doris": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
+        )
+
+        # ADDDATE / SUBDATE aliases
+        self.validate_all(
+            "SELECT ADDDATE(x, 7)",
+            write={"doris": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
+        )
+        self.validate_all(
+            "SELECT SUBDATE(x, 7)",
+            write={"doris": "SELECT DATE_SUB(x, INTERVAL 7 DAY)"},
+        )
+
     def test_regex(self):
         self.validate_all(
             "SELECT REGEXP_LIKE(abc, '%foo%')",

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -111,24 +111,12 @@ class TestDoris(Validator):
         self.validate_identity("SELECT DATE_SUB(x, INTERVAL '3' MONTH)")
 
         # Two-argument shorthand - default unit DAY
-        self.validate_all(
-            "SELECT DATE_SUB(x, 3)",
-            write={"doris": "SELECT DATE_SUB(x, INTERVAL 3 DAY)"},
-        )
-        self.validate_all(
-            "SELECT DATE_ADD(x, 7)",
-            write={"doris": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
-        )
+        self.validate_identity("SELECT DATE_SUB(x, 3)", "SELECT DATE_SUB(x, INTERVAL 3 DAY)")
+        self.validate_identity("SELECT DATE_ADD(x, 7)", "SELECT DATE_ADD(x, INTERVAL 7 DAY)")
 
         # ADDDATE / SUBDATE aliases
-        self.validate_all(
-            "SELECT ADDDATE(x, 7)",
-            write={"doris": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
-        )
-        self.validate_all(
-            "SELECT SUBDATE(x, 7)",
-            write={"doris": "SELECT DATE_SUB(x, INTERVAL 7 DAY)"},
-        )
+        self.validate_identity("SELECT ADDDATE(x, 7)", "SELECT DATE_ADD(x, INTERVAL 7 DAY)")
+        self.validate_identity("SELECT SUBDATE(x, 7)", "SELECT DATE_SUB(x, INTERVAL 7 DAY)")
 
     def test_regex(self):
         self.validate_all(

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -142,6 +142,31 @@ class TestStarrocks(Validator):
             "SELECT DATE_DIFF('MINUTE', '2010-11-30 23:59:59', '2010-11-30 20:58:59')"
         )
 
+    def test_date_add_sub(self):
+        # Standard INTERVAL form
+        self.validate_identity("SELECT DATE_ADD(x, INTERVAL '3' DAY)")
+        self.validate_identity("SELECT DATE_SUB(x, INTERVAL '3' MONTH)")
+
+        # Two-argument shorthand - default unit DAY
+        self.validate_all(
+            "SELECT DATE_SUB(x, 3)",
+            write={"starrocks": "SELECT DATE_SUB(x, INTERVAL 3 DAY)"},
+        )
+        self.validate_all(
+            "SELECT DATE_ADD(x, 7)",
+            write={"starrocks": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
+        )
+
+        # ADDDATE / SUBDATE aliases
+        self.validate_all(
+            "SELECT ADDDATE(x, 7)",
+            write={"starrocks": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
+        )
+        self.validate_all(
+            "SELECT SUBDATE(x, 7)",
+            write={"starrocks": "SELECT DATE_SUB(x, INTERVAL 7 DAY)"},
+        )
+
     def test_regex(self):
         self.validate_all(
             "SELECT REGEXP(abc, '%foo%')",

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -148,24 +148,12 @@ class TestStarrocks(Validator):
         self.validate_identity("SELECT DATE_SUB(x, INTERVAL '3' MONTH)")
 
         # Two-argument shorthand - default unit DAY
-        self.validate_all(
-            "SELECT DATE_SUB(x, 3)",
-            write={"starrocks": "SELECT DATE_SUB(x, INTERVAL 3 DAY)"},
-        )
-        self.validate_all(
-            "SELECT DATE_ADD(x, 7)",
-            write={"starrocks": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
-        )
+        self.validate_identity("SELECT DATE_SUB(x, 3)", "SELECT DATE_SUB(x, INTERVAL 3 DAY)")
+        self.validate_identity("SELECT DATE_ADD(x, 7)", "SELECT DATE_ADD(x, INTERVAL 7 DAY)")
 
         # ADDDATE / SUBDATE aliases
-        self.validate_all(
-            "SELECT ADDDATE(x, 7)",
-            write={"starrocks": "SELECT DATE_ADD(x, INTERVAL 7 DAY)"},
-        )
-        self.validate_all(
-            "SELECT SUBDATE(x, 7)",
-            write={"starrocks": "SELECT DATE_SUB(x, INTERVAL 7 DAY)"},
-        )
+        self.validate_identity("SELECT ADDDATE(x, 7)", "SELECT DATE_ADD(x, INTERVAL 7 DAY)")
+        self.validate_identity("SELECT SUBDATE(x, 7)", "SELECT DATE_SUB(x, INTERVAL 7 DAY)")
 
     def test_regex(self):
         self.validate_all(


### PR DESCRIPTION
## Problem

Doris and StarRocks natively support the two-argument form of `DATE_ADD` / `DATE_SUB`:

```sql
SELECT DATE_SUB(current_date(), 3);  -- equivalent to INTERVAL 3 DAY
```

Both dialects inherit from MySQL, which binds these functions to build_date_delta_with_interval (strict INTERVAL-only). As a result, parsing the shorthand form raised ParseError: INTERVAL expression expected but got 'N'.

Fixes #6341.

## Change

1. build_date_delta_with_interval gains an optional default_unit: str | None = None parameter. When set and args[1] is not an Interval, the builder falls back to expression_class(this=args[0], expression=<bare literal>, unit=Literal.string(default_unit)). Default is None, preserving the strict behavior for MySQL, BigQuery and every other existing caller.
2. DorisParser and StarRocksParser override DATE_ADD / DATE_SUB / ADDDATE / SUBDATE with default_unit="DAY".
3. The resulting AST shape is identical to the one produced from the explicit INTERVAL form, so the MySQL generator's date_add_sql helper (which wraps expression.expression in Interval) emits DATE_ADD(date, INTERVAL N DAY) without any generator changes.

## Tests

New test_date_add_sub in tests/dialects/test_doris.py and tests/dialects/test_starrocks.py covers:
- validate_identity on INTERVAL '3' DAY / INTERVAL '3' MONTH — no regression on standard form or non-DAY units
- validate_all on DATE_SUB(x, 3) / DATE_ADD(x, 7) round-tripping to INTERVAL N DAY
- ADDDATE / SUBDATE aliasing to DATE_ADD / DATE_SUB

MySQL and BigQuery suites remain green — their callers pass no default_unit, so strict behavior is preserved.
