### PR TITLE
Refactor (Expr): improve `Expr.transform()` annotations

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1830,7 +1830,7 @@ def pivot_column_names(aggregations: Iterable[exp.Expr], dialect: DialectType) -
             be quoted in the base parser's `_parse_pivot` method, due to `to_identifier`.
             Otherwise, we'd end up with `col_avg(`foo`)` (notice the double quotes).
             """
-            agg_all_unquoted = agg.transform(
+            agg_all_unquoted: exp.Expr = agg.transform(
                 lambda node: (
                     exp.Identifier(this=node.name, quoted=False)
                     if isinstance(node, exp.Identifier)

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -1113,8 +1113,8 @@ class Expression(Expr):
         Returns:
             The transformed tree.
         """
-        root = None
-        new_node = None
+        root: t.Any = None
+        new_node: t.Any = None
 
         for node in (self.copy() if copy else self).dfs(prune=lambda n: n is not new_node):
             parent, arg_key, index = node.parent, node.arg_key, node.index

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -282,8 +282,8 @@ class Expr:
         raise NotImplementedError
 
     def transform(
-        self, fun: t.Callable, *args: object, copy: bool = True, **kwargs: object
-    ) -> t.Any:
+        self, fun: t.Callable[..., T], *args: object, copy: bool = True, **kwargs: object
+    ) -> T:
         raise NotImplementedError
 
     def replace(self, expression: T) -> T:
@@ -1097,8 +1097,8 @@ class Expression(Expr):
         return Dialect.get_or_raise(dialect).generate(self, copy=copy, **opts)
 
     def transform(
-        self, fun: t.Callable, *args: object, copy: bool = True, **kwargs: object
-    ) -> t.Any:
+        self, fun: t.Callable[..., T], *args: object, copy: bool = True, **kwargs: object
+    ) -> T:
         """
         Visits all tree nodes (excluding already transformed ones)
         and applies the given transformation function to each node.
@@ -1113,8 +1113,8 @@ class Expression(Expr):
         Returns:
             The transformed tree.
         """
-        root: t.Any = None
-        new_node: t.Any = None
+        root = None
+        new_node = None
 
         for node in (self.copy() if copy else self).dfs(prune=lambda n: n is not new_node):
             parent, arg_key, index = node.parent, node.arg_key, node.index

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -53,7 +53,7 @@ def _add_local_prefix_for_aliases(expression: exp.Expr) -> exp.Expr:
         ):
             table_ident.replace(exp.to_identifier(table_ident.name.upper(), quoted=True))
 
-        def prefix_local(node, visible_aliases: dict[str, bool]) -> exp.Expr:
+        def prefix_local(node: exp.Expr, visible_aliases: dict[str, bool]) -> exp.Expr:
             if isinstance(node, exp.Column) and not node.table:
                 if node.name in visible_aliases:
                     return exp.Column(

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -219,8 +219,8 @@ def nodes_for_predicate(predicate, sources, scope_ref_count):
     return nodes
 
 
-def replace_aliases(source, predicate):
-    aliases = {}
+def replace_aliases(source: exp.Select, predicate: exp.Expr) -> exp.Expr:
+    aliases: dict[str, exp.Expr] = {}
 
     for select in source.selects:
         if isinstance(select, exp.Alias):
@@ -228,7 +228,7 @@ def replace_aliases(source, predicate):
         else:
             aliases[select.name] = select
 
-    def _replace_alias(column):
+    def _replace_alias(column: exp.Expr) -> exp.Expr:
         if isinstance(column, exp.Column) and column.name in aliases:
             return aliases[column.name].copy()
         return column

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -999,7 +999,7 @@ def quote_identifiers(expression: E, dialect: DialectType = None, identify: bool
     """Makes sure all identifiers that need to be quoted are quoted."""
     return expression.transform(
         Dialect.get_or_raise(dialect).quote_identifier, identify=identify, copy=False
-    )  # type: ignore
+    )
 
 
 def pushdown_cte_alias_columns(scope: Scope) -> None:

--- a/sqlglot/parsers/prql.py
+++ b/sqlglot/parsers/prql.py
@@ -96,7 +96,7 @@ class PRQLParser(parser.Parser):
     def _parse_selection(
         self,
         query: exp.Query,
-        parse_method: t.Callable | None = None,
+        parse_method: t.Callable[..., exp.Expr | None] | None = None,
         append: bool = True,
     ) -> exp.Query:
         parse_method = parse_method if parse_method else self._parse_expression
@@ -109,7 +109,7 @@ class PRQLParser(parser.Parser):
             expression = parse_method()
             selects = [expression] if expression else []
 
-        projections = {
+        projections: dict[str, exp.Expr] = {
             select.alias_or_name: select.this if isinstance(select, exp.Alias) else select
             for select in query.selects
         }


### PR DESCRIPTION
This PR improve the typing of Expr.transform by giving it a proper return type instead of Any, and improve the typing of various call sites of this method.

## Note
Currently, `typing.ParamSpec` can't  be used with this method. this would require moving `copy` as the first positional argument, which imply a breaking change, + we would need a default value for `fun`. So `Callable[..., T]` is the best that can be done for now.