### PR TITLE
fix(bigquery.parser): handle biguqery chain functions 

### DIFF
--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -710,7 +710,58 @@ class BigQueryParser(parser.Parser):
             )
         )
 
+    def _parse_chained_call(self, receiver: exp.Expr) -> exp.Expr | None:
+        saved = self._index
+        self._advance()
+
+        if self._curr.token_type not in self.ID_VAR_TOKENS:
+            self._retreat(saved)
+            return None
+
+        method_name = self._curr.text.upper()
+        self._advance()
+
+        if not self._match(TokenType.L_PAREN):
+            self._retreat(saved)
+            return None
+
+        if isinstance(receiver, exp.Paren):
+            inner = receiver.this
+            if isinstance(inner, exp.Dot):
+                parts: list[exp.Expr] = []
+                node: exp.Expr = inner
+                while isinstance(node, exp.Dot):
+                    parts.append(node.expression)
+                    node = node.this
+                parts.append(node)
+                parts.reverse()
+                keys = ("catalog", "db", "table", "this")
+                receiver = exp.Column(**{k: v for k, v in zip(reversed(keys), reversed(parts))})
+            elif isinstance(inner, exp.Identifier):
+                receiver = exp.Column(this=inner)
+            else:
+                receiver = inner
+
+        args = [receiver] + self._parse_function_args()
+        self._match_r_paren()
+
+        func_builder = self.FUNCTIONS.get(method_name)
+        if func_builder:
+            try:
+                return func_builder(args)
+            except TypeError:
+                return func_builder(args, dialect=self.dialect)
+        else:
+            return self.expression(exp.Anonymous(this=method_name, expressions=args))
+
     def _parse_column_ops(self, this: exp.Expr | None) -> exp.Expr | None:
+        # parse BigQuery chained functions first
+        while isinstance(this, (exp.Func, exp.Paren)) and self._curr.token_type == TokenType.DOT:
+            result = self._parse_chained_call(this)
+            if result is None:
+                break
+            this = result
+
         func_index = self._index + 1
         this = super()._parse_column_ops(this)
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3847,3 +3847,76 @@ OPTIONS (
                         "duckdb": "SELECT CAST(1 AS DECIMAL(38, 5))",
                     },
                 )
+
+    def test_chained_functions(self):
+        # Single chain: func().method()
+        self.validate_all(
+            "SELECT LOWER(text).UPPER()",
+            write={
+                "bigquery": "SELECT UPPER(LOWER(text))",
+                "duckdb": "SELECT UPPER(LOWER(text))",
+            },
+        )
+
+        # Single chain with explicit args on the method
+        self.validate_all(
+            "SELECT LOWER(text).REPLACE('a', 'b')",
+            write={
+                "bigquery": "SELECT REPLACE(LOWER(text), 'a', 'b')",
+                "duckdb": "SELECT REPLACE(LOWER(text), 'a', 'b')",
+            },
+        )
+
+        # Multi-level chain: a().b().c()
+        self.validate_all(
+            "SELECT LOWER(text).TRIM().UPPER()",
+            write={
+                "bigquery": "SELECT UPPER(TRIM(LOWER(text)))",
+                "duckdb": "SELECT UPPER(TRIM(LOWER(text)))",
+            },
+        )
+
+        # Paren receiver: (col).method()
+        self.validate_all(
+            "SELECT (text).UPPER()",
+            write={
+                "bigquery": "SELECT UPPER(text)",
+                "duckdb": "SELECT UPPER(text)",
+            },
+        )
+
+        # Paren receiver with extra args
+        self.validate_all(
+            "SELECT (text).REPLACE('a', 'b')",
+            write={
+                "bigquery": "SELECT REPLACE(text, 'a', 'b')",
+                "duckdb": "SELECT REPLACE(text, 'a', 'b')",
+            },
+        )
+
+        # Paren receiver multi-level chain
+        self.validate_all(
+            "SELECT (text).LOWER().UPPER()",
+            write={
+                "bigquery": "SELECT UPPER(LOWER(text))",
+                "duckdb": "SELECT UPPER(LOWER(text))",
+            },
+        )
+
+        # Qualified column receiver wrapped in parens: (table.col).method()
+        self.validate_all(
+            "SELECT (n.text).UPPER()",
+            write={
+                "bigquery": "SELECT UPPER(n.text)",
+                "duckdb": "SELECT UPPER(n.text)",
+            },
+        )
+
+        # Qualified column receiver multi-level chain
+        self.validate_all(
+            "SELECT (n.text).LOWER().UPPER()",
+            write={
+                "bigquery": "SELECT UPPER(LOWER(n.text))",
+                "duckdb": "SELECT UPPER(LOWER(n.text))",
+            },
+        )


### PR DESCRIPTION
fixes #7644

```
from sqlglot import parse_one
QUERY = "SELECT (t.text_col).replace('a','b').trim() from table as t"
ast=parse_one(QUERY, dialect="bigquery")
pg_sql =Generator(dialect='postgres').generate(ast)
```


### before PR

```
Select(
  expressions=[
    Dot(
      this=Dot(
        this=Paren(
          this=Dot(
            this=Identifier(this=t, quoted=False),
            expression=Identifier(this=text_col, quoted=False))),
        expression=Anonymous(
          this=replace,
          expressions=[
            Literal(this='a', is_string=True),
            Literal(this='b', is_string=True)])),
      expression=Anonymous(this=trim))],
  from_=From(
    this=Table(
      this=Identifier(this=table, quoted=False),
      alias=TableAlias(
        this=Identifier(this=t, quoted=False)))))
```
pg_sql
```
"SELECT (t.text_col).replace('a', 'b').trim() FROM table AS t"
```

### after PR


```
Select(
  expressions=[
    Trim(
      this=Replace(
        this=Column(
          this=Identifier(this=text_col, quoted=False),
          table=Identifier(this=t, quoted=False)),
        expression=Literal(this='a', is_string=True),
        replacement=Literal(this='b', is_string=True)))],
  from_=From(
    this=Table(
      this=Identifier(this=table, quoted=False),
      alias=TableAlias(
        this=Identifier(this=t, quoted=False)))))
```

pg_sql
```
"SELECT TRIM(REPLACE(t.text_col, 'a', 'b')) FROM table AS t"
```