### PR TITLE
fix(exasol): case-insensitive alias matching for LOCAL. prefix 

### DIFF
--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -62,7 +62,7 @@ def _add_local_prefix_for_aliases(expression: exp.Expr, dialect: Dialect) -> exp
                 alias = visible_aliases.get(_key(node.this))
                 if alias is not None:
                     return exp.Column(
-                        this=alias.copy(),
+                        this=alias,
                         table=exp.to_identifier("LOCAL", quoted=False),
                     )
             return node

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -78,9 +78,8 @@ def _add_local_prefix_for_aliases(expression: exp.Expr, dialect: Dialect) -> exp
                 inner = sel.this.transform(lambda node: prefix_local(node, seen_aliases))
                 sel.set("this", inner)
 
-                alias_node = sel.args.get("alias")
-
-                seen_aliases[_key(alias_node)] = alias_node
+                if alias_node := sel.args.get("alias"):
+                    seen_aliases[_key(alias_node)] = alias_node
                 new_selects.append(sel)
             else:
                 new_selects.append(sel.transform(lambda node: prefix_local(node, seen_aliases)))
@@ -309,10 +308,10 @@ class ExasolGenerator(generator.Generator):
     }
 
     def select_sql(self, expression: exp.Select) -> str:
-        expression = _qualify_unscoped_star(expression)
-        expression = _add_local_prefix_for_aliases(expression, self.dialect)
-        expression = _group_by_all(expression)
-        return super().select_sql(expression)
+        processed = _qualify_unscoped_star(expression)
+        processed = _add_local_prefix_for_aliases(processed, self.dialect)
+        processed = _group_by_all(processed)
+        return super().select_sql(t.cast(exp.Select, processed))
 
     def datatype_sql(self, expression: exp.DataType) -> str:
         # Exasol supports a fixed default precision of 3 for TIMESTAMP WITH LOCAL TIME ZONE

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import typing as t
 
