### PR TITLE
fix(clickhouse): apply version-aware unit lowercase to DateTrunc

### DIFF
--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -681,9 +681,12 @@ class ClickHouseGenerator(generator.Generator):
 
         return super().values_sql(expression, values_as_table=values_as_table)
 
-    def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
+    def timestamptrunc_sql(self, expression: exp.DateTrunc | exp.TimestampTrunc) -> str:
         unit = unit_to_str(expression)
         # https://clickhouse.com/docs/whats-new/changelog/2023#improvement
         if self.dialect.version < (23, 12) and unit and unit.is_string:
             unit = exp.Literal.string(unit.name.lower())
         return self.func("dateTrunc", unit, expression.this, expression.args.get("zone"))
+
+    def datetrunc_sql(self, expression: exp.DateTrunc) -> str:
+        return self.timestamptrunc_sql(expression)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1817,6 +1817,14 @@ LIFETIME(MIN 0 MAX 0)""",
             },
         )
 
+        self.validate_all(
+            "date_trunc('WEEK', today())",
+            write={
+                "clickhouse, version=23.8": "dateTrunc('week', today())",
+                "clickhouse, version=24.1": "dateTrunc('WEEK', today())",
+            },
+        )
+
     def test_string_split(self):
         self.validate_all(
             "splitByString('s', x)",

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -744,7 +744,7 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
         self.validate_all(
             "TRUNC(SYSDATE, 'YEAR')",
             write={
-                "clickhouse": "DATE_TRUNC('YEAR', CURRENT_TIMESTAMP())",
+                "clickhouse": "dateTrunc('YEAR', CURRENT_TIMESTAMP())",
                 "oracle": "TRUNC(SYSDATE, 'YEAR')",
             },
         )


### PR DESCRIPTION
## Summary

- ClickHouse's `dateTrunc` requires lowercase unit literals on versions < 23.12. The existing `timestamptrunc_sql` handled this, but `exp.DateTrunc` (e.g. parsed from `date_trunc('WEEK', x)`) had no ClickHouse-specific generator and fell through to the base, producing `DATE_TRUNC('WEEK', x)` — wrong function name and wrong case on older versions.
- Add `datetrunc_sql` that delegates to `timestamptrunc_sql` so both expressions share the version-aware lowercasing and the correct `dateTrunc` camelCase function name.
- Update `tests/dialects/test_oracle.py::test_datetrunc` whose ClickHouse expectation relied on the previous (incorrect) `DATE_TRUNC` output.

## Test plan

- [x] `python -m unittest tests.dialects.test_clickhouse`
- [x] `python -m unittest tests.dialects.test_oracle.TestOracle.test_datetrunc`
- [x] New `validate_all` cases cover `clickhouse, version=23.8` (lowercases) and `clickhouse, version=24.1` (preserves case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)