### PR TITLE
fix(mysql): parse quoted constraint names.

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7257,7 +7257,11 @@ class Parser:
         return result
 
     def _parse_unique_key(self) -> exp.Expr | None:
-        if self._curr and self._curr.text.upper() in self.CONSTRAINT_PARSERS:
+        if (
+            self._curr
+            and self._curr.token_type != TokenType.IDENTIFIER
+            and self._curr.text.upper() in self.CONSTRAINT_PARSERS
+        ):
             return None
         return self._parse_id_var(any_token=False)
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -142,6 +142,18 @@ class TestMySQL(Validator):
             "CREATE TABLE IF NOT EXISTS industry_info (a BIGINT(20) NOT NULL AUTO_INCREMENT, b BIGINT(20) NOT NULL, c VARCHAR(1000), PRIMARY KEY (a), UNIQUE d (b), INDEX e (b))",
         )
         self.validate_identity(
+            "CREATE TABLE t (a INT, b INT, UNIQUE KEY `Unique` (a, b))",
+            "CREATE TABLE t (a INT, b INT, UNIQUE `Unique` (a, b))",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INT, UNIQUE KEY `Index` (a))",
+            "CREATE TABLE t (a INT, UNIQUE `Index` (a))",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INT, UNIQUE KEY `Key` (a))",
+            "CREATE TABLE t (a INT, UNIQUE `Key` (a))",
+        )
+        self.validate_identity(
             "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMPTZ, ts_ltz TIMESTAMPLTZ)",
             "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMP, ts_ltz TIMESTAMP)",
         )


### PR DESCRIPTION
sqlglot's `_parse_unique_key` checks whether the current token matches a `CONSTRAINT_PARSERS` keyword to decide if it should stop parsing the index name. The check used `self._curr.text.upper()` without considering the token type, so backtick-quoted identifiers like `` `Unique` ``, `` `Index` ``, and `` `Key` `` were mistaken for constraint keywords and rejected.

MySQL allows any identifier as an index name when it is quoted.  The tokenizer already classifies these as `TokenType.IDENTIFIER`, so the fix adds a `token_type != TokenType.IDENTIFIER` guard to the existing check. Quoted names skip the keyword lookup entirely and fall through to `_parse_id_var` as intended.