### PR TITLE
fix(hive): add additional string escape for single quotes in Hive dialects

### DIFF
--- a/sqlglot/dialects/hive.py
+++ b/sqlglot/dialects/hive.py
@@ -89,7 +89,7 @@ class Hive(Dialect):
     class Tokenizer(tokens.Tokenizer):
         QUOTES = ["'", '"']
         IDENTIFIERS = ["`"]
-        STRING_ESCAPES = ["\\"]
+        STRING_ESCAPES = ["\\", "'"]
 
         SINGLE_TOKENS = {
             **tokens.Tokenizer.SINGLE_TOKENS,

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -33,6 +33,17 @@ class TestDatabricks(Validator):
         self.validate_identity("DESCRIBE history.tbl")
         self.validate_identity("CREATE TABLE t (a STRUCT<c: MAP<STRING, STRING>>)")
         self.validate_identity("CREATE TABLE t (c STRUCT<interval: DOUBLE COMMENT 'aaa'>)")
+        self.validate_identity("CREATE TABLE t (c STRING COMMENT 'Hello World')")
+        self.validate_all(
+            "CREATE TABLE t (c STRING COMMENT 'Hello ''World!')",
+            write={
+                "databricks": "CREATE TABLE t (c STRING COMMENT 'Hello \\'World!')",
+            },
+        )
+        self.validate_all(
+            "SELECT 'Hello ''World!'",
+            write={"databricks": "SELECT 'Hello \\'World!'"},
+        )
         self.validate_identity("CREATE TABLE my_table TBLPROPERTIES (a.b=15)")
         self.validate_identity("CREATE TABLE my_table TBLPROPERTIES ('a.b'=15)")
         self.validate_identity("CREATE TABLE table1 CLUSTER BY AUTO")


### PR DESCRIPTION
## Summary
- Add `'` to Hive tokenizer `STRING_ESCAPES` so `''` is parsed as an escaped single quote in Hive/Spark/Databricks string literals
- Fixes parsing of column COMMENT strings like `'Hello ''World!'`
- Add Databricks tests for simple and escaped COMMENT strings

Fixes issue #7740.

## Test plan
- [ ] `python -m unittest tests.dialects.test_databricks tests.dialects.test_hive tests.dialects.test_spark`
- [ ] Verified `CREATE TABLE t (c STRING COMMENT 'Hello ''World!')` parses successfully

## Disclosure
This was generated with Cursor. I understand the code and am prepared to answer questions about it.