### PR TITLE
fix(clickhouse): parse file() as a table function

### DIFF
--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -316,6 +316,7 @@ class ClickHouseParser(parser.Parser):
     FUNC_TOKENS = {
         *parser.Parser.FUNC_TOKENS,
         TokenType.AND,
+        TokenType.FILE,
         TokenType.OR,
         TokenType.SET,
     }

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1855,6 +1855,13 @@ LIFETIME(MIN 0 MAX 0)""",
         )
         self.validate_identity("splitByChar('', x)")
 
+    def test_table_functions(self):
+        self.validate_identity(
+            "CREATE VIEW myschema.myview (c1 String NOT NULL) AS SELECT c1 FROM file('base/dir/*.parquet', Parquet)"
+        )
+        self.validate_identity("SELECT * FROM file('path', Parquet) WHERE x > 1")
+        self.validate_identity("SELECT * FROM file('path', Parquet)")
+
     def test_sql_security(self):
         stmts = [
             "CREATE VIEW v DEFINER='alice' SQL SECURITY DEFINER AS SELECT 1",


### PR DESCRIPTION
Fixes #7715.

TokenType.FILE was missing from FUNC_TOKENS, so `file(...)` in ClickHouse was parsed as a table name followed by alias columns instead of as a table function call.