### PR TITLE
fix(optimizer)!: skip unnesting NOT IN to preserve NULL semantics

### DIFF
--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -53,6 +53,9 @@ def unnest(select, parent_select, next_alias_name):
         )
         or parent_select is not predicate.parent_select
         or not parent_select.args.get("from_")
+        # NOT IN has three-valued semantics that the LEFT-JOIN-anti rewrite doesn't preserve:
+        # a NULL in the subquery makes NOT IN evaluate to NULL for every outer row.
+        or (isinstance(predicate, exp.In) and isinstance(predicate.parent, exp.Not))
     ):
         return
 

--- a/tests/fixtures/optimizer/tpc-h/tpc-h.sql
+++ b/tests/fixtures/optimizer/tpc-h/tpc-h.sql
@@ -933,15 +933,6 @@ order by
         p_brand,
         p_type,
         p_size;
-WITH "_u_0" AS (
-  SELECT
-    "supplier"."s_suppkey" AS "s_suppkey"
-  FROM "supplier" AS "supplier"
-  WHERE
-    "supplier"."s_comment" LIKE '%Customer%Complaints%'
-  GROUP BY
-    "supplier"."s_suppkey"
-)
 SELECT
   "part"."p_brand" AS "p_brand",
   "part"."p_type" AS "p_type",
@@ -953,10 +944,14 @@ JOIN "part" AS "part"
   AND "part"."p_partkey" = "partsupp"."ps_partkey"
   AND "part"."p_size" IN (49, 14, 23, 45, 19, 3, 36, 9)
   AND "part"."p_type" NOT LIKE 'MEDIUM POLISHED%'
-LEFT JOIN "_u_0" AS "_u_0"
-  ON "_u_0"."s_suppkey" = "partsupp"."ps_suppkey"
 WHERE
-  "_u_0"."s_suppkey" IS NULL
+  NOT "partsupp"."ps_suppkey" IN (
+    SELECT
+      "supplier"."s_suppkey" AS "s_suppkey"
+    FROM "supplier" AS "supplier"
+    WHERE
+      "supplier"."s_comment" LIKE '%Customer%Complaints%'
+  )
 GROUP BY
   "part"."p_brand",
   "part"."p_type",

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -117,3 +117,11 @@ SELECT COALESCE((SELECT MAX(b.val) FROM t AS b WHERE b.val < a.val AND b.id = a.
 # title: IN with UNION ALL subquery should use derived alias in wrapper SELECT
 SELECT * FROM x WHERE x.a IN (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
 SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z) AS _u_0 GROUP BY _u_0.a) AS _u_1 ON x.a = _u_1.a WHERE NOT _u_1.a IS NULL;
+
+# title: NOT IN is not unnested because LEFT-JOIN-anti loses three-valued NULL semantics
+SELECT * FROM x WHERE x.a NOT IN (SELECT y.a AS a FROM y);
+SELECT * FROM x WHERE NOT x.a IN (SELECT y.a AS a FROM y);
+
+# title: NOT IN with UNION ALL subquery is not unnested
+SELECT * FROM x WHERE x.a NOT IN (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);
+SELECT * FROM x WHERE NOT x.a IN (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);


### PR DESCRIPTION
`unnest_subqueries` rewrites `x NOT IN (subq)` to a LEFT-JOIN-anti pattern (`LEFT JOIN ... WHERE _u.col IS NULL`), but this loses SQL's three-valued semantics: if `subq` contains any NULL, `NOT IN` should evaluate to NULL for every outer row (filtering them all out), while the anti-join keeps rows that didn't find a match.

Example:

```sql
CREATE TABLE x AS SELECT * FROM (VALUES (1),(2),(3),(4)) AS t(a);
CREATE TABLE y AS SELECT * FROM (VALUES (1),(NULL)) AS t(a);
CREATE TABLE z AS SELECT * FROM (VALUES (2),(3)) AS t(a);

SELECT * FROM x WHERE x.a NOT IN (
  SELECT y.a FROM y UNION ALL SELECT z.a FROM z
);
-- correct: 0 rows (NULL in subquery poisons every comparison)
-- after unnesting: returns 4
```

Fix is to skip the rewrite when the `In` predicate is wrapped in `Not`. Plain `IN` is unaffected because `WHERE`/`HAVING`/inner-join `ON` reject `NULL` and `FALSE` identically; the rewrite preserves the `TRUE`-vs-not-`TRUE` distinction that those contexts care about.


