### PR TITLE
Feat(optimizer): canonicalize internal query names

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2068,7 +2068,9 @@ class Semicolon(Expression):
 
 
 class TableColumn(Expression):
-    pass
+    @property
+    def output_name(self) -> str:
+        return self.name
 
 
 class Variadic(Expression):

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -76,9 +76,7 @@ def canonicalize_internal_names(
         table_map: dict[str, str] = {}
 
         for source_name, source in scope.sources.items():
-            source_cols = columns_by_source.get(source_name)
-            if not source_cols:
-                continue
+            source_cols = columns_by_source.get(source_name, [])
 
             alias_holder: exp.Expr | None = None
             is_base_source = isinstance(source, exp.Table)

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+import typing as t
+
+from sqlglot import exp
+from sqlglot.dialects.dialect import DialectType
+from sqlglot.helper import name_sequence
+from sqlglot.optimizer.qualify import qualify
+from sqlglot.optimizer.scope import Scope, find_all_in_scope, traverse_scope
+from sqlglot.schema import Schema
+
+if t.TYPE_CHECKING:
+    from sqlglot._typing import E
+
+
+def canonicalize_internal_names(
+    expression: E,
+    dialect: DialectType = None,
+    schema: dict[str, object] | Schema | None = None,
+    **qualify_kwargs: t.Any,
+) -> E:
+    """
+    Rewrite a query to a canonical structural form.
+
+    Preserves data-contract names (base-table names and columns, top-level output
+    aliases) and canonicalizes internal names (table aliases, CTE/subquery names,
+    internal column aliases) to sequential `_tN` / `_cN`. For set operations the
+    top-level output is the leftmost leaf SELECT.
+
+    Example:
+        >>> import sqlglot
+        >>> schema = {"src": {"c1": "INT", "c2": "INT"}}
+        >>> canonicalize_internal_names(sqlglot.parse_one("WITH t AS (SELECT c1, c2 FROM c.db.src) SELECT * FROM t"), schema=schema).sql()
+        'WITH "_t1" AS (SELECT "_t0"."c1" AS "_c0", "_t0"."c2" AS "_c1" FROM "c"."db"."src" AS "_t0") SELECT "_t1"."_c0" AS "c1", "_t1"."_c1" AS "c2" FROM "_t1" AS "_t1"'
+    """
+    expression = t.cast("E", qualify(expression, dialect=dialect, schema=schema, **qualify_kwargs))
+
+    # Top-level output scopes: their aliases are the query's data contract.
+    # Regular UNION takes names from the left branch; UNION BY NAME takes names
+    # from the union of all branches, so both sides of a by_name SetOperation
+    # contribute.
+    output_scope_exprs: set[int] = set()
+    stack: list[exp.Expr] = [expression]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, exp.SetOperation):
+            stack.append(node.left.unnest())
+            if node.args.get("by_name"):
+                stack.append(node.right.unnest())
+        else:
+            output_scope_exprs.add(id(node))
+
+    next_table = name_sequence("_t")
+    next_column = name_sequence("_c")
+
+    def _canon(ident: exp.Identifier, name: str) -> None:
+        ident.set("this", name)
+        ident.set("quoted", True)
+
+    scope_table: dict[int, str] = {}
+    scope_outputs: dict[int, dict[str, str]] = {}
+
+    # Shared across scopes so a Table referenced from multiple scopes (LATERAL/UNNEST) gets consistent column names
+    table_columns: dict[int, dict[str, str]] = {}
+
+    for scope in traverse_scope(expression):
+        scope_expr = scope.expression
+        is_output_scope = id(scope_expr) in output_scope_exprs
+
+        columns_by_source: dict[str, list[exp.Column | exp.TableColumn]] = {}
+        for col in scope.columns:
+            columns_by_source.setdefault(col.table, []).append(col)
+        for table_col in scope.table_columns:
+            columns_by_source.setdefault(table_col.name, []).append(table_col)
+
+        table_map: dict[str, str] = {}
+
+        for source_name, source in scope.sources.items():
+            source_cols = columns_by_source.get(source_name)
+            if not source_cols:
+                continue
+
+            alias_holder: exp.Expr | None = None
+            is_base_source = isinstance(source, exp.Table)
+
+            if is_base_source:
+                canon_t = scope_table.get(id(source), "")
+                if not canon_t:
+                    canon_t = next_table()
+                    scope_table[id(source)] = canon_t
+                child_output: dict[str, str] = {}
+                name_map: dict[str, str] = table_columns.setdefault(id(source), {})
+            elif isinstance(source, Scope):
+                # Key by id(expression) so a recursive CTE's self-reference, i.e., a separate
+                # Scope whose `expression` is the same object as the CTE's base branch, shares
+                # the base branch's output mapping.
+                src_expr = source.expression
+                child_output = scope_outputs.get(id(src_expr), {})
+
+                parent = src_expr.parent
+                if isinstance(parent, (exp.CTE, exp.Subquery)):
+                    alias_holder = parent
+                elif (
+                    isinstance(parent, exp.SetOperation)
+                    and isinstance(cte := parent.parent, exp.CTE)
+                    and isinstance(with_ := cte.parent, exp.With)
+                    and with_.recursive
+                ):
+                    alias_holder = cte
+                elif source.is_udtf:
+                    alias_holder = src_expr
+
+                table_key = id(alias_holder) if alias_holder else id(source)
+                canon_t = scope_table.get(table_key, "")
+
+                if not canon_t:
+                    canon_t = next_table()
+                    scope_table[table_key] = canon_t
+                else:
+                    alias_holder = None  # already renamed on a previous encounter
+
+                name_map = {}
+            else:
+                continue
+
+            table_map[source_name] = canon_t
+
+            for src_col in source_cols:
+                # BigQuery whole-row struct ref (`SELECT t FROM t`): the identifier
+                # IS the table alias, so rename it to the canonical table name.
+                if isinstance(src_col, exp.TableColumn):
+                    _canon(src_col.this, canon_t)
+                    continue
+
+                old_name = src_col.name
+                canon_col = name_map.get(old_name)
+
+                if canon_col is None:
+                    if is_base_source:
+                        canon_col = old_name
+                    else:
+                        canon_col = child_output.get(old_name) or next_column()
+
+                    name_map[old_name] = canon_col
+
+                # Base-table column refs are part of the data contract => preserve verbatim (including quote state).
+                # Scope-sourced column refs are internal handles pointing at CTE/subquery aliases (injected unquoted
+                # via exp.to_identifier); they must match, so _canon
+                if not is_base_source:
+                    _canon(src_col.this, canon_col)
+
+                table_id = src_col.args.get("table")
+                if table_id:
+                    _canon(table_id, canon_t)
+
+            if alias_holder:
+                if alias := alias_holder.args.get("alias"):
+                    if isinstance(alias.this, exp.Identifier):
+                        _canon(alias.this, canon_t)
+                    if alias.columns:
+                        alias.set(
+                            "columns",
+                            [
+                                exp.to_identifier(name_map.get(c.name, c.name), quoted=c.quoted)
+                                for c in alias.columns
+                            ],
+                        )
+
+                # BigQuery UNNEST ... WITH OFFSET AS <id> declares a pseudo-column via
+                # the offset arg (not the alias).
+                if isinstance(alias_holder, exp.Unnest):
+                    offset_id = alias_holder.args.get("offset")
+                    if isinstance(offset_id, exp.Identifier) and offset_id.name in name_map:
+                        _canon(offset_id, name_map[offset_id.name])
+
+        # PIVOT output column names are bound to the IN-clause literals, so only the
+        # alias (which qualifies column refs like `my_pivot.x`) is canonicalized.
+        for pivot in scope.pivots:
+            pivot_alias = pivot.args.get("alias")
+            if not (pivot_alias and isinstance(pivot_alias.this, exp.Identifier)):
+                continue
+            pivot_cols = columns_by_source.get(pivot_alias.this.name)
+            if not pivot_cols:
+                continue
+
+            canon_t = next_table()
+            _canon(pivot_alias.this, canon_t)
+
+            for pivot_col in pivot_cols:
+                table_id = pivot_col.args.get("table")
+                if table_id:
+                    _canon(table_id, canon_t)
+
+        for table in scope.tables:
+            canon = table_map.get(table.alias_or_name)
+            if not canon:
+                continue
+
+            # Real tables (qualified with db/catalog) keep their physical name;
+            # CTE/subquery references get the canonical `_tN`.
+            if isinstance(table.this, exp.Identifier) and not table.args.get("db"):
+                _canon(table.this, canon)
+
+            alias = table.args.get("alias")
+            if alias:
+                if isinstance(alias.this, exp.Identifier):
+                    _canon(alias.this, canon)
+                if alias.columns:
+                    tc = table_columns.get(id(table), {})
+                    alias.set(
+                        "columns",
+                        [
+                            exp.to_identifier(tc.get(c.name, c.name), quoted=c.quoted)
+                            for c in alias.columns
+                        ],
+                    )
+
+        output_map: dict[str, str] = {}
+        if isinstance(scope_expr, exp.Select):
+            for sel in scope_expr.selects:
+                if isinstance(sel, exp.Alias):
+                    old_alias = sel.alias
+                    if is_output_scope:
+                        new_name = old_alias
+                    else:
+                        new_name = next_column()
+                        sel.set("alias", exp.to_identifier(new_name, quoted=True))
+
+                    output_map[old_alias] = new_name
+        elif isinstance(scope_expr, exp.SetOperation) and scope.union_scopes:
+            # Regular UNION names come from the left branch. UNION BY NAME folds
+            # in right-branch names too (any column unique to the right still
+            # appears in the output).
+            output_map = scope_outputs.get(id(scope.union_scopes[0].expression), {}).copy()
+            if scope_expr.args.get("by_name"):
+                right_out = scope_outputs.get(id(scope.union_scopes[1].expression), {})
+                for k, v in right_out.items():
+                    output_map.setdefault(k, v)
+        elif scope.is_udtf and scope.subquery_scopes:
+            output_map = scope_outputs.get(id(scope.subquery_scopes[0].expression), {}).copy()
+
+        scope_outputs[id(scope_expr)] = output_map
+
+        # Unqualified alias references (ORDER BY a, HAVING a > 5, ...)
+        for col in find_all_in_scope(scope_expr, exp.Column):
+            if not col.table and col.name in output_map:
+                _canon(col.this, output_map[col.name])
+
+        # UBN matches branches by original alias. When both branches are internal
+        # and aliased to distinct _cN, matching originals land on different slots
+        # and UBN splits them into disjoint output columns, dropping data. Align
+        # the right branch's canonicals to the left's. No-op when both branches
+        # preserved their aliases (top-level UBN).
+        if isinstance(scope_expr, exp.SetOperation) and scope_expr.args.get("by_name"):
+            left_scope, right_scope = scope.union_scopes
+            left_out = scope_outputs.get(id(left_scope.expression), {})
+            right_out = scope_outputs.get(id(right_scope.expression), {})
+
+            rename: dict[str, str] = {}
+            for orig_name, left_canon in left_out.items():
+                right_canon = right_out.get(orig_name)
+                if right_canon and right_canon != left_canon:
+                    rename[right_canon] = left_canon
+
+            if rename:
+                rename_stack: list[exp.Expr] = [right_scope.expression]
+                while rename_stack:
+                    node = rename_stack.pop()
+                    if isinstance(node, exp.SetOperation):
+                        rename_stack.append(node.left)
+                        rename_stack.append(node.right)
+                        continue
+                    if not isinstance(node, exp.Select):
+                        continue
+                    for sel in node.selects:
+                        if isinstance(sel, exp.Alias):
+                            aid = sel.args.get("alias")
+                            if isinstance(aid, exp.Identifier) and aid.name in rename:
+                                _canon(aid, rename[aid.name])
+                    for col in find_all_in_scope(node, exp.Column):
+                        if not col.table and col.name in rename:
+                            _canon(col.this, rename[col.name])
+
+                scope_outputs[id(right_scope.expression)] = {
+                    k: rename.get(v, v) for k, v in right_out.items()
+                }
+
+    return expression

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -3,22 +3,14 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp
-from sqlglot.dialects.dialect import DialectType
 from sqlglot.helper import name_sequence
