### PR TITLE
clickhouse: parse documented SHOW and EXPLAIN statements

### DIFF
--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -90,6 +90,7 @@ class ClickHouse(Dialect):
             "ENUM8": TokenType.ENUM8,
             "ENUM16": TokenType.ENUM16,
             "EXCHANGE": TokenType.COMMAND,
+            "EXPLAIN": TokenType.DESCRIBE,
             "FINAL": TokenType.FINAL,
             "FIXEDSTRING": TokenType.FIXEDSTRING,
             "FLOAT32": TokenType.FLOAT,
@@ -125,6 +126,8 @@ class ClickHouse(Dialect):
             **tokens.Tokenizer.SINGLE_TOKENS,
             "$": TokenType.HEREDOC_STRING,
         }
+
+        COMMANDS = tokens.Tokenizer.COMMANDS - {TokenType.SHOW}
 
     Parser = ClickHouseParser
 

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -191,6 +191,7 @@ class SetItem(Expression):
 class Show(Expression):
     arg_types = {
         "this": True,
+        "expressions": False,
         "history": False,
         "terse": False,
         "target": False,
@@ -199,6 +200,8 @@ class Show(Expression):
         "limit": False,
         "from_": False,
         "like": False,
+        "ilike": False,
+        "not_": False,
         "where": False,
         "db": False,
         "scope": False,
@@ -217,6 +220,9 @@ class Show(Expression):
         "for_user": False,
         "for_role": False,
         "into_outfile": False,
+        "format": False,
+        "implicit": False,
+        "final": False,
         "json": False,
         "iceberg": False,
     }

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -416,6 +416,119 @@ class ClickHouseGenerator(generator.Generator):
         exp.DType.MULTIPOLYGON,
     }
 
+    SHOW_SPACE_TARGET_KINDS = {
+        "TABLE",
+        "TEMPORARY TABLE",
+        "DICTIONARY",
+        "VIEW",
+        "DATABASE",
+        "CREATE TABLE",
+        "CREATE TEMPORARY TABLE",
+        "CREATE DICTIONARY",
+        "CREATE VIEW",
+        "CREATE DATABASE",
+        "CREATE POLICY",
+        "CREATE ROW POLICY",
+        "CREATE MASKING POLICY",
+        "CLUSTER",
+        "SETTING",
+    }
+
+    SHOW_SPACE_EXPRESSIONS_KINDS = {
+        "CREATE USER",
+        "CREATE ROLE",
+        "CREATE QUOTA",
+        "CREATE PROFILE",
+        "CREATE SETTINGS PROFILE",
+    }
+
+    SHOW_ON_TARGET_KINDS = {"POLICIES", "ROW POLICIES"}
+
+    SHOW_ON_EXPRESSIONS_KINDS = {
+        "CREATE POLICY",
+        "CREATE ROW POLICY",
+        "CREATE MASKING POLICY",
+    }
+
+    def _show_like_sql(self, expression: exp.Show) -> str:
+        like = self.sql(expression, "like")
+        if not like:
+            return ""
+
+        not_ = " NOT" if expression.args.get("not_") else ""
+        operator = "ILIKE" if expression.args.get("ilike") else "LIKE"
+        return f"{not_} {operator} {like}"
+
+    def show_sql(self, expression: exp.Show) -> str:
+        name = expression.name
+        sql = f"SHOW {name}"
+
+        target = self.sql(expression, "target")
+        if target:
+            if name.endswith("COLUMNS") or name.endswith(("INDEX", "INDEXES", "INDICES", "KEYS")):
+                sql = f"{sql} FROM {target}"
+            elif name in self.SHOW_ON_TARGET_KINDS:
+                sql = f"{sql} ON {target}"
+            elif name in self.SHOW_SPACE_TARGET_KINDS:
+                sql = f"{sql} {target}"
+
+        expressions = self.expressions(expression, flat=True)
+        if expressions:
+            if name == "GRANTS":
+                sql = f"{sql} FOR {expressions}"
+            elif name in self.SHOW_ON_EXPRESSIONS_KINDS:
+                sql = f"{sql} ON {expressions}"
+            elif name in self.SHOW_SPACE_EXPRESSIONS_KINDS:
+                sql = f"{sql} {expressions}"
+
+        db = self.sql(expression, "db")
+        if db:
+            sql = f"{sql} FROM {db}"
+
+        like = self._show_like_sql(expression)
+        like = f"{like}" if like else ""
+
+        where = self.sql(expression, "where")
+
+        limit = self.sql(expression, "limit")
+
+        into_outfile = self.sql(expression, "into_outfile")
+        into_outfile = f" INTO OUTFILE {into_outfile}" if into_outfile else ""
+
+        format = self.sql(expression, "format")
+        format = f" FORMAT {format}" if format else ""
+
+        implicit = " WITH IMPLICIT" if expression.args.get("implicit") else ""
+        final = " FINAL" if expression.args.get("final") else ""
+
+        return f"{sql}{like}{where}{limit}{into_outfile}{format}{implicit}{final}"
+
+    def describe_sql(self, expression: exp.Describe) -> str:
+        if expression.args.get("kind") != "EXPLAIN":
+            return super().describe_sql(expression)
+
+        style = expression.args.get("style")
+        style = f" {style}" if style else ""
+
+        properties = ""
+        if props := expression.args.get("properties"):
+            properties = ", ".join(
+                f"{self.sql(prop, 'this')} = {self.sql(prop, 'value')}"
+                for prop in props.expressions
+            )
+            properties = f" {properties}" if properties else ""
+
+        this = self.sql(expression, "this")
+
+        expression_parts = [self.sql(e).strip() for e in expression.args.get("expressions") or []]
+        expression_parts = [part for part in expression_parts if part]
+        expressions = f" {' '.join(expression_parts)}" if expression_parts else ""
+
+        format = self.sql(expression, "format")
+        format = f" FORMAT {format}" if format else ""
+
+        return f"EXPLAIN{style}{properties} {this}{expressions}{format}"
+
     def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
         this = expression.this
         separator = expression.args.get("separator")

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -11,7 +11,7 @@ from sqlglot.dialects.dialect import (
     build_json_extract_path,
     build_like,
 )
