### PR TITLE
feat(annotate_types): add ROUND type annotators for Spark and Snowflake [CLAUDE]

### DIFF
--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -11,6 +11,31 @@ if t.TYPE_CHECKING:
 
 DATE_PARTS = {"DAY", "WEEK", "MONTH", "QUARTER", "YEAR"}
 
+
+def _decimal(p: int, s: int) -> exp.DataType:
+    return exp.DataType(
+        this=exp.DType.DECIMAL,
+        expressions=[
+            exp.DataTypeParam(this=exp.Literal.number(p)),
+            exp.DataTypeParam(this=exp.Literal.number(s)),
+        ],
+    )
+
+
+def _decimal_ps(datatype: exp.DataType) -> tuple[int, int] | None:
+    if datatype and datatype.is_type(exp.DType.DECIMAL) and datatype.expressions:
+        return int(datatype.expressions[0].name), int(datatype.expressions[1].name)
+    return None
+
+
+def _round_literal_int(expr: exp.Expression) -> int | None:
+    if isinstance(expr, exp.Literal) and expr.is_int:
+        return int(expr.to_py())
+    if isinstance(expr, exp.Neg) and isinstance(expr.this, exp.Literal) and expr.this.is_int:
+        return -int(expr.this.to_py())
+    return None
+
+
 MAX_PRECISION = 38
 
 MAX_SCALE = 37
@@ -239,6 +264,21 @@ def _annotate_str_to_time(self: TypeAnnotator, expression: exp.StrToTime) -> exp
     return expression
 
 