-from sqlglot.optimizer.qualify import qualify
 from sqlglot.optimizer.scope import Scope, find_all_in_scope, traverse_scope
-from sqlglot.schema import Schema
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
 
-def canonicalize_internal_names(
-    expression: E,
-    dialect: DialectType = None,
-    schema: dict[str, object] | Schema | None = None,
-    **qualify_kwargs: t.Any,
-) -> E:
+def canonicalize_internal_names(expression: E) -> E:
     """
     Rewrite a query to a canonical structural form.
 
@@ -27,13 +19,17 @@ def canonicalize_internal_names(
     internal column aliases) to sequential `_tN` / `_cN`. For set operations the
     top-level output is the leftmost leaf SELECT.
 
+    Assumes the expression has already been processed by `qualify` (or equivalent),
+    so that columns are bound to sources and aliases exist on every projection /
+    subquery / CTE.
+
     Example:
         >>> import sqlglot
+        >>> from sqlglot.optimizer.qualify import qualify
         >>> schema = {"src": {"c1": "INT", "c2": "INT"}}
-        >>> canonicalize_internal_names(sqlglot.parse_one("WITH t AS (SELECT c1, c2 FROM c.db.src) SELECT * FROM t"), schema=schema).sql()
+        >>> canonicalize_internal_names(qualify(sqlglot.parse_one("WITH t AS (SELECT c1, c2 FROM c.db.src) SELECT * FROM t"), schema=schema)).sql()
         'WITH "_t1" AS (SELECT "_t0"."c1" AS "_c0", "_t0"."c2" AS "_c1" FROM "c"."db"."src" AS "_t0") SELECT "_t1"."_c0" AS "c1", "_t1"."_c1" AS "c2" FROM "_t1" AS "_t1"'
     """
-    expression = t.cast("E", qualify(expression, dialect=dialect, schema=schema, **qualify_kwargs))
 
     # Top-level output scopes: their aliases are the query's data contract.
     # Regular UNION takes names from the left branch; UNION BY NAME takes names

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -69,7 +69,16 @@ def canonicalize_internal_names(expression: E) -> E:
         for table_col in scope.table_columns:
             columns_by_source.setdefault(table_col.name, []).append(table_col)
 
-        table_map: dict[str, str] = {}
+        # source_canon: source's canonical name (used in WITH "_tN" AS, and as
+        #   the physical table name in `Table.this`). Shared across every reference
+        #   to the same source within this scope.
+        # ref_alias:   per-reference canonical alias (used as the alias on each
+        #   `Table` node and as the qualifier on its column refs). The first
+        #   reference reuses source_canon for compactness; subsequent refs get
+        #   fresh `_tN` names so a self-join like `cte AS x JOIN cte AS y`
+        #   produces unique aliases.
+        table_map: dict[str, tuple[str, str]] = {}
+        ref_canon_taken: set[str] = set()
 
         for source_name, source in scope.sources.items():
             source_cols = columns_by_source.get(source_name, [])
@@ -117,13 +126,19 @@ def canonicalize_internal_names(expression: E) -> E:
             else:
                 continue
 
-            table_map[source_name] = canon_t
+            if canon_t in ref_canon_taken:
+                ref_alias = next_table()
+            else:
+                ref_alias = canon_t
+                ref_canon_taken.add(canon_t)
+
+            table_map[source_name] = (canon_t, ref_alias)
 
             for src_col in source_cols:
                 # BigQuery whole-row struct ref (`SELECT t FROM t`): the identifier
-                # IS the table alias, so rename it to the canonical table name.
+                # IS the table alias, so rename it to this reference's alias.
                 if isinstance(src_col, exp.TableColumn):
-                    _canon(src_col.this, canon_t)
+                    _canon(src_col.this, ref_alias)
                     continue
 
                 old_name = src_col.name
@@ -145,11 +160,13 @@ def canonicalize_internal_names(expression: E) -> E:
 
                 table_id = src_col.args.get("table")
                 if table_id:
-                    _canon(table_id, canon_t)
+                    _canon(table_id, ref_alias)
 
             if alias_holder:
                 if alias := alias_holder.args.get("alias"):
                     if isinstance(alias.this, exp.Identifier):
