### PR TITLE
fix(optimizer): propagate types through CTE / unnamed-subquery boundary

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -401,7 +401,7 @@ class TypeAnnotator:
                     stack.append((child_expr, False))
                 continue
 
-            if scope and isinstance(expr, exp.Column) and expr.table:
+            if scope and isinstance(expr, exp.Column) and expr.args.get("table") is not None:
                 source = None
                 source_scope: Scope | None = scope
                 while source_scope and not source:

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1180,6 +1180,18 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                         exp.DataType.build(expected, dialect=dialect).sql(dialect),
                     )
 
+    def test_annotate_types_cte_over_unnamed_subquery(self):
+        schema = MappingSchema({"t": {"id": "VARCHAR", "ts": "TIMESTAMP"}})
+        sql = "WITH c AS (SELECT * FROM (SELECT * FROM t)) SELECT id, ts FROM c"
+
+        expression = annotate_types(
+            optimizer.qualify_columns.qualify_columns(parse_one(sql), schema=schema),
+            schema=schema,
+        )
+
+        self.assertEqual(expression.selects[0].type.this, exp.DataType.Type.VARCHAR)
+        self.assertEqual(expression.selects[1].type.this, exp.DataType.Type.TIMESTAMP)
+
     def test_cast_type_annotation(self):
         expression = annotate_types(parse_one("CAST('2020-01-01' AS TIMESTAMPTZ(9))"))
         self.assertEqual(expression.type.this, exp.DataType.Type.TIMESTAMPTZ)


### PR DESCRIPTION
When a CTE body reads from an unaliased inline subquery, qualify_columns attaches an Identifier(this='', quoted=True) as the table arg on columns projected from that subquery. The scope system registers a matching empty-string source key.

_annotate_expression's gate on source resolution used the Column.table property -- self.text("table") -- which collapses "no table arg" and "empty-string table Identifier" to the same "". The empty-string case was therefore routed to the generic fallback that sets UNKNOWN, and that UNKNOWN propagated through the CTE's re-projections to the outer scope.

Switch to a node-presence check (args.get("table") is not None) so the empty-string case enters the source-lookup branch. scope.sources.get("") then succeeds because the scope key is "" too.

Matches the existing args.get("table") idiom used in generator.py, parser.py, parsers/exasol.py, generators/tsql.py,
optimizer/qualify_columns.py, and dialects/dialect.py.