### PR TITLE
perf(build): enable mypyc separate=True for fast incremental builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ endif
 
 SO_BACKUP := /tmp/sqlglot_so_backup
 FIND_SO := find sqlglot -name "*.so"
+NPROC := $(shell python -c "import os; print(os.cpu_count() or 1)")
 
 hidec:
 	rm -rf $(SO_BACKUP) && $(FIND_SO) | tar cf $(SO_BACKUP) -T - 2>/dev/null && $(FIND_SO) -delete; true
@@ -38,10 +39,10 @@ install-dev:
 	fi
 
 install-devc:
-	cd sqlglotc && MYPYC_OPT=0 python setup.py build_ext --inplace
+	cd sqlglotc && MYPYC_OPT=0 python setup.py build_ext --inplace -j $(NPROC)
 
 install-devc-release: clean
-	cd sqlglotc && python setup.py build_ext --inplace
+	cd sqlglotc && python setup.py build_ext --inplace -j $(NPROC)
 
 install-pre-commit:
 	pre-commit install

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -7,24 +7,7 @@
 
 from __future__ import annotations
 
-# bootstrap mypyc runtime: compiled .so modules do a top-level `import HASH__mypyc`,
-# but the runtime .so lives inside sqlglot/. Pre-load it into sys.modules.
-# this is only needed for editable builds
-from collections.abc import Collection
-import sys
-from pathlib import Path
 from builtins import type as Type
-
-for path in Path(__file__).parent.glob("*__mypyc*.so"):
-    name = path.stem.split(".")[0]
-    if name not in sys.modules:
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location(name, path)
-        if spec and spec.loader:
-            mod = importlib.util.module_from_spec(spec)
-            sys.modules[name] = mod
-            spec.loader.exec_module(mod)
 
 import logging
 import typing as t

--- a/sqlglot/optimizer/__init__.py
+++ b/sqlglot/optimizer/__init__.py
@@ -1,11 +1,39 @@
-# ruff: noqa: F401
+from __future__ import annotations
 
-from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
-from sqlglot.optimizer.scope import (
-    Scope as Scope,
-    build_scope as build_scope,
-    find_all_in_scope as find_all_in_scope,
-    find_in_scope as find_in_scope,
-    traverse_scope as traverse_scope,
-    walk_in_scope as walk_in_scope,
-)
+import importlib
+import typing as t
+
+if t.TYPE_CHECKING:
+    from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
+    from sqlglot.optimizer.scope import (
+        Scope as Scope,
+        build_scope as build_scope,
+        find_all_in_scope as find_all_in_scope,
+        find_in_scope as find_in_scope,
+        traverse_scope as traverse_scope,
+        walk_in_scope as walk_in_scope,
+    )
+
+_LAZY_ATTRS = {
+    "RULES": "sqlglot.optimizer.optimizer",
+    "optimize": "sqlglot.optimizer.optimizer",
+    "Scope": "sqlglot.optimizer.scope",
+    "build_scope": "sqlglot.optimizer.scope",
+    "find_all_in_scope": "sqlglot.optimizer.scope",
+    "find_in_scope": "sqlglot.optimizer.scope",
+    "traverse_scope": "sqlglot.optimizer.scope",
+    "walk_in_scope": "sqlglot.optimizer.scope",
+}
+
+
+def __getattr__(name: str) -> t.Any:
+    module_name = _LAZY_ATTRS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(importlib.import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(_LAZY_ATTRS)

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -129,6 +129,8 @@ class sdist(_sdist):
 setup(
     name="sqlglotc",
     packages=[],
-    ext_modules=mypycify(_source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2")),
+    ext_modules=mypycify(
+        _source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2"), separate=True
+    ),
     cmdclass={"build_ext": build_ext, "sdist": sdist},
 )


### PR DESCRIPTION
## Summary

- Turn on mypyc \`separate=True\` in \`sqlglotc/setup.py\` so editing a single \`.py\` only rebuilds that module's \`.so\` pair — incremental rebuild drops from the full-compile time to a few seconds.
- Drop the legacy \`HASH__mypyc\` pre-load loop in \`sqlglot/__init__.py\`. Under separate mode, per-module shared libs sit next to their \`.py\` siblings and resolve via normal dotted imports, so the bootstrap is dead code.
- Convert \`sqlglot/optimizer/__init__.py\` to a PEP 562 lazy \`__getattr__\`. Separate mode's eager cross-group init otherwise triggers a circular import (\`sqlglot.optimizer.optimizer\` → \`sqlglot.Schema/exp\` before \`sqlglot/__init__.py\` has bound those names).
- Add \`-j \$(NPROC)\` to \`install-devc\` / \`install-devc-release\`. \`NPROC\` is computed via \`python -c \"import os; print(os.cpu_count() or 1)\"\` so it works identically on Linux, macOS, and Windows without depending on \`nproc\` / \`sysctl\` / \`%NUMBER_OF_PROCESSORS%\`. Compiler-agnostic — setuptools' thread pool drives \`gcc\` / \`clang\` / \`cl.exe\` the same way.

## Depends on

Requires \`sqlglot-mypy >= 1.20\` — prior versions have latent bugs that \`separate=True\` exercises (non-ext vtable crash, cross-group method decl lookup, exports-table bypass in emitwrapper/emitfunc/emitclass, deferred cross-group imports, broken \`CPyImport_ImportFrom\` fallback, incremental-mode IR plumbing). Merge after the 1.20 release is on PyPI.

## Test plan

- [ ] \`make clean && make install-devc\` succeeds and produces per-module \`.so\` pairs
- [ ] \`make testc\` passes
- [ ] Edit one dialect file, re-run \`make install-devc\` — only that module rebuilds
- [ ] \`pip install sqlglot[c]\` from a clean env works once sqlglot-mypy 1.20 is published