### PR TITLE
optimizer/normalize: fix redundant CNF clauses from distributive_law

### DIFF
--- a/sqlglot/optimizer/normalize.py
+++ b/sqlglot/optimizer/normalize.py
@@ -199,7 +199,10 @@ def _distribute(
     to_func: Callable[..., exp.Condition],
     simplifier: Simplifier,
 ):
-    if isinstance(a, exp.Connector):
+    # When `a` and `b` are connectors of the SAME polarity (e.g. both AND in
+    # CNF mode), `b` is distributed across `a`'s children so the existing
+    # cross-product handling can simplify them.
+    if isinstance(a, exp.Connector) and isinstance(a, type(b)):
         exp.replace_children(
             a,
             lambda c: to_func(
@@ -208,11 +211,18 @@ def _distribute(
                 copy=False,
             ),
         )
-    else:
-        a = to_func(
-            simplifier.uniq_sort(flatten(from_func(a, b.left))),
-            simplifier.uniq_sort(flatten(from_func(a, b.right))),
-            copy=False,
-        )
+        return a
 
-    return a
+    # Otherwise apply the textbook rule
+    # ``a OR (b.left AND b.right) -> (a OR b.left) AND (a OR b.right)`` (or
+    # the AND/OR dual). When `a` is a connector of the OPPOSITE polarity to
+    # `b` (e.g. `Or(...) ∨ And(...)` in CNF mode) the previous behaviour was
+    # to push `b` into each child of `a`, leaving an intermediate
+    # ``Or(And, And)`` that `while_changing` would later cross-product into
+    # redundant superset and duplicate clauses. Returning the direct rewrite
+    # avoids that detour.
+    return to_func(
+        simplifier.uniq_sort(flatten(from_func(a, b.left))),
+        simplifier.uniq_sort(flatten(from_func(a, b.right))),
+        copy=False,
+    )

--- a/tests/fixtures/optimizer/normalize.sql
+++ b/tests/fixtures/optimizer/normalize.sql
@@ -45,3 +45,6 @@ SELECT * FROM x WHERE (A OR C) AND (B OR C);
 
 dt2 between '2022-01-01 12:00:00' and '2022-12-31' and dt2 >= '2022-05-01 12:00:00' or dt2 = '2021-06-01 12:00:00';
 (dt2 <= '2022-12-31' OR dt2 = '2021-06-01 12:00:00') AND (dt2 = '2021-06-01 12:00:00' OR dt2 >= '2022-01-01 12:00:00') AND (dt2 = '2021-06-01 12:00:00' OR dt2 >= '2022-05-01 12:00:00');
+
+(A OR B OR C OR (D AND E)) AND F;
+(A OR B OR C OR D) AND (A OR B OR C OR E) AND F;


### PR DESCRIPTION
Closes #7648.

### Summary

`optimizer.normalize._distribute` produced redundant superset and duplicate CNF conjuncts when asked to distribute one connector across another of the OPPOSITE polarity (e.g. `Or(...) ∨ And(...)` while normalizing to CNF). It called `replace_children(a, ...)`, pushing `b` into each child of `a`, which preserved the outer OR and left an intermediate `Or(And, And)`. `while_changing` then ran `distributive_law` again, took the both-AND branch, and cross-producted the two AND children — generating redundant superset and duplicate clauses that `Simplifier.uniq_sort` (which only dedupes disjuncts within a single OR) never absorbs.

For the textbook input `(a OR b OR c OR (d AND e)) AND f` the buggy path produces 5 conjuncts including two strict-superset duplicates:

```
(a OR b OR c OR d) AND (a OR b OR c OR d OR e) AND (a OR b OR c OR d OR e) AND (a OR b OR c OR e) AND f
                       ^ strict superset of    ^ exact duplicate of [2]
                         (a OR b OR c OR d)
```

The minimal CNF has only 3 conjuncts: `(a OR b OR c OR d) AND (a OR b OR c OR e) AND f`.

### Fix

Keep the existing `replace_children` path **only** when both sides are connectors of the SAME polarity (so the existing both-AND cross-product handling is preserved verbatim). In every other case, take the direct rewrite `a OR (b.left AND b.right) -> (a OR b.left) AND (a OR b.right)` (or the AND/OR dual) — which is what the previous `else` branch already did when `a` was a leaf.

This avoids building the `Or(And, And)` intermediate that triggered the bug on the next `while_changing` pass.

### Verification

Reproducer before the fix:

```
((a OR b OR c OR d) AND (a OR b OR c OR d OR e) AND (a OR b OR c OR d OR e) AND (a OR b OR c OR e)) AND f
```

After the fix:

```
((a OR b OR c OR d) AND (a OR b OR c OR e)) AND f
```

### Tests

- All 17 existing input/output pairs in `tests/fixtures/optimizer/normalize.sql` still match exactly.
- New regression entry added to that fixture covering the reproducer from the issue.
- `pytest tests/test_optimizer.py` — 79/79 pass.
