### PR TITLE
fix(bigquery): preserve domain-scoped project IDs [CLAUDE]

### DIFF
--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -140,6 +140,29 @@ def _build_to_hex(args: list) -> exp.Hex | exp.MD5:
     return exp.MD5(this=arg.this) if isinstance(arg, exp.MD5Digest) else exp.LowerHex(this=arg)
 
 
+def _split_name_parts(name: str, min_num_words: int) -> list[str | None]:
+    # A dotted reference (e.g. `project.dataset.table`) is split into a fixed number of
+    # parts, the first of which is the project. Domain-scoped (legacy) project IDs have the
+    # form `domain.com:project-id`, where the dots in the domain are part of the project
+    # identifier, not path separators. We isolate that leading project segment so it isn't
+    # split apart, which would drop the domain prefix and corrupt the project ID.
+    # See: https://docs.cloud.google.com/artifact-registry/docs/docker/names#domain
+    colon = name.find(":")
+    if colon != -1 and "." in name[:colon]:
+        project_end = name.find(".", colon)
+        if project_end == -1:
+            # The domain-scoped project is the whole reference (no dataset/table follows),
+            # so keep it in the last (name) position like any bare identifier. This mirrors
+            # `split_num_words`' default `fill_from_start=True` ordering (`None`s first, value last).
+            return [*([None] * (min_num_words - 1)), name]
+
+        project = name[:project_end]
+        rest = split_num_words(name[project_end + 1 :], ".", min_num_words - 1)
+        return [project, *rest]
+
+    return split_num_words(name, ".", min_num_words)
+
+
 MAKE_INTERVAL_KWARGS = ["year", "month", "day", "hour", "minute", "second"]
 
 
@@ -419,7 +442,7 @@ class BigQueryParser(parser.Parser):
             alias = table.this
             catalog, db, this_id, *rest = (
                 exp.to_identifier(p, quoted=True)
-                for p in split_num_words(".".join(p.name for p in table.parts), ".", 3)
+                for p in _split_name_parts(".".join(p.name for p in table.parts), 3)
             )
 
             for part in (catalog, db, this_id):
@@ -478,7 +501,7 @@ class BigQueryParser(parser.Parser):
             if any("." in p.name for p in parts):
                 catalog, db, table, this, *rest = (
                     exp.to_identifier(p, quoted=True)
-                    for p in split_num_words(".".join(p.name for p in parts), ".", 4)
+                    for p in _split_name_parts(".".join(p.name for p in parts), 4)
                 )
 
                 if rest and this:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -42,6 +42,69 @@ class TestBigQuery(Validator):
         self.assertEqual(table.db, "x-0")
         self.assertEqual(table.name, "_y")
 
+        # Domain-scoped (legacy) project IDs (`domain.com:project-id`) contain dots in
+        # the domain that must not be treated as path separators, otherwise the domain
+        # prefix is dropped and the project ID becomes invalid.
+        table = self.parse_one(
+            "`domain.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`", into=exp.Table
+        )
+        self.assertEqual(table.catalog, "domain.com:project-id")
+        self.assertEqual(table.db, "region-us")
+        self.assertEqual(table.name, "INFORMATION_SCHEMA.JOBS")
+
+        table = self.parse_one("`domain.com:project-id.mydataset.mytable`", into=exp.Table)
+        self.assertEqual(table.catalog, "domain.com:project-id")
+        self.assertEqual(table.db, "mydataset")
+        self.assertEqual(table.name, "mytable")
+
+        # A domain-scoped project with no dataset/table must stay in the name position
+        # (like any bare identifier), not be promoted to catalog — otherwise consumers
+        # that read the identifier's name (e.g. macro interpolation) lose the project.
+        table = self.parse_one("`domain.com:project-id`", into=exp.Table)
+        self.assertEqual(table.name, "domain.com:project-id")
+        self.assertIsNone(table.args.get("catalog"))
+        self.assertIsNone(table.args.get("db"))
+
+        # A colon without a domain (no dot before it) is not a domain-scoped project,
+        # so the reference splits on dots as usual.
+        table = self.parse_one("`proj:weird.ds.tbl`", into=exp.Table)
+        self.assertEqual(table.catalog, "proj:weird")
+        self.assertEqual(table.db, "ds")
+        self.assertEqual(table.name, "tbl")
+
+        # Domains with multiple dots (e.g. `a.b.com:`) are kept intact too.
+        table = self.parse_one("`a.b.com:project-id.mydataset.mytable`", into=exp.Table)
+        self.assertEqual(table.catalog, "a.b.com:project-id")
+        self.assertEqual(table.db, "mydataset")
+        self.assertEqual(table.name, "mytable")
+
+        table = self.parse_one(
+            "`a.b.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`", into=exp.Table
+        )
+        self.assertEqual(table.catalog, "a.b.com:project-id")
+        self.assertEqual(table.db, "region-us")
+        self.assertEqual(table.name, "INFORMATION_SCHEMA.JOBS")
+
+        table = self.parse_one("`a.b.com:project-id`", into=exp.Table)
+        self.assertEqual(table.name, "a.b.com:project-id")
+        self.assertIsNone(table.args.get("catalog"))
+        self.assertIsNone(table.args.get("db"))
+
+        self.validate_identity("SELECT * FROM `domain.com:project-id.mydataset.mytable`")
+        self.validate_identity(
+            "SELECT * FROM `domain.com:project-id.region-us.INFORMATION_SCHEMA`.JOBS",
+            "SELECT * FROM `domain.com:project-id.region-us.INFORMATION_SCHEMA.JOBS` AS JOBS",
+        )
+        self.validate_identity(
+            "SELECT * FROM `domain.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`",
+            "SELECT * FROM `domain.com:project-id.region-us.INFORMATION_SCHEMA.JOBS` AS `domain.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`",
+        )
+        self.validate_identity("SELECT * FROM `a.b.com:project-id.mydataset.mytable`")
+        self.validate_identity(
+            "SELECT * FROM `a.b.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`",
+            "SELECT * FROM `a.b.com:project-id.region-us.INFORMATION_SCHEMA.JOBS` AS `a.b.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`",
+        )
+
         self.validate_identity("SAFE.SOME_RANDOM_FUNC(a, b, c)").assert_is(exp.SafeFunc)
         self.validate_identity(
             "SAFE.SUBSTR('foo', 0, -2)",


### PR DESCRIPTION
Domain-scoped (legacy) BigQuery project IDs have the form `domain.com:project-id`, where the dots in the domain are part of the project identifier rather than path separators. When such a project appeared in a backtick-quoted table reference (e.g. `domain.com:project-id.region-us.INFORMATION_SCHEMA.JOBS`), the parser split the whole name on dots, peeling `domain` off as the catalog and corrupting the project ID into `com:project-id` — which BigQuery rejects as an invalid project ID.

Isolate the leading `domain.com:project-id` segment as the catalog before splitting the remaining dataset/table parts, so the project ID round-trips losslessly. Non-domain-scoped references are unaffected.