### PR TITLE
fix(databricks)!: string-promote COALESCE/IF/CASE per findWiderCommonType [CLAUDE]

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -9,6 +9,43 @@ from sqlglot.generators.databricks import DatabricksGenerator
 from sqlglot.parsers.databricks import DatabricksParser
 from sqlglot.tokens import TokenType
 from sqlglot.optimizer.annotate_types import TypeAnnotator
+from sqlglot.typing.spark import EXPRESSION_METADATA as SPARK_EXPRESSION_METADATA
+
+
+def _string_promotes(values: list[exp.Expression]) -> bool:
+    """
+    Whether a least-common-type function string-promotes given its value arguments.
+
+    Databricks resolves COALESCE/IF/CASE via Spark's findWiderCommonType string
+    promotion: when an argument is text and the rest are non-boolean/non-binary
+    atomics, the common type is text. boolean+text and binary+text have no common
+    type (query-time DATATYPE_MISMATCH), so we defer those to numeric widening.
+    """
+    return any(v.is_type(*exp.DataType.TEXT_TYPES) for v in values) and not any(
+        v.is_type(exp.DType.BOOLEAN, exp.DType.BINARY) for v in values
+    )
+
+
+def _annotate_coalesce(self: TypeAnnotator, e: exp.Coalesce) -> exp.Coalesce:
+    if _string_promotes([v for v in (e.this, *e.expressions) if v]):
+        self._set_type(e, exp.DType.TEXT)
+        return e
+    return self._annotate_by_args(e, "this", "expressions", promote=True)
+
+
+def _annotate_if(self: TypeAnnotator, e: exp.If) -> exp.If:
+    if _string_promotes([v for v in (e.args.get("true"), e.args.get("false")) if v]):
+        self._set_type(e, exp.DType.TEXT)
+        return e
+    return self._annotate_by_args(e, "true", "false", promote=True)
+
+
+def _annotate_case(self: TypeAnnotator, e: exp.Case) -> exp.Case:
+    thens = [if_expr.args["true"] for if_expr in e.args["ifs"]]
+    if _string_promotes([v for v in (*thens, e.args.get("default")) if v]):
+        self._set_type(e, exp.DType.TEXT)
+        return e
+    return self._annotate_by_args(e, *thens, "default")
 
 
 class Databricks(Spark):
@@ -24,6 +61,13 @@ class Databricks(Spark):
             exp.DType.BOOLEAN,
             exp.DType.INTERVAL,
         }
+
+    EXPRESSION_METADATA = {
+        **SPARK_EXPRESSION_METADATA,
+        exp.Coalesce: {"annotator": _annotate_coalesce},
+        exp.If: {"annotator": _annotate_if},
+        exp.Case: {"annotator": _annotate_case},
+    }
 
     class JSONPathTokenizer(Spark.JSONPathTokenizer):
         IDENTIFIERS = ["`", '"']

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -307,11 +307,11 @@ STRING;
 
 # dialect: databricks
 IF(cond, tbl.str_col, tbl.double_col);
-DOUBLE;
+STRING;
 
 # dialect: databricks
 IF(cond, tbl.double_col, tbl.str_col);
-DOUBLE;
+STRING;
 
 # dialect: hive, spark2, spark
 IF(cond, tbl.date_col, tbl.str_col);
@@ -323,11 +323,11 @@ STRING;
 
 # dialect: databricks
 IF(cond, tbl.date_col, tbl.str_col);
-DATE;
+STRING;
 
 # dialect: databricks
 IF(cond, tbl.str_col, tbl.date_col);
-DATE;
+STRING;
 
 # dialect: hive, spark2, spark, databricks
 IF(cond, tbl.date_col, tbl.timestamp_col);
@@ -371,19 +371,19 @@ STRING;
 
 # dialect: databricks
 COALESCE(tbl.str_col, tbl.bigint_col);
-BIGINT;
+STRING;
 
 # dialect: databricks
 COALESCE(tbl.bigint_col, tbl.str_col);
-BIGINT;
+STRING;
 
 # dialect: databricks
 COALESCE(tbl.str_col, NULL, tbl.bigint_col);
-BIGINT;
+STRING;
 
 # dialect: databricks
 COALESCE(tbl.bigint_col, NULL, tbl.str_col);
-BIGINT;
+STRING;
 
 # dialect: databricks
 COALESCE(tbl.bool_col, tbl.str_col);
