### PR TITLE
Fix: Parametrized bigdecimal mapping was being concatenated with params

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -623,8 +623,10 @@ class Generator:
 
     UNSUPPORTED_TYPES: t.ClassVar[set[exp.DType]] = set()
 
-    TYPE_DEFAULT_PARAMS: t.ClassVar[dict[exp.DType, tuple[int, ...]]] = {}
-    TYPE_PARAM_BOUNDS: t.ClassVar[dict[exp.DType, tuple[int | None, ...]]] = {}
+    # mapping of DType to its default parameters, bounds
+    TYPE_PARAM_SETTINGS: t.ClassVar[
+        dict[exp.DType, tuple[tuple[int, ...], tuple[int | None, ...]]]
+    ] = {}
 
     TIME_PART_SINGULARS: t.ClassVar = {
         "MICROSECONDS": "MICROSECOND",
@@ -1640,12 +1642,16 @@ class Generator:
         return f"{this}{specifier}"
 
     def datatype_param_bound_limiter(
-        self, expression: exp.DataType, type_value: exp.DType
+        self,
+        expression: exp.DataType,
+        type_value: exp.DType,
+        defaults: tuple[int, ...],
+        bounds: tuple[int | None, ...],
     ) -> exp.DataType:
         params = expression.expressions
 
         if not params:
-            if defaults := self.TYPE_DEFAULT_PARAMS.get(type_value):
+            if defaults:
                 expression = expression.copy()
                 expression.set(
                     "expressions",
@@ -1653,7 +1659,6 @@ class Generator:
                 )
             return expression
 
-        bounds = self.TYPE_PARAM_BOUNDS.get(type_value)
         if not bounds:
             return expression
 
@@ -1671,16 +1676,10 @@ class Generator:
                 and int(param_value.to_py()) > bound
             ):
                 self.unsupported(
-                    f"{type_value.value} parameter ({int(param_value.to_py())}) "
-                    f"exceeds {self.dialect.__class__.__name__}'s maximum capping to {bound}"
+                    f"{type_value.value} parameter {param_value.name} exceeds "
+                    f"{self.dialect.__class__.__name__}'s maximum of {bound}; capping"
                 )
-                new_param = param.copy()
-                capped = exp.Literal.number(bound)
-                if isinstance(new_param, exp.DataTypeParam):
-                    new_param.set("this", capped)
-                else:
-                    new_param = capped
-                new_params[i] = new_param
+                new_params[i] = exp.DataTypeParam(this=exp.Literal.number(bound))
                 changed = True
 
         if changed:
@@ -1695,8 +1694,12 @@ class Generator:
         expr_nested = expression.args.get("nested")
         type_value = expression.this
 
