### PR TITLE
test(exasol): pin GROUP BY alias rewrite via _add_local_prefix_for_aliases

### DIFF
--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -991,3 +991,29 @@ class TestExasol(Validator):
                 "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA"
             },
         )
+
+    def test_group_by_alias_local(self):
+        # GROUP BY bare alias -> LOCAL prefix
+        self.validate_all(
+            "SELECT city, COUNT(*) AS cnt FROM t GROUP BY LOCAL.cnt",
+            read={"mysql": "SELECT city, COUNT(*) AS cnt FROM t GROUP BY cnt"},
+            write={"exasol": "SELECT city, COUNT(*) AS cnt FROM t GROUP BY LOCAL.cnt"},
+        )
+        # GROUP BY expression alias -> LOCAL prefix
+        self.validate_all(
+            "SELECT YEAR(TO_DATE(a_date)) AS a_year FROM t GROUP BY LOCAL.a_year",
+            read={"mysql": "SELECT YEAR(a_date) AS a_year FROM t GROUP BY a_year"},
+            write={"exasol": "SELECT YEAR(TO_DATE(a_date)) AS a_year FROM t GROUP BY LOCAL.a_year"},
+        )
+        # GROUP BY non-alias column -> unchanged
+        self.validate_all(
+            "SELECT city, COUNT(*) FROM t GROUP BY city",
+            read={"mysql": "SELECT city, COUNT(*) FROM t GROUP BY city"},
+            write={"exasol": "SELECT city, COUNT(*) FROM t GROUP BY city"},
+        )
+        # HAVING alias -> LOCAL prefix
+        self.validate_all(
+            "SELECT COUNT(*) AS cnt FROM t HAVING LOCAL.cnt > 1",
+            read={"mysql": "SELECT COUNT(*) AS cnt FROM t HAVING cnt > 1"},
+            write={"exasol": "SELECT COUNT(*) AS cnt FROM t HAVING LOCAL.cnt > 1"},
+        )


### PR DESCRIPTION
## Summary

Test-only PR. Pin the existing `_add_local_prefix_for_aliases` preprocessor's behaviour so MySQL→Exasol transpilation of GROUP BY / HAVING references to SELECT-list aliases is captured against future regressions (e.g. `GROUP BY cnt` from MySQL becomes `GROUP BY LOCAL.cnt` on Exasol).

Split from #7539 per review request to land orthogonal changes as separate PRs.

## Implementation

* No generator changes — the preprocessor already lives on `main`.
* New `tests/dialects/test_exasol.py::test_group_by_alias_local` covers:
  * Bare-alias GROUP BY → `LOCAL.<alias>`
  * Expression-alias GROUP BY → `LOCAL.<alias>`
  * Non-alias column GROUP BY → unchanged
  * HAVING alias reference → `LOCAL.<alias>`

## Test plan

- [x] `tests/dialects/test_exasol.py::test_group_by_alias_local` — 4 cases above
- [x] `make check` — 0 failures

## Related

Replaces part of #7539. See companion PRs for the CTE-auto-alias and JSON_OBJECT changes.
