### PR TITLE
chore(parser): PARSE_DATETIME uses year as default

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4056,6 +4056,14 @@ class Generator:
     def strtotime_sql(self, expression: exp.StrToTime) -> str:
         return self.func("STR_TO_TIME", expression.this, expression.args.get("format"))
 
+    def parsedatetime_sql(self, expression: exp.ParseDatetime) -> str:
+        return self.func(
+            "PARSE_DATETIME",
+            expression.this,
+            expression.args.get("format"),
+            expression.args.get("zone"),
+        )
+
     def currentdate_sql(self, expression: exp.CurrentDate) -> str:
         zone = self.sql(expression, "this")
         return f"CURRENT_DATE({zone})" if zone else "CURRENT_DATE"

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -377,7 +377,9 @@ class ClickHouseGenerator(generator.Generator):
         exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
             rename_func("editDistance")
         ),
-        exp.ParseDatetime: rename_func("parseDateTime"),
+        exp.ParseDatetime: lambda self, e: self.func(
+            "parseDateTime", e.this, e.args.get("format"), e.args.get("zone")
+        ),
     }
 
     PROPERTIES_LOCATION = {

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2661,16 +2661,15 @@ class DuckDBGenerator(generator.Generator):
 
     def parsedatetime_sql(self, expression: exp.ParseDatetime) -> str:
         formatted_time = self.format_time(expression)
-        if expression.args.get("default_year"):
-            # BigQuery defaults a missing year to 1970, DuckDB to 1900. Prepend a 1970
-            # year to both value and format so a yearless input lands on 1970. When the
-            # input already carries a year, DuckDB binds the last %Y match, so the real
-            # year overrides the prepended 1970 harmlessly.
-            year_str = exp.Literal.string("1970 ")
+
+        default_year = expression.args.get("default_year")
+        if default_year:
+            year_str = exp.Literal.string(f"{default_year.name} ")
             fmt_prefix = exp.Literal.string("%Y ")
             value = exp.DPipe(this=year_str, expression=expression.this)
             fmt = exp.DPipe(this=fmt_prefix, expression=formatted_time)
             return self.func("STRPTIME", value, fmt)
+
         return self.func("STRPTIME", expression.this, formatted_time)
 
     def parsetime_sql(self, expression: exp.ParseTime) -> str:

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -98,12 +98,6 @@ def _build_parse_timestamp(args: list, dialect: Dialect) -> exp.StrToTime:
     return this
 
 
-def _build_parse_datetime(args: list, dialect: Dialect) -> exp.ParseDatetime:
-    this = build_formatted_time(exp.ParseDatetime)([seq_get(args, 1), seq_get(args, 0)], dialect)
-    this.set("default_year", True)
-    return this
-
-
 def _build_regexp_extract(expr_type: type[E], default_group: exp.Expr | None = None) -> t.Callable:
     def _builder(args: list, dialect: Dialect) -> E:
         try:
@@ -254,7 +248,11 @@ class BigQueryParser(parser.Parser):
             [seq_get(args, 1), seq_get(args, 0)], dialect
         ),
         "PARSE_TIMESTAMP": _build_parse_timestamp,
-        "PARSE_DATETIME": _build_parse_datetime,
+        "PARSE_DATETIME": lambda args, dialect: exp.ParseDatetime(
+            this=seq_get(args, 1),
+            format=dialect.format_time(seq_get(args, 0)),
+            default_year=exp.Literal.number(1970),
+        ),
         "REGEXP_CONTAINS": exp.RegexpLike.from_arg_list,
         "REGEXP_EXTRACT": _build_regexp_extract(exp.RegexpExtract),
         "REGEXP_SUBSTR": _build_regexp_extract(exp.RegexpExtract),

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -98,6 +98,12 @@ def _build_parse_timestamp(args: list, dialect: Dialect) -> exp.StrToTime:
     return this
 
 
