### PR TITLE
feat(snowflake): add UNDROP support for all Snowflake Time Travel obj…

### DIFF
--- a/sqlglot/dialects/snowflake.py
+++ b/sqlglot/dialects/snowflake.py
@@ -152,6 +152,7 @@ class Snowflake(Dialect):
             "POLICY": TokenType.POLICY,
             "POOL": TokenType.POOL,
             "PUT": TokenType.PUT,
+            "UNDROP": TokenType.UNDROP,
             "REMOVE": TokenType.COMMAND,
             "RM": TokenType.COMMAND,
             "ROLE": TokenType.ROLE,

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -370,6 +370,14 @@ class DropPrimaryKey(Expression):
     arg_types = {}
 
 
+class Undrop(Expression):
+    arg_types = {"this": True, "kind": True}
+
+    @property
+    def kind(self) -> str:
+        return self.args["kind"].upper()
+
+
 class Command(Expression):
     arg_types = {"this": True, "expression": False}
 

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -837,6 +837,11 @@ class SnowflakeGenerator(generator.Generator):
 
         return f"{value}{explode}{alias}"
 
+    def undrop_sql(self, expression: exp.Undrop) -> str:
+        this = self.sql(expression, "this")
+        kind = expression.kind
+        return f"UNDROP {kind} {this}"
+
     def show_sql(self, expression: exp.Show) -> str:
         terse = "TERSE " if expression.args.get("terse") else ""
         iceberg = "ICEBERG " if expression.args.get("iceberg") else ""

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -760,6 +760,7 @@ class SnowflakeParser(parser.Parser):
         TokenType.GET: lambda self: self._parse_get(),
         TokenType.PUT: lambda self: self._parse_put(),
         TokenType.SHOW: lambda self: self._parse_show(),
+        TokenType.UNDROP: lambda self: self._parse_undrop(),
     }
 
     PROPERTY_PARSERS = {
@@ -864,6 +865,21 @@ class SnowflakeParser(parser.Parser):
     SCHEMA_KINDS = {"OBJECTS", "TABLES", "VIEWS", "SEQUENCES", "UNIQUE KEYS", "IMPORTED KEYS"}
 
     NON_TABLE_CREATABLES = {"STORAGE INTEGRATION", "TAG", "WAREHOUSE", "STREAMLIT"}
+
+    UNDROP_OBJECTS = {
+        "ACCOUNT",
+        "DATABASE",
+        "DYNAMIC TABLE",
+        "EXTERNAL VOLUME",
+        "ICEBERG TABLE",
+        "NOTEBOOK",
+        "SCHEMA",
+        "SNAPSHOT",
+        "STREAMLIT",
+        "TABLE",
+        "TAG",
+        "TYPE",
+    }
 
     CREATABLES = {
         *parser.Parser.CREATABLES,
@@ -1180,6 +1196,25 @@ class SnowflakeParser(parser.Parser):
                 and self._parse_csv(lambda: self._parse_var(any_token=True, upper=True)),
             )
         )
+
+    def _parse_undrop(self) -> exp.Undrop | exp.Command:
+        start = self._prev
+        kind_parts: list[str] = []
+
+        while self._curr:
+            kind_parts.append(self._curr.text.upper())
+            self._advance()
+            kind = " ".join(kind_parts)
+            if kind in self.UNDROP_OBJECTS:
+                break
+            if not any(k.startswith(f"{kind} ") for k in self.UNDROP_OBJECTS):
+                return self._parse_as_command(start)
+        else:
+            return self._parse_as_command(start)
+
+        is_db_ref = kind in {"ACCOUNT", "DATABASE", "SCHEMA"}
+        this = self._parse_table_parts(is_db_reference=is_db_ref)
+        return self.expression(exp.Undrop(this=this, kind=kind))
 
     def _parse_put(self) -> exp.Put | exp.Command:
         if self._curr.token_type != TokenType.STRING:

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -431,6 +431,7 @@ class TokenType(IntEnum):
     TRIGGER = auto()
     TYPE = auto()
     UNCACHE = auto()
+    UNDROP = auto()
     UNION = auto()
     UNNEST = auto()
     UNPIVOT = auto()

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -6784,3 +6784,18 @@ FROM SEMANTIC_VIEW(
                     prefix = natural + join_side + outer + " DIRECTED"
                     with self.subTest(f"Testing {prefix} JOIN"):
                         self.validate_identity(f"SELECT * FROM a {prefix} JOIN b USING (id)")
+
+    def test_undrop(self):
+        self.validate_identity("UNDROP TABLE my_table")
+        self.validate_identity("UNDROP SCHEMA my_schema")
+        self.validate_identity("UNDROP DATABASE my_db")
+        self.validate_identity("UNDROP ACCOUNT my_account")
+        self.validate_identity("UNDROP NOTEBOOK my_nb")
+        self.validate_identity("UNDROP SNAPSHOT my_snap")
+        self.validate_identity("UNDROP STREAMLIT my_app")
+        self.validate_identity("UNDROP TAG my_tag")
+        self.validate_identity("UNDROP TYPE my_type")
+        self.validate_identity("UNDROP DYNAMIC TABLE my_table")
+        self.validate_identity("UNDROP EXTERNAL VOLUME my_vol")
+        self.validate_identity("UNDROP ICEBERG TABLE my_table")
+        self.validate_identity("UNDROP TABLE db.schema.my_table")


### PR DESCRIPTION
…ect types

Adds parsing and generation support for all 11 Snowflake UNDROP variants:
  - Single-word: TABLE, SCHEMA, DATABASE, ACCOUNT, NOTEBOOK, SNAPSHOT, STREAMLIT, TAG, TYPE
  - Multi-word:  DYNAMIC TABLE, EXTERNAL VOLUME, ICEBERG TABLE

Also supports IDENTIFIER(id) restore syntax for Time Travel by system ID.

Changes:
  - tokenizer_core.py: add TokenType.UNDROP enum value
  - tokens.py: map 'UNDROP' keyword to TokenType.UNDROP
  - dialects/snowflake.py: add 'UNDROP' to Tokenizer KEYWORDS
  - parsers/snowflake.py: add _parse_undrop() + STATEMENT_PARSERS entry
  - generators/snowflake.py: add undrop_sql() generator
  - expressions/ddl.py: add Undrop expression class

Fixes #7734