### PR TITLE
fix(redshift): support APPROXIMATE PERCENTILE_DISC round-trip

### DIFF
--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -270,6 +270,14 @@ class RedshiftGenerator(PostgresGenerator):
         "without",
     }
 
+    def approxquantile_sql(self, expression: exp.ApproxQuantile) -> str:
+        return "APPROXIMATE " + self.sql(
+            exp.WithinGroup(
+                this=exp.PercentileDisc(this=expression.args["quantile"]),
+                expression=exp.Order(expressions=[exp.Ordered(this=expression.this)]),
+            )
+        )
+
     def unnest_sql(self, expression: exp.Unnest) -> str:
         args = expression.expressions
         num_args = len(args)

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -96,12 +96,20 @@ class RedshiftParser(PostgresParser):
         this = self._parse_bitwise()
         return self.expression(exp.TryCast(this=this, to=to, safe=safe))
 
-    def _parse_approximate_count(self) -> exp.ApproxDistinct | None:
+    def _parse_approximate_count(self) -> exp.ApproxDistinct | exp.ApproxQuantile | None:
         index = self._index - 1
         func = self._parse_function()
 
         if isinstance(func, exp.Count) and isinstance(func.this, exp.Distinct):
             return self.expression(exp.ApproxDistinct(this=seq_get(func.this.expressions, 0)))
+        if isinstance(func, exp.WithinGroup) and isinstance(func.this, exp.PercentileDisc):
+            ordered = seq_get(func.expression.expressions, 0)
+            return self.expression(
+                exp.ApproxQuantile(
+                    this=ordered.this if ordered else None,
+                    quantile=func.this.this,
+                )
+            )
         self._retreat(index)
         return None
 

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -362,6 +362,9 @@ class TestRedshift(Validator):
         self.validate_identity("'%' SIMILAR TO '^%' ESCAPE '^'")
         self.validate_identity("CREATE TABLE datetable (start_date DATE, end_date DATE)")
         self.validate_identity("SELECT APPROXIMATE AS y")
+        self.validate_identity(
+            "SELECT APPROXIMATE PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY totalprice)"
+        )
         self.validate_identity("CREATE TABLE t (c BIGINT IDENTITY(0, 1))")
         self.validate_identity(
             "COPY test_staging_tbl FROM 's3://your/bucket/prefix/here' IAM_ROLE default FORMAT AS AVRO 'auto'"


### PR DESCRIPTION
`APPROXIMATE PERCENTILE_DISC(p) WITHIN GROUP (ORDER BY x)` is valid Redshift syntax that was causing a `ParseError` on round-trip. `_parse_approximate_count` only handled `APPROXIMATE COUNT(DISTINCT ...)` — when it saw a `PercentileDisc` it retreated, leaving `APPROXIMATE` stranded in the projection list.

To fix, another branch was added to `_parse_approximate_count` and generator was updated to output `exp.ApproxQuantile` correctly.