### PR TITLE
refactor(datatypes): improve typing

### DIFF
--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -40,6 +40,7 @@ class DataTypeArgs(ParserNoDialectArgs, total=False):
     nullable: bool
     collate: exp.Identifier | exp.Column
 
+
 class ParserArgs(ParserNoDialectArgs, _DialectArg, total=False):
     pass
 

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -33,9 +33,12 @@ class ParserNoDialectArgs(t.TypedDict, total=False):
 
 
 class DataTypeArgs(ParserNoDialectArgs, total=False):
-    expressions: list[exp.Literal | exp.Neg | exp.DataTypeParam | exp.ColumnDef]
+    expressions: list[exp.Literal | exp.Neg | exp.DataTypeParam | exp.ColumnDef] | None
     nested: bool
-
+    values: list[exp.Expr] | None
+    kind: exp.Expr | str
+    nullable: bool
+    collate: exp.Identifier | exp.Column
 
 class ParserArgs(ParserNoDialectArgs, _DialectArg, total=False):
     pass

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -11,9 +11,9 @@ if t.TYPE_CHECKING:
 
     P = ParamSpec("P")
 
-B = t.TypeVar("B", bound=exp.Binary)
-E = t.TypeVar("E", bound=exp.Expr)
-F = t.TypeVar("F", bound=exp.Func)
+B = t.TypeVar("B", bound="exp.Binary")
+E = t.TypeVar("E", bound="exp.Expr")
+F = t.TypeVar("F", bound="exp.Func")
 T = t.TypeVar("T")
 
 BuilderArgs = Sequence[t.Any]

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -4,17 +4,16 @@ import typing as t
 from collections.abc import Mapping, Sequence
 
 if t.TYPE_CHECKING:
+    from sqlglot import exp
     from typing_extensions import ParamSpec
-
-    import sqlglot
     from sqlglot.dialects.dialect import DialectType
     from sqlglot.errors import ErrorLevel
 
     P = ParamSpec("P")
 
-B = t.TypeVar("B", bound="sqlglot.exp.Binary")
-E = t.TypeVar("E", bound="sqlglot.exp.Expr")
-F = t.TypeVar("F", bound="sqlglot.exp.Func")
+B = t.TypeVar("B", bound=exp.Binary)
+E = t.TypeVar("E", bound=exp.Expr)
+F = t.TypeVar("F", bound=exp.Func)
 T = t.TypeVar("T")
 
 BuilderArgs = Sequence[t.Any]
@@ -30,6 +29,11 @@ class ParserNoDialectArgs(t.TypedDict, total=False):
     error_message_context: int
     max_errors: int
     max_nodes: int
+
+
+class DataTypeArgs(ParserNoDialectArgs, total=False):
+    expressions: list[exp.Literal | exp.Neg | exp.DataTypeParam | exp.ColumnDef]
+    nested: bool
 
 
 class ParserArgs(ParserNoDialectArgs, _DialectArg, total=False):

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -4,6 +4,7 @@ import typing as t
 from collections.abc import Mapping, Sequence
 
 if t.TYPE_CHECKING:
+    import sqlglot
     from sqlglot import exp
     from typing_extensions import ParamSpec
     from sqlglot.dialects.dialect import DialectType
@@ -11,9 +12,9 @@ if t.TYPE_CHECKING:
 
     P = ParamSpec("P")
 
-B = t.TypeVar("B", bound="exp.Binary")
-E = t.TypeVar("E", bound="exp.Expr")
-F = t.TypeVar("F", bound="exp.Func")
+B = t.TypeVar("B", bound="sqlglot.exp.Binary")
+E = t.TypeVar("E", bound="sqlglot.exp.Expr")
+F = t.TypeVar("F", bound="sqlglot.exp.Func")
 T = t.TypeVar("T")
 
 BuilderArgs = Sequence[t.Any]

