### PR TITLE
feat(bigquery): support LOAD DATA INTO TEMP TABLE syntax

### DIFF
--- a/sqlglot/expressions/dml.py
+++ b/sqlglot/expressions/dml.py
@@ -283,6 +283,7 @@ class LoadData(Expression):
         "this": True,
         "local": False,
         "overwrite": False,
+        "temp": False,
         "inpath": False,
         "files": False,
         "partition": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2896,7 +2896,12 @@ class Generator:
         if files:
             files_sql = self.expressions(files, flat=True)
             files_sql = f"FILES{self.wrap(files_sql)}"
-            this = f" {this}" if is_overwrite else f" INTO TABLE {this}"
+            if is_overwrite:
+                this = f" {this}"
+            elif expression.args.get("temp"):
+                this = f" INTO TEMP TABLE {this}"
+            else:
+                this = f" INTO TABLE {this}"
             return f"LOAD DATA{overwrite}{this} FROM {files_sql}"
 
         local = " LOCAL" if expression.args.get("local") else ""

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3592,13 +3592,17 @@ class Parser:
             self._match_text_seq("INPATH")
             inpath = self._parse_string()
             overwrite = self._match(TokenType.OVERWRITE)
-            self._match_pair(TokenType.INTO, TokenType.TABLE)
+            temp = False
+            if self._match(TokenType.INTO):
+                temp = self._match(TokenType.TEMPORARY)
+                self._match(TokenType.TABLE)
 
             return self.expression(
                 exp.LoadData(
                     this=self._parse_table(schema=True),
                     local=local,
                     overwrite=overwrite,
+                    temp=temp,
                     inpath=inpath,
                     files=self._match_text_seq("FROM", "FILES")
                     and exp.Properties(expressions=self._parse_wrapped_properties()),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3592,7 +3592,7 @@ class Parser:
             self._match_text_seq("INPATH")
             inpath = self._parse_string()
             overwrite = self._match(TokenType.OVERWRITE)
-            temp = False
+            temp: t.Optional[bool] = None
             if self._match(TokenType.INTO):
                 temp = self._match(TokenType.TEMPORARY)
                 self._match(TokenType.TABLE)

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -334,7 +334,6 @@ class BigQueryParser(parser.Parser):
         TokenType.END: lambda self: self._parse_as_command(self._prev),
         TokenType.FOR: lambda self: self._parse_for_in(),
         TokenType.EXPORT: lambda self: self._parse_export_data(),
-        TokenType.LOAD: lambda self: self._parse_load_data(),
         TokenType.DECLARE: lambda self: self._parse_declare(),
     }
 
@@ -710,25 +709,6 @@ class BigQueryParser(parser.Parser):
                 this=self._match_text_seq("AS") and self._parse_select(nested=True),
             )
         )
-
-    def _parse_load_data(self) -> exp.LoadData | exp.Command:
-        if self._match_text_seq("DATA"):
-            overwrite = self._match(TokenType.OVERWRITE)
-            temp = False
-            if self._match(TokenType.INTO):
-                temp = self._match(TokenType.TEMPORARY)
-                self._match(TokenType.TABLE)
-
-            return self.expression(
-                exp.LoadData(
-                    this=self._parse_table(schema=True),
-                    overwrite=overwrite,
-                    temp=temp,
-                    files=self._match_text_seq("FROM", "FILES")
-                    and exp.Properties(expressions=self._parse_wrapped_properties()),
-                )
-            )
-        return self._parse_as_command(self._prev)
 
     def _parse_column_ops(self, this: exp.Expr | None) -> exp.Expr | None:
         func_index = self._index + 1

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -334,6 +334,7 @@ class BigQueryParser(parser.Parser):
         TokenType.END: lambda self: self._parse_as_command(self._prev),
         TokenType.FOR: lambda self: self._parse_for_in(),
         TokenType.EXPORT: lambda self: self._parse_export_data(),
+        TokenType.LOAD: lambda self: self._parse_load_data(),
         TokenType.DECLARE: lambda self: self._parse_declare(),
     }
 
@@ -709,6 +710,25 @@ class BigQueryParser(parser.Parser):
                 this=self._match_text_seq("AS") and self._parse_select(nested=True),
             )
         )
+
+    def _parse_load_data(self) -> exp.LoadData | exp.Command:
+        if self._match_text_seq("DATA"):
+            overwrite = self._match(TokenType.OVERWRITE)
+            temp = False
+            if self._match(TokenType.INTO):
+                temp = self._match(TokenType.TEMPORARY)
+                self._match(TokenType.TABLE)
+
+            return self.expression(
+                exp.LoadData(
+                    this=self._parse_table(schema=True),
+                    overwrite=overwrite,
+                    temp=temp,
+                    files=self._match_text_seq("FROM", "FILES")
+                    and exp.Properties(expressions=self._parse_wrapped_properties()),
+                )
+            )
+        return self._parse_as_command(self._prev)
 
     def _parse_column_ops(self, this: exp.Expr | None) -> exp.Expr | None:
         func_index = self._index + 1

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -217,6 +217,7 @@ class TestBigQuery(Validator):
         for load_data_sql in (
             "LOAD DATA OVERWRITE mydataset.table1 FROM FILES(FORMAT='AVRO', uris=['gs://bucket/path/file.avro'])",
             "LOAD DATA INTO TABLE mydataset.table1 FROM FILES(FORMAT='AVRO', uris=['gs://bucket/path/file.avro'])",
+            "LOAD DATA INTO TEMP TABLE mydataset.table1 FROM FILES(FORMAT='AVRO', uris=['gs://bucket/path/file.avro'])",
         ):
             with self.subTest(load_data_sql=load_data_sql):
                 self.validate_identity(load_data_sql).assert_is(exp.LoadData)


### PR DESCRIPTION
## Summary

Adds support for BigQuery's `LOAD DATA INTO TEMP TABLE` syntax, which was previously failing to parse because the base `_parse_load` used        
`_match_pair(INTO, TABLE)` which requires `INTO` to be immediately followed by `TABLE`, with no room for the `TEMP`/`TEMPORARY` keyword in       
between.

### Changes

- **`sqlglot/expressions/dml.py`**: Added `"temp": False` to `LoadData.arg_types`
- **`sqlglot/parsers/bigquery.py`**: Added a BigQuery-specific `_parse_load_data()` override that handles all three variants and registered it
under `TokenType.LOAD` in `STATEMENT_PARSERS`
- **`sqlglot/generator.py`**: Updated `loaddata_sql()` to emit `INTO TEMP TABLE` when `temp=True`
- **`tests/dialects/test_bigquery.py`**: Added `LOAD DATA INTO TEMP TABLE` to the existing round-trip test

### All three BigQuery LOAD DATA variants are supported and round-trip correctly

```sql
-- existing, unchanged
LOAD DATA OVERWRITE mydataset.table1 FROM FILES(...)
LOAD DATA INTO TABLE mydataset.table1 FROM FILES(...)

-- new
LOAD DATA INTO TEMP TABLE mydataset.table1 FROM FILES(...)
```

Ref: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/load-statements