### PR TITLE
fix(spark): CONCAT/PAD type leaks non-string arg when string args aren't TEXT [CLAUDE]

### DIFF
--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -13,13 +13,20 @@ if t.TYPE_CHECKING:
 
 
 def _annotate_by_similar_args(
-    self: TypeAnnotator, expression: E, *args: str, target_type: exp.DataType | exp.DType
+    self: TypeAnnotator,
+    expression: E,
+    *args: str,
+    target_type: exp.DataType | exp.DType | tuple[exp.DataType | exp.DType, ...],
 ) -> E:
     """
     Infers the type of the expression according to the following rules:
-    - If all args are of the same type OR any arg is of target_type, the expr is inferred as such
-    - If any arg is of UNKNOWN type and none of target_type, the expr is inferred as UNKNOWN
+    - If any arg matches a target_type, the expr is inferred as the first target_type
+    - If any arg is of UNKNOWN type and none match target_type, the expr is inferred as UNKNOWN.
+    - Otherwise the expr is inferred as the type of the last non-matching arg.
     """
+    target_types = target_type if isinstance(target_type, tuple) else (target_type,)
+    result_type = target_types[0]
+
     expressions: list[exp.Expr] = []
     for arg in args:
         arg_expr = expression.args.get(arg)
@@ -31,9 +38,9 @@ def _annotate_by_similar_args(
     for expr in expressions:
         if expr.is_type(exp.DType.UNKNOWN):
             has_unknown = True
-        elif expr.is_type(target_type):
+        elif expr.is_type(*target_types):
             has_unknown = False
-            last_datatype = target_type
+            last_datatype = result_type
             break
         else:
             last_datatype = expr.type
@@ -74,13 +81,13 @@ EXPRESSION_METADATA: ExprMetadataType = {
     exp.AtTimeZone: {"returns": exp.DType.TIMESTAMP},
     exp.Concat: {
         "annotator": lambda self, e: _annotate_by_similar_args(
-            self, e, "expressions", target_type=exp.DType.TEXT
+            self, e, "expressions", target_type=(exp.DType.TEXT, *exp.DataType.TEXT_TYPES)
         )
     },
     exp.NextDay: {"returns": exp.DType.DATE},
     exp.Pad: {
         "annotator": lambda self, e: _annotate_by_similar_args(
-            self, e, "this", "fill_pattern", target_type=exp.DType.TEXT
+            self, e, "this", "fill_pattern", target_type=(exp.DType.TEXT, *exp.DataType.TEXT_TYPES)
         )
     },
 }

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -12,40 +12,65 @@ if t.TYPE_CHECKING:
     from sqlglot.typing import ExprMetadataType
 
 
-def _annotate_by_similar_args(
-    self: TypeAnnotator,
-    expression: E,
-    *args: str,
-    target_type: exp.DataType | exp.DType | tuple[exp.DataType | exp.DType, ...],
-) -> E:
+def _common_array_element_type(types: list[exp.DataType]) -> exp.DataType | exp.DType:
     """
-    Infers the type of the expression according to the following rules:
-    - If any arg matches a target_type, the expr is inferred as the first target_type
-    - If any arg is of UNKNOWN type and none match target_type, the expr is inferred as UNKNOWN.
-    - Otherwise the expr is inferred as the type of the last non-matching arg.
+    Recursively narrows a list of CONCAT-arg DataTypes to their common type.
+
+    - Returns UNKNOWN for incompatible types: scalar mismatches (INT + DATE),
+      ARRAY mixed with non-ARRAY (e.g. CONCAT(ARRAY<INT>, INT)), and unmatched
+      nesting depths (which yield ARRAY<UNKNOWN> at the appropriate level).
+      UNKNOWN means "no common type", which the caller relies on.
+    - Return type is exp.DataType | exp.DType: bare DType for simple cases,
+      DataType for the recursive ARRAY case where nesting is required.
     """
-    target_types = target_type if isinstance(target_type, tuple) else (target_type,)
-    result_type = target_types[0]
+    normalized = [
+        exp.DataType(this=exp.DType.TEXT) if t.this in exp.DataType.TEXT_TYPES else t for t in types
+    ]
+    if len({t.sql() for t in normalized}) == 1:
+        return normalized[0]
+    if all(t.this == exp.DType.ARRAY for t in normalized):
+        elem_types = [
+            t.expressions[0] if t.expressions else exp.DataType(this=exp.DType.UNKNOWN)
+            for t in normalized
+        ]
+        common_elem = _common_array_element_type(elem_types)
+        elem_dt = (
+            common_elem if isinstance(common_elem, exp.DataType) else exp.DataType(this=common_elem)
+        )
+        return exp.DataType(this=exp.DType.ARRAY, expressions=[elem_dt], nested=True)
+    if any(t.this == exp.DType.TEXT for t in normalized):
+        return exp.DType.TEXT
+    return exp.DType.UNKNOWN
 
-    expressions: list[exp.Expr] = []
-    for arg in args:
-        arg_expr = expression.args.get(arg)
-        expressions.extend(expr for expr in ensure_list(arg_expr) if expr)
 
-    last_datatype = None
+def _annotate_by_similar_args(self: TypeAnnotator, expression: E, *arg_keys: str) -> E:
+    """
+    Type inference for CONCAT-family expressions (CONCAT, LPAD, RPAD).
 
-    has_unknown = False
-    for expr in expressions:
-        if expr.is_type(exp.DType.UNKNOWN):
-            has_unknown = True
-        elif expr.is_type(*target_types):
-            has_unknown = False
-            last_datatype = result_type
-            break
-        else:
-            last_datatype = expr.type
+    - TEXT-before-UNKNOWN is load-bearing: a known text arg forces a text
+      result, since the query either coerces the unknown to string or fails
+      entirely — no valid execution produces a non-text result.
+    - TEXT_TYPES on input narrows to DType.TEXT on output: CONCAT/LPAD
+      accept any TEXT_TYPES member (VARCHAR/CHAR/NCHAR/NVARCHAR/NAME) as
+      input, but Spark always emits DType.TEXT.
+    """
+    arg_exprs: list[exp.Expression] = []
+    for key in arg_keys:
+        arg_exprs.extend(e for e in ensure_list(expression.args.get(key)) if e)
 
-    self._set_type(expression, exp.DType.UNKNOWN if has_unknown else last_datatype)
+    result: exp.DataType | exp.DType
+    if any(e.is_type(*exp.DataType.TEXT_TYPES) for e in arg_exprs):
+        result = exp.DType.TEXT
+    elif any(e.is_type(exp.DType.UNKNOWN) for e in arg_exprs):
+        result = exp.DType.UNKNOWN
+    elif all(e.is_type(exp.DType.BINARY) for e in arg_exprs):
+        result = exp.DType.BINARY
+    elif any(e.is_type(exp.DType.ARRAY) for e in arg_exprs):
+        result = _common_array_element_type([e.type for e in arg_exprs])
+    else:
+        result = exp.DType.TEXT
+
+    self._set_type(expression, result)
     return expression
 
 
@@ -79,15 +104,9 @@ EXPRESSION_METADATA: ExprMetadataType = {
         )
     },
     exp.AtTimeZone: {"returns": exp.DType.TIMESTAMP},
