### PR TITLE
fix(parser): Avoid `__tmp#` CTEs getting replaced with outer CTEs for pipe syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3812,6 +3812,10 @@ class Parser:
 
             assert this is not None
             if "with_" in this.arg_types:
+                if inner_cte := this.args.get("with_"):
+                    cte.set("expressions", cte.expressions + inner_cte.expressions)
+                    if inner_cte.args.get("recursive"):
+                        cte.set("recursive", True)
                 this.set("with_", cte)
             else:
                 self.raise_error(f"{this.key} does not support CTE")

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -75,6 +75,14 @@ class TestPipeSyntax(Validator):
             "(SELECT 1 AS col1) |> EXTEND col1 + 1 AS col2",
             "WITH __tmp1 AS (SELECT *, col1 + 1 AS col2 FROM (SELECT 1 AS col1)) SELECT * FROM __tmp1",
         )
+        self.validate_identity(
+            "WITH x AS (SELECT 1 AS x1) FROM x |> SELECT x1, 2 AS x2",
+            "WITH x AS (SELECT 1 AS x1), __tmp1 AS (SELECT x1, 2 AS x2 FROM x) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "WITH RECURSIVE x AS (SELECT 1 AS x1 UNION ALL SELECT x1 + 1 FROM x WHERE x1 < 5) FROM x |> SELECT x1, 2 AS x2",
+            "WITH RECURSIVE x AS (SELECT 1 AS x1 UNION ALL SELECT x1 + 1 FROM x WHERE x1 < 5), __tmp1 AS (SELECT x1, 2 AS x2 FROM x) SELECT * FROM __tmp1",
+        )
 
     def test_order_by(self):
         self.validate_identity("FROM x |> ORDER BY x1", "SELECT * FROM x ORDER BY x1")

--- a/tests/dialects/test_pipe_syntax.py
+++ b/tests/dialects/test_pipe_syntax.py
@@ -80,8 +80,16 @@ class TestPipeSyntax(Validator):
             "WITH x AS (SELECT 1 AS x1), __tmp1 AS (SELECT x1, 2 AS x2 FROM x) SELECT * FROM __tmp1",
         )
         self.validate_identity(
+            "WITH x AS (SELECT 1 AS x1) FROM x |> SELECT x1 AS a |> SELECT a AS b",
+            "WITH x AS (SELECT 1 AS x1), __tmp1 AS (SELECT x1 AS a FROM x), __tmp2 AS (SELECT a AS b FROM __tmp1) SELECT * FROM __tmp2",
+        )
+        self.validate_identity(
             "WITH RECURSIVE x AS (SELECT 1 AS x1 UNION ALL SELECT x1 + 1 FROM x WHERE x1 < 5) FROM x |> SELECT x1, 2 AS x2",
             "WITH RECURSIVE x AS (SELECT 1 AS x1 UNION ALL SELECT x1 + 1 FROM x WHERE x1 < 5), __tmp1 AS (SELECT x1, 2 AS x2 FROM x) SELECT * FROM __tmp1",
+        )
+        self.validate_identity(
+            "WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 5) FROM r |> SELECT n |> EXTEND n * 2 AS m",
+            "WITH RECURSIVE r AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM r WHERE n < 5), __tmp1 AS (SELECT n FROM r), __tmp2 AS (SELECT *, n * 2 AS m FROM __tmp1) SELECT * FROM __tmp2",
         )
 
     def test_order_by(self):


### PR DESCRIPTION
Fixes a bug where pipe syntax queries with leading CTEs were getting misinterpreted to have references to nonexistent `__tmp#` CTEs, because the `__tmp#` CTEs were getting replaced with the leading CTEs.

Example query:
```sql
WITH x AS (SELECT 1 AS x1) FROM x |> SELECT x1, 2 AS x2
```

Current interpretation without this PR (invalid query):
```sql
WITH x AS (SELECT 1 AS x1) SELECT * FROM __tmp1
```

Corrected interpretation with this PR:
```sql
WITH x AS (SELECT 1 AS x1), __tmp1 AS (SELECT x1, 2 AS x2 FROM x) SELECT * FROM __tmp1
```