### PR TITLE
fix(exasol): transpile MySQL SHOW DATABASES/SCHEMAS to SELECT over SYS.EXA_SCHEMAS [CLAUDE]

### DIFF
--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -916,6 +916,12 @@ class ExasolGenerator(generator.Generator):
             )
             return self.sql(select)
 
+        if expression.name == "DATABASES":
+            select = exp.select(exp.column("SCHEMA_NAME")).from_(
+                exp.table_("EXA_SCHEMAS", db="SYS")
+            )
+            return self.sql(select)
+
         return super().show_sql(expression)
 
     def collate_sql(self, expression: exp.Collate) -> str:

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -1000,6 +1000,18 @@ class TestExasol(Validator):
             },
         )
 
+    def test_show_databases(self):
+        self.validate_all(
+            "SELECT SCHEMA_NAME FROM SYS.EXA_SCHEMAS",
+            read={"mysql": "SHOW DATABASES"},
+            write={"exasol": "SELECT SCHEMA_NAME FROM SYS.EXA_SCHEMAS"},
+        )
+        self.validate_all(
+            "SELECT SCHEMA_NAME FROM SYS.EXA_SCHEMAS",
+            read={"mysql": "SHOW SCHEMAS"},
+            write={"exasol": "SELECT SCHEMA_NAME FROM SYS.EXA_SCHEMAS"},
+        )
+
     def test_group_by_alias_local(self):
         # GROUP BY bare alias -> LOCAL prefix
         self.validate_all(


### PR DESCRIPTION
## What
Teaches the Exasol generator to transpile MySQL/MariaDB `SHOW DATABASES`
(and its alias `SHOW SCHEMAS`) instead of emitting an unsupported empty
statement.

Both parse to `exp.Show(this=DATABASES)`. The generator already handled
`SHOW TABLES`; this adds the sibling `DATABASES` branch in `show_sql`:

    SHOW DATABASES  ->  SELECT SCHEMA_NAME FROM SYS.EXA_SCHEMAS
    SHOW SCHEMAS    ->  SELECT SCHEMA_NAME FROM SYS.EXA_SCHEMAS

`SYS.EXA_SCHEMAS` is the documented Exasol metadata table listing schemas,
the Exasol analogue of a MySQL database.

## Tests
Added `test_show_databases` to `tests/dialects/test_exasol.py` covering
both `SHOW DATABASES` and `SHOW SCHEMAS`. Full `make check` green
(ruff, ruff-format, mypy, pure-Python suite, mypyc-compiled suite).