-from sqlglot import exp, generator, transforms
+from sqlglot import exp, generator
 from sqlglot.dialects.dialect import (
     DATE_ADD_OR_SUB,
+    Dialect,
     groupconcat_sql,
     no_last_day_sql,
     rename_func,
@@ -35,10 +36,13 @@ def _date_diff_sql(self: ExasolGenerator, expression: exp.DateDiff | exp.TsOrDsD
 
 
 # https://docs.exasol.com/db/latest/sql/select.htm#:~:text=If%20you%20have,local.x%3E10
-def _add_local_prefix_for_aliases(expression: exp.Expr) -> exp.Expr:
+def _add_local_prefix_for_aliases(expression: exp.Expr, dialect: Dialect) -> exp.Expr:
+    def _key(ident: exp.Identifier) -> str:
+        return dialect.normalize_identifier(ident.copy()).this
+
     if isinstance(expression, exp.Select):
-        aliases: dict[str, bool] = {
-            alias.name: bool(alias.args.get("quoted"))
+        aliases: dict[str, exp.Identifier] = {
+            _key(alias): alias
             for sel in expression.selects
             if isinstance(sel, exp.Alias) and (alias := sel.args.get("alias"))
         }
@@ -53,11 +57,12 @@ def _add_local_prefix_for_aliases(expression: exp.Expr) -> exp.Expr:
         ):
             table_ident.replace(exp.to_identifier(table_ident.name.upper(), quoted=True))
 
-        def prefix_local(node: exp.Expr, visible_aliases: dict[str, bool]) -> exp.Expr:
+        def prefix_local(node: exp.Expr, visible_aliases: dict[str, exp.Identifier]) -> exp.Expr:
             if isinstance(node, exp.Column) and not node.table:
-                if node.name in visible_aliases:
+                alias = visible_aliases.get(_key(node.this))
+                if alias is not None:
                     return exp.Column(
-                        this=exp.to_identifier(node.name, quoted=visible_aliases[node.name]),
+                        this=alias.copy(),
                         table=exp.to_identifier("LOCAL", quoted=False),
                     )
             return node
@@ -66,7 +71,7 @@ def _add_local_prefix_for_aliases(expression: exp.Expr) -> exp.Expr:
             if arg := expression.args.get(key):
                 expression.set(key, arg.transform(lambda node: prefix_local(node, aliases)))
 
-        seen_aliases: dict[str, bool] = {}
+        seen_aliases: dict[str, exp.Identifier] = {}
         new_selects: list[exp.Expr] = []
         for sel in expression.selects:
             if isinstance(sel, exp.Alias):
@@ -75,7 +80,7 @@ def _add_local_prefix_for_aliases(expression: exp.Expr) -> exp.Expr:
 
                 alias_node = sel.args.get("alias")
 
-                seen_aliases[sel.alias] = bool(alias_node and getattr(alias_node, "quoted", False))
+                seen_aliases[_key(alias_node)] = alias_node
                 new_selects.append(sel)
             else:
                 new_selects.append(sel.transform(lambda node: prefix_local(node, seen_aliases)))
@@ -303,6 +308,12 @@ class ExasolGenerator(generator.Generator):
         exp.DType.TIMESTAMPNTZ: "TIMESTAMP",
     }
 
+    def select_sql(self, expression: exp.Select) -> str:
+        expression = _qualify_unscoped_star(expression)
+        expression = _add_local_prefix_for_aliases(expression, self.dialect)
+        expression = _group_by_all(expression)
+        return super().select_sql(expression)
+
     def datatype_sql(self, expression: exp.DataType) -> str:
         # Exasol supports a fixed default precision of 3 for TIMESTAMP WITH LOCAL TIME ZONE
         # and does not allow specifying a different custom precision
@@ -390,13 +401,6 @@ class ExasolGenerator(generator.Generator):
         exp.MD5Digest: rename_func("HASHTYPE_MD5"),
         # https://docs.exasol.com/db/latest/sql/create_view.htm
         exp.CommentColumnConstraint: lambda self, e: f"COMMENT IS {self.sql(e, 'this')}",
-        exp.Select: transforms.preprocess(
-            [
-                _qualify_unscoped_star,
-                _add_local_prefix_for_aliases,
-                _group_by_all,
-            ]
-        ),
         exp.SubstringIndex: _substring_index_sql,
         exp.WeekOfYear: rename_func("WEEK"),
         # https://docs.exasol.com/db/latest/sql_references/functions/alphabeticallistfunctions/to_date.htm

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -820,6 +820,14 @@ class TestExasol(Validator):
         self.validate_identity(
             'SELECT a_year AS a_year FROM "LOCAL" GROUP BY "LOCAL".a_year',
         )
+        self.validate_identity(
+            "SELECT YEAR(a_date) AS A_YEAR FROM my_table WHERE a_year > 2020",
+            "SELECT YEAR(a_date) AS A_YEAR FROM my_table WHERE LOCAL.A_YEAR > 2020",
+        )
+        self.validate_identity(
+            "SELECT SUM(amount) AS Total FROM my_table HAVING TOTAL > 10000",
+            "SELECT SUM(amount) AS Total FROM my_table HAVING LOCAL.Total > 10000",
+        )
 
         test_cases = [
             (


### PR DESCRIPTION
`_add_local_prefix_for_aliases` did case-sensitive string matching when rewriting alias references to `LOCAL.<alias>` in `WHERE`/`GROUP BY`/`HAVING`. Exasol folds unquoted identifiers to uppercase, so an alias `idField` and a reference `idfield` are the same identifier but the lookup missed, producing invalid SQL:            
 
```                     
  sqlglot.transpile(                                                                                                                                              
      "SELECT 1 AS idField FROM t GROUP BY idfield",            
      read="mysql", write="exasol",   
  )
  # before: ... GROUP BY idfield        → Exasol error
  # after:  ... GROUP BY LOCAL.idField  → ok                                                                                                                      
```
                                                                                                                                   
Fix: use `dialect.normalize_identifier()` to compute the comparison key. The `exp.Select` preprocessing moves into a `select_sql` override so `self.dialect` is available.

We went with this approach, because [now Exasol supports setting a different normalization strategy](https://docs.exasol.com/db/latest/sql_references/basiclanguageelements.htm#:~:text=Comparison%20of%20identifiers), so the function would work consistently when using an extended Exasol dialect using a different normalization strategy.
                                                                                                                                                                  
Tests added to `test_local_prefix_for_alias`. Verified against a live Exasol instance.   