### PR TITLE
feat(optimizer)!: Annotate MINUTE function for Hive/Spark/DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -50,6 +50,7 @@ EXPRESSION_METADATA = {
             exp.Rank,
             exp.RowNumber,
             exp.Second,
+            exp.Minute,
         }
     },
     exp.PercentileDisc: {"returns": exp.DType.DOUBLE},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -945,6 +945,10 @@ ARRAY<INT>;
 ARRAY_EXCEPT(tbl.array_col, tbl.array_col);
 ARRAY<STRING>;
 
+# dialect: hive, spark2, spark, databricks
+MINUTE('2024-01-01 12:30:00');
+INT;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
**SQL:**
```sql
SELECT minute('2024-01-01 12:30:00'), typeof(minute('2024-01-01 12:30:00'))
```
**Output:**
```
+---------------------------+-----------------------------------+
|minute(2024-01-01 12:30:00)|typeof(minute(2024-01-01 12:30:00))|
+---------------------------+-----------------------------------+
|                         30|                                int|
+---------------------------+-----------------------------------+
```

https://spark.apache.org/docs/latest/api/sql/index.html#minute