-    exp.Concat: {
-        "annotator": lambda self, e: _annotate_by_similar_args(
-            self, e, "expressions", target_type=(exp.DType.TEXT, *exp.DataType.TEXT_TYPES)
-        )
-    },
+    exp.Concat: {"annotator": lambda self, e: _annotate_by_similar_args(self, e, "expressions")},
     exp.NextDay: {"returns": exp.DType.DATE},
     exp.Pad: {
-        "annotator": lambda self, e: _annotate_by_similar_args(
-            self, e, "this", "fill_pattern", target_type=(exp.DType.TEXT, *exp.DataType.TEXT_TYPES)
-        )
+        "annotator": lambda self, e: _annotate_by_similar_args(self, e, "this", "fill_pattern")
     },
 }

--- a/sqlglot/typing/spark2.py
+++ b/sqlglot/typing/spark2.py
@@ -12,63 +12,32 @@ if t.TYPE_CHECKING:
     from sqlglot.typing import ExprMetadataType
 
 
-def _common_array_element_type(types: list[exp.DataType]) -> exp.DataType | exp.DType:
-    """
-    Recursively narrows a list of CONCAT-arg DataTypes to their common type.
-
-    - Returns UNKNOWN for incompatible types: scalar mismatches (INT + DATE),
-      ARRAY mixed with non-ARRAY (e.g. CONCAT(ARRAY<INT>, INT)), and unmatched
-      nesting depths (which yield ARRAY<UNKNOWN> at the appropriate level).
-      UNKNOWN means "no common type", which the caller relies on.
-    - Return type is exp.DataType | exp.DType: bare DType for simple cases,
-      DataType for the recursive ARRAY case where nesting is required.
-    """
-    normalized = [
-        exp.DataType(this=exp.DType.TEXT) if t.this in exp.DataType.TEXT_TYPES else t for t in types
-    ]
-    if len({t.sql() for t in normalized}) == 1:
-        return normalized[0]
-    if all(t.this == exp.DType.ARRAY for t in normalized):
-        elem_types = [
-            t.expressions[0] if t.expressions else exp.DataType(this=exp.DType.UNKNOWN)
-            for t in normalized
-        ]
-        common_elem = _common_array_element_type(elem_types)
-        elem_dt = (
-            common_elem if isinstance(common_elem, exp.DataType) else exp.DataType(this=common_elem)
-        )
-        return exp.DataType(this=exp.DType.ARRAY, expressions=[elem_dt], nested=True)
-    if any(t.this == exp.DType.TEXT for t in normalized):
-        return exp.DType.TEXT
-    return exp.DType.UNKNOWN
-
-
 def _annotate_by_similar_args(self: TypeAnnotator, expression: E, *arg_keys: str) -> E:
     """
     Type inference for CONCAT-family expressions (CONCAT, LPAD, RPAD).
 
-    - TEXT-before-UNKNOWN is load-bearing: a known text arg forces a text
-      result, since the query either coerces the unknown to string or fails
-      entirely — no valid execution produces a non-text result.
-    - TEXT_TYPES on input narrows to DType.TEXT on output: CONCAT/LPAD
-      accept any TEXT_TYPES member (VARCHAR/CHAR/NCHAR/NVARCHAR/NAME) as
-      input, but Spark always emits DType.TEXT.
+    - All-BINARY → BINARY (the binary overload).
+    - Otherwise, if any arg has a known, non-array, non-binary type → STRING.
+      Spark coerces scalars (dates, ints, etc.) to string when mixed with a
+      string-resolving arg. The binary exclusion preserves the binary+unknown
+      case as UNKNOWN: Spark can't disambiguate the string vs. binary overload
+      there.
+    - Else → UNKNOWN. Covers all-unknown, binary+unknown, and anything
+      involving arrays (array handling is intentionally out of scope here).
     """
     arg_exprs: list[exp.Expression] = []
     for key in arg_keys:
         arg_exprs.extend(e for e in ensure_list(expression.args.get(key)) if e)
 
