### PR TITLE
fix(optimizer): prevent merge_subqueries from incorrectly merging window expressions when column table prefix is missing

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -149,7 +149,8 @@ def _mergeable(
             )
         ]
         return any(
-            column.table == inner_select_name and column.name in window_aliases
+            (not column.table or column.table == inner_select_name)
+            and column.name in window_aliases
             for column in unmergable_window_columns
         )
 

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -349,6 +349,23 @@ WHERE
   t2.row_num = 2;
 WITH t1 AS (SELECT ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x AS x) SELECT t2.row_num AS row_num FROM t1 AS t2 WHERE t2.row_num = 2;
 
+# title: Test preventing merge of window expressions where clause without table prefix
+# execute: false
+SELECT
+  a,
+  b
+FROM (
+  SELECT
+    x.a,
+    x.b,
+    ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) as row_num
+  FROM
+    x
+) AS t1
+WHERE
+  row_num = 1;
+SELECT t1.a AS a, t1.b AS b FROM (SELECT x.a AS a, x.b AS b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x AS x) AS t1 WHERE t1.row_num = 1;
+
 # title: Values Test
 # dialect: spark
 WITH t1 AS (


### PR DESCRIPTION
## Description

Fixes a bug where `merge_subqueries` incorrectly merges derived tables containing window expressions when the outer query references the window result without an explicit table prefix (e.g., `rk` instead of `t2.rk`).

Closes #7531

## Changes

- Modified `_is_a_window_expression_in_unmergable_operation()` in `sqlglot/optimizer/merge_subqueries.py` to also check for unqualified column references that match window expression aliases.
- Added a test case to `tests/fixtures/optimizer/merge_subqueries.sql` covering this scenario.

## Before

```sql
-- Input
SELECT a, b FROM (
    SELECT x.a, x.b, ROW_NUMBER() OVER (...) AS row_num FROM x
) AS t1 WHERE row_num = 1

-- Incorrectly merged into (window function lost!)
SELECT a, b FROM x WHERE row_num = 1
```

## After

```sql
-- Input
SELECT a, b FROM (
    SELECT x.a, x.b, ROW_NUMBER() OVER (...) AS row_num FROM x
) AS t1 WHERE row_num = 1

-- Correctly preserved
SELECT t1.a, t1.b FROM (
    SELECT x.a, x.b, ROW_NUMBER() OVER (...) AS row_num FROM x
) AS t1 WHERE t1.row_num = 1
```

## Testing

- Added new test case: "Test preventing merge of window expressions where clause without table prefix"
- Verified existing test suite passes (61/66, 5 pre-existing failures unrelated to this change)
