### PR TITLE
Refactor!: map duckdb `LIST` to `ArrayAgg`

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -511,7 +511,6 @@ class SnowflakeGenerator(generator.Generator):
         exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost")(
             rename_func("EDITDISTANCE")
         ),
-        exp.List: rename_func("ARRAY_AGG"),
         exp.LocationProperty: lambda self, e: f"LOCATION={self.sql(e, 'this')}",
         exp.LogicalAnd: rename_func("BOOLAND_AGG"),
         exp.LogicalOr: rename_func("BOOLOR_AGG"),

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -133,6 +133,7 @@ class DuckDBParser(parser.Parser):
         "JSON_ARRAY": lambda args: exp.JSONArray(expressions=args),
         "JSON_EXTRACT_PATH": parser.build_extract_json_with_path(exp.JSONExtract),
         "JSON_EXTRACT_STRING": parser.build_extract_json_with_path(exp.JSONExtractScalar),
+        "LIST": exp.ArrayAgg.from_arg_list,
         "LIST_DISTINCT": exp.ArrayDistinct.from_arg_list,
         "LIST_APPEND": exp.ArrayAppend.from_arg_list,
         "LIST_CONCAT": parser.build_array_concat,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -693,7 +693,7 @@ class TestDuckDB(Validator):
         self.validate_all(
             "SELECT LIST(col) FROM t",
             write={
-                "duckdb": "SELECT LIST(col) FROM t",
+                "duckdb": "SELECT ARRAY_AGG(col) FROM t",
                 "snowflake": "SELECT ARRAY_AGG(col) FROM t",
             },
         )


### PR DESCRIPTION
This is Copilot's response when I asked whether `LIST` and `ARRAY_AGG` are synonymous in DuckDB:

«In DuckDB, **`list(expr)` and `array_agg(expr)` are essentially the same kind of aggregate**: both collect the grouped input values into a single **LIST (array) value**.

Practical differences are mostly about **name/compatibility and a few option/details**, not the core semantics:

- **Purpose**
  - `array_agg` is the more *standard SQL / Postgres-style* name.
  - `list` is a shorter DuckDB-friendly alias/name for the same idea.

- **Return type**
  - Both return DuckDB’s **LIST** type (conceptually an array).

- **Options**
  - Both typically support the same aggregate features you’d expect: `DISTINCT`, `FILTER`, and often `ORDER BY` within the aggregate (depending on DuckDB version).

So: **yes, for normal usage they’re interchangeable**—use `array_agg` if you want portability/readability for SQL folks, use `list` if you prefer the concise DuckDB idiom.

If you tell me your DuckDB version (or paste `SELECT version();`), I can be precise about any version-specific differences (e.g., ordering guarantees/availability of `ORDER BY` within the aggregate).»

Original PR: https://github.com/tobymao/sqlglot/pull/7551