### PR TITLE
Fix: correctly handle follow-tokens for unit-less intervals

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5835,7 +5835,11 @@ class Parser:
             else (
                 self._parse_function()
                 or (
-                    not self._match_set((TokenType.ALIAS, TokenType.DCOLON), advance=False)
+                    self._curr is not None
+                    and (
+                        self._curr.token_type == TokenType.VAR
+                        or self._curr.text.upper() in self.dialect.VALID_INTERVAL_UNITS
+                    )
                     and self._parse_var(any_token=True, upper=True)
                 )
             )

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -91,6 +91,16 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT INTERVAL '2.5 MONTH'")
         self.validate_identity("SELECT INTERVAL '-10.75 MINUTE'")
         self.validate_identity("SELECT INTERVAL '0.123456789 SECOND'")
+        self.validate_identity("SELECT date_col - INTERVAL '30' FROM t")
+        self.validate_identity("SELECT date_col - INTERVAL '1' AS one_second_later")
+        self.validate_identity(
+            "SELECT date_col - INTERVAL '30' DAY FROM t",
+            "SELECT date_col - INTERVAL '30 DAY' FROM t",
+        )
+        self.validate_identity(
+            "SELECT date_col - INTERVAL '1' HOUR AS one_hour_later",
+            "SELECT date_col - INTERVAL '1 HOUR' AS one_hour_later",
+        )
         self.validate_identity(
             "SELECT SUM(x) OVER (PARTITION BY y ORDER BY interval ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) - SUM(x) OVER (PARTITION BY y ORDER BY interval ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS total"
         )

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -344,6 +344,16 @@ class TestRedshift(Validator):
         self.validate_identity("SELECT DATEADD(DAY, 1, 'today')")
         self.validate_identity("SELECT * FROM #x")
         self.validate_identity("SELECT INTERVAL '5 DAY'")
+        self.validate_identity("SELECT date_col - INTERVAL '30' FROM t")
+        self.validate_identity("SELECT date_col - INTERVAL '1' AS one_second_later")
+        self.validate_identity(
+            "SELECT date_col - INTERVAL '30' DAY FROM t",
+            "SELECT date_col - INTERVAL '30 DAY' FROM t",
+        )
+        self.validate_identity(
+            "SELECT date_col - INTERVAL '1' HOUR AS one_hour_later",
+            "SELECT date_col - INTERVAL '1 HOUR' AS one_hour_later",
+        )
         self.validate_identity("foo$")
         self.validate_identity("CAST('bla' AS SUPER)")
         self.validate_identity("CREATE TABLE real1 (realcol REAL)")


### PR DESCRIPTION
Fixes the handling of the unit-less `INTERVAL '30'` format, which is supported by both Postgres and Redshift and where the units default to seconds.

Previously, this was consuming the following token (e.g. `FROM` in the test example) and failing.