+def _build_parse_datetime(args: list, dialect: Dialect) -> exp.ParseDatetime:
+    this = build_formatted_time(exp.ParseDatetime)([seq_get(args, 1), seq_get(args, 0)], dialect)
+    this.set("default_year", exp.Literal.number(1970))
+    return this
+
+
 def _build_regexp_extract(expr_type: type[E], default_group: exp.Expr | None = None) -> t.Callable:
     def _builder(args: list, dialect: Dialect) -> E:
         try:
@@ -248,11 +254,7 @@ class BigQueryParser(parser.Parser):
             [seq_get(args, 1), seq_get(args, 0)], dialect
         ),
         "PARSE_TIMESTAMP": _build_parse_timestamp,
-        "PARSE_DATETIME": lambda args, dialect: exp.ParseDatetime(
-            this=seq_get(args, 1),
-            format=dialect.format_time(seq_get(args, 0)),
-            default_year=exp.Literal.number(1970),
-        ),
+        "PARSE_DATETIME": _build_parse_datetime,
         "REGEXP_CONTAINS": exp.RegexpLike.from_arg_list,
         "REGEXP_EXTRACT": _build_regexp_extract(exp.RegexpExtract),
         "REGEXP_SUBSTR": _build_regexp_extract(exp.RegexpExtract),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1978,8 +1978,6 @@ WHERE
         self.validate_all(
             "SELECT PARSE_DATETIME('%F %T', '2023-01-15 14:30:00')",
             write={
-                # The default_year flag set by the parser must not leak as an argument
-                # when generating for dialects without a dedicated ParseDatetime handler.
                 "snowflake": "SELECT PARSE_DATETIME('2023-01-15 14:30:00', '%Y-%m-%d %H:%M:%S')",
                 "duckdb": "SELECT STRPTIME('1970 ' || '2023-01-15 14:30:00', '%Y ' || '%Y-%m-%d %H:%M:%S')",
             },

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1827,19 +1827,27 @@ class TestDuckDB(Validator):
         )
         self.validate_all(
             "SELECT CAST(CAST(STRPTIME('05/06/2020', '%m/%d/%Y') AS DATE) AS DATE)",
-            read={"bigquery": "SELECT DATE(PARSE_DATE('%m/%d/%Y', '05/06/2020'))"},
+            read={
+                "bigquery": "SELECT DATE(PARSE_DATE('%m/%d/%Y', '05/06/2020'))",
+            },
         )
         self.validate_all(
             "SELECT CAST(STRPTIME('14:30', '%H:%M') AS TIME)",
-            read={"bigquery": "SELECT PARSE_TIME('%H:%M', '14:30')"},
+            read={
+                "bigquery": "SELECT PARSE_TIME('%H:%M', '14:30')",
+            },
         )
         self.validate_all(
             "SELECT CAST(STRPTIME('15:30:00.123456', '%H:%M:%S.%f') AS TIME)",
-            read={"bigquery": "SELECT PARSE_TIME('%H:%M:%E6S', '15:30:00.123456')"},
+            read={
+                "bigquery": "SELECT PARSE_TIME('%H:%M:%E6S', '15:30:00.123456')",
+            },
         )
         self.validate_all(
             "SELECT STRPTIME('1970 ' || '2023-01-15 14:30:00', '%Y ' || '%Y-%m-%d %H:%M:%S')",
-            read={"bigquery": "SELECT PARSE_DATETIME('%Y-%m-%d %H:%M:%S', '2023-01-15 14:30:00')"},
+            read={
+                "bigquery": "SELECT PARSE_DATETIME('%Y-%m-%d %H:%M:%S', '2023-01-15 14:30:00')",
+            },
         )
         self.validate_all(
             "SELECT STRPTIME('1970 ' || 'Thu Dec 25 07:30:00 2008', '%Y ' || '%a %b %-d %I:%M:%S %Y')",


### PR DESCRIPTION
refactor to use direclty the year and not a boolean flag as the default for `PARSE_DATETIME` expression.

ref: https://github.com/tobymao/sqlglot/pull/7704