-    result: exp.DataType | exp.DType
-    if any(e.is_type(*exp.DataType.TEXT_TYPES) for e in arg_exprs):
+    if arg_exprs and all(e.is_type(exp.DType.BINARY) for e in arg_exprs):
+        result: exp.DataType | exp.DType = exp.DType.BINARY
+    elif any(
+        e.type is not None and not e.is_type(exp.DType.UNKNOWN, exp.DType.ARRAY, exp.DType.BINARY)
+        for e in arg_exprs
+    ):
         result = exp.DType.TEXT
-    elif any(e.is_type(exp.DType.UNKNOWN) for e in arg_exprs):
-        result = exp.DType.UNKNOWN
-    elif all(e.is_type(exp.DType.BINARY) for e in arg_exprs):
-        result = exp.DType.BINARY
-    elif any(e.is_type(exp.DType.ARRAY) for e in arg_exprs):
-        result = _common_array_element_type([e.type for e in arg_exprs])
     else:
-        result = exp.DType.TEXT
+        result = exp.DType.UNKNOWN
 
     self._set_type(expression, result)
     return expression

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -258,11 +258,23 @@ CONCAT(unknown, unknown);
 UNKNOWN;
 
 # dialect: spark2, spark, databricks
-CONCAT(tbl.varchar_col, '-', tbl.date_col);
+CONCAT('x', tbl.str_col);
 STRING;
 
 # dialect: spark2, spark, databricks
