### PR TITLE
feat(exasol): auto-alias CTE projections

### DIFF
--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -232,6 +232,33 @@ def _add_date_sql(self: ExasolGenerator, expression: DATE_ADD_OR_SUB) -> str:
     return self.func(f"ADD_{unit}S", expression.this, offset_expr)
 
 
+def _add_cte_column_aliases(expression: exp.Expr) -> exp.Expr:
+    """
+    Exasol rejects unaliased non-column expressions inside CTE SELECT lists.
+    Inject synthetic aliases like ``_col_0`` for any projection that isn't
+    already aliased, a bare column reference, or a star (which Exasol expands
+    by itself and would be invalid wrapped in an alias).
+    """
+    if not isinstance(expression, exp.Select):
+        return expression
+
+    if not isinstance(expression.parent, exp.CTE):
+        return expression
+
+    new_selects: list[exp.Expr] = []
+    counter = 0
+    for sel in expression.expressions:
+        if isinstance(sel, (exp.Alias, exp.Column, exp.Star)) or sel.find(exp.Star):
+            new_selects.append(sel)
+            continue
+
+        new_selects.append(exp.alias_(sel, exp.to_identifier(f"_col_{counter}", quoted=True)))
+        counter += 1
+
+    expression.set("expressions", new_selects)
+    return expression
+
+
 def _group_by_all(expression: exp.Expr) -> exp.Expr:
     if not isinstance(expression, exp.Select):
         return expression
@@ -392,6 +419,7 @@ class ExasolGenerator(generator.Generator):
         exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
         exp.Select: transforms.preprocess(
             [
+                _add_cte_column_aliases,
                 _qualify_unscoped_star,
                 _add_local_prefix_for_aliases,
                 _group_by_all,

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -991,3 +991,43 @@ class TestExasol(Validator):
                 "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA"
             },
         )
+
+    def test_cte_literal_auto_alias(self):
+        # Integer literal in CTE gets synthetic alias
+        self.validate_all(
+            'WITH cte AS (SELECT 12345 AS "_col_0") SELECT * FROM cte',
+            read={"mysql": "WITH cte AS (SELECT 12345) SELECT * FROM cte"},
+            write={"exasol": 'WITH cte AS (SELECT 12345 AS "_col_0") SELECT * FROM cte'},
+        )
+        # Mixed literals get sequential aliases
+        self.validate_all(
+            'WITH cte AS (SELECT 12345 AS "_col_0", \'value\' AS "_col_1") SELECT * FROM cte',
+            read={"mysql": "WITH cte AS (SELECT 12345, 'value') SELECT * FROM cte"},
+            write={
+                "exasol": 'WITH cte AS (SELECT 12345 AS "_col_0", \'value\' AS "_col_1") SELECT * FROM cte'
+            },
+        )
+        # Existing alias preserved
+        self.validate_identity(
+            "WITH cte AS (SELECT 12345 AS id, 'value' AS name) SELECT * FROM cte"
+        )
+        # Function call / arithmetic gets alias
+        self.validate_all(
+            'WITH cte AS (SELECT LOWER(name) AS "_col_0", 1 + 2 AS "_col_1" FROM t) SELECT * FROM cte',
+            read={"mysql": "WITH cte AS (SELECT LOWER(name), 1 + 2 FROM t) SELECT * FROM cte"},
+            write={
+                "exasol": 'WITH cte AS (SELECT LOWER(name) AS "_col_0", 1 + 2 AS "_col_1" FROM t) SELECT * FROM cte'
+            },
+        )
+        # Bare column: no alias injected
+        self.validate_identity("WITH cte AS (SELECT col FROM t) SELECT * FROM cte")
+        # Bare star inside CTE: no alias injected (wrapping star would be invalid SQL)
+        self.validate_identity("WITH cte AS (SELECT * FROM t) SELECT * FROM cte")
+        # Qualified star inside CTE: no alias injected
+        self.validate_identity("WITH cte AS (SELECT t.* FROM t) SELECT * FROM cte")
+        # Nested CTE: outer star still passes through unwrapped
+        self.validate_identity(
+            "WITH outer_cte AS (WITH inner_cte AS (SELECT 1 AS x) SELECT * FROM inner_cte) SELECT * FROM outer_cte"
+        )
+        # Non-CTE subquery: no alias injected
+        self.validate_identity("SELECT * FROM (SELECT 1) AS t")


### PR DESCRIPTION
## Summary

Inject synthetic `_col_N` aliases for unaliased non-column projections inside CTE SELECT lists. Exasol rejects the unaliased form with `"must name expression in query <cte> with a column alias"`.

Bare columns and stars (including `t.*`) are left untouched so the rewrite never produces invalid SQL like `SELECT * AS "_col_0"`.

Split from #7539 per review request to land orthogonal changes as separate PRs.

## Before / After

```python
>>> sqlglot.transpile("WITH cte AS (SELECT 12345, 'val') SELECT * FROM cte", read="mysql", write="exasol")[0]
# Before:
"WITH cte AS (SELECT 12345, 'val') SELECT * FROM cte"     # Exasol rejects
# After:
'WITH cte AS (SELECT 12345 AS "_col_0", \'val\' AS "_col_1") SELECT * FROM cte'
```

## Implementation

* New `_add_cte_column_aliases` preprocessor wired into `ExasolGenerator.TRANSFORMS[exp.Select]`.
* Skips `exp.Alias`, `exp.Column`, `exp.Star`, and any projection containing a `Star` so `SELECT *` / `SELECT t.*` round-trip unchanged.

## Test plan

- [x] `tests/dialects/test_exasol.py::test_cte_literal_auto_alias` — 8 scenarios (literal, mixed literals, existing alias, function/arithmetic, bare column, bare `*`, qualified `t.*`, nested CTE, non-CTE subquery)
- [x] `make check` — 0 failures

## Related

Replaces part of #7539. See companion PRs for the JSON_OBJECT and GROUP-BY-alias-test changes.
