### PR TITLE
feat(duckdb): Add transpilation support for Snowflake STARTS WITH ... CONNECT BY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ bench-transpile:
 bench-optimize:
 	python -m benchmarks.optimize
 
+BRANCH_BASE ?= main
+
 test: hidec
 	trap '$(MAKE) showc' EXIT; python -m unittest
 
 test-fast:
 	python -m unittest --failfast
-
-BRANCH_BASE ?= main
 
 test-branch:
 	@changed_main=$$({ git diff origin/$(BRANCH_BASE)...HEAD --name-only 2>/dev/null; git diff HEAD --name-only; git diff --cached --name-only; } \

--- a/Makefile
+++ b/Makefile
@@ -79,13 +79,13 @@ bench-transpile:
 bench-optimize:
 	python -m benchmarks.optimize
 
-BRANCH_BASE ?= main
-
 test: hidec
 	trap '$(MAKE) showc' EXIT; python -m unittest
 
 test-fast:
 	python -m unittest --failfast
+
+BRANCH_BASE ?= main
 
 test-branch:
 	@changed_main=$$({ git diff origin/$(BRANCH_BASE)...HEAD --name-only 2>/dev/null; git diff HEAD --name-only; git diff --cached --name-only; } \

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -41,6 +41,8 @@ from sqlglot.helper import find_new_name, is_date_unit, seq_get
 from sqlglot.optimizer.scope import find_all_in_scope
 from builtins import type as Type
 
+_CONNECT_BY_ARGS_TO_SKIP = frozenset({"connect", "where", "from_", "with_", "expressions"})
+
 # Regex to detect time zones in timestamps of the form [+|-]TT[:tt]
 # The pattern matches timezone offsets that appear after the time portion
 TIMEZONE_PATTERN = re.compile(r":\d{2}.*?[+\-]\d{2}(?::\d{2})?")
@@ -794,7 +796,7 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
     )
 
     for arg, val in expression.args.items():
-        if val and arg not in {"connect", "where", "from_", "with_", "expressions"}:
+        if val and arg not in _CONNECT_BY_ARGS_TO_SKIP:
             outer_query.set(arg, val)
 
     # Strip stale source table qualifiers in one pass; CTEs are child scopes so

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -710,20 +710,16 @@ def _seq_to_range_in_generator(expression: exp.Expr) -> exp.Expr:
 
 
 def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
-    # Rewrites START WITH ... CONNECT BY PRIOR into WITH RECURSIVE with path-based cycle detection.
-    # Falls through unchanged for multiple PRIORs or a non-column PRIOR expression.
+    # Rewrites START WITH ... CONNECT BY PRIOR into WITH RECURSIVE
+    # Falls through unchanged if there are no PRIORs.
     if not isinstance(expression, exp.Select) or not expression.args.get("connect"):
         return expression
 
     connect = expression.args["connect"]
-    connect_pred = connect.args.get("connect")
+    connect_pred = connect.args["connect"]
 
     priors = list(connect_pred.find_all(exp.Prior))
-    if len(priors) != 1:
-        return expression
-
-    prior = priors[0]
-    if not isinstance(prior.this, exp.Column):
+    if not priors:
         return expression
 
     from_ = expression.args.get("from_")
@@ -733,7 +729,7 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
     # Pull everything we need from the original SELECT up front.
     source_table = from_.this
     source_table_alias = source_table.alias
-    child_col_name = prior.this.name
+    prior_col_names = [p.this.name for p in priors if isinstance(p.this, exp.Column)]
     base_select_exprs = expression.expressions
     base_where = expression.args.get("where")
     base_with = expression.args.get("with_")
@@ -762,14 +758,15 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
             for col in (base_where.find_all(exp.Column) if base_where else [])
             if (not col.table or col.table == source_table_alias) and col.name not in select_names
         )
-    # The PRIOR column must be projected into the CTE so _parent_row.<col> is valid in the join.
-    if not has_star and child_col_name not in select_names:
-        extra_cols.setdefault(child_col_name, None)
+    # All PRIOR columns must be projected into the CTE so _parent_row.<col> is valid in the join.
+    if not has_star:
+        for col_name in prior_col_names:
+            if col_name not in select_names:
+                extra_cols.setdefault(col_name, None)
 
-    # Anchor: seed LEVEL at 1 and start the ancestor path with the root's parent key value.
+    # Anchor: seed LEVEL at 1.
     anchor_projs = non_level_exprs + [exp.column(c) for c in extra_cols]
     anchor_projs.append(exp.alias_(exp.Literal.number(1), "level"))
-    anchor_projs.append(exp.alias_(exp.array(exp.column(child_col_name)), "_path"))
     anchor = exp.select(*anchor_projs).from_(source_table)
     if connect.args.get("start"):
         anchor = anchor.where(connect.args["start"])
@@ -799,9 +796,6 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
 
         return node.transform(_transform)
 
-    parent_row = exp.column("_path", "_parent_row")
-    child_row = exp.column(child_col_name, "_child_row")
-
     inner_select_exprs: list[exp.Expr] = [
         exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row"))
         if e.is_star
@@ -810,7 +804,6 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
     ]
     inner_select_exprs += [exp.column(c, "_child_row") for c in extra_cols]
     inner_select_exprs.append(exp.alias_(exp.column("level", "_parent_row") + 1, "level"))
-    inner_select_exprs.append(exp.alias_(exp.func("LIST_APPEND", parent_row, child_row), "_path"))
 
     # Avoid colliding with any CTE names already on the query.
     cte_name = find_new_name(
@@ -822,7 +815,6 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
         exp.select(*inner_select_exprs)
         .from_(source_table.as_("_child_row"))
         .join(exp.to_table(cte_name).as_("_parent_row"), on=_qualify_connect_pred(connect_pred))
-        .where(exp.not_(exp.func("LIST_CONTAINS", parent_row, child_row)))
     )
 
     # CTE body is anchor UNION ALL recursive arm.
@@ -831,12 +823,12 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
         alias=exp.TableAlias(this=exp.to_identifier(cte_name)),
     )
 
-    # Outer SELECT re-projects from the CTE. Synthetic _path and level columns are excluded.
+    # Outer SELECT re-projects from the CTE. Synthetic level column is excluded unless referenced.
     # Explicit LEVEL references are projected from the CTE's computed column, preserving aliases.
     if has_star:
-        exclude = [] if has_level else [exp.column("level")]
-        exclude.append(exp.column("_path"))
-        outer_select_exprs: list[exp.Expr] = [exp.Star(except_=exclude)]
+        outer_select_exprs: list[exp.Expr] = (
+            [exp.Star()] if has_level else [exp.Star(except_=[exp.column("level")])]
+        )
     else:
 
         def _replace_level(n: exp.Expression) -> exp.Expression:

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -726,50 +726,19 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
     if not from_ or expression.args.get("joins"):
         return expression
 
