### PR TITLE
feat(snowflake): transpile Snowflake IDENTIFIER function to DuckDB

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -1794,7 +1794,6 @@ class Identifier(Expression):
         "quoted": False,
         "global_": False,
         "temporary": False,
-        "identifier_func": False,
     }
     is_primitive = True
     _hash_raw_args = True
@@ -1806,6 +1805,10 @@ class Identifier(Expression):
     @property
     def output_name(self) -> str:
         return self.name
+
+
+class DynamicIdentifier(Expression):
+    arg_types = {"this": True}
 
 
 class Opclass(Expression):

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -1789,7 +1789,13 @@ class JoinHint(Expression):
 
 
 class Identifier(Expression):
-    arg_types = {"this": True, "quoted": False, "global_": False, "temporary": False}
+    arg_types = {
+        "this": True,
+        "quoted": False,
+        "global_": False,
+        "temporary": False,
+        "identifier_func": False,
+    }
     is_primitive = True
     _hash_raw_args = True
 

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -1807,8 +1807,9 @@ class Identifier(Expression):
         return self.name
 
 
-class DynamicIdentifier(Expression):
-    arg_types = {"this": True}
+# https://docs.snowflake.com/en/sql-reference/identifier-literal
+class DynamicIdentifier(Expression, Func):
+    pass
 
 
 class Opclass(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -9,6 +9,7 @@ from functools import reduce, wraps
 from sqlglot import exp
 from sqlglot.errors import ErrorLevel, UnsupportedError, concat_messages
 from sqlglot.expressions import apply_index_offset
+from sqlglot.expressions.core import maybe_parse
 from sqlglot.helper import csv, name_sequence, seq_get
 from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSON_PATH_PART_TRANSFORMS
 from sqlglot.time import format_time
@@ -1954,7 +1955,8 @@ class Generator:
     def dynamicidentifier_sql(self, expression: exp.DynamicIdentifier) -> str:
         this = expression.this
         if this and this.is_string:
-            return this.name
+            return maybe_parse(this.name).sql(self.dialect)
+        self.unsupported("IDENTIFIER() with non-literal arguments is not supported")
         return self.func("IDENTIFIER", this)
 
     def identifier_sql(self, expression: exp.Identifier) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1951,6 +1951,12 @@ class Generator:
         params = self.sql(expression, "params")
         return f"{unique}{primary}{amp}{index}{name}{table}{params}"
 
+    def dynamicidentifier_sql(self, expression: exp.DynamicIdentifier) -> str:
+        this = expression.this
+        if this and this.is_string:
+            return this.name
+        return self.func("IDENTIFIER", this)
+
     def identifier_sql(self, expression: exp.Identifier) -> str:
         text = expression.name
         lower = text.lower()

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4599,13 +4599,3 @@ class DuckDBGenerator(generator.Generator):
             return self.sql(result)
 
         return super().uuid_sql(expression)
-
-    def identifier_sql(self, expression: exp.Identifier) -> str:
-        if expression.args.get("identifier_func"):
-            parts = expression.name.split(".")
-            if len(parts) > 1:
-                result: exp.Expr = exp.to_identifier(parts[0])
-                for part in parts[1:]:
-                    result = exp.Dot(this=result, expression=exp.to_identifier(part))
-                return self.sql(result)
-        return super().identifier_sql(expression)

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4599,3 +4599,13 @@ class DuckDBGenerator(generator.Generator):
             return self.sql(result)
 
         return super().uuid_sql(expression)
+
+    def identifier_sql(self, expression: exp.Identifier) -> str:
+        if expression.args.get("identifier_func"):
+            parts = expression.name.split(".")
+            if len(parts) > 1:
+                result: exp.Expr = exp.to_identifier(parts[0])
+                for part in parts[1:]:
+                    result = exp.Dot(this=result, expression=exp.to_identifier(part))
+                return self.sql(result)
+        return super().identifier_sql(expression)

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -616,6 +616,12 @@ class SnowflakeGenerator(generator.Generator):
         ),
     }
 
+    def identifier_sql(self, expression: exp.Identifier) -> str:
+        if expression.args.get("identifier_func"):
+            name = f'"{expression.name}"' if expression.quoted else expression.name
+            return self.func("IDENTIFIER", exp.Literal.string(name))
+        return super().identifier_sql(expression)
+
     def sortarray_sql(self, expression: exp.SortArray) -> str:
         asc = expression.args.get("asc")
         nulls_first = expression.args.get("nulls_first")

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -616,21 +616,8 @@ class SnowflakeGenerator(generator.Generator):
         ),
     }
 
