### PR TITLE
Fix: raise ParseError, not IndexError, on an unclosed JSONPath filter

### DIFF
--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -103,7 +103,12 @@ def parse(path: str, dialect: DialectType = None) -> exp.JSONPath:
                 _advance()
 
             expr_type = exp.JSONPathScript if script else exp.JSONPathFilter
-            return expr_type(this=path[tokens[start].start : tokens[i].end])
+            # The loop above also stops at the end of the token stream, where
+            # `i == size`; fall back to the last token so an unclosed filter
+            # surfaces as a ParseError (from the unmatched `]` below) instead
+            # of an IndexError.
+            end = tokens[i].end if i < size else tokens[-1].end
+            return expr_type(this=path[tokens[start].start : end])
 
         number = "-" if _match(TokenType.DASH) else ""
 

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -30,6 +30,14 @@ class TestJsonpath(unittest.TestCase):
             exp.JSONPath(expressions=expected_expressions),
         )
 
+    def test_unclosed_filter_raises_parse_error(self):
+        # A filter/script that runs off the end of the path without a closing
+        # bracket must raise ParseError, not IndexError.
+        for selector in ("$[?(@.x", "$[(@.x", "$[?(1"):
+            with self.subTest(selector):
+                with self.assertRaises(ParseError):
+                    parse(selector)
+
     def test_identity(self):
         for selector, expected in (
             ("$.select", "$.select"),


### PR DESCRIPTION
`jsonpath.parse()` crashes with `IndexError` on a filter or script expression that runs off the end of the path:

```pycon
>>> from sqlglot import jsonpath
>>> jsonpath.parse("$[?(@.x")
IndexError: list index out of range
```

In `_parse_literal`, the loop that consumes a `?(...)` filter / `(...)` script also stops at the end of the token stream — that's one of its break conditions (`_curr()` is `None`). When it stops there, `i == size`, and the next line reads `tokens[i].end`, which is out of bounds.

This falls back to the last token's `end` when `i` has run past the stream. The path is still malformed, but now `_parse_bracket`'s existing `_match(TokenType.R_BRACKET, raise_unmatched=True)` reports it as a normal `ParseError` instead:

```pycon
>>> jsonpath.parse("$[?(@.x")
sqlglot.errors.ParseError: Expected TokenType.R_BRACKET at index 7: $[?(@.x
```

Added `test_unclosed_filter_raises_parse_error` covering `$[?(@.x`, `$[(@.x`, and `$[?(1` — it raises `IndexError` on `main` and passes with the fix. Existing `test_jsonpath.py` cases still pass.