### PR TITLE
perf(optimizer): speed up qualify by ~24% and optimize by ~17%

### DIFF
--- a/sqlglot/dialects/bigquery.py
+++ b/sqlglot/dialects/bigquery.py
@@ -147,9 +147,9 @@ class BigQuery(Dialect):
                 or (
                     isinstance(parent, exp.Table)
                     and parent.db
-                    and (parent.meta.get("quoted_table") or not parent.meta.get("maybe_column"))
+                    and (parent.meta_get("quoted_table") or not parent.meta_get("maybe_column"))
                 )
-                or expression.meta.get("is_table")
+                or expression.meta_get("is_table")
             )
             if not case_sensitive:
                 expression.set("this", expression.this.lower())

--- a/sqlglot/expressions/builders.py
+++ b/sqlglot/expressions/builders.py
@@ -319,6 +319,11 @@ def parse_identifier(name: str | Identifier, dialect: DialectType = None) -> Ide
     Returns:
         The identifier ast node.
     """
+    if isinstance(name, str) and SAFE_IDENTIFIER_RE.match(name):
+        # Simple names parse to a single unquoted identifier in all dialects, so we can
+        # avoid the tokenizer/parser round-trip for them.
+        return Identifier(this=name, quoted=False)
+
     try:
         expression = maybe_parse(name, dialect=dialect, into=Identifier)
     except (ParseError, TokenError):
@@ -822,7 +827,7 @@ def replace_tables(
     mapping = {normalize_table_name(k, dialect=dialect): v for k, v in mapping.items()}
 
     def _replace_tables(node: Expr) -> Expr:
-        if isinstance(node, Table) and node.meta.get("replace") is not False:
+        if isinstance(node, Table) and node.meta_get("replace") is not False:
             original = normalize_table_name(node, dialect=dialect)
             new_name = mapping.get(original)
 

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -240,6 +240,9 @@ class Expr:
     def meta(self) -> dict[str, t.Any]:
         raise NotImplementedError
 
+    def meta_get(self, key: str, default: t.Any = None) -> t.Any:
+        raise NotImplementedError
+
     def __deepcopy__(self, memo: t.Any) -> Expr:
         raise NotImplementedError
 
@@ -989,6 +992,11 @@ class Expression(Expr):
         if self._meta is None:
             self._meta = {}
         return self._meta
+
+    def meta_get(self, key: str, default: t.Any = None) -> t.Any:
+        """Reads a meta value without allocating the meta dict (unlike the `meta` property)."""
+        meta = self._meta
+        return meta.get(key, default) if meta is not None else default
 
     def __deepcopy__(self, memo: t.Any) -> Expr:
         root = self.__class__()

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4546,7 +4546,7 @@ class Generator:
                 args.append(arg_value)
 
         if self.dialect.PRESERVE_ORIGINAL_NAMES:
-            name = (expression._meta and expression.meta.get("name")) or expression.sql_name()
+            name = expression.meta_get("name") or expression.sql_name()
         else:
             name = expression.sql_name()
 
@@ -5250,7 +5250,7 @@ class Generator:
             )
             return self.sql(this)
 
-        if self.IGNORE_NULLS_IN_FUNC and not expression.meta.get("inline"):
+        if self.IGNORE_NULLS_IN_FUNC and not expression.meta_get("inline"):
             if self.IGNORE_NULLS_BEFORE_ORDER:
                 # The first modifier here will be the one closest to the AggFunc's arg
                 mods = sorted(

--- a/sqlglot/generators/bigquery.py
+++ b/sqlglot/generators/bigquery.py
@@ -201,7 +201,7 @@ def _levenshtein_sql(self: BigQueryGenerator, expression: exp.Levenshtein) -> st
 
 
 def _json_extract_sql(self: BigQueryGenerator, expression: JSON_EXTRACT_TYPE) -> str:
-    name = (expression._meta and expression.meta.get("name")) or expression.sql_name()
+    name = expression.meta_get("name") or expression.sql_name()
     upper = name.upper()
 
     dquote_escaping = upper in DQUOTES_ESCAPING_JSON_FUNCTIONS
@@ -565,7 +565,7 @@ class BigQueryGenerator(generator.Generator):
         )
 
     def column_parts(self, expression: exp.Column) -> str:
-        if expression.meta.get("quoted_column"):
+        if expression.meta_get("quoted_column"):
             # If a column reference is of the form `dataset.table`.name, we need
             # to preserve the quoted table path, otherwise the reference breaks
             table_parts = ".".join(p.name for p in expression.parts[:-1])
@@ -583,7 +583,7 @@ class BigQueryGenerator(generator.Generator):
         #
         # - WITH x AS (SELECT [1, 2] AS y) SELECT * FROM x, `x.y`   -> cross join
         # - WITH x AS (SELECT [1, 2] AS y) SELECT * FROM x, `x`.`y` -> implicit unnest
-        if expression.meta.get("quoted_table"):
+        if expression.meta_get("quoted_table"):
             table_parts = ".".join(p.name for p in expression.parts)
             return self.sql(exp.Identifier(this=table_parts, quoted=True))
 

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -400,7 +400,7 @@ class TypeAnnotator:
                     isinstance(source, Scope)
                     and isinstance(source.expression, exp.Query)
                     and (
-                        source.expression.meta.get("query_type") or exp.DType.UNKNOWN.into_expr()
+                        source.expression.meta_get("query_type") or exp.DType.UNKNOWN.into_expr()
                     ).is_type(exp.DType.STRUCT)
                 ):
                     self._set_type(table_column, source.expression.meta["query_type"])
@@ -497,7 +497,7 @@ class TypeAnnotator:
                 else:
                     self._set_type(expr, exp.DType.UNKNOWN)
 
-                if expr.is_type(exp.DType.JSON) and (dot_parts := expr.meta.get("dot_parts")):
+                if expr.is_type(exp.DType.JSON) and (dot_parts := expr.meta_get("dot_parts")):
                     # JSON dot access is case sensitive across all dialects, so we need to undo the normalization.
                     i = iter(dot_parts)
                     parent = expr.parent
@@ -740,7 +740,7 @@ class TypeAnnotator:
             self._annotate_by_args(expression, left, right)
 
         if isinstance(expression, exp.Is) or (
-            left.meta.get("nonnull") is True and right.meta.get("nonnull") is True
+            left.meta_get("nonnull") is True and right.meta_get("nonnull") is True
         ):
             expression.meta["nonnull"] = True
 
@@ -752,7 +752,7 @@ class TypeAnnotator:
         else:
             self._set_type(expression, expression.this.type)
 
-        if expression.this.meta.get("nonnull") is True:
+        if expression.this.meta_get("nonnull") is True:
             expression.meta["nonnull"] = True
 
         return expression

--- a/sqlglot/optimizer/normalize_identifiers.py
+++ b/sqlglot/optimizer/normalize_identifiers.py
@@ -63,8 +63,8 @@ def normalize_identifiers(expression, dialect=None, store_original_column_identi
     if isinstance(expression, str):
         expression = exp.parse_identifier(expression, dialect=dialect)
 
-    for node in expression.walk(prune=lambda n: bool(n.meta.get("case_sensitive"))):
-        if not node.meta.get("case_sensitive"):
+    for node in expression.walk(prune=lambda n: bool(n.meta_get("case_sensitive"))):
+        if not node.meta_get("case_sensitive"):
             if store_original_column_identifiers and isinstance(node, exp.Column):
                 # TODO: This does not handle non-column cases, e.g PARSE_JSON(...).key
                 parent = node
@@ -73,6 +73,7 @@ def normalize_identifiers(expression, dialect=None, store_original_column_identi
 
                 node.meta["dot_parts"] = [p.name for p in parent.parts]
 
-            dialect.normalize_identifier(node)
+            if isinstance(node, exp.Identifier):
+                dialect.normalize_identifier(node)
 
     return expression

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -124,10 +124,10 @@ def validate_qualify_columns(expression: E, sql: str | None = None) -> E:
             if scope.external_columns and not scope.is_correlated_subquery and not scope.pivots:
                 column = scope.external_columns[0]
                 for_table = f" for table: '{column.table}'" if column.table else ""
-                line = column.this.meta.get("line")
-                col = column.this.meta.get("col")
-                start = column.this.meta.get("start")
-                end = column.this.meta.get("end")
+                line = column.this.meta_get("line")
+                col = column.this.meta_get("col")
+                start = column.this.meta_get("start")
+                end = column.this.meta_get("end")
 
                 error_msg = f"Column '{column.name}' could not be resolved{for_table}."
                 if line and col:
@@ -142,10 +142,10 @@ def validate_qualify_columns(expression: E, sql: str | None = None) -> E:
 
     if all_unqualified_columns:
         first_column = all_unqualified_columns[0]
-        line = first_column.this.meta.get("line")
-        col = first_column.this.meta.get("col")
-        start = first_column.this.meta.get("start")
-        end = first_column.this.meta.get("end")
+        line = first_column.this.meta_get("line")
+        col = first_column.this.meta_get("col")
+        start = first_column.this.meta_get("start")
+        end = first_column.this.meta_get("end")
 
         error_msg = f"Ambiguous column '{first_column.name}'"
         if line and col:
@@ -204,6 +204,9 @@ def _expand_using(scope: Scope, resolver: Resolver) -> dict[str, t.Any]:
                 columns[column_name] = source_name
 
     joins = list(scope.find_all(exp.Join))
+    if not joins:
+        return {}
+
     names = {join.alias_or_name for join in joins}
     ordered = [key for key in scope.selected_sources if key not in names]
 
@@ -212,6 +215,9 @@ def _expand_using(scope: Scope, resolver: Resolver) -> dict[str, t.Any]:
 
     # Mapping of automatically joined column names to an ordered set of source names (dict).
     column_tables: dict[str, dict[str, t.Any]] = {}
+
+    if not any(join.args.get("using") for join in joins):
+        return column_tables
 
     for source_name in ordered:
         _update_source_columns(source_name)
@@ -954,9 +960,15 @@ def qualify_outputs(scope_or_expression: Scope | exp.Expr) -> None:
 
 def quote_identifiers(expression: E, dialect: DialectType = None, identify: bool = True) -> E:
     """Makes sure all identifiers that need to be quoted are quoted."""
-    return expression.transform(
-        Dialect.get_or_raise(dialect).quote_identifier, identify=identify, copy=False
-    )
+    dialect = Dialect.get_or_raise(dialect)
+
+    # `quote_identifier` only mutates identifiers in place, so we avoid `transform` here
+    # because its node replacement machinery is wasteful for this case.
+    for node in expression.walk():
+        if isinstance(node, exp.Identifier):
+            dialect.quote_identifier(node, identify=identify)
+
+    return expression
 
 
 def pushdown_cte_alias_columns(scope: Scope) -> None:

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -21,6 +21,20 @@ TRAVERSABLES = (exp.Query, exp.DDL, exp.DML)
 
 ROW_LEVEL_AGG_FUNCS = (exp.Count,)
 
+# The node types `Scope._collect` classifies, roughly ordered by frequency. `exp.Query`
+# covers subqueries, and `exp.UDTF` covers laterals.
+COLLECTIBLE_TYPES = (
+    exp.Column,
+    exp.Dot,
+    exp.Table,
+    exp.Query,
+    exp.UDTF,
+    exp.CTE,
+    exp.Star,
+    exp.TableColumn,
+    exp.JoinHint,
+)
+
 
 class ScopeType(Enum):
     ROOT = auto()
@@ -170,7 +184,9 @@ class Scope:
         self._column_index = set()
 
         for node in self.walk():
-            if node is self.expression:
+            # Most nodes (identifiers, literals, operators etc.) aren't collectible, so a
+            # single isinstance gate lets them skip the classification chain below.
+            if node is self.expression or not isinstance(node, COLLECTIBLE_TYPES):
                 continue
 
             if isinstance(node, exp.Dot) and node.is_star:
@@ -460,8 +476,10 @@ class Scope:
             list[exp.Column]: Column instances that reference sources in the current scope.
         """
         if self._local_columns is None:
