### PR TITLE
fix(presto): Use valid bitwise shift left and right functions

### DIFF
--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -279,13 +279,11 @@ class PrestoGenerator(generator.Generator):
         exp.ArraySlice: rename_func("SLICE"),
         exp.AtTimeZone: rename_func("AT_TIMEZONE"),
         exp.BitwiseAnd: lambda self, e: self.func("BITWISE_AND", e.this, e.expression),
-        exp.BitwiseLeftShift: lambda self, e: self.func(
-            "BITWISE_ARITHMETIC_SHIFT_LEFT", e.this, e.expression
-        ),
+        exp.BitwiseLeftShift: lambda self, e: self.func("BITWISE_LEFT_SHIFT", e.this, e.expression),
         exp.BitwiseNot: lambda self, e: self.func("BITWISE_NOT", e.this),
         exp.BitwiseOr: lambda self, e: self.func("BITWISE_OR", e.this, e.expression),
         exp.BitwiseRightShift: lambda self, e: self.func(
-            "BITWISE_ARITHMETIC_SHIFT_RIGHT", e.this, e.expression
+            "BITWISE_RIGHT_SHIFT", e.this, e.expression
         ),
         exp.BitwiseXor: lambda self, e: self.func("BITWISE_XOR", e.this, e.expression),
         exp.Cast: transforms.preprocess([transforms.epoch_cast_to_ts]),

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -227,7 +227,7 @@ class TestExasol(Validator):
             write={
                 "exasol": "SELECT BIT_LSHIFT(x, 1)",
                 "duckdb": "SELECT x << 1",
-                "presto": "SELECT BITWISE_ARITHMETIC_SHIFT_LEFT(x, 1)",
+                "presto": "SELECT BITWISE_LEFT_SHIFT(x, 1)",
                 "hive": "SELECT x << 1",
                 "spark": "SELECT SHIFTLEFT(x, 1)",
             },
@@ -243,7 +243,7 @@ class TestExasol(Validator):
             write={
                 "exasol": "SELECT BIT_RSHIFT(x, 1)",
                 "duckdb": "SELECT x >> 1",
-                "presto": "SELECT BITWISE_ARITHMETIC_SHIFT_RIGHT(x, 1)",
+                "presto": "SELECT BITWISE_RIGHT_SHIFT(x, 1)",
                 "hive": "SELECT x >> 1",
                 "spark": "SELECT SHIFTRIGHT(x, 1)",
             },

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -69,7 +69,7 @@ class TestHive(Validator):
             },
             write={
                 "duckdb": "x << 1",
-                "presto": "BITWISE_ARITHMETIC_SHIFT_LEFT(x, 1)",
+                "presto": "BITWISE_LEFT_SHIFT(x, 1)",
                 "hive": "x << 1",
                 "spark": "SHIFTLEFT(x, 1)",
             },
@@ -81,7 +81,7 @@ class TestHive(Validator):
             },
             write={
                 "duckdb": "x >> 1",
-                "presto": "BITWISE_ARITHMETIC_SHIFT_RIGHT(x, 1)",
+                "presto": "BITWISE_RIGHT_SHIFT(x, 1)",
                 "hive": "x >> 1",
                 "spark": "SHIFTRIGHT(x, 1)",
             },


### PR DESCRIPTION
The wrong functions are invoked, both do not exist and have never existed in Presto and seem to be copied from hive. Functions have been introduced in Presto since v340: https://trino.io/docs/340/functions/bitwise.html

Trino documentation for these functions can be found here: https://trino.io/docs/481/functions/bitwise.html