### PR TITLE
fix(redshift): roundtrip for optional arguments for TRIM

### DIFF
--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -282,6 +282,12 @@ class RedshiftGenerator(PostgresGenerator):
             )
         return self.func("ST_POINT", expression.this, expression.expression)
 
+    def trim_sql(self, expression: exp.Trim) -> str:
+        trim_type = self.sql(expression, "position")
+        if trim_type and not expression.args.get("expression"):
+            return f"TRIM({trim_type} FROM {self.sql(expression, 'this')})"
+        return super().trim_sql(expression)
+
     def arraycontains_sql(self, expression: exp.ArrayContains) -> str:
         return self.func(
             "ARRAY_CONTAINS",

--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -284,8 +284,8 @@ class RedshiftGenerator(PostgresGenerator):
 
     def trim_sql(self, expression: exp.Trim) -> str:
         trim_type = self.sql(expression, "position")
-        if trim_type and not expression.args.get("expression"):
-            return f"TRIM({trim_type} FROM {self.sql(expression, 'this')})"
+        if trim_type == "BOTH" and not expression.args.get("expression"):
+            return f"TRIM(BOTH FROM {self.sql(expression, 'this')})"
         return super().trim_sql(expression)
 
     def arraycontains_sql(self, expression: exp.ArrayContains) -> str:


### PR DESCRIPTION
Roundtrip for  [TRIM](https://docs.aws.amazon.com/redshift/latest/dg/r_TRIM.html)`TRIM(BOTH | LEADING | TRAILING FROM string)` was losing the position keyword.

Example:
```
TRIM(BOTH FROM '  dog  ') → TRIM('  dog  ')
```

Fix: Added `trim_sql` override in RedshiftGenerator.

