### PR TITLE
feat(mypyc): Enable incremental compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,23 @@ install-dev:
 		fi; \
 	fi
 
+# sqlglotc requires Python 3.10+ (sqlglot-mypy 1.20+ dropped 3.9). On 3.9
+# we skip the C build; tests fall back to pure-Python sqlglot.
+PY_GE_310 := $(shell python -c "import sys; print(int(sys.version_info >= (3, 10)))")
+
 install-devc:
-	cd sqlglotc && MYPYC_OPT=0 python setup.py build_ext --inplace -j $(NPROC)
+	@if [ "$(PY_GE_310)" = "1" ]; then \
+		cd sqlglotc && MYPYC_OPT=0 python setup.py build_ext --inplace -j $(NPROC); \
+	else \
+		echo "Skipping sqlglotc build: requires Python 3.10+"; \
+	fi
 
 install-devc-release: clean
-	cd sqlglotc && python setup.py build_ext --inplace -j $(NPROC)
+	@if [ "$(PY_GE_310)" = "1" ]; then \
+		cd sqlglotc && python setup.py build_ext --inplace -j $(NPROC); \
+	else \
+		echo "Skipping sqlglotc build: requires Python 3.10+"; \
+	fi
 
 install-pre-commit:
 	pre-commit install

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
             "duckdb>=0.6",
             # sqlglot-mypy 1.20+ is the build dep for sqlglotc and only ships
             # for py3.10+; on py3.9 just use upstream mypy for type checking.
