### PR TITLE
fix(optimizer): retain set-returning projections in pushdown_projections

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -18,6 +18,12 @@ if t.TYPE_CHECKING:
 # Sentinel value that means an outer query selecting ALL columns
 SELECT_ALL = object()
 
+# Set-returning (table) functions multiply the rows of the entire query, so a projection
+# containing one affects the cardinality of every output column and must never be pruned,
+# even when the projection itself is otherwise unreferenced. Posexplode and the *Outer
+# variants are subclasses of Explode, so matching Explode covers them too.
+SET_RETURNING_FUNCTIONS = (exp.Explode, exp.Inline, exp.Unnest)
+
 
 # Selection to use if selection list is empty
 def default_selection(is_agg: bool) -> exp.Alias:
@@ -150,6 +156,12 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count):
         if select_all or name in parent_selections or name in order_refs or alias_count > 0:
             new_selections.append(selection)
             alias_count -= 1
+        elif selection.find(*SET_RETURNING_FUNCTIONS):
+            # A set-returning function multiplies the rows of the whole query, so this
+            # projection affects the cardinality of every output column and must be kept
+            # even though it is otherwise unreferenced. It is not a positional alias slot,
+            # so alias_count is left untouched.
+            new_selections.append(selection)
         else:
             if selection.is_star:
                 star = True

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -142,3 +142,19 @@ WITH cte AS (SELECT a AS a, b AS b FROM x AS x) SELECT COUNT(* EXCLUDE (a)) AS _
 
 WITH cte1 AS (SELECT a, SUM(b) AS sale FROM x GROUP BY a), cte2 AS (SELECT cte1.a, COUNT(*) AS cnt FROM cte1 GROUP BY cte1.a) SELECT a, cnt FROM cte2;
 WITH cte1 AS (SELECT x.a AS a FROM x AS x GROUP BY x.a), cte2 AS (SELECT cte1.a AS a, COUNT(*) AS cnt FROM cte1 AS cte1 GROUP BY cte1.a) SELECT cte2.a AS a, cte2.cnt AS cnt FROM cte2 AS cte2;
+
+--------------------------------------
+-- Set-returning functions affect cardinality and are retained even when unused
+--------------------------------------
+SELECT d FROM (SELECT EXPLODE(e) AS col, d FROM w);
+SELECT _0.d AS d FROM (SELECT EXPLODE(w.e) AS col, w.d AS d FROM w AS w) AS _0;
+
+SELECT d FROM (SELECT POSEXPLODE(e) AS col, d FROM w);
+SELECT _0.d AS d FROM (SELECT POSEXPLODE(w.e) AS col, w.d AS d FROM w AS w) AS _0;
+
+SELECT d FROM (SELECT INLINE(e) AS col, d FROM w);
+SELECT _0.d AS d FROM (SELECT INLINE(w.e) AS col, w.d AS d FROM w AS w) AS _0;
+
+-- Window functions do not affect cardinality and stay prunable
+SELECT d FROM (SELECT d, ROW_NUMBER() OVER (PARTITION BY e ORDER BY d) AS rn FROM w);
+SELECT _0.d AS d FROM (SELECT w.d AS d FROM w AS w) AS _0;


### PR DESCRIPTION
## Problem

`pushdown_projections` removes any projection that the outer query doesn't reference. But a projection whose expression is a **set-returning / table function** (`EXPLODE`, `POSEXPLODE`, `INLINE`, `UNNEST`) multiplies the rows of the *entire* query, so dropping it because it's otherwise unused silently changes the result's row cardinality:

```sql
-- before this PR: slicing to `d` drops EXPLODE(e) and loses the row multiplication
SELECT d FROM (SELECT EXPLODE(e) AS col, d FROM w)
-- becomes
SELECT d FROM (SELECT d FROM w)   -- WRONG: different row count
```

## Fix

Retain any otherwise-unused projection whose expression contains a set-returning function. `Posexplode` and the `*Outer` variants subclass `Explode`, so matching `Explode` covers them. Window functions are not set-returning and remain prunable; `LATERAL VIEW` is already retained.

## Tests

Added fixtures to `tests/fixtures/optimizer/pushdown_projections.sql` covering EXPLODE / POSEXPLODE / INLINE retention and ROW_NUMBER pruning. The full optimizer suite passes.
