### PR TITLE
fix(postgres): preserve NOT LIKE quantifiers during generation

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1219,7 +1219,9 @@ def inline_array_unless_query(self: Generator, expression: exp.Expr) -> str:
 def no_ilike_sql(self: Generator, expression: exp.ILike) -> str:
     return self.like_sql(
         exp.Like(
-            this=exp.Lower(this=expression.this), expression=exp.Lower(this=expression.expression)
+            this=exp.Lower(this=expression.this),
+            expression=exp.Lower(this=expression.expression),
+            negate=expression.args.get("negate"),
         )
     )
 

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2135,7 +2135,7 @@ class GTE(Expression, Binary, Predicate):
 
 
 class ILike(Expression, Binary, Predicate):
-    pass
+    arg_types = {"this": True, "expression": True, "negate": False}
 
 
 class IntDiv(Expression, Binary):
@@ -2147,7 +2147,7 @@ class Is(Expression, Binary, Predicate):
 
 
 class Like(Expression, Binary, Predicate):
-    pass
+    arg_types = {"this": True, "expression": True, "negate": False}
 
 
 class Match(Expression, Binary, Predicate):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4193,6 +4193,9 @@ class Generator:
             exp_class = exp.ILike
             op = "ILIKE"
 
+        if expression.args.get("negate"):
+            op = f"NOT {op}"
+
         if isinstance(rhs, (exp.All, exp.Any)) and not self.SUPPORTS_LIKE_QUANTIFIERS:
             exprs = rhs.this.unnest()
 
@@ -4204,7 +4207,9 @@ class Generator:
             connective = exp.or_ if isinstance(rhs, exp.Any) else exp.and_
 
             def _make_like(expr: exp.Expression) -> exp.Expression:
-                like: exp.Expression = exp_class(this=this, expression=expr)
+                like: exp.Expression = exp_class(
+                    this=this, expression=expr, negate=expression.args.get("negate")
+                )
                 if escape:
                     like = exp.Escape(this=like, expression=escape.expression.copy())
                 return like

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5768,6 +5768,11 @@ class Parser:
         if not this:
             return this
 
