### PR TITLE
[CLAUDE] [OPUS 4.7] fix(annotate): register typing for FirstValue and RegexpExtract

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -252,6 +252,7 @@ EXPRESSION_METADATA: ExprMetadataType = {
             exp.ArrayReverse,
             exp.ArraySlice,
             exp.Filter,
+            exp.FirstValue,
             exp.HavingMax,
             exp.LastValue,
             exp.Limit,

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -178,7 +178,6 @@ EXPRESSION_METADATA = {
             exp.DateAdd,
             exp.DateTrunc,
             exp.DatetimeTrunc,
-            exp.FirstValue,
             exp.GroupConcat,
             exp.IgnoreNulls,
             exp.JSONExtract,

--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -28,6 +28,7 @@ EXPRESSION_METADATA = {
             exp.CurrentSchema,
             exp.Hex,
             exp.NextDay,
+            exp.RegexpExtract,
             exp.Repeat,
             exp.Replace,
             exp.Soundex,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -91,6 +91,12 @@ BIGINT;
 LAST_VALUE(tbl.bigint_col) OVER (ORDER BY tbl.bigint_col);
 BIGINT;
 
+FIRST_VALUE(tbl.bigint_col) OVER (ORDER BY tbl.bigint_col);
+BIGINT;
+
+FIRST_VALUE(tbl.str_col) OVER (ORDER BY tbl.str_col);
+TEXT;
+
 TO_BASE32(tbl.bytes_col);
 VARCHAR;
 
@@ -198,6 +204,14 @@ STRING;
 # dialect: spark2, spark, databricks
 SUBSTRING(tbl.bin_col, 0, 0);
 BINARY;
+
+# dialect: spark2, spark, databricks
+REGEXP_EXTRACT(tbl.str_col, pattern, 0);
+STRING;
+
+# dialect: spark2, spark, databricks
+REGEXP_EXTRACT(tbl.bin_col, pattern, 0);
+STRING;
 
 # dialect: spark2, spark, databricks
 CONCAT(tbl.bin_col, tbl.bin_col);
@@ -2374,6 +2388,10 @@ BIGINT;
 # dialect: snowflake
 ABS(tbl.bigint_col);
 BIGINT;
+
+# dialect: snowflake
+REGEXP_SUBSTR(tbl.str_col, pattern, 1);
+VARCHAR;
 
 # dialect: snowflake
 ABS(tbl.double_col);
@@ -6010,6 +6028,10 @@ DATETIME;
 --------------------------------------
 -- DuckDB
 --------------------------------------
+
+# dialect: duckdb
+REGEXP_EXTRACT(tbl.str_col, pattern, 0);
+UNKNOWN;
 
 # dialect: duckdb
 SHA1(tbl.str_col);


### PR DESCRIPTION
Register `FirstValue`  in base `EXPRESSION_METADATA` and `RegexpExtract` in Hive `EXPRESSION_METADATA` so the type annotator returns the right type instead of UNKNOWN.

- `FirstValue`: propagates type of `this` arg — correct for every dialect. Presumed harmless in dialects (like SQLite) where FirstValue is not supported.
- `RegexpExtract`: VARCHAR in Hive (and descendants: Spark2, Spark, Databricks) and Snowflake. Left out of base since DuckDB handles regexp_extract unlike other implementations.
- Regression fixture pins DuckDB `REGEXP_EXTRACT` → UNKNOWN.