### PR TITLE
fix(optimizer): robust scope for UDTF

### DIFF
--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -186,7 +186,10 @@ class Scope:
                 self._tables.append(node)
             elif isinstance(node, exp.JoinHint):
                 self._join_hints.append(node)
-            elif isinstance(node, exp.UDTF):
+            elif isinstance(node, exp.Lateral) or (
+                isinstance(node, exp.UDTF)
+                and isinstance(node.parent, (exp.From, exp.Join, exp.Lateral))
+            ):
                 self._udtfs.append(node)
             elif isinstance(node, exp.CTE):
                 self._ctes.append(node)

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -186,9 +186,8 @@ class Scope:
                 self._tables.append(node)
             elif isinstance(node, exp.JoinHint):
                 self._join_hints.append(node)
-            elif isinstance(node, exp.Lateral) or (
-                isinstance(node, exp.UDTF)
-                and isinstance(node.parent, (exp.From, exp.Join, exp.Lateral))
+            elif type(node) is exp.Lateral or (
+                isinstance(node, exp.UDTF) and isinstance(node.parent, (exp.From, exp.Join))
             ):
                 self._udtfs.append(node)
             elif isinstance(node, exp.CTE):


### PR DESCRIPTION
For the cases where we have a `UDTF` and we have to avoid collecting it if it's not a source.

There are cases such as the following 

```
SELECT ... FROM ... WHERE x IN UNNEST(...)
```

where udtf doesn't work as a source.