### PR TITLE
fix: preserve indentation of lines inside quoted identifiers with pretty=True

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1056,9 +1056,7 @@ class Generator:
         in_quote = ""
 
         for i, line in enumerate(lines):
-            should_indent = not (
-                (skip_first and i == 0) or (skip_last and i == len(lines) - 1)
-            )
+            should_indent = not ((skip_first and i == 0) or (skip_last and i == len(lines) - 1))
             result.append(
                 f"{' ' * (level * self._indent + pad)}{line}"
                 if should_indent and not in_quote

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1052,15 +1052,33 @@ class Generator:
 
         pad = self.pad if pad is None else pad
         lines = sql.split("\n")
+        result = []
+        in_quote = ""
 
-        return "\n".join(
-            (
-                line
-                if (skip_first and i == 0) or (skip_last and i == len(lines) - 1)
-                else f"{' ' * (level * self._indent + pad)}{line}"
+        for i, line in enumerate(lines):
+            should_indent = not (
+                (skip_first and i == 0) or (skip_last and i == len(lines) - 1)
             )
-            for i, line in enumerate(lines)
-        )
+            result.append(
+                f"{' ' * (level * self._indent + pad)}{line}"
+                if should_indent and not in_quote
+                else line
+            )
+            it = enumerate(line)
+            for j, c in it:
+                if in_quote:
+                    if c == in_quote:
+                        if j + 1 < len(line) and line[j + 1] == in_quote:
+                            next(it, None)
+                        else:
+                            in_quote = ""
+                else:
+                    if c == self.dialect.QUOTE_START:
+                        in_quote = self.dialect.QUOTE_END
+                    elif c == self._identifier_start:
+                        in_quote = self._identifier_end
+
+        return "\n".join(result)
 
     def sql(
         self,

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -988,6 +988,12 @@ ORDER BY
             transpile("SELECT '1\n2'", pretty=True, unsupported_level=ErrorLevel.IGNORE)[0],
             "SELECT\n  '1\n2'",
         )
+        # Quoted identifiers with literal newlines must not be reindented (GH #7593)
+        self.assertEqual(transpile('SELECT "1\n2"', pretty=True)[0], 'SELECT\n  "1\n2"')
+        self.assertEqual(
+            transpile('SELECT "Product\n(Foo, Bar)" AS x FROM t', pretty=True)[0],
+            'SELECT\n  "Product\n(Foo, Bar)" AS x\nFROM t',
+        )
 
     def test_sql_security(self):
         sqlglot_sql = "CREATE VIEW v SQL SECURITY INVOKER AS SELECT 1"


### PR DESCRIPTION
Fixes #7593
## Root cause
`Generator.indent()` splits `sql` on `"\n"` and prepends spaces to every
line unconditionally. If a quoted string or identifier contains a literal
newline, the continuation line is a content byte — not a structural line
break — so adding indentation there corrupts the value.
## Fix
Track quote state while iterating the characters of each line. When the
current position is inside a quoted string (`'...'`) or a quoted identifier
(`"..."`), the line is appended as-is. Outside quotes, normal indentation
applies. Doubled quote characters (the SQL escape for a literal quote) are
handled with a one-step lookahead so they don't prematurely close the state.
## Tests
Two assertions added to the existing `test_pretty_line_breaks` test:
```python
self.assertEqual(transpile('SELECT "1\n2"', pretty=True)[0], 'SELECT\n  "1\n2"')
self.assertEqual(
    transpile('SELECT "Product\n(Foo, Bar)" AS x FROM t', pretty=True)[0],
    'SELECT\n  "Product\n(Foo, Bar)" AS x\nFROM t',
)