### PR TITLE
Chore: avoid git submodule errors when publishing API docs

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -135,6 +135,9 @@ jobs:
           git checkout -B api-docs origin/main
           rm -rf docs
           mv /tmp/generated-docs docs
+          git rm -f .gitmodules
+          git rm -f --cached sqlglot-integration-tests
+          rm -rf sqlglot-integration-tests
       - name: Commit API docs
         uses: stefanzweifel/git-auto-commit-action@v4
         with:


### PR DESCRIPTION
The git submodule appears to cause some issues when publishing the API docs page: https://github.com/tobymao/sqlglot/actions/runs/24682456936/job/72182993316. This PR tries to fix that issue.
