### PR TITLE
refactor: improve `optimizer::{eliminate_joins, eliminate_subqueries}` typing

### DIFF
--- a/sqlglot/optimizer/eliminate_joins.py
+++ b/sqlglot/optimizer/eliminate_joins.py
@@ -131,7 +131,7 @@ def _is_limit_1(scope: Scope) -> bool:
     return limit is not None and limit.expression.this == "1"
 
 
-def join_condition(join):
+def join_condition(join: exp.Join) -> tuple[list[exp.Expr], list[exp.Expr], exp.Expr]:
     """
     Extract the join condition from a join expression.
 
@@ -142,11 +142,11 @@ def join_condition(join):
             Tuple of (source key, join key, remaining predicate)
     """
     name = join.alias_or_name
-    on = (join.args.get("on") or exp.true()).copy()
-    source_key = []
-    join_key = []
+    on: exp.Expr = (join.args.get("on") or exp.true()).copy()
+    source_key: list[exp.Expr] = []
+    join_key: list[exp.Expr] = []
 
-    def extract_condition(condition):
+    def extract_condition(condition: exp.Expr) -> None:
         left, right = condition.unnest_operands()
         left_tables = exp.column_table_names(left)
         right_tables = exp.column_table_names(right)
@@ -174,14 +174,14 @@ def join_condition(join):
             if isinstance(condition, exp.EQ):
                 extract_condition(condition)
     elif normalized(on, dnf=True):
-        conditions = None
+        conditions: list[exp.EQ] = []
 
         for condition in on.flatten():
             parts = [part for part in condition.flatten() if isinstance(part, exp.EQ)]
-            if conditions is None:
+            if not conditions:
                 conditions = parts
             else:
-                temp = []
+                temp: list[exp.EQ] = []
                 for p in parts:
                     cs = [c for c in conditions if p == c]
 

--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -68,13 +68,14 @@ def eliminate_subqueries(expression: E) -> E:
     # Existing CTES in the root expression. We'll use this for deduplication.
     existing_ctes: ExistingCTEsMapping = {}
 
-    with_ = root.expression.args.get("with_")
-    recursive = False
+    with_: exp.With | None = root.expression.args.get("with_")
+    recursive: bool | None = False
     if with_:
         recursive = with_.args.get("recursive")
-        for cte in with_.expressions:
+        with_exprs: list[exp.CTE] = with_.expressions
+        for cte in with_exprs:
             existing_ctes[cte.this] = cte.alias
-    new_ctes = []
+    new_ctes: list[exp.Expr] = []
 
     # We're adding more CTEs, but we want to maintain the DAG order.
     # Derived tables within an existing CTE need to come before the existing CTE.

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -349,7 +349,7 @@ class Join(Step):
     def __init__(self) -> None:
         super().__init__()
         self.source_name: str | None = None
-        self.joins: dict[str, dict[str, list[str] | exp.Expr]] = {}
+        self.joins: dict[str, dict[str, list[str] | exp.Expr | list[exp.Expr]]] = {}
 
     def _to_s(self, indent: str) -> list[str]:
         lines = [f"{indent}Source: {self.source_name or self.name}"]


### PR DESCRIPTION
Another typing PR!

I originally planned to do only `eliminate_joins`, but a sub-10 LOC PR felt like it was too small, so I also refactored the `eliminate_subqueries` module. 

Now all `eliminate_*` optimizer modules are type safe!