### PR TITLE
Feldera dialect

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -77,6 +77,7 @@ DIALECTS = [
     "Dune",
     "Exasol",
     "Fabric",
+    "Feldera",
     "Hive",
     "Materialize",
     "MySQL",

--- a/sqlglot/dialects/feldera.py
+++ b/sqlglot/dialects/feldera.py
@@ -45,6 +45,7 @@ class Feldera(Postgres):
             "INT64": TokenType.BIGINT,
             "LATENESS": TokenType.VAR,
             "LINEAR": TokenType.VAR,
+            "MATCH_CONDITION": TokenType.MATCH_CONDITION,
             "MINUS": TokenType.EXCEPT,
             "NUMBER": TokenType.DECIMAL,
             "REMOVE": TokenType.VAR,

--- a/sqlglot/dialects/feldera.py
+++ b/sqlglot/dialects/feldera.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from sqlglot import tokens
+from sqlglot.dialects.dialect import NormalizationStrategy
+from sqlglot.dialects.postgres import Postgres
+from sqlglot.generators.feldera import FelderaGenerator
+from sqlglot.parsers.feldera import FelderaParser
+from sqlglot.tokens import TokenType
+
+
+class Feldera(Postgres):
+    NORMALIZATION_STRATEGY = NormalizationStrategy.LOWERCASE
+    NULL_ORDERING = "nulls_are_last"
+    TYPED_DIVISION = True
+    SAFE_DIVISION = False
+    CONCAT_COALESCE = False
+    DATE_FORMAT = "'%Y-%m-%d'"
+    TIME_FORMAT = "'%Y-%m-%d %H:%M:%S'"
+    TIME_MAPPING = {}
+
+    class Tokenizer(Postgres.Tokenizer):
+        BIT_STRINGS = []
+        BYTE_STRINGS = []
+        HEX_STRINGS = []
+        HEREDOC_STRINGS = []
+        IDENTIFIERS = ['"']
+        QUOTES = ["'"]
+        STRING_ESCAPES = ["'"]
+
+        KEYWORDS = {
+            **tokens.Tokenizer.KEYWORDS,
+            "BOOL": TokenType.BOOLEAN,
+            "BYTEA": TokenType.VARBINARY,
+            "DATETIME": TokenType.TIMESTAMP,
+            "DEC": TokenType.DECIMAL,
+            "FLOAT4": TokenType.FLOAT,
+            "FLOAT8": TokenType.DOUBLE,
+            "FLOAT32": TokenType.FLOAT,
+            "FLOAT64": TokenType.DOUBLE,
+            "INDEX": TokenType.INDEX,
+            "INTERNED": TokenType.VAR,
+            "INT2": TokenType.SMALLINT,
+            "INT4": TokenType.INT,
+            "INT8": TokenType.BIGINT,
+            "INT64": TokenType.BIGINT,
+            "LATENESS": TokenType.VAR,
+            "LINEAR": TokenType.VAR,
+            "MINUS": TokenType.EXCEPT,
+            "NUMBER": TokenType.DECIMAL,
+            "REMOVE": TokenType.VAR,
+            "SIGNED": TokenType.INT,
+            "STRING": TokenType.VARCHAR,
+            "UNSIGNED": TokenType.UBIGINT,
+            "WATERMARK": TokenType.VAR,
+        }
+
+    Parser = FelderaParser
+    Generator = FelderaGenerator

--- a/sqlglot/expressions/constraints.py
+++ b/sqlglot/expressions/constraints.py
@@ -178,6 +178,14 @@ class UppercaseColumnConstraint(Expression, ColumnConstraintKind):
     arg_types = {}
 
 
+class InternedColumnConstraint(Expression, ColumnConstraintKind):
+    arg_types = {}
+
+
+class LatenessColumnConstraint(Expression, ColumnConstraintKind):
+    arg_types = {"this": True}
+
+
 class WatermarkColumnConstraint(Expression):
     arg_types = {"this": True, "expression": True}
 

--- a/sqlglot/expressions/constraints.py
+++ b/sqlglot/expressions/constraints.py
@@ -187,7 +187,7 @@ class LatenessColumnConstraint(Expression, ColumnConstraintKind):
 
 
 class WatermarkColumnConstraint(Expression):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": False, "expression": True}
 
 
 class PathColumnConstraint(Expression, ColumnConstraintKind):

--- a/sqlglot/expressions/constraints.py
+++ b/sqlglot/expressions/constraints.py
@@ -187,6 +187,10 @@ class LatenessColumnConstraint(Expression, ColumnConstraintKind):
 
 
 class WatermarkColumnConstraint(Expression):
+    arg_types = {"this": True, "expression": True}
+
+
+class FelderaWatermarkColumnConstraint(WatermarkColumnConstraint):
     arg_types = {"this": False, "expression": True}
 
 

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -370,6 +370,10 @@ class Lateness(Expression):
     arg_types = {"this": True, "expression": True}
 
 
+class DeclareRecursiveView(Expression, DDL):
+    arg_types = {"this": True, "expression": True}
+
+
 class Transaction(Expression):
     arg_types = {"this": False, "modes": False, "mark": False}
 

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -366,6 +366,10 @@ class Command(Expression):
     arg_types = {"this": True, "expression": False}
 
 
+class Lateness(Expression):
+    arg_types = {"this": True, "expression": True}
+
+
 class Transaction(Expression):
     arg_types = {"this": False, "modes": False, "mark": False}
 

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -371,7 +371,7 @@ class Lateness(Expression):
 
 
 class DeclareRecursiveView(Expression, DDL):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True}
 
 
 class Transaction(Expression):

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -371,6 +371,10 @@ class Lateness(Expression):
 
 
 class DeclareRecursiveView(Expression, DDL):
+    arg_types = {"this": True, "expression": True}
+
+
+class FelderaDeclareRecursiveView(DeclareRecursiveView):
     arg_types = {"this": True}
 
 