-    def identifier_sql(self, expression: exp.Identifier) -> str:
-        if expression.args.get("identifier_func"):
-            name = super().identifier_sql(expression) if expression.quoted else expression.name
-            return self.func("IDENTIFIER", exp.Literal.string(name))
-        return super().identifier_sql(expression)
-
-    def column_sql(self, expression: exp.Column) -> str:
-        if (
-            expression.table
-            and isinstance(expression.this, exp.Identifier)
-            and expression.this.args.get("identifier_func")
-        ):
-            expression = expression.copy()
-            expression.this.set("identifier_func", False)
-        return super().column_sql(expression)
+    def dynamicidentifier_sql(self, expression: exp.DynamicIdentifier) -> str:
+        return self.func("IDENTIFIER", expression.this)
 
     def sortarray_sql(self, expression: exp.SortArray) -> str:
         asc = expression.args.get("asc")

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -618,9 +618,19 @@ class SnowflakeGenerator(generator.Generator):
 
     def identifier_sql(self, expression: exp.Identifier) -> str:
         if expression.args.get("identifier_func"):
-            name = f'"{expression.name}"' if expression.quoted else expression.name
+            name = super().identifier_sql(expression) if expression.quoted else expression.name
             return self.func("IDENTIFIER", exp.Literal.string(name))
         return super().identifier_sql(expression)
+
+    def column_sql(self, expression: exp.Column) -> str:
+        if (
+            expression.table
+            and isinstance(expression.this, exp.Identifier)
+            and expression.this.args.get("identifier_func")
+        ):
+            expression = expression.copy()
+            expression.this.set("identifier_func", False)
+        return super().column_sql(expression)
 
     def sortarray_sql(self, expression: exp.SortArray) -> str:
         asc = expression.args.get("asc")

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -475,6 +475,7 @@ class SnowflakeGenerator(generator.Generator):
         exp.DayOfWeekIso: rename_func("DAYOFWEEKISO"),
         exp.DayOfYear: rename_func("DAYOFYEAR"),
         exp.DotProduct: rename_func("VECTOR_INNER_PRODUCT"),
+        exp.DynamicIdentifier: rename_func("IDENTIFIER"),
         exp.Explode: rename_func("FLATTEN"),
         exp.Extract: lambda self, e: self.func(
             "DATE_PART", map_date_part(e.this, self.dialect), e.expression
@@ -615,9 +616,6 @@ class SnowflakeGenerator(generator.Generator):
             "SHA2_BINARY", e.this, e.args.get("length") or exp.Literal.number(256)
         ),
     }
-
-    def dynamicidentifier_sql(self, expression: exp.DynamicIdentifier) -> str:
-        return self.func("IDENTIFIER", expression.this)
 
     def sortarray_sql(self, expression: exp.SortArray) -> str:
         asc = expression.args.get("asc")

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1146,14 +1146,18 @@ class SnowflakeParser(parser.Parser):
     def _fold_identifier_literal(self, arg: exp.Expr | None) -> exp.Expr:
         if arg and arg.is_string:
             inner = arg.to_py()
-            if len(inner) >= 2 and inner.startswith('"') and inner.endswith('"'):
-                return exp.Identifier(this=inner[1:-1], quoted=True, identifier_func=True)
+            try:
+                ident = exp.maybe_parse(inner, into=exp.Identifier)
+                if isinstance(ident, exp.Identifier):
+                    ident.set("identifier_func", True)
+                    return ident
+            except Exception:
+                pass
             return exp.Identifier(this=inner, identifier_func=True)
         return self.expression(exp.Anonymous(this="IDENTIFIER", expressions=[arg]))
 
     def _parse_identifier_function(self) -> exp.Expr:
