### PR TITLE
fix(redshift): roundtrip fix for CONVERT

### DIFF
--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -99,7 +99,7 @@ class RedshiftParser(PostgresParser):
         to = self._parse_types()
         self._match(TokenType.COMMA)
         this = self._parse_bitwise()
-        return self.expression(exp.TryCast(this=this, to=to, safe=safe))
+        return self.expression(exp.Cast(this=this, to=to, safe=safe))
 
     def _parse_object_transform(self) -> exp.ObjectTransform:
         this = self._parse_column()


### PR DESCRIPTION
Fixed the call to `CONVERT(type, expr)` which was being parsed as `exp.TryCast` and generated as `CAST(expr AS type)`, which is both semantically wrong (assigns try/null-on-failure semantics) and loses the original function name on roundtrip.