### PR TITLE
Perf: improve `__hash__` performance

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -837,26 +837,35 @@ class Expression(Expr):
     def __hash__(self) -> int:
         if self._hash is None:
             nodes: list[Expr] = []
-            queue: deque[Expr] = deque()
-            queue.append(self)
+            stack: list[Expr] = [self]
 
-            while queue:
-                node = queue.popleft()
+            # Collect nodes, finding child expressions inline instead of via the
+            # iter_expressions generator (whose per-node generator object dominates the
+            # hash's cost). reversed(nodes) is a valid post-order regardless of DFS/BFS.
+            while stack:
+                node = stack.pop()
                 nodes.append(node)
 
-                for child in node.iter_expressions():
-                    if child._hash is None:
-                        queue.append(child)
+                for v in node.args.values():
+                    if isinstance(v, Expr):
+                        if v._hash is None:
+                            stack.append(v)
+                    elif type(v) is list:
+                        for x in v:
+                            if isinstance(x, Expr) and x._hash is None:
+                                stack.append(x)
 
             for node in reversed(nodes):
                 hash_ = hash(node.key)
 
                 if node._hash_raw_args:
-                    for k, v in sorted(node.args.items()):
+                    for k in sorted(node.args):
+                        v = node.args[k]
                         if v:
                             hash_ = hash((hash_, k, v))
                 else:
-                    for k, v in sorted(node.args.items()):
+                    for k in sorted(node.args):
+                        v = node.args[k]
                         vt = type(v)
 
                         if vt is list:


### PR DESCRIPTION
Profiling the compiled hash showed it was allocation-bound, not compute-bound. Actual hashing was ~3% of samples; the rest was Python object churn. Two changes remove the biggest allocation sources:

  1. Drop the `iter_expressions()` generator in the traversal. Instead, walk `args.values()` inline (list-stack DFS), avoiding a generator object + `StopIteration` per node
  2. Sort keys, not items: `sorted(node.args)` + lookup instead of `sorted(node.args.items())`, avoiding a `(k, v)` tuple per arg.

Results (isolated `__hash__`, best-of-N):

```
  ┌──────────────────┬─────────┬─────────┬─────────┐
  │                  │ before  │  after  │ speedup │
  ├──────────────────┼─────────┼─────────┼─────────┤
  │ pure Python      │ 36.3 ms │ 27.4 ms │ 1.33×   │
  ├──────────────────┼─────────┼─────────┼─────────┤
  │ compiled (mypyc) │ 19.8 ms │ 13.1 ms │ 1.52×   │
  └──────────────────┴─────────┴─────────┴─────────┘
```

The numbers come from this isolated `__hash__` benchmark. It builds 2000 fresh trees (~26 nodes each) and times `hash()` on each.

```python
# bench_hash.py
import time
from sqlglot import exp

def build_operand(j, cols=5):
    return (
        exp.select(*(exp.column(f"col_{k}", f"t{j}") for k in range(cols)))
        .from_(f"schema.table_{j}")
        .where(exp.column("ts", f"t{j}") > exp.Literal.number(j))
    )

N = 2000
def fresh():
    return [build_operand(i) for i in range(N)]

def best(fn, r=11):
    b = float("inf")
    for _ in range(r):
        o = fresh()                       # fresh => cold _hash caches
        t = time.perf_counter()
        fn(o)
        b = min(b, time.perf_counter() - t)
    return b * 1000

print(f"{best(lambda o: [hash(e) for e in o]):.2f}")  # ms
```

How I ran it for the before/after, in each mode:

```bash
# pure Python
make clean
python bench_hash.py                 # = "after" (branch checked out)
git stash && python bench_hash.py    # = "before" (original)
git stash pop

# compiled — recompile between each
make install-devc-release && python bench_hash.py
git stash && make install-devc-release && python bench_hash.py && git stash pop
```