### PR TITLE
Fix!: parse xor(a,b,c) as xor(a,xor(b,c)), fix value unpacking bug in `normalize`

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2278,8 +2278,7 @@ class Or(Expression, Connector, Func):
 
 
 class Xor(Expression, Connector, Func):
-    arg_types = {"this": False, "expression": False, "expressions": False, "round_input": False}
-    is_var_len_args = True
+    arg_types = {"this": True, "expression": True, "round_input": False}
 
 
 class Pow(Expression, Binary, Func):

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -349,7 +349,7 @@ class ClickHouseGenerator(generator.Generator):
         exp.TimestampSub: _datetime_delta_sql("TIMESTAMP_SUB"),
         exp.Typeof: rename_func("toTypeName"),
         exp.VarMap: _map_sql,
-        exp.Xor: lambda self, e: self.func("xor", e.this, e.expression, *e.expressions),
+        exp.Xor: lambda self, e: self.func("xor", e.this, e.expression),
         exp.MD5Digest: rename_func("MD5"),
         exp.MD5: lambda self, e: self.func("LOWER", self.func("HEX", self.func("MD5", e.this))),
         exp.SHA: rename_func("SHA1"),

--- a/sqlglot/optimizer/normalize.py
+++ b/sqlglot/optimizer/normalize.py
@@ -143,7 +143,7 @@ def _predicate_lengths(
         return
 
     depth += 1
-    left, right = expression.args.values()
+    left, right = expression.left, expression.right
 
     if isinstance(expression, exp.And if dnf else exp.Or):
         for a in _predicate_lengths(left, dnf, max_, depth):

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -296,7 +296,6 @@ class ClickHouseParser(parser.Parser):
         "TIMESTAMPADD": build_date_delta(exp.TimestampAdd, default_unit=None),
         "TOMONDAY": _build_timestamp_trunc("WEEK"),
         "UNIQ": exp.ApproxDistinct.from_arg_list,
-        "XOR": lambda args: exp.Xor(expressions=args),
         "MD5": exp.MD5Digest.from_arg_list,
         "SHA256": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(256)),
         "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
@@ -370,6 +369,7 @@ class ClickHouseParser(parser.Parser):
         "TUPLE": lambda self: exp.Struct.from_arg_list(self._parse_function_args(alias=True)),
         "AND": lambda self: exp.and_(*self._parse_function_args(alias=False)),
         "OR": lambda self: exp.or_(*self._parse_function_args(alias=False)),
+        "XOR": lambda self: exp.xor(*self._parse_function_args(alias=False)),
     }
 
     PROPERTY_PARSERS = {

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -454,22 +454,24 @@ class TestClickhouse(Validator):
         self.validate_all(
             "SELECT xor(0, 1, xor(1, 0, 0))",
             write={
-                "clickhouse": "SELECT xor(0, 1, xor(1, 0, 0))",
-                "mysql": "SELECT 0 XOR 1 XOR 1 XOR 0 XOR 0",
+                "clickhouse": "SELECT xor(xor(0, 1), (xor(xor(1, 0), 0)))",
+                "mysql": "SELECT 0 XOR 1 XOR (1 XOR 0 XOR 0)",
             },
         )
         self.validate_all(
             "SELECT xor(xor(1, 0), 1)",
             read={
-                "clickhouse": "SELECT xor(xor(1, 0), 1)",
                 "mysql": "SELECT 1 XOR 0 XOR 1",
             },
             write={
-                "clickhouse": "SELECT xor(xor(1, 0), 1)",
-                "mysql": "SELECT 1 XOR 0 XOR 1",
+                "clickhouse": "SELECT xor((xor(1, 0)), 1)",
+                "mysql": "SELECT (1 XOR 0) XOR 1",
             },
         )
-        self.validate_identity("SELECT xor(0, 1, 1, 0)")
+        self.validate_identity(
+            "SELECT xor(0, 1, 1, 0)",
+            "SELECT xor(xor(xor(0, 1), 1), 0)",
+        )
         self.validate_all(
             "CONCAT(a, b)",
             read={

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -341,6 +341,16 @@ class TestOptimizer(unittest.TestCase):
             "x AND (y OR z)",
         )
 
+        # Snowflake's BOOLXOR builds a Xor connector carrying a `round_input` arg, so unpacking
+        # via args.values() yields 3 values. The enclosing predicate isn't normalized, which forces
+        # _predicate_lengths to recurse into the Xor node.
+        self.assertEqual(
+            optimizer.normalize.normalize(
+                parse_one("(a AND b) OR BOOLXOR(x, y)", read="snowflake"),
+            ).sql(dialect="snowflake"),
+            "((BOOLXOR(x, y)) OR a) AND ((BOOLXOR(x, y)) OR b)",
+        )
+
         self.check_file("normalize", normalize, schema=self.schema)
 
     @patch("sqlglot.generator.logger")


### PR DESCRIPTION
Fixes #7698

The `xor` change is consistent with how the other connectors (`and`, `or`) are handled by ClickHouse's parser.
