### PR TITLE
Fix(optimizer): unwrap parens less aggressively in `qualify_tables`

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -114,7 +114,13 @@ def qualify_tables(
         for query in scope.subqueries:
             subquery = query.parent
             if isinstance(subquery, exp.Subquery):
-                subquery.unwrap().replace(subquery)
+                unwrapped = subquery.unwrap()
+                if isinstance(unwrapped.parent, exp.Create) and unwrapped is not subquery:
+                    # Function bodies may require wrapping parentheses, e.g. in BigQuery
+                    # `... AS ((SELECT 1))` the outer parens delimit the body itself
+                    unwrapped.set("this", subquery)
+                else:
+                    unwrapped.replace(subquery)
 
         for derived_table in scope.derived_tables:
             unnested = derived_table.unnest()

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -287,3 +287,8 @@ SELECT g FROM GENERATE_SERIES(1, 2) AS _0(g);
 # canonicalize_table_aliases: true
 SELECT jsonvalue.id FROM deal, JSONB_TO_RECORDSET(CAST(deal.type AS JSONB)) AS jsonvalue(id INT, key VARCHAR, text VARCHAR);
 SELECT _1.id FROM c.db.deal AS _0, JSONB_TO_RECORDSET(CAST(_0.type AS JSONB)) AS _1(id INT, key VARCHAR, text VARCHAR);
+
+# title: Preserve wrapping parens of a query used as a function body
+# dialect: bigquery
+CREATE TEMPORARY FUNCTION f() RETURNS STRING AS ((((SELECT 'foo'))));
+CREATE TEMPORARY FUNCTION c.db.f() RETURNS STRING AS ((SELECT 'foo'));


### PR DESCRIPTION
This bug was surfaced by a SQLMesh user. SQLMesh's renderer relies on `qualify_tables` and triggers this bug.