### PR TITLE
Fix(optimizer): column-to-dot conversion bug in qualify due to looking at wrong source set

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -544,7 +544,7 @@ def _convert_columns_to_dots(scope: Scope, resolver: Resolver) -> None:
         dot_parts = column.meta.pop("dot_parts", [])
         if (
             column_table
-            and column_table not in scope.sources
+            and column_table not in scope.selected_sources
             and (
                 not scope.parent
                 or column_table not in scope.parent.sources
@@ -553,7 +553,7 @@ def _convert_columns_to_dots(scope: Scope, resolver: Resolver) -> None:
         ):
             root, *parts = column.parts
 
-            if isinstance(root, exp.Identifier) and root.name in scope.sources:
+            if isinstance(root, exp.Identifier) and root.name in scope.selected_sources:
                 # The struct is already qualified, but we still need to change the AST
                 column_table = root
                 root, *parts = parts

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -543,6 +543,18 @@ WITH tbl1 AS (SELECT STRUCT(1 AS f0, 2 AS f1) AS col) SELECT tbl1.col.f0 AS f0, 
 SELECT one.* FROM structs;
 SELECT structs.one.a_1 AS a_1, structs.one.b_1 AS b_1 FROM structs AS structs;
 
+# dialect: bigquery
+# execute: false
+# title: BigQuery - Unreferenced CTE does not shadow struct column in star expansion
+WITH one AS (SELECT 1 AS x) SELECT one.* FROM structs;
+WITH one AS (SELECT 1 AS x) SELECT structs.one.a_1 AS a_1, structs.one.b_1 AS b_1 FROM structs AS structs;
+
+# dialect: bigquery
+# execute: false
+# title: BigQuery - CTE in FROM takes precedence over struct column in star expansion
+WITH one AS (SELECT 1 AS x) SELECT one.* FROM structs, one;
+WITH one AS (SELECT 1 AS x) SELECT one.x AS x FROM structs AS structs CROSS JOIN one AS one;
+
 # dialect: risingwave
 # execute: false
 # title: RisingWave - Expand top level nested struct


### PR DESCRIPTION
This PR aims to fix the following qualification failure:

```
>>> import sqlglot
>>> from sqlglot.optimizer.qualify import qualify
>>>
>>> from sqlglot.schema import MappingSchema
>>> sql = '''
... WITH struct_col AS (
...     SELECT 1 AS a, 2 AS b
... )
... SELECT struct_col.* FROM t
... '''
...
... schema = MappingSchema({
...     't': {
...         'id': 'INT64',
...         'struct_col': 'STRUCT<a INT64, b INT64>'
...     }
... }, dialect='bigquery')
... result = qualify(sqlglot.parse_one(sql, dialect='bigquery'), schema=schema, dialect='bigquery')
... print(result.sql(dialect='bigquery'))
...
Traceback (most recent call last):
  File "<python-input-5>", line 14, in <module>
    result = qualify(sqlglot.parse_one(sql, dialect='bigquery'), schema=schema, dialect='bigquery')
  File "/Users/georgesittas/Dev/sqlglot/sqlglot/optimizer/qualify.py", line 111, in qualify
    validate_qualify_columns_func(expression, sql=sql)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/Users/georgesittas/Dev/sqlglot/sqlglot/optimizer/qualify_columns.py", line 139, in validate_qualify_columns
    raise OptimizeError(error_msg)
sqlglot.errors.OptimizeError: Column 'a' could not be resolved for table: 'struct_col'.
```

This shouldn't break like this. Resolving struct_col to the only source, `t`, should be trivial. The issue was that we were looking at `Scope.sources` instead of `Scope.selected_sources`.
