### PR TITLE
feat(duckdb): Add transpilation support for BOOLEAN and TEXT cases of TRY_CAST function

### DIFF
--- a/sqlglot/expressions/functions.py
+++ b/sqlglot/expressions/functions.py
@@ -70,7 +70,7 @@ class Cast(Expression, Func):
 
 
 class TryCast(Cast):
-    arg_types = {**Cast.arg_types, "requires_string": False}
+    arg_types = {**Cast.arg_types, "requires_string": False, "null_on_text_overflow": False}
 
 
 class JSONCast(Cast):

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4326,6 +4326,27 @@ class DuckDBGenerator(generator.Generator):
 
         return self.func(func, this, decimals, truncate)
 
+    def trycast_sql(self, expression: exp.TryCast) -> str:
+        to = expression.to
+        to_type = to.this
+
+        if (
+            expression.args.get("null_on_text_overflow")
+            and to_type in exp.DataType.TEXT_TYPES
+            and to.expressions
+        ):
+            src = expression.this
+            return self.sql(
+                exp.case()
+                .when(
+                    exp.LTE(this=exp.func("LENGTH", src), expression=to.expressions[0].this),
+                    exp.cast(src, "TEXT"),
+                )
+                .else_(exp.Null())
+            )
+
+        return super().trycast_sql(expression)
+
     def strtok_sql(self, expression: exp.Strtok) -> str:
         string_arg = expression.this
         delimiter_arg = expression.args.get("delimiter")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -10009,7 +10009,7 @@ class Parser:
 
         return self.expression(exp.Declare(expressions=expressions, replace=replace))
 
-    def build_cast(self, strict: bool, **kwargs) -> exp.Cast:
+    def build_cast(self, strict: bool, **kwargs) -> exp.Expr:
         exp_class = exp.Cast if strict else exp.TryCast
 
         if exp_class == exp.TryCast:

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1303,6 +1303,22 @@ class SnowflakeParser(parser.Parser):
         result.set("zero_start", True)
         return result
 
+    def build_cast(self, strict: bool, **kwargs) -> exp.Cast:
+        to = kwargs.get("to")
+        if to and to.this == exp.DataType.Type.BOOLEAN:
+            return t.cast(
+                exp.Cast, self.expression(exp.ToBoolean(this=kwargs["this"], safe=not strict))
+            )
+        cast = super().build_cast(strict, **kwargs)
+        if (
+            isinstance(cast, exp.TryCast)
+            and to
+            and to.this in exp.DataType.TEXT_TYPES
+            and to.expressions
+        ):
+            cast.set("null_on_text_overflow", True)
+        return cast
+
     def _parse_window(self, this: exp.Expr | None, alias: bool = False) -> exp.Expr | None:
         if isinstance(this, exp.NthValue):
             if self._match_text_seq("FROM"):

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1306,7 +1306,7 @@ class SnowflakeParser(parser.Parser):
     def build_cast(self, strict: bool, **kwargs) -> exp.Expr:
         to = kwargs.get("to")
         if not strict and to and to.this == exp.DataType.Type.BOOLEAN:
