### PR TITLE
fix(redshift): roundtrip for ST_MAKEPOINT / 4 parameters

### DIFF
--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -365,5 +365,5 @@ class StDistance(Expression, Func):
 
 
 class StPoint(Expression, Func):
-    arg_types = {"this": True, "expression": True, "null": False, "m": False}
+    arg_types = {"this": True, "expression": True, "z": False, "m": False}
     _sql_names = ["ST_POINT", "ST_MAKEPOINT"]

--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -365,5 +365,5 @@ class StDistance(Expression, Func):
 
 
 class StPoint(Expression, Func):
-    arg_types = {"this": True, "expression": True, "null": False}
+    arg_types = {"this": True, "expression": True, "null": False, "m": False}
     _sql_names = ["ST_POINT", "ST_MAKEPOINT"]

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -270,6 +270,18 @@ class RedshiftGenerator(PostgresGenerator):
         "without",
     }
 
+    def stpoint_sql(self, expression: exp.StPoint) -> str:
+        # ST_POINT only accepts 2 args in Redshift; use ST_MAKEPOINT for 3 or 4 args
+        if expression.args.get("null") or expression.args.get("m"):
+            return self.func(
+                "ST_MAKEPOINT",
+                expression.this,
+                expression.expression,
+                expression.args.get("null"),
+                expression.args.get("m"),
+            )
+        return self.func("ST_POINT", expression.this, expression.expression)
+
     def objecttransform_sql(self, expression: exp.ObjectTransform) -> str:
         this = self.sql(expression, "this")
         keep = self.expressions(expression, key="keep", flat=True)

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -272,12 +272,12 @@ class RedshiftGenerator(PostgresGenerator):
 
     def stpoint_sql(self, expression: exp.StPoint) -> str:
         # ST_POINT only accepts 2 args in Redshift; use ST_MAKEPOINT for 3 or 4 args
-        if expression.args.get("null") or expression.args.get("m"):
+        if expression.args.get("z") or expression.args.get("m"):
             return self.func(
                 "ST_MAKEPOINT",
                 expression.this,
                 expression.expression,
-                expression.args.get("null"),
+                expression.args.get("z"),
                 expression.args.get("m"),
             )
         return self.func("ST_POINT", expression.this, expression.expression)


### PR DESCRIPTION
Redshift's [ST_MakePoint](https://docs.aws.amazon.com/redshift/latest/dg/ST_MakePoint-function.html) supports 2D, 3D (XYZ), and 4D (XYZM) geometry but `ST_POINT` only accepts 2 args. Previously, parsing `ST_MakePoint(1, 2, 3, 4)` raised a ParseError.