### PR TITLE
chore(publish): Do not build sqlglotc wheels for 3.9

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     strategy:
       matrix:
-        python: ["cp39", "cp310", "cp311", "cp312", "cp313", "cp314"]
+        python: ["cp310", "cp311", "cp312", "cp313", "cp314"]
         platform:
           - os: ubuntu-latest
             archs: x86_64


### PR DESCRIPTION
This should have been removed by https://github.com/tobymao/sqlglot/pull/7574