### PR TITLE
fix(annotate_types)!: propagate type through IgnoreNulls/RespectNulls wrappers [CLAUDE]

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -22,7 +22,9 @@ EXPRESSION_METADATA: ExprMetadataType = {
     },
     **{
         expr_type: {"annotator": lambda self, e: self._annotate_unary(e)}
-        for expr_type in subclasses(exp.__name__, (exp.Unary, exp.Alias))
+        for expr_type in subclasses(
+            exp.__name__, (exp.Unary, exp.Alias, exp.IgnoreNulls, exp.RespectNulls)
+        )
     },
     **{
         expr_type: {"returns": exp.DType.BIGINT}

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6376,3 +6376,14 @@ VARCHAR;
 # dialect: clickhouse
 MD5(tbl.str_col);
 FIXEDSTRING(16);
+--------------------------------------
+-- IGNORE NULLS / RESPECT NULLS
+--------------------------------------
+
+# dialect: spark, databricks, snowflake, bigquery, trino, redshift
+FIRST_VALUE(tbl.str_col) IGNORE NULLS;
+TEXT;
+
+# dialect: spark, databricks, snowflake, bigquery, trino, redshift
+LAST_VALUE(tbl.str_col) RESPECT NULLS;
+TEXT;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1530,33 +1530,6 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         self.assertEqual(expression.this.type.this, exp.DataType.Type.UNKNOWN)
         self.assertEqual(expression.args["to"].type.this, exp.DataType.Type.INTERVAL)
 
-    def test_ignore_respect_nulls_annotation(self):
-        schema = {"t": {"name": "VARCHAR"}}
-
-        # IGNORE NULLS propagates the inner expression's type (Databricks dialect)
-        ast = annotate_types(
-            parse_one("SELECT FIRST_VALUE(name) IGNORE NULLS AS x FROM t", dialect="databricks"),
-            schema=schema,
-            dialect="databricks",
-        )
-        self.assertEqual(ast.selects[0].this.type.this, exp.DataType.Type.VARCHAR)
-
-        # IGNORE NULLS propagates the inner expression's type (Snowflake dialect)
-        ast = annotate_types(
-            parse_one("SELECT FIRST_VALUE(name) IGNORE NULLS AS x FROM t", dialect="snowflake"),
-            schema=schema,
-            dialect="snowflake",
-        )
-        self.assertEqual(ast.selects[0].this.type.this, exp.DataType.Type.VARCHAR)
-
-        # RESPECT NULLS propagates the inner expression's type
-        ast = annotate_types(
-            parse_one("SELECT LAST_VALUE(name) RESPECT NULLS AS x FROM t", dialect="spark"),
-            schema=schema,
-            dialect="spark",
-        )
-        self.assertEqual(ast.selects[0].this.type.this, exp.DataType.Type.VARCHAR)
-
     def test_cache_annotation(self):
         expression = annotate_types(
             parse_one("CACHE LAZY TABLE x OPTIONS('storageLevel' = 'value') AS SELECT 1")

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1530,6 +1530,33 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         self.assertEqual(expression.this.type.this, exp.DataType.Type.UNKNOWN)
         self.assertEqual(expression.args["to"].type.this, exp.DataType.Type.INTERVAL)
 
+    def test_ignore_respect_nulls_annotation(self):
+        schema = {"t": {"name": "VARCHAR"}}
+
+        # IGNORE NULLS propagates the inner expression's type (Databricks dialect)
+        ast = annotate_types(
+            parse_one("SELECT FIRST_VALUE(name) IGNORE NULLS AS x FROM t", dialect="databricks"),
+            schema=schema,
+            dialect="databricks",
+        )
+        self.assertEqual(ast.selects[0].this.type.this, exp.DataType.Type.VARCHAR)
+
+        # IGNORE NULLS propagates the inner expression's type (Snowflake dialect)
+        ast = annotate_types(
+            parse_one("SELECT FIRST_VALUE(name) IGNORE NULLS AS x FROM t", dialect="snowflake"),
+            schema=schema,
+            dialect="snowflake",
+        )
+        self.assertEqual(ast.selects[0].this.type.this, exp.DataType.Type.VARCHAR)
+
+        # RESPECT NULLS propagates the inner expression's type
+        ast = annotate_types(
+            parse_one("SELECT LAST_VALUE(name) RESPECT NULLS AS x FROM t", dialect="spark"),
+            schema=schema,
+            dialect="spark",
+        )
+        self.assertEqual(ast.selects[0].this.type.this, exp.DataType.Type.VARCHAR)
+
     def test_cache_annotation(self):
         expression = annotate_types(
             parse_one("CACHE LAZY TABLE x OPTIONS('storageLevel' = 'value') AS SELECT 1")


### PR DESCRIPTION
Added unary type annotation to `exp.IgnoreNulls` and `exp.RespectNulls`. 

## Summary

`FIRST_VALUE(expr, true)` gets parsed into `IgnoreNulls(FirstValue(expr))`, blocking type annotation until IgnoreNulls and RespectNulls are annotated.

## Test plan

Fixture cases to `tests/fixtures/optimizer/annotate_functions.sql` covering `FIRST_VALUE(col) IGNORE NULLS` and `LAST_VALUE(col) RESPECT NULLS` across six dialects: Spark, Databricks, Snowflake, BigQuery, Trino, and Redshift