### PR TITLE
fix(bigquery): avoid self join auto unnest

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4125,7 +4125,7 @@ class Parser:
             normalized_table = _norm(normalized_table, dialect=self.dialect)
 
             if isinstance(table, exp.Table) and not join.args.get("on"):
-                if normalized_table.parts[0].name in refs:
+                if len(normalized_table.parts) > 1 and normalized_table.parts[0].name in refs:
                     table_as_column = table.to_column()
                     unnest = exp.Unnest(expressions=[table_as_column])
 


### PR DESCRIPTION
In the main when we had a self reference in a join, we auto generated an `UNNEST` which is not correct.

This PR fixs this. Keeps the following roundtrip the same.

```
WITH t1 AS (SELECT [1, 2, 3] AS id) SELECT * FROM t1 CROSS JOIN t1 AS t2
```