+        expression = this.this if isinstance(this, exp.Escape) else this
+        if isinstance(expression, (exp.Like, exp.ILike)):
+            expression.set("negate", True)
+            return this
+
         return self.expression(exp.Not(this=this))
 
     def _parse_is(self, this: exp.Expr | None) -> exp.Expr | None:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -4185,6 +4185,24 @@ FROM subquery2""",
                     },
                 )
 
+            with self.subTest(f"Testing NOT LIKE {quantifier}"):
+                self.validate_all(
+                    f"SELECT col NOT LIKE {quantifier} (x, y, z)",
+                    write={
+                        "": f"SELECT col NOT LIKE {quantifier} (x, y, z)",
+                        "duckdb": f"SELECT (col NOT LIKE x {connector} col NOT LIKE y) {connector} col NOT LIKE z",
+                    },
+                )
+
+            with self.subTest(f"Testing NOT ILIKE {quantifier}"):
+                self.validate_all(
+                    f"SELECT col NOT ILIKE {quantifier} (x, y, z)",
+                    write={
+                        "": f"SELECT col NOT ILIKE {quantifier} (x, y, z)",
+                        "duckdb": f"SELECT (col NOT ILIKE x {connector} col NOT ILIKE y) {connector} col NOT ILIKE z",
+                    },
+                )
+
         self.validate_all(
             "SELECT 'foo' LIKE ANY((('bar', 'fo%')))",
             write={

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1351,11 +1351,11 @@ class TestDuckDB(Validator):
         self.validate_identity("a ^@ b", "STARTS_WITH(a, b)")
         self.validate_identity(
             "a !~~ b",
-            "NOT a LIKE b",
+            "a NOT LIKE b",
         )
         self.validate_identity(
             "a !~~* b",
-            "NOT a ILIKE b",
+            "a NOT ILIKE b",
         )
 
         self.validate_all(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -270,10 +270,7 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT 'testa 1' NOT LIKE ALL (ARRAY['testa%', 'testb%'])")
         self.validate_identity("SELECT 'testa 1' NOT LIKE ANY(ARRAY['testa%', 'testb%'])")
         self.validate_identity("SELECT 'testa 1' NOT ILIKE ALL (ARRAY['testa%', 'testb%'])")
-        self.validate_identity(
-            "SELECT 'testa 1' NOT ILIKE ANY (ARRAY['testa%', 'testb%'])",
-            "SELECT 'testa 1' NOT ILIKE ANY(ARRAY['testa%', 'testb%'])",
-        )
+        self.validate_identity("SELECT 'testa 1' NOT ILIKE ANY(ARRAY['testa%', 'testb%'])")
         self.validate_identity("SELECT NOT 'testa 1' LIKE ALL (ARRAY['testa%', 'testb%'])")
         self.validate_identity("SELECT NOT ('testa 1' LIKE ALL (ARRAY['testa%', 'testb%']))")
         infix_not_like = self.parse_one("SELECT a NOT LIKE ALL (b)").expressions[0]

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -268,10 +268,7 @@ class TestPostgres(Validator):
             "x NOT ILIKE 'y'",
         )
         self.validate_identity("SELECT 'testa 1' NOT LIKE ALL (ARRAY['testa%', 'testb%'])")
-        self.validate_identity(
-            "SELECT 'testa 1' NOT LIKE ANY (ARRAY['testa%', 'testb%'])",
-            "SELECT 'testa 1' NOT LIKE ANY(ARRAY['testa%', 'testb%'])",
-        )
+        self.validate_identity("SELECT 'testa 1' NOT LIKE ANY(ARRAY['testa%', 'testb%'])")
         self.validate_identity("SELECT 'testa 1' NOT ILIKE ALL (ARRAY['testa%', 'testb%'])")
         self.validate_identity(
             "SELECT 'testa 1' NOT ILIKE ANY (ARRAY['testa%', 'testb%'])",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -261,12 +261,32 @@ class TestPostgres(Validator):
         )
         self.validate_identity(
             "x !~~ 'y'",
-            "NOT x LIKE 'y'",
+            "x NOT LIKE 'y'",
         )
         self.validate_identity(
             "x !~~* 'y'",
-            "NOT x ILIKE 'y'",
+            "x NOT ILIKE 'y'",
         )
+        self.validate_identity("SELECT 'testa 1' NOT LIKE ALL (ARRAY['testa%', 'testb%'])")
+        self.validate_identity(
+            "SELECT 'testa 1' NOT LIKE ANY (ARRAY['testa%', 'testb%'])",
+            "SELECT 'testa 1' NOT LIKE ANY(ARRAY['testa%', 'testb%'])",
+        )
+        self.validate_identity("SELECT 'testa 1' NOT ILIKE ALL (ARRAY['testa%', 'testb%'])")
+        self.validate_identity(
+            "SELECT 'testa 1' NOT ILIKE ANY (ARRAY['testa%', 'testb%'])",
+            "SELECT 'testa 1' NOT ILIKE ANY(ARRAY['testa%', 'testb%'])",
+        )
+        self.validate_identity("SELECT NOT 'testa 1' LIKE ALL (ARRAY['testa%', 'testb%'])")
+        self.validate_identity("SELECT NOT ('testa 1' LIKE ALL (ARRAY['testa%', 'testb%']))")
+        infix_not_like = self.parse_one("SELECT a NOT LIKE ALL (b)").expressions[0]
+        prefix_not_like = self.parse_one("SELECT NOT a LIKE ALL (b)").expressions[0]
+        self.assertIsInstance(infix_not_like, exp.Like)
+        self.assertTrue(infix_not_like.args.get("negate"))
+        self.assertIsInstance(prefix_not_like, exp.Not)
+        self.assertIsInstance(prefix_not_like.this, exp.Like)
+        self.assertFalse(prefix_not_like.this.args.get("negate"))
+        self.assertNotEqual(infix_not_like, prefix_not_like)
         self.validate_identity(
             "'45 days'::interval day",
             "CAST('45 days' AS INTERVAL DAY)",

--- a/tests/fixtures/optimizer/tpc-h/tpc-h.sql
+++ b/tests/fixtures/optimizer/tpc-h/tpc-h.sql
@@ -781,7 +781,7 @@ WITH "orders_2" AS (
     "orders"."o_comment" AS "o_comment"
   FROM "orders" AS "orders"
   WHERE
-    NOT "orders"."o_comment" LIKE '%special%requests%'
+    "orders"."o_comment" NOT LIKE '%special%requests%'
 ), "c_orders" AS (
   SELECT
     COUNT("orders"."o_orderkey") AS "c_count"
@@ -952,7 +952,7 @@ JOIN "part" AS "part"
   ON "part"."p_brand" <> 'Brand#45'
   AND "part"."p_partkey" = "partsupp"."ps_partkey"
   AND "part"."p_size" IN (49, 14, 23, 45, 19, 3, 36, 9)
-  AND NOT "part"."p_type" LIKE 'MEDIUM POLISHED%'
+  AND "part"."p_type" NOT LIKE 'MEDIUM POLISHED%'
 LEFT JOIN "_u_0" AS "_u_0"
   ON "_u_0"."s_suppkey" = "partsupp"."ps_suppkey"
 WHERE

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -678,7 +678,7 @@ ORDER BY
             transpile("x::z", read="clickhouse")
 
     def test_not_range(self):
-        self.validate("a NOT LIKE b", "NOT a LIKE b")
+        self.validate("a NOT LIKE b", "a NOT LIKE b")
         self.validate("a NOT BETWEEN b AND c", "NOT a BETWEEN b AND c")
         self.validate("a NOT IN (1, 2)", "NOT a IN (1, 2)")
         self.validate("a IS NOT NULL", "NOT a IS NULL")


### PR DESCRIPTION
Fixes PostgreSQL generation for quantified NOT LIKE/NOT ILIKE expressions.
sqlglot represents x NOT LIKE ALL (...) as Not(Like(..., All(...))). The generator emits NOT x LIKE ALL (...), which is wrong for PostgreSQL and can change query results.
The fix preserves native NOT LIKE / NOT ILIKE quantified syntax when the dialect supports LIKE quantifiers, while keeping explicit external negation unchanged:
- NOT (x LIKE ALL (...))
- NOT (x LIKE ANY (...))

Tests:
- uv run python -m unittest tests.dialects.test_postgres -q
- uv run python -m unittest tests.dialects.test_dialect.TestDialect.test_like_quantifiers -q
- uv run pre-commit run --files sqlglot/generator.py tests/dialects/test_postgres.py
- uv run make unit