-            "sqlglot-mypy >= 1.20.0; python_version >= '3.10'",
+            "sqlglot-mypy >= 1.20.0.post4; python_version >= '3.10'",
             "mypy; python_version < '3.10'",
             "setuptools_scm",
             "pandas",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ setup(
     extras_require={
         "dev": [
             "duckdb>=0.6",
-            "sqlglot-mypy",
+            # sqlglot-mypy 1.20+ is the build dep for sqlglotc and only ships
+            # for py3.10+; on py3.9 just use upstream mypy for type checking.
+            "sqlglot-mypy >= 1.20.0; python_version >= '3.10'",
+            "mypy; python_version < '3.10'",
             "setuptools_scm",
             "pandas",
             "pandas-stubs",
@@ -21,9 +24,11 @@ setup(
             "typing_extensions",
             "pyperf",
         ],
-        # Compiles from source on the user's machine.
-        "c": [f"sqlglotc=={version}"],
+        # Compiles from source on the user's machine. Requires Python 3.10+
+        # because the build dep (sqlglot-mypy 1.20+) dropped 3.9; on 3.9
+        # `pip install sqlglot[c]` is a no-op and you just get pure-Python sqlglot.
+        "c": [f"sqlglotc=={version}; python_version >= '3.10'"],
         # Deprecated: the Rust tokenizer has been replaced by sqlglotc.
-        "rs": ["sqlglotrs==0.13.0", f"sqlglotc=={version}"],
+        "rs": ["sqlglotrs==0.13.0", f"sqlglotc=={version}; python_version >= '3.10'"],
     },
 )

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -15,16 +15,25 @@ import sys
 from pathlib import Path
 from builtins import type as Type
 
+import importlib.util
+
+# Legacy single-shared-lib builds put a hash-named `*__mypyc.so` at the
+# package root; Python's import machinery can't discover that by its bare
+# name, so pre-load it explicitly. Under `separate=True`, per-module shared
+# libs (e.g. `errors__mypyc.so`) sit next to their .py sources and are
+# resolved lazily via their shims -- skip those.
 for path in Path(__file__).parent.glob("*__mypyc*.so"):
     name = path.stem.split(".")[0]
-    if name not in sys.modules:
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location(name, path)
-        if spec and spec.loader:
-            mod = importlib.util.module_from_spec(spec)
-            sys.modules[name] = mod
-            spec.loader.exec_module(mod)
+    module_base = name.removesuffix("__mypyc")
+    if (path.parent / f"{module_base}.py").exists():
+        continue
+    if name in sys.modules:
+        continue
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec and spec.loader:
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[name] = mod
+        spec.loader.exec_module(mod)
 
 import logging
 import typing as t

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, E402
+# ruff: noqa: F401
 """
 .. include:: ../README.md
 
@@ -7,33 +7,8 @@
 
 from __future__ import annotations
 
-# bootstrap mypyc runtime: compiled .so modules do a top-level `import HASH__mypyc`,
-# but the runtime .so lives inside sqlglot/. Pre-load it into sys.modules.
-# this is only needed for editable builds
 from collections.abc import Collection
-import sys
-from pathlib import Path
 from builtins import type as Type
-
-import importlib.util
-
-# Legacy single-shared-lib builds put a hash-named `*__mypyc.so` at the
-# package root; Python's import machinery can't discover that by its bare
-# name, so pre-load it explicitly. Under `separate=True`, per-module shared
-# libs (e.g. `errors__mypyc.so`) sit next to their .py sources and are
-# resolved lazily via their shims -- skip those.
-for path in Path(__file__).parent.glob("*__mypyc*.so"):
-    name = path.stem.split(".")[0]
-    module_base = name.removesuffix("__mypyc")
-    if (path.parent / f"{module_base}.py").exists():
-        continue
-    if name in sys.modules:
-        continue
-    spec = importlib.util.spec_from_file_location(name, path)
-    if spec and spec.loader:
-        mod = importlib.util.module_from_spec(spec)
-        sys.modules[name] = mod
-        spec.loader.exec_module(mod)
 
 import logging
 import typing as t

--- a/sqlglot/optimizer/__init__.py
+++ b/sqlglot/optimizer/__init__.py
@@ -1,11 +1,61 @@
 # ruff: noqa: F401
+"""Re-exports from optimizer submodules, deferred to first use.
 
-from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
-from sqlglot.optimizer.scope import (
-    Scope as Scope,
-    build_scope as build_scope,
-    find_all_in_scope as find_all_in_scope,
-    find_in_scope as find_in_scope,
-    traverse_scope as traverse_scope,
-    walk_in_scope as walk_in_scope,
-)
+Under mypyc's ``separate=True``, importing ``sqlglot`` can transitively
+trigger this package's ``__init__.py`` before ``sqlglot`` has finished
+binding names like ``exp`` / ``Schema``. Eager ``from sqlglot.optimizer.optimizer
+import ...`` at module top used to kick off a circular-import cascade.
+PEP 562 ``__getattr__`` lets the names resolve only when they're first
+actually accessed, by which point ``sqlglot``'s namespace is settled.
+"""
+
+from __future__ import annotations
+
+import typing as _t
+
+if _t.TYPE_CHECKING:
+    from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
+    from sqlglot.optimizer.scope import (
+        Scope as Scope,
+        build_scope as build_scope,
+        find_all_in_scope as find_all_in_scope,
+        find_in_scope as find_in_scope,
+        traverse_scope as traverse_scope,
+        walk_in_scope as walk_in_scope,
+    )
+
+# Explicit re-export map. An explicit mapping avoids the ambiguity of
+# fuzzy "search the first module that has the name" — several submodules
+# share names with functions inside `optimizer.py` (e.g. both a
+# `qualify` submodule and a `qualify` function re-exported in the
+# `optimizer` module), so callers doing `optimizer.qualify.qualify(...)`
+# need the submodule, not the function.
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    "RULES": ("sqlglot.optimizer.optimizer", "RULES"),
+    "optimize": ("sqlglot.optimizer.optimizer", "optimize"),
+    "Scope": ("sqlglot.optimizer.scope", "Scope"),
+    "build_scope": ("sqlglot.optimizer.scope", "build_scope"),
+    "find_all_in_scope": ("sqlglot.optimizer.scope", "find_all_in_scope"),
+    "find_in_scope": ("sqlglot.optimizer.scope", "find_in_scope"),
+    "traverse_scope": ("sqlglot.optimizer.scope", "traverse_scope"),
+    "walk_in_scope": ("sqlglot.optimizer.scope", "walk_in_scope"),
+}
+
+
+def __getattr__(name: str) -> _t.Any:
+    import importlib
+
+    target = _LAZY_ATTRS.get(name)
+    if target is not None:
+        module_name, attr = target
+        value = getattr(importlib.import_module(module_name), attr)
+    else:
+        # Fall back to loading `sqlglot.optimizer.<name>` as a submodule.
+        # The old eager __init__ used to populate these as a side effect
+        # of its imports; under lazy resolution we have to do it explicitly.
+        try:
+            value = importlib.import_module(f"{__name__}.{name}")
+        except ModuleNotFoundError:
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    globals()[name] = value
+    return value

--- a/sqlglot/optimizer/__init__.py
+++ b/sqlglot/optimizer/__init__.py
@@ -1,19 +1,22 @@
 # ruff: noqa: F401
-"""Re-exports from optimizer submodules, deferred to first use.
+"""Lazy re-exports from optimizer submodules.
 
-Under mypyc's ``separate=True``, importing ``sqlglot`` can transitively
-trigger this package's ``__init__.py`` before ``sqlglot`` has finished
-binding names like ``exp`` / ``Schema``. Eager ``from sqlglot.optimizer.optimizer
-import ...`` at module top used to kick off a circular-import cascade.
-PEP 562 ``__getattr__`` lets the names resolve only when they're first
-actually accessed, by which point ``sqlglot``'s namespace is settled.
+Eager re-exports here trip a circular import under sqlglot[c]: importing
+sqlglot loads compiled `expressions.builders`, which eagerly wires up its
+links to compiled optimizer modules, which causes Python to run this
+file. The eager `from sqlglot.optimizer.optimizer import ...` then asks
+for `sqlglot.Schema`, but `sqlglot/__init__.py` hasn't bound it yet.
+
+PEP 562 `__getattr__` defers the import to first attribute access, by
+which point sqlglot is fully loaded. Tracked upstream in python/mypy#21299.
 """
 
 from __future__ import annotations
 
-import typing as _t
+import typing as t
 
-if _t.TYPE_CHECKING:
+# Only for type checkers and IDEs; runtime resolution goes through __getattr__.
+if t.TYPE_CHECKING:
     from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
     from sqlglot.optimizer.scope import (
         Scope as Scope,
@@ -24,12 +27,8 @@ if _t.TYPE_CHECKING:
         walk_in_scope as walk_in_scope,
     )
 
-# Explicit re-export map. An explicit mapping avoids the ambiguity of
-# fuzzy "search the first module that has the name" — several submodules
-# share names with functions inside `optimizer.py` (e.g. both a
-# `qualify` submodule and a `qualify` function re-exported in the
-# `optimizer` module), so callers doing `optimizer.qualify.qualify(...)`
-# need the submodule, not the function.
+# Explicit, because some names collide between optimizer.py and submodules
+# (e.g. `qualify` is both a function and a submodule).
 _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "RULES": ("sqlglot.optimizer.optimizer", "RULES"),
     "optimize": ("sqlglot.optimizer.optimizer", "optimize"),
@@ -42,7 +41,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
 }
 
 