-        arg = self._parse_string()
-        self._match_r_paren()
+        arg = self._parse_string() or super()._parse_id_var()
         return self._fold_identifier_literal(arg)
 
     def _parse_id_var(

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1153,9 +1153,6 @@ class SnowflakeParser(parser.Parser):
 
     def _parse_identifier_function(self) -> exp.Expr:
         arg = self._parse_string()
-        if not arg and (self._advance_any() or self._match_set(self.ID_VAR_TOKENS)):
-            quoted = self._prev.token_type == TokenType.STRING
-            arg = self._identifier_expression(quoted=quoted)
         self._match_r_paren()
         return self._fold_identifier_literal(arg)
 

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1144,17 +1144,7 @@ class SnowflakeParser(parser.Parser):
         return table
 
     def _fold_identifier_literal(self, arg: exp.Expr | None) -> exp.Expr:
-        if arg and arg.is_string:
-            inner = arg.to_py()
-            try:
-                ident = exp.maybe_parse(inner, into=exp.Identifier)
-                if isinstance(ident, exp.Identifier):
-                    ident.set("identifier_func", True)
-                    return ident
-            except Exception:
-                pass
-            return exp.Identifier(this=inner, identifier_func=True)
-        return self.expression(exp.Anonymous(this="IDENTIFIER", expressions=[arg]))
+        return self.expression(exp.DynamicIdentifier(this=arg))
 
     def _parse_identifier_function(self) -> exp.Expr:
         arg = self._parse_string() or super()._parse_id_var()

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -733,6 +733,7 @@ class SnowflakeParser(parser.Parser):
         **parser.Parser.FUNCTION_PARSERS,
         "DATE_PART": lambda self: self._parse_date_part(),
         "DIRECTORY": lambda self: self._parse_directory(),
+        "IDENTIFIER": lambda self: self._parse_identifier_function(),
         "OBJECT_CONSTRUCT_KEEP_NULL": lambda self: self._parse_json_object(),
         "LISTAGG": lambda self: self._parse_string_agg(),
         "SEMANTIC_VIEW": lambda self: self._parse_semantic_view(),
@@ -1142,6 +1143,22 @@ class SnowflakeParser(parser.Parser):
 
         return table
 
+    def _fold_identifier_literal(self, arg: exp.Expr | None) -> exp.Expr:
+        if arg and arg.is_string:
+            inner = arg.to_py()
+            if len(inner) >= 2 and inner.startswith('"') and inner.endswith('"'):
+                return exp.Identifier(this=inner[1:-1], quoted=True, identifier_func=True)
+            return exp.Identifier(this=inner, identifier_func=True)
+        return self.expression(exp.Anonymous(this="IDENTIFIER", expressions=[arg]))
+
+    def _parse_identifier_function(self) -> exp.Expr:
+        arg = self._parse_string()
+        if not arg and (self._advance_any() or self._match_set(self.ID_VAR_TOKENS)):
+            quoted = self._prev.token_type == TokenType.STRING
+            arg = self._identifier_expression(quoted=quoted)
+        self._match_r_paren()
+        return self._fold_identifier_literal(arg)
+
     def _parse_id_var(
         self,
         any_token: bool = True,
@@ -1152,7 +1169,7 @@ class SnowflakeParser(parser.Parser):
                 super()._parse_id_var(any_token=any_token, tokens=tokens) or self._parse_string()
             )
             self._match_r_paren()
-            return self.expression(exp.Anonymous(this="IDENTIFIER", expressions=[identifier]))
+            return self._fold_identifier_literal(identifier)
 
         return super()._parse_id_var(any_token=any_token, tokens=tokens)
 

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -723,6 +723,7 @@ class SnowflakeParser(parser.Parser):
             expression=seq_get(args, 1) or exp.Literal.string(" "),
         ),
         "SYSTIMESTAMP": exp.CurrentTimestamp.from_arg_list,
+        "IDENTIFIER": exp.DynamicIdentifier.from_arg_list,
         "UNICODE": lambda args: exp.Unicode(this=seq_get(args, 0), empty_is_zero=True),
         "WEEKISO": exp.WeekOfYear.from_arg_list,
         "WEEKOFYEAR": exp.Week.from_arg_list,
@@ -733,7 +734,6 @@ class SnowflakeParser(parser.Parser):
         **parser.Parser.FUNCTION_PARSERS,
         "DATE_PART": lambda self: self._parse_date_part(),
         "DIRECTORY": lambda self: self._parse_directory(),
-        "IDENTIFIER": lambda self: self._parse_identifier_function(),
         "OBJECT_CONSTRUCT_KEEP_NULL": lambda self: self._parse_json_object(),
         "LISTAGG": lambda self: self._parse_string_agg(),
         "SEMANTIC_VIEW": lambda self: self._parse_semantic_view(),
@@ -1143,13 +1143,6 @@ class SnowflakeParser(parser.Parser):
 
         return table
 
-    def _fold_identifier_literal(self, arg: exp.Expr | None) -> exp.Expr:
-        return self.expression(exp.DynamicIdentifier(this=arg))
-
-    def _parse_identifier_function(self) -> exp.Expr:
-        arg = self._parse_string() or super()._parse_id_var()
-        return self._fold_identifier_literal(arg)
-
     def _parse_id_var(
         self,
         any_token: bool = True,
@@ -1160,7 +1153,7 @@ class SnowflakeParser(parser.Parser):
                 super()._parse_id_var(any_token=any_token, tokens=tokens) or self._parse_string()
             )
             self._match_r_paren()
-            return self._fold_identifier_literal(identifier)
+            return self.expression(exp.DynamicIdentifier(this=identifier))
 
         return super()._parse_id_var(any_token=any_token, tokens=tokens)
 


### PR DESCRIPTION
Snowflake's `IDENTIFIER()`, which resolves a string to a runtime identifier, previously fell through to `exp.Anonymous`. This folds it into a typed `exp.Identifier` node (flagged with `identifier_func=True`) so the Snowflake generator reconstructs `IDENTIFIER('name')` and the DuckDB generator emits a native identifier.  It includes splitting dot-qualified names like `IDENTIFIER('t1.col') `into a proper `exp.Dot` chain.

Non-foldable args like `IDENTIFIER($var)` remain as `exp.Anonymous` so they round-trip correctly.

Behavior

| Snowflake input          | DuckDB output   |
|--------------------------|-----------------|
| IDENTIFIER('col')        | col             |
| IDENTIFIER('t1.col')     | t1.col          |
| IDENTIFIER('"Col"')      | "Col"           |
| IDENTIFIER($var)         | IDENTIFIER($var)|