### PR TITLE
fix(spark): parse month, day without leading zeros

### DIFF
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -6,6 +6,7 @@ from sqlglot.dialects.spark2 import Spark2
 from sqlglot.generators.spark import SparkGenerator
 from sqlglot.parsers.spark import SparkParser
 from sqlglot.tokens import TokenType
+from sqlglot.trie import new_trie
 from sqlglot.typing.spark import EXPRESSION_METADATA
 
 
@@ -15,6 +16,13 @@ class Spark(Spark2):
     SUPPORTS_NULL_TYPE = True
     ARRAY_FUNCS_PROPAGATES_NULLS = True
     EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
+
+    LENIENT_INVERSE_TIME_MAPPING = {v: k for k, v in Spark2.TIME_MAPPING.items()} | {
+        # Parse zero-padded months and days, as per strptime() behavior.
+        "%m": "M",
+        "%d": "d",
+    }
+    LENIENT_INVERSE_TIME_TRIE = new_trie(LENIENT_INVERSE_TIME_MAPPING)
 
     class Tokenizer(Spark2.Tokenizer):
         STRING_ESCAPES_ALLOWED_IN_RAW_STRINGS = False

--- a/sqlglot/generators/spark.py
+++ b/sqlglot/generators/spark.py
@@ -42,6 +42,9 @@ def _normalize_partition(e: exp.Expr) -> exp.Expr:
 
 
 def _str_to_datetime_sql(self: SparkGenerator, expression: exp.StrToDate | exp.StrToTime) -> str:
