### PR TITLE
[CLAUDE] fix(annotate): register First and Last in Hive typing

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -53,6 +53,8 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.ArrayDistinct,
             exp.ArrayExcept,
+            exp.First,
+            exp.Last,
             exp.Reverse,
         }
     },

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -205,6 +205,22 @@ STRING;
 SUBSTRING(tbl.bin_col, 0, 0);
 BINARY;
 
+# dialect: hive, spark2, spark, databricks
+FIRST(tbl.str_col);
+TEXT;
+
+# dialect: hive, spark2, spark, databricks
+FIRST(tbl.bigint_col);
+BIGINT;
+
+# dialect: hive, spark2, spark, databricks
+LAST(tbl.str_col);
+TEXT;
+
+# dialect: hive, spark2, spark, databricks
+LAST(tbl.bigint_col);
+BIGINT;
+
 # dialect: spark2, spark, databricks
 REGEXP_EXTRACT(tbl.str_col, pattern, 0);
 STRING;


### PR DESCRIPTION
I've registered `exp.First` and `exp.Last` in the Hive `EXPRESSION_METADATA`, so that the type annotator propagates the type of the first argument rather than returning UNKNOWN.

Both functions are only parsed in the Hive dialect chain (`hive.py:89-95`), so the annotators are added in `sqlglot/typing/hive.py` alongside `RegexpExtract`, which allows them to be inherited by Spark and Databricks.

`exp.First` and `exp.Last` use the `expression` arg for `IGNORE NULLS`/`RESPECT NULLS` but this has no effect on the return type and so we can still use `lambda self, e: self._annotate_by_args(e, "this")` as the annotator.

Four new tests document the new behavior.