### PR TITLE
Refactor(schema): cache `find` lookups in schema

### DIFF
--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -317,6 +317,7 @@ class MappingSchema(AbstractMappingSchema, Schema):
         self._type_mapping_cache: dict[str, exp.DataType] = {}
         self._normalized_table_cache: dict[tuple[exp.Table, DialectType, bool], exp.Table] = {}
         self._normalized_name_cache: dict[tuple[str, DialectType, bool, bool], str] = {}
+        self._find_cache: dict[tuple[exp.Table, bool], dict[str, object] | None] = {}
         self._depth: int = 0
         schema = {} if schema is None else schema
         udf_mapping = {} if udf_mapping is None else udf_mapping
@@ -344,14 +345,17 @@ class MappingSchema(AbstractMappingSchema, Schema):
     def find(
         self, table: exp.Table, raise_on_missing: bool = True, ensure_data_types: bool = False
     ) -> t.Any | None:
-        schema: dict[str, object] | None = super().find(
-            table, raise_on_missing=raise_on_missing, ensure_data_types=ensure_data_types
-        )
-        if ensure_data_types and isinstance(schema, dict):
-            schema = {
-                col: self._to_data_type(dtype) if isinstance(dtype, str) else dtype
-                for col, dtype in schema.items()
-            }
+        cache_key = (table, ensure_data_types)
+        schema = self._find_cache.get(cache_key)
+
+        if schema is None:
+            schema = super().find(table, raise_on_missing=raise_on_missing)
+            if ensure_data_types and isinstance(schema, dict):
+                schema = {
+                    col: self._to_data_type(dtype) if isinstance(dtype, str) else dtype
+                    for col, dtype in schema.items()
+                }
+            self._find_cache[cache_key] = schema
 
         return schema
 
@@ -407,6 +411,8 @@ class MappingSchema(AbstractMappingSchema, Schema):
 
         nested_set(self.mapping, tuple(reversed(parts)), normalized_column_mapping)
         new_trie([parts], self.mapping_trie)
+        self._find_cache.pop((normalized_table, True), None)
+        self._find_cache.pop((normalized_table, False), None)
 
     def column_names(
         self,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1469,6 +1469,13 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                     exp.DataType.build(expected, dialect=dialect).sql(dialect),
                 )
 
+    def test_annotate_types_caches_schema_lookups(self):
+        schema = MappingSchema({"t": {"a": "INT"}})
+        qualified = qualify(parse_one("SELECT a, a FROM t"), schema=schema)
+        pre = len(schema._find_cache)
+        annotate_types(qualified, schema=schema)
+        self.assertEqual(len(schema._find_cache) - pre, 1)
+
     def test_annotate_funcs(self):
         test_schema = {
             "tbl": {


### PR DESCRIPTION
Benched this using `annotate_types` on a query with 2,400 columns references across 8 tables (8x60 cols, each referenced 5x).

before (main): 35.9ms median, 33.7ms min
after (cache): 33.3ms median, 32.0ms min (~7% faster)

The gain is modest in wall-time because the trie walk itself is cheap. The main benefit is eliminating 2,400 redundant base `find()` calls down to the number of unique (table, ensure_data_types) pairs.
