### PR TITLE
fix(oracle): Support FORMAT JSON in JSON_TABLE

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -1956,6 +1956,7 @@ class JSONColumnDef(Expression):
         "path": False,
         "nested_schema": False,
         "ordinality": False,
+        "format_json": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3609,9 +3609,10 @@ class Generator:
         this = self.sql(expression, "this")
         kind = self.sql(expression, "kind")
         kind = f" {kind}" if kind else ""
+        format_json = " FORMAT JSON" if expression.args.get("format_json") else ""
 
         ordinality = " FOR ORDINALITY" if expression.args.get("ordinality") else ""
-        return f"{this}{kind}{path}{ordinality}"
+        return f"{this}{kind}{format_json}{path}{ordinality}"
 
     def jsonschema_sql(self, expression: exp.JSONSchema) -> str:
         return self.func("COLUMNS", *expression.expressions)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7931,12 +7931,18 @@ class Parser:
             kind = None
             nested = True
 
+        format_json = self._match_text_seq("FORMAT", "JSON")
         path = self._match_text_seq("PATH") and self._parse_string()
         nested_schema = nested and self._parse_json_schema()
 
         return self.expression(
             exp.JSONColumnDef(
-                this=this, kind=kind, path=path, nested_schema=nested_schema, ordinality=ordinality
+                this=this,
+                kind=kind,
+                path=path,
+                nested_schema=nested_schema,
+                ordinality=ordinality,
+                format_json=format_json,
             )
         )
 

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -580,6 +580,9 @@ FROM JSON_TABLE(res, '$.info[*]' COLUMNS(
 )) src""",
             pretty=True,
         )
+        self.validate_identity(
+            "SELECT * FROM JSON_TABLE(my_doc, '$.data[*]' COLUMNS(NAME VARCHAR2(200) PATH '$.name', DATA CLOB FORMAT JSON PATH '$.data')) j"
+        )
         self.validate_identity("CONVERT('foo', 'dst')")
         self.validate_identity("CONVERT('foo', 'dst', 'src')")
 


### PR DESCRIPTION
Don't fail when parsing `JSON_TABLE` with `FORMAT JSON`

from docs: _You must specify FORMAT JSON if expr is a column of data type BLOB._

Docs: https://docs.oracle.com/en/database/oracle/oracle-database/26/sqlrf/JSON_TABLE.html