-CONCAT(tbl.date_col, tbl.varchar_col);
+CONCAT('x', '-', tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT('x', tbl.date_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, tbl.date_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.date_col, 'x');
 STRING;
 
 # dialect: spark2, spark, databricks
@@ -274,7 +286,35 @@ CONCAT(tbl.str_col, tbl.int_col);
 STRING;
 
 # dialect: spark2, spark, databricks
-LPAD(tbl.varchar_col, 10, '0');
+CONCAT('x', tbl.bin_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.array_col, tbl.array_col);
+ARRAY<STRING>;
+
+# dialect: spark2, spark, databricks
+CONCAT(array(1, 2), array(3, 4));
+ARRAY<INT>;
+
+# dialect: spark2, spark, databricks
+CONCAT(array(unhex('aa')), array(unhex('bb')));
+ARRAY<BINARY>;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.str_col, 10, '0');
+STRING;
+
+# dialect: spark2, spark, databricks
+LPAD('x', 10, tbl.str_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+LPAD('x', 10, tbl.date_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.date_col, 10, 'x');
 STRING;
 
 # dialect: spark2, spark, databricks

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -270,14 +270,6 @@ CONCAT('x', tbl.bin_col);
 STRING;
 
 # dialect: spark2, spark, databricks
-CONCAT(array('a', 'b'), array(1, 2));
-ARRAY<STRING>;
-
-# dialect: spark2, spark, databricks
-CONCAT(array(array('a')), array(array(1)));
-ARRAY<ARRAY<STRING>>;
-
-# dialect: spark2, spark, databricks
 CONCAT(tbl.date_col, tbl.int_col);
 STRING;
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -258,31 +258,11 @@ CONCAT(unknown, unknown);
 UNKNOWN;
 
 # dialect: spark2, spark, databricks
-CONCAT('x', tbl.str_col);
-STRING;
-
-# dialect: spark2, spark, databricks
-CONCAT('x', '-', tbl.str_col);
-STRING;
-
-# dialect: spark2, spark, databricks
 CONCAT('x', tbl.date_col);
 STRING;
 
 # dialect: spark2, spark, databricks
-CONCAT(tbl.str_col, tbl.date_col);
-STRING;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.date_col, 'x');
-STRING;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.str_col, '-', tbl.date_col);
-STRING;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.str_col, tbl.int_col);
+CONCAT(tbl.date_col, tbl.date_col);
 STRING;
 
 # dialect: spark2, spark, databricks
@@ -290,31 +270,19 @@ CONCAT('x', tbl.bin_col);
 STRING;
 
 # dialect: spark2, spark, databricks
-CONCAT(tbl.array_col, tbl.array_col);
+CONCAT(array('a', 'b'), array(1, 2));
 ARRAY<STRING>;
 
 # dialect: spark2, spark, databricks
-CONCAT(array(1, 2), array(3, 4));
-ARRAY<INT>;
+CONCAT(array(array('a')), array(array(1)));
+ARRAY<ARRAY<STRING>>;
 
 # dialect: spark2, spark, databricks
