### PR TITLE
fix(redshift): support ALL in aggregate funcs

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2249,10 +2249,6 @@ class Distinct(Expression):
     arg_types = {"expressions": False, "on": False}
 
 
-class AllQuantifier(Expression):
-    arg_types = {"expressions": False}
-
-
 class In(Expression, Predicate):
     arg_types = {
         "this": True,

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2249,6 +2249,10 @@ class Distinct(Expression):
     arg_types = {"expressions": False, "on": False}
 
 
+class AllQuantifier(Expression):
+    arg_types = {"expressions": False}
+
+
 class In(Expression, Predicate):
     arg_types = {
         "this": True,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4071,6 +4071,10 @@ class Generator:
         location = f" {location}" if location else ""
         return f"ADD {exists}{self.sql(expression.this)}{location}"
 
+    def allquantifier_sql(self, expression: exp.AllQuantifier) -> str:
+        this = self.expressions(expression, flat=True)
+        return f"ALL {this}"
+
     def distinct_sql(self, expression: exp.Distinct) -> str:
         this = self.expressions(expression, flat=True)
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4071,10 +4071,6 @@ class Generator:
         location = f" {location}" if location else ""
         return f"ADD {exists}{self.sql(expression.this)}{location}"
 
-    def allquantifier_sql(self, expression: exp.AllQuantifier) -> str:
-        this = self.expressions(expression, flat=True)
-        return f"ALL {this}"
-
     def distinct_sql(self, expression: exp.Distinct) -> str:
         this = self.expressions(expression, flat=True)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7010,6 +7010,10 @@ class Parser:
             this = self.expression(
                 exp.Distinct(expressions=self._parse_csv(self._parse_disjunction))
             )
+        elif self._match(TokenType.ALL):
+            this = self.expression(
+                exp.AllQuantifier(expressions=self._parse_csv(self._parse_disjunction))
+            )
         else:
             this = self._parse_select_or_expression(alias=alias)
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7010,11 +7010,8 @@ class Parser:
             this = self.expression(
                 exp.Distinct(expressions=self._parse_csv(self._parse_disjunction))
             )
-        elif self._match(TokenType.ALL):
-            this = self.expression(
-                exp.AllQuantifier(expressions=self._parse_csv(self._parse_disjunction))
-            )
         else:
+            self._match(TokenType.ALL)  # ALL is the default/no-op aggregate modifier (SQL-92)
             this = self._parse_select_or_expression(alias=alias)
 
         return self._parse_limit(


### PR DESCRIPTION
`COUNT(ALL x)` is valid Redshift syntax but previously threw a ParseError.  `ALL` is also valid SQL-92 so the fix is applied in the base parser, added `exp.AllQuantifier` (similar to `exp.Distinct`) to preserve the `ALL` modifier through parse and generate, enabling identical roundtrip.

```
SELECT COUNT(ALL eventname) FROM event
```