### PR TITLE
fix(sqlite): transpile Postgres escaped strings as text literals

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -82,6 +82,10 @@ def _generated_to_auto_increment(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
+def bytestring_to_text_sql(self: SQLiteGenerator, expression: exp.ByteString) -> str:
+    return self.sql(exp.Literal.string(expression.this))
+
+
 class SQLiteGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     TRY_SUPPORTED = False
@@ -135,6 +139,7 @@ class SQLiteGenerator(generator.Generator):
     TRANSFORMS = {
         **generator.Generator.TRANSFORMS,
         exp.AnyValue: any_value_to_max_sql,
+        exp.ByteString: bytestring_to_text_sql,
         exp.Chr: rename_func("CHAR"),
         exp.Concat: concat_to_dpipe_sql,
         exp.CountIf: count_if_to_sum,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -457,7 +457,28 @@ FROM json_data, field_ids""",
             write={
                 "postgres": "SELECT e'a\\tb'",
                 "mysql": "SELECT 'a\\tb'",
-                "sqlite": UnsupportedError,
+                "sqlite": "SELECT 'a\tb'",
+            },
+        )
+        self.validate_all(
+            "SELECT E'a\\nb'",
+            write={
+                "postgres": "SELECT e'a\\nb'",
+                "sqlite": "SELECT 'a\nb'",
+            },
+        )
+        self.validate_all(
+            "SELECT E'a\\'b'",
+            write={
+                "postgres": "SELECT e'a''b'",
+                "sqlite": "SELECT 'a''b'",
+            },
+        )
+        self.validate_all(
+            "SELECT LENGTH(E'a\\nb')",
+            write={
+                "postgres": "SELECT LENGTH(e'a\\nb')",
+                "sqlite": "SELECT LENGTH('a\nb')",
             },
         )
         self.validate_all(
@@ -652,7 +673,7 @@ FROM json_data, field_ids""",
             write={
                 "postgres": "e'x'",
                 "mysql": "'x'",
-                "sqlite": UnsupportedError,
+                "sqlite": "'x'",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Follow-up to #7677. Postgres `E'...'` strings parse as `ByteString`, and SQLite currently has no byte string delimiter, so generation falls back to an unsupported empty string. That drops valid text payloads during Postgres -> SQLite transpilation.

This makes the SQLite generator render `ByteString` as a normal quoted text literal, preserving the decoded payload.

Examples fixed:

```sql
SELECT E'a\nb'         -- SELECT 'a
b'
SELECT E'a\tb'         -- SELECT 'a	b'
SELECT E'a\'b'         -- SELECT 'a''b'
SELECT LENGTH(E'a\nb') -- SELECT LENGTH('a
b')
```

Checks run:

```bash
uv run pytest tests/dialects/test_postgres.py -q -k postgres
uv run pytest tests/dialects/test_sqlite.py -q
uv run ruff check sqlglot/generators/sqlite.py tests/dialects/test_postgres.py
uv run ruff format --check sqlglot/generators/sqlite.py tests/dialects/test_postgres.py
```