-    # Pull everything we need from the original SELECT up front.
     source_table = from_.this
     source_table_alias = source_table.alias
-    prior_col_names = [p.this.name for p in priors if isinstance(p.this, exp.Column)]
     base_select_exprs = expression.expressions
     base_where = expression.args.get("where")
     base_with = expression.args.get("with_")
 
-    # LEVEL is a Snowflake pseudo-column: it's always computed as a depth counter in the CTE
-    # Raw LEVEL column refs are replaced with the computed value
-    def _has_level_ref(e: exp.Expr) -> bool:
-        return any(
-            isinstance(col, exp.Column) and col.name.upper() == "LEVEL" and not col.table
-            for col in e.find_all(exp.Column)
-        )
-
-    level_exprs = [e for e in base_select_exprs if _has_level_ref(e)]
-    non_level_exprs = [e for e in base_select_exprs if not _has_level_ref(e)]
-    has_level = bool(level_exprs)
+    # LEVEL is a Snowflake pseudo-column: it's always computed as a depth counter in the CTE.
+    has_level = any(
+        isinstance(col, exp.Column) and col.name.upper() == "LEVEL" and not col.table
+        for e in base_select_exprs
+        for col in e.find_all(exp.Column)
+    )
     has_star = expression.is_star
-
-    # WHERE columns absent from SELECT must be carried through the CTE so the outer filter can see them.
-    # With SELECT *, all columns are already included so no extras are needed.
-    select_names = expression.named_selects
-    if has_star:
-        extra_cols = {}
-    else:
-        extra_cols = dict.fromkeys(
-            col.name
-            for col in (base_where.find_all(exp.Column) if base_where else [])
-            if (not col.table or col.table == source_table_alias) and col.name not in select_names
-        )
-    # All PRIOR columns must be projected into the CTE so _parent_row.<col> is valid in the join.
-    if not has_star:
-        for col_name in prior_col_names:
-            if col_name not in select_names:
-                extra_cols.setdefault(col_name, None)
-
-    # Anchor: seed LEVEL at 1.
-    anchor_projs = non_level_exprs + [exp.column(c) for c in extra_cols]
-    anchor_projs.append(exp.alias_(exp.Literal.number(1), "level"))
-    anchor = exp.select(*anchor_projs).from_(source_table)
-    if connect.args.get("start"):
-        anchor = anchor.where(connect.args["start"])
 
     def _qualify_cols(node: exp.Expression, table: str) -> exp.Expression:
         def _transform(n: exp.Expression) -> exp.Expression:
@@ -796,35 +765,28 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
 
         return node.transform(_transform)
 
-    inner_select_exprs: list[exp.Expr] = [
-        exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row"))
-        if e.is_star
-        else exp.column(e.alias_or_name, "_child_row")
-        for e in non_level_exprs
-    ]
-    inner_select_exprs += [exp.column(c, "_child_row") for c in extra_cols]
-    inner_select_exprs.append(exp.alias_(exp.column("level", "_parent_row") + 1, "level"))
-
     # Avoid colliding with any CTE names already on the query.
     cte_name = find_new_name(
         {cte.alias for cte in (base_with.expressions if base_with else [])}, "_rootcte"
     )
 
-    # Build main query body
+    # Anchor: project all source columns + seed LEVEL at 1.
+    anchor = exp.select(exp.Star(), exp.alias_(exp.Literal.number(1), "level")).from_(source_table)
+    if connect.args.get("start"):
+        anchor = anchor.where(connect.args["start"])
+
+    # Recursive arm: carry all child columns + increment level.
+    # SELECT * in both arms means WHERE/PRIOR columns are always available without explicit tracking.
     inner_query = (
-        exp.select(*inner_select_exprs)
+        exp.select(
+            exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row")),
+            exp.alias_(exp.column("level", "_parent_row") + 1, "level"),
+        )
         .from_(source_table.as_("_child_row"))
         .join(exp.to_table(cte_name).as_("_parent_row"), on=_qualify_connect_pred(connect_pred))
     )
 
-    # CTE body is anchor UNION ALL recursive arm.
-    cte = exp.CTE(
-        this=anchor.union(inner_query, distinct=False),
-        alias=exp.TableAlias(this=exp.to_identifier(cte_name)),
-    )
-
     # Outer SELECT re-projects from the CTE. Synthetic level column is excluded unless referenced.
