### PR TITLE
fix(redshift): roundtrip for HH12 time mapping

### DIFF
--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -25,6 +25,7 @@ class Redshift(Postgres):
     # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
     TIME_MAPPING = {**Postgres.TIME_MAPPING, "MON": "%b", "HH24": "%H", "HH": "%I"}
+    INVERSE_TIME_MAPPING = {**Postgres.INVERSE_TIME_MAPPING, "%I": "HH12", "%H": "HH24"}
 
     Parser = RedshiftParser
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -24,7 +24,8 @@ class Redshift(Postgres):
 
     # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
-    TIME_MAPPING = {**Postgres.TIME_MAPPING, "MON": "%b"}
+    TIME_MAPPING = {**Postgres.TIME_MAPPING, "MON": "%b", "MONTH": "%B"}
+    INVERSE_TIME_MAPPING = {**Postgres.INVERSE_TIME_MAPPING, "%b": "MON", "%B": "MONTH"}
 
     Parser = RedshiftParser
 

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -24,8 +24,7 @@ class Redshift(Postgres):
 
     # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
-    TIME_MAPPING = {**Postgres.TIME_MAPPING, "MON": "%b", "HH24": "%H", "HH": "%I"}
-    INVERSE_TIME_MAPPING = {**Postgres.INVERSE_TIME_MAPPING, "%I": "HH12", "%H": "HH24"}
+    TIME_MAPPING = {**Postgres.TIME_MAPPING, "MON": "%b"}
 
     Parser = RedshiftParser
 

--- a/sqlglot/parsers/redshift.py
+++ b/sqlglot/parsers/redshift.py
@@ -7,7 +7,7 @@ from sqlglot.helper import seq_get
 from sqlglot.parsers.postgres import PostgresParser
 from sqlglot.parser import build_convert_timezone
 from sqlglot.tokens import TokenType
-from sqlglot.dialects.dialect import map_date_part
+from sqlglot.dialects.dialect import build_formatted_time, map_date_part
 from builtins import type as Type
 
 if t.TYPE_CHECKING:
@@ -63,6 +63,13 @@ class RedshiftParser(PostgresParser):
         ),
         "STRTOL": exp.FromBase.from_arg_list,
         "TEXTLEN": exp.Length.from_arg_list,
+        "TO_CHAR": build_formatted_time(exp.TimeToStr, "redshift"),
+        "TO_DATE": build_formatted_time(exp.StrToDate, "redshift"),
+        "TO_TIMESTAMP": lambda args: (
+            exp.UnixToTime.from_arg_list(args)
+            if len(args) == 1
+            else build_formatted_time(exp.StrToTime, "redshift")(args)
+        ),
     }
 
     NO_PAREN_FUNCTION_PARSERS = {


### PR DESCRIPTION
`TO_CHAR` format strings with `HH12` round-tripped back as `HH`. Root cause: `TIME_MAPPING` had both `"HH12": "%I"` (from Postgres) and `"HH": "%I"` (Redshift override), and since HH appeared later in the dict, the auto-generated `INVERSE_TIME_MAPPING` mapped `%I → HH` instead of `%I → HH12`.

Fix: Added `INVERSE_TIME_MAPPING` override in `dialects/redshift.py`