### PR TITLE
fix(optimizer): handle multi-arg XOR in normalize predicate lengths [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/normalize.py
+++ b/sqlglot/optimizer/normalize.py
@@ -143,7 +143,7 @@ def _predicate_lengths(
         return
 
     depth += 1
-    left, right = expression.args.values()
+    left, right = expression.left, expression.right
 
     if isinstance(expression, exp.And if dnf else exp.Or):
         for a in _predicate_lengths(left, dnf, max_, depth):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -341,6 +341,14 @@ class TestOptimizer(unittest.TestCase):
             "x AND (y OR z)",
         )
 
+        # A multi-argument XOR is a Connector with more than two operands, which
+        # previously crashed predicate-length estimation with
+        # "ValueError: too many values to unpack". See #7698.
+        self.assertEqual(
+            normalization_distance(parse_one("(a AND b) OR XOR(c, d, e)", dialect="mysql")),
+            4,
+        )
+
         self.check_file("normalize", normalize, schema=self.schema)
 
     @patch("sqlglot.generator.logger")


### PR DESCRIPTION
### Problem

`normalize` crashes with `ValueError: too many values to unpack (expected 2)` on boolean expressions containing a function-form `XOR(...)`:

```python
import sqlglot
from sqlglot.optimizer.normalize import normalize

e = sqlglot.parse_one("SELECT * FROM t WHERE (a AND b) OR XOR(c, d, e)", dialect="mysql")
normalize(e)
# ValueError: too many values to unpack (expected 2)
#   sqlglot/optimizer/normalize.py, in _predicate_lengths: left, right = expression.args.values()
```

Closes #7698.

### Cause

`_predicate_lengths()` did `left, right = expression.args.values()`, assuming every `exp.Connector` has exactly two operands (`this`, `expression`). That holds for `And`/`Or` and binary `a XOR b`, but `Xor` is also a `Func`, so the function form `XOR(a, b, c)` parses to a `Connector` whose `args` also include `expressions` (and `round_input`) — more than two values — and the unpack fails.

### Fix

Use the canonical `Connector.left` / `Connector.right` accessors instead of unpacking the raw args dict. Behavior is unchanged for all two-operand connectors; multi-arg `Xor` no longer crashes.

### Tests

Added a regression assertion to `test_normalize` exercising `normalization_distance` on `(a AND b) OR XOR(c, d, e)`. `python -m unittest tests.test_optimizer` passes (79 tests); `ruff` and `mypy` are clean.

---
Disclosure: prepared with the assistance of an AI agent (model: Claude), per the repository's contributor policy.