+    from sqlglot.dialects.spark import Spark
+
+    assert isinstance(self.dialect, Spark)
     return self.func(
         f"TO_{'DATE' if isinstance(expression, exp.StrToDate) else 'TIMESTAMP'}",
         expression.this,

--- a/sqlglot/generators/spark.py
+++ b/sqlglot/generators/spark.py
@@ -11,7 +11,6 @@ from sqlglot.dialects.dialect import (
     date_delta_to_binary_interval_op,
     groupconcat_sql,
 )
-from sqlglot.generators.hive import HIVE_DATE_FORMAT
 from sqlglot.generators.spark2 import Spark2Generator, temporary_storage_provider
 from sqlglot.helper import seq_get
 from sqlglot.transforms import (
@@ -42,15 +41,16 @@ def _normalize_partition(e: exp.Expr) -> exp.Expr:
     return e
 
 
-def _str_to_date_sql(self: SparkGenerator, expression: exp.StrToDate) -> str:
-     time_format = self.format_time(
-         expression,
-         self.dialect.LENIENT_INVERSE_TIME_MAPPING,
-         self.dialect.LENIENT_INVERSE_TIME_TRIE,
-     )
-     if time_format == HIVE_DATE_FORMAT:
-         return self.func("TO_DATE", expression.this)
-     return self.func("TO_DATE", expression.this, time_format)
+def _str_to_datetime_sql(self: SparkGenerator, expression: exp.StrToDate | exp.StrToTime) -> str:
+    return self.func(
+        f"TO_{'DATE' if isinstance(expression, exp.StrToDate) else 'TIMESTAMP'}",
+        expression.this,
+        self.format_time(
+            expression,
+            self.dialect.LENIENT_INVERSE_TIME_MAPPING,
+            self.dialect.LENIENT_INVERSE_TIME_TRIE,
+        ),
+    )
 
 
 def _dateadd_sql(self: SparkGenerator, expression: exp.TsOrDsAdd | exp.TimestampAdd) -> str:
@@ -141,7 +141,8 @@ class SparkGenerator(Spark2Generator):
             exp.SafeMultiply: rename_func("TRY_MULTIPLY"),
             exp.SafeSubtract: rename_func("TRY_SUBTRACT"),
             exp.StartsWith: rename_func("STARTSWITH"),
-            exp.StrToDate: _str_to_date_sql,
+            exp.StrToDate: _str_to_datetime_sql,
+            exp.StrToTime: _str_to_datetime_sql,
             exp.TimeAdd: date_delta_to_binary_interval_op(cast=False),
             exp.TimeSub: date_delta_to_binary_interval_op(cast=False),
             exp.TsOrDsAdd: _dateadd_sql,

--- a/sqlglot/generators/spark.py
+++ b/sqlglot/generators/spark.py
@@ -11,6 +11,7 @@ from sqlglot.dialects.dialect import (
     date_delta_to_binary_interval_op,
     groupconcat_sql,
 )
+from sqlglot.generators.hive import HIVE_DATE_FORMAT
 from sqlglot.generators.spark2 import Spark2Generator, temporary_storage_provider
 from sqlglot.helper import seq_get
 from sqlglot.transforms import (
@@ -21,6 +22,17 @@ from sqlglot.transforms import (
 )
 
 
+def _groupconcat_sql(self: SparkGenerator, expression: exp.GroupConcat) -> str:
+    if self.dialect.version < (4,):
+        expr = exp.ArrayToString(
+            this=exp.ArrayAgg(this=expression.this),
+            expression=expression.args.get("separator") or exp.Literal.string(""),
+        )
+        return self.sql(expr)
+
+    return groupconcat_sql(self, expression)
+
+
 def _normalize_partition(e: exp.Expr) -> exp.Expr:
     """Normalize the expressions in PARTITION BY (<expression>, <expression>, ...)"""
     if isinstance(e, str):
@@ -28,6 +40,17 @@ def _normalize_partition(e: exp.Expr) -> exp.Expr:
     if isinstance(e, exp.Literal):
         return exp.to_identifier(e.name)
     return e
+
+
+def _str_to_date_sql(self: SparkGenerator, expression: exp.StrToDate) -> str:
+     time_format = self.format_time(
+         expression,
+         self.dialect.LENIENT_INVERSE_TIME_MAPPING,
+         self.dialect.LENIENT_INVERSE_TIME_TRIE,
+     )
+     if time_format == HIVE_DATE_FORMAT:
+         return self.func("TO_DATE", expression.this)
+     return self.func("TO_DATE", expression.this, time_format)
 
 
 def _dateadd_sql(self: SparkGenerator, expression: exp.TsOrDsAdd | exp.TimestampAdd) -> str:
@@ -52,17 +75,6 @@ def _dateadd_sql(self: SparkGenerator, expression: exp.TsOrDsAdd | exp.Timestamp
             this = f"CAST({this} AS {return_type})"
 
     return this
-
-
-def _groupconcat_sql(self: SparkGenerator, expression: exp.GroupConcat) -> str:
-    if self.dialect.version < (4,):
-        expr = exp.ArrayToString(
-            this=exp.ArrayAgg(this=expression.this),
-            expression=expression.args.get("separator") or exp.Literal.string(""),
-        )
-        return self.sql(expr)
-
-    return groupconcat_sql(self, expression)
 
 
 class SparkGenerator(Spark2Generator):
@@ -129,6 +141,7 @@ class SparkGenerator(Spark2Generator):
             exp.SafeMultiply: rename_func("TRY_MULTIPLY"),
             exp.SafeSubtract: rename_func("TRY_SUBTRACT"),
             exp.StartsWith: rename_func("STARTSWITH"),
+            exp.StrToDate: _str_to_date_sql,
             exp.TimeAdd: date_delta_to_binary_interval_op(cast=False),
             exp.TimeSub: date_delta_to_binary_interval_op(cast=False),
             exp.TsOrDsAdd: _dateadd_sql,

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -27,7 +27,7 @@ def _map_sql(self: Spark2Generator, expression: exp.Map) -> str:
     return self.func("MAP_FROM_ARRAYS", keys, values)
 
 
-def _str_to_date(self: Spark2Generator, expression: exp.StrToDate) -> str:
+def _str_to_date_sql(self: Spark2Generator, expression: exp.StrToDate) -> str:
     time_format = self.format_time(expression)
     if time_format == HIVE_DATE_FORMAT:
         return self.func("TO_DATE", expression.this)
@@ -184,7 +184,7 @@ class Spark2Generator(HiveGenerator):
             exp.SHA2Digest: lambda self, e: self.func(
                 "SHA2", e.this, e.args.get("length") or exp.Literal.number(256)
             ),
-            exp.StrToDate: _str_to_date,
+            exp.StrToDate: _str_to_date_sql,
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
             exp.TimestampTrunc: lambda self, e: self.func("DATE_TRUNC", unit_to_str(e), e.this),
             exp.UnixToTime: _unix_to_time_sql,

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -763,7 +763,7 @@ class TestDialect(Validator):
                 "presto": "DATE_PARSE(x, '%Y-%m-%dT%T')",
                 "drill": "TO_TIMESTAMP(x, 'yyyy-MM-dd''T''HH:mm:ss')",
                 "redshift": "TO_TIMESTAMP(x, 'YYYY-MM-DDTHH24:MI:SS')",
-                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-ddTHH:mm:ss')",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-M-dTHH:mm:ss')",
             },
         )
         self.validate_all(
@@ -776,7 +776,7 @@ class TestDialect(Validator):
                 "postgres": "TO_TIMESTAMP('2020-01-01', 'YYYY-MM-DD')",
                 "presto": "DATE_PARSE('2020-01-01', '%Y-%m-%d')",
                 "redshift": "TO_TIMESTAMP('2020-01-01', 'YYYY-MM-DD')",
-                "spark": "TO_TIMESTAMP('2020-01-01', 'yyyy-MM-dd')",
+                "spark": "TO_TIMESTAMP('2020-01-01', 'yyyy-M-d')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1219,7 +1219,7 @@ class TestDialect(Validator):
                 "starrocks": "STR_TO_DATE(x, '%Y-%m-%dT%T')",
                 "hive": "CAST(FROM_UNIXTIME(UNIX_TIMESTAMP(x, 'yyyy-MM-ddTHH:mm:ss')) AS DATE)",
                 "presto": "CAST(DATE_PARSE(x, '%Y-%m-%dT%T') AS DATE)",
-                "spark": "TO_DATE(x, 'yyyy-MM-ddTHH:mm:ss')",
+                "spark": "TO_DATE(x, 'yyyy-M-dTHH:mm:ss')",
                 "doris": "STR_TO_DATE(x, '%Y-%m-%dT%T')",
             },
         )