--- a/sqlglot/_typing.py
+++ b/sqlglot/_typing.py
@@ -33,7 +33,7 @@ class ParserNoDialectArgs(t.TypedDict, total=False):
 
 
 class DataTypeArgs(ParserNoDialectArgs, total=False):
-    expressions: list[exp.Literal | exp.Neg | exp.DataTypeParam | exp.ColumnDef] | None
+    expressions: list[exp.Expr] | None
     nested: bool
     values: list[exp.Expr] | None
     kind: exp.Expr | str

--- a/sqlglot/expressions/datatypes.py
+++ b/sqlglot/expressions/datatypes.py
@@ -430,7 +430,6 @@ class DataType(Expression):
         return False
 
 
-
 class PseudoType(DataType):
     arg_types = {"this": True}
 

--- a/sqlglot/expressions/datatypes.py
+++ b/sqlglot/expressions/datatypes.py
@@ -429,9 +429,6 @@ class DataType(Expression):
                 return True
         return False
 
-    @property
-    def this(self) -> DType:
-        return self.args["this"]
 
 
 class PseudoType(DataType):

--- a/sqlglot/expressions/datatypes.py
+++ b/sqlglot/expressions/datatypes.py
@@ -370,7 +370,11 @@ class DataType(Expression):
 
     @classmethod
     def from_str(
-        cls, dtype: str, dialect: DialectType = None, udt: bool = False, **kwargs: object
+        cls,
+        dtype: str,
+        dialect: DialectType = None,
+        udt: bool = False,
+        **kwargs: Unpack[DataTypeArgs],
     ) -> Self:
         """
         Constructs a `DataType` object from a `str` representation.

--- a/sqlglot/expressions/datatypes.py
+++ b/sqlglot/expressions/datatypes.py
@@ -8,6 +8,7 @@ from enum import auto
 from sqlglot.helper import AutoName
 from sqlglot.errors import ErrorLevel, ParseError
 from sqlglot.expressions.core import (
+    Expr,
     Expression,
     _TimeUnit,
     Identifier,
@@ -17,12 +18,17 @@ from sqlglot.expressions.core import (
 from builtins import type as Type
 
 if t.TYPE_CHECKING:
+    from sqlglot._typing import DataTypeArgs
     from sqlglot.dialects.dialect import DialectType
-    from typing_extensions import Self
+    from typing_extensions import Self, Unpack
 
 
 class DataTypeParam(Expression):
     arg_types = {"this": True, "expression": False}
+
+    @property
+    def this(self) -> Expr:
+        return self.args["this"]
 
     @property
     def name(self) -> str:
@@ -331,7 +337,7 @@ class DataType(Expression):
         dialect: DialectType = None,
         udt: bool = False,
         copy: bool = True,
-        **kwargs: object,
+        **kwargs: Unpack[DataTypeArgs],
     ) -> Self:
         """
         Constructs a DataType object.
@@ -405,10 +411,10 @@ class DataType(Expression):
         Returns:
             True, if and only if there is a type in `dtypes` which is equal to this DataType.
         """
-        self_is_nullable = self.args.get("nullable")
+        self_is_nullable: bool | None = self.args.get("nullable")
         for dtype in dtypes:
             other_type = DataType.build(dtype, copy=False, udt=True)
-            other_is_nullable = other_type.args.get("nullable")
+            other_is_nullable: bool | None = other_type.args.get("nullable")
             if (
                 other_type.expressions
                 or (check_nullable and (self_is_nullable or other_is_nullable))
@@ -422,6 +428,10 @@ class DataType(Expression):
             if matches:
                 return True
         return False
+
+    @property
+    def this(self) -> DType:
+        return self.args["this"]
 
 
 class PseudoType(DataType):


### PR DESCRIPTION
This PR improve the `expressions::datatypes::{DataType, DataTypeParam}` type safety, with the `kwargs` argument in `DataType::build` narrowed from object to a new dedicated `TypedDict` in the `_typing` module, and a narrowed `this` property on `DataTypeParam`