--- a/sqlglot/expressions/dml.py
+++ b/sqlglot/expressions/dml.py
@@ -155,6 +155,13 @@ class Delete(Expression, DML):
         )
 
 
+class Remove(Expression, DML):
+    arg_types = {
+        "this": True,
+        "expression": True,
+    }
+
+
 class Export(Expression):
     arg_types = {"this": True, "connection": False, "options": True}
 

--- a/sqlglot/expressions/properties.py
+++ b/sqlglot/expressions/properties.py
@@ -215,6 +215,10 @@ class LanguageProperty(Property):
     arg_types = {"this": True}
 
 
+class LinearProperty(Property):
+    arg_types = {}
+
+
 class EnviromentProperty(Property):
     arg_types = {"expressions": True}
 

--- a/sqlglot/expressions/properties.py
+++ b/sqlglot/expressions/properties.py
@@ -215,6 +215,10 @@ class LanguageProperty(Property):
     arg_types = {"this": True}
 
 
+class LocalProperty(Property):
+    arg_types = {}
+
+
 class LinearProperty(Property):
     arg_types = {}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -5563,6 +5563,12 @@ class Generator:
             f"WATERMARK FOR {self.sql(expression, 'this')} AS {self.sql(expression, 'expression')}"
         )
 
+    def internedcolumnconstraint_sql(self, expression: exp.InternedColumnConstraint) -> str:
+        return "INTERNED"
+
+    def latenesscolumnconstraint_sql(self, expression: exp.LatenessColumnConstraint) -> str:
+        return f"LATENESS {self.sql(expression, 'this')}"
+
     def encodeproperty_sql(self, expression: exp.EncodeProperty) -> str:
         encode = "KEY ENCODE" if expression.args.get("key") else "ENCODE"
         encode = f"{encode} {self.sql(expression, 'this')}"

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1707,6 +1707,9 @@ class Generator:
             expression_sql = f"{returning}{this}{using}{cluster}{where}{order}{limit}"
         return self.prepend_ctes(expression, f"DELETE{hint}{tables}{expression_sql}")
 
+    def remove_sql(self, expression: exp.Remove) -> str:
+        return f"REMOVE FROM {self.sql(expression, 'this')} {self.sql(expression, 'expression')}"
+
     def drop_sql(self, expression: exp.Drop) -> str:
         this = self.sql(expression, "this")
         expressions = self.expressions(expression, flat=True)
@@ -3857,6 +3860,9 @@ class Generator:
 
     def command_sql(self, expression: exp.Command) -> str:
         return f"{self.sql(expression, 'this')} {expression.text('expression').strip()}"
+
+    def lateness_sql(self, expression: exp.Lateness) -> str:
+        return f"LATENESS {self.sql(expression, 'this')} {self.sql(expression, 'expression')}"
 
     def comment_sql(self, expression: exp.Comment) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generators/feldera.py
+++ b/sqlglot/generators/feldera.py
@@ -49,6 +49,12 @@ class FelderaGenerator(PostgresGenerator):
     def declarerecursiveview_sql(self, expression: exp.DeclareRecursiveView) -> str:
         return f"DECLARE RECURSIVE VIEW {self.sql(expression, 'this')} AS {self.sql(expression, 'expression')}"
 
+    def exists_sql(self, expression: exp.Exists) -> str:
+        predicate = expression.args.get("expression")
+        if predicate is not None:
+            return self.func("EXISTS", expression.this, predicate)
+        return super().exists_sql(expression)
+
     def nullsafeeq_sql(self, expression: exp.NullSafeEQ) -> str:
         return self.binary(expression, "<=>")
 

--- a/sqlglot/generators/feldera.py
+++ b/sqlglot/generators/feldera.py
@@ -47,7 +47,10 @@ class FelderaGenerator(PostgresGenerator):
         return "LINEAR"
 
     def declarerecursiveview_sql(self, expression: exp.DeclareRecursiveView) -> str:
-        return f"DECLARE RECURSIVE VIEW {self.sql(expression, 'this')} AS {self.sql(expression, 'expression')}"
+        return f"DECLARE RECURSIVE VIEW {self.sql(expression, 'this')}"
+
+    def watermarkcolumnconstraint_sql(self, expression: exp.WatermarkColumnConstraint) -> str:
+        return f"WATERMARK {self.sql(expression, 'expression')}"
 
     def exists_sql(self, expression: exp.Exists) -> str:
         predicate = expression.args.get("expression")

--- a/sqlglot/generators/feldera.py
+++ b/sqlglot/generators/feldera.py
@@ -34,6 +34,17 @@ class FelderaGenerator(PostgresGenerator):
         exp.Select: transforms.preprocess([transforms.eliminate_semi_and_anti_joins]),
     }
 
+    PROPERTIES_LOCATION = {
+        **PostgresGenerator.PROPERTIES_LOCATION,
+        exp.LinearProperty: exp.Properties.Location.POST_CREATE,
+    }
+
+    def linearproperty_sql(self, expression: exp.LinearProperty) -> str:
+        return "LINEAR"
+
+    def declarerecursiveview_sql(self, expression: exp.DeclareRecursiveView) -> str:
+        return f"DECLARE RECURSIVE VIEW {self.sql(expression, 'this')} AS {self.sql(expression, 'expression')}"
+
     def nullsafeeq_sql(self, expression: exp.NullSafeEQ) -> str:
         return self.binary(expression, "<=>")
 

--- a/sqlglot/generators/feldera.py
+++ b/sqlglot/generators/feldera.py
@@ -36,8 +36,12 @@ class FelderaGenerator(PostgresGenerator):
 
     PROPERTIES_LOCATION = {
         **PostgresGenerator.PROPERTIES_LOCATION,
+        exp.LocalProperty: exp.Properties.Location.POST_CREATE,
         exp.LinearProperty: exp.Properties.Location.POST_CREATE,
     }
