### PR TITLE
fix(json): remove artificial arg limit on JSONArray [CLAUDE]

### DIFF
--- a/sqlglot/expressions/json.py
+++ b/sqlglot/expressions/json.py
@@ -16,6 +16,7 @@ class JSONArray(Expression, Func):
         "return_type": False,
         "strict": False,
     }
+    is_var_len_args = True
 
 
 class JSONArrayAgg(Expression, AggFunc):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -577,6 +577,13 @@ class TestDuckDB(Validator):
                 "snowflake": "SELECT TO_VARIANT(ARRAY_CONSTRUCT())",
             },
         )
+        self.validate_all(
+            "SELECT JSON_ARRAY('a', 'b', 'c', 'd', 'e')",
+            write={
+                "duckdb": "SELECT JSON_ARRAY('a', 'b', 'c', 'd', 'e')",
+                "snowflake": "SELECT TO_VARIANT(ARRAY_CONSTRUCT('a', 'b', 'c', 'd', 'e'))",
+            },
+        )
         self.validate_identity(
             "SELECT col FROM t WHERE JSON_EXTRACT_STRING(col, '$.id') NOT IN ('b')",
             "SELECT col FROM t WHERE NOT (col ->> '$.id') IN ('b')",


### PR DESCRIPTION
## Summary
- `JSONArray` enforced a 4-argument maximum because `is_var_len_args` was `False` and `arg_types` had only 4 keys
- DuckDB's `JSON_ARRAY` is variadic and accepts any number of arguments ([docs](https://duckdb.org/docs/current/data/json/creating_json)), so queries like `JSON_ARRAY('a', 'b', 'c', 'd', 'e')` failed at parse time
- Setting `is_var_len_args = True` skips the arg count validation while preserving existing parsing behavior across all dialects

To the best of my understanding this isn't really a problem for other dialect parsers

## Test plan
- [x] Added `validate_all` test with 5 args covering DuckDB round-trip and Snowflake transpilation
- [x] Verified existing JSON_ARRAY tests (0, 1, 3 args) still pass
- [x] Verified against real DuckDB CLI with 5 and 10 args
- [x] Full unit test suite passes (1042 tests)
- [x] Linting, formatting, and type checks pass