-            return self.expression(exp.ToBoolean(this=kwargs["this"], safe=True))
+            return self.expression(exp.ToBoolean(this=kwargs.get("this"), safe=True))
         cast = super().build_cast(strict, **kwargs)
         if (
             isinstance(cast, exp.TryCast)

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1303,12 +1303,10 @@ class SnowflakeParser(parser.Parser):
         result.set("zero_start", True)
         return result
 
-    def build_cast(self, strict: bool, **kwargs) -> exp.Cast:
+    def build_cast(self, strict: bool, **kwargs) -> exp.Expr:
         to = kwargs.get("to")
-        if to and to.this == exp.DataType.Type.BOOLEAN:
-            return t.cast(
-                exp.Cast, self.expression(exp.ToBoolean(this=kwargs["this"], safe=not strict))
-            )
+        if not strict and to and to.this == exp.DataType.Type.BOOLEAN:
+            return self.expression(exp.ToBoolean(this=kwargs["this"], safe=True))
         cast = super().build_cast(strict, **kwargs)
         if (
             isinstance(cast, exp.TryCast)


### PR DESCRIPTION
PR#1
Refer https://github.com/tobymao/sqlglot/pull/7672 for comments.

BOOLEAN: Snowflake's `TRY_CAST(x AS BOOLEAN)` accepts `'on'/'off'` and returns `TRUE/FALSE`, but DuckDB's native `TRY_CAST(x AS BOOLEAN)` returns `NULL` for those two values silently.

TEXT(n): Snowflake's `TRY_CAST(x AS VARCHAR(n))` returns `NULL` if the string exceeds length n, but DuckDB's native `TRY_CAST(x AS VARCHAR(n))` silently ignores the length constraint and returns the full string.

After fixing the above,
Boolean:

```
SF:
SELECT TRY_CAST('on' AS BOOLEAN), TRY_CAST('off' AS BOOLEAN), TRY_CAST('true' AS BOOLEAN), TRY_CAST('false' AS BOOLEAN), TRY_CAST('yes' AS BOOLEAN), TRY_CAST('invalid' AS BOOLEAN), TRY_CAST(NULL AS BOOLEAN);
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| TRY_CAST('ON' AS    | TRY_CAST('OFF' AS   | TRY_CAST('TRUE' AS  | TRY_CAST('FALSE' AS | TRY_CAST('YES' AS    | TRY_CAST('INVALID'  | TRY_CAST(NULL AS     |
| BOOLEAN)            | BOOLEAN)            | BOOLEAN)            | BOOLEAN)            | BOOLEAN)             | AS BOOLEAN)         | BOOLEAN)             |
|---------------------+---------------------+---------------------+---------------------+----------------------+---------------------+----------------------|
| True                | False               | True                | False               | True                 | None                | None                 |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+

DDB:
┌───────────────────────┬───────────────────────┬───────────────────────┬──────────────────────┬──────────────────────┬───────────────────────┐
│ CASE  WHEN ((upper(CA │ CASE  WHEN ((upper(CA │ CASE  WHEN ((upper(CA │ CASE  WHEN ((upper(C │ CASE  WHEN ((upper(C │ CASE  WHEN ((upper(CA │
│ ST('on' AS VARCHAR))  │ ST('off' AS VARCHAR)) │ ST('true' AS VARCHAR) │ AST('false' AS VARCH │ AST('invalid' AS VAR │ ST(NULL AS VARCHAR))  │
│ = 'ON')) THEN (CAST(' │  = 'ON')) THEN (CAST( │ ) = 'ON')) THEN (CAST │ AR)) = 'ON')) THEN ( │ CHAR)) = 'ON')) THEN │ = 'ON')) THEN (CAST(' │
│ t' AS BOOLEAN)) WHEN  │ 't' AS BOOLEAN)) WHEN │ ('t' AS BOOLEAN)) WHE │ CAST('t' AS BOOLEAN) │  (CAST('t' AS BOOLEA │ t' AS BOOLEAN)) WHEN  │
│ ((upper(CAST('on' AS  │  ((upper(CAST('off' A │ N ((upper(CAST('true' │ ) WHEN ((upper(CAST( │ N)) WHEN ((upper(CAS │ ((upper(CAST(NULL AS  │
│ VARCHAR)) = 'OFF')) T │ S VARCHAR)) = 'OFF')) │  AS VARCHAR)) = 'OFF' │ 'false' AS VARCHAR)) │ T('invalid' AS VARCH │ VARCHAR)) = 'OFF')) T │
│ HEN (CAST('f' AS BOOL │  THEN (CAST('f' AS BO │ )) THEN (CAST('f' AS  │  = 'OFF')) THEN (CAS │ AR)) = 'OFF')) THEN  │ HEN (CAST('f' AS BOOL │
│ EAN)) ELSE TRY_CAST(' │ OLEAN)) ELSE TRY_CAST │ BOOLEAN)) ELSE TRY_CA │ T('f' AS BOOLEAN)) E │ (CAST('f' AS BOOLEAN │ EAN)) ELSE TRY_CAST(N │
│  on' AS BOOLEAN) END  │ ('off' AS BOOLEAN) EN │ ST('true' AS BOOLEAN) │ LSE TRY_CAST('false' │ )) ELSE TRY_CAST('in │  ULL AS BOOLEAN) END  │
│                       │           D           │          END          │    AS BOOLEAN) END   │ valid' AS BOOLEAN) E │                       │
│                       │                       │                       │                      │          ND          │                       │
│        boolean        │        boolean        │        boolean        │       boolean        │       boolean        │        boolean        │
├───────────────────────┼───────────────────────┼───────────────────────┼──────────────────────┼──────────────────────┼───────────────────────┤
│ true                  │ false                 │ true                  │ false                │ NULL                 │ NULL                  │
└───────────────────────┴───────────────────────┴───────────────────────┴──────────────────────┴──────────────────────┴───────────────────────┘
```


Text:

```
SF:
SELECT
  CASE WHEN LENGTH('hello') <= 3 THEN CAST('hello' AS TEXT) ELSE NULL END,
  CASE WHEN LENGTH('hi') <= 3 THEN CAST('hi' AS TEXT) ELSE NULL END,
  CASE WHEN LENGTH(NULL) <= 3 THEN CAST(NULL AS TEXT) ELSE NULL END;
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| CASE WHEN LENGTH('HELLO') <= 3 THEN CAST('HELLO' AS TEXT) ELSE NULL END | CASE WHEN LENGTH('HI') <= 3 THEN CAST('HI' AS TEXT) ELSE NULL END | CASE WHEN LENGTH(NULL) <= 3 THEN CAST(NULL AS TEXT) ELSE NULL END |
|-------------------------------------------------------------------------+-------------------------------------------------------------------+-------------------------------------------------------------------|
| None                                                                    | hi                                                                | None                                                              |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


DDB:
"SELECT CASE WHEN LENGTH('hello') <= 3 THEN CAST('hello' AS TEXT) ELSE NULL END, CASE WHEN LENGTH('hi') <= 3 THEN CAST('hi' AS TEXT) ELSE NULL END, CASE WHEN LENGTH(NULL) <= 3 THEN CAST(NULL AS TEXT) ELSE NULL END"
┌───────────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────┬─────────────────────────────────────────────────────────────────────────────┐
│ CASE  WHEN ((length('hello') <= 3)) THEN (CAST('hello' AS VARCHAR)) ELSE NULL END │ CASE  WHEN ((length('hi') <= 3)) THEN (CAST('hi' AS VARCHAR)) ELSE NULL END │ CASE  WHEN ((length(NULL) <= 3)) THEN (CAST(NULL AS VARCHAR)) ELSE NULL END │
│                                      varchar                                      │                                   varchar                                   │                                   varchar                                   │
├───────────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┼─────────────────────────────────────────────────────────────────────────────┤
│ NULL                                                                              │ hi                                                                          │ NULL                                                                        │
```