+                        # The CTE/Subquery name itself uses source_canon (canon_t),
+                        # not ref_alias — it's the source's identity, not a reference.
                         _canon(alias.this, canon_t)
                     if alias.columns:
                         alias.set(
@@ -186,19 +203,22 @@ def canonicalize_internal_names(expression: E) -> E:
                     _canon(table_id, canon_t)
 
         for table in scope.tables:
-            canon = table_map.get(table.alias_or_name)
-            if not canon:
+            entry = table_map.get(table.alias_or_name)
+            if not entry:
                 continue
+            source_canon, ref_alias = entry
 
             # Real tables (qualified with db/catalog) keep their physical name;
-            # CTE/subquery references get the canonical `_tN`.
+            # CTE/subquery references get the source's canonical `_tN`.
             if isinstance(table.this, exp.Identifier) and not table.args.get("db"):
-                _canon(table.this, canon)
+                _canon(table.this, source_canon)
 
             alias = table.args.get("alias")
             if alias:
+                # The reference alias uses ref_alias, which is unique per Table
+                # node so multiple references to the same source can coexist.
                 if isinstance(alias.this, exp.Identifier):
-                    _canon(alias.this, canon)
+                    _canon(alias.this, ref_alias)
                 if alias.columns:
                     tc = table_columns.get(id(table), {})
                     alias.set(

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -68,6 +68,7 @@ def _source_files(src_dir):
                 "qualify_columns.py",
                 "simplify.py",
                 "annotate_types.py",
+                "canonicalize_internal_names.py",
             ],
         ),
         *_subpkg_files(src_dir, "parsers"),

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -20,7 +20,7 @@ WITH "_t1" AS (SELECT "_t0"."a" AS "_c0", "_t0"."b" AS "_c1" FROM "c"."db"."x" A
 
 # title: multi cte
 WITH t1 AS (SELECT a FROM x), t2 AS (SELECT b FROM y) SELECT t1.a, t2.b FROM t1 JOIN t2 ON t1.a = t2.b;
-WITH "_t2" AS (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0"), "_t3" AS (SELECT "_t1"."b" AS "_c1" FROM "c"."db"."y" AS "_t1") SELECT "_t2"."_c0" AS "a", "_t3"."_c1" AS "b" FROM "_t2" AS "_t2" JOIN "_t3" AS "_t3" ON "_t2"."_c0" = "_t3"."_c1";
+WITH "_t1" AS (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0"), "_t3" AS (SELECT "_t2"."b" AS "_c1" FROM "c"."db"."y" AS "_t2") SELECT "_t1"."_c0" AS "a", "_t3"."_c1" AS "b" FROM "_t1" AS "_t1" JOIN "_t3" AS "_t3" ON "_t1"."_c0" = "_t3"."_c1";
 
 # title: cross join
 SELECT x.a, y.c FROM x CROSS JOIN y;
@@ -161,7 +161,7 @@ SELECT "_t0"."_c0" AS "i", "_t0"."_c1" AS "s" FROM (VALUES (1, 'a'), (2, 'b')) A
 # title: lateral subquery alias is canonicalized, outer table shared with lateral body
 # dialect: postgres
 SELECT x.a, t.b FROM x, LATERAL (SELECT x.a + 1 AS b) AS t;
-SELECT "_t0"."a" AS "a", "_t1"."_c0" AS "b" FROM "c"."db"."x" AS "_t0", LATERAL (SELECT "_t0"."a" + 1 AS "_c0") AS "_t1";
+SELECT "_t0"."a" AS "a", "_t2"."_c0" AS "b" FROM "c"."db"."x" AS "_t0", LATERAL (SELECT "_t0"."a" + 1 AS "_c0") AS "_t2";
 
 # title: window function with partition and order
 SELECT a, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rn FROM x;

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -1,0 +1,251 @@
+# title: simple select
+SELECT a FROM x;
+SELECT "_t0"."a" AS "a" FROM "c"."db"."x" AS "_t0";
+
+# title: select with where
+SELECT a FROM x WHERE b > 5;
+SELECT "_t0"."a" AS "a" FROM "c"."db"."x" AS "_t0" WHERE "_t0"."b" > 5;
+
+# title: select star expanded
+SELECT * FROM x;
+SELECT "_t0"."a" AS "a", "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0";
+
+# title: two columns
+SELECT a, b FROM x;
+SELECT "_t0"."a" AS "a", "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0";
+
+# title: single cte
+WITH t AS (SELECT a, b FROM x) SELECT * FROM t;
+WITH "_t1" AS (SELECT "_t0"."a" AS "_c0", "_t0"."b" AS "_c1" FROM "c"."db"."x" AS "_t0") SELECT "_t1"."_c0" AS "a", "_t1"."_c1" AS "b" FROM "_t1" AS "_t1";
+
+# title: multi cte
+WITH t1 AS (SELECT a FROM x), t2 AS (SELECT b FROM y) SELECT t1.a, t2.b FROM t1 JOIN t2 ON t1.a = t2.b;
+WITH "_t2" AS (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0"), "_t3" AS (SELECT "_t1"."b" AS "_c1" FROM "c"."db"."y" AS "_t1") SELECT "_t2"."_c0" AS "a", "_t3"."_c1" AS "b" FROM "_t2" AS "_t2" JOIN "_t3" AS "_t3" ON "_t2"."_c0" = "_t3"."_c1";
+
+# title: cross join
+SELECT x.a, y.c FROM x CROSS JOIN y;
+SELECT "_t0"."a" AS "a", "_t1"."c" AS "c" FROM "c"."db"."x" AS "_t0" CROSS JOIN "c"."db"."y" AS "_t1";
+
+# title: inner join
+SELECT x.a, y.c FROM x JOIN y ON x.b = y.b;
+SELECT "_t0"."a" AS "a", "_t1"."c" AS "c" FROM "c"."db"."x" AS "_t0" JOIN "c"."db"."y" AS "_t1" ON "_t0"."b" = "_t1"."b";
+
+# title: self join
+SELECT a.a, b.b FROM x AS a JOIN x AS b ON a.a = b.b;
+SELECT "_t0"."a" AS "a", "_t1"."b" AS "b" FROM "c"."db"."x" AS "_t0" JOIN "c"."db"."x" AS "_t1" ON "_t0"."a" = "_t1"."b";
+
+# title: subquery in from
+SELECT t.a FROM (SELECT a FROM x) AS t;
+SELECT "_t1"."_c0" AS "a" FROM (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0") AS "_t1";
+
+# title: subquery with column aliases, user-declared aliases on the subquery are internal handles
+SELECT t.p, t.q FROM (SELECT a, b FROM x) AS t(p, q);
+SELECT "_t1"."_c0" AS "p", "_t1"."_c1" AS "q" FROM (SELECT "_t0"."a" AS "_c0", "_t0"."b" AS "_c1" FROM "c"."db"."x" AS "_t0") AS "_t1";
+
+# title: nested subqueries
+SELECT t.a FROM (SELECT t.a FROM (SELECT a FROM x) AS t) AS t;
+SELECT "_t2"."_c1" AS "a" FROM (SELECT "_t1"."_c0" AS "_c1" FROM (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0") AS "_t1") AS "_t2";
+
+# title: uncorrelated subquery
+SELECT a FROM x WHERE b IN (SELECT b FROM y);
+SELECT "_t1"."a" AS "a" FROM "c"."db"."x" AS "_t1" WHERE "_t1"."b" IN (SELECT "_t0"."b" AS "_c0" FROM "c"."db"."y" AS "_t0");
+
+# title: correlated subquery
+SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.b = x.b);
+SELECT "_t1"."a" AS "a" FROM "c"."db"."x" AS "_t1" WHERE EXISTS(SELECT 1 AS "_c0" FROM "c"."db"."y" AS "_t0" WHERE "_t0"."b" = "_t1"."b");
+
+# title: aggregation, auto-generated _col_N alias from qualify is left untouched at top level
+SELECT a, COUNT(b) FROM x GROUP BY a HAVING COUNT(b) > 1;
+SELECT "_t0"."a" AS "a", COUNT("_t0"."b") AS "_col_1" FROM "c"."db"."x" AS "_t0" GROUP BY "_t0"."a" HAVING COUNT("_t0"."b") > 1;
+
+# title: expression in select
+SELECT a + 1 FROM x;
+SELECT "_t0"."a" + 1 AS "_col_0" FROM "c"."db"."x" AS "_t0";
+
+# title: order by alias reference
+SELECT a, b FROM x ORDER BY a LIMIT 10;
+SELECT "_t0"."a" AS "a", "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0" ORDER BY "a" LIMIT 10;
+
+# title: order by positional reference
+SELECT a, b FROM x ORDER BY 1 DESC;
+SELECT "_t0"."a" AS "a", "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0" ORDER BY "a" DESC;
+
+# title: group by positional reference
+SELECT a, COUNT(b) FROM x GROUP BY 1;
+SELECT "_t0"."a" AS "a", COUNT("_t0"."b") AS "_col_1" FROM "c"."db"."x" AS "_t0" GROUP BY "_t0"."a";
+
+# title: group by multiple positional references
+SELECT a, b, COUNT(*) FROM x GROUP BY 1, 2;
+SELECT "_t0"."a" AS "a", "_t0"."b" AS "b", COUNT(*) AS "_col_2" FROM "c"."db"."x" AS "_t0" GROUP BY "_t0"."a", "_t0"."b";
+
+# title: union
+SELECT a FROM x UNION SELECT b FROM y;
+SELECT "_t0"."a" AS "a" FROM "c"."db"."x" AS "_t0" UNION SELECT "_t1"."b" AS "_c0" FROM "c"."db"."y" AS "_t1";
+
+# title: union by name, matching column names unify to the same canonical name
+# dialect: duckdb
+SELECT a, b FROM x UNION BY NAME SELECT b, c FROM z;
+SELECT "_t0"."a" AS "a", "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0" UNION BY NAME SELECT "_t1"."b" AS "b", "_t1"."c" AS "c" FROM "c"."db"."z" AS "_t1";
+
+# title: union by name, disjoint column names stay distinct
+# dialect: duckdb
+SELECT a FROM x UNION BY NAME SELECT c FROM y;
+SELECT "_t0"."a" AS "a" FROM "c"."db"."x" AS "_t0" UNION BY NAME SELECT "_t1"."c" AS "c" FROM "c"."db"."y" AS "_t1";
+
+# title: union by name, nested rhs — inner branch aliases align with the outer left's canonical name
+# dialect: duckdb
+SELECT a + 1 AS shared FROM x UNION BY NAME (SELECT b AS shared FROM y UNION BY NAME SELECT c AS shared FROM z);
+SELECT "_t0"."a" + 1 AS "shared" FROM "c"."db"."x" AS "_t0" UNION BY NAME (SELECT "_t1"."b" AS "shared" FROM "c"."db"."y" AS "_t1" UNION BY NAME SELECT "_t2"."c" AS "shared" FROM "c"."db"."z" AS "_t2");
+
+# title: union by name inside a CTE, right branch's internal _cN is aligned with the left's so UBN merges correctly
+# dialect: duckdb
+WITH t AS (SELECT a AS k FROM x UNION BY NAME SELECT b AS k FROM y) SELECT k FROM t;
+WITH "_t2" AS (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0" UNION BY NAME SELECT "_t1"."b" AS "_c0" FROM "c"."db"."y" AS "_t1") SELECT "_t2"."_c0" AS "k" FROM "_t2" AS "_t2";
+
+# title: case when
+SELECT CASE WHEN a > 0 THEN b ELSE a END FROM x;
+SELECT CASE WHEN "_t0"."a" > 0 THEN "_t0"."b" ELSE "_t0"."a" END AS "_col_0" FROM "c"."db"."x" AS "_t0";
+
+# title: three way join
+SELECT x.a, y.b, z.c FROM x JOIN y ON x.b = y.b JOIN z ON y.c = z.c;
+SELECT "_t0"."a" AS "a", "_t1"."b" AS "b", "_t2"."c" AS "c" FROM "c"."db"."x" AS "_t0" JOIN "c"."db"."y" AS "_t1" ON "_t0"."b" = "_t1"."b" JOIN "c"."db"."z" AS "_t2" ON "_t1"."c" = "_t2"."c";
+
+# title: struct field access, field names are preserved
+SELECT structs.one.a_1 FROM structs;
+SELECT "_t0"."one"."a_1" AS "a_1" FROM "c"."db"."structs" AS "_t0";
+
+# title: nested struct field access, field names are preserved
+SELECT structs.nested_0.nested_1.a_2 FROM structs;
+SELECT "_t0"."nested_0"."nested_1"."a_2" AS "a_2" FROM "c"."db"."structs" AS "_t0";
+
+# title: struct field access in where, field names are preserved
+SELECT structs.one.b_1 FROM structs WHERE structs.one.a_1 > 0;
+SELECT "_t0"."one"."b_1" AS "b_1" FROM "c"."db"."structs" AS "_t0" WHERE "_t0"."one"."a_1" > 0;
+
+# title: json bracket access, field names are preserved
+SELECT j['name'] FROM jtbl WHERE j['age'] > 18;
+SELECT "_t0"."j"['name'] AS "name" FROM "c"."db"."jtbl" AS "_t0" WHERE "_t0"."j"['age'] > 18;
+
+# title: json nested bracket access, field names are preserved
+SELECT j['a']['b'] FROM jtbl;
+SELECT "_t0"."j"['a']['b'] AS "b" FROM "c"."db"."jtbl" AS "_t0";
+
+# title: json extract function, path string is preserved
+SELECT JSON_EXTRACT(j, '$.field') FROM jtbl;
+SELECT JSON_EXTRACT("_t0"."j", '$.field') AS "field" FROM "c"."db"."jtbl" AS "_t0";
+
+# title: postgres json arrow operator, field name is preserved
+# dialect: postgres
+SELECT j -> 'field' FROM jtbl;
+SELECT "_t0"."j" -> 'field' AS "field" FROM "c"."db"."jtbl" AS "_t0";
+
+# title: select star except, excluded columns are dropped before canonicalization
+# dialect: duckdb
+SELECT * EXCEPT (a) FROM x;
+SELECT "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0";
+
+# title: select star replace, replacement expression is canonicalized (top-level alias 'a' is preserved)
+# dialect: bigquery
+SELECT * REPLACE (a + 1 AS a) FROM x;
+SELECT `_t0`.`a` + 1 AS `a`, `_t0`.`b` AS `b` FROM `c`.`db`.`x` AS `_t0`;
+
+# title: select star rename, the renamed top-level alias is preserved
+# dialect: snowflake
+SELECT * RENAME (a AS new_a) FROM x;
+SELECT "_t0"."A" AS "NEW_A", "_t0"."B" AS "B" FROM "C"."DB"."X" AS "_t0";
+
+# title: values clause with column aliases, alias and column names are internal handles
+SELECT t.i, t.s FROM (VALUES (1, 'a'), (2, 'b')) AS t(i, s);
+SELECT "_t0"."_c0" AS "i", "_t0"."_c1" AS "s" FROM (VALUES (1, 'a'), (2, 'b')) AS "_t0"("_c0", "_c1");
+
+# title: lateral subquery alias is canonicalized, outer table shared with lateral body
+# dialect: postgres
+SELECT x.a, t.b FROM x, LATERAL (SELECT x.a + 1 AS b) AS t;
+SELECT "_t0"."a" AS "a", "_t1"."_c0" AS "b" FROM "c"."db"."x" AS "_t0", LATERAL (SELECT "_t0"."a" + 1 AS "_c0") AS "_t1";
+
+# title: window function with partition and order
+SELECT a, ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) AS rn FROM x;
+SELECT "_t0"."a" AS "a", ROW_NUMBER() OVER (PARTITION BY "_t0"."a" ORDER BY "_t0"."b") AS "rn" FROM "c"."db"."x" AS "_t0";
+
+# title: qualify clause with window function
+# dialect: bigquery
+SELECT a, b FROM x QUALIFY ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) = 1;
+SELECT `_t0`.`a` AS `a`, `_t0`.`b` AS `b` FROM `c`.`db`.`x` AS `_t0` QUALIFY ROW_NUMBER() OVER (PARTITION BY `_t0`.`a` ORDER BY `_t0`.`b`) = 1;
+
+# title: scalar subquery in select, the subquery's internal alias is canonicalized, the outer one is preserved
+SELECT x.a, (SELECT MAX(y.c) FROM y) AS m FROM x;
+SELECT "_t1"."a" AS "a", (SELECT MAX("_t0"."c") AS "_c0" FROM "c"."db"."y" AS "_t0") AS "m" FROM "c"."db"."x" AS "_t1";
+
+# title: distinct on
+# dialect: postgres
+SELECT DISTINCT ON (a) a, b FROM x;
+SELECT DISTINCT ON ("a") "_t0"."a" AS "a", "_t0"."b" AS "b" FROM "c"."db"."x" AS "_t0";
+
+# title: join using is expanded to on with coalesce
+SELECT * FROM x JOIN y USING (b);
+SELECT "_t0"."a" AS "a", COALESCE("_t0"."b", "_t1"."b") AS "b", "_t1"."c" AS "c" FROM "c"."db"."x" AS "_t0" JOIN "c"."db"."y" AS "_t1" ON "_t0"."b" = "_t1"."b";
+
+# title: chained union
+SELECT a FROM x UNION SELECT b FROM y UNION SELECT c FROM z;
+SELECT "_t0"."a" AS "a" FROM "c"."db"."x" AS "_t0" UNION SELECT "_t1"."b" AS "_c0" FROM "c"."db"."y" AS "_t1" UNION SELECT "_t2"."c" AS "_c1" FROM "c"."db"."z" AS "_t2";
+
+# title: filter clause on aggregate
+SELECT SUM(a) FILTER (WHERE b > 0) FROM x;
+SELECT SUM("_t0"."a") FILTER(WHERE "_t0"."b" > 0) AS "_col_0" FROM "c"."db"."x" AS "_t0";
+
+# title: left semi join, right side columns are canonicalized even when not selected
+# dialect: spark
+SELECT a FROM x LEFT SEMI JOIN y ON x.b = y.b;
+SELECT `_t0`.`a` AS `a` FROM `c`.`db`.`x` AS `_t0` LEFT SEMI JOIN `c`.`db`.`y` AS `_t1` ON `_t0`.`b` = `_t1`.`b`;
+
+# title: array constructor in select
+# dialect: duckdb
+SELECT [a, b] FROM x;
+SELECT ["_t0"."a", "_t0"."b"] AS "_col_0" FROM "c"."db"."x" AS "_t0";
+
+# title: recursive cte, self-reference and definition share the same canonical name
+# validate_qualify_columns: false
+WITH RECURSIVE cte AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM cte WHERE n < 5) SELECT * FROM cte;
+WITH RECURSIVE "_t0" AS (SELECT 1 AS "_c0" UNION ALL SELECT "_t0"."_c0" + 1 AS "_c1" FROM "_t0" AS "_t0" WHERE "_t0"."_c0" < 5) SELECT "_t0"."_c0" AS "n" FROM "_t0" AS "_t0";
+
+# title: bigquery unnest with offset, both primary and offset pseudo-columns are canonicalized
+# dialect: bigquery
+SELECT n, off FROM UNNEST([10, 20, 30]) AS n WITH OFFSET AS off;
+SELECT `_c0` AS `n`, `_c1` AS `off` FROM UNNEST([10, 20, 30]) AS `_c0` WITH OFFSET AS `_c1`;
+
+
+# title: bigquery correlated unnest, outer table shared with unnest expression
+# dialect: bigquery
+SELECT t.id, u FROM t CROSS JOIN UNNEST(t.arr) AS u;
+SELECT `_t0`.`id` AS `id`, `_c0` AS `u` FROM `c`.`db`.`t` AS `_t0` CROSS JOIN UNNEST(`_t0`.`arr`) AS `_c0`;
+
+# title: bigquery whole-row struct selection — TableColumn follows the table's canonical name, output alias preserves the row-struct's contract name
+# dialect: bigquery
+SELECT t FROM t;
+SELECT `_t0` AS `t` FROM `c`.`db`.`t` AS `_t0`;
+
+# title: table valued function with column alias, base-table-style column name is preserved
+# dialect: postgres
+SELECT * FROM generate_series(1, 10) AS g(n);
+SELECT "_t0"."n" AS "n" FROM GENERATE_SERIES(1, 10) AS "_t0"("n");
+
+# title: pivot with user alias, alias is canonicalized but output column names (from IN literals) are preserved
+# dialect: bigquery
+SELECT my_pivot.x FROM pvt PIVOT(SUM(v) FOR c IN ('x')) AS my_pivot;
+SELECT `_t1`.`x` AS `x` FROM `c`.`db`.`pvt` AS `_t0` PIVOT(SUM(`_t0`.`v`) FOR `_t0`.`c` IN ('x')) AS `_t1`;
+
+# title: CTE-level user alias on a pass-through column is replaced with _cN, outer preserves the user-facing alias
+WITH t AS (SELECT a AS foo FROM x) SELECT foo FROM t;
+WITH "_t1" AS (SELECT "_t0"."a" AS "_c0" FROM "c"."db"."x" AS "_t0") SELECT "_t1"."_c0" AS "foo" FROM "_t1" AS "_t1";
+
+# title: top-level user-provided alias on an expression stays as-is
+SELECT a + 1 AS total FROM x;
+SELECT "_t0"."a" + 1 AS "total" FROM "c"."db"."x" AS "_t0";
+
+# title: CTE-level user alias on an expression is replaced with _cN, outer preserves the user-facing alias
+WITH t AS (SELECT a + 1 AS total FROM x) SELECT total FROM t;
+WITH "_t1" AS (SELECT "_t0"."a" + 1 AS "_c0" FROM "c"."db"."x" AS "_t0") SELECT "_t1"."_c0" AS "total" FROM "_t1" AS "_t1";
+
+# title: ORDER BY reference to a CTE-level alias follows the alias's _cN canonicalization
+WITH t AS (SELECT a + 1 AS total FROM x ORDER BY total) SELECT total FROM t;
+WITH "_t1" AS (SELECT "_t0"."a" + 1 AS "_c0" FROM "c"."db"."x" AS "_t0" ORDER BY "_c0") SELECT "_t1"."_c0" AS "total" FROM "_t1" AS "_t1";

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -290,7 +290,7 @@ SELECT tbl.first AS first, tbl.second AS second FROM (SELECT 'val' AS col, STACK
 # execute: false
 # dialect: postgres
 WITH t AS (SELECT 1 AS c) SELECT t FROM t;
-WITH t AS (SELECT 1 AS c) SELECT t AS _col_0 FROM t AS t;
+WITH t AS (SELECT 1 AS c) SELECT t AS t FROM t AS t;
 
 --------------------------------------
 -- Derived tables

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1074,6 +1074,29 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         )
         self.assertEqual(canon_alias_a.sql(), canon_alias_b.sql())
 
+        # Aliases on sources whose columns are never referenced are still internal
+        # handles and must be canonicalized — otherwise structurally identical queries
+        # would diverge purely on user-chosen names.
+        canon_unref_a = canonicalize_internal_names(
+            parse_one("SELECT 1 FROM users AS foo CROSS JOIN logs AS bar"),
+            schema={"users": {"id": "INT"}, "logs": {"id": "INT"}},
+        )
+        canon_unref_b = canonicalize_internal_names(
+            parse_one("SELECT 1 FROM users AS baz CROSS JOIN logs AS qux"),
+            schema={"users": {"id": "INT"}, "logs": {"id": "INT"}},
+        )
+        self.assertEqual(canon_unref_a.sql(), canon_unref_b.sql())
+
+        canon_exists_a = canonicalize_internal_names(
+            parse_one("SELECT 1 FROM t WHERE EXISTS(SELECT 1 FROM s AS abc)"),
+            schema={"t": {"id": "INT"}, "s": {"id": "INT"}},
+        )
+        canon_exists_b = canonicalize_internal_names(
+            parse_one("SELECT 1 FROM t WHERE EXISTS(SELECT 1 FROM s AS xyz)"),
+            schema={"t": {"id": "INT"}, "s": {"id": "INT"}},
+        )
+        self.assertEqual(canon_exists_a.sql(), canon_exists_b.sql())
+
         # Physical table identity is preserved for real tables (only the alias is
         # canonicalized); base-table column names and top-level output aliases are
         # preserved because they're part of the query's outward data contract.

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -10,6 +10,7 @@ import sqlglot
 from sqlglot import exp, optimizer, parse_one
 from sqlglot.errors import ANSI_RESET, ANSI_UNDERLINE, OptimizeError, SchemaError
 from sqlglot.optimizer.annotate_types import annotate_types
+from sqlglot.optimizer.canonicalize_internal_names import canonicalize_internal_names
 from sqlglot.optimizer.normalize import normalization_distance
 from sqlglot.optimizer.scope import build_scope, traverse_scope, walk_in_scope
 from sqlglot.schema import MappingSchema
@@ -1024,6 +1025,179 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
 
     def test_eliminate_subqueries(self):
         self.check_file("eliminate_subqueries", optimizer.eliminate_subqueries.eliminate_subqueries)
+
+    def test_canonicalize_internal_names(self):
+        schema = {
+            **self.schema,
+            "jtbl": {"j": "JSON"},
+            "pvt": {"c": "TEXT", "v": "INT"},
+        }
+        self.check_file(
+            "canonicalize_internal_names",
+            canonicalize_internal_names,
+            schema=schema,
+            catalog="c",
+            db="db",
+        )
+
+        # Physical table identity is part of the data contract: reading the same columns
+        # from a different table is a real change and must produce a different canonical form.
+        # (Tables are assumed to be qualified with catalog.db.table; an unqualified table
+        # name is treated as an internal handle and canonicalized, like a CTE reference.)
+        canon_a = canonicalize_internal_names(
+            parse_one("SELECT id, name FROM cat.db.users WHERE id > 5"),
+            schema={"cat": {"db": {"users": {"id": "INT", "name": "TEXT"}}}},
+        )
+        canon_diff_table = canonicalize_internal_names(
+            parse_one("SELECT id, name FROM cat.db.employees WHERE id > 5"),
+            schema={"cat": {"db": {"employees": {"id": "INT", "name": "TEXT"}}}},
+        )
+        self.assertNotEqual(canon_a.sql(), canon_diff_table.sql())
+
+        # Renaming a base-table column is likewise a data-contract change and must be
+        # detected even when everything else about the query shape is identical.
+        canon_rename = canonicalize_internal_names(
+            parse_one("SELECT emp_id, full_name FROM cat.db.users WHERE emp_id > 5"),
+            schema={"cat": {"db": {"users": {"emp_id": "INT", "full_name": "TEXT"}}}},
+        )
+        self.assertNotEqual(canon_a.sql(), canon_rename.sql())
+
+        # User-chosen table alias is an internal handle with no semantic effect — the same
+        # query with a different alias produces the same canonical form.
+        canon_alias_a = canonicalize_internal_names(
+            parse_one("SELECT foo.id FROM users AS foo"),
+            schema={"users": {"id": "INT"}},
+        )
+        canon_alias_b = canonicalize_internal_names(
+            parse_one("SELECT bar.id FROM users AS bar"),
+            schema={"users": {"id": "INT"}},
+        )
+        self.assertEqual(canon_alias_a.sql(), canon_alias_b.sql())
+
+        # Physical table identity is preserved for real tables (only the alias is
+        # canonicalized); base-table column names and top-level output aliases are
+        # preserved because they're part of the query's outward data contract.
+        canon = canonicalize_internal_names(
+            parse_one("SELECT a FROM x"),
+            schema={"x": {"a": "INT"}},
+            db="mydb",
+            catalog="cat",
+        )
+        self.assertEqual(canon.sql(), 'SELECT "_t0"."a" AS "a" FROM "cat"."mydb"."x" AS "_t0"')
+
+        # Top-level output alias is part of the contract — renaming it changes the
+        # canonical form even though the underlying data is identical.
+        canon_named = canonicalize_internal_names(
+            parse_one("SELECT a AS alpha FROM x"), schema={"x": {"a": "INT"}}
+        )
+        canon_renamed = canonicalize_internal_names(
+            parse_one("SELECT a AS beta FROM x"), schema={"x": {"a": "INT"}}
+        )
+        self.assertNotEqual(canon_named.sql(), canon_renamed.sql())
+
+        # Internal alias inside a CTE is self-consistent (the outer query must use the
+        # same name for the rename to be valid SQL), so renaming it with the top-level
+        # contract name held constant must not change the canonical form.
+        canon_inner_a = canonicalize_internal_names(
+            parse_one("WITH t AS (SELECT a AS foo FROM x) SELECT foo AS result FROM t"),
+            schema={"x": {"a": "INT"}},
+        )
+        canon_inner_b = canonicalize_internal_names(
+            parse_one("WITH t AS (SELECT a AS bar FROM x) SELECT bar AS result FROM t"),
+            schema={"x": {"a": "INT"}},
+        )
+        self.assertEqual(canon_inner_a.sql(), canon_inner_b.sql())
+
+        # Changing which base-table column a CTE reads must be detected as a real
+        # change even when the outer query is byte-for-byte identical (the CTE
+        # internally aliases the column so the outer reference name doesn't move).
+        canon_cte_col_a = canonicalize_internal_names(
+            parse_one("WITH t AS (SELECT a AS x FROM src) SELECT x FROM t"),
+            schema={"src": {"a": "INT", "b": "INT"}},
+        )
+        canon_cte_col_b = canonicalize_internal_names(
+            parse_one("WITH t AS (SELECT b AS x FROM src) SELECT x FROM t"),
+            schema={"src": {"a": "INT", "b": "INT"}},
+        )
+        self.assertNotEqual(canon_cte_col_a.sql(), canon_cte_col_b.sql())
+
+        # UNION BY NAME: different column-name sets must produce different canonical forms
+        # (two branches share no column name => NULL-padded) vs (both share "a" => unified)
+        schema_ux = {"x": {"a": "INT"}, "y": {"a": "INT", "b": "INT"}}
+        canon_match = canonicalize_internal_names(
+            parse_one("SELECT a FROM x UNION BY NAME SELECT a FROM y", dialect="duckdb"),
+            schema=schema_ux,
+            dialect="duckdb",
+        ).sql(dialect="duckdb")
+        canon_diff = canonicalize_internal_names(
+            parse_one("SELECT a FROM x UNION BY NAME SELECT b FROM y", dialect="duckdb"),
+            schema=schema_ux,
+            dialect="duckdb",
+        ).sql(dialect="duckdb")
+        self.assertNotEqual(canon_match, canon_diff)
+
+        # UNION BY NAME with a nested rhs: swapping the source column inside the nested
+        # branch must still be caught as a data-contract change.
+        schema_nested = {
+            "x": {"a": "INT"},
+            "y": {"b": "INT"},
+            "z": {"c": "INT", "d": "INT"},
+        }
+        canon_nested_a = canonicalize_internal_names(
+            parse_one(
+                "SELECT a + 1 AS shared FROM x UNION BY NAME "
+                "(SELECT b AS shared FROM y UNION BY NAME SELECT c AS shared FROM z)",
+                dialect="duckdb",
+            ),
+            schema=schema_nested,
+            dialect="duckdb",
+        ).sql(dialect="duckdb")
+        canon_nested_b = canonicalize_internal_names(
+            parse_one(
+                "SELECT a + 1 AS shared FROM x UNION BY NAME "
+                "(SELECT b AS shared FROM y UNION BY NAME SELECT d AS shared FROM z)",
+                dialect="duckdb",
+            ),
+            schema=schema_nested,
+            dialect="duckdb",
+        ).sql(dialect="duckdb")
+        self.assertNotEqual(canon_nested_a, canon_nested_b)
+
+        # Case-folding semantics: in case-insensitive dialects (e.g. postgres, lowercase-folding)
+        # unquoted `a` and quoted `"a"` refer to the same column and must match.
+        pg_schema = {"x": {"a": "INT", "b": "INT"}}
+        canon_pg_a = canonicalize_internal_names(
+            parse_one("SELECT a FROM x", dialect="postgres"), schema=pg_schema, dialect="postgres"
+        ).sql(dialect="postgres")
+        canon_pg_qa = canonicalize_internal_names(
+            parse_one('SELECT "a" FROM x', dialect="postgres"), schema=pg_schema, dialect="postgres"
+        ).sql(dialect="postgres")
+        self.assertEqual(canon_pg_a, canon_pg_qa)
+
+        # In Snowflake (upper-folding), unquoted `a` becomes `A`, while quoted `"a"` stays
+        # lowercase — they reference *different* columns. Base-table names are preserved,
+        # and the quote state on the lowercase column is retained because dropping it
+        # would let Snowflake re-case-fold `a` back to `A` (changing semantics).
+        sf_schema = {"X": {"A": "INT", '"a"': "INT"}}
+        canon_sf = canonicalize_internal_names(
+            parse_one('SELECT a, "a" FROM x', dialect="snowflake"),
+            schema=sf_schema,
+            dialect="snowflake",
+        ).sql(dialect="snowflake")
+        self.assertEqual(
+            canon_sf,
+            'SELECT "_t0"."A" AS "A", "_t0"."a" AS "a" FROM "_t0" AS "_t0"',
+        )
+
+        # But unquoted `A` and quoted `"A"` reference the same column — they must coalesce
+        # to the same canonical form.
+        sf_schema2 = {"X": {"A": "INT"}}
+        canon_sf2 = canonicalize_internal_names(
+            parse_one('SELECT A, "A" FROM x', dialect="snowflake"),
+            schema=sf_schema2,
+            dialect="snowflake",
+        ).sql(dialect="snowflake")
+        self.assertEqual(canon_sf2, 'SELECT "_t0"."A" AS "A", "_t0"."A" AS "A" FROM "_t0" AS "_t0"')
 
     def test_canonicalize(self):
         optimize = partial(
@@ -2110,9 +2284,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         annotated = _annotate(example_query)
 
         self.assertIsInstance(annotated.selects[0].this, exp.TableColumn)
-        self.assertEqual(
-            annotated.sql("bigquery"), "SELECT `t` AS `_col_0` FROM `d`.`s`.`t` AS `t`"
-        )
+        self.assertEqual(annotated.sql("bigquery"), "SELECT `t` AS `t` FROM `d`.`s`.`t` AS `t`")
         self.assertTrue(
             annotated.selects[0].is_type("STRUCT<c1 BIGINT, c2 STRUCT<f1 BIGINT, f2 TEXT>>")
         )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -12,6 +12,7 @@ from sqlglot.errors import ANSI_RESET, ANSI_UNDERLINE, OptimizeError, SchemaErro
 from sqlglot.optimizer.annotate_types import annotate_types
 from sqlglot.optimizer.canonicalize_internal_names import canonicalize_internal_names
 from sqlglot.optimizer.normalize import normalization_distance
+from sqlglot.optimizer.qualify import qualify
 from sqlglot.optimizer.scope import build_scope, traverse_scope, walk_in_scope
 from sqlglot.schema import MappingSchema
 from tests.helpers import (
@@ -26,6 +27,10 @@ from tests.helpers import (
 
 def parse_and_optimize(func, sql, read_dialect, **kwargs):
     return func(parse_one(sql, read=read_dialect), **kwargs)
+
+
+def qualify_then_canonicalize(expression, **qualify_kwargs):
+    return canonicalize_internal_names(qualify(expression, **qualify_kwargs))
 
 
 def qualify_columns(expression, validate_qualify_columns=True, **kwargs):
@@ -1032,9 +1037,10 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             "jtbl": {"j": "JSON"},
             "pvt": {"c": "TEXT", "v": "INT"},
         }
+
         self.check_file(
             "canonicalize_internal_names",
-            canonicalize_internal_names,
+            qualify_then_canonicalize,
             schema=schema,
             catalog="c",
             db="db",
@@ -1044,11 +1050,11 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # from a different table is a real change and must produce a different canonical form.
         # (Tables are assumed to be qualified with catalog.db.table; an unqualified table
         # name is treated as an internal handle and canonicalized, like a CTE reference.)
-        canon_a = canonicalize_internal_names(
+        canon_a = qualify_then_canonicalize(
             parse_one("SELECT id, name FROM cat.db.users WHERE id > 5"),
             schema={"cat": {"db": {"users": {"id": "INT", "name": "TEXT"}}}},
         )
-        canon_diff_table = canonicalize_internal_names(
+        canon_diff_table = qualify_then_canonicalize(
             parse_one("SELECT id, name FROM cat.db.employees WHERE id > 5"),
             schema={"cat": {"db": {"employees": {"id": "INT", "name": "TEXT"}}}},
         )
@@ -1056,7 +1062,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
 
         # Renaming a base-table column is likewise a data-contract change and must be
         # detected even when everything else about the query shape is identical.
-        canon_rename = canonicalize_internal_names(
+        canon_rename = qualify_then_canonicalize(
             parse_one("SELECT emp_id, full_name FROM cat.db.users WHERE emp_id > 5"),
             schema={"cat": {"db": {"users": {"emp_id": "INT", "full_name": "TEXT"}}}},
         )
@@ -1064,11 +1070,11 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
 
         # User-chosen table alias is an internal handle with no semantic effect — the same
         # query with a different alias produces the same canonical form.
-        canon_alias_a = canonicalize_internal_names(
+        canon_alias_a = qualify_then_canonicalize(
             parse_one("SELECT foo.id FROM users AS foo"),
             schema={"users": {"id": "INT"}},
         )
-        canon_alias_b = canonicalize_internal_names(
+        canon_alias_b = qualify_then_canonicalize(
             parse_one("SELECT bar.id FROM users AS bar"),
             schema={"users": {"id": "INT"}},
         )
@@ -1077,21 +1083,21 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # Aliases on sources whose columns are never referenced are still internal
         # handles and must be canonicalized — otherwise structurally identical queries
         # would diverge purely on user-chosen names.
-        canon_unref_a = canonicalize_internal_names(
+        canon_unref_a = qualify_then_canonicalize(
             parse_one("SELECT 1 FROM users AS foo CROSS JOIN logs AS bar"),
             schema={"users": {"id": "INT"}, "logs": {"id": "INT"}},
         )
-        canon_unref_b = canonicalize_internal_names(
+        canon_unref_b = qualify_then_canonicalize(
             parse_one("SELECT 1 FROM users AS baz CROSS JOIN logs AS qux"),
             schema={"users": {"id": "INT"}, "logs": {"id": "INT"}},
         )
         self.assertEqual(canon_unref_a.sql(), canon_unref_b.sql())
 
-        canon_exists_a = canonicalize_internal_names(
+        canon_exists_a = qualify_then_canonicalize(
             parse_one("SELECT 1 FROM t WHERE EXISTS(SELECT 1 FROM s AS abc)"),
             schema={"t": {"id": "INT"}, "s": {"id": "INT"}},
         )
-        canon_exists_b = canonicalize_internal_names(
+        canon_exists_b = qualify_then_canonicalize(
             parse_one("SELECT 1 FROM t WHERE EXISTS(SELECT 1 FROM s AS xyz)"),
             schema={"t": {"id": "INT"}, "s": {"id": "INT"}},
         )
@@ -1100,7 +1106,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # Physical table identity is preserved for real tables (only the alias is
         # canonicalized); base-table column names and top-level output aliases are
         # preserved because they're part of the query's outward data contract.
-        canon = canonicalize_internal_names(
+        canon = qualify_then_canonicalize(
             parse_one("SELECT a FROM x"),
             schema={"x": {"a": "INT"}},
             db="mydb",
@@ -1110,10 +1116,10 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
 
         # Top-level output alias is part of the contract — renaming it changes the
         # canonical form even though the underlying data is identical.
-        canon_named = canonicalize_internal_names(
+        canon_named = qualify_then_canonicalize(
             parse_one("SELECT a AS alpha FROM x"), schema={"x": {"a": "INT"}}
         )
-        canon_renamed = canonicalize_internal_names(
+        canon_renamed = qualify_then_canonicalize(
             parse_one("SELECT a AS beta FROM x"), schema={"x": {"a": "INT"}}
         )
         self.assertNotEqual(canon_named.sql(), canon_renamed.sql())
@@ -1121,11 +1127,11 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # Internal alias inside a CTE is self-consistent (the outer query must use the
         # same name for the rename to be valid SQL), so renaming it with the top-level
         # contract name held constant must not change the canonical form.
-        canon_inner_a = canonicalize_internal_names(
+        canon_inner_a = qualify_then_canonicalize(
             parse_one("WITH t AS (SELECT a AS foo FROM x) SELECT foo AS result FROM t"),
             schema={"x": {"a": "INT"}},
         )
-        canon_inner_b = canonicalize_internal_names(
+        canon_inner_b = qualify_then_canonicalize(
             parse_one("WITH t AS (SELECT a AS bar FROM x) SELECT bar AS result FROM t"),
             schema={"x": {"a": "INT"}},
         )
@@ -1134,11 +1140,11 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # Changing which base-table column a CTE reads must be detected as a real
         # change even when the outer query is byte-for-byte identical (the CTE
         # internally aliases the column so the outer reference name doesn't move).
-        canon_cte_col_a = canonicalize_internal_names(
+        canon_cte_col_a = qualify_then_canonicalize(
             parse_one("WITH t AS (SELECT a AS x FROM src) SELECT x FROM t"),
             schema={"src": {"a": "INT", "b": "INT"}},
         )
-        canon_cte_col_b = canonicalize_internal_names(
+        canon_cte_col_b = qualify_then_canonicalize(
             parse_one("WITH t AS (SELECT b AS x FROM src) SELECT x FROM t"),
             schema={"src": {"a": "INT", "b": "INT"}},
         )
@@ -1147,12 +1153,12 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # UNION BY NAME: different column-name sets must produce different canonical forms
         # (two branches share no column name => NULL-padded) vs (both share "a" => unified)
         schema_ux = {"x": {"a": "INT"}, "y": {"a": "INT", "b": "INT"}}
-        canon_match = canonicalize_internal_names(
+        canon_match = qualify_then_canonicalize(
             parse_one("SELECT a FROM x UNION BY NAME SELECT a FROM y", dialect="duckdb"),
             schema=schema_ux,
             dialect="duckdb",
         ).sql(dialect="duckdb")
-        canon_diff = canonicalize_internal_names(
+        canon_diff = qualify_then_canonicalize(
             parse_one("SELECT a FROM x UNION BY NAME SELECT b FROM y", dialect="duckdb"),
             schema=schema_ux,
             dialect="duckdb",
@@ -1166,7 +1172,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             "y": {"b": "INT"},
             "z": {"c": "INT", "d": "INT"},
         }
-        canon_nested_a = canonicalize_internal_names(
+        canon_nested_a = qualify_then_canonicalize(
             parse_one(
                 "SELECT a + 1 AS shared FROM x UNION BY NAME "
                 "(SELECT b AS shared FROM y UNION BY NAME SELECT c AS shared FROM z)",
@@ -1175,7 +1181,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             schema=schema_nested,
             dialect="duckdb",
         ).sql(dialect="duckdb")
-        canon_nested_b = canonicalize_internal_names(
+        canon_nested_b = qualify_then_canonicalize(
             parse_one(
                 "SELECT a + 1 AS shared FROM x UNION BY NAME "
                 "(SELECT b AS shared FROM y UNION BY NAME SELECT d AS shared FROM z)",
@@ -1189,10 +1195,10 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # Case-folding semantics: in case-insensitive dialects (e.g. postgres, lowercase-folding)
         # unquoted `a` and quoted `"a"` refer to the same column and must match.
         pg_schema = {"x": {"a": "INT", "b": "INT"}}
-        canon_pg_a = canonicalize_internal_names(
+        canon_pg_a = qualify_then_canonicalize(
             parse_one("SELECT a FROM x", dialect="postgres"), schema=pg_schema, dialect="postgres"
         ).sql(dialect="postgres")
-        canon_pg_qa = canonicalize_internal_names(
+        canon_pg_qa = qualify_then_canonicalize(
             parse_one('SELECT "a" FROM x', dialect="postgres"), schema=pg_schema, dialect="postgres"
         ).sql(dialect="postgres")
         self.assertEqual(canon_pg_a, canon_pg_qa)
@@ -1202,7 +1208,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # and the quote state on the lowercase column is retained because dropping it
         # would let Snowflake re-case-fold `a` back to `A` (changing semantics).
         sf_schema = {"X": {"A": "INT", '"a"': "INT"}}
-        canon_sf = canonicalize_internal_names(
+        canon_sf = qualify_then_canonicalize(
             parse_one('SELECT a, "a" FROM x', dialect="snowflake"),
             schema=sf_schema,
             dialect="snowflake",
@@ -1215,7 +1221,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # But unquoted `A` and quoted `"A"` reference the same column — they must coalesce
         # to the same canonical form.
         sf_schema2 = {"X": {"A": "INT"}}
-        canon_sf2 = canonicalize_internal_names(
+        canon_sf2 = qualify_then_canonicalize(
             parse_one('SELECT A, "A" FROM x', dialect="snowflake"),
             schema=sf_schema2,
             dialect="snowflake",

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1228,6 +1228,48 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         ).sql(dialect="snowflake")
         self.assertEqual(canon_sf2, 'SELECT "_t0"."A" AS "A", "_t0"."A" AS "A" FROM "_t0" AS "_t0"')
 
+        # Multiple references to the same source within a single scope (self-join on a
+        # CTE) must produce distinct per-reference aliases. Forcing each Table.alias to
+        # match the source's canonical name collapses both into `_tN AS _tN` and breaks
+        # downstream consumers (lineage's Scope.selected_sources raises "Alias already
+        # used"); column qualifiers like `x.foo` and `y.foo` also collapse to identical
+        # AST nodes, losing the distinction between the two references.
+        cte_self_join_schema = {"src": {"foo": "INT", "bar": "INT"}}
+        canon_self_join = qualify_then_canonicalize(
+            parse_one(
+                "WITH t AS (SELECT * FROM src) "
+                "SELECT x.foo AS l, y.bar AS r FROM t AS x JOIN t AS y ON x.foo = y.foo"
+            ),
+            schema=cte_self_join_schema,
+        )
+        self.assertEqual(
+            canon_self_join.sql(),
+            'WITH "_t1" AS (SELECT "_t0"."foo" AS "_c0", "_t0"."bar" AS "_c1" FROM "_t0" AS "_t0") '
+            'SELECT "_t2"."_c0" AS "l", "_t3"."_c1" AS "r" '
+            'FROM "_t1" AS "_t2" JOIN "_t1" AS "_t3" ON "_t2"."_c0" = "_t3"."_c0"',
+        )
+
+        # Three references to the same CTE: each gets its own alias from the global
+        # `_tN` sequence, and column refs are correctly disambiguated per reference.
+        canon_triple = qualify_then_canonicalize(
+            parse_one(
+                "WITH t AS (SELECT * FROM src) "
+                "SELECT a.foo, b.foo, c.foo FROM t AS a "
+                "JOIN t AS b ON a.foo = b.foo "
+                "JOIN t AS c ON b.foo = c.foo"
+            ),
+            schema=cte_self_join_schema,
+        )
+        # Re-walking the canonicalized AST must succeed (this is exactly what lineage
+        # does when computing Scope.selected_sources, and where the bug surfaced).
+        # selected_sources on the outer scope must contain three distinct entries —
+        # one per Table reference — even though they all back the same CTE source.
+        canon_triple_scope = build_scope(canon_triple)
+        assert canon_triple_scope is not None
+        outer_table_aliases = [t.alias for t in canon_triple_scope.tables]
+        self.assertEqual(len(set(outer_table_aliases)), 3, outer_table_aliases)
+        self.assertEqual(len(canon_triple_scope.selected_sources), 3)
+
     def test_canonicalize(self):
         optimize = partial(
             optimizer.optimize,


### PR DESCRIPTION
New optimizer pass that rewrites a query into a canonical structural form: data-contract names (base-table names/columns, top-level output aliases) are preserved, while internal names (table aliases, CTE/subquery names, internal column aliases) are renamed to sequential `_tN` / `_cN`. Useful for query equivalence and deduplication.

Handles set operations (`UNION` / `UNION BY NAME`), pivots, `UDTF`s, recursive CTEs, `LATERAL`/`UNNEST`, BigQuery whole-row struct refs, and case-folding semantics across dialects.