### PR TITLE
feat(snowflake)!: transpile DuckDB list() and list_distinct() [CLAUDE]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -511,6 +511,7 @@ class SnowflakeGenerator(generator.Generator):
         exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost")(
             rename_func("EDITDISTANCE")
         ),
+        exp.List: rename_func("ARRAY_AGG"),
         exp.LocationProperty: lambda self, e: f"LOCATION={self.sql(e, 'this')}",
         exp.LogicalAnd: rename_func("BOOLAND_AGG"),
         exp.LogicalOr: rename_func("BOOLOR_AGG"),
@@ -1047,6 +1048,11 @@ class SnowflakeGenerator(generator.Generator):
             expr_sql = self.sql(exp.WithinGroup(this=expr_sql, expression=order))
 
         return expr_sql
+
+    def arraydistinct_sql(self, expression: exp.ArrayDistinct) -> str:
+        if expression.args.get("check_null"):
+            return self.func("ARRAY_DISTINCT", expression.this)
+        return self.func("ARRAY_DISTINCT", exp.ArrayCompact(this=expression.this))
 
     def arraytostring_sql(self, expression: exp.ArrayToString) -> str:
         return self.func("ARRAY_TO_STRING", expression.this, expression.expression)

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -133,6 +133,7 @@ class DuckDBParser(parser.Parser):
         "JSON_ARRAY": lambda args: exp.JSONArray(expressions=args),
         "JSON_EXTRACT_PATH": parser.build_extract_json_with_path(exp.JSONExtract),
         "JSON_EXTRACT_STRING": parser.build_extract_json_with_path(exp.JSONExtractScalar),
+        "LIST_DISTINCT": exp.ArrayDistinct.from_arg_list,
         "LIST_APPEND": exp.ArrayAppend.from_arg_list,
         "LIST_CONCAT": parser.build_array_concat,
         "LIST_CONTAINS": exp.ArrayContains.from_arg_list,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -691,6 +691,20 @@ class TestDuckDB(Validator):
             read={"spark": "SELECT COLLECT_SET(sample_col) FROM sample_table"},
         )
         self.validate_all(
+            "SELECT LIST(col) FROM t",
+            write={
+                "duckdb": "SELECT LIST(col) FROM t",
+                "snowflake": "SELECT ARRAY_AGG(col) FROM t",
+            },
+        )
+        self.validate_all(
+            "SELECT LIST_DISTINCT(col)",
+            write={
+                "duckdb": "SELECT LIST_DISTINCT(col)",
+                "snowflake": "SELECT ARRAY_DISTINCT(ARRAY_COMPACT(col))",
+            },
+        )
+        self.validate_all(
             "SELECT LIST_TRANSFORM(STR_SPLIT_REGEX('abc , dfg ', ','), x -> TRIM(x))",
             write={
                 "duckdb": "SELECT LIST_TRANSFORM(STR_SPLIT_REGEX('abc , dfg ', ','), x -> TRIM(x))",

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -675,6 +675,20 @@ class TestSnowflake(Validator):
                 "duckdb": "SELECT LIST(DISTINCT col) FILTER(WHERE NOT col IS NULL) OVER (PARTITION BY grp) FROM t"
             },
         )
+        self.validate_all(
+            "SELECT ARRAY_AGG(col) FROM t",
+            write={
+                "snowflake": "SELECT ARRAY_AGG(col) FROM t",
+                "duckdb": "SELECT ARRAY_AGG(col) FILTER(WHERE col IS NOT NULL) FROM t",
+            },
+        )
+        self.validate_all(
+            "SELECT ARRAY_DISTINCT(col)",
+            write={
+                "snowflake": "SELECT ARRAY_DISTINCT(col)",
+                "duckdb": "SELECT CASE WHEN ARRAY_LENGTH(col) <> LIST_COUNT(col) THEN LIST_APPEND(LIST_DISTINCT(LIST_FILTER(col, _u -> NOT _u IS NULL)), NULL) ELSE LIST_DISTINCT(col) END",
+            },
+        )
         self.validate_identity("SELECT ARRAY_APPEND([1, 2, 3], 4)")
         self.validate_identity("SELECT ARRAY_CAT([1, 2], [3, 4])")
         self.validate_identity("SELECT ARRAY_PREPEND([2, 3, 4], 1)")


### PR DESCRIPTION
## Summary

- Map DuckDB's `list(col)` to Snowflake's `ARRAY_AGG(col)` via `rename_func` in the Snowflake generator TRANSFORMS.
- Parse DuckDB's `list_distinct(col)` into `exp.ArrayDistinct` by adding the missing `LIST_DISTINCT` entry in the DuckDB parser FUNCTIONS.
- Add `arraydistinct_sql` to the Snowflake generator to handle NULL semantics: DuckDB's `LIST_DISTINCT` strips NULLs while Snowflake's `ARRAY_DISTINCT` preserves them, so the output wraps with `ARRAY_COMPACT` when the source doesn't preserve NULLs (`check_null=False`).

## Test plan

- [x] `list(col)` transpiles DuckDB → Snowflake as `ARRAY_AGG(col)`
- [x] `list_distinct(col)` transpiles DuckDB → Snowflake as `ARRAY_DISTINCT(ARRAY_COMPACT(col))`
- [x] Snowflake `ARRAY_DISTINCT` round-trips correctly (check_null=True path)
- [x] Snowflake `ARRAY_AGG` → DuckDB preserves existing null-filter behavior
- [x] Full unit test suite passes