-CONCAT(array(unhex('aa')), array(unhex('bb')));
-ARRAY<BINARY>;
-
-# dialect: spark2, spark, databricks
-LPAD(tbl.str_col, 10, '0');
-STRING;
-
-# dialect: spark2, spark, databricks
-LPAD('x', 10, tbl.str_col);
+CONCAT(tbl.date_col, tbl.int_col);
 STRING;
 
 # dialect: spark2, spark, databricks
 LPAD('x', 10, tbl.date_col);
-STRING;
-
-# dialect: spark2, spark, databricks
-LPAD(tbl.date_col, 10, 'x');
 STRING;
 
 # dialect: spark2, spark, databricks

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -302,6 +302,30 @@ CONCAT(array(unhex('aa')), array(unhex('bb')));
 ARRAY<BINARY>;
 
 # dialect: spark2, spark, databricks
+CONCAT(tbl.array_col, tbl.str_col);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, tbl.array_col);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.array_col, tbl.bin_col);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.bin_col, tbl.array_col);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.array_col, 'x');
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
+CONCAT('x', tbl.array_col);
+UNKNOWN;
+
+# dialect: spark2, spark, databricks
 LPAD(tbl.str_col, 10, '0');
 STRING;
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -302,30 +302,6 @@ CONCAT(array(unhex('aa')), array(unhex('bb')));
 ARRAY<BINARY>;
 
 # dialect: spark2, spark, databricks
-CONCAT(tbl.array_col, tbl.str_col);
-UNKNOWN;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.str_col, tbl.array_col);
-UNKNOWN;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.array_col, tbl.bin_col);
-UNKNOWN;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.bin_col, tbl.array_col);
-UNKNOWN;
-
-# dialect: spark2, spark, databricks
-CONCAT(tbl.array_col, 'x');
-UNKNOWN;
-
-# dialect: spark2, spark, databricks
-CONCAT('x', tbl.array_col);
-UNKNOWN;
-
-# dialect: spark2, spark, databricks
 LPAD(tbl.str_col, 10, '0');
 STRING;
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -258,6 +258,26 @@ CONCAT(unknown, unknown);
 UNKNOWN;
 
 # dialect: spark2, spark, databricks
+CONCAT(tbl.varchar_col, '-', tbl.date_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.date_col, tbl.varchar_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, '-', tbl.date_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+CONCAT(tbl.str_col, tbl.int_col);
+STRING;
+
+# dialect: spark2, spark, databricks
+LPAD(tbl.varchar_col, 10, '0');
+STRING;
+
+# dialect: spark2, spark, databricks
 LPAD(tbl.bin_col, 1, tbl.bin_col);
 BINARY;
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1489,6 +1489,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             "tbl": {
                 "bin_col": "BINARY",
                 "str_col": "STRING",
+                "varchar_col": "VARCHAR",
                 "bignum_col": "BIGNUMERIC",
                 "date_col": "DATE",
                 "decfloat_col": "DECFLOAT",

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1489,7 +1489,6 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             "tbl": {
                 "bin_col": "BINARY",
                 "str_col": "STRING",
-                "varchar_col": "VARCHAR",
                 "bignum_col": "BIGNUMERIC",
                 "date_col": "DATE",
                 "decfloat_col": "DECFLOAT",


### PR DESCRIPTION
SQLGlot and the native spark query analyzer were returning disparate results in testing for a query that had a clause of the form:
```
CONCAT(varchar2_type_column, '-', date_type_column)
```
...Where SQLGlot parsed this CONCAT as emitting a Date type, and the native parser saw it as emitting a Varchar type.

We tracked down the root cause to a subtle error in the logic of `sqlglot/typing/spark2.py:_annotate_by_similar_args`; when it swept the arguments of CONCAT (or LPAD) for types, it searched for exp.DType.TEXT, but it didn't have any special handling for other text types like VARCHAR2. So it went with whatever the last type was: in this case, date.

CONCAT can also handle concatenation of arrays. However, we backed away from fully implementing that, on account of SQLGlot intentionally skipping type coercions for nested structures today. Rather, we went for a simplified model with three possible outputs: TEXT, UNKNOWN, or BINARY.