### PR TITLE
fix(mypyc): support interpreted dialect plugin subclasses under sqlglot[c]

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -18,6 +18,7 @@ from sqlglot.helper import (
     AutoName,
     flatten,
     is_int,
+    mypyc_attr,
     seq_get,
     suggest_closest_match_and_fail,
     to_bool,
@@ -321,6 +322,7 @@ class _Dialect(type):
         return klass
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class Dialect(metaclass=_Dialect):
     INDEX_OFFSET = 0
     """The base index offset for arrays."""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -9,7 +9,7 @@ from functools import reduce, wraps
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel, UnsupportedError, concat_messages
 from sqlglot.expressions import apply_index_offset
-from sqlglot.helper import csv, name_sequence, seq_get
+from sqlglot.helper import csv, mypyc_attr, name_sequence, seq_get
 from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSON_PATH_PART_TRANSFORMS
 from sqlglot.time import format_time
 from sqlglot.tokens import TokenType
@@ -92,6 +92,7 @@ def _build_dispatch(
     return dispatch
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class Generator:
     """
     Generator converts a given syntax tree to the corresponding SQL string.

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -16,7 +16,7 @@ from sqlglot.errors import (
     merge_errors,
 )
 from sqlglot.expressions import apply_index_offset
-from sqlglot.helper import ensure_list, i64, seq_get
+from sqlglot.helper import ensure_list, i64, mypyc_attr, seq_get
 from sqlglot.trie import new_trie
 from sqlglot.time import format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
@@ -287,6 +287,7 @@ def _unpivot_target(expr: exp.Expr) -> exp.Expr:
 SENTINEL_NONE: Token = Token(TokenType.SENTINEL, "SENTINEL")
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class Parser:
     """
     Parser consumes a list of tokens produced by the Tokenizer and produces a parsed syntax tree.
@@ -1887,7 +1888,7 @@ class Parser:
         self._chunk_index = 0
         self._node_count = 0
 
-    def _advance(self, times: i64 = 1) -> None:
+    def _advance(self, times: int = 1) -> None:
         index = self._index + times
         self._index = index
         tokens = self._tokens

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -4,6 +4,7 @@ import threading
 import typing as t
 
 from sqlglot.trie import new_trie
+from sqlglot.helper import mypyc_attr
 
 from sqlglot.tokenizer_core import Token, TokenizerCore, TokenType
 
@@ -132,6 +133,7 @@ class _TokenizerBase:
         )
 
 
+@mypyc_attr(allow_interpreted_subclasses=True)
 class Tokenizer(_TokenizerBase):
     SINGLE_TOKENS = {
         "(": TokenType.L_PAREN,

--- a/tests/test_dialect_entry_points.py
+++ b/tests/test_dialect_entry_points.py
@@ -1,12 +1,34 @@
 import unittest
 from unittest.mock import Mock, patch
 
+import sqlglot
 from sqlglot import Dialect
 from sqlglot.dialects.dialect import Dialect as DialectBase
+from sqlglot.generator import Generator
+from sqlglot.parser import Parser
+from sqlglot.tokens import Tokenizer
 
 
 class FakeDialect(DialectBase):
     pass
+
+
+class PluginDialect(DialectBase):
+    """A pure-Python dialect plugin, mimicking an external entry-point dialect.
+
+    Its nested Tokenizer/Parser/Generator are interpreted subclasses of the
+    (possibly mypyc-compiled) base classes. Instantiating them must not raise
+    "interpreted classes cannot inherit from compiled" under the sqlglot[c] build.
+    """
+
+    class Tokenizer(Tokenizer):
+        pass
+
+    class Parser(Parser):
+        pass
+
+    class Generator(Generator):
+        pass
 
 
 class TestDialectEntryPoints(unittest.TestCase):
@@ -62,3 +84,19 @@ class TestDialectEntryPoints(unittest.TestCase):
             dialect = Dialect.get("nonexistent")
 
         self.assertIsNone(dialect)
+
+    def test_interpreted_subclass_roundtrip(self):
+        # A pure-Python dialect whose Parser/Generator/Tokenizer subclass the
+        # base classes must parse and generate even when those bases are
+        # mypyc-compiled (sqlglot[c]). Regression test for external dialect
+        # plugins breaking with "interpreted classes cannot inherit from compiled".
+        self.assertEqual(
+            sqlglot.transpile("SELECT 1 AS x FROM t", read=PluginDialect, write=PluginDialect),
+            ["SELECT 1 AS x FROM t"],
+        )
+
+    def test_interpreted_subclass_instantiation(self):
+        dialect = PluginDialect()
+        self.assertIsInstance(dialect.tokenizer(), Tokenizer)
+        self.assertIsInstance(dialect.parser(), Parser)
+        self.assertIsInstance(dialect.generator(), Generator)


### PR DESCRIPTION
## Problem

External dialect plugins registered via the `sqlglot.dialects` entry point work on `pip install sqlglot` but break on `pip install sqlglot[c]`.

mypyc compiles `Parser` and `Generator` into native classes. An interpreted (pure-Python) class can't subclass a native one unless the base is decorated with `@mypyc_attr(allow_interpreted_subclasses=True)`. None of the base classes carry it, so every external plugin fails on first parse:

```
TypeError: interpreted classes cannot inherit from compiled
```

Reproduced with `sqlglot[c]` + `ydb-sqlglot-plugin==0.2.8`:

```python
sqlglot.parse_one("SELECT 1 FROM t", dialect="ydb")  # TypeError
```

## Fix

Two changes, both required:

1. **`@mypyc_attr(allow_interpreted_subclasses=True)`** on `Dialect`, `Parser`, `Generator`, `Tokenizer`. Removes the instantiation error:

   ```
   TypeError: interpreted classes cannot inherit from compiled
   ```

   No-op for the pure-Python build (`mypyc_attr` already has a no-op fallback in `helper.py`).

2. **`Parser._advance(self, times: i64 = 1)` → `times: int = 1`.** The decorator alone is insufficient: with it, the subclass instantiates but parsing still fails on every query:

   ```
   sqlglot.errors.ParseError: Invalid expression / Unexpected token. Line 1, Col: 8.
   ```

   A native `i64` default argument is passed as `0` instead of `1` when the method is called across the compiled→interpreted-subclass boundary, so the parser cursor never advances. This is the only `i64`-typed parameter with a default in the codebase. Changing it to `int` fixes parsing.

## Notes

Only `Parser` and `Generator` are currently compiled, so the decorator is strictly required just on those two. We took the liberty of also adding it to `Dialect` and `Tokenizer`: it's a no-op for them today (and in the pure-Python build), but it future-proofs the plugin contract should those classes be added to the compilation group later.
