### PR TITLE
fix(sqlite): prevent ALTER TABLE RENAME TO from falling back to Command

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8681,7 +8681,9 @@ class Parser:
         return self._parse_csv(self._parse_alter_drop_action)
 
     def _parse_alter_table_rename(self) -> exp.AlterRename | exp.RenameColumn | None:
-        if self._match(TokenType.COLUMN) or not self.ALTER_RENAME_REQUIRES_COLUMN:
+        if self._match(TokenType.COLUMN) or (
+            not self.ALTER_RENAME_REQUIRES_COLUMN and not self._match_text_seq("TO", advance=False)
+        ):
             exists = self._parse_exists()
             old_column = self._parse_column()
             to = self._match_text_seq("TO")

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -56,6 +56,7 @@ class TestSQLite(Validator):
             "ALTER TABLE t RENAME a TO b",
             "ALTER TABLE t RENAME COLUMN a TO b",
         )
+        self.validate_identity("ALTER TABLE t1 RENAME TO t2")
 
         self.validate_all("SELECT LIKE(y, x)", write={"sqlite": "SELECT x LIKE y"})
         self.validate_all("SELECT GLOB('*y*', 'xyz')", write={"sqlite": "SELECT 'xyz' GLOB '*y*'"})


### PR DESCRIPTION
Fixes #7427

### Context
Currently, parsing `ALTER TABLE t1 RENAME TO t2;` in SQLite fails and falls back to a `Command` node. 

This is a regression introduced by #5195 (which allowed [column renaming without the `COLUMN` keyword](https://www.sqlite.org/lang_altertable.html)). That change caused the parser to assume *any* `RENAME` was a column rename if the `ALTER_RENAME_REQUIRES_COLUMN `flag is set to `False`.

### Solution
Added a simple check `not self._match_text_seq("TO", advance=False)` to `_parse_alter_table_rename`. 

Now, if the parser sees `RENAME TO`, it skips the column logic and parses the table rename correctly. Table rename is now covered in `test_sqlite.py`.