### PR TITLE
feat(postgres): add support for PostGIS 3D distance operator <<->>

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2117,8 +2117,10 @@ class PropertyEQ(Expression, Binary):
 class Distance(Expression, Binary):
     pass
 
+
 class Distance3d(Expression, Binary):
     pass
+
 
 class Escape(Expression, Binary):
     pass

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2117,6 +2117,8 @@ class PropertyEQ(Expression, Binary):
 class Distance(Expression, Binary):
     pass
 
+class Distance3d(Expression, Binary):
+    pass
 
 class Escape(Expression, Binary):
     pass

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4222,6 +4222,9 @@ class Generator:
     def distance_sql(self, expression: exp.Distance) -> str:
         return self.binary(expression, "<->")
 
+    def distance3d_sql(self, expression: exp.Distance3d) -> str:
+        return self.binary(expression, "<<->>")
+
     def dot_sql(self, expression: exp.Dot) -> str:
         return f"{self.sql(expression, 'this')}.{self.sql(expression, 'expression')}"
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -916,6 +916,7 @@ class Parser:
     FACTOR: t.ClassVar = {
         TokenType.DIV: exp.IntDiv,
         TokenType.LR_ARROW: exp.Distance,
+        TokenType.DISTANCE3D: exp.Distance3d,
         TokenType.SLASH: exp.Div,
         TokenType.STAR: exp.Mul,
     }

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -916,7 +916,7 @@ class Parser:
     FACTOR: t.ClassVar = {
         TokenType.DIV: exp.IntDiv,
         TokenType.LR_ARROW: exp.Distance,
-        TokenType.DISTANCE3D: exp.Distance3d,
+        TokenType.LLRR_ARROW: exp.Distance3d,
         TokenType.SLASH: exp.Div,
         TokenType.STAR: exp.Mul,
     }

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -62,6 +62,7 @@ class TokenType(IntEnum):
     HASH_ARROW = auto()
     DHASH_ARROW = auto()
     LR_ARROW = auto()
+    DISTANCE3D = auto()
     DAT = auto()
     LT_AT = auto()
     AT_GT = auto()

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -62,7 +62,7 @@ class TokenType(IntEnum):
     HASH_ARROW = auto()
     DHASH_ARROW = auto()
     LR_ARROW = auto()
-    DISTANCE3D = auto()
+    LLRR_ARROW = auto()
     DAT = auto()
     LT_AT = auto()
     AT_GT = auto()

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -236,6 +236,7 @@ class Tokenizer(_TokenizerBase):
         "#>": TokenType.HASH_ARROW,
         "#>>": TokenType.DHASH_ARROW,
         "<->": TokenType.LR_ARROW,
+        "<<->>": TokenType.DISTANCE3D,
         "&&": TokenType.DAMP,
         "??": TokenType.DQMARK,
         "~~~": TokenType.GLOB,

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -236,7 +236,7 @@ class Tokenizer(_TokenizerBase):
         "#>": TokenType.HASH_ARROW,
         "#>>": TokenType.DHASH_ARROW,
         "<->": TokenType.LR_ARROW,
-        "<<->>": TokenType.DISTANCE3D,
+        "<<->>": TokenType.LLRR_ARROW,
         "&&": TokenType.DAMP,
         "??": TokenType.DQMARK,
         "~~~": TokenType.GLOB,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1929,9 +1929,4 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
         )
 
     def test_postgis_distance_3d(self):
-        self.validate_all(
-            "SELECT a <<->> b",
-            write={
-                "postgres": "SELECT a <<->> b",
-            },
-        )
+        self.validate_identity("SELECT a <<->> b")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1927,3 +1927,11 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
         self.validate_identity(
             'CREATE TRIGGER "MyTrigger" BEFORE INSERT ON "MyTable" FOR EACH ROW EXECUTE FUNCTION MYFUNCTION()'
         )
+
+    def test_postgis_distance_3d(self):
+        self.validate_all(
+            "SELECT a <<->> b",
+            write={
+                "postgres": "SELECT a <<->> b",
+            },
+        )


### PR DESCRIPTION
### Summary
This PR adds native tokenization, parsing, and generation support for the PostGIS 3D distance operator (`<<->>`). 

### Details
- **Tokens**: Added `DISTANCE3D` to `TokenType` and mapped the symbol `<<->>` to it.
- **Parser**: Added `TokenType.DISTANCE3D` to the `FACTOR` lookup table to parse into `exp.Distance3d`.
- **Expressions**: Added `Distance3d` as a core `Binary` expression.
- **Generator**: Added `distance3d_sql` to seamlessly generate `<<->>`.
- **Tests**: Included a regression identity test under `tests/dialects/test_postgres.py`.

Addresses syntax compatibility issues for engine workloads using spatial extensions (like SQLMesh models interacting with PostGIS).