@@ -1231,7 +1231,7 @@ class TestDialect(Validator):
                 "starrocks": "STR_TO_DATE(x, '%Y-%m-%d')",
                 "hive": "CAST(x AS DATE)",
                 "presto": "CAST(DATE_PARSE(x, '%Y-%m-%d') AS DATE)",
-                "spark": "TO_DATE(x)",
+                "spark": "TO_DATE(x, 'yyyy-M-d')",
                 "doris": "STR_TO_DATE(x, '%Y-%m-%d')",
             },
         )

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -306,7 +306,7 @@ class TestPresto(Validator):
                 "duckdb": "STRPTIME(x, '%Y-%m-%d %H:%M:%S')",
                 "presto": "DATE_PARSE(x, '%Y-%m-%d %T')",
                 "hive": "CAST(x AS TIMESTAMP)",
-                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd HH:mm:ss')",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-M-d HH:mm:ss')",
             },
         )
         self.validate_all(
@@ -315,7 +315,7 @@ class TestPresto(Validator):
                 "duckdb": "STRPTIME(x, '%Y-%m-%d')",
                 "presto": "DATE_PARSE(x, '%Y-%m-%d')",
                 "hive": "CAST(x AS TIMESTAMP)",
-                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd')",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-M-d')",
             },
         )
         self.validate_all(
@@ -330,7 +330,7 @@ class TestPresto(Validator):
                 "duckdb": "STRPTIME(SUBSTRING(x, 1, 10), '%Y-%m-%d')",
                 "presto": "DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d')",
                 "hive": "CAST(SUBSTRING(x, 1, 10) AS TIMESTAMP)",
-                "spark": "TO_TIMESTAMP(SUBSTRING(x, 1, 10), 'yyyy-MM-dd')",
+                "spark": "TO_TIMESTAMP(SUBSTRING(x, 1, 10), 'yyyy-M-d')",
             },
         )
         self.validate_all(
@@ -339,7 +339,7 @@ class TestPresto(Validator):
                 "duckdb": "STRPTIME(SUBSTRING(x, 1, 10), '%Y-%m-%d')",
                 "presto": "DATE_PARSE(SUBSTR(x, 1, 10), '%Y-%m-%d')",
                 "hive": "CAST(SUBSTRING(x, 1, 10) AS TIMESTAMP)",
-                "spark": "TO_TIMESTAMP(SUBSTRING(x, 1, 10), 'yyyy-MM-dd')",
+                "spark": "TO_TIMESTAMP(SUBSTRING(x, 1, 10), 'yyyy-M-d')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1839,7 +1839,7 @@ class TestSnowflake(Validator):
                 "bigquery": "SELECT PARSE_TIMESTAMP('%d-%m-%Y %I:%M:%S', col) FROM t",
                 "duckdb": "SELECT STRPTIME(col, '%d-%m-%Y %I:%M:%S') FROM t",
                 "snowflake": "SELECT TO_TIMESTAMP(col, 'DD-mm-yyyy hh12:mi:ss') FROM t",
-                "spark": "SELECT TO_TIMESTAMP(col, 'dd-MM-yyyy hh:mm:ss') FROM t",
+                "spark": "SELECT TO_TIMESTAMP(col, 'd-M-yyyy hh:mm:ss') FROM t",
             },
         )
         self.validate_all(
@@ -1904,7 +1904,7 @@ class TestSnowflake(Validator):
             write={
                 "bigquery": "SELECT PARSE_TIMESTAMP('%m/%d/%Y %T', '04/05/2013 01:02:03')",
                 "snowflake": "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'mm/DD/yyyy hh24:mi:ss')",
-                "spark": "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'MM/dd/yyyy HH:mm:ss')",
+                "spark": "SELECT TO_TIMESTAMP('04/05/2013 01:02:03', 'M/d/yyyy HH:mm:ss')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -659,14 +659,14 @@ TBLPROPERTIES (
             },
         )
         self.validate_all(
-            "SELECT TO_TIMESTAMP('2016-12-31', 'yyyy-MM-dd')",
+            "SELECT TO_TIMESTAMP('2016-1-1', 'yyyy-M-d')",
             read={
-                "duckdb": "SELECT STRPTIME('2016-12-31', '%Y-%m-%d')",
+                "duckdb": "SELECT STRPTIME('2016-1-1', '%Y-%m-%d')",
             },
             write={
-                "": "SELECT STR_TO_TIME('2016-12-31', '%Y-%m-%d')",
-                "duckdb": "SELECT STRPTIME('2016-12-31', '%Y-%m-%d')",
-                "spark": "SELECT TO_TIMESTAMP('2016-12-31', 'yyyy-MM-dd')",
+                "": "SELECT STR_TO_TIME('2016-1-1', '%Y-%-m-%-d')",
+                "duckdb": "SELECT STRPTIME('2016-1-1', '%Y-%-m-%-d')",
+                "spark": "SELECT TO_TIMESTAMP('2016-1-1', 'yyyy-M-d')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_teradata.py
+++ b/tests/dialects/test_teradata.py
@@ -233,9 +233,9 @@ class TestTeradata(Validator):
             write={
                 "teradata": "CAST('1992-01' AS DATE FORMAT 'YYYY-DD')",
                 "bigquery": "PARSE_DATE('%Y-%d', '1992-01')",
-                "databricks": "TO_DATE('1992-01', 'yyyy-dd')",
+                "databricks": "TO_DATE('1992-01', 'yyyy-d')",
                 "mysql": "STR_TO_DATE('1992-01', '%Y-%d')",
-                "spark": "TO_DATE('1992-01', 'yyyy-dd')",
+                "spark": "TO_DATE('1992-01', 'yyyy-d')",
                 "": "STR_TO_DATE('1992-01', '%Y-%d')",
             },
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1749,7 +1749,7 @@ WHERE
         self.validate_all(
             "CONVERT(DATE, x, 121)",
             write={
-                "spark": "TO_DATE(x, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+                "spark": "TO_DATE(x, 'yyyy-M-d HH:mm:ss.SSSSSS')",
                 "tsql": "CONVERT(DATE, x, 121)",
             },
         )

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1756,14 +1756,14 @@ WHERE
         self.validate_all(
             "CONVERT(DATETIME, x, 121)",
             write={
-                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-M-d HH:mm:ss.SSSSSS')",
                 "tsql": "CONVERT(DATETIME, x, 121)",
             },
         )
         self.validate_all(
             "CONVERT(DATETIME2, x, 121)",
             write={
-                "spark": "TO_TIMESTAMP(x, 'yyyy-MM-dd HH:mm:ss.SSSSSS')",
+                "spark": "TO_TIMESTAMP(x, 'yyyy-M-d HH:mm:ss.SSSSSS')",
                 "tsql": "CONVERT(DATETIME2, x, 121)",
             },
         )


### PR DESCRIPTION
Resolves https://github.com/ibis-project/ibis/issues/12004 (happy to also raise an issue on this repo, if helpful)

In short, Spark 3+ is different from most other SQL dialects in that `MM` and `dd` will not parse single-digit months and days without leading zeros (it's very strict).

Unfortunately, this creates some round-trip complications, although it shouldn't be a big deal unless somebody is relying on Spark 3+'s inability to parse something like `"2026-6-9"` using `"yyyy-MM-dd"`, and we round trip that back out to the more lenient `"yyyy-M-d"` and then their dates parse (like they would in just about any other SQL dialect with `"yyyy-MM-dd"`...).

Note that there are a couple tests where the result in other dialects is getting spit out like `"%Y-%-m-%-d"` now (instead of `"%Y-%m-%d"`), which reflects that leniency. I was trying to suppress that by adding some additional mappings to the Spark dialect:

```diff
diff --git a/sqlglot/dialects/spark.py b/sqlglot/dialects/spark.py
index 5ea11f6f..4e9524ee 100644
--- a/sqlglot/dialects/spark.py
+++ b/sqlglot/dialects/spark.py
@@ -17,6 +17,17 @@ class Spark(Spark2):
     ARRAY_FUNCS_PROPAGATES_NULLS = True
     EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
 
+    TIME_MAPPING = {
+        **Spark2.TIME_MAPPING,
+        "M": "%m",
+        "d": "%d",
+    }
+
+    INVERSE_TIME_MAPPING = {
+        "%m": "MM",
+        "%d": "DD",
+    }
+
     LENIENT_INVERSE_TIME_MAPPING = {v: k for k, v in Spark2.TIME_MAPPING.items()} | {
         # Parse zero-padded months and days, as per strptime() behavior.
         "%m": "M",
```

But I've decided to get feedback before going further down that rabbithole. 🐰 