### PR TITLE
refactor (optimizer): rules as generic when possible

### DIFF
--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -6,13 +6,14 @@ import typing as t
 from sqlglot import expressions as exp
 from sqlglot.helper import find_new_name
 from sqlglot.optimizer.scope import Scope, build_scope
+from sqlglot._typing import E
 
 if t.TYPE_CHECKING:
     ExistingCTEsMapping = dict[exp.Expr, str]
     TakenNameMapping = dict[str, t.Union[Scope, exp.Expr]]
 
 
-def eliminate_subqueries(expression: exp.Expr) -> exp.Expr:
+def eliminate_subqueries(expression: E) -> E:
     """
     Rewrite derived tables as CTES, deduplicating if possible.
 

--- a/sqlglot/optimizer/optimize_joins.py
+++ b/sqlglot/optimizer/optimize_joins.py
@@ -3,12 +3,13 @@ from collections.abc import Iterable
 
 from sqlglot import exp
 from sqlglot.errors import OptimizeError
+from sqlglot._typing import E
 from sqlglot.helper import tsort
 
 JOIN_ATTRS = ("on", "side", "kind", "using", "method")
 
 
-def optimize_joins(expression: exp.Expr) -> exp.Expr:
+def optimize_joins(expression: E) -> E:
     """
     Removes cross joins if possible and reorder joins based on predicate dependencies.
 
@@ -58,7 +59,7 @@ def optimize_joins(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-def reorder_joins(expression: exp.Expr) -> exp.Expr:
+def reorder_joins(expression: E) -> E:
     """
     Reorder joins by topological sort order based on predicate references.
     """
@@ -84,7 +85,7 @@ def reorder_joins(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-def normalize(expression: exp.Expr) -> exp.Expr:
+def normalize(expression: E) -> E:
     """
     Remove INNER and OUTER from joins as they are optional.
     """

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -13,10 +13,11 @@ from sqlglot.optimizer.qualify_columns import (
 )
 from sqlglot.optimizer.qualify_tables import qualify_tables
 from sqlglot.schema import Schema, ensure_schema
+from sqlglot._typing import E
 
 
 def qualify(
-    expression: exp.Expr,
+    expression: E,
     dialect: DialectType = None,
     db: str | None = None,
     catalog: str | None = None,
@@ -33,7 +34,7 @@ def qualify(
     canonicalize_table_aliases: bool = False,
     on_qualify: t.Callable[[exp.Expr], None] | None = None,
     sql: str | None = None,
-) -> exp.Expr:
+) -> E:
     """
     Rewrite sqlglot AST to have normalized and qualified tables and columns.
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -19,14 +19,14 @@ if t.TYPE_CHECKING:
 
 
 def qualify_columns(
-    expression: exp.Expr,
+    expression: E,
     schema: dict[str, object] | Schema,
     expand_alias_refs: bool = True,
     expand_stars: bool = True,
     infer_schema: bool | None = None,
     allow_partial_qualification: bool = False,
     dialect: DialectType = None,
-) -> exp.Expr:
+) -> E:
     """
     Rewrite sqlglot AST to have fully qualified columns.
 

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 from sqlglot import exp
 from sqlglot.helper import name_sequence
 from sqlglot.optimizer.scope import ScopeType, find_in_scope, traverse_scope
+from sqlglot._typing import E
 
 
-def unnest_subqueries(expression: exp.Expr) -> exp.Expr:
+def unnest_subqueries(expression: E) -> E:
     """
     Rewrite sqlglot AST to convert some predicates with subqueries into joins.
 


### PR DESCRIPTION
Small typing PR that makes various optimizer rules generic for the expr input, i.e `E -> E`.

The logic is straightforward: If it don't reassign the `expression` argument, it can be generic.

This is the last "multi-files" PR for optimizer. the next ones will be focused on one module at a time.