### PR TITLE
feat(duckdb): Consolidate HEX_ENCODE_ into HEX function

### DIFF
--- a/sqlglot/expressions/string.py
+++ b/sqlglot/expressions/string.py
@@ -303,15 +303,11 @@ class FromBase64(Expression, Func):
 
 
 class Hex(Expression, Func):
-    pass
+    arg_types = {"this": True, "case": False}
 
 
 class HexDecodeString(Expression, Func):
     pass
-
-
-class HexEncode(Expression, Func):
-    arg_types = {"this": True, "case": False}
 
 
 class LowerHex(Hex):

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3608,15 +3608,13 @@ class DuckDBGenerator(generator.Generator):
 
         return self.sql(result)
 
-    def hexencode_sql(self, expression: exp.HexEncode) -> str:
-        arg = expression.this
+    def hex_sql(self, expression: exp.Hex) -> str:
         case = expression.args.get("case")
-        hex_expr = exp.Hex(this=arg)
 
         if not case:
-            return self.sql(hex_expr)
+            return self.func("HEX", expression.this)
 
-        # Emit runtime CASE WHEN to handle NULL propagation and case=0 (lowercase) vs case=1 (uppercase)
+        hex_expr = exp.Hex(this=expression.this)
         return self.sql(
             exp.case()
             .when(case.is_(exp.null()), exp.null())

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -559,7 +559,7 @@ class SnowflakeGenerator(generator.Generator):
         exp.MD5Digest: rename_func("MD5_BINARY"),
         exp.MD5NumberLower64: rename_func("MD5_NUMBER_LOWER64"),
         exp.MD5NumberUpper64: rename_func("MD5_NUMBER_UPPER64"),
-        exp.Hex: lambda self, e: self.func("HEX_ENCODE", e.this, e.args.get("case")),
+        exp.Hex: rename_func("HEX_ENCODE"),
         exp.LowerHex: rename_func("TO_CHAR"),
         exp.Skewness: rename_func("SKEW"),
         exp.StarMap: rename_func("OBJECT_CONSTRUCT"),

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -559,6 +559,7 @@ class SnowflakeGenerator(generator.Generator):
         exp.MD5Digest: rename_func("MD5_BINARY"),
         exp.MD5NumberLower64: rename_func("MD5_NUMBER_LOWER64"),
         exp.MD5NumberUpper64: rename_func("MD5_NUMBER_UPPER64"),
+        exp.Hex: lambda self, e: self.func("HEX_ENCODE", e.this, e.args.get("case")),
         exp.LowerHex: rename_func("TO_CHAR"),
         exp.Skewness: rename_func("SKEW"),
         exp.StarMap: rename_func("OBJECT_CONSTRUCT"),

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -534,7 +534,7 @@ class SnowflakeParser(parser.Parser):
             this=seq_get(args, 0), expression=seq_get(args, 1), negative_length_returns_empty=True
         ),
         "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
-        "HEX_ENCODE": lambda args: exp.Hex(this=seq_get(args, 0), case=seq_get(args, 1)),
+        "HEX_ENCODE": exp.Hex.from_arg_list,
         "IFF": exp.If.from_arg_list,
         "JAROWINKLER_SIMILARITY": lambda args: exp.JarowinklerSimilarity(
             this=seq_get(args, 0),

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -534,6 +534,7 @@ class SnowflakeParser(parser.Parser):
             this=seq_get(args, 0), expression=seq_get(args, 1), negative_length_returns_empty=True
         ),
         "HEX_DECODE_BINARY": exp.Unhex.from_arg_list,
+        "HEX_ENCODE": lambda args: exp.Hex(this=seq_get(args, 0), case=seq_get(args, 1)),
         "IFF": exp.If.from_arg_list,
         "JAROWINKLER_SIMILARITY": lambda args: exp.JarowinklerSimilarity(
             this=seq_get(args, 0),

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -510,7 +510,7 @@ EXPRESSION_METADATA = {
             exp.CurrentOrganizationName,
             exp.DecompressString,
             exp.HexDecodeString,
-            exp.HexEncode,
+            exp.Hex,
             exp.Randstr,
             exp.RegexpExtract,
             exp.RegexpReplace,


### PR DESCRIPTION
`HEX_ENCODE` (Snowflake) and `HEX` (DuckDB) produce identical output for a single argument, yet `SQLGlot` represented them as two separate `AST` nodes — HexEncode and Hex.
The only behavioral difference between the two functions is Snowflake's optional second argument (case: 0 for lowercase, 1 for uppercase), which was already modeled on HexEncode but had no equivalent path through Hex.

This PR consolidates both into Hex by promoting the case argument up, registering `HEX_ENCODE` explicitly in the Snowflake parser to build a Hex node, and updating the Snowflake and DuckDB generators to handle case accordingly. The `HexEncode` class is removed entirely.

```
sqlglot.parse_one(\"HEX_ENCODE('hello', 0)\", dialect='snowflake'))

Hex(
  this=Literal(this='hello', is_string=True),
  case=Literal(this=0, is_string=False))
```