### PR TITLE
fix(mysql): support SHOW TABLES IN <schema> parsing

### DIFF
--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -393,7 +393,13 @@ class MySQLParser(parser.Parser):
         else:
             target_id = None
 
-        log = self._parse_string() if self._match_text_seq("IN") else None
+        index = self._index
+        if self._match_text_seq("IN"):
+            log = self._parse_string()
+            if log is None:
+                self._retreat(index)
+        else:
+            log = None
 
         if this in ("BINLOG EVENTS", "RELAYLOG EVENTS"):
             position = self._parse_number() if self._match_text_seq("FROM") else None
@@ -402,7 +408,7 @@ class MySQLParser(parser.Parser):
             position = None
             db = None
 
-            if self._match(TokenType.FROM):
+            if self._match(TokenType.FROM) or self._match_text_seq("IN"):
                 db = self._parse_id_var()
             elif self._match(TokenType.DOT):
                 db = target_id

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1363,6 +1363,14 @@ COMMENT='客户账户表'"""
         self.assertIsInstance(show.args["like"], exp.Literal)
         self.assertEqual(show.text("like"), "%foo%")
 
+        show = self.validate_identity("SHOW TABLES IN test", "SHOW TABLES FROM test")
+        self.assertEqual(show.name, "TABLES")
+        self.assertEqual(show.text("db"), "test")
+
+        show = self.validate_identity("SHOW FULL TABLES IN test", "SHOW FULL TABLES FROM test")
+        self.assertTrue(show.args["full"])
+        self.assertEqual(show.text("db"), "test")
+
     def test_set_variable(self):
         cmd = self.parse_one("SET SESSION x = 1")
         item = cmd.expressions[0]


### PR DESCRIPTION
## Summary

MariaDB and MySQL both accept `SHOW TABLES IN schema` as a synonym for `SHOW TABLES FROM schema`, but the parser only handled `FROM`. This PR teaches `_parse_show_mysql` to also accept `IN` as a schema-name alias without breaking the existing log-file handling for `SHOW BINLOG EVENTS IN 'logfile'`.

### Before

```
>>> sqlglot.parse_one("SHOW TABLES IN test", dialect="mysql")
ParseError: Invalid expression / Unexpected token. Line 1, Col: 19.
```

### After

```
>>> sqlglot.parse_one("SHOW TABLES IN test", dialect="mysql").sql(dialect="mysql")
'SHOW TABLES FROM test'
```

## Why it broke

The `IN` token was being consumed unconditionally as a potential log-file specifier. When followed by an identifier (e.g. `test`) rather than a string literal, `_parse_string()` returned `None` but `IN` was already consumed — leaving the schema identifier as an unexpected token.

## Fix

Save the parser index before consuming `IN`; if no string literal follows, `_retreat(index)` so the schema-name branch can match `IN` as an alias for `FROM`. BINLOG/RELAYLOG EVENTS behavior is preserved because those variants always have a string literal following `IN`.

## Test plan

- [x] New assertions in `test_show_tables` cover `SHOW TABLES IN test` and `SHOW FULL TABLES IN test` round-trips
- [x] Pre-existing `test_show_events` (line 1175) still passes — confirms `SHOW BINLOG EVENTS IN 'log' FROM 1 LIMIT 2, 3` regression guard
- [x] Full `tests/dialects/` suite runs cleanly (no new failures vs. main)
- [x] `ruff check` + `ruff format --check` pass