### PR TITLE
fix: unnest_subqueries produces invalid column references when subquery contains a UNION

### DIFF
--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -58,13 +58,12 @@ def unnest(select, parent_select, next_alias_name):
 
     if isinstance(select, exp.SetOperation):
         inner_alias = next_alias_name()
-        select = (
-            exp.select(*(
+        select = exp.select(
+            *(
                 exp.alias_(exp.column(s.alias_or_name, inner_alias), s.alias_or_name)
                 for s in select.selects
-            ))
-            .from_(select.subquery(inner_alias))
-        )
+            )
+        ).from_(select.subquery(inner_alias))
 
     alias = next_alias_name()
     clause = predicate.find_ancestor(exp.Having, exp.Where, exp.Join)

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -57,7 +57,14 @@ def unnest(select, parent_select, next_alias_name):
         return
 
     if isinstance(select, exp.SetOperation):
-        select = exp.select(*select.selects).from_(select.subquery(next_alias_name()))
+        inner_alias = next_alias_name()
+        select = (
+            exp.select(*(
+                exp.alias_(exp.column(s.alias_or_name, inner_alias), s.alias_or_name)
+                for s in select.selects
+            ))
+            .from_(select.subquery(inner_alias))
+        )
 
     alias = next_alias_name()
     clause = predicate.find_ancestor(exp.Having, exp.Where, exp.Join)

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -1451,10 +1451,10 @@ WITH "_u_0" AS (
     "cascade"."tag_input" = 'XXX' OR "cascade"."tag_output" = 'XXX'
 ), "_u_1" AS (
   SELECT
-    "cascade"."tag_input" AS "tagname"
+    "_u_0"."tagname" AS "tagname"
   FROM "_u_0" AS "_u_0"
   GROUP BY
-    "cascade"."tag_input"
+    "_u_0"."tagname"
 )
 SELECT
   *

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -115,5 +115,5 @@ SELECT COALESCE((SELECT MAX(b.val) FROM t b WHERE b.val < a.val AND b.id = a.id)
 SELECT COALESCE((SELECT MAX(b.val) FROM t AS b WHERE b.val < a.val AND b.id = a.id), a.val) AS result FROM t AS a;
 
 # title: IN with UNION ALL subquery should use derived alias in wrapper SELECT
-SELECT * FROM x WHERE x.a IN (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
-SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT _u_1.a IS NULL;
+SELECT * FROM x WHERE x.a IN (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
+SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT _u_1.a IS NULL;

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -113,3 +113,11 @@ SELECT t1.c1 > _u_0.b FROM x JOIN GENERATE_SERIES((SELECT MAX(x.a) FROM x AS x),
 # title: correlated scalar subquery with EQ + range predicates inside a function in SELECT should not crash (issue #7295)
 SELECT COALESCE((SELECT MAX(b.val) FROM t b WHERE b.val < a.val AND b.id = a.id), a.val) AS result FROM t a;
 SELECT COALESCE((SELECT MAX(b.val) FROM t AS b WHERE b.val < a.val AND b.id = a.id), a.val) AS result FROM t AS a;
+
+# title: NOT IN with UNION ALL subquery should use derived alias in wrapper SELECT (issue #7666)
+SELECT * FROM x WHERE x.a NOT IN (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
+SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT NOT _u_1.a IS NULL;
+
+# title: IN with UNION ALL subquery should use derived alias in wrapper SELECT (issue #7666)
+SELECT * FROM x WHERE x.a IN (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
+SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT _u_1.a IS NULL;

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -114,10 +114,6 @@ SELECT t1.c1 > _u_0.b FROM x JOIN GENERATE_SERIES((SELECT MAX(x.a) FROM x AS x),
 SELECT COALESCE((SELECT MAX(b.val) FROM t b WHERE b.val < a.val AND b.id = a.id), a.val) AS result FROM t a;
 SELECT COALESCE((SELECT MAX(b.val) FROM t AS b WHERE b.val < a.val AND b.id = a.id), a.val) AS result FROM t AS a;
 
-# title: NOT IN with UNION ALL subquery should use derived alias in wrapper SELECT (issue #7666)
-SELECT * FROM x WHERE x.a NOT IN (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
-SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT NOT _u_1.a IS NULL;
-
-# title: IN with UNION ALL subquery should use derived alias in wrapper SELECT (issue #7666)
+# title: IN with UNION ALL subquery should use derived alias in wrapper SELECT
 SELECT * FROM x WHERE x.a IN (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
 SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT DISTINCT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT _u_1.a IS NULL;


### PR DESCRIPTION
Fixes #7666

## Problem

When `unnest_subqueries` encounters a `SetOperation` (UNION/UNION ALL) subquery, it wraps it in a derived table:

```python
if isinstance(select, exp.SetOperation):
    select = exp.select(*select.selects).from_(select.subquery(next_alias_name()))
```

`select.selects` returns the fully-qualified column expressions from the left branch of the UNION (e.g. `child_table.col_a AS col_a`). These are copied verbatim into the outer wrapper SELECT, but the FROM source is the new subquery alias `_u_0`, making the column references invalid in that scope.

## Fix

Build column references that point to the derived alias instead of copying the inner expressions:

```python
if isinstance(select, exp.SetOperation):
    inner_alias = next_alias_name()
    select = (
        exp.select(*(
            exp.alias_(exp.column(s.alias_or_name, inner_alias), s.alias_or_name)
            for s in select.selects
        ))
        .from_(select.subquery(inner_alias))
    )
```

## Reproducer

```python
import sqlglot
from sqlglot.optimizer.qualify import qualify
from sqlglot.optimizer.unnest_subqueries import unnest_subqueries

sql = """
SELECT t.id AS ref_id
FROM parent_table t
WHERE t.id NOT IN (
    SELECT DISTINCT col_a FROM child_table
    UNION ALL
    SELECT col_b FROM child_table
)
"""

ast = sqlglot.parse_one(sql)
result = unnest_subqueries(qualify(ast))
print(result.sql(pretty=True))
```

**Before:** `child_table.col_a` referenced inside a scope where only `_u_0` exists.

**After:** `_u_0.col_a` — correctly qualified against the derived alias.
