### PR TITLE
fix(redshift): parser issue for TOP N DISTINCT

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3838,14 +3838,27 @@ class Parser:
                 else None
             )
 
-            if all_ and distinct:
-                self.raise_error("Cannot specify both ALL and DISTINCT after SELECT")
-
             operation_modifiers = []
             while self._curr and self._match_texts(self.OPERATION_MODIFIERS):
                 operation_modifiers.append(exp.var(self._prev.text.upper()))
 
             limit = self._parse_limit(top=True)
+
+            # Some dialects (e.g. Redshift, T-SQL) allow SELECT TOP N DISTINCT ...
+            if limit and not matched_distinct:
+                matched_distinct = self._match_set(self.DISTINCT_TOKENS)
+                if matched_distinct:
+                    distinct = self.expression(
+                        exp.Distinct(
+                            on=self._parse_value(values=False)
+                            if self._match(TokenType.ON)
+                            else None
+                        )
+                    )
+
+            if all_ and distinct:
+                self.raise_error("Cannot specify both ALL and DISTINCT after SELECT")
+
             projections, exclude = self._parse_projections()
 
             this = self.expression(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3845,7 +3845,7 @@ class Parser:
             limit = self._parse_limit(top=True)
 
             # Some dialects (e.g. Redshift, T-SQL) allow SELECT TOP N DISTINCT ...
-            if limit and not matched_distinct:
+            if limit and not matched_distinct and not all_:
                 matched_distinct = self._match_set(self.DISTINCT_TOKENS)
                 if matched_distinct:
                     distinct = self.expression(
@@ -3855,6 +3855,8 @@ class Parser:
                             else None
                         )
                     )
+                else:
+                    all_ = self._match(TokenType.ALL)
 
             if all_ and distinct:
                 self.raise_error("Cannot specify both ALL and DISTINCT after SELECT")

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -128,6 +128,28 @@ class RedshiftParser(PostgresParser):
         self._retreat(index)
         return None
 
+    def _parse_limit(self, this=None, top=False, skip_limit_token=False):
+        limit = super()._parse_limit(this=this, top=top, skip_limit_token=skip_limit_token)
+        if top and limit and self._match_set(self.DISTINCT_TOKENS):
+            limit.set("distinct", self.expression(exp.Distinct()))
+        return limit
+
+    def _parse_select_query(
+        self, nested=False, table=False, parse_subquery_alias=True, parse_set_operation=True
+    ):
+        result = super()._parse_select_query(
+            nested=nested,
+            table=table,
+            parse_subquery_alias=parse_subquery_alias,
+            parse_set_operation=parse_set_operation,
+        )
+        if isinstance(result, exp.Select) and not result.args.get("distinct"):
+            limit = result.args.get("limit")
+            distinct = limit and limit.args.pop("distinct", None)
+            if distinct:
+                result.set("distinct", distinct)
+        return result
+
     def _parse_projections(self) -> tuple[list[exp.Expr], list[exp.Expr] | None]:
         projections, _ = super()._parse_projections()
         if self._prev.text.upper() == "EXCLUDE" and self._curr:

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -128,28 +128,6 @@ class RedshiftParser(PostgresParser):
         self._retreat(index)
         return None
 
-    def _parse_limit(self, this=None, top=False, skip_limit_token=False):
-        limit = super()._parse_limit(this=this, top=top, skip_limit_token=skip_limit_token)
-        if top and limit and self._match_set(self.DISTINCT_TOKENS):
-            limit.set("distinct", self.expression(exp.Distinct()))
-        return limit
-
-    def _parse_select_query(
-        self, nested=False, table=False, parse_subquery_alias=True, parse_set_operation=True
-    ):
-        result = super()._parse_select_query(
-            nested=nested,
-            table=table,
-            parse_subquery_alias=parse_subquery_alias,
-            parse_set_operation=parse_set_operation,
-        )
-        if isinstance(result, exp.Select) and not result.args.get("distinct"):
-            limit = result.args.get("limit")
-            distinct = limit and limit.args.pop("distinct", None)
-            if distinct:
-                result.set("distinct", distinct)
-        return result
-
     def _parse_projections(self) -> tuple[list[exp.Expr], list[exp.Expr] | None]:
         projections, _ = super()._parse_projections()
         if self._prev.text.upper() == "EXCLUDE" and self._curr:


### PR DESCRIPTION
Redshift supports `SELECT TOP N DISTINCT ...` where TOP N precedes `DISTINCT`. The base parser checks for `DISTINCT` immediately after `SELECT` before consuming `TOP N`

The fix adds two overrides to `RedshiftParser. _parse_limit` detects a `DISTINCT` token immediately following `TOP N`, consumes it, and temporarily stashes an `exp.Distinct()` on the `exp.Limit` node as a carrier.  Redshift's `_parse_select_query` then promotes that value up to `exp.Select.distinct` and removes it from the limit once the `exp.Select` is fully built.

I don't see a more elegant way to handle it because `distinct` is resolved as a local variable in the base `_parse_select_query` before `_parse_limit` is ever called.  There's no obvious way to reach back, so the limit node acts as a handoff point between the two.
