### PR TITLE
feat(snowflake):  DOUBLE CAST fix for div_sql for Snowflake to DuckDB

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4348,6 +4348,13 @@ class DuckDBGenerator(generator.Generator):
 
         return self.func(func, this, decimals, truncate)
 
+    def div_sql(self, expression: exp.Div) -> str:
+        for side in ("this", "expression"):
+            operand = expression.args[side]
+            if operand.is_string:
+                operand.replace(exp.cast(operand, "DOUBLE"))
+        return super().div_sql(expression)
+
     def trycast_sql(self, expression: exp.TryCast) -> str:
         to = expression.to
         to_type = to.this


### PR DESCRIPTION
Snowflake implicitly coerces string literals in division `('10' / 1.0)`. DuckDB has no` /(STRING_LITERAL, DECIMAL)` overload so the transpiled query fails at the binder. Added `div_sql` that casts any `is_string` operand before delegating to `super().div_sql()`.

Transpilation examples

| Input (Snowflake)                              | Output (DuckDB)                                          |
|------------------------------------------------|----------------------------------------------------------|
| CAST('10' / 1.0 AS NUMBER(24,6))               | CAST(CAST('10' AS DOUBLE) / 1.0 AS DECIMAL(24, 6))      |
| '10' / 2.0                                     | CAST('10' AS DOUBLE) / 2.0                               |
| 10 / 2                                         | 10 / 2  (unchanged)                                      |
| a / b                                          | a / b   (unchanged)                                      |