### PR TITLE
fix(oracle): Support LISTAGG on overflow

### DIFF
--- a/sqlglot/generators/oracle.py
+++ b/sqlglot/generators/oracle.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from sqlglot import exp, generator, transforms
 from sqlglot.dialects.dialect import (
+    groupconcat_sql,
     no_ilike_sql,
     rename_func,
     strposition_sql,
@@ -64,6 +65,7 @@ class OracleGenerator(generator.Generator):
 
     TRANSFORMS = {
         **generator.Generator.TRANSFORMS,
+        exp.GroupConcat: lambda self, e: groupconcat_sql(self, e, on_overflow=True),
         exp.DateStrToDate: lambda self, e: self.func(
             "TO_DATE", e.this, exp.Literal.string("YYYY-MM-DD")
         ),

--- a/sqlglot/parsers/oracle.py
+++ b/sqlglot/parsers/oracle.py
@@ -56,6 +56,7 @@ class OracleParser(parser.Parser):
         "JSON_ARRAY": lambda self: self._parse_oracle_json_array(),
         "JSON_ARRAYAGG": lambda self: self._parse_oracle_json_arrayagg(),
         "JSON_EXISTS": lambda self: self._parse_json_exists(),
+        "LISTAGG": lambda self: self._parse_string_agg(),
     }
 
     PROPERTY_PARSERS = {

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -881,6 +881,16 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
         self.validate_identity("UTC_TIMESTAMP()").assert_is(exp.UtcTimestamp)
         self.validate_identity("UTC_TIMESTAMP(6)").assert_is(exp.UtcTimestamp)
 
+    def test_listagg(self):
+        self.validate_identity(
+            "SELECT LISTAGG(last_name, '; ' ON OVERFLOW TRUNCATE '...' WITH COUNT) "
+            "WITHIN GROUP (ORDER BY hire_date) FROM employees"
+        )
+        self.validate_identity(
+            "SELECT LISTAGG(last_name, '; ' ON OVERFLOW ERROR) "
+            "WITHIN GROUP (ORDER BY hire_date) FROM employees"
+        )
+
     def test_merge(self):
         self.validate_all(
             "MERGE INTO target tgt USING (SELECT id, col1 FROM source_tbl) src ON tgt.id = src.id "


### PR DESCRIPTION
Oracle supports the `LISTAGG(last_name, '; ' ON OVERFLOW TRUNCATE '...')` syntax
sqlglot already supports it (for Snowflake) - This PR adds support for Oracle 

official docs: https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/LISTAGG.html