### PR TITLE
fix(redshift): support OBJECT_TRANSFORM function

### DIFF
--- a/sqlglot/expressions/functions.py
+++ b/sqlglot/expressions/functions.py
@@ -148,6 +148,10 @@ class Nullif(Expression, Func):
     arg_types = {"this": True, "expression": True}
 
 
+class ObjectTransform(Expression, Func):
+    arg_types = {"this": True, "keep": False, "set_": False}
+
+
 class Nvl2(Expression, Func):
     arg_types = {"this": True, "true": True, "false": False}
 

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -276,7 +276,7 @@ class RedshiftGenerator(PostgresGenerator):
         set_ = self.expressions(expression, key="set_", flat=True)
         keep_sql = " KEEP " + keep if keep else ""
         set_sql = " SET " + set_ if set_ else ""
-        return self.func("OBJECT_TRANSFORM", prefix="(" + this + keep_sql + set_sql)
+        return f"OBJECT_TRANSFORM({this}{keep_sql}{set_sql})"
 
     def approxquantile_sql(self, expression: exp.ApproxQuantile) -> str:
         return "APPROXIMATE " + self.sql(

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -270,6 +270,14 @@ class RedshiftGenerator(PostgresGenerator):
         "without",
     }
 
+    def objecttransform_sql(self, expression: exp.ObjectTransform) -> str:
+        this = self.sql(expression, "this")
+        keep = self.expressions(expression, key="keep", flat=True)
+        set_ = self.expressions(expression, key="set_", flat=True)
+        keep_sql = " KEEP " + keep if keep else ""
+        set_sql = " SET " + set_ if set_ else ""
+        return self.func("OBJECT_TRANSFORM", prefix="(" + this + keep_sql + set_sql)
+
     def approxquantile_sql(self, expression: exp.ApproxQuantile) -> str:
         return "APPROXIMATE " + self.sql(
             exp.WithinGroup(

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -66,6 +66,11 @@ class RedshiftParser(PostgresParser):
         "SYSDATE": lambda self: self.expression(exp.CurrentTimestamp(sysdate=True)),
     }
 
+    FUNCTION_PARSERS = {
+        **PostgresParser.FUNCTION_PARSERS,
+        "OBJECT_TRANSFORM": lambda self: self._parse_object_transform(),
+    }
+
     SUPPORTS_IMPLICIT_UNNEST = True
 
     def _parse_table(
@@ -95,6 +100,16 @@ class RedshiftParser(PostgresParser):
         self._match(TokenType.COMMA)
         this = self._parse_bitwise()
         return self.expression(exp.TryCast(this=this, to=to, safe=safe))
+
+    def _parse_object_transform(self) -> exp.ObjectTransform:
+        this = self._parse_column()
+        keep: list[exp.Expr] = []
+        set_: list[exp.Expr] = []
+        if self._match(TokenType.KEEP):
+            keep = self._parse_csv(self._parse_primary)
+        if self._match(TokenType.SET):
+            set_ = self._parse_csv(self._parse_expression)
+        return self.expression(exp.ObjectTransform(this=this, keep=keep, set_=set_))
 
     def _parse_approximate_count(self) -> exp.ApproxDistinct | exp.ApproxQuantile | None:
         index = self._index - 1


### PR DESCRIPTION
[OBJECT_TRANSFORM](https://docs.aws.amazon.com/redshift/latest/dg/r_object_transform_function.html) is a Redshift-specific function for transforming object columns. It uses non-standard syntax with `KEEP` and `SET` keyword sections that the generic function argument parser cannot handle, causing a ParseError.

Example syntax:
```
SELECT OBJECT_TRANSFORM(col KEEP 'a') FROM t
SELECT OBJECT_TRANSFORM(col SET 'a', col.a + 1) FROM t
```