### PR TITLE
feat(mypyc): Enable incremental compilation, deprecate Python 3.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,23 @@ install-dev:
 		fi; \
 	fi
 
+# sqlglotc requires Python 3.10+ (sqlglot-mypy 1.20+ dropped 3.9). On 3.9
+# we skip the C build; tests fall back to pure-Python sqlglot.
+PY_GE_310 := $(shell python -c "import sys; print(int(sys.version_info >= (3, 10)))")
+
 install-devc:
-	cd sqlglotc && MYPYC_OPT=0 python setup.py build_ext --inplace -j $(NPROC)
+	@if [ "$(PY_GE_310)" = "1" ]; then \
+		cd sqlglotc && MYPYC_OPT=0 python setup.py build_ext --inplace -j $(NPROC); \
+	else \
+		echo "Skipping sqlglotc build: requires Python 3.10+"; \
+	fi
 
 install-devc-release: clean
-	cd sqlglotc && python setup.py build_ext --inplace -j $(NPROC)
+	@if [ "$(PY_GE_310)" = "1" ]; then \
+		cd sqlglotc && python setup.py build_ext --inplace -j $(NPROC); \
+	else \
+		echo "Skipping sqlglotc build: requires Python 3.10+"; \
+	fi
 
 install-pre-commit:
 	pre-commit install

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,10 @@ setup(
     extras_require={
         "dev": [
             "duckdb>=0.6",
-            "sqlglot-mypy",
+            # sqlglot-mypy 1.20+ is the build dep for sqlglotc and only ships
+            # for py3.10+; on py3.9 just use upstream mypy for type checking.
+            "sqlglot-mypy >= 1.20.0.post4; python_version >= '3.10'",
+            "mypy; python_version < '3.10'",
             "setuptools_scm",
             "pandas",
             "pandas-stubs",
@@ -21,9 +24,11 @@ setup(
             "typing_extensions",
             "pyperf",
         ],
-        # Compiles from source on the user's machine.
-        "c": [f"sqlglotc=={version}"],
+        # Compiles from source on the user's machine. Requires Python 3.10+
+        # because the build dep (sqlglot-mypy 1.20+) dropped 3.9; on 3.9
+        # `pip install sqlglot[c]` is a no-op and you just get pure-Python sqlglot.
+        "c": [f"sqlglotc=={version}; python_version >= '3.10'"],
         # Deprecated: the Rust tokenizer has been replaced by sqlglotc.
-        "rs": ["sqlglotrs==0.13.0", f"sqlglotc=={version}"],
+        "rs": ["sqlglotrs==0.13.0", f"sqlglotc=={version}; python_version >= '3.10'"],
     },
 )

--- a/sqlglot/__init__.py
+++ b/sqlglot/__init__.py
@@ -1,4 +1,4 @@
-# ruff: noqa: F401, E402
+# ruff: noqa: F401
 """
 .. include:: ../README.md
 
@@ -7,24 +7,8 @@
 
 from __future__ import annotations
 
-# bootstrap mypyc runtime: compiled .so modules do a top-level `import HASH__mypyc`,
-# but the runtime .so lives inside sqlglot/. Pre-load it into sys.modules.
-# this is only needed for editable builds
 from collections.abc import Collection
-import sys
-from pathlib import Path
 from builtins import type as Type
-
-for path in Path(__file__).parent.glob("*__mypyc*.so"):
-    name = path.stem.split(".")[0]
-    if name not in sys.modules:
-        import importlib.util
-
-        spec = importlib.util.spec_from_file_location(name, path)
-        if spec and spec.loader:
-            mod = importlib.util.module_from_spec(spec)
-            sys.modules[name] = mod
-            spec.loader.exec_module(mod)
 
 import logging
 import typing as t

--- a/sqlglot/optimizer/__init__.py
+++ b/sqlglot/optimizer/__init__.py
@@ -1,11 +1,65 @@
 # ruff: noqa: F401
+"""Lazy re-exports from optimizer submodules.
 
-from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
-from sqlglot.optimizer.scope import (
-    Scope as Scope,
-    build_scope as build_scope,
-    find_all_in_scope as find_all_in_scope,
-    find_in_scope as find_in_scope,
-    traverse_scope as traverse_scope,
-    walk_in_scope as walk_in_scope,
-)
+Eager re-exports here trip a circular import under sqlglot[c]: importing
+sqlglot loads compiled `expressions.builders`, which eagerly wires up its
+links to compiled optimizer modules, which causes Python to run this
+file. The eager `from sqlglot.optimizer.optimizer import ...` then asks
+for `sqlglot.Schema`, but `sqlglot/__init__.py` hasn't bound it yet.
+
+PEP 562 `__getattr__` defers the import to first attribute access, by
+which point sqlglot is fully loaded. Tracked upstream in python/mypy#21299.
+"""
+
+from __future__ import annotations
+
+import threading
+import typing as t
+
+# Serialise concurrent first-access lookups; importlib's per-module lock is
+# released before our caching write to globals(), so two threads racing on
+# the same name could otherwise both run the import + getattr.
+_import_lock = threading.RLock()
+
+# Only for type checkers and IDEs; runtime resolution goes through __getattr__.
+if t.TYPE_CHECKING:
+    from sqlglot.optimizer.optimizer import RULES as RULES, optimize as optimize
+    from sqlglot.optimizer.scope import (
+        Scope as Scope,
+        build_scope as build_scope,
+        find_all_in_scope as find_all_in_scope,
+        find_in_scope as find_in_scope,
+        traverse_scope as traverse_scope,
+        walk_in_scope as walk_in_scope,
+    )
+
+# Explicit, because some names collide between optimizer.py and submodules
+# (e.g. `qualify` is both a function and a submodule).
+_LAZY_ATTRS: dict[str, tuple[str, str]] = {
+    "RULES": ("sqlglot.optimizer.optimizer", "RULES"),
+    "optimize": ("sqlglot.optimizer.optimizer", "optimize"),
+    "Scope": ("sqlglot.optimizer.scope", "Scope"),
+    "build_scope": ("sqlglot.optimizer.scope", "build_scope"),
+    "find_all_in_scope": ("sqlglot.optimizer.scope", "find_all_in_scope"),
+    "find_in_scope": ("sqlglot.optimizer.scope", "find_in_scope"),
+    "traverse_scope": ("sqlglot.optimizer.scope", "traverse_scope"),
+    "walk_in_scope": ("sqlglot.optimizer.scope", "walk_in_scope"),
+}
+
+
+def __getattr__(name: str) -> t.Any:
+    import importlib
+
+    with _import_lock:
+        target = _LAZY_ATTRS.get(name)
+        if target is not None:
+            module_name, attr = target
+            value = getattr(importlib.import_module(module_name), attr)
+        else:
+            # Submodule fallback so `from sqlglot.optimizer import qualify` works.
+            try:
+                value = importlib.import_module(f"{__name__}.{name}")
+            except ModuleNotFoundError:
+                raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+        globals()[name] = value
+        return value

--- a/sqlglotc/pyproject.toml
+++ b/sqlglotc/pyproject.toml
@@ -4,17 +4,23 @@ dynamic = ["version"]
 description = "mypyc-compiled extensions for sqlglot"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
 license = "MIT"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 
 [project.optional-dependencies]
-dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy"]
+dev = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy >= 1.20.0.post4"]
 
 [project.urls]
 Homepage = "https://sqlglot.com/"
 Repository = "https://github.com/tobymao/sqlglot"
 
 [build-system]
-requires = ["setuptools >= 61.0", "setuptools_scm", "sqlglot-mypy", "types-python-dateutil", "sqlglot"]
+requires = [
+    "setuptools >= 61.0",
+    "setuptools_scm",
+    "sqlglot-mypy >= 1.20.0.post4",
+    "types-python-dateutil",
+    "sqlglot",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -129,6 +129,8 @@ class sdist(_sdist):
 setup(
     name="sqlglotc",
     packages=[],
-    ext_modules=mypycify(_source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2")),
+    ext_modules=mypycify(
+        _source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2"), separate=True, verbose=True
+    ),
     cmdclass={"build_ext": build_ext, "sdist": sdist},
 )


### PR DESCRIPTION
## What

Switch `sqlglotc`'s mypyc build to `separate=True`, plus the small sqlglot-side tweaks needed to make it work end-to-end. Also deprecates Python 3.9 for `sqlglot[c]` (pure-Python `sqlglot` still supports 3.9).

The `separate=True` flag gives each compiled module its own shared lib + shim, so mypyc only has to regenerate / recompile the modules whose source actually changed.


## Changes

`sqlglot[c]` build:

- **`sqlglotc/setup.py`**: pass `separate=True` to `mypycify()`.
- **`sqlglotc/pyproject.toml`**: bump `requires-python` to `>= 3.10`, pin build dep `sqlglot-mypy >= 1.20.0.post4`. The post4 release carries a cached-SCC codegen fix that makes pip's two-pass wheel build actually package the shared libs (without it, the second `mypycify` pass returned `Extension(sources=[])` and produced an installable but broken wheel).
- **`setup.py`**: gate the `[c]` / `[rs]` extras on `python_version >= '3.10'`. On 3.9, `pip install sqlglot[c]` is a no-op and you get pure-Python sqlglot. Dev extras fall back to upstream `mypy` for type checking on 3.9.
- **`Makefile`**: `install-devc` / `install-devc-release` skip the sqlglotc build on 3.9 with a clear message.

sqlglot package:

- **`sqlglot/__init__.py`**: drop the legacy `*__mypyc*.so` bootstrap preloader. It was written for the old monolithic build where a single hash-named `.so` sat at the package root; under `separate=True` the per-module shared libs (e.g. `errors__mypyc.so`) live next to their `.py` siblings and resolve through Python's normal import machinery via the shim.
- **`sqlglot/optimizer/__init__.py`**: swap the eager top-level re-exports for PEP 562 `__getattr__`. Under `separate=True`'s cross-group init ordering, the previous eager `from sqlglot.optimizer.optimizer import ...` could fire while `sqlglot/__init__.py` was still mid-bootstrap and trip a circular `ImportError` on `from sqlglot import Schema, exp`. Lazy resolution defers the cycle past sqlglot's init. Concurrent first-access lookups are serialised with an `RLock`, mirroring `sqlglot/dialects/__init__.py`.

Replaces #7558 (squashed history).