### PR TITLE
fix(optimizer): guard against None type in _coerce_datediff_args [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/canonicalize.py
+++ b/sqlglot/optimizer/canonicalize.py
@@ -238,7 +238,7 @@ def _coerce_timeunit_arg(arg: exp.Expr, unit: exp.Expr | None) -> exp.Expr:
 
 def _coerce_datediff_args(node: exp.DateDiff) -> None:
     for e in (node.this, node.expression):
-        if e.type.this not in exp.DataType.TEMPORAL_TYPES:
+        if e.type is None or e.type.this not in exp.DataType.TEMPORAL_TYPES:
             e.replace(exp.cast(e.copy(), to=exp.DType.DATETIME))
 
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1290,6 +1290,14 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             'SELECT CAST("t"."a" AS TEXT) || CAST("t"."b" AS TEXT) AS "_col_0" FROM "t" AS "t"',
         )
 
+        # DateDiff args without inferred types should not crash _coerce_datediff_args.
+        # Callers that run canonicalize without annotate_types (or whose args fall outside
+        # the schema) used to hit AttributeError: 'NoneType' object has no attribute 'this'.
+        self.assertEqual(
+            optimizer.canonicalize.canonicalize(parse_one("SELECT DATEDIFF(a, b) FROM t")).sql(),
+            "SELECT DATEDIFF(CAST(a AS DATETIME), CAST(b AS DATETIME)) FROM t",
+        )
+
     def test_tpch(self):
         self.check_file("tpc-h/tpc-h", optimizer.optimize, schema=TPCH_SCHEMA, pretty=True)
 


### PR DESCRIPTION
## Summary

`canonicalize` crashes with `AttributeError: 'NoneType' object has no attribute 'this'` whenever a `DateDiff` argument has no inferred type. `_coerce_datediff_args` dereferences `e.type.this` without checking that `e.type is not None`, while the sibling helpers (`_coerce_date`, `_coerce_timeunit_arg`) already short-circuit on missing types.

Minimal repro (no schema, no `annotate_types`):

```python
from sqlglot import parse_one
from sqlglot.optimizer.canonicalize import canonicalize

canonicalize(parse_one("SELECT DATEDIFF(a, b) FROM t"))
# AttributeError: 'NoneType' object has no attribute 'this'
```

## Fix

Treat a missing type the same as "not known to be temporal" — the existing branch already casts to `DATETIME` in that case, so the patch is a one-token change:

```python
if e.type is None or e.type.this not in exp.DataType.TEMPORAL_TYPES:
```

Output after the fix:

```sql
SELECT DATEDIFF(CAST(a AS DATETIME), CAST(b AS DATETIME)) FROM t
```

## Test plan

Added an assertion to `test_canonicalize` in `tests/test_optimizer.py` that pins the original crashing query through `optimizer.canonicalize.canonicalize` directly (no `annotate_types` upfront, matching the failure mode). Locally `python -m unittest tests.test_optimizer.TestOptimizer.test_canonicalize` passes.