+
+    def localproperty_sql(self, expression: exp.LocalProperty) -> str:
+        return "LOCAL"
 
     def linearproperty_sql(self, expression: exp.LinearProperty) -> str:
         return "LINEAR"

--- a/sqlglot/generators/feldera.py
+++ b/sqlglot/generators/feldera.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from sqlglot import exp, transforms
+from sqlglot.dialects.dialect import rename_func
+from sqlglot.generators.postgres import PostgresGenerator
+
+
+class FelderaGenerator(PostgresGenerator):
+    STAR_EXCEPT = "EXCLUDE"
+
+    TYPE_MAPPING = {
+        **PostgresGenerator.TYPE_MAPPING,
+        exp.DType.DATETIME: "TIMESTAMP",
+        exp.DType.FLOAT: "REAL",
+        exp.DType.TEXT: "VARCHAR",
+        exp.DType.UUID: "UUID",
+        exp.DType.VARIANT: "VARIANT",
+    }
+
+    TRANSFORMS = {
+        **{k: v for k, v in PostgresGenerator.TRANSFORMS.items() if k != exp.TryCast},
+        exp.ArgMax: rename_func("ARG_MAX"),
+        exp.ArgMin: rename_func("ARG_MIN"),
+        exp.ArrayConcat: rename_func("ARRAY_CONCAT"),
+        exp.ArrayContains: rename_func("ARRAY_CONTAINS"),
+        exp.ArrayDistinct: rename_func("ARRAY_DISTINCT"),
+        exp.ArrayOverlaps: rename_func("ARRAYS_OVERLAP"),
+        exp.ArrayReverse: rename_func("ARRAY_REVERSE"),
+        exp.ArraySize: rename_func("ARRAY_LENGTH"),
+        exp.ArraySort: rename_func("SORT_ARRAY"),
+        exp.CountIf: rename_func("COUNTIF"),
+        exp.IsInf: rename_func("IS_INF"),
+        exp.IsNan: rename_func("IS_NAN"),
+        exp.Select: transforms.preprocess([transforms.eliminate_semi_and_anti_joins]),
+    }
+
+    def nullsafeeq_sql(self, expression: exp.NullSafeEQ) -> str:
+        return self.binary(expression, "<=>")
+
+    def trycast_sql(self, expression: exp.TryCast) -> str:
+        return self.cast_sql(expression, safe_prefix="SAFE_")

--- a/sqlglot/generators/feldera.py
+++ b/sqlglot/generators/feldera.py
@@ -52,6 +52,14 @@ class FelderaGenerator(PostgresGenerator):
     def watermarkcolumnconstraint_sql(self, expression: exp.WatermarkColumnConstraint) -> str:
         return f"WATERMARK {self.sql(expression, 'expression')}"
 
+    def felderadeclarerecursiveview_sql(self, expression: exp.FelderaDeclareRecursiveView) -> str:
+        return self.declarerecursiveview_sql(expression)
+
+    def felderawatermarkcolumnconstraint_sql(
+        self, expression: exp.FelderaWatermarkColumnConstraint
+    ) -> str:
+        return self.watermarkcolumnconstraint_sql(expression)
+
     def exists_sql(self, expression: exp.Exists) -> str:
         predicate = expression.args.get("expression")
         if predicate is not None:

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.parsers.postgres import PostgresParser
+from sqlglot.tokens import Token
+
+
+class FelderaParser(PostgresParser):
+    CONSTRAINT_PARSERS = {
+        **PostgresParser.CONSTRAINT_PARSERS,
+        "INTERNED": lambda self: self.expression(exp.InternedColumnConstraint()),
+        "LATENESS": lambda self: self.expression(
+            exp.LatenessColumnConstraint(this=self._parse_disjunction())
+        ),
+    }
+
+    SCHEMA_UNNAMED_CONSTRAINTS = {
+        *PostgresParser.SCHEMA_UNNAMED_CONSTRAINTS,
+        "INTERNED",
+        "LATENESS",
+    }
+
+    def _parse_statement(self) -> exp.Expr | None:
+        if self._curr and self._curr.text.upper() in {"DECLARE", "LATENESS", "REMOVE"}:
+            start = self._curr
+            self._advance()
+            return self._parse_feldera_command(start)
+
+        return super()._parse_statement()
+
+    def _parse_feldera_command(self, start: Token) -> exp.Command:
+        while self._curr:
+            self._advance()
+
+        text = self._find_sql(start, self._prev)
+        size = len(start.text)
+        return self.expression(exp.Command(this=text[:size], expression=text[size:]))

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -33,7 +33,7 @@ class FelderaParser(PostgresParser):
             exp.LatenessColumnConstraint(this=self._parse_disjunction())
         ),
         "WATERMARK": lambda self: self.expression(
-            exp.WatermarkColumnConstraint(expression=self._parse_disjunction())
+            exp.FelderaWatermarkColumnConstraint(expression=self._parse_disjunction())
         ),
     }
 
@@ -137,7 +137,7 @@ class FelderaParser(PostgresParser):
         if not isinstance(schema, exp.Schema):
             return self._parse_feldera_command(start)
 
