### PR TITLE
fix(parser): allow WINDOW clause without FROM

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5559,6 +5559,23 @@ class Parser:
 
         return result
 
+    def _can_parse_named_window(self) -> bool:
+        # `WINDOW` is in ID_VAR_TOKENS so it could be mistakenly consumed as an implicit alias.
+        # Refuse only when the following tokens look like a named-window clause: `WINDOW <id> AS (`.
+        if not self._match(TokenType.WINDOW, advance=False):
+            return False
+
+        name = self._tokens[self._index + 1] if self._index + 1 < len(self._tokens) else None
+        if name is None or name.token_type not in self.ID_VAR_TOKENS:
+            return False
+
+        alias_tok = self._tokens[self._index + 2] if self._index + 2 < len(self._tokens) else None
+        if alias_tok is None or alias_tok.token_type != TokenType.ALIAS:
+            return False
+
+        body = self._tokens[self._index + 3] if self._index + 3 < len(self._tokens) else None
+        return body is not None and body.token_type == TokenType.L_PAREN
+
     def _parse_limit_by(self) -> list[exp.Expr] | None:
         return self._parse_csv(self._parse_bitwise) if self._match_text_seq("BY") else None
 
@@ -8310,6 +8327,11 @@ class Parser:
         # so this section tries to parse the clause version and if it fails, it treats the token
         # as an identifier (alias)
         if self._can_parse_limit_or_offset():
+            return this
+
+        # WINDOW is in ID_VAR_TOKENS, so it can be consumed as an implicit alias. Detect the
+        # named-window clause shape (`WINDOW <ident> AS (...)`) and avoid swallowing it.
+        if self._can_parse_named_window():
             return this
 
         any_token = self._match(TokenType.ALIAS)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1075,6 +1075,24 @@ class TestParser(unittest.TestCase):
             "SELECT * FROM a WHERE c = 'false'",
         )
 
+    def test_window_clause_without_from(self):
+        # https://github.com/tobymao/sqlglot/issues/7438
+        for dialect in (None, "sqlite", "postgres", "mysql", "duckdb", "bigquery"):
+            sql = "SELECT 1 WINDOW a AS (PARTITION BY x)"
+            self.assertEqual(parse_one(sql, dialect=dialect).sql(dialect=dialect), sql)
+
+        # multiple named windows still work
+        self.assertEqual(
+            parse_one("SELECT 1 WINDOW a AS (PARTITION BY x), b AS (ORDER BY y)").sql(),
+            "SELECT 1 WINDOW a AS (PARTITION BY x), b AS (ORDER BY y)",
+        )
+
+        # WINDOW can still be used as an explicit alias (SELECT 1 AS WINDOW)
+        self.assertEqual(parse_one("SELECT 1 AS WINDOW").sql(), "SELECT 1 AS WINDOW")
+
+        # WINDOW remains usable as an implicit alias when not followed by `<id> AS (`
+        self.assertEqual(parse_one("SELECT col window FROM t").sql(), "SELECT col AS window FROM t")
+
     def test_parse_into_grant_principal(self):
         self.assertIsInstance(parse_one("ROLE blah", into=exp.GrantPrincipal), exp.GrantPrincipal)
         self.assertIsInstance(parse_one("GROUP blah", into=exp.GrantPrincipal), exp.GrantPrincipal)


### PR DESCRIPTION
Closes #7438.

## What

`SELECT 1 WINDOW a AS (PARTITION BY x)` raised `ParseError: Invalid expression / Unexpected token`. With a FROM clause the parser short-circuits earlier and the query parses fine, but SQLite and DuckDB both happily execute the FROM-less form against real databases, so users hit this writing portable SQL.

Root cause: `WINDOW` is in `Parser.ID_VAR_TOKENS` and `Parser.ALIAS_TOKENS`, so the projection-alias parser greedily consumes `WINDOW` as an implicit alias for `1`. Then it hits the next identifier (`a`) without a separator and fails.

## Fix

Add a `_can_parse_named_window` lookahead, mirroring the existing `_can_parse_limit_or_offset` pattern. Called from `_parse_alias` before consuming the alias. It checks the exact 4-token shape `WINDOW <ident> AS (` — strict enough to preserve `SELECT col window FROM t` → `SELECT col AS window FROM t` (implicit alias) and `SELECT WINDOW()` (function call), while catching the legitimate named-window clause.

## Tests

`tests.test_parser.TestParser.test_window_clause_without_from` covers:

- Default + sqlite/postgres/mysql/duckdb/bigquery — all parse `SELECT 1 WINDOW a AS (PARTITION BY x)`
- Multi-window form `WINDOW a AS (...), b AS (...)`
- `SELECT 1 AS WINDOW` — explicit alias still works
- `SELECT col window FROM t` — implicit alias still resolves to `col AS window`