+def _annotate_round(self: TypeAnnotator, expression: exp.Round) -> exp.Round:
+    in_type = expression.this.type
+    ps = _decimal_ps(in_type)
+    if ps is not None:
+        p, s = ps
+        d_expr = expression.args.get("decimals")
+        d = _round_literal_int(d_expr) if d_expr is not None else 0
+        if d is None:
+            return self._set_type(expression, _decimal(MAX_PRECISION if p > 18 else 18, s))
+        return self._set_type(expression, _decimal(min(MAX_PRECISION, p + 1), min(s, max(0, d))))
+    if in_type and in_type.this in exp.DataType.INTEGER_TYPES:
+        return self._set_type(expression, _decimal(MAX_PRECISION, 0))
+    return self._annotate_by_args(expression, "this")
+
+
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
@@ -252,7 +292,6 @@ EXPRESSION_METADATA = {
             exp.Mode,
             exp.Pad,
             exp.Right,
-            exp.Round,
             exp.Stuff,
             exp.Substring,
             exp.TimeSlice,
@@ -561,6 +600,7 @@ EXPRESSION_METADATA = {
     },
     exp.Median: {"annotator": _annotate_median},
     exp.Reverse: {"annotator": _annotate_reverse},
+    exp.Round: {"annotator": _annotate_round},
     exp.StrToTime: {"annotator": _annotate_str_to_time},
     exp.TimeAdd: {"annotator": _annotate_date_or_time_add},
     exp.TimestampFromParts: {"annotator": _annotate_timestamp_from_parts},

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -276,9 +276,6 @@ def _annotate_round(self: TypeAnnotator, expression: exp.Round) -> exp.Round:
         else:
             self._set_type(expression, _decimal(min(MAX_PRECISION, p + 1), min(s, max(0, d))))
         return expression
-    if in_type and in_type.this in exp.DataType.INTEGER_TYPES:
-        self._set_type(expression, _decimal(MAX_PRECISION, 0))
-        return expression
     return self._annotate_by_args(expression, "this")
 
 

--- a/sqlglot/typing/snowflake.py
+++ b/sqlglot/typing/snowflake.py
@@ -272,10 +272,13 @@ def _annotate_round(self: TypeAnnotator, expression: exp.Round) -> exp.Round:
         d_expr = expression.args.get("decimals")
         d = _round_literal_int(d_expr) if d_expr is not None else 0
         if d is None:
-            return self._set_type(expression, _decimal(MAX_PRECISION if p > 18 else 18, s))
-        return self._set_type(expression, _decimal(min(MAX_PRECISION, p + 1), min(s, max(0, d))))
+            self._set_type(expression, _decimal(MAX_PRECISION if p > 18 else 18, s))
+        else:
+            self._set_type(expression, _decimal(min(MAX_PRECISION, p + 1), min(s, max(0, d))))
+        return expression
     if in_type and in_type.this in exp.DataType.INTEGER_TYPES:
-        return self._set_type(expression, _decimal(MAX_PRECISION, 0))
+        self._set_type(expression, _decimal(MAX_PRECISION, 0))
+        return expression
     return self._annotate_by_args(expression, "this")
 
 

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -1,7 +1,49 @@
 from __future__ import annotations
 
+import typing as t
+
 from sqlglot import exp
 from sqlglot.typing.spark2 import EXPRESSION_METADATA
+
+if t.TYPE_CHECKING:
+    from sqlglot.optimizer.annotate_types import TypeAnnotator
+
+
+def _decimal(p: int, s: int) -> exp.DataType:
+    return exp.DataType(
+        this=exp.DType.DECIMAL,
+        expressions=[
+            exp.DataTypeParam(this=exp.Literal.number(p)),
+            exp.DataTypeParam(this=exp.Literal.number(s)),
+        ],
+    )
+
+
+def _decimal_ps(datatype: exp.DataType) -> tuple[int, int] | None:
+    if datatype and datatype.is_type(exp.DType.DECIMAL) and datatype.expressions:
+        return int(datatype.expressions[0].name), int(datatype.expressions[1].name)
+    return None
+
+
+def _round_literal_int(expr: exp.Expression) -> int | None:
+    if isinstance(expr, exp.Literal) and expr.is_int:
+        return int(expr.to_py())
+    if isinstance(expr, exp.Neg) and isinstance(expr.this, exp.Literal) and expr.this.is_int:
+        return -int(expr.this.to_py())
+    return None
+
+
+def _annotate_round(self: TypeAnnotator, expression: exp.Round) -> exp.Round:
+    ps = _decimal_ps(expression.this.type)
+    if ps is None:
+        return self._annotate_by_args(expression, "this")
+    p, s = ps
+    d_expr = expression.args.get("decimals")
+    d = _round_literal_int(d_expr) if d_expr is not None else 0
+    if d is None or d < 0:
+        return self._set_type(expression, _decimal(min(38, max(p - s + 1, -(d or 0) + 1)), 0))
+    d_eff = min(s, d)
+    return self._set_type(expression, _decimal(min(38, p - s + 1 + d_eff), d_eff))
 
 
 EXPRESSION_METADATA = {
@@ -45,4 +87,5 @@ EXPRESSION_METADATA = {
     # TsOrDsAdd by Hive/Spark parsers; both return DATE per the Spark
     # and Databricks contracts.
     exp.TsOrDsAdd: {"returns": exp.DType.DATE},
+    exp.Round: {"annotator": _annotate_round},
 }

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -41,9 +41,11 @@ def _annotate_round(self: TypeAnnotator, expression: exp.Round) -> exp.Round:
     d_expr = expression.args.get("decimals")
     d = _round_literal_int(d_expr) if d_expr is not None else 0
     if d is None or d < 0:
-        return self._set_type(expression, _decimal(min(38, max(p - s + 1, -(d or 0) + 1)), 0))
-    d_eff = min(s, d)
-    return self._set_type(expression, _decimal(min(38, p - s + 1 + d_eff), d_eff))
+        self._set_type(expression, _decimal(min(38, max(p - s + 1, -(d or 0) + 1)), 0))
+    else:
+        d_eff = min(s, d)
+        self._set_type(expression, _decimal(min(38, p - s + 1 + d_eff), d_eff))
+    return expression
 
 
 EXPRESSION_METADATA = {

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4391,11 +4391,11 @@ VARCHAR;
 
 # dialect: snowflake
 ROUND(42);
-INT;
+DECIMAL(38, 0);
 
 # dialect: snowflake
 ROUND(tbl.bigint_col, -1);
-BIGINT;
+DECIMAL(38, 0);
 
 # dialect: snowflake
 ROUND(tbl.double_col, 0, 'HALF_TO_EVEN');
@@ -4408,6 +4408,30 @@ FLOAT;
 # dialect: snowflake
 ROUND(CAST(1.5 AS DECFLOAT), 0);
 DECFLOAT;
+
+# dialect: snowflake
+ROUND(CAST(1 AS NUMBER(10, 4)), 2);
+DECIMAL(11, 2);
+
+# dialect: snowflake
+ROUND(CAST(1 AS NUMBER(10, 4)), 0);
+DECIMAL(11, 0);
+
+# dialect: snowflake
+ROUND(CAST(1 AS NUMBER(38, 4)), 2);
+DECIMAL(38, 2);
+
+# dialect: snowflake
+ROUND(CAST(1 AS NUMBER(10, 4)), -2);
+DECIMAL(11, 0);
+
+# dialect: snowflake
+ROUND(CAST(1 AS NUMBER(10, 4)), ABS(0));
+DECIMAL(18, 4);
+
+# dialect: snowflake
+ROUND(CAST(1 AS NUMBER(20, 4)), ABS(0));
+DECIMAL(38, 4);
 
 # dialect: snowflake
 FLOOR(CAST(3.7 AS DECFLOAT));
@@ -6554,3 +6578,39 @@ INT;
 # dialect: duckdb
 PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY tbl.double_col);
 DOUBLE;
+
+--------------------------------------
+-- Spark3 / Databricks ROUND
+--------------------------------------
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)));
+DECIMAL(7, 0);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)), 2);
+DECIMAL(9, 2);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)), 0);
+DECIMAL(7, 0);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(38, 4)), 0);
+DECIMAL(35, 0);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(38, 4)), -2);
+DECIMAL(35, 0);
+
+# dialect: spark, databricks
+ROUND(tbl.bigint_col, 0);
+BIGINT;
+
+# dialect: spark, databricks
+ROUND(tbl.double_col, 0);
+DOUBLE;
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)), ABS(0));
+DECIMAL(7, 0);

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4427,11 +4427,11 @@ VARCHAR;
 
 # dialect: snowflake
 ROUND(42);