-from sqlglot.helper import seq_get
+from sqlglot.helper import ensure_list, seq_get
 from sqlglot.trie import new_trie
 from sqlglot.tokens import Token, TokenType
 from builtins import type as Type
@@ -832,6 +832,7 @@ class ClickHouseParser(parser.Parser):
         expressions = []
 
         while True:
+            expression: exp.Expr | list[exp.Expr] | None
             if self._match_text_seq("COLUMNS"):
                 expression = self._parse_schema(this=exp.var("COLUMNS"))
             elif self._match_texts(
@@ -844,7 +845,7 @@ class ClickHouseParser(parser.Parser):
             if not expression:
                 break
 
-            expressions.append(expression)
+            expressions.extend(ensure_list(expression))
 
         return expressions
 
@@ -886,7 +887,7 @@ class ClickHouseParser(parser.Parser):
 
         return self.expression(exp.Properties(expressions=properties)) if properties else None
 
-    def _parse_describe(self) -> exp.Describe | exp.Command:
+    def _parse_describe(self) -> exp.Describe | exp.Command:  # type: ignore[override]
         if self._prev.text.upper() != "EXPLAIN":
             return super()._parse_describe()
 
@@ -901,6 +902,8 @@ class ClickHouseParser(parser.Parser):
             style = self._prev.text.upper()
 
         properties = None if style == "TABLE OVERRIDE" else self._parse_explain_settings()
+
+        this: exp.Expr | None
 
         if style == "TABLE OVERRIDE":
             this = self._parse_table_parts()

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -12,6 +12,7 @@ from sqlglot.dialects.dialect import (
     build_like,
 )
 from sqlglot.helper import seq_get
+from sqlglot.trie import new_trie
 from sqlglot.tokens import Token, TokenType
 from builtins import type as Type
 
@@ -70,6 +71,15 @@ def _build_split(exp_class: Type[E]) -> t.Callable[[list], E]:
     return lambda args: exp_class(
         this=seq_get(args, 1), expression=seq_get(args, 0), limit=seq_get(args, 2)
     )
+
+
+def _show_parser(
+    name: str, *args: t.Any, **kwargs: t.Any
+) -> t.Callable[[ClickHouseParser], exp.Show | None]:
+    def _parse(self: ClickHouseParser) -> exp.Show | None:
+        return getattr(self, name)(*args, **kwargs)
+
+    return _parse
 
 
 # Skip the 'week' unit since ClickHouse's toStartOfWeek
@@ -459,7 +469,473 @@ class ClickHouseParser(parser.Parser):
     STATEMENT_PARSERS = {
         **parser.Parser.STATEMENT_PARSERS,
         TokenType.DETACH: lambda self: self._parse_detach(),
+        TokenType.SHOW: lambda self: self._parse_show(),
     }
+
+    SHOW_PARSERS = {
+        "CREATE TABLE": _show_parser(
+            "_parse_show_target", "CREATE TABLE", allow_into_outfile=True, allow_format=True
+        ),
+        "CREATE TEMPORARY TABLE": _show_parser(
+            "_parse_show_target",
+            "CREATE TEMPORARY TABLE",
+            allow_into_outfile=True,
+            allow_format=True,
+        ),
+        "CREATE DICTIONARY": _show_parser(
+            "_parse_show_target", "CREATE DICTIONARY", allow_into_outfile=True, allow_format=True
+        ),
+        "CREATE VIEW": _show_parser(
+            "_parse_show_target", "CREATE VIEW", allow_into_outfile=True, allow_format=True
+        ),
+        "CREATE DATABASE": _show_parser(
+            "_parse_show_target", "CREATE DATABASE", allow_into_outfile=True, allow_format=True
+        ),
+        "CREATE POLICY": _show_parser("_parse_show_on_expressions", "CREATE POLICY"),
+        "CREATE ROW POLICY": _show_parser("_parse_show_on_expressions", "CREATE ROW POLICY"),
+        "CREATE MASKING POLICY": _show_parser(
+            "_parse_show_on_expressions", "CREATE MASKING POLICY"
+        ),
+        "CREATE USER": _show_parser("_parse_show_expressions", "CREATE USER"),
+        "CREATE ROLE": _show_parser("_parse_show_expressions", "CREATE ROLE"),
+        "CREATE QUOTA": _show_parser("_parse_show_expressions", "CREATE QUOTA"),
+        "CREATE PROFILE": _show_parser("_parse_show_expressions", "CREATE PROFILE"),
+        "CREATE SETTINGS PROFILE": _show_parser(
+            "_parse_show_expressions", "CREATE SETTINGS PROFILE"
+        ),
+        "DATABASES": _show_parser("_parse_show_databases"),
+        "FULL TEMPORARY TABLES": _show_parser("_parse_show_tables", "FULL TEMPORARY TABLES"),
+        "FULL TABLES": _show_parser("_parse_show_tables", "FULL TABLES"),
+        "TEMPORARY TABLES": _show_parser("_parse_show_tables", "TEMPORARY TABLES"),
+        "TABLES": _show_parser("_parse_show_tables", "TABLES"),
+        "EXTENDED FULL COLUMNS": _show_parser("_parse_show_columns", "EXTENDED FULL COLUMNS"),
+        "EXTENDED COLUMNS": _show_parser("_parse_show_columns", "EXTENDED COLUMNS"),
+        "FULL COLUMNS": _show_parser("_parse_show_columns", "FULL COLUMNS"),
+        "COLUMNS": _show_parser("_parse_show_columns", "COLUMNS"),
+        "DICTIONARIES": _show_parser("_parse_show_dictionaries"),
+        "EXTENDED INDEX": _show_parser("_parse_show_indexes", "EXTENDED INDEX"),
+        "EXTENDED INDEXES": _show_parser("_parse_show_indexes", "EXTENDED INDEXES"),
+        "EXTENDED INDICES": _show_parser("_parse_show_indexes", "EXTENDED INDICES"),
+        "EXTENDED KEYS": _show_parser("_parse_show_indexes", "EXTENDED KEYS"),
+        "INDEX": _show_parser("_parse_show_indexes", "INDEX"),
+        "INDEXES": _show_parser("_parse_show_indexes", "INDEXES"),
+        "INDICES": _show_parser("_parse_show_indexes", "INDICES"),
+        "KEYS": _show_parser("_parse_show_indexes", "KEYS"),
+        "PROCESSLIST": _show_parser(
+            "_parse_show_output_only", "PROCESSLIST", allow_into_outfile=True, allow_format=True
+        ),
+        "GRANTS": _show_parser("_parse_show_grants"),
+        "TABLE": _show_parser(
+            "_parse_show_target", "TABLE", allow_into_outfile=True, allow_format=True
+        ),
+        "TEMPORARY TABLE": _show_parser(
+            "_parse_show_target", "TEMPORARY TABLE", allow_into_outfile=True, allow_format=True
+        ),
+        "DICTIONARY": _show_parser(
+            "_parse_show_target", "DICTIONARY", allow_into_outfile=True, allow_format=True
+        ),
+        "VIEW": _show_parser(
+            "_parse_show_target", "VIEW", allow_into_outfile=True, allow_format=True
+        ),
+        "DATABASE": _show_parser(
+            "_parse_show_target", "DATABASE", allow_into_outfile=True, allow_format=True
+        ),
+        "USERS": _show_parser("_parse_show_simple", "USERS"),
+        "CURRENT ROLES": _show_parser("_parse_show_simple", "CURRENT ROLES"),
+        "ENABLED ROLES": _show_parser("_parse_show_simple", "ENABLED ROLES"),
+        "ROLES": _show_parser("_parse_show_simple", "ROLES"),
+        "PROFILES": _show_parser("_parse_show_simple", "PROFILES"),
+        "ROW POLICIES": _show_parser("_parse_show_policies", "ROW POLICIES"),
+        "POLICIES": _show_parser("_parse_show_policies", "POLICIES"),
+        "QUOTAS": _show_parser("_parse_show_simple", "QUOTAS"),
+        "CURRENT QUOTA": _show_parser("_parse_show_simple", "CURRENT QUOTA"),
+        "QUOTA": _show_parser("_parse_show_simple", "QUOTA"),
+        "ACCESS": _show_parser("_parse_show_simple", "ACCESS"),
+        "CLUSTER": _show_parser("_parse_show_target", "CLUSTER", allow_format=True),
+        "CLUSTERS": _show_parser("_parse_show_clusters"),
+        "CHANGED SETTINGS": _show_parser("_parse_show_settings", "CHANGED SETTINGS"),
+        "SETTINGS": _show_parser("_parse_show_settings_or_profiles"),
+        "SETTING": _show_parser("_parse_show_target", "SETTING"),
+        "FILESYSTEM CACHES": _show_parser("_parse_show_simple", "FILESYSTEM CACHES"),
+        "ENGINES": _show_parser(
+            "_parse_show_output_only", "ENGINES", allow_into_outfile=True, allow_format=True
+        ),
+        "FUNCTIONS": _show_parser("_parse_show_functions"),
+        "MERGES": _show_parser("_parse_show_merges"),
+    }
+
+    SHOW_TRIE = new_trie(key.split(" ") for key in SHOW_PARSERS)
+
+    def _show(self, this: str, **kwargs: t.Any) -> exp.Show:
+        return self.expression(exp.Show(this=this, **kwargs))
+
+    def _parse_show_expression(self) -> exp.Expr | None:
+        return (
+            self._parse_string()
+            or self._parse_primary()
+            or self._parse_table_parts()
+            or self._parse_var(any_token=True)
+        )
+
+    def _parse_show_expression_list(self) -> list[exp.Expr]:
+        return self._parse_csv(self._parse_show_expression)
+
+    def _parse_show_like(
+        self, allow_not: bool = True
+    ) -> tuple[exp.Expr | None, bool | None, bool | None]:
+        index = self._index
+        not_ = self._match(TokenType.NOT) if allow_not else False
+
+        if self._match_set((TokenType.LIKE, TokenType.ILIKE)):
+            ilike = self._prev.token_type == TokenType.ILIKE
+            like = self._parse_string() or self._parse_var(any_token=True)
+            if like:
+                return like, ilike, not_ or None
+
+        self._retreat(index)
+        return None, None, None
+
+    def _parse_show_output(
+        self, allow_into_outfile: bool = False, allow_format: bool = False
+    ) -> tuple[exp.Expr | None, exp.Expr | None] | None:
+        index = self._index
+        into_outfile = None
+        format = None
+
+        if allow_into_outfile and self._match_text_seq("INTO", "OUTFILE"):
+            into_outfile = self._parse_string() or self._parse_var(any_token=True)
+            if not into_outfile:
+                self._retreat(index)
+                return None
+
+        if allow_format and self._match(TokenType.FORMAT):
+            format = self._parse_id_var(any_token=True) or self._parse_string()
+            if not format:
+                self._retreat(index)
+                return None
+
+        return into_outfile, format
+
+    def _parse_show(self) -> exp.Show | exp.Command:
+        start = self._prev
+        parser = self._find_parser(self.SHOW_PARSERS, self.SHOW_TRIE)
+
+        if not parser:
+            return self._parse_as_command(start)
+
+        expression = parser(self)
+        return expression if expression and not self._curr else self._parse_as_command(start)
+
+    def _parse_show_simple(self, this: str) -> exp.Show:
+        return self._show(this)
+
+    def _parse_show_target(
+        self, this: str, allow_into_outfile: bool = False, allow_format: bool = False
+    ) -> exp.Show | None:
+        target = self._parse_show_expression()
+        if not target:
+            return None
+
+        output = self._parse_show_output(
+            allow_into_outfile=allow_into_outfile, allow_format=allow_format
+        )
+        if output is None:
+            return None
+
+        into_outfile, format = output
+        return self._show(this, target=target, into_outfile=into_outfile, format=format)
+
+    def _parse_show_expressions(self, this: str) -> exp.Show | None:
+        expressions = self._parse_show_expression_list()
+        return self._show(this, expressions=expressions) if expressions else None
+
+    def _parse_show_on_expressions(self, this: str) -> exp.Show | None:
+        target = self._parse_show_expression()
+        if not target or not self._match(TokenType.ON):
+            return None
+
+        expressions = self._parse_show_expression_list()
+        return self._show(this, target=target, expressions=expressions) if expressions else None
+
+    def _parse_show_like_limit_output(
+        self,
+        this: str,
+        allow_not: bool = True,
+        allow_limit: bool = True,
+        allow_into_outfile: bool = False,
+        allow_format: bool = False,
+        **kwargs: t.Any,
+    ) -> exp.Show | None:
+        like, ilike, not_ = self._parse_show_like(allow_not=allow_not)
+        limit = self._parse_limit() if allow_limit else None
+        output = self._parse_show_output(
+            allow_into_outfile=allow_into_outfile, allow_format=allow_format
+        )
+        if output is None:
+            return None
+
+        into_outfile, format = output
+        return self._show(
+            this,
+            like=like,
+            ilike=ilike,
+            not_=not_,
+            limit=limit,
+            into_outfile=into_outfile,
+            format=format,
+            **kwargs,
+        )
+
+    def _parse_show_output_only(
+        self, this: str, allow_into_outfile: bool = False, allow_format: bool = False
+    ) -> exp.Show | None:
+        output = self._parse_show_output(
+            allow_into_outfile=allow_into_outfile, allow_format=allow_format
+        )
+        if output is None:
+            return None
+
+        into_outfile, format = output
+        return self._show(this, into_outfile=into_outfile, format=format)
+
+    def _parse_show_databases(self) -> exp.Show | None:
+        return self._parse_show_like_limit_output(
+            "DATABASES", allow_into_outfile=True, allow_format=True
+        )
+
+    def _parse_show_tables(self, this: str) -> exp.Show | None:
+        db = (
+            self._parse_show_expression()
+            if self._match_set((TokenType.FROM, TokenType.IN))
+            else None
+        )
+        return self._parse_show_like_limit_output(
+            this,
+            allow_into_outfile=True,
+            allow_format=True,
+            db=db,
+        )
+
+    def _parse_show_columns(self, this: str) -> exp.Show | None:
+        if not self._match_set((TokenType.FROM, TokenType.IN)):
+            return None
+
+        target = self._parse_show_expression()
+        if not target:
+            return None
+
+        db = (
+            self._parse_show_expression()
+            if self._match_set((TokenType.FROM, TokenType.IN))
+            else None
+        )
+        like, ilike, not_ = self._parse_show_like()
+        where = None if like is not None else self._parse_where()
+        limit = self._parse_limit()
+        output = self._parse_show_output(allow_into_outfile=True, allow_format=True)
+        if output is None:
+            return None
+
+        into_outfile, format = output
+        return self._show(
+            this,
+            target=target,
+            db=db,
+            like=like,
+            ilike=ilike,
+            not_=not_,
+            where=where,
+            limit=limit,
+            into_outfile=into_outfile,
+            format=format,
+        )
+
+    def _parse_show_dictionaries(self) -> exp.Show | None:
+        db = self._parse_show_expression() if self._match(TokenType.FROM) else None
+        return self._parse_show_like_limit_output(
+            "DICTIONARIES",
+            allow_into_outfile=True,
+            allow_format=True,
+            db=db,
+        )
+
+    def _parse_show_indexes(self, this: str) -> exp.Show | None:
+        if not self._match_set((TokenType.FROM, TokenType.IN)):
+            return None
+
+        target = self._parse_show_expression()
+        if not target:
+            return None
+
+        db = (
+            self._parse_show_expression()
+            if self._match_set((TokenType.FROM, TokenType.IN))
+            else None
+        )
+        where = self._parse_where()
+        output = self._parse_show_output(allow_into_outfile=True, allow_format=True)
+        if output is None:
+            return None
+
+        into_outfile, format = output
+        return self._show(
+            this,
+            target=target,
+            db=db,
+            where=where,
+            into_outfile=into_outfile,
+            format=format,
+        )
+
+    def _parse_show_grants(self) -> exp.Show | None:
+        expressions = None
+        if self._match(TokenType.FOR):
+            expressions = self._parse_show_expression_list()
+            if not expressions:
+                return None
+
+        return self._show(
+            "GRANTS",
+            expressions=expressions,
+            implicit=self._match_text_seq("WITH", "IMPLICIT"),
+            final=self._match_text_seq("FINAL"),
+        )
+
+    def _parse_show_policies(self, this: str) -> exp.Show | None:
+        target = None
+        if self._match(TokenType.ON):
+            target = self._parse_show_expression()
+            if not target:
+                return None
+
+        return self._show(this, target=target)
+
+    def _parse_show_clusters(self) -> exp.Show | None:
+        return self._parse_show_like_limit_output("CLUSTERS")
+
+    def _parse_show_settings(self, this: str) -> exp.Show | None:
+        return self._parse_show_like_limit_output(this, allow_not=False, allow_limit=False)
+
+    def _parse_show_settings_or_profiles(self) -> exp.Show | None:
+        if self._match_text_seq("PROFILES"):
+            return self._show("SETTINGS PROFILES")
+
+        return self._parse_show_settings("SETTINGS")
+
+    def _parse_show_functions(self) -> exp.Show | None:
+        return self._parse_show_like_limit_output("FUNCTIONS", allow_not=False, allow_limit=False)
+
+    def _parse_show_merges(self) -> exp.Show | None:
+        return self._parse_show_like_limit_output("MERGES")
+
+    def _parse_explain_table_override_expressions(self) -> list[exp.Expr]:
+        expressions = []
+
+        while True:
+            if self._match_text_seq("COLUMNS"):
+                expression = self._parse_schema(this=exp.var("COLUMNS"))
+            elif self._match_texts(
+                ("ORDER BY", "PARTITION BY", "PRIMARY KEY", "SAMPLE", "TTL"), advance=False
+            ):
+                expression = self._parse_property()
+            else:
+                break
+
+            if not expression:
+                break
+
+            expressions.append(expression)
+
+        return expressions
+
+    def _parse_explain_setting(self) -> exp.Property | None:
+        index = self._index
+        key = self._parse_column() or self._parse_var(any_token=True)
+
+        if not key or not self._match(TokenType.EQ):
+            self._retreat(index)
+            return None
+
+        if isinstance(key, exp.Column):
+            key = key.to_dot() if len(key.parts) > 1 else exp.var(key.name)
+
+        value = self._parse_bitwise() or self._parse_var(any_token=True)
+        if isinstance(value, exp.Column):
+            value = exp.var(value.name)
+
+        if value is None:
+            self._retreat(index)
+            return None
+
+        return self.expression(exp.Property(this=key, value=value))
+
+    def _parse_explain_settings(self) -> exp.Properties | None:
+        properties = []
+
+        while not self._match_set(
+            {*self.STATEMENT_PARSERS, *self.SELECT_START_TOKENS}, advance=False
+        ):
+            property = self._parse_explain_setting()
+            if not property:
+                break
+
+            properties.append(property)
+
+            if not self._match(TokenType.COMMA):
+                break
+
+        return self.expression(exp.Properties(expressions=properties)) if properties else None
+
+    def _parse_describe(self) -> exp.Describe | exp.Command:
+        if self._prev.text.upper() != "EXPLAIN":
+            return super()._parse_describe()
+
+        start = self._prev
+        style = None
+
+        if self._match_text_seq("QUERY", "TREE"):
+            style = "QUERY TREE"
+        elif self._match_text_seq("TABLE", "OVERRIDE"):
+            style = "TABLE OVERRIDE"
+        elif self._match_texts(("AST", "SYNTAX", "PLAN", "PIPELINE", "ESTIMATE")):
+            style = self._prev.text.upper()
+
+        properties = None if style == "TABLE OVERRIDE" else self._parse_explain_settings()
+
+        if style == "TABLE OVERRIDE":
+            this = self._parse_table_parts()
+            expressions = self._parse_explain_table_override_expressions()
+        else:
+            if not self._match_set(
+                {*self.STATEMENT_PARSERS, *self.SELECT_START_TOKENS}, advance=False
+            ):
+                return self._parse_as_command(start)
+            this = self._parse_statement()
+            expressions = None
+
+        if not this:
+            return self._parse_as_command(start)
+
+        format = None
+        if isinstance(this, exp.Query):
+            format = this.args.pop("format", None)
+
+        if format is None and self._match(TokenType.FORMAT):
+            format = self._parse_id_var(any_token=True) or self._parse_string()
+            if format is None:
+                return self._parse_as_command(start)
+
+        expression = self.expression(
+            exp.Describe(
+                this=this,
+                kind="EXPLAIN",
+                style=style,
+                properties=properties,
+                expressions=expressions,
+                format=format,
+            )
+        )
+        return expression if not self._curr else self._parse_as_command(start)
 
     def _parse_wrapped_select_or_assignment(self) -> exp.Expr | None:
         return self._parse_wrapped(

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1760,6 +1760,124 @@ LIFETIME(MIN 0 MAX 0)""",
             },
         )
 
+    def test_show_and_explain(self):
+        show_identity = (
+            "SHOW DATABASES",
+            "SHOW DATABASES NOT ILIKE '%de%' LIMIT 2 INTO OUTFILE 'dbs.txt' FORMAT TSVRaw",
+            "SHOW FULL TEMPORARY TABLES FROM system ILIKE '%USER%' LIMIT 2 INTO OUTFILE 'tables.txt' FORMAT TSVRaw",
+            "SHOW EXTENDED FULL COLUMNS FROM system.numbers LIKE 'number%' LIMIT 1 INTO OUTFILE 'columns.txt' FORMAT TSVRaw",
+            "SHOW DICTIONARIES FROM db LIKE '%reg%' LIMIT 2 INTO OUTFILE 'dicts.txt' FORMAT TSVRaw",
+            "SHOW EXTENDED INDEXES FROM 'tbl' WHERE visible = 'YES' INTO OUTFILE 'indexes.txt' FORMAT TSVRaw",
+            "SHOW PROCESSLIST INTO OUTFILE 'processes.txt' FORMAT TSVRaw",
+            "SHOW GRANTS FOR user1, user2 WITH IMPLICIT FINAL",
+            "SHOW CREATE USER CURRENT_USER",
+            "SHOW CREATE ROLE role1, role2",
+            "SHOW CREATE ROW POLICY policy1 ON db.table1, table2",
+            "SHOW CREATE QUOTA CURRENT",
+            "SHOW CREATE SETTINGS PROFILE profile1, profile2",
+            "SHOW USERS",
+            "SHOW CURRENT ROLES",
+            "SHOW ENABLED ROLES",
+            "SHOW SETTINGS PROFILES",
+            "SHOW ROW POLICIES ON db.table",
+            "SHOW QUOTAS",
+            "SHOW CURRENT QUOTA",
+            "SHOW ACCESS",
+            "SHOW CLUSTER 'test_shard_localhost' FORMAT Vertical",
+            "SHOW CLUSTERS LIKE 'test%' LIMIT 1",
+            "SHOW CHANGED SETTINGS ILIKE '%MEMORY%'",
+            "SHOW SETTING send_timeout",
+            "SHOW FILESYSTEM CACHES",
+            "SHOW ENGINES INTO OUTFILE 'engines.txt' FORMAT TSVRaw",
+            "SHOW FUNCTIONS ILIKE '%connect_%'",
+            "SHOW MERGES NOT LIKE 'your_t%' LIMIT 1",
+            "SHOW CREATE MASKING POLICY mask1 ON db.table1",
+            "SHOW CREATE TEMPORARY TABLE t",
+            "SHOW TABLE t",
+            "SHOW CREATE DATABASE db1",
+        )
+
+        for sql in show_identity:
+            with self.subTest(sql):
+                self.validate_identity(sql).assert_is(exp.Show)
+
+        show_normalized = {
+            "SHOW TABLES IN system": "SHOW TABLES FROM system",
+            "SHOW COLUMNS IN tab IN db": "SHOW COLUMNS FROM tab FROM db",
+            "SHOW INDICES IN tab IN db WHERE visible = 'YES'": "SHOW INDICES FROM tab FROM db WHERE visible = 'YES'",
+        }
+
+        for sql, expected in show_normalized.items():
+            with self.subTest(sql):
+                self.validate_identity(sql, expected).assert_is(exp.Show)
+
+        explain_identity = (
+            "EXPLAIN SELECT 1",
+            "EXPLAIN SELECT 1 FORMAT TSVRaw",
+            "EXPLAIN AST SELECT 1",
+            "EXPLAIN AST ALTER TABLE t1 DELETE WHERE date = today()",
+            "EXPLAIN QUERY TREE dump_ast = 1 SELECT id, value FROM test_table",
+            "EXPLAIN PLAN json = 1, description = 0 SELECT * FROM t FORMAT TSVRaw",
+            "EXPLAIN PIPELINE graph = 1, compact = 0 SELECT sum(number) FROM numbers_mt(100000) GROUP BY number % 4",
+            "EXPLAIN ESTIMATE SELECT * FROM ttt",
+        )
+
+        for sql in explain_identity:
+            with self.subTest(sql):
+                self.validate_identity(sql).assert_is(exp.Describe)
+
+        explain_normalized = {
+            "EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT * FROM system.numbers AS a, system.numbers AS b WHERE a.number = b.number": "EXPLAIN SYNTAX run_query_tree_passes = 1 SELECT * FROM system.numbers AS a CROSS JOIN system.numbers AS b WHERE a.number = b.number",
+            "EXPLAIN TABLE OVERRIDE mysql('127.0.0.1:3306', 'db', 'tbl', 'root', 'clickhouse') COLUMNS (id Int64, created Nullable(DateTime)) ORDER BY id PARTITION BY toYYYYMM(created) PRIMARY KEY id SAMPLE BY id TTL created + INTERVAL 1 DAY": "EXPLAIN TABLE OVERRIDE mysql('127.0.0.1:3306', 'db', 'tbl', 'root', 'clickhouse') COLUMNS (id Int64, created Nullable(DateTime)) ORDER BY id PARTITION BY toYYYYMM(created) PRIMARY KEY (id) SAMPLE BY id TTL created + INTERVAL '1' DAY",
+        }
+
+        for sql, expected in explain_normalized.items():
+            with self.subTest(sql):
+                self.validate_identity(sql, expected).assert_is(exp.Describe)
+
+        explain = self.validate_identity(
+            "EXPLAIN PLAN json = 1, description = 0 SELECT * FROM t FORMAT TSVRaw"
+        )
+        explain.assert_is(exp.Describe)
+        self.assertEqual(explain.args["kind"], "EXPLAIN")
+        self.assertEqual(explain.args["style"], "PLAN")
+        self.assertIsInstance(explain.args["properties"], exp.Properties)
+        self.assertEqual(len(explain.args["properties"].expressions), 2)
+        self.assertTrue(
+            all(
+                isinstance(property, exp.Property)
+                for property in explain.args["properties"].expressions
+            )
+        )
+        self.assertIsInstance(explain.args["format"], exp.Identifier)
+        self.assertIsNone(explain.this.args.get("format"))
+
+        show = self.validate_identity(
+            "SHOW FULL TEMPORARY TABLES FROM system ILIKE '%USER%' LIMIT 2 INTO OUTFILE 'tables.txt' FORMAT TSVRaw"
+        )
+        show.assert_is(exp.Show)
+        self.assertEqual(show.name, "FULL TEMPORARY TABLES")
+        self.assertIsNotNone(show.args["db"])
+        self.assertIsNotNone(show.args["like"])
+        self.assertIsNotNone(show.args["limit"])
+        self.assertIsNotNone(show.args["into_outfile"])
+        self.assertIsNotNone(show.args["format"])
+
+        grants = self.validate_identity("SHOW GRANTS FOR user1, user2 WITH IMPLICIT FINAL")
+        grants.assert_is(exp.Show)
+        self.assertTrue(grants.args["implicit"])
+        self.assertTrue(grants.args["final"])
+
+        for sql in (
+            "SHOW FOO BAR",
+            "SHOW SETTINGS max_threads",
+            "SHOW FUNCTIONS NOT LIKE 'to%'",
+            "EXPLAIN FOO BAR",
+            "EXPLAIN SELECT 1 FOO BAR",
+        ):
+            with self.subTest(sql):
+                self.assertIsInstance(parse_one(sql, dialect="clickhouse"), exp.Command)
+
     def test_functions(self):
         self.validate_identity("SELECT TRANSFORM(foo, [1, 2], ['first', 'second']) FROM table")
         self.validate_identity(


### PR DESCRIPTION
## Description:

Issue #7548 reported that ClickHouse `SHOW` and `EXPLAIN` statements were falling back to `Command`, which lost structure and made them indistinguishable from unsupported commands.

This PR updates the ClickHouse dialect to parse documented `SHOW` and `EXPLAIN` forms into structured AST nodes:
- `SHOW ...` now parses to `exp.Show`.
- `EXPLAIN ...` now parses to `exp.Describe(kind="EXPLAIN")`.
- Unsupported or partially matched `SHOW` / `EXPLAIN` syntax still falls back to `Command`.

It also reshapes the implementation to follow the normal sqlglot parser flow:
- ClickHouse `SHOW` now uses dialect `SHOW_PARSERS` / `SHOW_TRIE` dispatch instead of one large manual parser.
- `EXPLAIN` settings now use a dedicated parser so the AST contains only real property nodes.

The regression coverage is based on the ClickHouse documentation for:
- https://clickhouse.com/docs/sql-reference/statements/show
- https://clickhouse.com/docs/sql-reference/statements/explain

It adds tests for documented syntax, representative AST shape checks, and explicit fallback behavior for unsupported tails.

Resolves #7548.

## Checklist:

- [x] I have reviewed all changes in this PR myself.
- [x] I have added relevant regression test cases for this fix.
- [x] I have run linting and formatting checks in WSL using `python -m ruff check sqlglot/parsers/clickhouse.py sqlglot/generators/clickhouse.py tests/dialects/test_clickhouse.py` and `python -m ruff format --check sqlglot/parsers/clickhouse.py sqlglot/generators/clickhouse.py tests/dialects/test_clickhouse.py`.
- [x] I have run focused tests in WSL using `python -m unittest tests.dialects.test_clickhouse`, broader validation with `python -m unittest tests.test_transpile tests.dialects.test_clickhouse`, and `make unit`.


### The validation screenshot of the tests run, locally:

<img width="2533" height="1101" alt="image" src="https://github.com/user-attachments/assets/71477621-38c6-4c9a-82f1-dbd4c211db20" />

