### PR TITLE
Fix: Make `DataType.type` return `self`

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -88,6 +88,7 @@ class Expr:
     _hash_raw_args: t.ClassVar[bool] = False
     is_subquery: t.ClassVar[bool] = False
     is_cast: t.ClassVar[bool] = False
+    is_data_type: t.ClassVar[bool] = False
 
     args: dict[str, t.Any]
     parent: Expr | None
@@ -953,6 +954,8 @@ class Expression(Expr):
 
     @property
     def type(self) -> DataType | None:
+        if self.is_data_type:
+            return self  # type: ignore[return-value]
         if self.is_cast:
             return self._type or self.to  # type: ignore[attr-defined]
         return self._type
@@ -2544,7 +2547,7 @@ def _to_s(node: t.Any, verbose: bool = False, level: int = 0, repr_str: bool = F
     if isinstance(node, Expr):
         args = {k: v for k, v in node.args.items() if (v is not None and v != []) or verbose}
 
-        if (node.type or verbose) and type(node).__name__ != "DataType":
+        if (node.type or verbose) and not node.is_data_type:
             args["_type"] = node.type
         if node.comments or verbose:
             args["_comments"] = node.comments

--- a/sqlglot/expressions/datatypes.py
+++ b/sqlglot/expressions/datatypes.py
@@ -187,6 +187,8 @@ class DataType(Expression):
         "collate": False,
     }
 
+    is_data_type: t.ClassVar[bool] = True
+
     Type: t.ClassVar[Type[DType]] = DType
 
     STRUCT_TYPES: t.ClassVar[set[DType]] = {

--- a/sqlglot/serde.py
+++ b/sqlglot/serde.py
@@ -50,7 +50,7 @@ def dump(expression: exp.Expr) -> list[dict[str, t.Any]]:
 
             payload[CLASS] = klass
 
-            if node.type:
+            if node.type and node.type is not node:
                 payload[TYPE] = dump(node.type)
             if node.comments:
                 payload[COMMENTS] = node.comments

--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -332,7 +332,7 @@ EXPRESSION_METADATA: ExprMetadataType = {
             e, exp.DType.BIGINT if e.args.get("big_int") else exp.DType.INT
         )
     },
-    exp.DataType: {"annotator": lambda self, e: self._set_type(e, e.copy())},
+    exp.DataType: {"annotator": lambda _, e: e},
     exp.Div: {"annotator": lambda self, e: self._annotate_div(e)},
     exp.Distinct: {"annotator": lambda self, e: self._annotate_by_args(e, "expressions")},
     exp.Dot: {"annotator": lambda self, e: self._annotate_dot(e)},


### PR DESCRIPTION
Copying expressions after `annotate_types` has run can be extremely slow e.g a deeply nested 150-field `STRUCT` can take upwarads of 100 seconds to copy, long enough to look like a hang. Most expressions are fine; the cost only shows up once the annotated type is large and nested.

Two innocuous pieces compound:

1. The `DataType` annotator stores a clone of each node in its own `_type`. As far as I can tell, `.copy()` is in place so that walking `e._type` does not run into infinite recursion (e.g. in `serde.dump`).

2. `Expr.__deepcopy__` recursively deep-clones `_type`

After (1), every `DataType` carries a near-clone of itself in `_type`. After (2), copying a node walks both the node and that clone. 

The clone has the same nested `DataType` children, each with their own `_type` clone, so the work doubles at every nesting level. Width W, depth D -> one `copy()` walks ~2^D · W nodes, and the annotator makes ~W * D of them.

PS:  The memo additions on `comments` and `_meta` are a separate correctness issue. Those lines already called `deepcopy(...)` without forwarding `memo` which silently breaks cycle detection and shared-reference preservation in the stdlib `deepcopy` protocol. 