-    # Explicit LEVEL references are projected from the CTE's computed column, preserving aliases.
     if has_star:
         outer_select_exprs: list[exp.Expr] = (
             [exp.Star()] if has_level else [exp.Star(except_=[exp.column("level")])]
@@ -837,10 +799,7 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
             return n
 
         outer_select_exprs = [
-            e.transform(_replace_level)
-            if _has_level_ref(e)
-            else exp.column(e.alias_or_name, cte_name)
-            for e in base_select_exprs
+            _qualify_cols(e.transform(_replace_level), cte_name) for e in base_select_exprs
         ]
     outer_query = exp.select(*outer_select_exprs).from_(cte_name)
     if base_where:
@@ -848,12 +807,10 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
 
     # Attach the CTE, marking the WITH clause recursive.
     if base_with:
-        new_with = base_with.copy()
-        new_with.set("recursive", True)
-        new_with.expressions.append(cte)
-        outer_query.set("with_", new_with)
-    else:
-        outer_query.set("with_", exp.With(expressions=[cte], recursive=True))
+        outer_query.set("with_", base_with.copy())
+    outer_query = outer_query.with_(
+        cte_name, as_=anchor.union(inner_query, distinct=False), recursive=True
+    )
 
     for arg in exp.QUERY_MODIFIERS:
         if arg not in ("connect", "where") and (val := expression.args.get(arg)):

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -38,6 +38,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import find_new_name, is_date_unit, seq_get
+from sqlglot.optimizer.scope import find_all_in_scope
 from builtins import type as Type
 
 # Regex to detect time zones in timestamps of the form [+|-]TT[:tt]
@@ -727,70 +728,31 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
         return expression
 
     source_table = from_.this
-    source_table_alias = source_table.alias
     base_select_exprs = expression.expressions
     base_where = expression.args.get("where")
     base_with = expression.args.get("with_")
 
     # LEVEL is a Snowflake pseudo-column: it's always computed as a depth counter in the CTE.
     has_level = any(
-        isinstance(col, exp.Column) and col.name.upper() == "LEVEL" and not col.table
+        isinstance(col, exp.Column) and col.name.upper() == "LEVEL"
         for e in base_select_exprs
         for col in e.find_all(exp.Column)
     )
     has_star = expression.is_star
 
-    def _scoped_transform(
-        node: exp.Expression, fn: t.Callable[[exp.Expression], exp.Expression]
-    ) -> exp.Expression:
-        if isinstance(node, exp.Subquery):
-            return node
-        result = fn(node)
-        if result is not node:
-            return result
-        node = node.copy()
-        for key, value in node.args.items():
-            if isinstance(value, exp.Expression):
-                node.set(key, _scoped_transform(value, fn))
-            elif isinstance(value, list):
-                node.set(
-                    key,
-                    [
-                        _scoped_transform(v, fn) if isinstance(v, exp.Expression) else v
-                        for v in value
-                    ],
-                )
-        return node
-
-    def _qualify_cols(
-        node: exp.Expression, table: str, replace_level: bool = False
-    ) -> exp.Expression:
-        def _fn(n: exp.Expression) -> exp.Expression:
-            if isinstance(n, exp.Column):
-                if replace_level and n.name.upper() == "LEVEL" and not n.table:
-                    return exp.column("level", table)
-                if not n.table or n.table == source_table_alias:
-                    return exp.column(n.name, table)
-            return n
-
-        return _scoped_transform(node, _fn)
-
     # Build the join condition from the full CONNECT BY predicate:
     # PRIOR(col) → _parent_row.col, unqualified cols → _child_row.col.
     def _qualify_connect_pred(node: exp.Expression) -> exp.Expression:
-        def _fn(n: exp.Expression) -> exp.Expression:
-            if isinstance(n, exp.Prior):
-                inner = n.this
-                if isinstance(inner, exp.Column) and (
-                    not inner.table or inner.table == source_table_alias
-                ):
-                    return exp.column(inner.name, "_parent_row")
-                return inner
-            if isinstance(n, exp.Column) and (not n.table or n.table == source_table_alias):
-                return exp.column(n.name, "_child_row")
-            return n
-
-        return _scoped_transform(node, _fn)
+        for col in find_all_in_scope(node, exp.Column):
+            col.set(
+                "table",
+                exp.to_identifier(
+                    "_parent_row" if isinstance(col.parent, exp.Prior) else "_child_row"
+                ),
+            )
+        for prior in find_all_in_scope(node, exp.Prior):
+            prior.replace(prior.this)
+        return node
 
     # Avoid colliding with any CTE names already on the query.
     cte_name = find_new_name(
@@ -819,23 +781,26 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
             [exp.Star()] if has_level else [exp.Star(except_=[exp.column("level")])]
         )
     else:
-        outer_select_exprs = [
-            _qualify_cols(e, cte_name, replace_level=True) for e in base_select_exprs
-        ]
+        outer_select_exprs = base_select_exprs
     outer_query = exp.select(*outer_select_exprs).from_(cte_name)
     if base_where:
-        outer_query = outer_query.where(_qualify_cols(base_where.this, cte_name))
+        outer_query = outer_query.where(base_where.this)
 
     # Attach the CTE, marking the WITH clause recursive.
     if base_with:
-        outer_query.set("with_", base_with.copy())
+        outer_query.set("with_", base_with)
     outer_query = outer_query.with_(
-        cte_name, as_=anchor.union(inner_query, distinct=False), recursive=True
+        cte_name, as_=anchor.union(inner_query, distinct=False), recursive=True, copy=False
     )
 
-    for arg in exp.QUERY_MODIFIERS:
-        if arg not in ("connect", "where") and (val := expression.args.get(arg)):
+    for arg, val in expression.args.items():
+        if val and arg not in {"connect", "where", "from_", "with_", "expressions"}:
             outer_query.set(arg, val)
+
+    # Strip stale source table qualifiers in one pass; CTEs are child scopes so
+    # find_all_in_scope stays within the outer query only.
+    for col in find_all_in_scope(outer_query, exp.Column):
+        col.set("table", None)
 
     return outer_query
 

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -740,18 +740,45 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
     )
     has_star = expression.is_star
 
-    def _qualify_cols(node: exp.Expression, table: str) -> exp.Expression:
-        def _transform(n: exp.Expression) -> exp.Expression:
-            if isinstance(n, exp.Column) and (not n.table or n.table == source_table_alias):
-                return exp.column(n.name, table)
+    def _scoped_transform(
+        node: exp.Expression, fn: t.Callable[[exp.Expression], exp.Expression]
+    ) -> exp.Expression:
+        if isinstance(node, exp.Subquery):
+            return node
+        result = fn(node)
+        if result is not node:
+            return result
+        node = node.copy()
+        for key, value in node.args.items():
+            if isinstance(value, exp.Expression):
+                node.set(key, _scoped_transform(value, fn))
+            elif isinstance(value, list):
+                node.set(
+                    key,
+                    [
+                        _scoped_transform(v, fn) if isinstance(v, exp.Expression) else v
+                        for v in value
+                    ],
+                )
+        return node
+
+    def _qualify_cols(
+        node: exp.Expression, table: str, replace_level: bool = False
+    ) -> exp.Expression:
+        def _fn(n: exp.Expression) -> exp.Expression:
+            if isinstance(n, exp.Column):
+                if replace_level and n.name.upper() == "LEVEL" and not n.table:
+                    return exp.column("level", table)
+                if not n.table or n.table == source_table_alias:
+                    return exp.column(n.name, table)
             return n
 
-        return node.transform(_transform)
+        return _scoped_transform(node, _fn)
 
     # Build the join condition from the full CONNECT BY predicate:
     # PRIOR(col) → _parent_row.col, unqualified cols → _child_row.col.
     def _qualify_connect_pred(node: exp.Expression) -> exp.Expression:
-        def _transform(n: exp.Expression) -> exp.Expression:
+        def _fn(n: exp.Expression) -> exp.Expression:
             if isinstance(n, exp.Prior):
                 inner = n.this
                 if isinstance(inner, exp.Column) and (
@@ -763,7 +790,7 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
                 return exp.column(n.name, "_child_row")
             return n
 
-        return node.transform(_transform)
+        return _scoped_transform(node, _fn)
 
     # Avoid colliding with any CTE names already on the query.
     cte_name = find_new_name(
@@ -792,14 +819,8 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
             [exp.Star()] if has_level else [exp.Star(except_=[exp.column("level")])]
         )
     else:
-
-        def _replace_level(n: exp.Expression) -> exp.Expression:
-            if isinstance(n, exp.Column) and n.name.upper() == "LEVEL" and not n.table:
-                return exp.column("level", cte_name)
-            return n
-
         outer_select_exprs = [
-            _qualify_cols(e.transform(_replace_level), cte_name) for e in base_select_exprs
+            _qualify_cols(e, cte_name, replace_level=True) for e in base_select_exprs
         ]
     outer_query = exp.select(*outer_select_exprs).from_(cte_name)
     if base_where:

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -717,8 +717,6 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
 
     connect = expression.args["connect"]
     connect_pred = connect.args.get("connect")
-    if not connect_pred:
-        return expression
 
     priors = list(connect_pred.find_all(exp.Prior))
     if len(priors) != 1:
@@ -742,33 +740,34 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
 
     # LEVEL is a Snowflake pseudo-column: it's always computed as a depth counter in the CTE
     # Raw LEVEL column refs are replaced with the computed value
-    def _is_level_ref(e: exp.Expr) -> bool:
-        col = e.this if isinstance(e, exp.Alias) else e
-        return isinstance(col, exp.Column) and col.name.upper() == "LEVEL" and not col.table
+    def _has_level_ref(e: exp.Expr) -> bool:
+        return any(
+            isinstance(col, exp.Column) and col.name.upper() == "LEVEL" and not col.table
+            for col in e.find_all(exp.Column)
+        )
 
-    has_level = any(_is_level_ref(e) for e in base_select_exprs)
-    has_star = any(e.is_star for e in base_select_exprs)
+    level_exprs = [e for e in base_select_exprs if _has_level_ref(e)]
+    non_level_exprs = [e for e in base_select_exprs if not _has_level_ref(e)]
+    has_level = bool(level_exprs)
+    has_star = expression.is_star
 
     # WHERE columns absent from SELECT must be carried through the CTE so the outer filter can see them.
     # With SELECT *, all columns are already included so no extras are needed.
-    select_names = {e.alias_or_name for e in base_select_exprs}
-    extra_cols = (
-        dict.fromkeys(
+    select_names = expression.named_selects
+    if has_star:
+        extra_cols = {}
+    else:
+        extra_cols = dict.fromkeys(
             col.name
             for col in (base_where.find_all(exp.Column) if base_where else [])
             if (not col.table or col.table == source_table_alias) and col.name not in select_names
         )
-        if not has_star
-        else {}
-    )
     # The PRIOR column must be projected into the CTE so _parent_row.<col> is valid in the join.
     if not has_star and child_col_name not in select_names:
         extra_cols.setdefault(child_col_name, None)
 
     # Anchor: seed LEVEL at 1 and start the ancestor path with the root's parent key value.
-    anchor_projs = [e for e in base_select_exprs if not _is_level_ref(e)] + [
-        exp.column(c) for c in extra_cols
-    ]
+    anchor_projs = non_level_exprs + [exp.column(c) for c in extra_cols]
     anchor_projs.append(exp.alias_(exp.Literal.number(1), "level"))
     anchor_projs.append(exp.alias_(exp.array(exp.column(child_col_name)), "_path"))
     anchor = exp.select(*anchor_projs).from_(source_table)
@@ -807,8 +806,7 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
         exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row"))
         if e.is_star
         else exp.column(e.alias_or_name, "_child_row")
-        for e in base_select_exprs
-        if not _is_level_ref(e)
+        for e in non_level_exprs
     ]
     inner_select_exprs += [exp.column(c, "_child_row") for c in extra_cols]
     inner_select_exprs.append(exp.alias_(exp.column("level", "_parent_row") + 1, "level"))
@@ -840,15 +838,18 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
         exclude.append(exp.column("_path"))
         outer_select_exprs: list[exp.Expr] = [exp.Star(except_=exclude)]
     else:
-        outer_select_exprs = []
-        for e in base_select_exprs:
-            if _is_level_ref(e):
-                col = exp.column("level", cte_name)
-                outer_select_exprs.append(
-                    exp.alias_(col, e.alias) if isinstance(e, exp.Alias) else col
-                )
-            else:
-                outer_select_exprs.append(exp.column(e.alias_or_name, cte_name))
+
+        def _replace_level(n: exp.Expression) -> exp.Expression:
+            if isinstance(n, exp.Column) and n.name.upper() == "LEVEL" and not n.table:
+                return exp.column("level", cte_name)
+            return n
+
+        outer_select_exprs = [
+            e.transform(_replace_level)
+            if _has_level_ref(e)
+            else exp.column(e.alias_or_name, cte_name)
+            for e in base_select_exprs
+        ]
     outer_query = exp.select(*outer_select_exprs).from_(cte_name)
     if base_where:
         outer_query = outer_query.where(_qualify_cols(base_where.this, cte_name))

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -6,7 +6,6 @@ import re
 import typing as t
 
 from sqlglot import exp, generator, transforms
-
 from sqlglot.dialects.dialect import (
     DATETIME_DELTA,
     JSON_EXTRACT_TYPE,
@@ -38,7 +37,7 @@ from sqlglot.dialects.dialect import (
     unit_to_str,
 )
 from sqlglot.generator import unsupported_args
-from sqlglot.helper import is_date_unit, seq_get
+from sqlglot.helper import find_new_name, is_date_unit, seq_get
 from builtins import type as Type
 
 # Regex to detect time zones in timestamps of the form [+|-]TT[:tt]
@@ -708,6 +707,141 @@ def _seq_to_range_in_generator(expression: exp.Expr) -> exp.Expr:
         return node
 
     return expression.transform(replace_seq, copy=False)
+
+
+def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
+    """
+    Rewrites Snowflake's START WITH ... CONNECT BY PRIOR into a WITH RECURSIVE CTE.
+
+    Snowflake CONNECT BY is a hierarchical traversal — each row in the result is
+    produced by following PRIOR links from a starting set. The equivalent in DuckDB
+    is a recursive CTE with two members joined by UNION ALL:
+
+        WITH RECURSIVE _hier AS (
+            -- anchor: starting rows (START WITH condition)
+            SELECT ... FROM t WHERE <start>
+            UNION ALL
+            -- recursive: one step down the hierarchy per iteration
+            SELECT _r.* FROM t AS _r JOIN _hier AS _h ON _r.child_col = _h.parent_col
+        )
+        SELECT ... FROM _hier WHERE <original where>
+
+    Only handles the common single-table, single-PRIOR equality case.
+    NOCYCLE, multiple PRIORs, and non-equality predicates fall through unchanged.
+    """
+    if not isinstance(expression, exp.Select) or not expression.args.get("connect"):
+        return expression
+
+    connect = expression.args["connect"]
+    if connect.args.get("nocycle") or not isinstance(connect.args.get("connect"), exp.EQ):
+        return expression
+
+    connect_expr = connect.args["connect"]
+    priors = list(connect_expr.find_all(exp.Prior))
+    if len(priors) != 1:
+        return expression
+
+    # CONNECT BY PRIOR parent_col = child_col  (or the reverse — PRIOR can be on either side)
+    prior = priors[0]
+    parent_col = prior.this
+    child_col = connect_expr.expression if connect_expr.this is prior else connect_expr.this
+
+    from_ = expression.args.get("from_")
+    source_table = from_.this  # type: ignore[union-attr]
+
+    # Generate names that don't collide with any CTEs already present in the query.
+    existing_with = expression.args.get("with_")
+    existing_ctes = {cte.alias for cte in (existing_with.expressions if existing_with else [])}
+    cte_name = find_new_name(existing_ctes, "_hier")
+    used_names = existing_ctes | {cte_name}
+    rec_alias = find_new_name(used_names, "_r")  # alias for the new-row side of the join
+    cte_ref_alias = find_new_name(used_names | {rec_alias}, "_h")  # alias for the CTE (parent) side
+
+    # --- Anchor member ---
+    # The anchor is the starting set: original SELECT columns filtered by START WITH.
+    # LEVEL is a Snowflake pseudo-column (depth in the hierarchy); seed it at 1.
+    anchor_projections = [e.copy() for e in expression.expressions]
+    has_level = any(p.alias_or_name.upper() == "LEVEL" for p in anchor_projections)
+
+    # Columns referenced in WHERE but absent from SELECT must be carried through the
+    # CTE so the outer SELECT can filter on them — DuckDB can't see them otherwise.
+    existing_where = expression.args.get("where")
+    select_col_names = {e.alias_or_name for e in expression.expressions}
+    where_extra: list[str] = []
+    if existing_where:
+        for col in existing_where.find_all(exp.Column):
+            if not col.table and col.name not in select_col_names and col.name not in where_extra:
+                where_extra.append(col.name)
+    for col_name in where_extra:
+        anchor_projections.append(exp.column(col_name))
+
+    if not has_level:
+        anchor_projections.append(exp.alias_(exp.Literal.number(1), "level"))
+
+    anchor = exp.select(*anchor_projections).from_(source_table.copy())
+    if connect.args.get("start"):
+        anchor.where(connect.args["start"].copy(), copy=False)
+
+    # --- Recursive member ---
+    # Each iteration extends the hierarchy by one level.  Columns must be qualified
+    # to the new-row alias (_r) so DuckDB knows they come from the source table,
+    # not from the CTE reference (_h) used on the join's other side.
+    def _qualify_rec(e: exp.Expression) -> exp.Expression:
+        if isinstance(e, exp.Column) and not e.table:
+            return exp.column(e.this, rec_alias)
+        if isinstance(e, exp.Star):
+            return exp.Column(this=exp.Star(), table=exp.to_identifier(rec_alias))
+        return e
+
+    rec_projections = [e.copy().transform(_qualify_rec) for e in expression.expressions]
+    for col_name in where_extra:
+        rec_projections.append(exp.column(col_name, rec_alias))
+    if not has_level:
+        # Increment LEVEL by joining to the parent row in the CTE (_h).
+        rec_projections.append(exp.alias_(exp.column("level", cte_ref_alias) + 1, "level"))
+
+    # Join condition: new row's child column matches the CTE's parent column.
+    join_cond = exp.column(child_col.this, rec_alias).eq(exp.column(parent_col.this, cte_ref_alias))
+
+    rec_select = (
+        exp.select(*rec_projections)
+        .from_(source_table.as_(rec_alias))
+        .join(exp.to_table(cte_name).as_(cte_ref_alias), on=join_cond)
+    )
+
+    cte = exp.CTE(
+        this=anchor.union(rec_select, distinct=False),  # UNION ALL
+        alias=exp.TableAlias(this=exp.to_identifier(cte_name)),
+    )
+
+    # --- Outer select ---
+    # Wraps the CTE to apply WHERE, ORDER BY, LIMIT, OFFSET.
+    # WHERE goes here (not inside the CTE) because Snowflake applies it post-hierarchy,
+    # filtering the fully-expanded result set rather than pruning the traversal.
+    def _outer_proj(e: exp.Expression) -> exp.Expression:
+        if isinstance(e, exp.Star):
+            return e.copy()
+        return exp.column(e.alias_or_name, cte_name)
+
+    outer = exp.select(*[_outer_proj(e) for e in expression.expressions]).from_(cte_name)
+
+    if existing_where:
+        outer.where(existing_where.this.copy(), copy=False)
+
+    # Preserve any WITH clause already on the query; mark it recursive.
+    if existing_with:
+        new_with = existing_with.copy()
+        new_with.set("recursive", True)
+        new_with.expressions.append(cte)
+        outer.set("with_", new_with)
+    else:
+        outer.set("with_", exp.With(expressions=[cte], recursive=True))
+
+    for arg in ("order", "limit", "offset"):
+        if expression.args.get(arg):
+            outer.set(arg, expression.args[arg].copy())
+
+    return outer
 
 
 def _seq_sql(self: DuckDBGenerator, expression: exp.Func, byte_width: int) -> str:
@@ -1616,7 +1750,9 @@ class DuckDBGenerator(generator.Generator):
         exp.Lateral: _explode_to_unnest_sql,
         exp.LogicalOr: lambda self, e: self.func("BOOL_OR", _cast_to_boolean(e.this)),
         exp.LogicalAnd: lambda self, e: self.func("BOOL_AND", _cast_to_boolean(e.this)),
-        exp.Select: transforms.preprocess([_seq_to_range_in_generator]),
+        exp.Select: transforms.preprocess(
+            [connect_by_to_recursive_cte, _seq_to_range_in_generator]
+        ),
         exp.Seq1: lambda self, e: _seq_sql(self, e, 1),
         exp.Seq2: lambda self, e: _seq_sql(self, e, 2),
         exp.Seq4: lambda self, e: _seq_sql(self, e, 4),

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -710,107 +710,163 @@ def _seq_to_range_in_generator(expression: exp.Expr) -> exp.Expr:
 
 
 def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
-    # Rewrites START WITH ... CONNECT BY PRIOR into WITH RECURSIVE.
-    # Falls through unchanged for NOCYCLE, multiple PRIORs, or non-equality predicates.
+    # Rewrites START WITH ... CONNECT BY PRIOR into WITH RECURSIVE with path-based cycle detection.
+    # Falls through unchanged for multiple PRIORs or a non-column PRIOR expression.
     if not isinstance(expression, exp.Select) or not expression.args.get("connect"):
         return expression
 
     connect = expression.args["connect"]
-    if connect.args.get("nocycle") or not isinstance(connect.args.get("connect"), exp.EQ):
+    connect_pred = connect.args.get("connect")
+    if not connect_pred:
         return expression
 
-    connect_pred = connect.args["connect"]
     priors = list(connect_pred.find_all(exp.Prior))
     if len(priors) != 1:
         return expression
 
     prior = priors[0]
+    if not isinstance(prior.this, exp.Column):
+        return expression
+
+    from_ = expression.args.get("from_")
+    if not from_ or expression.args.get("joins"):
+        return expression
 
     # Pull everything we need from the original SELECT up front.
-    src = expression.args["from_"].this  # type: ignore[union-attr]
-    selects = expression.expressions
-    existing_where = expression.args.get("where")
-    existing_with = expression.args.get("with_")
+    source_table = from_.this
+    source_table_alias = source_table.alias
+    child_col_name = prior.this.name
+    base_select_exprs = expression.expressions
+    base_where = expression.args.get("where")
+    base_with = expression.args.get("with_")
+
+    # LEVEL is a Snowflake pseudo-column: it's always computed as a depth counter in the CTE
+    # Raw LEVEL column refs are replaced with the computed value
+    def _is_level_ref(e: exp.Expr) -> bool:
+        col = e.this if isinstance(e, exp.Alias) else e
+        return isinstance(col, exp.Column) and col.name.upper() == "LEVEL" and not col.table
+
+    has_level = any(_is_level_ref(e) for e in base_select_exprs)
+    has_star = any(e.is_star for e in base_select_exprs)
 
     # WHERE columns absent from SELECT must be carried through the CTE so the outer filter can see them.
-    select_names = {e.alias_or_name for e in selects}
-    extra_cols = list(
+    # With SELECT *, all columns are already included so no extras are needed.
+    select_names = {e.alias_or_name for e in base_select_exprs}
+    extra_cols = (
         dict.fromkeys(
             col.name
-            for col in (existing_where.find_all(exp.Column) if existing_where else [])
-            if not col.table and col.name not in select_names
+            for col in (base_where.find_all(exp.Column) if base_where else [])
+            if (not col.table or col.table == source_table_alias) and col.name not in select_names
         )
+        if not has_star
+        else {}
     )
+    # The PRIOR column must be projected into the CTE so _parent_row.<col> is valid in the join.
+    if not has_star and child_col_name not in select_names:
+        extra_cols.setdefault(child_col_name, None)
 
-    # Inject LEVEL as a synthetic depth counter unless the query already projects it.
-    has_level = any(e.alias_or_name.upper() == "LEVEL" for e in selects)
-
-    # Anchor: original projections filtered by START WITH; seeds LEVEL at 1.
-    anchor_projs = [e.copy() for e in selects] + [exp.column(c) for c in extra_cols]
-    if not has_level:
-        anchor_projs.append(exp.alias_(exp.Literal.number(1), "level"))
-    anchor = exp.select(*anchor_projs).from_(src.copy())
-    if connect.args.get("start"):
-        anchor = anchor.where(connect.args["start"].copy())
-
-    # Recursive arm: qualify every column to _child_row (the new row) to disambiguate from _parent_row (the CTE/parent row).
-    # Identify which side of the equality is PRIOR (parent key) and which is the child FK.
-    parent_col = prior.this
-    child_col = connect_pred.expression if connect_pred.this is prior else connect_pred.this
-
-    rec_projs: list[exp.Expr] = []
-    rec_projs += [
-        exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row"))
-        if isinstance(e, exp.Star)
-        else exp.column(e.alias_or_name, "_child_row")
-        for e in selects
+    # Anchor: seed LEVEL at 1 and start the ancestor path with the root's parent key value.
+    anchor_projs = [e for e in base_select_exprs if not _is_level_ref(e)] + [
+        exp.column(c) for c in extra_cols
     ]
-    rec_projs += [exp.column(c, "_child_row") for c in extra_cols]
-    if not has_level:
-        rec_projs.append(exp.alias_(exp.column("level", "_parent_row") + 1, "level"))
-    join_on = exp.column(child_col.name, "_child_row").eq(
-        exp.column(parent_col.name, "_parent_row")
-    )
+    anchor_projs.append(exp.alias_(exp.Literal.number(1), "level"))
+    anchor_projs.append(exp.alias_(exp.array(exp.column(child_col_name)), "_path"))
+    anchor = exp.select(*anchor_projs).from_(source_table)
+    if connect.args.get("start"):
+        anchor = anchor.where(connect.args["start"])
+
+    def _qualify_cols(node: exp.Expression, table: str) -> exp.Expression:
+        def _transform(n: exp.Expression) -> exp.Expression:
+            if isinstance(n, exp.Column) and (not n.table or n.table == source_table_alias):
+                return exp.column(n.name, table)
+            return n
+
+        return node.transform(_transform)
+
+    # Build the join condition from the full CONNECT BY predicate:
+    # PRIOR(col) → _parent_row.col, unqualified cols → _child_row.col.
+    def _qualify_connect_pred(node: exp.Expression) -> exp.Expression:
+        def _transform(n: exp.Expression) -> exp.Expression:
+            if isinstance(n, exp.Prior):
+                inner = n.this
+                if isinstance(inner, exp.Column) and (
+                    not inner.table or inner.table == source_table_alias
+                ):
+                    return exp.column(inner.name, "_parent_row")
+                return inner
+            if isinstance(n, exp.Column) and (not n.table or n.table == source_table_alias):
+                return exp.column(n.name, "_child_row")
+            return n
+
+        return node.transform(_transform)
+
+    parent_row = exp.column("_path", "_parent_row")
+    child_row = exp.column(child_col_name, "_child_row")
+
+    inner_select_exprs: list[exp.Expr] = [
+        exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row"))
+        if e.is_star
+        else exp.column(e.alias_or_name, "_child_row")
+        for e in base_select_exprs
+        if not _is_level_ref(e)
+    ]
+    inner_select_exprs += [exp.column(c, "_child_row") for c in extra_cols]
+    inner_select_exprs.append(exp.alias_(exp.column("level", "_parent_row") + 1, "level"))
+    inner_select_exprs.append(exp.alias_(exp.func("LIST_APPEND", parent_row, child_row), "_path"))
 
     # Avoid colliding with any CTE names already on the query.
     cte_name = find_new_name(
-        {cte.alias for cte in (existing_with.expressions if existing_with else [])}, "_rootcte"
+        {cte.alias for cte in (base_with.expressions if base_with else [])}, "_rootcte"
     )
-    rec = (
-        exp.select(*rec_projs)
-        .from_(src.as_("_child_row"))
-        .join(exp.to_table(cte_name).as_("_parent_row"), on=join_on)
+
+    # Build main query body
+    inner_query = (
+        exp.select(*inner_select_exprs)
+        .from_(source_table.as_("_child_row"))
+        .join(exp.to_table(cte_name).as_("_parent_row"), on=_qualify_connect_pred(connect_pred))
+        .where(exp.not_(exp.func("LIST_CONTAINS", parent_row, child_row)))
     )
 
     # CTE body is anchor UNION ALL recursive arm.
     cte = exp.CTE(
-        this=anchor.union(rec, distinct=False),
+        this=anchor.union(inner_query, distinct=False),
         alias=exp.TableAlias(this=exp.to_identifier(cte_name)),
     )
 
-    # Outer SELECT re-projects from the CTE, applying WHERE post-hierarchy and preserving ORDER/LIMIT/OFFSET.
-    outer_projs = [
-        e.copy() if isinstance(e, exp.Star) else exp.column(e.alias_or_name, cte_name)
-        for e in selects
-    ]
-    outer = exp.select(*outer_projs).from_(cte_name)
-    if existing_where:
-        outer = outer.where(existing_where.this.copy())
+    # Outer SELECT re-projects from the CTE. Synthetic _path and level columns are excluded.
+    # Explicit LEVEL references are projected from the CTE's computed column, preserving aliases.
+    if has_star:
+        exclude = [] if has_level else [exp.column("level")]
+        exclude.append(exp.column("_path"))
+        outer_select_exprs: list[exp.Expr] = [exp.Star(except_=exclude)]
+    else:
+        outer_select_exprs = []
+        for e in base_select_exprs:
+            if _is_level_ref(e):
+                col = exp.column("level", cte_name)
+                outer_select_exprs.append(
+                    exp.alias_(col, e.alias) if isinstance(e, exp.Alias) else col
+                )
+            else:
+                outer_select_exprs.append(exp.column(e.alias_or_name, cte_name))
+    outer_query = exp.select(*outer_select_exprs).from_(cte_name)
+    if base_where:
+        outer_query = outer_query.where(_qualify_cols(base_where.this, cte_name))
 
-    # Attach the CTE, marking the WITH clause recursive. Preserve any existing CTEs.
-    if existing_with:
-        new_with = existing_with.copy()
+    # Attach the CTE, marking the WITH clause recursive.
+    if base_with:
+        new_with = base_with.copy()
         new_with.set("recursive", True)
         new_with.expressions.append(cte)
-        outer.set("with_", new_with)
+        outer_query.set("with_", new_with)
     else:
-        outer.set("with_", exp.With(expressions=[cte], recursive=True))
+        outer_query.set("with_", exp.With(expressions=[cte], recursive=True))
 
-    for arg in ("order", "limit", "offset"):
-        if val := expression.args.get(arg):
-            outer.set(arg, val.copy())
+    for arg in exp.QUERY_MODIFIERS:
+        if arg not in ("connect", "where") and (val := expression.args.get(arg)):
+            outer_query.set(arg, val)
 
-    return outer
+    return outer_query
 
 
 def _seq_sql(self: DuckDBGenerator, expression: exp.Func, byte_width: int) -> str:

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -710,25 +710,8 @@ def _seq_to_range_in_generator(expression: exp.Expr) -> exp.Expr:
 
 
 def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
-    """
-    Rewrites Snowflake's START WITH ... CONNECT BY PRIOR into a WITH RECURSIVE CTE.
-
-    Snowflake CONNECT BY is a hierarchical traversal — each row in the result is
-    produced by following PRIOR links from a starting set. The equivalent in DuckDB
-    is a recursive CTE with two members joined by UNION ALL:
-
-        WITH RECURSIVE _hier AS (
-            -- anchor: starting rows (START WITH condition)
-            SELECT ... FROM t WHERE <start>
-            UNION ALL
-            -- recursive: one step down the hierarchy per iteration
-            SELECT _r.* FROM t AS _r JOIN _hier AS _h ON _r.child_col = _h.parent_col
-        )
-        SELECT ... FROM _hier WHERE <original where>
-
-    Only handles the common single-table, single-PRIOR equality case.
-    NOCYCLE, multiple PRIORs, and non-equality predicates fall through unchanged.
-    """
+    # Rewrites START WITH ... CONNECT BY PRIOR into WITH RECURSIVE.
+    # Falls through unchanged for NOCYCLE, multiple PRIORs, or non-equality predicates.
     if not isinstance(expression, exp.Select) or not expression.args.get("connect"):
         return expression
 
@@ -736,99 +719,85 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
     if connect.args.get("nocycle") or not isinstance(connect.args.get("connect"), exp.EQ):
         return expression
 
-    connect_expr = connect.args["connect"]
-    priors = list(connect_expr.find_all(exp.Prior))
+    connect_pred = connect.args["connect"]
+    priors = list(connect_pred.find_all(exp.Prior))
     if len(priors) != 1:
         return expression
 
-    # CONNECT BY PRIOR parent_col = child_col  (or the reverse — PRIOR can be on either side)
     prior = priors[0]
-    parent_col = prior.this
-    child_col = connect_expr.expression if connect_expr.this is prior else connect_expr.this
 
-    from_ = expression.args.get("from_")
-    source_table = from_.this  # type: ignore[union-attr]
-
-    # Generate names that don't collide with any CTEs already present in the query.
-    existing_with = expression.args.get("with_")
-    existing_ctes = {cte.alias for cte in (existing_with.expressions if existing_with else [])}
-    cte_name = find_new_name(existing_ctes, "_hier")
-    used_names = existing_ctes | {cte_name}
-    rec_alias = find_new_name(used_names, "_r")  # alias for the new-row side of the join
-    cte_ref_alias = find_new_name(used_names | {rec_alias}, "_h")  # alias for the CTE (parent) side
-
-    # --- Anchor member ---
-    # The anchor is the starting set: original SELECT columns filtered by START WITH.
-    # LEVEL is a Snowflake pseudo-column (depth in the hierarchy); seed it at 1.
-    anchor_projections = [e.copy() for e in expression.expressions]
-    has_level = any(p.alias_or_name.upper() == "LEVEL" for p in anchor_projections)
-
-    # Columns referenced in WHERE but absent from SELECT must be carried through the
-    # CTE so the outer SELECT can filter on them — DuckDB can't see them otherwise.
+    # Pull everything we need from the original SELECT up front.
+    src = expression.args["from_"].this  # type: ignore[union-attr]
+    selects = expression.expressions
     existing_where = expression.args.get("where")
-    select_col_names = {e.alias_or_name for e in expression.expressions}
-    where_extra: list[str] = []
-    if existing_where:
-        for col in existing_where.find_all(exp.Column):
-            if not col.table and col.name not in select_col_names and col.name not in where_extra:
-                where_extra.append(col.name)
-    for col_name in where_extra:
-        anchor_projections.append(exp.column(col_name))
+    existing_with = expression.args.get("with_")
 
-    if not has_level:
-        anchor_projections.append(exp.alias_(exp.Literal.number(1), "level"))
-
-    anchor = exp.select(*anchor_projections).from_(source_table.copy())
-    if connect.args.get("start"):
-        anchor.where(connect.args["start"].copy(), copy=False)
-
-    # --- Recursive member ---
-    # Each iteration extends the hierarchy by one level.  Columns must be qualified
-    # to the new-row alias (_r) so DuckDB knows they come from the source table,
-    # not from the CTE reference (_h) used on the join's other side.
-    def _qualify_rec(e: exp.Expression) -> exp.Expression:
-        if isinstance(e, exp.Column) and not e.table:
-            return exp.column(e.this, rec_alias)
-        if isinstance(e, exp.Star):
-            return exp.Column(this=exp.Star(), table=exp.to_identifier(rec_alias))
-        return e
-
-    rec_projections = [e.copy().transform(_qualify_rec) for e in expression.expressions]
-    for col_name in where_extra:
-        rec_projections.append(exp.column(col_name, rec_alias))
-    if not has_level:
-        # Increment LEVEL by joining to the parent row in the CTE (_h).
-        rec_projections.append(exp.alias_(exp.column("level", cte_ref_alias) + 1, "level"))
-
-    # Join condition: new row's child column matches the CTE's parent column.
-    join_cond = exp.column(child_col.this, rec_alias).eq(exp.column(parent_col.this, cte_ref_alias))
-
-    rec_select = (
-        exp.select(*rec_projections)
-        .from_(source_table.as_(rec_alias))
-        .join(exp.to_table(cte_name).as_(cte_ref_alias), on=join_cond)
+    # WHERE columns absent from SELECT must be carried through the CTE so the outer filter can see them.
+    select_names = {e.alias_or_name for e in selects}
+    extra_cols = list(
+        dict.fromkeys(
+            col.name
+            for col in (existing_where.find_all(exp.Column) if existing_where else [])
+            if not col.table and col.name not in select_names
+        )
     )
 
+    # Inject LEVEL as a synthetic depth counter unless the query already projects it.
+    has_level = any(e.alias_or_name.upper() == "LEVEL" for e in selects)
+
+    # Anchor: original projections filtered by START WITH; seeds LEVEL at 1.
+    anchor_projs = [e.copy() for e in selects] + [exp.column(c) for c in extra_cols]
+    if not has_level:
+        anchor_projs.append(exp.alias_(exp.Literal.number(1), "level"))
+    anchor = exp.select(*anchor_projs).from_(src.copy())
+    if connect.args.get("start"):
+        anchor = anchor.where(connect.args["start"].copy())
+
+    # Recursive arm: qualify every column to _child_row (the new row) to disambiguate from _parent_row (the CTE/parent row).
+    # Identify which side of the equality is PRIOR (parent key) and which is the child FK.
+    parent_col = prior.this
+    child_col = connect_pred.expression if connect_pred.this is prior else connect_pred.this
+
+    rec_projs: list[exp.Expr] = []
+    rec_projs += [
+        exp.Column(this=exp.Star(), table=exp.to_identifier("_child_row"))
+        if isinstance(e, exp.Star)
+        else exp.column(e.alias_or_name, "_child_row")
+        for e in selects
+    ]
+    rec_projs += [exp.column(c, "_child_row") for c in extra_cols]
+    if not has_level:
+        rec_projs.append(exp.alias_(exp.column("level", "_parent_row") + 1, "level"))
+    join_on = exp.column(child_col.name, "_child_row").eq(
+        exp.column(parent_col.name, "_parent_row")
+    )
+
+    # Avoid colliding with any CTE names already on the query.
+    cte_name = find_new_name(
+        {cte.alias for cte in (existing_with.expressions if existing_with else [])}, "_rootcte"
+    )
+    rec = (
+        exp.select(*rec_projs)
+        .from_(src.as_("_child_row"))
+        .join(exp.to_table(cte_name).as_("_parent_row"), on=join_on)
+    )
+
+    # CTE body is anchor UNION ALL recursive arm.
     cte = exp.CTE(
-        this=anchor.union(rec_select, distinct=False),  # UNION ALL
+        this=anchor.union(rec, distinct=False),
         alias=exp.TableAlias(this=exp.to_identifier(cte_name)),
     )
 
-    # --- Outer select ---
-    # Wraps the CTE to apply WHERE, ORDER BY, LIMIT, OFFSET.
-    # WHERE goes here (not inside the CTE) because Snowflake applies it post-hierarchy,
-    # filtering the fully-expanded result set rather than pruning the traversal.
-    def _outer_proj(e: exp.Expression) -> exp.Expression:
-        if isinstance(e, exp.Star):
-            return e.copy()
-        return exp.column(e.alias_or_name, cte_name)
-
-    outer = exp.select(*[_outer_proj(e) for e in expression.expressions]).from_(cte_name)
-
+    # Outer SELECT re-projects from the CTE, applying WHERE post-hierarchy and preserving ORDER/LIMIT/OFFSET.
+    outer_projs = [
+        e.copy() if isinstance(e, exp.Star) else exp.column(e.alias_or_name, cte_name)
+        for e in selects
+    ]
+    outer = exp.select(*outer_projs).from_(cte_name)
     if existing_where:
-        outer.where(existing_where.this.copy(), copy=False)
+        outer = outer.where(existing_where.this.copy())
 
-    # Preserve any WITH clause already on the query; mark it recursive.
+    # Attach the CTE, marking the WITH clause recursive. Preserve any existing CTEs.
     if existing_with:
         new_with = existing_with.copy()
         new_with.set("recursive", True)
@@ -838,8 +807,8 @@ def connect_by_to_recursive_cte(expression: exp.Expr) -> exp.Expr:
         outer.set("with_", exp.With(expressions=[cte], recursive=True))
 
     for arg in ("order", "limit", "offset"):
-        if expression.args.get(arg):
-            outer.set(arg, expression.args[arg].copy())
+        if val := expression.args.get(arg):
+            outer.set(arg, val.copy())
 
     return outer
 


### PR DESCRIPTION
Adds Snowflake to DuckDB transpilation for `START WITH ... CONNECT BY PRIOR` hierarchical queries.

DuckDB rejects `CONNECT BY` verbatim. This adds `connect_by_to_recursive_cte` registered as a preprocessor on `exp.Select`, which rewrites the query into a `WITH RECURSIVE CTE` at generation time:

- Anchors `START WITH` rows from the source table
- Recursive arm: source table aliased `_child_row` joined to the `CTE` aliased _parent_row on the `PRIOR` predicate
- Outer `SELECT` re-projects from `_rootcte`, applying `WHERE` post-hierarchy and forwarding `ORDER BY, LIMIT, OFFSET`

Falls through unchanged for `NOCYCLE`, multiple `PRIORs`, or non-equality predicates. CTE name collision is avoided via `find_new_name`. `WHERE` columns absent from `SELECT` are carried through the CTE so the outer filter can see them. `LEVEL` is injected as a depth counter unless already projected.

Tests in sqlglot-integration-tests cover: SELECT *, explicit column list with ORDER BY, PRIOR on left side, WHERE carry-through, existing CTE preservation, and name collision.
