### PR TITLE
Feat(parser): handle `COLLATE` in nested types and `CAST` closes #7624

### DIFF
--- a/sqlglot/expressions/datatypes.py
+++ b/sqlglot/expressions/datatypes.py
@@ -178,6 +178,7 @@ class DataType(Expression):
         "values": False,
         "kind": False,
         "nullable": False,
+        "collate": False,
     }
 
     Type: t.ClassVar[Type[DType]] = DType

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1738,6 +1738,10 @@ class Generator:
         ):
             type_sql = f"{type_sql} WITH TIME ZONE"
 
+        collate = self.sql(expression, "collate")
+        if collate:
+            type_sql = f"{type_sql} COLLATE {collate}"
+
         return type_sql
 
     def directory_sql(self, expression: exp.Directory) -> str:

--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -433,17 +433,18 @@ class HiveGenerator(generator.Generator):
         if expression.this in self.PARAMETERIZABLE_TEXT_TYPES and (
             not expression.expressions or expression.expressions[0].name == "MAX"
         ):
-            expression = exp.DType.TEXT.into_expr()
+            expression.set("this", exp.DType.TEXT)
+            expression.set("expressions", None)
         elif expression.is_type(exp.DType.TEXT) and expression.expressions:
             expression.set("this", exp.DType.VARCHAR)
         elif expression.this in exp.DataType.TEMPORAL_TYPES:
-            expression = exp.DataType.build(expression.this)
+            expression.set("expressions", None)
         elif expression.is_type("float"):
             size_expression = expression.find(exp.DataTypeParam)
             if size_expression:
                 size = int(size_expression.name)
-                builder = exp.DType.FLOAT if size <= 32 else exp.DType.DOUBLE
-                expression = builder.into_expr()
+                expression.set("this", exp.DType.FLOAT if size <= 32 else exp.DType.DOUBLE)
+                expression.set("expressions", None)
         return super().datatype_sql(expression)
 
     def version_sql(self, expression: exp.Version) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6134,7 +6134,11 @@ class Parser:
         return exp.DataType.from_str(type_name, dialect=self.dialect, udt=True)
 
     def _parse_types(
-        self, check_func: bool = False, schema: bool = False, allow_identifiers: bool = True
+        self,
+        check_func: bool = False,
+        schema: bool = False,
+        allow_identifiers: bool = True,
+        with_collation: bool = False,
     ) -> exp.Expr | None:
         index = self._index
         this: exp.Expr | None = None
@@ -6255,7 +6259,10 @@ class Parser:
             else:
                 expressions = self._parse_csv(
                     lambda: self._parse_types(
-                        check_func=check_func, schema=schema, allow_identifiers=allow_identifiers
+                        check_func=check_func,
+                        schema=schema,
+                        allow_identifiers=allow_identifiers,
+                        with_collation=True,
                     )
                 )
 
@@ -6375,6 +6382,9 @@ class Parser:
             converter = self.TYPE_CONVERTERS.get(this.this)
             if converter:
                 this = converter(t.cast(exp.DataType, this))
+
+        if with_collation and isinstance(this, exp.DataType) and self._match(TokenType.COLLATE):
+            this.set("collate", self._parse_identifier() or self._parse_column())
 
         return this
 
@@ -7696,7 +7706,7 @@ class Parser:
             self.raise_error("Expected AS after CAST")
 
         fmt = None
-        to = self._parse_types()
+        to = self._parse_types(with_collation=True)
 
         default = None
         if self._match(TokenType.DEFAULT):

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -487,10 +487,17 @@ class ClickHouseParser(parser.Parser):
         return self._parse_lambda()
 
     def _parse_types(
-        self, check_func: bool = False, schema: bool = False, allow_identifiers: bool = True
+        self,
+        check_func: bool = False,
+        schema: bool = False,
+        allow_identifiers: bool = True,
+        with_collation: bool = False,
     ) -> exp.Expr | None:
         dtype = super()._parse_types(
-            check_func=check_func, schema=schema, allow_identifiers=allow_identifiers
+            check_func=check_func,
+            schema=schema,
+            allow_identifiers=allow_identifiers,
+            with_collation=with_collation,
         )
         if isinstance(dtype, exp.DataType) and dtype.args.get("nullable") is not True:
             # Mark every type as non-nullable which is ClickHouse's default, unless it's

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -66,6 +66,11 @@ def _show_parser(*args: t.Any, **kwargs: t.Any) -> t.Callable[[DuckDBParser], ex
     return _parse
 
 
+def _convert_text_type(dtype: exp.DataType) -> exp.DataType:
+    dtype.set("expressions", None)
+    return dtype
+
+
 class DuckDBParser(parser.Parser):
     MAP_KEYS_ARE_ARBITRARY_EXPRESSIONS = True
 
@@ -209,7 +214,7 @@ class DuckDBParser(parser.Parser):
         # https://duckdb.org/docs/sql/data_types/numeric
         exp.DType.DECIMAL: build_default_decimal_type(precision=18, scale=3),
         # https://duckdb.org/docs/sql/data_types/text
-        exp.DType.TEXT: lambda dtype: exp.DType.TEXT.into_expr(),
+        exp.DType.TEXT: _convert_text_type,
     }
 
     STATEMENT_PARSERS = {

--- a/sqlglot/parsers/hive.py
+++ b/sqlglot/parsers/hive.py
@@ -224,14 +224,14 @@ class HiveParser(parser.Parser):
         )
 
         if this and not schema:
