### PR TITLE
perf(optimizer): skip redundant hash invalidation in simplify's pointer-reset loop

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -699,9 +699,16 @@ class Simplifier:
             root = original is expression
 
             # Resets parent, arg_key, index pointers– this is needed because some of the
-            # previous transformations mutate the AST, leading to an inconsistent state
+            # previous transformations mutate the AST, leading to an inconsistent state.
+            # We only fix pointers instead of calling `set` because the values are unchanged:
+            # actual mutations go through `set`/`replace`, which already invalidate cached
+            # hashes, so clearing them again here would force `while_changing` to rehash
+            # entire subtrees after every (mostly no-op) pass.
             for k, v in tuple(original.args.items()):
-                original.set(k, v)
+                if v is None:
+                    original.args.pop(k)
+                else:
+                    original._set_parent(k, v)
 
             # Post-order transformations
             node = self.simplify_not(original)


### PR DESCRIPTION
`_simplify`'s post-order pass re-anchors child `parent`/`arg_key`/`index` pointers via `original.set(k, v)`. Besides fixing pointers, `set()` clears cached structural hashes up the ancestor chain — but this loop never changes a value, and real mutations already invalidate through `set`/`replace`/`pop`. The wasted invalidation forced `while_changing` to rehash entire condition subtrees on every (mostly no-op) pass just to detect the fix point.

Fix pointers directly with `_set_parent`, preserving `set(k, None)`'s arg-removal semantics. Safe because `__hash__` only covers `key` + `args` values, which this loop doesn't touch.

Simplify step is ~5-12% faster (condition and TPC fixtures), full `optimize()` ~2%. Optimized output is byte-identical on all fixtures; pure and compiled suites green.