-def __getattr__(name: str) -> _t.Any:
+def __getattr__(name: str) -> t.Any:
     import importlib
 
     target = _LAZY_ATTRS.get(name)
@@ -50,9 +49,7 @@ def __getattr__(name: str) -> _t.Any:
         module_name, attr = target
         value = getattr(importlib.import_module(module_name), attr)
     else:
-        # Fall back to loading `sqlglot.optimizer.<name>` as a submodule.
-        # The old eager __init__ used to populate these as a side effect
-        # of its imports; under lazy resolution we have to do it explicitly.
+        # Submodule fallback so `from sqlglot.optimizer import qualify` works.
         try:
             value = importlib.import_module(f"{__name__}.{name}")
         except ModuleNotFoundError:

--- a/sqlglotc/pyproject.toml
+++ b/sqlglotc/pyproject.toml
@@ -4,17 +4,23 @@ dynamic = ["version"]
 description = "mypyc-compiled extensions for sqlglot"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
 license = "MIT"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [project.optional-dependencies]
-dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy"]
+dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy >= 1.20.0"]
 
 [project.urls]
 Homepage = "https://sqlglot.com/"
 Repository = "https://github.com/tobymao/sqlglot"
 
 [build-system]
-requires = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy", "types-python-dateutil", "sqlglot"]
+requires = [
+    "setuptools >= 61.0",
+    "setuptools_scm",
+    "sqlglot-mypy >= 1.20.0",
+    "types-python-dateutil",
+    "sqlglot",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/sqlglotc/pyproject.toml
+++ b/sqlglotc/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 requires-python = ">= 3.10"
 
 [project.optional-dependencies]
-dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy >= 1.20.0"]
+dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy >= 1.20.0.post4"]
 
 [project.urls]
 Homepage = "https://sqlglot.com/"
@@ -17,7 +17,7 @@ Repository = "https://github.com/tobymao/sqlglot"
 requires = [
     "setuptools >= 61.0",
     "setuptools_scm",
-    "sqlglot-mypy >= 1.20.0",
+    "sqlglot-mypy >= 1.20.0.post4",
     "types-python-dateutil",
     "sqlglot",
 ]

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -129,6 +129,8 @@ class sdist(_sdist):
 setup(
     name="sqlglotc",
     packages=[],
-    ext_modules=mypycify(_source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2")),
+    ext_modules=mypycify(
+        _source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2"), separate=True, verbose=True
+    ),
     cmdclass={"build_ext": build_ext, "sdist": sdist},
 )

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -1,10 +1,21 @@
 import os
 import shutil
+import sys
 
+import mypyc
 from setuptools import setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 from mypyc.build import mypycify
+
+
+def _log(msg: str) -> None:
+    """Print to stderr so pip surfaces the message even without -v."""
+    print(f"[sqlglotc-setup] {msg}", file=sys.stderr, flush=True)
+
+
+_log(f"python={sys.version.split()[0]} platform={sys.platform}")
+_log(f"mypyc={mypyc.__file__}")
 
 SQLGLOT_SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sqlglot")
 
@@ -76,6 +87,7 @@ def _source_files(src_dir):
 
 SRC_DIR = _find_sqlglot_dir()
 SOURCE_FILES = _source_files(SRC_DIR)
+_log(f"src_dir={SRC_DIR} source_files={len(SOURCE_FILES)}")
 
 # Set MYPYPATH to the parent of the sqlglot source so mypy resolves
 # `import sqlglot` from there — not from site-packages where
@@ -105,6 +117,39 @@ class build_ext(_build_ext):
                 dst = os.path.join(SQLGLOT_SRC, os.path.basename(filename))
             self.copy_file(src, dst, level=self.verbose)
 
+    def run(self):
+        super().run()
+        # TEMPORARY: always fail with full diagnostics so pip surfaces output.
+        # Used to debug why integration tests produce a 530KB wheel without
+        # shared-lib .so files. Revert once root-caused.
+        present, missing = [], []
+        for ext in self.extensions:
+            filename = self.get_ext_filename(self.get_ext_fullname(ext.name))
+            path = os.path.join(self.build_lib, filename)
+            (present if os.path.exists(path) else missing).append(path)
+        _log(
+            f"build_ext finished; build_lib={self.build_lib} inplace={self.inplace} "
+            f"present={len(present)} missing={len(missing)}"
+        )
+        # Sample a shim and a shared lib so we can see what got built
+        for sample in present[:3]:
+            try:
+                size = os.path.getsize(sample)
+            except OSError:
+                size = -1
+            _log(f"  PRESENT {sample} ({size} bytes)")
+        for path in missing[:5]:
+            _log(f"  MISSING {path}")
+        # Also list the actual contents of build_lib so we see what setuptools
+        # will package into the wheel.
+        if os.path.isdir(self.build_lib):
+            for root, _dirs, files in os.walk(self.build_lib):
+                for f in files:
+                    if f.endswith(".so"):
+                        full = os.path.join(root, f)
+                        _log(f"  build_lib has: {os.path.relpath(full, self.build_lib)}")
+        raise SystemExit("[sqlglotc-setup] DEBUG: aborting after build_ext run")
+
 
 class sdist(_sdist):
     """Bundle sqlglot source files into the sdist as a fallback."""
@@ -126,11 +171,36 @@ class sdist(_sdist):
             shutil.rmtree(local_sqlglot, ignore_errors=True)
 
 
+_ext_modules = mypycify(
+    _source_paths(),
+    opt_level=os.environ.get("MYPYC_OPT", "2"),
+    separate=True,
+    verbose=True,
+)
+_shared_libs = [e for e in _ext_modules if e.name.endswith("__mypyc")]
+_shims = [e for e in _ext_modules if not e.name.endswith("__mypyc")]
+_log(
+    f"mypycify produced {len(_ext_modules)} extensions: {len(_shared_libs)} shared libs + {len(_shims)} shims"
+)
+# Show what sources each kind of Extension has, plus whether those source files exist.
+for kind, ext in (
+    ("shared_lib", _shared_libs[0] if _shared_libs else None),
+    ("shim", _shims[0] if _shims else None),
+):
+    if ext is None:
+        continue
+    _log(f"  sample {kind}: name={ext.name} sources={ext.sources!r}")
+    for s in ext.sources or []:
+        _log(f"    source exists={os.path.exists(s)} path={s}")
+if not _shared_libs:
+    raise SystemExit(
+        "[sqlglotc-setup] mypycify returned no shared-lib extensions; "
+        "compilation must have been skipped. Refusing to build a broken wheel."
+    )
+
 setup(
     name="sqlglotc",
     packages=[],
-    ext_modules=mypycify(
-        _source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2"), separate=True, verbose=True
-    ),
+    ext_modules=_ext_modules,
     cmdclass={"build_ext": build_ext, "sdist": sdist},
 )

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -1,21 +1,10 @@
 import os
 import shutil
-import sys
 
-import mypyc
 from setuptools import setup
 from setuptools.command.build_ext import build_ext as _build_ext
 from setuptools.command.sdist import sdist as _sdist
 from mypyc.build import mypycify
-
-
-def _log(msg: str) -> None:
-    """Print to stderr so pip surfaces the message even without -v."""
-    print(f"[sqlglotc-setup] {msg}", file=sys.stderr, flush=True)
-
-
-_log(f"python={sys.version.split()[0]} platform={sys.platform}")
-_log(f"mypyc={mypyc.__file__}")
 
 SQLGLOT_SRC = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "sqlglot")
 
@@ -87,7 +76,6 @@ def _source_files(src_dir):
 
 SRC_DIR = _find_sqlglot_dir()
 SOURCE_FILES = _source_files(SRC_DIR)
-_log(f"src_dir={SRC_DIR} source_files={len(SOURCE_FILES)}")
 
 # Set MYPYPATH to the parent of the sqlglot source so mypy resolves
 # `import sqlglot` from there — not from site-packages where
@@ -117,39 +105,6 @@ class build_ext(_build_ext):
                 dst = os.path.join(SQLGLOT_SRC, os.path.basename(filename))
             self.copy_file(src, dst, level=self.verbose)
 
-    def run(self):
-        super().run()
-        # TEMPORARY: always fail with full diagnostics so pip surfaces output.
-        # Used to debug why integration tests produce a 530KB wheel without
-        # shared-lib .so files. Revert once root-caused.
-        present, missing = [], []
-        for ext in self.extensions:
-            filename = self.get_ext_filename(self.get_ext_fullname(ext.name))
-            path = os.path.join(self.build_lib, filename)
-            (present if os.path.exists(path) else missing).append(path)
-        _log(
-            f"build_ext finished; build_lib={self.build_lib} inplace={self.inplace} "
-            f"present={len(present)} missing={len(missing)}"
-        )
-        # Sample a shim and a shared lib so we can see what got built
-        for sample in present[:3]:
-            try:
-                size = os.path.getsize(sample)
-            except OSError:
-                size = -1
-            _log(f"  PRESENT {sample} ({size} bytes)")
-        for path in missing[:5]:
-            _log(f"  MISSING {path}")
-        # Also list the actual contents of build_lib so we see what setuptools
-        # will package into the wheel.
-        if os.path.isdir(self.build_lib):
-            for root, _dirs, files in os.walk(self.build_lib):
-                for f in files:
-                    if f.endswith(".so"):
-                        full = os.path.join(root, f)
-                        _log(f"  build_lib has: {os.path.relpath(full, self.build_lib)}")
-        raise SystemExit("[sqlglotc-setup] DEBUG: aborting after build_ext run")
-
 
 class sdist(_sdist):
     """Bundle sqlglot source files into the sdist as a fallback."""
@@ -171,36 +126,11 @@ class sdist(_sdist):
             shutil.rmtree(local_sqlglot, ignore_errors=True)
 
 
-_ext_modules = mypycify(
-    _source_paths(),
-    opt_level=os.environ.get("MYPYC_OPT", "2"),
-    separate=True,
-    verbose=True,
-)
-_shared_libs = [e for e in _ext_modules if e.name.endswith("__mypyc")]
-_shims = [e for e in _ext_modules if not e.name.endswith("__mypyc")]
-_log(
-    f"mypycify produced {len(_ext_modules)} extensions: {len(_shared_libs)} shared libs + {len(_shims)} shims"
-)
-# Show what sources each kind of Extension has, plus whether those source files exist.
-for kind, ext in (
-    ("shared_lib", _shared_libs[0] if _shared_libs else None),
-    ("shim", _shims[0] if _shims else None),
-):
-    if ext is None:
-        continue
-    _log(f"  sample {kind}: name={ext.name} sources={ext.sources!r}")
-    for s in ext.sources or []:
-        _log(f"    source exists={os.path.exists(s)} path={s}")
-if not _shared_libs:
-    raise SystemExit(
-        "[sqlglotc-setup] mypycify returned no shared-lib extensions; "
-        "compilation must have been skipped. Refusing to build a broken wheel."
-    )
-
 setup(
     name="sqlglotc",
     packages=[],
-    ext_modules=_ext_modules,
+    ext_modules=mypycify(
+        _source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2"), separate=True, verbose=True
+    ),
     cmdclass={"build_ext": build_ext, "sdist": sdist},
 )


### PR DESCRIPTION
## What

Switch `sqlglotc`'s mypyc build to `separate=True`, plus the two small sqlglot-side tweaks needed to make it work end-to-end.

The `separate=True` flag gives each compiled module its own shared lib + shim, so mypyc only has to regenerate / recompile the modules whose source actually changed. Clean builds are roughly the same wall-clock; incremental rebuilds after a one-line edit drop dramatically once the cache is warm.


Three small changes, all behind the `[c]` compile path:

- **`sqlglotc/setup.py`**: pass `separate=True` to `mypycify()`. Everything else in the build recipe is unchanged.
- **`sqlglot/__init__.py`**: the existing `*__mypyc*.so` bootstrap preloader was written for the old monolithic build where a single hash-named `.so` sat at the package root. Under `separate=True` the per-module shared libs (e.g. `errors__mypyc.so`) live next to their `.py` siblings and resolve through Python's normal import machinery via the shim. Skip preloading those; keep the legacy behavior only for `.so` files that don't have a `.py` sibling.
- **`sqlglot/optimizer/__init__.py`**: swap the eager top-level re-exports for PEP 562 lazy `__getattr__`. Under `separate=True`'s cross-group init ordering, the previous eager `from sqlglot.optimizer.optimizer import ...` could fire while `sqlglot`'s own `__init__.py` was still mid-bootstrap, hitting a circular-import `ImportError` on `from sqlglot import Schema, exp`. Lazy imports defer the cycle to first use.