### PR TITLE
fix(parser): issue with no parenthesis functions

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6843,13 +6843,19 @@ class Parser:
         this: str | exp.Expr = self._curr.text
         upper = self._curr.text.upper()
 
+        after_dot = prev.token_type == TokenType.DOT
         parser = self.NO_PAREN_FUNCTION_PARSERS.get(upper)
-        if optional_parens and parser and token_type not in self.INVALID_FUNC_NAME_TOKENS:
+        if (
+            optional_parens
+            and parser
+            and token_type not in self.INVALID_FUNC_NAME_TOKENS
+            and not after_dot
+        ):
             self._advance()
             return self._parse_window(parser(self))
 
         if self._next.token_type != TokenType.L_PAREN:
-            if optional_parens and token_type in self.NO_PAREN_FUNCTIONS:
+            if optional_parens and token_type in self.NO_PAREN_FUNCTIONS and not after_dot:
                 self._advance()
                 return self.expression(self.NO_PAREN_FUNCTIONS[token_type]())
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -97,6 +97,22 @@ class TestParser(unittest.TestCase):
 
         self.assertIsNotNone(parse_one("date").find(exp.Column))
 
+    def test_no_paren_functions_after_dot(self):
+        # NO_PAREN_FUNCTIONS (token-type-based): should be identifiers after a dot
+        col = parse_one("SELECT t.current_date FROM t").find(exp.Column)
+        self.assertEqual(col.table, "t")
+        self.assertEqual(col.name, "current_date")
+
+        # Bare usage should still produce function expressions
+        self.assertIsInstance(
+            parse_one("SELECT CURRENT_DATE").find(exp.CurrentDate), exp.CurrentDate
+        )
+
+        # Slow path via :: cast
+        cast = parse_one("SELECT t.current_user::TEXT FROM t", dialect="postgres").find(exp.Cast)
+        self.assertIsInstance(cast.this, exp.Column)
+        self.assertEqual(cast.this.name, "current_user")
+
     def test_tuple(self):
         parse_one("(a,)").assert_is(exp.Tuple)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -103,11 +103,6 @@ class TestParser(unittest.TestCase):
         self.assertEqual(col.table, "t")
         self.assertEqual(col.name, "current_date")
 
-        # Bare usage should still produce function expressions
-        self.assertIsInstance(
-            parse_one("SELECT CURRENT_DATE").find(exp.CurrentDate), exp.CurrentDate
-        )
-
         # Slow path via :: cast
         cast = parse_one("SELECT t.current_user::TEXT FROM t", dialect="postgres").find(exp.Cast)
         self.assertIsInstance(cast.this, exp.Column)


### PR DESCRIPTION
This is a small fix for a parser bug where Tokens in `NO_PAREN_FUNCTIONS` / `NO_PAREN_FUNCTION_PARSERS` (e.g. `CURRENT_DATE`, CURRENT_USER, `SYSDATE`) were incorrectly resolved as function calls when appearing after a dot in a column reference.  Example of the issue:

```
SELECT myytable.current_user FROM mytable
→
SELECT myytable.CURRENT_USER() FROM mytable
```

Added tests, also updated fixture test files to reflect corrected identifier output for dotted column references.
