### PR TITLE
perf(optimizer): skip O(n^2) connector simplification when no operands can combine

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -526,6 +526,10 @@ class Simplifier:
         exp.Is,
     )
 
+    # Operand types that allow a connector pair to combine in _flat_simplify: constants
+    # (matched by the is_false/is_null/is_zero/always_true checks) and comparisons.
+    CONNECTOR_COMBINABLE: t.ClassVar = (exp.Boolean, exp.Literal, exp.Null, *COMPARISONS)
+
     INVERSE_COMPARISONS: t.ClassVar[dict[type[exp.Expr], type[exp.Expr]]] = {
         exp.LT: exp.GT,
         exp.GT: exp.LT,
@@ -1466,6 +1470,16 @@ class Simplifier:
             operands = []
             queue = deque(expression.flatten(unnest=False))
             size = len(queue)
+
+            # The pairwise scan below is O(n^2). For connectors, a pair only combines if one side
+            # is a constant or both are comparisons (see _simplify_connectors / _simplify_comparison);
+            # if no operand is combinable the scan is a guaranteed no-op, so return early. This
+            # avoids the quadratic blowup on large connectors of inert operands (e.g. a 1000-way OR
+            # of ANDs). Non-connector callers (simplify_equality) are unaffected by the type guard.
+            if isinstance(expression, exp.Connector) and not any(
+                isinstance(op, self.CONNECTOR_COMBINABLE) for op in queue
+            ):
+                return expression
 
             while queue:
                 a = queue.popleft()


### PR DESCRIPTION
## What

`_flat_simplify` scans connector operand pairs in O(n²). A pair can only combine when one side is a constant or both are comparisons (see `_simplify_connectors` / `_simplify_comparison`), so when **no** operand is combinable the entire scan is a guaranteed no-op. This adds an early return in that case.

The check lives inside `_flat_simplify` so it reuses the already-flattened operand `queue` (no extra traversal) and is gated on `exp.Connector`, leaving the `simplify_equality` caller unaffected.

## Why

`optimize` was ~O(n²) in the size of a flat boolean condition. A 1000-term `OR` of `AND`s spent ~1M pairwise `_simplify_connectors` calls, **0% of them productive** (the operands are parenthesized ANDs, which are inert).

## Impact

Benchmarks (`optimize`, best of 5):

| input | before | after | |
|---|---|---|---|
| condition_100 | 67.8ms | 54ms | |
| condition_500 | 648.7ms | 297ms | 2.2x |
| condition_1000 | 2124ms | 609ms | 3.5x |

TPC-H is neutral (verified via interleaved A/B). Output is unchanged — the optimizer and transpile fixtures (which assert exact SQL) pass, and the full unit suite is green.