### PR TITLE
fix(redshift): roundtrip fix ARRAY_CONTAINS 

### DIFF
--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -283,7 +283,12 @@ class RedshiftGenerator(PostgresGenerator):
         return self.func("ST_POINT", expression.this, expression.expression)
 
     def arraycontains_sql(self, expression: exp.ArrayContains) -> str:
-        return self.func("ARRAY_CONTAINS", expression.this, expression.expression)
+        return self.func(
+            "ARRAY_CONTAINS",
+            expression.this,
+            expression.expression,
+            expression.args.get("ensure_variant"),
+        )
 
     def objecttransform_sql(self, expression: exp.ObjectTransform) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -282,6 +282,9 @@ class RedshiftGenerator(PostgresGenerator):
             )
         return self.func("ST_POINT", expression.this, expression.expression)
 
+    def arraycontains_sql(self, expression: exp.ArrayContains) -> str:
+        return self.func("ARRAY_CONTAINS", expression.this, expression.expression)
+
     def objecttransform_sql(self, expression: exp.ObjectTransform) -> str:
         this = self.sql(expression, "this")
         keep = self.expressions(expression, key="keep", flat=True)

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -287,7 +287,7 @@ class RedshiftGenerator(PostgresGenerator):
             "ARRAY_CONTAINS",
             expression.this,
             expression.expression,
-            expression.args.get("ensure_variant"),
+            expression.args.get("check_null"),
         )
 
     def objecttransform_sql(self, expression: exp.ObjectTransform) -> str:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -682,7 +682,7 @@ def _expand_struct_stars_no_parens(
         taken_names.add(name)
 
         this = field.this.copy()
-        root, *parts = (part.copy() for part in itertools.chain(dot_parts, [this]))
+        root, *parts = [part.copy() for part in itertools.chain(dot_parts, [this])]
         new_column = exp.column(
             t.cast(exp.Identifier, root),
             table=dot_column.args.get("table"),

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -682,7 +682,7 @@ def _expand_struct_stars_no_parens(
         taken_names.add(name)
 
         this = field.this.copy()
-        root, *parts = [part.copy() for part in itertools.chain(dot_parts, [this])]
+        root, *parts = (part.copy() for part in itertools.chain(dot_parts, [this]))
         new_column = exp.column(
             t.cast(exp.Identifier, root),
             table=dot_column.args.get("table"),

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -56,6 +56,11 @@ class RedshiftParser(PostgresParser):
         "SPLIT_TO_ARRAY": lambda args: exp.StringToArray(
             this=seq_get(args, 0), expression=seq_get(args, 1) or exp.Literal.string(",")
         ),
+        "ARRAY_CONTAINS": lambda args: exp.ArrayContains(
+            this=seq_get(args, 0),
+            expression=seq_get(args, 1),
+            check_null=seq_get(args, 2),
+        ),
         "STRTOL": exp.FromBase.from_arg_list,
         "TEXTLEN": exp.Length.from_arg_list,
     }

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1342,7 +1342,6 @@ FROM foo""",
         assert expr1.meta == {}
 
     def test_pipe_and_apply(self) -> None:
-
         def add_val(expr: exp.Expr, val: int, *, squared: bool) -> exp.Expr:
             nb = val**2 if squared else val
             return expr + nb


### PR DESCRIPTION
[ARRAY_CONTAINS](https://docs.aws.amazon.com/redshift/latest/dg/array_contains.html) was being rewritten to a verbose `CASE WHEN ... COALESCE` expression. Redshift supports `ARRAY_CONTAINS` natively so no rewrite is needed.