### PR TITLE
feat(duckdb): Add transpilation support for HEX_DECODE_STRING

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1581,6 +1581,7 @@ class DuckDBGenerator(generator.Generator):
             f"CAST(STRFTIME({self.sql(e, 'this')}, {self.dialect.DATEINT_FORMAT}) AS INT)"
         ),
         exp.Decode: lambda self, e: encode_decode_sql(self, e, "DECODE", replace=False),
+        exp.HexDecodeString: lambda self, e: self.sql(exp.Decode(this=exp.Unhex(this=e.this))),
         exp.DiToDate: lambda self, e: (
             f"CAST(STRPTIME(CAST({self.sql(e, 'this')} AS TEXT), {self.dialect.DATEINT_FORMAT}) AS DATE)"
         ),
@@ -4220,9 +4221,6 @@ class DuckDBGenerator(generator.Generator):
     ) -> str:
         # UNHEX('FF') correctly produces blob \xFF in DuckDB
         return super().hexstring_sql(expression, binary_function_repr="UNHEX")
-
-    def hexdecodestring_sql(self, expression: exp.HexDecodeString) -> str:
-        return self.sql(exp.Decode(this=exp.Unhex(this=expression.this)))
 
     def datetrunc_sql(self, expression: exp.DateTrunc) -> str:
         unit = expression.args.get("unit")

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4221,6 +4221,9 @@ class DuckDBGenerator(generator.Generator):
         # UNHEX('FF') correctly produces blob \xFF in DuckDB
         return super().hexstring_sql(expression, binary_function_repr="UNHEX")
 
+    def hexdecodestring_sql(self, expression: exp.HexDecodeString) -> str:
+        return self.sql(exp.Decode(this=exp.Unhex(this=expression.this)))
+
     def datetrunc_sql(self, expression: exp.DateTrunc) -> str:
         unit = expression.args.get("unit")
         date = expression.this

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -534,6 +534,7 @@ class SnowflakeParser(parser.Parser):
             this=seq_get(args, 0), expression=seq_get(args, 1), negative_length_returns_empty=True
         ),
         "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
+        "HEX_DECODE_STRING": exp.HexDecodeString.from_arg_list,
         "IFF": exp.If.from_arg_list,
         "JAROWINKLER_SIMILARITY": lambda args: exp.JarowinklerSimilarity(
             this=seq_get(args, 0),

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -534,7 +534,6 @@ class SnowflakeParser(parser.Parser):
             this=seq_get(args, 0), expression=seq_get(args, 1), negative_length_returns_empty=True
         ),
         "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
-        "HEX_DECODE_STRING": exp.HexDecodeString.from_arg_list,
         "IFF": exp.If.from_arg_list,
         "JAROWINKLER_SIMILARITY": lambda args: exp.JarowinklerSimilarity(
             this=seq_get(args, 0),


### PR DESCRIPTION
`HEX_DECODE_STRING` is not transpiled; passes through unchanged, DuckDB has no such function (Catalog Error on all inputs)

