### PR TITLE
feat(duckdb): Add transpilation unsupported for GET_IGNORE_CASE function

### DIFF
--- a/sqlglot/expressions/functions.py
+++ b/sqlglot/expressions/functions.py
@@ -436,6 +436,10 @@ class XMLElement(Expression, Func):
     arg_types = {"this": True, "expressions": False, "evalname": False}
 
 
+class GetIgnoreCase(Expression, Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class XMLGet(Expression, Func):
     _sql_names = ["XMLGET"]
     arg_types = {"this": True, "expression": True, "instance": False}

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2285,6 +2285,10 @@ class DuckDBGenerator(generator.Generator):
             f"({self.sql(exp.replace_placeholders(self.BITMAP_CONSTRUCT_AGG_TEMPLATE, arg=arg))})"
         )
 
+    def getignorecase_sql(self, expression: exp.GetIgnoreCase) -> str:
+        self.unsupported("DuckDB does not support the GET_IGNORE_CASE() function")
+        return self.function_fallback_sql(expression)
+
     def compress_sql(self, expression: exp.Compress) -> str:
         self.unsupported("DuckDB does not support the COMPRESS() function")
         return self.function_fallback_sql(expression)


### PR DESCRIPTION
`GET_IGNORE_CASE(obj, key) `retrieves a value from a Snowflake `OBJECT/VARIANT` by key, case-insensitively, returning NULL if the key is missing. 
There is no DuckDB equivalent. 
This PR marks the function unsupported by DuckDB.