-        if not expr_nested and isinstance(type_value, exp.DType):
-            expression = self.datatype_param_bound_limiter(expression, type_value)
+        if (
+            not expr_nested
+            and isinstance(type_value, exp.DType)
+            and (settings := self.TYPE_PARAM_SETTINGS.get(type_value))
+        ):
+            expression = self.datatype_param_bound_limiter(expression, type_value, *settings)
 
         interior = (
             self.expressions(

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -623,6 +623,9 @@ class Generator:
 
     UNSUPPORTED_TYPES: t.ClassVar[set[exp.DType]] = set()
 
+    TYPE_DEFAULT_PARAMS: t.ClassVar[dict[exp.DType, tuple[int, ...]]] = {}
+    TYPE_PARAM_BOUNDS: t.ClassVar[dict[exp.DType, tuple[int | None, ...]]] = {}
+
     TIME_PART_SINGULARS: t.ClassVar = {
         "MICROSECONDS": "MICROSECOND",
         "SECONDS": "SECOND",
@@ -1636,11 +1639,65 @@ class Generator:
         specifier = f" {specifier}" if specifier and self.DATA_TYPE_SPECIFIERS_ALLOWED else ""
         return f"{this}{specifier}"
 
+    def datatype_param_bound_limiter(
+        self, expression: exp.DataType, type_value: exp.DType
+    ) -> exp.DataType:
+        params = expression.expressions
+
+        if not params:
+            if defaults := self.TYPE_DEFAULT_PARAMS.get(type_value):
+                expression = expression.copy()
+                expression.set(
+                    "expressions",
+                    [exp.DataTypeParam(this=exp.Literal.number(d)) for d in defaults],
+                )
+            return expression
+
+        bounds = self.TYPE_PARAM_BOUNDS.get(type_value)
+        if not bounds:
+            return expression
+
+        new_params = list(params)
+        changed = False
+        for i, param in enumerate(params):
+            bound = bounds[i] if i < len(bounds) else None
+            if bound is None:
+                continue
+
+            param_value = param.this if isinstance(param, exp.DataTypeParam) else param
+            if (
+                isinstance(param_value, exp.Literal)
+                and param_value.is_number
+                and int(param_value.to_py()) > bound
+            ):
+                self.unsupported(
+                    f"{type_value.value} parameter ({int(param_value.to_py())}) "
+                    f"exceeds {self.dialect.__class__.__name__}'s maximum capping to {bound}"
+                )
+                new_param = param.copy()
+                capped = exp.Literal.number(bound)
+                if isinstance(new_param, exp.DataTypeParam):
+                    new_param.set("this", capped)
+                else:
+                    new_param = capped
+                new_params[i] = new_param
+                changed = True
+
+        if changed:
+            expression = expression.copy()
+            expression.set("expressions", new_params)
+        return expression
+
     def datatype_sql(self, expression: exp.DataType) -> str:
         nested = ""
         values = ""
 
         expr_nested = expression.args.get("nested")
+        type_value = expression.this
+
+        if not expr_nested and isinstance(type_value, exp.DType):
+            expression = self.datatype_param_bound_limiter(expression, type_value)
+
         interior = (
             self.expressions(
                 expression, dynamic=True, new_line=True, skip_first=True, skip_last=True
@@ -1649,7 +1706,6 @@ class Generator:
             else self.expressions(expression, flat=True)
         )
 
-        type_value = expression.this
         if type_value in self.UNSUPPORTED_TYPES:
             self.unsupported(
                 f"Data type {type_value.value} is not supported when targeting {self.dialect.__class__.__name__}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1652,7 +1652,6 @@ class Generator:
 
         if not params:
             if defaults:
-                expression = expression.copy()
                 expression.set(
                     "expressions",
                     [exp.DataTypeParam(this=exp.Literal.number(d)) for d in defaults],
@@ -1662,8 +1661,6 @@ class Generator:
         if not bounds:
             return expression
 
-        new_params = list(params)
-        changed = False
         for i, param in enumerate(params):
             bound = bounds[i] if i < len(bounds) else None
             if bound is None:
@@ -1679,12 +1676,8 @@ class Generator:
                     f"{type_value.value} parameter {param_value.name} exceeds "
                     f"{self.dialect.__class__.__name__}'s maximum of {bound}; capping"
                 )
-                new_params[i] = exp.DataTypeParam(this=exp.Literal.number(bound))
-                changed = True
+                params[i] = exp.DataTypeParam(this=exp.Literal.number(bound))
 
-        if changed:
-            expression = expression.copy()
-            expression.set("expressions", new_params)
         return expression
 
     def datatype_sql(self, expression: exp.DataType) -> str:

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1745,16 +1745,10 @@ class DuckDBGenerator(generator.Generator):
         exp.DType.BIGDECIMAL: "DECIMAL",
     }
 
-    TYPE_DEFAULT_PARAMS = {
-        **generator.Generator.TYPE_DEFAULT_PARAMS,
-        exp.DType.BIGDECIMAL: (38, 5),
-        exp.DType.DECFLOAT: (38, 5),
-    }
-
-    TYPE_PARAM_BOUNDS = {
-        **generator.Generator.TYPE_PARAM_BOUNDS,
-        exp.DType.BIGDECIMAL: (38, 38),
-        exp.DType.DECFLOAT: (38, 38),
+    TYPE_PARAM_SETTINGS = {
+        **generator.Generator.TYPE_PARAM_SETTINGS,
+        exp.DType.BIGDECIMAL: ((38, 5), (38, 38)),
+        exp.DType.DECFLOAT: ((38, 5), (38, 38)),
     }
 
     # https://github.com/duckdb/duckdb/blob/ff7f24fd8e3128d94371827523dae85ebaf58713/third_party/libpg_query/grammar/keywords/reserved_keywords.list#L1-L77

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1728,7 +1728,7 @@ class DuckDBGenerator(generator.Generator):
         exp.DType.BPCHAR: "TEXT",
         exp.DType.CHAR: "TEXT",
         exp.DType.DATETIME: "TIMESTAMP",
-        exp.DType.DECFLOAT: "DECIMAL(38, 5)",
+        exp.DType.DECFLOAT: "DECIMAL",
         exp.DType.FLOAT: "REAL",
         exp.DType.JSONB: "JSON",
         exp.DType.NCHAR: "TEXT",
@@ -1742,7 +1742,19 @@ class DuckDBGenerator(generator.Generator):
         exp.DType.TIMESTAMP_S: "TIMESTAMP_S",
         exp.DType.TIMESTAMP_MS: "TIMESTAMP_MS",
         exp.DType.TIMESTAMP_NS: "TIMESTAMP_NS",
-        exp.DType.BIGDECIMAL: "DECIMAL(38, 5)",
+        exp.DType.BIGDECIMAL: "DECIMAL",
+    }
+
+    TYPE_DEFAULT_PARAMS = {
+        **generator.Generator.TYPE_DEFAULT_PARAMS,
+        exp.DType.BIGDECIMAL: (38, 5),
+        exp.DType.DECFLOAT: (38, 5),
+    }
+
+    TYPE_PARAM_BOUNDS = {
+        **generator.Generator.TYPE_PARAM_BOUNDS,
+        exp.DType.BIGDECIMAL: (38, 38),
+        exp.DType.DECFLOAT: (38, 38),
     }
 
     # https://github.com/duckdb/duckdb/blob/ff7f24fd8e3128d94371827523dae85ebaf58713/third_party/libpg_query/grammar/keywords/reserved_keywords.list#L1-L77

--- a/sqlglot/generators/singlestore.py
+++ b/sqlglot/generators/singlestore.py
@@ -364,9 +364,9 @@ class SingleStoreGenerator(MySQLGenerator):
         exp.DType.TIMESTAMP_MS: "TIMESTAMP",
     }
 
-    TYPE_DEFAULT_PARAMS = {
-        **MySQLGenerator.TYPE_DEFAULT_PARAMS,
-        exp.DType.TIMESTAMP_MS: (6,),
+    TYPE_PARAM_SETTINGS = {
+        **MySQLGenerator.TYPE_PARAM_SETTINGS,
+        exp.DType.TIMESTAMP_MS: ((6,), ()),
     }
 
     # https://docs.singlestore.com/cloud/reference/sql-reference/restricted-keywords/list-of-restricted-keywords/

--- a/sqlglot/generators/singlestore.py
+++ b/sqlglot/generators/singlestore.py
@@ -361,7 +361,12 @@ class SingleStoreGenerator(MySQLGenerator):
         exp.DType.JSONB: "BSON",
         exp.DType.TIMESTAMP: "TIMESTAMP",
         exp.DType.TIMESTAMP_S: "TIMESTAMP",
-        exp.DType.TIMESTAMP_MS: "TIMESTAMP(6)",
+        exp.DType.TIMESTAMP_MS: "TIMESTAMP",
+    }
+
+    TYPE_DEFAULT_PARAMS = {
+        **MySQLGenerator.TYPE_DEFAULT_PARAMS,
+        exp.DType.TIMESTAMP_MS: (6,),
     }
 
     # https://docs.singlestore.com/cloud/reference/sql-reference/restricted-keywords/list-of-restricted-keywords/

--- a/sqlglot/generators/spark.py
+++ b/sqlglot/generators/spark.py
@@ -76,11 +76,17 @@ class SparkGenerator(Spark2Generator):
 
     TYPE_MAPPING = {
         **Spark2Generator.TYPE_MAPPING,
-        exp.DType.MONEY: "DECIMAL(15, 4)",
-        exp.DType.SMALLMONEY: "DECIMAL(6, 4)",
+        exp.DType.MONEY: "DECIMAL",
+        exp.DType.SMALLMONEY: "DECIMAL",
         exp.DType.UUID: "STRING",
         exp.DType.TIMESTAMPLTZ: "TIMESTAMP_LTZ",
         exp.DType.TIMESTAMPNTZ: "TIMESTAMP_NTZ",
+    }
+
+    TYPE_DEFAULT_PARAMS = {
+        **Spark2Generator.TYPE_DEFAULT_PARAMS,
+        exp.DType.MONEY: (15, 4),
+        exp.DType.SMALLMONEY: (6, 4),
     }
 
     TRANSFORMS = {

--- a/sqlglot/generators/spark.py
+++ b/sqlglot/generators/spark.py
@@ -83,10 +83,10 @@ class SparkGenerator(Spark2Generator):
         exp.DType.TIMESTAMPNTZ: "TIMESTAMP_NTZ",
     }
 
-    TYPE_DEFAULT_PARAMS = {
-        **Spark2Generator.TYPE_DEFAULT_PARAMS,
-        exp.DType.MONEY: (15, 4),
-        exp.DType.SMALLMONEY: (6, 4),
+    TYPE_PARAM_SETTINGS = {
+        **Spark2Generator.TYPE_PARAM_SETTINGS,
+        exp.DType.MONEY: ((15, 4), ()),
+        exp.DType.SMALLMONEY: ((6, 4), ()),
     }
 
     TRANSFORMS = {

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3825,6 +3825,22 @@ OPTIONS (
                 )
 
                 self.validate_all(
+                    f"DECLARE x {type_}(20, 4)",
+                    write={
+                        "bigquery": "DECLARE x BIGNUMERIC(20, 4)",
+                        "duckdb": "DECLARE x DECIMAL(20, 4)",
+                    },
+                )
+
+                self.validate_all(
+                    f"DECLARE x {type_}(76, 38)",
+                    write={
+                        "bigquery": "DECLARE x BIGNUMERIC(76, 38)",
+                        "duckdb": "DECLARE x DECIMAL(38, 38)",
+                    },
+                )
+
+                self.validate_all(
                     f"SELECT CAST(1 AS {type_})",
                     write={
                         "bigquery": "SELECT CAST(1 AS BIGNUMERIC)",

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1342,7 +1342,6 @@ FROM foo""",
         assert expr1.meta == {}
 
     def test_pipe_and_apply(self) -> None:
-
         def add_val(expr: exp.Expr, val: int, *, squared: bool) -> exp.Expr:
             nb = val**2 if squared else val
             return expr + nb

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1342,6 +1342,7 @@ FROM foo""",
         assert expr1.meta == {}
 
     def test_pipe_and_apply(self) -> None:
+
         def add_val(expr: exp.Expr, val: int, *, squared: bool) -> exp.Expr:
             nb = val**2 if squared else val
             return expr + nb


### PR DESCRIPTION
the default BIGDECIMAL to DECIMAL(38, 5) mapping was being concatenated with explicit (76, 38) params, producing DECIMAL(38, 5)(76, 38) in ducked: 

```
DECLARE x DECIMAL(38, 5)(76, 38)
```

added a check in `_datatype_sql` to pass through the usersupplied params when present instead and falling back to the default otherwise