-            return this.transform(
-                lambda node: (
-                    node.replace(exp.DType.TEXT.into_expr())
-                    if isinstance(node, exp.DataType) and node.is_type("char", "varchar")
-                    else node
-                ),
-                copy=False,
-            )
+
+            def _to_text(node: exp.Expr) -> exp.Expr:
+                if isinstance(node, exp.DataType) and node.is_type("char", "varchar"):
+                    node.set("this", exp.DType.TEXT)
+                    node.set("expressions", None)
+                return node
+
+            return this.transform(_to_text, copy=False)
 
         return this
 

--- a/sqlglot/parsers/hive.py
+++ b/sqlglot/parsers/hive.py
@@ -192,7 +192,11 @@ class HiveParser(parser.Parser):
         return func.from_arg_list(args)
 
     def _parse_types(
-        self, check_func: bool = False, schema: bool = False, allow_identifiers: bool = True
+        self,
+        check_func: bool = False,
+        schema: bool = False,
+        allow_identifiers: bool = True,
+        with_collation: bool = False,
     ) -> exp.Expr | None:
         """
         Spark (and most likely Hive) treats casts to CHAR(length) and VARCHAR(length) as casts to
@@ -213,7 +217,10 @@ class HiveParser(parser.Parser):
         Reference: https://spark.apache.org/docs/latest/sql-ref-datatypes.html
         """
         this = super()._parse_types(
-            check_func=check_func, schema=schema, allow_identifiers=allow_identifiers
+            check_func=check_func,
+            schema=schema,
+            allow_identifiers=allow_identifiers,
+            with_collation=with_collation,
         )
 
         if this and not schema:

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -7,6 +7,9 @@ class TestDatabricks(Validator):
     dialect = "databricks"
 
     def test_databricks(self):
+        self.validate_identity("CREATE TABLE foo (my_arr ARRAY<STRING COLLATE UTF8_BINARY>)")
+        self.validate_identity("CREATE TABLE foo (m MAP<STRING, STRING COLLATE UTF8_BINARY>)")
+        self.validate_identity("SELECT CAST('a' AS STRING COLLATE UTF8_BINARY)")
         self.validate_identity("SELECT COSH(1.5)")
         null_type = exp.DataType.build("VOID", dialect="databricks")
         self.assertEqual(null_type.sql(), "NULL")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -22,6 +22,7 @@ class TestPostgres(Validator):
         expected_sql = "ARRAY[\n  x" + (",\n  x" * 27) + "\n]"
         self.validate_identity(sql, expected_sql, pretty=True)
 
+        self.validate_identity("""CAST('a' AS TEXT COLLATE "de_DE")""")
         self.validate_identity("SELECT '%' SIMILAR TO '^%' ESCAPE '^'")
         self.validate_identity("SELECT GET_BIT(CAST(44 AS BIT(10)), 6)")
         self.validate_identity("SELECT * FROM t GROUP BY ROLLUP (a || '^' || b)")

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -271,6 +271,20 @@ TBLPROPERTIES (
         )
 
     def test_spark(self):
+        # COLLATE on CHAR/VARCHAR should be preserved when the type is rewritten to STRING
+        self.validate_identity(
+            "SELECT CAST('a' AS CHAR(10) COLLATE UTF8_BINARY)",
+            "SELECT CAST('a' AS STRING COLLATE UTF8_BINARY)",
+        )
+        self.validate_identity(
+            "SELECT CAST('a' AS VARCHAR(10) COLLATE UTF8_BINARY)",
+            "SELECT CAST('a' AS STRING COLLATE UTF8_BINARY)",
+        )
+        self.validate_all(
+            "SELECT CAST('a' AS STRING COLLATE foo)",
+            read={"postgres": "SELECT CAST('a' AS VARCHAR COLLATE foo)"},
+        )
+
         self.assertEqual(
             parse_one("REFRESH TABLE t", read="spark").assert_is(exp.Refresh).sql(dialect="spark"),
             "REFRESH TABLE t",


### PR DESCRIPTION
I decided to handle `COLLATE` in this manner because in most cases it needs to be parsed as a binary operator.