-DECIMAL(38, 0);
+INT;
 
 # dialect: snowflake
 ROUND(tbl.bigint_col, -1);
-DECIMAL(38, 0);
+BIGINT;
 
 # dialect: snowflake
 ROUND(tbl.double_col, 0, 'HALF_TO_EVEN');

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -946,6 +946,42 @@ ARRAY_EXCEPT(tbl.array_col, tbl.array_col);
 ARRAY<STRING>;
 
 --------------------------------------
+-- Spark3 / Databricks ROUND
+--------------------------------------
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)));
+DECIMAL(7, 0);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)), 2);
+DECIMAL(9, 2);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)), 0);
+DECIMAL(7, 0);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(38, 4)), 0);
+DECIMAL(35, 0);
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(38, 4)), -2);
+DECIMAL(35, 0);
+
+# dialect: spark, databricks
+ROUND(tbl.bigint_col, 0);
+BIGINT;
+
+# dialect: spark, databricks
+ROUND(tbl.double_col, 0);
+DOUBLE;
+
+# dialect: spark, databricks
+ROUND(CAST(1 AS DECIMAL(10, 4)), ABS(0));
+DECIMAL(7, 0);
+
+--------------------------------------
 -- BigQuery
 --------------------------------------
 
@@ -6578,39 +6614,3 @@ INT;
 # dialect: duckdb
 PERCENTILE_DISC(0.5) WITHIN GROUP (ORDER BY tbl.double_col);
 DOUBLE;
-
---------------------------------------
--- Spark3 / Databricks ROUND
---------------------------------------
-
-# dialect: spark, databricks
-ROUND(CAST(1 AS DECIMAL(10, 4)));
-DECIMAL(7, 0);
-
-# dialect: spark, databricks
-ROUND(CAST(1 AS DECIMAL(10, 4)), 2);
-DECIMAL(9, 2);
-
-# dialect: spark, databricks
-ROUND(CAST(1 AS DECIMAL(10, 4)), 0);
-DECIMAL(7, 0);
-
-# dialect: spark, databricks
-ROUND(CAST(1 AS DECIMAL(38, 4)), 0);
-DECIMAL(35, 0);
-
-# dialect: spark, databricks
-ROUND(CAST(1 AS DECIMAL(38, 4)), -2);
-DECIMAL(35, 0);
-
-# dialect: spark, databricks
-ROUND(tbl.bigint_col, 0);
-BIGINT;
-
-# dialect: spark, databricks
-ROUND(tbl.double_col, 0);
-DOUBLE;
-
-# dialect: spark, databricks
-ROUND(CAST(1 AS DECIMAL(10, 4)), ABS(0));
-DECIMAL(7, 0);


### PR DESCRIPTION
## Human-Written Summary

I've updated the annotators to handle some ROUND quirks:
- Snowflake ROUND now correctly updates DECIMAL precision/scale.
- Spark/Databricks ROUND now correctly updates DECIMAL precision/scale.
- Spark/Databricks ROUND preserves integers as BIGINTs.
- Spark/Databricks ROUND still emits DOUBLE for DOUBLE.

## Empirically verified behavior

Verified via `typeof(ROUND(...))` / `SYSTEM$TYPEOF(ROUND(...))` against live Databricks SQL and Snowflake warehouses (2026-05-14 and 2026-06-05).

## Changes

- `sqlglot/typing/spark.py`: adds `_decimal`, `_decimal_ps`, `_round_literal_int` helpers and `_annotate_round`; registers `exp.Round`
- `sqlglot/typing/snowflake.py`: same helpers + `_annotate_round_snowflake`; removes `exp.Round` from the generic `_annotate_by_args` group and registers a proper annotator
- `tests/fixtures/optimizer/annotate_functions.sql`: adds 14 new cases covering the rules above