### PR TITLE
feat(mysql)!: support `DROP PRIMARY KEY`.

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -354,6 +354,10 @@ class Drop(Expression):
         return kind and kind.upper()
 
 
+class DropPrimaryKey(Expression):
+    arg_types = {}
+
+
 class Command(Expression):
     arg_types = {"this": True, "expression": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4041,6 +4041,9 @@ class Generator:
         exists = " IF EXISTS " if expression.args.get("exists") else " "
         return f"DROP{exists}{expressions}"
 
+    def dropprimarykey_sql(self, expression: exp.DropPrimaryKey) -> str:
+        return "DROP PRIMARY KEY"
+
     def addconstraint_sql(self, expression: exp.AddConstraint) -> str:
         return f"ADD {self.expressions(expression, indent=False)}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8503,6 +8503,14 @@ class Parser:
             drop.set("kind", drop.args.get("kind", "COLUMN"))
         return drop
 
+    def _parse_drop_primary_key(self) -> exp.DropPrimaryKey:
+        return self.expression(exp.DropPrimaryKey())
+
+    def _parse_alter_drop_action(self) -> exp.Expr | None:
+        if self._match_pair(TokenType.DROP, TokenType.PRIMARY_KEY):
+            return self._parse_drop_primary_key()
+        return self._parse_drop_column()
+
     # https://docs.aws.amazon.com/athena/latest/ug/alter-table-drop-partition.html
     def _parse_drop_partition(self, exists: bool | None = None) -> exp.DropPartition:
         return self.expression(
@@ -8613,7 +8621,7 @@ class Parser:
             return self._parse_csv(lambda: self._parse_drop_partition(exists=partition_exists))
 
         self._retreat(index)
-        return self._parse_csv(self._parse_drop_column)
+        return self._parse_csv(self._parse_alter_drop_action)
 
     def _parse_alter_table_rename(self) -> exp.AlterRename | exp.RenameColumn | None:
         if self._match(TokenType.COLUMN) or not self.ALTER_RENAME_REQUIRES_COLUMN:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8503,12 +8503,7 @@ class Parser:
             drop.set("kind", drop.args.get("kind", "COLUMN"))
         return drop
 
-    def _parse_drop_primary_key(self) -> exp.DropPrimaryKey:
-        return self.expression(exp.DropPrimaryKey())
-
     def _parse_alter_drop_action(self) -> exp.Expr | None:
-        if self._match_pair(TokenType.DROP, TokenType.PRIMARY_KEY):
-            return self._parse_drop_primary_key()
         return self._parse_drop_column()
 
     # https://docs.aws.amazon.com/athena/latest/ug/alter-table-drop-partition.html

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -310,6 +310,11 @@ class MySQLParser(parser.Parser):
             return self.expression(exp.RenameIndex(this=old, to=new))
         return super()._parse_alter_table_rename()
 
+    def _parse_alter_drop_action(self) -> exp.Expr | None:
+        if self._match_pair(TokenType.DROP, TokenType.PRIMARY_KEY):
+            return self.expression(exp.DropPrimaryKey())
+        return super()._parse_alter_drop_action()
+
     def _parse_generated_as_identity(
         self,
     ) -> (

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -202,6 +202,10 @@ class TestBigQuery(Validator):
         self.validate_identity("BEGIN DECLARE y INT64", check_command_warning=True)
         self.validate_identity("LOOP SET x = x + 1", check_command_warning=True)
         self.validate_identity("REPEAT SET x = x + 1", check_command_warning=True)
+        self.validate_identity(
+            "ALTER TABLE foo DROP PRIMARY KEY IF EXISTS",
+            check_command_warning=True,
+        )
         self.validate_identity("SELECT MAKE_INTERVAL(100, 11, 1, 12, 30, 10)")
         self.validate_identity(
             "WHILE i < ARRAY_LENGTH(batches) DO SET x = batches[OFFSET(i)]",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -35,6 +35,8 @@ class TestMySQL(Validator):
         self.validate_identity("ALTER TABLE t1 ADD COLUMN x INT, ALGORITHM=INPLACE, LOCK=EXCLUSIVE")
         self.validate_identity("ALTER TABLE t ADD INDEX `i` (`c`)")
         self.validate_identity("ALTER TABLE t ADD UNIQUE `i` (`c`)")
+        self.validate_identity("ALTER TABLE t DROP PRIMARY KEY")
+        self.validate_identity("ALTER TABLE t DROP COLUMN c, DROP PRIMARY KEY, DROP INDEX `i`")
         self.validate_identity("ALTER TABLE test_table MODIFY COLUMN test_column LONGTEXT")
         self.validate_identity("ALTER TABLE t AUTO_INCREMENT=3000000000")
         self.validate_identity("ALTER VIEW v AS SELECT a, b, c, d FROM foo")

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -937,7 +937,6 @@ ORDER BY
             "ALTER ROLE CURRENT_USER WITH REPLICATION",
             "ALTER RULE foo ON bla RENAME TO baz",
             "ALTER SEQUENCE IF EXISTS baz RESTART WITH boo",
-            "ALTER TABLE integers DROP PRIMARY KEY",
             "ALTER TABLE table1 MODIFY COLUMN name1 SET TAG foo='bar'",
             "ALTER TABLE table1 RENAME COLUMN c1 AS c2",
             "ALTER TABLE table1 RENAME COLUMN c1 TO c2, c2 TO c3",

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -937,6 +937,7 @@ ORDER BY
             "ALTER ROLE CURRENT_USER WITH REPLICATION",
             "ALTER RULE foo ON bla RENAME TO baz",
             "ALTER SEQUENCE IF EXISTS baz RESTART WITH boo",
+            "ALTER TABLE integers DROP PRIMARY KEY",
             "ALTER TABLE table1 MODIFY COLUMN name1 SET TAG foo='bar'",
             "ALTER TABLE table1 RENAME COLUMN c1 AS c2",
             "ALTER TABLE table1 RENAME COLUMN c1 TO c2, c2 TO c3",


### PR DESCRIPTION
This commit adds support for `ALTER TABLE t DROP PRIMARY KEY` for MySQL. I followed the general pattern of `DropPartition`, as it looked most extensible to other database vendors (eg. BigQuery, Oracle, Snowflake, Databricks) based on a sampling of syntax.