### PR TITLE
fix(mysql): accept quoted charset in `USING`.

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7601,7 +7601,8 @@ class Parser:
         return self.expression(
             exp.Chr(
                 expressions=self._parse_csv(self._parse_assignment),
-                charset=self._match(TokenType.USING) and self._parse_var(),
+                charset=self._match(TokenType.USING)
+                and self._parse_var(tokens={TokenType.IDENTIFIER}),
             )
         )
 
@@ -7722,7 +7723,9 @@ class Parser:
 
         if self._match(TokenType.USING):
             to: exp.Expr | None = exp.DType.CHARACTER_SET.into_expr(
-                kind=self._parse_var(tokens={TokenType.BINARY})
+                kind=self._parse_var(
+                    tokens={TokenType.BINARY, TokenType.IDENTIFIER},
+                )
             )
         elif self._match(TokenType.COMMA):
             to = self._parse_types()

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7602,7 +7602,9 @@ class Parser:
             exp.Chr(
                 expressions=self._parse_csv(self._parse_assignment),
                 charset=self._match(TokenType.USING)
-                and self._parse_var(tokens={TokenType.IDENTIFIER}),
+                and self._parse_var(
+                    tokens={TokenType.BINARY, TokenType.IDENTIFIER},
+                ),
             )
         )
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7611,6 +7611,8 @@ class Parser:
         Dialects that need to preserve quoting for
         specific name shapes override this.
         """
+        Parse a charset name after USING or CHARACTER SET. Dialects that need to preserve quoting
+        for specific name shapes override this.
         return self._parse_var(
             tokens={TokenType.BINARY, TokenType.IDENTIFIER},
         )

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7601,11 +7601,18 @@ class Parser:
         return self.expression(
             exp.Chr(
                 expressions=self._parse_csv(self._parse_assignment),
-                charset=self._match(TokenType.USING)
-                and self._parse_var(
-                    tokens={TokenType.BINARY, TokenType.IDENTIFIER},
-                ),
+                charset=self._match(TokenType.USING) and self._parse_charset_name(),
             )
+        )
+
+    def _parse_charset_name(self) -> exp.Expr | None:
+        """Parse a charset name after USING or CHARACTER SET.
+
+        Dialects that need to preserve quoting for
+        specific name shapes override this.
+        """
+        return self._parse_var(
+            tokens={TokenType.BINARY, TokenType.IDENTIFIER},
         )
 
     def _parse_cast(self, strict: bool, safe: bool | None = None) -> exp.Expr:
@@ -7724,11 +7731,7 @@ class Parser:
         this = self._parse_bitwise()
 
         if self._match(TokenType.USING):
-            to: exp.Expr | None = exp.DType.CHARACTER_SET.into_expr(
-                kind=self._parse_var(
-                    tokens={TokenType.BINARY, TokenType.IDENTIFIER},
-                )
-            )
+            to: exp.Expr | None = exp.DType.CHARACTER_SET.into_expr(kind=self._parse_charset_name())
         elif self._match(TokenType.COMMA):
             to = self._parse_types()
         else:

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import typing as t
 
 from sqlglot import exp, parser
@@ -18,6 +19,13 @@ from sqlglot.tokens import TokenType
 # All specifiers for time parts (as opposed to date parts)
 # https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format
 TIME_SPECIFIERS = {"f", "H", "h", "I", "i", "k", "l", "p", "r", "S", "s", "T"}
+
+# Character class for MySQL 8.0 unquoted identifiers.
+# https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
+# Use to decide whether a quoted name can safely be
+# emitted unquoted (e.g. normalizing `utf8mb4` → utf8mb4
+# while preserving quotes around names like `my charset`).
+UNQUOTED_IDENTIFIER = re.compile(r"[A-Za-z0-9_$]+")
 
 
 def _has_time_specifier(date_format: str) -> bool:
@@ -485,6 +493,21 @@ class MySQLParser(parser.Parser):
     def _parse_set_item_charset(self, kind: str) -> exp.Expr:
         this = self._parse_string() or self._parse_unquoted_field()
         return self.expression(exp.SetItem(this=this, kind=kind))
+
+    def _parse_charset_name(self) -> exp.Expr | None:
+        """Preserve quoting when a charset name has
+        characters that require it (e.g. spaces, as
+        allowed for custom XML-registered charsets).
+        Safe names unwrap to a bare Var so roundtrips
+        remain minimal.
+        """
+        identifier = self._parse_identifier()
+        if identifier:
+            name = identifier.name
+            if name and UNQUOTED_IDENTIFIER.fullmatch(name):
+                return exp.Var(this=name)
+            return identifier
+        return self._parse_var(tokens={TokenType.BINARY})
 
     def _parse_set_item_names(self) -> exp.Expr:
         charset = self._parse_string() or self._parse_unquoted_field()

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -487,18 +487,13 @@ class MySQLParser(parser.Parser):
         return self.expression(exp.SetItem(this=this, kind=kind))
 
     def _parse_charset_name(self) -> exp.Expr | None:
-        """Preserve quoting when a charset name has
-        characters that require it (e.g. spaces, as
-        allowed for custom XML-registered charsets).
-        Safe names unwrap to a bare Var so roundtrips
-        remain minimal.
+        """
+        Preserve quoting when a charset name has characters that require it (e.g. spaces, as allowed
+        for custom XML-registered charsets). Safe names unwrap to a bare Var so roundtrips remain minimal.
         """
         identifier = self._parse_identifier()
         if identifier:
-            name = identifier.name
-            if name and exp.SAFE_IDENTIFIER_RE.match(name):
-                return exp.Var(this=name)
-            return identifier
+            return exp.Var(this=name) if exp.SAFE_IDENTIFIER_RE.match(name := identifier.name) else identifier
         return self._parse_var(tokens={TokenType.BINARY})
 
     def _parse_set_item_names(self) -> exp.Expr:

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import typing as t
 
 from sqlglot import exp, parser
@@ -19,13 +18,6 @@ from sqlglot.tokens import TokenType
 # All specifiers for time parts (as opposed to date parts)
 # https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_date-format
 TIME_SPECIFIERS = {"f", "H", "h", "I", "i", "k", "l", "p", "r", "S", "s", "T"}
-
-# Character class for MySQL 8.0 unquoted identifiers.
-# https://dev.mysql.com/doc/refman/8.0/en/identifiers.html
-# Use to decide whether a quoted name can safely be
-# emitted unquoted (e.g. normalizing `utf8mb4` → utf8mb4
-# while preserving quotes around names like `my charset`).
-UNQUOTED_IDENTIFIER = re.compile(r"[A-Za-z0-9_$]+")
 
 
 def _has_time_specifier(date_format: str) -> bool:
@@ -504,7 +496,7 @@ class MySQLParser(parser.Parser):
         identifier = self._parse_identifier()
         if identifier:
             name = identifier.name
-            if name and UNQUOTED_IDENTIFIER.fullmatch(name):
+            if name and exp.SAFE_IDENTIFIER_RE.match(name):
                 return exp.Var(this=name)
             return identifier
         return self._parse_var(tokens={TokenType.BINARY})

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -651,6 +651,13 @@ class TestMySQL(Validator):
             "SELECT CONVERT(x USING `binary`)",
             "SELECT CAST(x AS CHAR CHARACTER SET binary)",
         )
+        self.validate_identity(
+            "SELECT CONVERT(x USING `my charset`)",
+            "SELECT CAST(x AS CHAR CHARACTER SET `my charset`)",
+        )
+        self.validate_identity(
+            "SELECT CHAR(65 USING `my charset`)",
+        )
 
     def test_match_against(self):
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -642,6 +642,15 @@ class TestMySQL(Validator):
             "SELECT CHAR(0xC3A9 USING `utf8mb4`)",
             "SELECT CHAR(x'C3A9' USING utf8mb4)",
         )
+        self.validate_identity("SELECT CHAR(65 USING BINARY)")
+        self.validate_identity(
+            "SELECT CHAR(65 USING `binary`)",
+            "SELECT CHAR(65 USING binary)",
+        )
+        self.validate_identity(
+            "SELECT CONVERT(x USING `binary`)",
+            "SELECT CAST(x AS CHAR CHARACTER SET binary)",
+        )
 
     def test_match_against(self):
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -634,6 +634,14 @@ class TestMySQL(Validator):
         self.validate_identity(
             "CONVERT('a' USING binary)", "CAST('a' AS CHAR CHARACTER SET binary)"
         )
+        self.validate_identity(
+            "SELECT CONVERT(`col` USING `utf8mb4`)",
+            "SELECT CAST(`col` AS CHAR CHARACTER SET utf8mb4)",
+        )
+        self.validate_identity(
+            "SELECT CHAR(0xC3A9 USING `utf8mb4`)",
+            "SELECT CHAR(x'C3A9' USING utf8mb4)",
+        )
 
     def test_match_against(self):
         self.validate_all(


### PR DESCRIPTION
MySQL allows backtick-quoted charset names in both ```CONVERT(... USING `utf8mb4`)``` and ```CHAR(... USING `utf8mb4`)```. Both called `_parse_var`, which only matches unquoted tokens. Adding `TokenType.IDENTIFIER` to the token set accepts quoted charsets without changing behavior for unquoted ones.