### PR TITLE
feat(duckdb)!: mark DECOMPRESS_STRING as unsupported

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2282,6 +2282,10 @@ class DuckDBGenerator(generator.Generator):
         self.unsupported("PARSE_IP is not supported in DuckDB")
         return self.function_fallback_sql(expression)
 
+    def decompressstring_sql(self, expression: exp.DecompressString) -> str:
+        self.unsupported("DECOMPRESS_STRING is not supported in DuckDB")
+        return self.function_fallback_sql(expression)
+
     def jarowinklersimilarity_sql(self, expression: exp.JarowinklerSimilarity) -> str:
         this = expression.this
         expr = expression.expression


### PR DESCRIPTION
- Added `decompressstring_sql` method to DuckDB generator that calls `self.unsupported()` and returns `function_fallback_sql`
- Added integration test in `sqlglot-integration-tests` to verify `UnsupportedError` is raised