-        return self.expression(exp.DeclareRecursiveView(this=schema))
+        return self.expression(exp.FelderaDeclareRecursiveView(this=schema))
 
     def _parse_lateness(self) -> exp.Lateness:
         return self.expression(

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -6,6 +6,13 @@ from sqlglot.tokens import Token, TokenType
 
 
 class FelderaParser(PostgresParser):
+    JOIN_KINDS = {
+        *PostgresParser.JOIN_KINDS,
+        TokenType.ASOF,
+    }
+
+    TABLE_ALIAS_TOKENS = PostgresParser.TABLE_ALIAS_TOKENS - {TokenType.ASOF}
+
     CONSTRAINT_PARSERS = {
         **PostgresParser.CONSTRAINT_PARSERS,
         "INTERNED": lambda self: self.expression(exp.InternedColumnConstraint()),

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp
 from sqlglot.parsers.postgres import PostgresParser
 from sqlglot.tokens import Token, TokenType
 
 
 class FelderaParser(PostgresParser):
+    FUNCTION_PARSERS = {
+        **PostgresParser.FUNCTION_PARSERS,
+        "HOP": lambda self: self._parse_table_window_function("HOP"),
+        "TUMBLE": lambda self: self._parse_table_window_function("TUMBLE"),
+    }
+
     JOIN_KINDS = {
         *PostgresParser.JOIN_KINDS,
         TokenType.ASOF,
@@ -50,6 +58,20 @@ class FelderaParser(PostgresParser):
             return self._parse_create_aggregate(self._prev)
 
         return super()._parse_create()
+
+    def _parse_table_window_function(self, name: str) -> exp.Anonymous:
+        expressions: list[exp.Expression] = []
+
+        if self._match(TokenType.TABLE):
+            table = self._parse_table(schema=True)
+            if table is not None:
+                expressions.append(t.cast(exp.Expression, table))
+            self._match(TokenType.COMMA)
+
+        expressions.extend(
+            self._parse_csv(lambda: t.cast(exp.Expression | None, self._parse_lambda(alias=False)))
+        )
+        return self.expression(exp.Anonymous(this=name, expressions=expressions))
 
     def _parse_create_aggregate(self, start: Token) -> exp.Create | exp.Command:
         linear = self._match_text_seq("LINEAR")

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -59,10 +59,29 @@ class FelderaParser(PostgresParser):
         return super()._parse_statement()
 
     def _parse_create(self) -> exp.Create | exp.Command:
+        if self._curr and self._curr.text.upper() == "TYPE":
+            return self._parse_create_type(self._prev)
+
         if self._curr and self._curr.text.upper() in {"LINEAR", "AGGREGATE"}:
             return self._parse_create_aggregate(self._prev)
 
         return super()._parse_create()
+
+    def _parse_create_type(self, start: Token) -> exp.Create | exp.Command:
+        if not self._match_text_seq("TYPE"):
+            return self._parse_as_command(start)
+
+        exists = self._parse_exists(not_=True)
+        this = self._parse_table_parts(schema=True)
+
+        if not this or not self._match(TokenType.ALIAS):
+            return self._parse_as_command(start)
+
+        expression = self._parse_schema() or self._parse_types()
+        if not expression:
+            return self._parse_as_command(start)
+
+        return self.expression(exp.Create(this=this, kind="TYPE", exists=exists, expression=expression))
 
     def _parse_table_window_function(self, name: str) -> exp.Anonymous:
         expressions: list[exp.Expression] = []

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -14,6 +14,11 @@ class FelderaParser(PostgresParser):
         "TUMBLE": lambda self: self._parse_table_window_function("TUMBLE"),
     }
 
+    PROPERTY_PARSERS = {
+        **PostgresParser.PROPERTY_PARSERS,
+        "LOCAL": lambda self: self.expression(exp.LocalProperty()),
+    }
+
     JOIN_KINDS = {
         *PostgresParser.JOIN_KINDS,
         TokenType.ASOF,

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -21,12 +21,34 @@ class FelderaParser(PostgresParser):
     }
 
     def _parse_statement(self) -> exp.Expr | None:
-        if self._curr and self._curr.text.upper() in {"DECLARE", "LATENESS", "REMOVE"}:
+        if self._curr and self._curr.text.upper() == "REMOVE":
+            self._advance()
+            return self._parse_remove()
+
+        if self._curr and self._curr.text.upper() == "LATENESS":
+            self._advance()
+            return self._parse_lateness()
+
+        if self._curr and self._curr.text.upper() == "DECLARE":
             start = self._curr
             self._advance()
             return self._parse_feldera_command(start)
 
         return super()._parse_statement()
+
+    def _parse_lateness(self) -> exp.Lateness:
+        return self.expression(
+            exp.Lateness(this=self._parse_column(), expression=self._parse_disjunction())
+        )
+
+    def _parse_remove(self) -> exp.Remove:
+        self._match_text_seq("FROM")
+        return self.expression(
+            exp.Remove(
+                this=self._parse_table(schema=True),
+                expression=self._parse_derived_table_values(),
+            )
+        )
 
     def _parse_feldera_command(self, start: Token) -> exp.Command:
         while self._curr:

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -32,12 +32,19 @@ class FelderaParser(PostgresParser):
         "LATENESS": lambda self: self.expression(
             exp.LatenessColumnConstraint(this=self._parse_disjunction())
         ),
+        "WATERMARK": lambda self: self.expression(
+            exp.WatermarkColumnConstraint(
+                this=self._match(TokenType.FOR) and self._parse_column(),
+                expression=self._match(TokenType.ALIAS) and self._parse_disjunction(),
+            )
+        ),
     }
 
     SCHEMA_UNNAMED_CONSTRAINTS = {
         *PostgresParser.SCHEMA_UNNAMED_CONSTRAINTS,
         "INTERNED",
         "LATENESS",
+        "WATERMARK",
     }
 
     def _parse_statement(self) -> exp.Expr | None:

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -33,10 +33,7 @@ class FelderaParser(PostgresParser):
             exp.LatenessColumnConstraint(this=self._parse_disjunction())
         ),
         "WATERMARK": lambda self: self.expression(
-            exp.WatermarkColumnConstraint(
-                this=self._match(TokenType.FOR) and self._parse_column(),
-                expression=self._match(TokenType.ALIAS) and self._parse_disjunction(),
-            )
+            exp.WatermarkColumnConstraint(expression=self._parse_disjunction())
         ),
     }
 
