### PR TITLE
fix(redshift): roundtrip fix for CONCAT

### DIFF
--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from sqlglot import exp, transforms
 from sqlglot.dialects.dialect import (
     array_concat_sql,
-    concat_to_dpipe_sql,
     concat_ws_to_dpipe_sql,
     date_delta_sql,
     generatedasidentitycolumnconstraint_sql,
@@ -70,7 +69,6 @@ class RedshiftGenerator(PostgresGenerator):
             }
         },
         exp.ArrayConcat: array_concat_sql("ARRAY_CONCAT"),
-        exp.Concat: concat_to_dpipe_sql,
         exp.ConcatWs: concat_ws_to_dpipe_sql,
         exp.ApproxDistinct: lambda self, e: f"APPROXIMATE COUNT(DISTINCT {self.sql(e, 'this')})",
         exp.CurrentTimestamp: lambda self, e: "SYSDATE" if e.args.get("sysdate") else "GETDATE()",

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -385,10 +385,7 @@ class TestRedshift(Validator):
             'DATE_PART(year, "somecol")',
             'EXTRACT(year FROM "somecol")',
         ).this.assert_is(exp.Var)
-        self.validate_identity(
-            "SELECT CONCAT('abc', 'def')",
-            "SELECT 'abc' || 'def'",
-        )
+        self.validate_identity("SELECT CONCAT('abc', 'def')")
         self.validate_identity(
             "SELECT CONCAT_WS('DELIM', 'abc', 'def', 'ghi')",
             "SELECT 'abc' || 'DELIM' || 'def' || 'DELIM' || 'ghi'",


### PR DESCRIPTION
[CONCAT](https://docs.aws.amazon.com/redshift/latest/dg/r_CONCAT.html) was being rewritten to `||` but Redshift supports `CONCAT` natively so the rewrite was unnecessary.