-            external_columns = set(self.external_columns)
-            self._local_columns = [c for c in self.columns if c not in external_columns]
+            # Compare nodes by identity: structural equality would conflate distinct
+            # column nodes that happen to look the same, and is much more expensive.
+            external_column_ids = {id(c) for c in self.external_columns}
+            self._local_columns = [c for c in self.columns if id(c) not in external_column_ids]
 
         return self._local_columns
 
@@ -950,11 +968,17 @@ def walk_in_scope(
 
         yield node
 
-        if node is not expression and (
-            isinstance(node, exp.CTE)
-            or (isinstance(node.parent, (exp.From, exp.Join)) and _is_derived_table(node))
-            or (isinstance(node.parent, exp.UDTF) and isinstance(node, exp.Query))
-            or isinstance(node, exp.UNWRAPPED_QUERIES)
+        # Only CTEs and Queries can start child scopes; checking that first lets all
+        # other nodes (the vast majority) skip the rest of the boundary checks.
+        if (
+            node is not expression
+            and isinstance(node, (exp.CTE, exp.Query))
+            and (
+                isinstance(node, exp.CTE)
+                or (isinstance(node.parent, (exp.From, exp.Join)) and _is_derived_table(node))
+                or isinstance(node.parent, exp.UDTF)
+                or isinstance(node, exp.UNWRAPPED_QUERIES)
+            )
         ):
             if isinstance(node, (exp.Subquery, exp.UDTF)):
                 for key in ("joins", "laterals", "pivots"):

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -596,9 +596,9 @@ class Simplifier:
         joins: list[exp.Join] = []
 
         for node in expression.walk(
-            prune=lambda n: bool(isinstance(n, exp.Condition) or n.meta.get(FINAL))
+            prune=lambda n: bool(isinstance(n, exp.Condition) or n.meta_get(FINAL))
         ):
-            if node.meta.get(FINAL):
+            if node.meta_get(FINAL):
                 continue
 
             # group by expressions cannot be simplified, for example
@@ -687,10 +687,10 @@ class Simplifier:
                 original.replace(node)
 
             for n in node.iter_expressions(reverse=True):
-                if n.meta.get(FINAL):
+                if n.meta_get(FINAL):
                     raise
             pre_transformation_stack.extend(
-                n for n in node.iter_expressions(reverse=True) if not n.meta.get(FINAL)
+                n for n in node.iter_expressions(reverse=True) if not n.meta_get(FINAL)
             )
             post_transformation_stack.append((node, parent))
 
@@ -937,7 +937,7 @@ class Simplifier:
             ops = set(expression.flatten())
             for op in ops:
                 if isinstance(op, exp.Not) and op.this in ops:
-                    if expression.meta.get("nonnull") is True:
+                    if expression.meta_get("nonnull") is True:
                         return exp.false() if isinstance(expression, exp.And) else exp.true()
 
         return expression

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -480,10 +480,10 @@ class BigQueryParser(parser.Parser):
 
             info_schema_view = f"{table_parts[-2].name}.{table_parts[-1].name}"
             new_this = exp.Identifier(this=info_schema_view, quoted=True).update_positions(
-                line=table_parts[-2].meta.get("line"),
-                col=table_parts[-1].meta.get("col"),
-                start=table_parts[-2].meta.get("start"),
-                end=table_parts[-1].meta.get("end"),
+                line=table_parts[-2].meta_get("line"),
+                col=table_parts[-1].meta_get("col"),
+                start=table_parts[-2].meta_get("start"),
+                end=table_parts[-1].meta_get("end"),
             )
             table.set("this", new_this)
             table.set("db", seq_get(table_parts, -3))

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -101,7 +101,7 @@ def _annotate_array(self: TypeAnnotator, expression: exp.Array) -> exp.Array:
 
         # Handle ARRAY(SELECT ...) - single SELECT query
         if isinstance(unnested, exp.Select):
-            query_type = unnested.meta.get("query_type")
+            query_type = unnested.meta_get("query_type")
 
             if query_type and query_type.is_type(exp.DType.STRUCT):
                 query_exprs = query_type.expressions


### PR DESCRIPTION
Targeted optimizations to `qualify()` and a new non-allocating meta accessor. Every change was validated with paired wall-clock A/B runs against `main` (interleaved to cancel machine drift); cProfile was used only for candidate discovery since its per-call overhead misattributes hotspots in this codebase.

### Benchmarks (TPC-DS / TPC-H fixtures, qualify only)

| | TPC-H | TPC-DS |
|---|---|---|
| pure Python | **-24%** (49.4 → 37.4ms) | **-26%** (446 → 331ms) |
| mypyc release build | **-21%** (27.6 → 21.7ms) | **-24%** (252 → 192ms) |

Full `optimize()` on TPC-H: **-17%** (452 → 374ms). Qualified output is byte-identical on all TPC-H/TPC-DS queries.

### Changes

- **`Expression.meta_get(key, default)`** — non-allocating meta read. The `meta` property allocates `{}` on first read, so hot read paths (`normalize_identifiers`' per-node prune, `simplify`'s `FINAL` checks) were allocating a dict on every AST node and slowing every subsequent `copy()` (deepcopy of empty dicts). All read-only `.meta.get(...)` sites now use `meta_get`; writes still go through `meta`. This is most of the `optimize()` win.
- **`Scope._collect`**: a single tuple-isinstance gate (`COLLECTIBLE_TYPES`) lets non-collectible nodes (identifiers, literals, operators — the vast majority) skip the ~10-branch classification chain. Paid 3× per query, since `qualify_tables`, `qualify_columns` and `validate_qualify_columns` each build scopes.
- **`walk_in_scope`**: only `CTE`/`Query` nodes can start child scopes, so one cheap isinstance gate replaces up to 4 isinstance checks + 2 parent loads per node.
- **`Scope.local_columns`**: identity (`id()`) set instead of a structural-equality set of column nodes — cheaper, and identity is the intended semantics (matches `_column_index`).
- **`parse_identifier`**: names matching `SAFE_IDENTIFIER_RE` skip the tokenizer/parser round-trip; both the parse path and the existing fallback provably produce `Identifier(this=name, quoted=False)` for such names. `qualify_tables` was re-parsing every alias name through this.
- **`_expand_using`**: early-exit when the scope has no joins / no `USING` joins (it was resolving all source columns per scope for nothing). The `Joins ... missing source table` validation is preserved.
- **`quote_identifiers`**: direct walk over `Identifier` nodes instead of `transform()` — `quote_identifier` mutates in place and never replaces, so transform's replacement bookkeeping was pure overhead.

### Verification

- `make unit` (pure) and the full suite against a clean `make install-devc-release` build: green.
- ruff / ruff-format / mypy: clean.
- Qualified SQL byte-identical to `main` for every TPC-H and TPC-DS fixture query.