### PR TITLE
Fix(sqlglotc): pin sqlglot to the exact matching version

### DIFF
--- a/sqlglotc/pyproject.toml
+++ b/sqlglotc/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sqlglotc"
-dynamic = ["version"]
+dynamic = ["version", "dependencies"]
 description = "mypyc-compiled extensions for sqlglot"
 authors = [{ name = "Toby Mao", email = "toby.mao@gmail.com" }]
 license = "MIT"

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -130,20 +130,30 @@ class sdist(_sdist):
 
 def _sqlglot_requirement():
     """Pin sqlglot to the matching version so resolvers keep the two packages in lockstep."""
-    pkg_info = os.path.join(os.path.dirname(os.path.abspath(__file__)), "PKG-INFO")
-    if os.path.isfile(pkg_info):
-        # Building from an sdist: no git metadata; the released version is frozen in PKG-INFO.
-        with open(pkg_info, encoding="utf-8") as fd:
-            version = next(
-                (line.split(":", 1)[1].strip() for line in fd if line.startswith("Version:")), ""
+    try:
+        pkg_info = os.path.join(os.path.dirname(os.path.abspath(__file__)), "PKG-INFO")
+        if os.path.isfile(pkg_info):
+            # Building from an sdist: no git metadata; the released version is frozen in PKG-INFO.
+            with open(pkg_info, encoding="utf-8") as fd:
+                version = next(
+                    (line.split(":", 1)[1].strip() for line in fd if line.startswith("Version:")),
+                    "",
+                )
+        else:
+            from setuptools_scm import get_version
+
+            version = get_version(
+                root="..",
+                relative_to=__file__,
+                local_scheme="no-local-version",
+                fallback_version="0.0.0",
             )
-    else:
-        from setuptools_scm import get_version
+    except Exception as e:
+        print(f"sqlglotc: failed to determine the sqlglot version to pin, skipping it: {e}")
+        version = ""
 
-        version = get_version(root="..", relative_to=__file__, local_scheme="no-local-version")
-
-    # Dev builds have no matching sqlglot release on PyPI, so skip the pin.
-    return [] if not version or ".dev" in version else [f"sqlglot=={version}"]
+    # Dev and fallback (no git metadata) builds have no matching sqlglot release on PyPI.
+    return [] if version in ("", "0.0.0") or ".dev" in version else [f"sqlglot=={version}"]
 
 
 setup(

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -149,11 +149,15 @@ def _sqlglot_requirement():
                 fallback_version="0.0.0",
             )
     except Exception as e:
-        print(f"sqlglotc: failed to determine the sqlglot version to pin, skipping it: {e}")
+        print(f"sqlglotc: failed to determine the sqlglot version to pin: {e}")
         version = ""
 
-    # Dev and fallback (no git metadata) builds have no matching sqlglot release on PyPI.
-    return [] if version in ("", "0.0.0") or ".dev" in version else [f"sqlglot=={version}"]
+    # Dev and fallback (no git metadata) builds have no matching sqlglot release on PyPI;
+    # depend on sqlglot unpinned since the extensions can't be imported without it.
+    if version in ("", "0.0.0") or ".dev" in version:
+        return ["sqlglot"]
+
+    return [f"sqlglot=={version}"]
 
 
 setup(

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -128,9 +128,28 @@ class sdist(_sdist):
             shutil.rmtree(local_sqlglot, ignore_errors=True)
 
 
+def _sqlglot_requirement():
+    """Pin sqlglot to the matching version so resolvers keep the two packages in lockstep."""
+    pkg_info = os.path.join(os.path.dirname(os.path.abspath(__file__)), "PKG-INFO")
+    if os.path.isfile(pkg_info):
+        # Building from an sdist: no git metadata; the released version is frozen in PKG-INFO.
+        with open(pkg_info, encoding="utf-8") as fd:
+            version = next(
+                (line.split(":", 1)[1].strip() for line in fd if line.startswith("Version:")), ""
+            )
+    else:
+        from setuptools_scm import get_version
+
+        version = get_version(root="..", relative_to=__file__, local_scheme="no-local-version")
+
+    # Dev builds have no matching sqlglot release on PyPI, so skip the pin.
+    return [] if not version or ".dev" in version else [f"sqlglot=={version}"]
+
+
 setup(
     name="sqlglotc",
     packages=[],
+    install_requires=_sqlglot_requirement(),
     ext_modules=mypycify(
         _source_paths(), opt_level=os.environ.get("MYPYC_OPT", "2"), separate=True, verbose=True
     ),


### PR DESCRIPTION
Upgrading `sqlglot` without upgrading `sqlglotc` currently breaks silently: the stale compiled
`tokenizer_core` extension shadows the newer `tokenizer_core.py`, so the compiled `TokenType` enum
lacks newly added members while the pure (never-compiled) `tokens.py` references them. The result is
an import-time crash whose message on Python ≤ 3.11 is just the bare member name, e.g.
`AttributeError: LLRR_ARROW` after `<<->>` support landed in v30.9.0 — reproducible with
`sqlglot==30.10.0` + `sqlglotc==30.8.0` on Python 3.11.

The coupling today is one-directional: the `sqlglotc=={version}` pin only lives in sqlglot's `[c]`
extra, and pip does not remember extras on upgrade, so `pip install -U sqlglot` leaves an old
`sqlglotc` behind.

This makes the pin bidirectional by having `sqlglotc` declare `sqlglot==<its own version>` in its
metadata:

- CI wheel/sdist builds resolve the version from git via setuptools-scm (exact at release tags)
- Rebuilds from a published sdist (no git) read the frozen version from `PKG-INFO`
- Dev builds (`.dev` versions) skip the pin, since no matching sqlglot release exists on PyPI;
  local development uses `build_ext --inplace` and never installs the dist anyway

With this, resolvers keep the two packages in lockstep: uv/poetry refuse to create a skewed
environment, and pip surfaces a clear conflict naming both packages instead of a cryptic one-word
`AttributeError` at import time.

Verified by generating metadata through `setup.py egg_info` for both branches: a git checkout at a
dev version emits no pin, and a simulated sdist rebuild emits `sqlglot==30.10.0` in `requires.txt`.