@@ -395,11 +395,27 @@ STRING;
 
 # dialect: databricks
 COALESCE(tbl.interval_col, tbl.str_col);
-INTERVAL;
+STRING;
 
 # dialect: databricks
 COALESCE(tbl.bin_col, tbl.str_col);
 BINARY;
+
+# dialect: databricks
+COALESCE(tbl.int_col, tbl.str_col);
+STRING;
+
+# dialect: databricks
+NVL(tbl.int_col, tbl.str_col);
+STRING;
+
+# dialect: databricks
+CASE WHEN cond THEN tbl.int_col ELSE tbl.str_col END;
+STRING;
+
+# dialect: databricks
+COALESCE(tbl.int_col, tbl.bigint_col);
+BIGINT;
 
 # dialect: spark, databricks
 LOCALTIMESTAMP();


### PR DESCRIPTION
## Problem

For the `databricks` dialect, least-common-type functions — `COALESCE` (and `IFNULL`/`NVL`, which parse to `Coalesce`), `IF`, and `CASE` — annotate as the **numeric** type when an argument is text and the rest are numeric. Real Databricks resolves these to **string** (Spark's `findWiderCommonType` string promotion).

```python
from sqlglot.optimizer.annotate_types import annotate_types
from sqlglot import parse_one

schema = {"tbl": {"int_col": "INT", "str_col": "STRING"}}
e = parse_one("SELECT COALESCE(tbl.int_col, tbl.str_col) FROM tbl", dialect="databricks")
annotate_types(e, schema=schema, dialect="databricks").selects[0].type
# before: BIGINT   after: STRING
```

`spark`/`spark2`/`hive` are already correct (they string-promote via their lattice); only `databricks` is affected.

## Root cause

`Databricks` defines its own `COERCES_TO` lattice in the **opposite** direction from Hive/Spark — text coerces *into* numeric/temporal rather than numeric/temporal *into* text. LCT functions fold through that lattice via `_annotate_by_args` → `_maybe_coerce`, so the numeric type always wins regardless of argument order.

That lattice was introduced deliberately in #5096 on the premise that Databricks defaults to **ANSI mode** (where open-source Spark's `AnsiTypeCoercion.findWiderTypeForString` returns `LONG` for `string + int`, not `string`).

## Why the ANSI premise doesn't hold for Databricks

Verified on a Databricks **serverless** warehouse (which is *always* ANSI):

```sql
SELECT
  typeof(coalesce(cast(1 as int), 'abc')),                  -- string
  typeof(coalesce(cast(1.5 as double), 'abc')),             -- string
  typeof(coalesce(cast('2020-01-01' as date), 'abc')),      -- string
  typeof(coalesce(interval 1 day, 'abc')),                  -- string
  typeof(if(true, cast(1 as int), 'abc')),                  -- string
  typeof(case when true then cast(1 as int) else 'abc' end);-- string
```

Databricks string-promotes these functions **even under ANSI**, contrary to open-source Spark's `AnsiTypeCoercion`. It follows the *non-ANSI* `stringPromotion` rule — `(StringType, AtomicType) if t2 != BinaryType && t2 != BooleanType` (plus interval). The excluded combinations error:

```
coalesce(cast(1 as boolean), 'abc')  -> [DATATYPE_MISMATCH.DATA_DIFF_TYPES]
coalesce(cast(1 as binary), 'abc')   -> [DATATYPE_MISMATCH.DATA_DIFF_TYPES]
```

## Fix

Three Databricks-scoped annotators for `Coalesce`/`If`/`Case`: if a value argument is text and none is boolean/binary, the result is text; otherwise fall back to the existing numeric-widening behavior. `boolean`/`binary` + text and `GREATEST`/`LEAST` (which require a common type and error on mixed text/numeric in Databricks) are intentionally left on the fallback — there is no representable "type mismatch error" annotation, so their current best-effort type is retained.

Scoped to Databricks only; Spark/Hive and all other dialects are unchanged. Arithmetic coercion (`'5' + 3 -> INT`) is unaffected — it goes through `BINARY_COERCIONS`, not `COERCES_TO`.

## Tests

`tests/fixtures/optimizer/annotate_functions.sql`: the Databricks `COALESCE`/`IF` rows for text + numeric/date/interval now assert `STRING`; `boolean`/`binary` rows keep their current annotation; added `COALESCE`/`NVL`/`CASE` cases and an all-numeric regression. Each asserted result matches the empirical `typeof(...)` output above.