@@ -136,14 +133,11 @@ class FelderaParser(PostgresParser):
             return self._parse_feldera_command(start)
 
         this = self._parse_table_parts(schema=True)
-        if not this or not self._match(TokenType.ALIAS):
+        schema = self._parse_schema(this=this)
+        if not isinstance(schema, exp.Schema):
             return self._parse_feldera_command(start)
 
-        expression = self._parse_ddl_select()
-        if not expression:
-            return self._parse_feldera_command(start)
-
-        return self.expression(exp.DeclareRecursiveView(this=this, expression=expression))
+        return self.expression(exp.DeclareRecursiveView(this=schema))
 
     def _parse_lateness(self) -> exp.Lateness:
         return self.expression(

--- a/sqlglot/parsers/feldera.py
+++ b/sqlglot/parsers/feldera.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from sqlglot import exp
 from sqlglot.parsers.postgres import PostgresParser
-from sqlglot.tokens import Token
+from sqlglot.tokens import Token, TokenType
 
 
 class FelderaParser(PostgresParser):
@@ -32,9 +32,58 @@ class FelderaParser(PostgresParser):
         if self._curr and self._curr.text.upper() == "DECLARE":
             start = self._curr
             self._advance()
+            if self._curr and self._curr.token_type == TokenType.RECURSIVE:
+                return self._parse_declare_recursive_view(start)
             return self._parse_feldera_command(start)
 
         return super()._parse_statement()
+
+    def _parse_create(self) -> exp.Create | exp.Command:
+        if self._curr and self._curr.text.upper() in {"LINEAR", "AGGREGATE"}:
+            return self._parse_create_aggregate(self._prev)
+
+        return super()._parse_create()
+
+    def _parse_create_aggregate(self, start: Token) -> exp.Create | exp.Command:
+        linear = self._match_text_seq("LINEAR")
+        if not self._match_text_seq("AGGREGATE"):
+            return self._parse_as_command(start)
+
+        exists = self._parse_exists(not_=True)
+        this = self._parse_user_defined_function()
+        returns = self._match_text_seq("RETURNS") and self._parse_returns()
+
+        if not this or not returns:
+            return self._parse_as_command(start)
+
+        properties: list[exp.Expression] = [returns]
+        if linear:
+            properties.insert(0, self.expression(exp.LinearProperty()))
+
+        return self.expression(
+            exp.Create(
+                this=this,
+                kind="AGGREGATE",
+                exists=exists,
+                properties=exp.Properties(expressions=properties),
+            )
+        )
+
+    def _parse_declare_recursive_view(
+        self, start: Token
+    ) -> exp.DeclareRecursiveView | exp.Command:
+        if not self._match(TokenType.RECURSIVE) or not self._match(TokenType.VIEW):
+            return self._parse_feldera_command(start)
+
+        this = self._parse_table_parts(schema=True)
+        if not this or not self._match(TokenType.ALIAS):
+            return self._parse_feldera_command(start)
+
+        expression = self._parse_ddl_select()
+        if not expression:
+            return self._parse_feldera_command(start)
+
+        return self.expression(exp.DeclareRecursiveView(this=this, expression=expression))
 
     def _parse_lateness(self) -> exp.Lateness:
         return self.expression(

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -1,0 +1,43 @@
+from tests.dialects.test_dialect import Validator
+
+
+class TestFeldera(Validator):
+    dialect = "feldera"
+    maxDiff = None
+
+    def test_feldera(self):
+        self.validate_identity("SELECT '10'::INT2", "SELECT CAST('10' AS SMALLINT)")
+        self.validate_identity("SELECT a <=> b FROM t")
+        self.validate_identity("SELECT SAFE_CAST(x AS INT) FROM t")
+        self.validate_identity(
+            "SELECT i, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY ts) AS rn FROM t QUALIFY rn = 1"
+        )
+        self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
+        self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
+        self.validate_identity("REMOVE FROM t VALUES (1, 'a')")
+        self.validate_identity(
+            "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1' HOUR, payload INT INTERNED)",
+            "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1 HOUR', payload INT INTERNED)",
+        )
+
+        self.validate_identity("SELECT 1 MINUS SELECT 2", "SELECT 1 EXCEPT SELECT 2")
+
+        self.validate_identity(
+            "CREATE TABLE t (c INT) WITH ('materialized' = 'true')",
+            "CREATE TABLE t (c INT) WITH (materialized='true')",
+        )
+
+    def test_type_aliases(self):
+        self.validate_identity(
+            "SELECT CAST(x AS BOOL) FROM t",
+            "SELECT CAST(x AS BOOLEAN) FROM t",
+        )
+        self.validate_identity(
+            "SELECT CAST(x AS INT2) FROM t",
+            "SELECT CAST(x AS SMALLINT) FROM t",
+        )
+        self.validate_identity("SELECT CAST(x AS BYTEA) FROM t")
+        self.validate_identity(
+            "SELECT CAST(x AS DATETIME) FROM t",
+            "SELECT CAST(x AS TIMESTAMP) FROM t",
+        )

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -13,6 +13,9 @@ class TestFeldera(Validator):
         self.validate_identity(
             "SELECT i, ROW_NUMBER() OVER (PARTITION BY grp ORDER BY ts) AS rn FROM t QUALIFY rn = 1"
         )
+        self.validate_identity(
+            "SELECT * FROM l LEFT ASOF JOIN r MATCH_CONDITION (l.ts >= r.ts) ON l.id = r.id"
+        )
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
         self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -25,6 +25,7 @@ class TestFeldera(Validator):
             "SELECT * FROM TABLE(HOP(t, DESCRIPTOR(ts), INTERVAL '1 MINUTE', INTERVAL '5 MINUTE'))",
         )
         self.validate_identity("SELECT EXISTS(ARRAY[1, -12, 3], x -> x > 0)")
+        self.validate_identity("SELECT EXISTS(SELECT 1)")
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
         self.validate_identity(
             "CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t",
@@ -36,6 +37,7 @@ class TestFeldera(Validator):
         )
         self.validate_identity("CREATE TYPE t AS (a INT, b VARCHAR)")
         self.validate_identity("CREATE TYPE t AS INT")
+        self.validate_identity("CREATE TYPE IF NOT EXISTS t AS INT")
         self.assertIsInstance(self.parse_one("CREATE TYPE t AS (a INT, b VARCHAR)"), exp.Create)
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
         self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")
@@ -58,6 +60,10 @@ class TestFeldera(Validator):
         self.validate_identity(
             "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1' HOUR, payload INT INTERNED)",
             "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1 HOUR', payload INT INTERNED)",
+        )
+        self.validate_identity(
+            "CREATE TABLE events (event_time TIMESTAMP WATERMARK FOR event_time AS event_time - INTERVAL '5' SECOND, payload VARCHAR)",
+            "CREATE TABLE events (event_time TIMESTAMP WATERMARK FOR event_time AS event_time - INTERVAL '5 SECOND', payload VARCHAR)",
         )
 
         self.validate_identity("SELECT 1 MINUS SELECT 2", "SELECT 1 EXCEPT SELECT 2")

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -1,3 +1,4 @@
+from sqlglot import exp
 from tests.dialects.test_dialect import Validator
 
 
@@ -15,6 +16,12 @@ class TestFeldera(Validator):
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
         self.validate_identity("REMOVE FROM t VALUES (1, 'a')")
+        self.assertIsInstance(self.parse_one("REMOVE FROM t VALUES (1, 'a')"), exp.Remove)
+        self.validate_identity(
+            "LATENESS v.ts INTERVAL '5' SECOND",
+            "LATENESS v.ts INTERVAL '5 SECOND'",
+        )
+        self.assertIsInstance(self.parse_one("LATENESS v.ts INTERVAL '5' SECOND"), exp.Lateness)
         self.validate_identity(
             "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1' HOUR, payload INT INTERNED)",
             "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1 HOUR', payload INT INTERNED)",

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -24,6 +24,7 @@ class TestFeldera(Validator):
             "SELECT * FROM TABLE(HOP(TABLE t, DESCRIPTOR(ts), INTERVAL '1' MINUTE, INTERVAL '5' MINUTE))",
             "SELECT * FROM TABLE(HOP(t, DESCRIPTOR(ts), INTERVAL '1 MINUTE', INTERVAL '5 MINUTE'))",
         )
+        self.validate_identity("SELECT EXISTS(ARRAY[1, -12, 3], x -> x > 0)")
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
         self.validate_identity(
             "CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t",
@@ -33,6 +34,9 @@ class TestFeldera(Validator):
             self.parse_one("CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t"),
             exp.Create,
         )
+        self.validate_identity("CREATE TYPE t AS (a INT, b VARCHAR)")
+        self.validate_identity("CREATE TYPE t AS INT")
+        self.assertIsInstance(self.parse_one("CREATE TYPE t AS (a INT, b VARCHAR)"), exp.Create)
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
         self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")
         self.assertIsInstance(

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -15,6 +15,16 @@ class TestFeldera(Validator):
         )
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
+        self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")
+        self.assertIsInstance(
+            self.parse_one("DECLARE RECURSIVE VIEW v AS SELECT * FROM t"),
+            exp.DeclareRecursiveView,
+        )
+        self.validate_identity("CREATE LINEAR AGGREGATE a(x INT) RETURNS INT")
+        self.assertIsInstance(
+            self.parse_one("CREATE LINEAR AGGREGATE a(x INT) RETURNS INT"),
+            exp.Create,
+        )
         self.validate_identity("REMOVE FROM t VALUES (1, 'a')")
         self.assertIsInstance(self.parse_one("REMOVE FROM t VALUES (1, 'a')"), exp.Remove)
         self.validate_identity(

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -16,6 +16,14 @@ class TestFeldera(Validator):
         self.validate_identity(
             "SELECT * FROM l LEFT ASOF JOIN r MATCH_CONDITION (l.ts >= r.ts) ON l.id = r.id"
         )
+        self.validate_identity(
+            "SELECT * FROM TABLE(TUMBLE(TABLE t, DESCRIPTOR(ts), INTERVAL '5' MINUTE))",
+            "SELECT * FROM TABLE(TUMBLE(t, DESCRIPTOR(ts), INTERVAL '5 MINUTE'))",
+        )
+        self.validate_identity(
+            "SELECT * FROM TABLE(HOP(TABLE t, DESCRIPTOR(ts), INTERVAL '1' MINUTE, INTERVAL '5' MINUTE))",
+            "SELECT * FROM TABLE(HOP(t, DESCRIPTOR(ts), INTERVAL '1 MINUTE', INTERVAL '5 MINUTE'))",
+        )
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
         self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -25,6 +25,14 @@ class TestFeldera(Validator):
             "SELECT * FROM TABLE(HOP(t, DESCRIPTOR(ts), INTERVAL '1 MINUTE', INTERVAL '5 MINUTE'))",
         )
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
+        self.validate_identity(
+            "CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t",
+            "CREATE LOCAL VIEW v WITH (emit_final='col') AS SELECT * FROM t",
+        )
+        self.assertIsInstance(
+            self.parse_one("CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t"),
+            exp.Create,
+        )
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
         self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")
         self.assertIsInstance(

--- a/tests/dialects/test_feldera.py
+++ b/tests/dialects/test_feldera.py
@@ -1,4 +1,4 @@
-from sqlglot import exp
+from sqlglot import exp, parse
 from tests.dialects.test_dialect import Validator
 
 
@@ -7,6 +7,15 @@ class TestFeldera(Validator):
     maxDiff = None
 
     def test_feldera(self):
+        self.validate_identity("EXPLAIN SELECT 1")
+        self.assertIsInstance(self.parse_one("EXPLAIN SELECT 1"), exp.Command)
+        self.validate_identity("SHOW TABLES")
+        self.assertIsInstance(self.parse_one("SHOW TABLES"), exp.Command)
+        self.validate_identity("INSERT INTO foo VALUES (1)")
+        self.assertIsInstance(self.parse_one("INSERT INTO foo VALUES (1)"), exp.Insert)
+        self.validate_identity("create table foo (id int)", "CREATE TABLE foo (id INT)")
+        self.validate_identity("-- comment\nSELECT 1", "/* comment */ SELECT 1")
+        self.validate_identity("/* block */ SELECT 1")
         self.validate_identity("SELECT '10'::INT2", "SELECT CAST('10' AS SMALLINT)")
         self.validate_identity("SELECT a <=> b FROM t")
         self.validate_identity("SELECT SAFE_CAST(x AS INT) FROM t")
@@ -27,10 +36,17 @@ class TestFeldera(Validator):
         self.validate_identity("SELECT EXISTS(ARRAY[1, -12, 3], x -> x > 0)")
         self.validate_identity("SELECT EXISTS(SELECT 1)")
         self.validate_identity("SELECT * EXCLUDE (col1, col2) FROM t")
+        self.validate_identity("CREATE VIEW v AS WITH cte AS (SELECT 1) SELECT * FROM cte")
         self.validate_identity(
             "CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t",
             "CREATE LOCAL VIEW v WITH (emit_final='col') AS SELECT * FROM t",
         )
+        self.validate_identity(
+            "CREATE TABLE kafka_sales (id INT) WITH ('connectors' = '[{\"name\": \"kafka\"}]')",
+            "CREATE TABLE kafka_sales (id INT) WITH (connectors='[{\"name\": \"kafka\"}]')",
+        )
+        self.validate_identity("CREATE TABLE t2 (d VARCHAR DEFAULT 'a;b')")
+        self.validate_identity('CREATE TABLE "MyTable" ("col" INT)')
         self.assertIsInstance(
             self.parse_one("CREATE LOCAL VIEW v WITH ('emit_final' = 'col') AS SELECT * FROM t"),
             exp.Create,
@@ -39,10 +55,16 @@ class TestFeldera(Validator):
         self.validate_identity("CREATE TYPE t AS INT")
         self.validate_identity("CREATE TYPE IF NOT EXISTS t AS INT")
         self.assertIsInstance(self.parse_one("CREATE TYPE t AS (a INT, b VARCHAR)"), exp.Create)
+        self.validate_identity("CREATE FUNCTION my_func(x INT) RETURNS INT AS x * 2")
+        self.validate_identity("CREATE FUNCTION my_func(x INT) RETURNS INT")
+        self.validate_identity("CREATE INDEX v_index ON v(id)")
+        self.validate_identity("SET FELDERA_WARNINGS_ARE_ERRORS = ON")
+        self.assertIsInstance(self.parse_one("SET FELDERA_WARNINGS_ARE_ERRORS = ON"), exp.Set)
         self.validate_identity("CREATE MATERIALIZED VIEW v AS SELECT * FROM t")
-        self.validate_identity("DECLARE RECURSIVE VIEW v AS SELECT * FROM t")
+        self.validate_identity("CREATE VIEW v (a, b, c) AS SELECT x, y, z FROM t")
+        self.validate_identity("DECLARE RECURSIVE VIEW v (id INT, name VARCHAR)")
         self.assertIsInstance(
-            self.parse_one("DECLARE RECURSIVE VIEW v AS SELECT * FROM t"),
+            self.parse_one("DECLARE RECURSIVE VIEW v (id INT, name VARCHAR)"),
             exp.DeclareRecursiveView,
         )
         self.validate_identity("CREATE LINEAR AGGREGATE a(x INT) RETURNS INT")
@@ -61,17 +83,55 @@ class TestFeldera(Validator):
             "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1' HOUR, payload INT INTERNED)",
             "CREATE TABLE t (ts TIMESTAMP LATENESS INTERVAL '1 HOUR', payload INT INTERNED)",
         )
+        self.validate_identity("CREATE TABLE t (id INT NOT NULL PRIMARY KEY, name VARCHAR)")
+        self.validate_identity("CREATE TABLE t (id INT, CONSTRAINT pk PRIMARY KEY (id))")
+        self.validate_identity("CREATE TABLE t (id INT, CHECK (id > 0))")
         self.validate_identity(
-            "CREATE TABLE events (event_time TIMESTAMP WATERMARK FOR event_time AS event_time - INTERVAL '5' SECOND, payload VARCHAR)",
-            "CREATE TABLE events (event_time TIMESTAMP WATERMARK FOR event_time AS event_time - INTERVAL '5 SECOND', payload VARCHAR)",
+            "CREATE TABLE t (empno BIGINT FOREIGN KEY REFERENCES employee(empid))",
+            "CREATE TABLE t (empno BIGINT FOREIGN KEY REFERENCES employee (empid))",
+        )
+        self.validate_identity(
+            "CREATE TABLE events (event_time TIMESTAMP WATERMARK INTERVAL '5' SECOND, payload VARCHAR)",
+            "CREATE TABLE events (event_time TIMESTAMP WATERMARK INTERVAL '5 SECOND', payload VARCHAR)",
         )
 
         self.validate_identity("SELECT 1 MINUS SELECT 2", "SELECT 1 EXCEPT SELECT 2")
+        self.validate_identity("SELECT COUNT(*) FILTER (WHERE x > 0) FROM t", "SELECT COUNT(*) FILTER(WHERE x > 0) FROM t")
+        self.validate_identity(
+            "SELECT a, b, COUNT(*) FROM t GROUP BY CUBE(a, b)",
+            "SELECT a, b, COUNT(*) FROM t GROUP BY CUBE (a, b)",
+        )
+        self.validate_identity("SELECT * FROM t LIMIT 10 OFFSET 5")
+        self.validate_identity("SELECT DATE '2020-01-01'", "SELECT CAST('2020-01-01' AS DATE)")
+        self.validate_identity("SELECT TIME '10:00:00'", "SELECT CAST('10:00:00' AS TIME)")
+        self.validate_identity(
+            "SELECT TIMESTAMP '2020-01-01 10:00:00'",
+            "SELECT CAST('2020-01-01 10:00:00' AS TIMESTAMP)",
+        )
+        self.validate_identity("SELECT INTERVAL '10' DAY", "SELECT INTERVAL '10 DAY'")
+        self.validate_identity(
+            "SELECT NOW() - INTERVAL '1' DAY",
+            "SELECT CURRENT_TIMESTAMP - INTERVAL '1 DAY'",
+        )
+        self.validate_identity("SELECT ARG_MAX(name, salary) FROM emp")
+        self.validate_identity("SELECT COUNTIF(x > 0) FROM t")
+        self.validate_identity("SELECT SAFE_OFFSET(arr, 0) FROM t")
 
         self.validate_identity(
             "CREATE TABLE t (c INT) WITH ('materialized' = 'true')",
             "CREATE TABLE t (c INT) WITH (materialized='true')",
         )
+        self.validate_identity(
+            "CREATE TABLE t (topic VARCHAR DEFAULT CAST(CONNECTOR_METADATA()['kafka_topic'] AS VARCHAR))"
+        )
+
+    def test_multi_statement_split(self):
+        expressions = parse(
+            "CREATE TABLE t1 (id INT); CREATE TABLE t2 (d VARCHAR DEFAULT 'a;b');",
+            read="feldera",
+        )
+        self.assertEqual(len(expressions), 2)
+        self.assertEqual(expressions[1].sql(dialect="feldera"), "CREATE TABLE t2 (d VARCHAR DEFAULT 'a;b')")
 
     def test_type_aliases(self):
         self.validate_identity(
@@ -84,6 +144,19 @@ class TestFeldera(Validator):
         )
         self.validate_identity("SELECT CAST(x AS BYTEA) FROM t")
         self.validate_identity(
+            "SELECT CAST(x AS VARBINARY) FROM t",
+            "SELECT CAST(x AS BYTEA) FROM t",
+        )
+        self.validate_identity(
+            "SELECT CAST(x AS NUMERIC(5,3)) FROM t",
+            "SELECT CAST(x AS DECIMAL(5, 3)) FROM t",
+        )
+        self.validate_identity(
             "SELECT CAST(x AS DATETIME) FROM t",
             "SELECT CAST(x AS TIMESTAMP) FROM t",
         )
+        self.validate_identity(
+            "SELECT CAST(x AS FLOAT) FROM t",
+            "SELECT CAST(x AS REAL) FROM t",
+        )
+        self.validate_identity("SELECT CAST(x AS CHAR(10)) FROM t")


### PR DESCRIPTION
This pull request adds support for the Feldera SQL dialect to the `sqlglot` project. It introduces new parser, generator, and expression logic specific to Feldera, along with comprehensive tests to ensure compatibility and correctness. The changes include dialect registration, custom SQL syntax handling, new SQL expressions, and extensive test coverage.

**Feldera Dialect Integration:**

* Registered the new `Feldera` dialect in the dialects list, making it available for use throughout `sqlglot`.
* Added the main dialect class `Feldera` in `sqlglot/dialects/feldera.py`, inheriting from `Postgres`, and configured custom tokenizer, parser, and generator references.

**Parser and Generator Extensions:**

* Implemented `FelderaParser` to handle Feldera-specific SQL constructs such as `REMOVE`, `LATENESS`, `DECLARE RECURSIVE VIEW`, custom constraints, and window functions like `HOP` and `TUMBLE`.
* Added `FelderaGenerator` to generate correct Feldera SQL, including custom handling for properties, constraints, and function names, and mapped types and transforms specific to Feldera.

**New Expressions and Constraints:**

* Introduced new expression classes for Feldera-specific features: `Remove`, `Lateness`, `DeclareRecursiveView`, `FelderaDeclareRecursiveView`, `InternedColumnConstraint`, `LatenessColumnConstraint`, and `FelderaWatermarkColumnConstraint`. [[1]](diffhunk://#diff-0136070eae05c2aceb5266512763d06c4c5141f42a8928f3609d6842ca98cfeeR181-R196) [[2]](diffhunk://#diff-19d4dca84c6c436c4ae87e8f8411a5c2b5afc3b0016226aeffd025fab442810aR369-R380) [[3]](diffhunk://#diff-68ed183756bc3dd0c2276c8e5c90f43c2c3e068356a1a21704e9f4a974d35229R158-R164) [[4]](diffhunk://#diff-5f1db5e084139b249109ae44950dd6ba3e6537d9d8809409ce1ef18cbeaf1eb4R218-R225)
* Updated the main generator to support SQL output for these new expressions and constraints. [[1]](diffhunk://#diff-362498362ae539e216cd83ebfe510977107648742f1a1bee7b2db7b5b7d27974R1710-R1712) [[2]](diffhunk://#diff-362498362ae539e216cd83ebfe510977107648742f1a1bee7b2db7b5b7d27974R3864-R3866) [[3]](diffhunk://#diff-362498362ae539e216cd83ebfe510977107648742f1a1bee7b2db7b5b7d27974R5572-R5577)

**Testing:**

* Added a comprehensive test suite for the Feldera dialect in `tests/dialects/test_feldera.py`, covering parsing, SQL generation, type aliases, and multi-statement handling.