### PR TITLE
docs: Add lineage, schema contract and AST diff governance guide [CLAUDE]

### DIFF
--- a/posts/dialect_cookbook.md
+++ b/posts/dialect_cookbook.md
@@ -1,0 +1,871 @@
+# Dialect Extension Cookbook
+
+> How to extend SQLGlot with a new warehouse dialect — a step-by-step guide
+> using the Redshift-to-Snowflake transpilation path as a running example.
+
+---
+
+## Table of Contents
+
+- [Introduction](#introduction)
+- [Architecture Overview](#architecture-overview)
+- [Transpilation Pipeline Diagram](#transpilation-pipeline-diagram)
+- [Step 0: Register Your Dialect](#step-0-register-your-dialect)
+- [Step 1: The Dialect Class](#step-1-the-dialect-class)
+- [Step 2: Extend the Tokenizer](#step-2-extend-the-tokenizer)
+- [Step 3: Extend the Parser](#step-3-extend-the-parser)
+- [Step 4: Extend the Generator](#step-4-extend-the-generator)
+- [Step 5: End-to-End Test](#step-5-end-to-end-test)
+- [Plugin Dialects (External Packages)](#plugin-dialects-external-packages)
+- [Checklist](#checklist)
+- [Reference: Key Source Files](#reference-key-source-files)
+
+---
+
+## Introduction
+
+SQLGlot supports 34+ SQL dialects out of the box, but production data
+pipelines often encounter proprietary extensions — stored-procedure keywords,
+custom functions, vendor-specific data types — that no built-in dialect covers.
+
+This cookbook shows you how to **extend an existing dialect** (or create a new
+one from scratch) by walking through the three extension points that every
+dialect owns:
+
+| Layer | Source file | Responsibility |
+|-------|-------------|----------------|
+| **Tokenizer** | `sqlglot/tokens.py` | Break raw SQL into tokens |
+| **Parser** | `sqlglot/parser.py` | Convert tokens into an AST |
+| **Generator** | `sqlglot/generator.py` | Convert an AST back into SQL |
+
+We use **Redshift → Snowflake** as the running example because:
+
+1. Redshift inherits from Postgres (`sqlglot/dialects/redshift.py` → `class Redshift(Postgres)`), giving you a realistic inheritance chain.
+2. Snowflake is a direct `Dialect` subclass (`sqlglot/dialects/snowflake.py` → `class Snowflake(Dialect)`), showing the "from scratch" path.
+3. Both dialects are already in the codebase, so every code snippet below references **real module paths and function names** you can grep for.
+
+By the end of this guide you will be able to answer:
+
+- "My source dialect has a keyword the tokenizer doesn't recognize — how do I add it?"
+- "My target dialect generates the wrong SQL for a standard AST node — how do I override it?"
+- "How do I register a brand-new dialect so `sqlglot.transpile(sql, read='mydb', write='mydb')` works?"
+
+---
+
+## Architecture Overview
+
+Every call to `sqlglot.transpile(sql, read=..., write=...)` runs three phases:
+
+```
+ ┌──────────┐      ┌──────────┐      ┌───────────┐
+ │ Tokenizer│      │  Parser  │      │ Generator │
+ │ (read)   │ ──>  │  (read)  │ ──>  │  (write)  │
+ │          │      │          │      │           │
+ │ SQL str  │      │ Token[]  │      │  AST      │
+ │  ───>    │      │  ───>    │      │  ───>     │
+ │ Token[]  │      │   AST    │      │  SQL str  │
+ └──────────┘      └──────────┘      └───────────┘
+```
+
+The **read** dialect controls the Tokenizer and Parser; the **write** dialect
+controls the Generator. A dialect class wires all three together.
+
+The base dialect (`sqlglot.dialects.dialect.Dialect`) aims to be a **superset**
+of common SQL syntax so that individual dialects only need to override what
+they *differ* on. This is why `Redshift` can inherit from `Postgres` and
+override only the parts that are Redshift-specific.
+
+> **Key source file**: `sqlglot/dialects/dialect.py` contains the `Dialect`
+> base class, the `_Dialect` metaclass (which handles auto-registration), and
+> the `NormalizationStrategy` enum.
+
+---
+
+## Transpilation Pipeline Diagram
+
+The sequence below traces a single `transpile()` call from Redshift to Snowflake.
+Each box is a method call; arrows show data flow.
+
+```
+User code
+  │
+  │  sqlglot.transpile(sql, read="redshift", write="snowflake")
+  ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Dialect.get_or_raise("redshift")                            │
+│   └─> _Dialect._try_load("redshift")                       │
+│         └─> importlib.import_module("sqlglot.dialects.redshift")
+│   └─> _Dialect._classes["redshift"]  →  Redshift class      │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 1 — Tokenizer  (Redshift.Tokenizer)                   │
+│                                                             │
+│   Redshift.Tokenizer  extends  Postgres.Tokenizer           │
+│     KEYWORDS = { ...Postgres.Tokenizer.KEYWORDS,            │
+│                  "(+)":   TokenType.JOIN_MARKER,            │
+│                  "MINUS": TokenType.EXCEPT,                 │
+│                  "SUPER": TokenType.SUPER, ... }            │
+│                                                             │
+│   tokenize(sql) ──> list[Token]                             │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 2 — Parser  (RedshiftParser)                          │
+│                                                             │
+│   RedshiftParser  extends  PostgresParser                   │
+│     FUNCTIONS = { ...PostgresParser.FUNCTIONS,              │
+│                   "DATEADD":   _build_date_delta(TsOrDsAdd),│
+│                   "DATEDIFF":  _build_date_delta(TsOrDsDiff),│
+│                   "GETDATE":   CurrentTimestamp.from_arg_list│
+│                   ... }                                     │
+│                                                             │
+│   _parse_statement()                                        │
+│     └─> _parse_select() / _parse_create() / ...             │
+│           └─> _parse_expression()                           │
+│                 └─> _parse_conjunction()                    │
+│                       └─> ... (recursive descent)           │
+│                                                             │
+│   list[Token] ──> exp.Expression (AST)                      │
+└────────────────────────────┬────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────┐
+│ Phase 3 — Generator  (SnowflakeGenerator)                   │
+│                                                             │
+│   SnowflakeGenerator  extends  generator.Generator          │
+│     TRANSFORMS = { ...Generator.TRANSFORMS,                 │
+│       exp.DateAdd:    date_delta_sql("DATEADD"),            │
+│       exp.If:         if_sql(name="IFF", false_value="NULL"),│
+│       exp.Select:     transforms.preprocess([...]),         │
+│       ...                                                   │
+│     }                                                       │
+│                                                             │
+│   generate(ast)                                             │
+│     └─> sql(node)                                           │
+│           └─> _build_dispatch(cls)                          │
+│                 ├─> TRANSFORMS lookup  (priority)           │
+│                 └─> <expr>_sql() auto-discovery (fallback)  │
+│                                                             │
+│   exp.Expression ──> SQL string (Snowflake dialect)         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Step 0: Register Your Dialect
+
+Before writing any logic, your dialect must be **discoverable** by SQLGlot's
+lazy-loading machinery. Two files need updating:
+
+### 0a. Add to the `Dialects` enum
+
+In `sqlglot/dialects/dialect.py`, locate the `Dialects` enum (around line 83)
+and add your dialect name:
+
+```python
+class Dialects(str, Enum):
+    ...
+    REDSHIFT = "redshift"
+    MYNEWDB  = "mynewdb"      # <— add here
+    SNOWFLAKE = "snowflake"
+```
+
+### 0b. Add to the `DIALECTS` list
+
+In `sqlglot/dialects/__init__.py`, add the class name to the `DIALECTS` list
+(alphabetical order):
+
+```python
+DIALECTS = [
+    ...
+    "MySQL",
+    "MyNewDB",           # <— add here (class name, not module name)
+    "Oracle",
+    ...
+]
+```
+
+### How auto-discovery works
+
+The `_Dialect` metaclass (`sqlglot/dialects/dialect.py`, line 137) intercepts
+every `class` definition that subclasses `Dialect`. Its `__new__` method:
+
+1. **Registers** the class into `_Dialect._classes[key]` using the lowercase
+   class name (or the `Dialects` enum value if one exists).
+2. **Builds time-format tries** (`TIME_TRIE`, `FORMAT_TRIE`, etc.) from the
+   dialect's `TIME_MAPPING`.
+3. **Wires up** the inner `Tokenizer`, `Parser`, and `Generator` classes —
+   creating empty subclasses if they are not explicitly defined.
+
+The lazy loader (`_Dialect._try_load`, line 162) uses a three-tier strategy:
+1. Standard module import: `importlib.import_module(f"sqlglot.dialects.{key}")`.
+2. Entry-point lookup for plugin dialects (`entry_points(group="sqlglot.dialects")`).
+3. Direct import fallback.
+
+> **For built-in dialects**, steps 0a and 0b are sufficient.
+> For **plugin dialects**, see [Plugin Dialects](#plugin-dialects-external-packages).
+
+---
+
+## Step 1: The Dialect Class
+
+Create `sqlglot/dialects/mynewdb.py`. The dialect class is the **entry point**
+that ties Tokenizer, Parser, and Generator together.
+
+### Minimal skeleton
+
+```python
+from sqlglot.dialects.dialect import Dialect, NormalizationStrategy
+from sqlglot.generators.mynewdb import MyNewDBGenerator
+from sqlglot.parsers.mynewdb import MyNewDBParser
+
+
+class MyNewDB(Dialect):
+    # How unquoted identifiers are normalized
+    NORMALIZATION_STRATEGY = NormalizationStrategy.UPPERCASE
+
+    # Array index base offset (0-based or 1-based)
+    INDEX_OFFSET = 0
+
+    # Time format for TO_TIMESTAMP / TO_DATE
+    TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
+    TIME_MAPPING = {
+        "YYYY": "%Y",
+        "MM": "%m",
+        "DD": "%d",
+        "HH24": "%H",
+        "MI": "%M",
+        "SS": "%S",
+    }
+
+    # Wire up the three components
+    class Tokenizer(tokens.Tokenizer):
+        ...  # see Step 2
+
+    Parser = MyNewDBParser        # see Step 3
+    Generator = MyNewDBGenerator   # see Step 4
+```
+
+### Choosing a parent dialect
+
+The single most impactful decision is which existing dialect to inherit from.
+Inheritance means you **only override what differs**.
+
+| If your new dialect is… | Inherit from… | Example in codebase |
+|-------------------------|--------------|---------------------|
+| A fork of an existing DB | That DB's dialect | `Redshift(Postgres)` |
+| Close to standard SQL | `Dialect` directly | `Snowflake(Dialect)` |
+| A Presto/Trino variant | `Presto` | `Databricks(Spark)` → `Spark(Hive)` → `Hive(Presto)` |
+
+### Key configuration flags on `Dialect`
+
+These flags live on the `Dialect` class and control cross-cutting behavior.
+Override them as needed:
+
+| Flag | Type | Meaning |
+|------|------|---------|
+| `NORMALIZATION_STRATEGY` | `NormalizationStrategy` | Identifier case handling |
+| `INDEX_OFFSET` | `int` | Array base index (0 or 1) |
+| `NULL_ORDERING` | `str` | `"nulls_are_small"`, `"nulls_are_large"`, `"nulls_are_last"` |
+| `DPIPE_IS_STRING_CONCAT` | `bool` | Whether `\|\|` concatenates strings |
+| `SAFE_DIVISION` | `bool` | Division by zero returns NULL |
+| `SUPPORTS_USER_DEFINED_TYPES` | `bool` | Whether UDTs are allowed |
+| `CONCAT_COALESCE` | `bool` | NULL arg in CONCAT → empty string |
+| `TRY_CAST_REQUIRES_STRING` | `bool` | TRY_CAST LHS must be string type |
+
+**Real example** — Redshift's flags (`sqlglot/dialects/redshift.py`):
+
+```python
+class Redshift(Postgres):
+    NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
+    SUPPORTS_USER_DEFINED_TYPES = False
+    INDEX_OFFSET = 0
+    HEX_LOWERCASE = True
+    ARRAY_FUNCS_PROPAGATES_NULLS = True
+```
+
+**Real example** — Snowflake's flags (`sqlglot/dialects/snowflake.py`):
+
+```python
+class Snowflake(Dialect):
+    NORMALIZATION_STRATEGY = NormalizationStrategy.UPPERCASE
+    NULL_ORDERING = "nulls_are_large"
+    TRY_CAST_REQUIRES_STRING = True
+    PREFER_CTE_ALIAS_COLUMN = True
+    SUPPORTS_ALIAS_REFS_IN_JOIN_CONDITIONS = True
+```
+
+---
+
+## Step 2: Extend the Tokenizer
+
+The tokenizer converts a SQL string into a list of `Token` objects. Most
+dialect customization happens through two dictionaries:
+
+| Dictionary | Purpose | Example |
+|------------|---------|---------|
+| `KEYWORDS` | Multi-character lexemes → `TokenType` | `"MINUS": TokenType.EXCEPT` |
+| `SINGLE_TOKENS` | Single-character symbols → `TokenType` | `"#": TokenType.HASH` |
+
+### How it works internally
+
+The base `_TokenizerBase` (in `sqlglot/tokens.py`) uses `__init_subclass__`
+(line 93) to automatically compute derived data structures whenever a
+`Tokenizer` subclass is defined:
+
+- `_KEYWORD_TRIE` — a trie built from all multi-word keywords for fast lookup
+- `_QUOTES`, `_IDENTIFIERS` — normalized string/identifier delimiters
+- `_FORMAT_STRINGS` — bit/hex/byte/raw string prefixes
+- `_COMMENTS` — comment delimiters
+
+This means you only need to set class variables; the metaclass handles the rest.
+
+### Adding keywords
+
+```python
+class Tokenizer(ParentTokenizer):
+    KEYWORDS = {
+        **ParentTokenizer.KEYWORDS,
+        # New keywords specific to your dialect
+        "MY_FUNC":   TokenType.MY_FUNC,
+        "WAREHOUSE": TokenType.WAREHOUSE,
+    }
+```
+
+**Real example** — Redshift adds vendor-specific keywords
+(`sqlglot/dialects/redshift.py`):
+
+```python
+class Tokenizer(Postgres.Tokenizer):
+    KEYWORDS = {
+        **Postgres.Tokenizer.KEYWORDS,
+        "(+)":            TokenType.JOIN_MARKER,   # Oracle-style outer join
+        "BINARY VARYING": TokenType.VARBINARY,
+        "MINUS":          TokenType.EXCEPT,         # MINUS = EXCEPT in Redshift
+        "SUPER":          TokenType.SUPER,          # Semi-structured type
+        "TOP":            TokenType.TOP,
+        "UNLOAD":         TokenType.COMMAND,
+    }
+```
+
+### Removing inherited keywords
+
+Sometimes a parent dialect defines a keyword that your dialect doesn't use:
+
+```python
+KEYWORDS = {
+    **ParentTokenizer.KEYWORDS,
+    ...
+}
+KEYWORDS.pop("VALUES")   # Redshift treats VALUES differently
+```
+
+### Adjusting single-token behavior
+
+```python
+SINGLE_TOKENS = ParentTokenizer.SINGLE_TOKENS.copy()
+SINGLE_TOKENS.pop("#")   # Redshift allows # as a table identifier prefix
+```
+
+### Other tokenizer class variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `QUOTES` | `["'"]` | String literal delimiters |
+| `IDENTIFIERS` | `['"']` | Quoted-identifier delimiters |
+| `STRING_ESCAPES` | `["'"]` | Characters that escape within strings |
+| `COMMENTS` | `["--", ("/*", "*/")]` | Comment delimiters |
+| `RAW_STRINGS` | `[]` | Raw string prefixes (e.g., Snowflake's `$$`) |
+| `HEX_STRINGS` | `[]` | Hex literal prefixes |
+| `VAR_SINGLE_TOKENS` | `set()` | Tokens allowed inside VAR names (e.g., `$` in Snowflake) |
+
+**Real example** — Snowflake tokenizer (`sqlglot/dialects/snowflake.py`):
+
+```python
+class Tokenizer(tokens.Tokenizer):
+    STRING_ESCAPES = ["\\", "'"]
+    HEX_STRINGS = [("x'", "'"), ("X'", "'")]
+    RAW_STRINGS = ["$$"]
+    COMMENTS = ["--", "//", ("/*", "*/")]
+    VAR_SINGLE_TOKENS = {"$"}
+    KEYWORDS = {
+        **tokens.Tokenizer.KEYWORDS,
+        "FILE://":       TokenType.URI_START,
+        "FILE FORMAT":   TokenType.FILE_FORMAT,
+        "WAREHOUSE":     TokenType.WAREHOUSE,
+        "FLOAT":         TokenType.DOUBLE,
+        ...
+    }
+```
+
+---
+
+## Step 3: Extend the Parser
+
+The parser converts a token list into an AST using **recursive descent**.
+The base `Parser` class (`sqlglot/parser.py`) provides the parsing framework;
+dialect-specific parsers override dictionaries and `_parse_*` methods.
+
+### Parser inheritance in the codebase
+
+```
+parser.Parser                              (base, in sqlglot/parser.py)
+    └── BaseParser                         (sqlglot/parsers/base.py)
+        └── PostgresParser                 (sqlglot/parsers/postgres.py)
+            └── RedshiftParser             (sqlglot/parsers/redshift.py)
+```
+
+`BaseParser` (`sqlglot/parsers/base.py`) is a thin layer that adds common
+no-paren functions like `LOCALTIME`, `LOCALTIMESTAMP`, `CURRENT_CATALOG`:
+
+```python
+class BaseParser(parser.Parser):
+    NO_PAREN_FUNCTIONS = {
+        **parser.Parser.NO_PAREN_FUNCTIONS,
+        TokenType.LOCALTIME:        exp.Localtime,
+        TokenType.LOCALTIMESTAMP:   exp.Localtimestamp,
+        TokenType.CURRENT_CATALOG:  exp.CurrentCatalog,
+        TokenType.SESSION_USER:     exp.SessionUser,
+    }
+```
+
+### The five key dictionaries
+
+| Dictionary | Maps | To | Purpose |
+|------------|------|----|---------|
+| `FUNCTIONS` | Function name `str` | `Callable → exp.Expr` | Standard function calls: `MY_FUNC(a, b)` |
+| `FUNCTION_PARSERS` | Function name `str` | `Callable(self) → exp.Expr` | Non-standard arg syntax: `CAST(x AS INT)` |
+| `NO_PAREN_FUNCTIONS` | `TokenType` | `exp.Expr` subclass | No-arg functions: `CURRENT_DATE` |
+| `NO_PAREN_FUNCTION_PARSERS` | Keyword `str` | `Callable(self) → exp.Expr` | Special no-paren constructs: `CASE ... END` |
+| `STATEMENT_PARSERS` | `TokenType` | `Callable(self) → exp.Expr` | Top-level statements: `CREATE`, `INSERT` |
+
+### Overriding `FUNCTIONS` — the most common extension
+
+When your dialect has a function whose name or argument semantics differ from
+the base, add an entry to `FUNCTIONS`:
+
+```python
+class MyParser(ParentParser):
+    FUNCTIONS = {
+        **ParentParser.FUNCTIONS,
+        # Map function name → builder callable
+        "NVL":        lambda args: exp.Coalesce(this=seq_get(args, 0), expressions=[seq_get(args, 1)]),
+        "DATEADD":    _build_date_delta(exp.TsOrDsAdd),
+        "GETDATE":    exp.CurrentTimestamp.from_arg_list,
+        "LISTAGG":    exp.GroupConcat.from_arg_list,
+    }
+```
+
+**Real example** — Redshift parser (`sqlglot/parsers/redshift.py`):
+
+```python
+class RedshiftParser(PostgresParser):
+    FUNCTIONS = {
+        **{k: v for k, v in PostgresParser.FUNCTIONS.items() if k != "GET_BIT"},
+        "ADD_MONTHS":  lambda args: exp.TsOrDsAdd(...),
+        "DATEADD":     _build_date_delta(exp.TsOrDsAdd),
+        "DATEDIFF":    _build_date_delta(exp.TsOrDsDiff),
+        "GETDATE":     exp.CurrentTimestamp.from_arg_list,
+        "LISTAGG":     exp.GroupConcat.from_arg_list,
+        "REGEXP_SUBSTR": lambda args: exp.RegexpExtract(...),
+    }
+```
+
+Notice the pattern `{k: v for k, v in Parent.FUNCTIONS.items() if k != "..."}`
+— this is how you **remove** a parent function mapping that conflicts with your
+dialect.
+
+### Builder helpers from `dialect.py`
+
+The `sqlglot.dialects.dialect` module provides factory functions for common
+parser patterns:
+
+| Factory | Returns | Use case |
+|---------|---------|----------|
+| `build_formatted_time(exp_class)` | `Callable` | Functions with time-format args |
+| `build_date_delta(exp_class)` | `Callable` | `DATEADD`/`DATEDIFF`-style functions |
+| `_build_bitwise(exp_class, name)` | `Callable` | Bitwise functions (`BITAND`, `BITOR`) |
+
+### Overriding `_parse_*` methods
+
+When a function has non-standard argument syntax (not just a name mapping),
+override the parsing method directly:
+
+```python
+class MyParser(ParentParser):
+    FUNCTION_PARSERS = {
+        **ParentParser.FUNCTION_PARSERS,
+        "SPECIAL_FUNC": lambda self: self._parse_special_func(),
+    }
+
+    def _parse_special_func(self):
+        # Custom parsing logic using token-matching methods
+        this = self._parse_bitwise()
+        self._match(TokenType.COMMA)
+        fmt = self._parse_string()
+        return self.expression(exp.SpecialFunc, this=this, format=fmt)
+```
+
+### Token-matching methods (recursive descent toolkit)
+
+These methods are the building blocks of any custom `_parse_*` method:
+
+| Method | Signature | Behavior |
+|--------|-----------|----------|
+| `_match(token_type)` | `(TokenType, advance=True) → bool` | Match one token by type |
+| `_match_set(types)` | `(set[TokenType]) → bool` | Match any token in a set |
+| `_match_texts(texts)` | `(set[str]) → bool` | Match a keyword string |
+| `_match_text_seq(*texts)` | `(*str) → bool` | Match a sequence of keywords |
+| `_advance(n=1)` | — | Move cursor forward |
+| `_retreat(index)` | — | Move cursor back |
+| `_parse_csv(method)` | `(Callable) → list` | Parse comma-separated values |
+| `_parse_wrapped(method)` | `(Callable) → result` | Parse `(...)` wrapped construct |
+
+### Token sets that control identifier resolution
+
+The parser uses several token sets to decide which tokens can serve as
+identifiers, aliases, etc. Extend these when your dialect reserves fewer (or
+more) keywords:
+
+```python
+class MyParser(ParentParser):
+    ID_VAR_TOKENS = ParentParser.ID_VAR_TOKENS | {TokenType.MY_KEYWORD}
+    TABLE_ALIAS_TOKENS = ParentParser.TABLE_ALIAS_TOKENS - {TokenType.RESERVED}
+```
+
+---
+
+## Step 4: Extend the Generator
+
+The generator converts an AST back into a SQL string for the target dialect.
+It has two customization mechanisms that work together:
+
+1. **`TRANSFORMS` dictionary** — maps `exp.Expr` subclass → `Callable(self, e) → str`
+2. **Auto-discovered `*_sql` methods** — methods named `<lowercase_expr>_sql`
+
+### Generator feature flags
+
+These boolean flags on the Generator class control structural SQL generation:
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `LIMIT_IS_TOP` | `False` | Generate `TOP n` instead of `LIMIT n` |
+| `JOIN_HINTS` | `True` | Allow join hints (`/*+ HASH_JOIN */`) |
+| `TABLE_HINTS` | `True` | Allow table hints (`WITH (NOLOCK)`) |
+| `QUERY_HINTS` | `True` | Allow query-level hints |
+| `VALUES_AS_TABLE` | `True` | Whether `VALUES` can appear as a table |
+| `AGGREGATE_FILTER_SUPPORTED` | `True` | Support `FILTER (WHERE ...)` on aggregates |
+| `SINGLE_STRING_INTERVAL` | `False` | Interval as a single string literal |
+
+**Real example** — Snowflake generator flags (`sqlglot/generators/snowflake.py`):
+
+```python
+class SnowflakeGenerator(generator.Generator):
+    JOIN_HINTS = False
+    TABLE_HINTS = False
+    QUERY_HINTS = False
+    AGGREGATE_FILTER_SUPPORTED = False
+    SINGLE_STRING_INTERVAL = True
+    STAR_EXCEPT = "EXCLUDE"
+```
+
+---
+
+### Dispatch priority
+
+When the generator encounters an AST node of type `exp.Foo`:
+
+1. **Check `TRANSFORMS`**: If `exp.Foo` has an entry, use it.
+2. **Check auto-discovery**: If a method named `foo_sql` exists on the class, use it.
+3. **Fallback**: Use `function_fallback_sql` (for `Func` subclasses) or raise.
+
+The dispatch table is built by `_build_dispatch()` (`sqlglot/generator.py`,
+line 77):
+
+```python
+def _build_dispatch(cls):
+    dispatch = dict(cls.TRANSFORMS)          # TRANSFORMS take priority
+    for attr_name in dir(cls):
+        if not attr_name.endswith("_sql") or attr_name.startswith("_"):
+            continue
+        expr_key = attr_name[:-4]
+        expr_cls = exp.EXPR_CLASSES.get(expr_key)
+        if expr_cls and expr_cls not in dispatch:
+            dispatch[expr_cls] = getattr(cls, attr_name)
+    return dispatch
+```
+
+### Pattern A: Simple function rename via `TRANSFORMS`
+
+Use `rename_func()` for one-to-one function renames:
+
+```python
+from sqlglot.dialects.dialect import rename_func
+
+class MyGenerator(ParentGenerator):
+    TRANSFORMS = {
+        **ParentGenerator.TRANSFORMS,
+        exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
+    }
+```
+
+### Pattern B: Argument reshaping via `TRANSFORMS`
+
+Use helper factories when the target function has different argument order:
+
+```python
+from sqlglot.dialects.dialect import date_delta_sql, if_sql
+
+TRANSFORMS = {
+    exp.DateAdd:  date_delta_sql("DATEADD"),
+    exp.DateDiff: date_delta_sql("DATEDIFF"),
+    exp.If:       if_sql(name="IFF", false_value="NULL"),
+}
+```
+
+### Pattern C: AST preprocessing via `transforms.preprocess()`
+
+For structural transformations (not just renaming), chain AST rewriters:
+
+```python
+from sqlglot import transforms
+
+TRANSFORMS = {
+    exp.Select: transforms.preprocess([
+        transforms.eliminate_window_clause,      # Inline window → subquery
+        transforms.eliminate_distinct_on,        # DISTINCT ON → ROW_NUMBER
+        transforms.eliminate_semi_and_anti_joins, # SEMI/ANTI → EXISTS
+        transforms.explode_projection_to_unnest(),
+    ]),
+}
+```
+
+**Real example** — Snowflake (`sqlglot/generators/snowflake.py`):
+
+```python
+TRANSFORMS = {
+    **generator.Generator.TRANSFORMS,
+    exp.ApproxDistinct: rename_func("APPROX_COUNT_DISTINCT"),
+    exp.ArrayConcat:    array_concat_sql("ARRAY_CAT"),
+    exp.AtTimeZone:     lambda self, e: self.func("CONVERT_TIMEZONE",
+                            e.args.get("zone"), e.this),
+    exp.DateAdd:        date_delta_sql("DATEADD"),
+    exp.If:             if_sql(name="IFF", false_value="NULL"),
+    exp.Map:            lambda self, e: var_map_sql(self, e, "OBJECT_CONSTRUCT"),
+    exp.Select:         transforms.preprocess([
+        transforms.eliminate_window_clause,
+        transforms.eliminate_distinct_on,
+        transforms.explode_projection_to_unnest(),
+        _transform_generate_date_array,
+        _qualify_unnested_columns,
+        _eliminate_dot_variant_lookup,
+    ]),
+}
+```
+
+### Pattern D: Auto-discovered `*_sql` methods
+
+For complex generation logic that needs multiple lines, define a method named
+after the expression class (lowercased, with `_sql` suffix):
+
+```python
+class MyGenerator(ParentGenerator):
+    # No TRANSFORMS entry needed — auto-discovered by name
+    def myfunction_sql(self, expression: exp.MyFunction) -> str:
+        arg = expression.this
+        return self.func("MY_FUNC", arg, expression.args.get("format"))
+```
+
+> **Important**: `TRANSFORMS` entries take precedence over `*_sql` methods.
+> Only use `TRANSFORMS` for one-liners or lambdas. For multi-line logic, use
+> an auto-discovered method.
+
+### Pattern E: Overriding `TYPE_MAPPING`
+
+Map AST data types to target-dialect type names:
+
+```python
+TYPE_MAPPING = {
+    **ParentGenerator.TYPE_MAPPING,
+    exp.DType.BINARY:    "VARBYTE",
+    exp.DType.INT:       "INTEGER",
+    exp.DType.TIMESTAMPTZ: "TIMESTAMP",
+}
+```
+
+### Generator helper methods
+
+Use these instead of building SQL strings manually:
+
+| Method | Purpose | Example |
+|--------|---------|---------|
+| `self.func(name, *args)` | Render a function call | `self.func("DATEADD", unit, n, date)` |
+| `self.binary(e, op)` | Render a binary operation | `self.binary(e, "||")` |
+| `self.expressions(e, key)` | Render a list of child expressions | Used in SELECT lists |
+| `self.sql(e, key)` | Recursively generate SQL for a child | `self.sql(expression.this)` |
+| `self.seg(sql, sep)` | Add segment separator (newline) | Pretty-printing |
+
+### The `@unsupported_args` decorator
+
+When a target dialect doesn't support certain arguments, use this decorator
+to emit a warning instead of silently dropping them:
+
+```python
+from sqlglot.generator import unsupported_args
+
+@unsupported_args("accuracy")
+def approx_count_distinct_sql(self, expression):
+    return self.func("APPROX_COUNT_DISTINCT", expression.this)
+```
+
+---
+
+## Step 5: End-to-End Test
+
+Add tests to `tests/dialects/test_<dialect>.py` to verify transpilation works
+correctly in both directions.
+
+### Round-trip test (`validate_identity`)
+
+Verify that SQL survives a parse → generate cycle in the same dialect:
+
+```python
+class TestMyDialect(unittest.TestCase):
+    def test_my_feature(self):
+        self.validate_identity("SELECT MY_FUNC(a, b) FROM t")
+```
+
+### Cross-dialect test (`validate_all`)
+
+Verify that Redshift SQL transpiles correctly to Snowflake:
+
+```python
+def test_redshift_to_snowflake(self):
+    self.validate_all(
+        "SELECT DATEADD(day, 7, created_at) FROM events",  # Redshift SQL
+        read={
+            "redshift": "SELECT DATEADD(day, 7, created_at) FROM events",
+        },
+        write={
+            "snowflake": "SELECT DATEADD(day, 7, created_at) FROM events",
+        },
+    )
+```
+
+### Type-annotated tests
+
+When transpilation depends on `is_type()` checks, use `annotate_types`:
+
+```python
+from sqlglot.optimizer import annotate_types
+
+expr = self.validate_identity("SELECT BASE64_ENCODE(col)")
+annotated = annotate_types(expr, dialect="mydialect")
+self.assertEqual(annotated.sql("snowflake"), "SELECT ...")
+```
+
+### Running tests
+
+```bash
+# Run specific dialect test file
+python -m unittest tests.dialects.test_mydialect
+
+# Run specific test method
+python -m unittest tests.dialects.test_mydialect.TestMyDialect.test_my_feature
+
+# Run all tests
+make test
+```
+
+---
+
+## Plugin Dialects (External Packages)
+
+If your dialect lives in a separate Python package, you don't need to modify
+SQLGlot's source. Instead, register it via Python **entry points**.
+
+In your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."sqlglot.dialects"]
+mynewdb = "my_package.mynewdb:MyNewDB"
+```
+
+The `_Dialect._try_load()` method (line 162 in `sqlglot/dialects/dialect.py`)
+searches entry points under the group `"sqlglot.dialects"` as its second
+resolution tier:
+
+```python
+# 2. Try entry points (for plugins)
+all_eps = entry_points()
+eps = all_eps.select(group="sqlglot.dialects", name=key)
+for entry_point in eps:
+    dialect_class = entry_point.load()
+    if isinstance(dialect_class, type) and issubclass(dialect_class, Dialect):
+        cls._classes[key] = dialect_class
+```
+
+Once installed, `sqlglot.transpile(sql, read="mynewdb")` works automatically.
+
+---
+
+## Checklist
+
+Use this checklist when adding a new dialect or extending an existing one:
+
+- [ ] **Registration**
+  - [ ] Added enum value to `Dialects` in `sqlglot/dialects/dialect.py`
+  - [ ] Added class name to `DIALECTS` list in `sqlglot/dialects/__init__.py`
+  - [ ] (Plugin only) Configured `pyproject.toml` entry point
+
+- [ ] **Dialect class** (`sqlglot/dialects/<name>.py`)
+  - [ ] Chosen correct parent dialect
+  - [ ] Set `NORMALIZATION_STRATEGY`
+  - [ ] Set `TIME_MAPPING` and `TIME_FORMAT`
+  - [ ] Set other relevant flags (`INDEX_OFFSET`, `NULL_ORDERING`, etc.)
+  - [ ] Wired up `Parser` and `Generator` references
+
+- [ ] **Tokenizer** (inner class or `sqlglot/tokens.py` override)
+  - [ ] Added dialect-specific `KEYWORDS`
+  - [ ] Removed conflicting inherited keywords (via `.pop()`)
+  - [ ] Set `STRING_ESCAPES`, `COMMENTS`, etc. if different from parent
+
+- [ ] **Parser** (`sqlglot/parsers/<name>.py`)
+  - [ ] Added function mappings to `FUNCTIONS`
+  - [ ] Added custom `FUNCTION_PARSERS` for non-standard syntax
+  - [ ] Extended `ID_VAR_TOKENS` / `TABLE_ALIAS_TOKENS` if needed
+  - [ ] Overridden `_parse_*` methods for dialect-specific constructs
+
+- [ ] **Generator** (`sqlglot/generators/<name>.py`)
+  - [ ] Added `TRANSFORMS` entries for simple renames / argument reshaping
+  - [ ] Added auto-discovered `*_sql` methods for complex logic
+  - [ ] Overridden `TYPE_MAPPING` for data type differences
+  - [ ] Set feature flags (`JOIN_HINTS`, `LIMIT_IS_TOP`, etc.)
+  - [ ] Added `RESERVED_KEYWORDS` set if needed
+
+- [ ] **Testing** (`tests/dialects/test_<name>.py`)
+  - [ ] Added `validate_identity()` round-trip tests
+  - [ ] Added `validate_all()` cross-dialect tests
+  - [ ] Added type-annotated tests where `is_type()` is used
+  - [ ] All tests pass: `make test`
+  - [ ] Linter passes: `make style`
+
+---
+
+## Reference: Key Source Files
+
+| File | Role |
+|------|------|
+| `sqlglot/dialects/dialect.py` | `Dialect` base class, `_Dialect` metaclass, `Dialects` enum, helper factories |
+| `sqlglot/dialects/__init__.py` | `DIALECTS` list, lazy import via `__getattr__` |
+| `sqlglot/tokens.py` | `Tokenizer`, `TokenType` enum, `_TokenizerBase` with `__init_subclass__` |
+| `sqlglot/parser.py` | `Parser` base class, `_parse_*` methods, token-matching methods |
+| `sqlglot/parsers/base.py` | `BaseParser` — thin layer adding common no-paren functions |
+| `sqlglot/generator.py` | `Generator` base class, `TRANSFORMS`, `_build_dispatch`, `*_sql` auto-discovery |
+| `sqlglot/expressions.py` | All AST node types (`exp.Expr` subclasses) |
+| `sqlglot/dialects/redshift.py` | Redshift dialect — example of inheriting from Postgres |
+| `sqlglot/dialects/snowflake.py` | Snowflake dialect — example of inheriting from Dialect directly |
+| `posts/onboarding.md` | Architecture deep-dive (recommended prerequisite) |

--- a/posts/lineage_schema_governance.md
+++ b/posts/lineage_schema_governance.md
@@ -1,0 +1,533 @@
+# Spark SQL 变更治理：列级血缘、Schema 契约与 AST Diff 实战
+
+## 背景
+
+数据仓库治理的核心难题之一是：**Spark SQL 变更上线前，如何自动校验列级血缘与 schema 契约？** 人工 review 容易遗漏，而 SQLGlot 提供了四个可组合的模块来构建自动化治理流水线：
+
+| 模块 | 职责 |
+|------|------|
+| `sqlglot/lineage.py` | 追踪列级数据血缘，构建 `Node` 链表 |
+| `sqlglot/schema.py` | 绑定表结构元数据，提供类型推断 |
+| `sqlglot/diff.py` | 对两棵 AST 做语义 diff，产出编辑脚本 |
+| `sqlglot/serde.py` | AST 序列化/反序列化，用于存储与传输 |
+
+本文面向数据工程读者，讲解如何将这四个模块串起来，构建一套完整的 **变更审批 → 血缘校验 → schema 契约 → AST diff → 结果归档** 流水线。
+
+---
+
+## 整体流水线概览
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    Spark SQL 变更治理流水线                        │
+│                                                                 │
+│  ① 解析 SQL          ② 绑定 Schema        ③ 追踪列级血缘         │
+│  ┌──────────┐       ┌──────────┐         ┌──────────┐          │
+│  │ parse_one│──────▶│MappingSch│────────▶│ lineage()│          │
+│  │ (AST)    │       │ ema      │         │ → Node   │          │
+│  └──────────┘       └──────────┘         └──────────┘          │
+│       │                                       │                 │
+│       ▼                                       ▼                 │
+│  ④ AST Diff          ⑤ AST 序列化                              │
+│  ┌──────────┐       ┌──────────┐                                │
+│  │ diff()   │       │ dump() / │                                │
+│  │ → Edit[] │       │ load()   │                                │
+│  └──────────┘       └──────────┘                                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+**步骤说明：**
+
+1. 用 `parse_one()` 将新旧 SQL 解析为 AST
+2. 用 `MappingSchema` 绑定数仓表结构元数据
+3. 用 `lineage()` 追踪每个输出列的上游来源
+4. 用 `diff()` 对比新旧 AST，生成语义级变更列表
+5. 用 `dump()` / `load()` 将 AST 序列化存储，用于审计归档
+
+---
+
+## Step 1：解析 SQL 为 AST
+
+一切从 `sqlglot.parse_one()` 开始。它将 Spark SQL 字符串转换为结构化的 AST：
+
+```python
+from sqlglot import parse_one
+
+old_sql = """
+SELECT user_id, amount * 1.1 AS adjusted_amount
+FROM orders
+WHERE status = 'completed'
+"""
+
+new_sql = """
+SELECT user_id, amount * 1.2 AS adjusted_amount, created_at
+FROM orders
+WHERE status = 'completed'
+  AND created_at >= '2024-01-01'
+"""
+
+old_ast = parse_one(old_sql, dialect="spark")
+new_ast = parse_one(new_sql, dialect="spark")
+```
+
+`parse_one()` 返回一个 `exp.Select` 节点，它是整棵 AST 的根。后续所有模块都基于这棵树工作。
+
+---
+
+## Step 2：绑定 Schema 元数据
+
+### MappingSchema：表结构的内存表示
+
+`MappingSchema` 是 `schema.py` 中的核心类，它用嵌套字典描述数仓的 catalog → db → table → column 层级结构：
+
+```python
+from sqlglot.schema import MappingSchema
+
+schema = MappingSchema(
+    schema={
+        "analytics": {  # catalog
+            "sales": {  # db
+                "orders": {  # table
+                    "user_id": "BIGINT",
+                    "amount": "DECIMAL(10,2)",
+                    "status": "STRING",
+                    "created_at": "TIMESTAMP",
+                },
+                "users": {
+                    "user_id": "BIGINT",
+                    "user_name": "STRING",
+                    "region": "STRING",
+                },
+            }
+        }
+    },
+    dialect="spark",
+)
+```
+
+### Schema 的三种嵌套深度
+
+`MappingSchema` 根据字典嵌套层数自动推断 `supported_table_args`：
+
+| 深度 | 结构 | 支持的引用方式 |
+|------|------|----------------|
+| 1 | `{table: {col: type}}` | `orders` |
+| 2 | `{db: {table: {col: type}}}` | `sales.orders` |
+| 3 | `{catalog: {db: {table: {col: type}}}}` | `analytics.sales.orders` |
+
+`AbstractMappingSchema` 内部使用 Trie（`new_trie()`）索引表路径，`find()` 方法通过 `_find_in_trie()` 做前缀匹配查找。这意味着 `orders` 可以匹配到 `analytics.sales.orders`，前提是路径无歧义。
+
+### 动态注册表
+
+如果 schema 无法在初始化时全量提供，可以用 `add_table()` 动态注册：
+
+```python
+schema.add_table(
+    "analytics.sales.refunds",
+    column_mapping={"refund_id": "BIGINT", "amount": "DECIMAL(10,2)"},
+)
+```
+
+### 查询列类型
+
+`get_column_type()` 返回 `exp.DataType` 对象，这在后续的类型推断和血缘追踪中至关重要：
+
+```python
+col_type = schema.get_column_type(
+    "analytics.sales.orders", "amount", dialect="spark"
+)
+print(col_type)  # DECIMAL(10, 2)
+```
+
+### 列可见性控制
+
+`MappingSchema` 支持 `visible` 参数控制列的可见性，这对治理场景非常有用——可以隐藏内部实现列，只暴露契约列：
+
+```python
+schema = MappingSchema(
+    schema={"orders": {"user_id": "BIGINT", "amount": "DECIMAL", "_internal_flag": "BOOLEAN"}},
+    visible={"orders": {"user_id", "amount"}},  # 只暴露这两列
+)
+
+# column_names(only_visible=True) 会过滤掉 _internal_flag
+visible_cols = schema.column_names("orders", only_visible=True)
+```
+
+---
+
+## Step 3：列级血缘追踪
+
+### lineage() 函数
+
+`lineage.py` 的核心入口是 `lineage()` 函数。它接受目标列名、SQL 语句和 schema，返回一个 `Node` 链表：
+
+```python
+from sqlglot.lineage import lineage
+
+node = lineage(
+    column="adjusted_amount",
+    sql=new_sql,
+    schema=schema,
+    dialect="spark",
+)
+```
+
+### Node 数据结构
+
+每个 `Node` 包含：
+
+| 字段 | 说明 |
+|------|------|
+| `name` | 列名（含作用域前缀，如 `orders.amount`） |
+| `expression` | 该列对应的 AST 表达式节点 |
+| `source` | 包含该表达式的完整 SELECT 语句 |
+| `downstream` | 下游 `Node` 列表（上游依赖列） |
+| `source_name` | 数据源名称（用于跨查询追踪） |
+| `reference_node_name` | CTE 或子查询的引用名 |
+| `payload` | 调用方可注入的自定义数据字典 |
+
+### 遍历血缘链
+
+`Node.walk()` 方法以深度优先方式遍历整条血缘链：
+
+```python
+for n in node.walk():
+    print(f"{n.name} <- {n.expression.sql(dialect='spark')}")
+```
+
+输出示例：
+
+```
+adjusted_amount <- amount * 1.2
+orders.amount <- amount
+```
+
+### 跨查询追踪：sources 参数
+
+当 SQL 引用了其他查询的结果（如 dbt model 依赖），用 `sources` 参数传入上游查询定义：
+
+```python
+node = lineage(
+    column="total_revenue",
+    sql="SELECT user_id, SUM(adjusted_amount) AS total_revenue FROM staging_orders GROUP BY user_id",
+    sources={
+        "staging_orders": "SELECT user_id, amount * 1.2 AS adjusted_amount FROM analytics.sales.orders WHERE status = 'completed'",
+    },
+    schema=schema,
+    dialect="spark",
+)
+```
+
+`lineage()` 内部调用 `exp.expand()` 将 `sources` 中的查询内联展开到主查询中，然后继续追踪。
+
+### on_node 回调
+
+`on_node` 参数允许在遍历每个 `Node` 时注入自定义逻辑，例如记录元数据：
+
+```python
+def tag_node(node):
+    node.payload["owner"] = "data-platform-team"
+    node.payload["pii"] = node.name.endswith("_email")
+
+lineage("user_id", sql, schema=schema, dialect="spark", on_node=tag_node)
+```
+
+### 全列血缘
+
+当 `column=None` 时，`lineage()` 返回 `dict[str, Node]`，键为每个输出列名：
+
+```python
+all_lineage = lineage(column=None, sql=new_sql, schema=schema, dialect="spark")
+for col_name, node in all_lineage.items():
+    print(f"{col_name}: {[n.name for n in node.downstream]}")
+```
+
+### 可视化
+
+`Node.to_html()` 方法基于 vis.js 生成可交互的血缘图：
+
+```python
+html = node.to_html(dialect="spark")
+# 返回 GraphHTML 对象，可直接在 Jupyter Notebook 中渲染
+```
+
+`GraphHTML` 类将 `Node` 树转换为 vis-network 格式的节点和边数据，支持层级布局。
+
+### 内部工作机制
+
+`lineage()` 内部依赖优化器的 `qualify.qualify()` 来规范化标识符和补全表限定名，然后通过 `build_scope()` 构建作用域树。`to_node()` 递归函数负责：
+
+1. 在当前 `Scope` 中找到目标列的 SELECT 表达式
+2. 创建 `Node` 并关联到上游
+3. 查找表达式中引用的所有 `exp.Column`
+4. 如果列来自子查询或 CTE（`Scope` 类型），递归进入该作用域
+5. 如果列来自物理表（`exp.Table`），创建叶子节点
+
+对于 `UNION` / `UNION ALL`（`exp.SetOperation`），`to_node()` 会创建一个 `UNION` 节点，然后对每个分支递归追踪。
+
+---
+
+## Step 4：AST 语义 Diff
+
+### diff() 函数
+
+`diff.py` 实现了 Change Distiller 算法，对两棵 AST 做语义级比较：
+
+```python
+from sqlglot.diff import diff, Insert, Remove, Update, Move, Keep
+
+changes = diff(old_ast, new_ast)
+```
+
+### 编辑操作类型
+
+`diff()` 返回一个编辑脚本（`list[Edit]`），每个元素是以下五种之一：
+
+| 类型 | 含义 | 治理关注点 |
+|------|------|-----------|
+| `Insert(expression)` | 目标中新增的节点 | 新增列或条件 |
+| `Remove(expression)` | 源中被删除的节点 | 删除列或条件 |
+| `Update(source, target)` | 节点值被修改 | 逻辑变更（如系数变化） |
+| `Move(source, target)` | 节点位置移动 | 通常为结构重构，无功能影响 |
+| `Keep(source, target)` | 未变化的节点 | 可忽略 |
+
+### 治理场景：变更分类
+
+```python
+from sqlglot.diff import diff, Insert, Remove, Update
+
+changes = diff(old_ast, new_ast, delta_only=True)  # delta_only 排除 Keep 节点
+
+structural_changes = []
+logic_changes = []
+
+for change in changes:
+    if isinstance(change, Update):
+        # Update 意味着同类型节点的值发生了变化
+        logic_changes.append(f"逻辑变更: {change.source.sql()} → {change.target.sql()}")
+    elif isinstance(change, Insert):
+        structural_changes.append(f"新增: {change.expression.sql()}")
+    elif isinstance(change, Remove):
+        structural_changes.append(f"删除: {change.expression.sql()}")
+
+print("=== 逻辑变更（需要回刷数据） ===")
+for c in logic_changes:
+    print(c)
+
+print("\n=== 结构变更（需要 schema 校验） ===")
+for c in structural_changes:
+    print(c)
+```
+
+### ChangeDistiller 参数调优
+
+`ChangeDistiller` 类接受两个阈值参数：
+
+- `f`（默认 0.6）：叶子节点匹配的 Dice 系数阈值
+- `t`（默认 0.6）：内部节点匹配的子叶相似度阈值
+
+对于治理场景，建议保持默认值。降低阈值会产生更多 `Update`（匹配更宽松），升高阈值会产生更多 `Insert` + `Remove`（匹配更严格）。
+
+### UPDATABLE_EXPRESSION_TYPES
+
+`diff.py` 定义了 `UPDATABLE_EXPRESSION_TYPES`，只有这些类型的节点才会产生 `Update` 编辑：
+
+```python
+UPDATABLE_EXPRESSION_TYPES = (
+    exp.Alias, exp.Boolean, exp.Column, exp.DataType,
+    exp.Lambda, exp.Literal, exp.Table, exp.Window,
+)
+```
+
+这意味着 `amount * 1.1` 变为 `amount * 1.2` 时，只有 `Literal("1.1")` → `Literal("1.2")` 会被标记为 `Update`，而外层的 `Mul` 节点会被标记为 `Keep`。
+
+### 预匹配节点
+
+当你知道某些子树在新旧 AST 中完全对应时，可以通过 `matchings` 参数提供预匹配对，帮助算法产出更精准的结果：
+
+```python
+changes = diff(old_ast, new_ast, matchings=[(old_subtree, new_subtree)])
+```
+
+---
+
+## Step 5：AST 序列化与归档
+
+### dump() 与 load()
+
+`serde.py` 提供了 AST 的 JSON 序列化能力，用于审计归档和跨服务传输：
+
+```python
+from sqlglot.serde import dump, load
+import json
+
+# 序列化
+payload = dump(new_ast)
+json_str = json.dumps(payload)  # 可存入数据库或消息队列
+
+# 反序列化
+restored_ast = load(json.loads(json_str))
+assert restored_ast.sql(dialect="spark") == new_ast.sql(dialect="spark")
+```
+
+### 序列化格式
+
+`dump()` 将 AST 展平为一个 `list[dict]`，每个字典代表一个节点：
+
+| 键 | 含义 |
+|---|------|
+| `c` (CLASS) | 节点的类名（如 `Select`、`Column`） |
+| `i` (INDEX) | 父节点在列表中的索引 |
+| `k` (ARG_KEY) | 在父节点 `args` 中的键名 |
+| `a` (IS_ARRAY) | 是否为数组元素 |
+| `t` (TYPE) | 类型信息（如果已推断） |
+| `o` (COMMENTS) | 注释 |
+| `m` (META) | 元数据 |
+| `v` (VALUE) | 叶子值（如字面量） |
+
+`load()` 按照索引顺序重建父子关系：先创建根节点，然后依次通过 `parent.set(arg_key, node)` 或 `parent.append(arg_key, node)` 挂载子节点。
+
+### 类型信息保留
+
+`dump()` 会序列化 `node.type`（如果存在），这意味着经过 `annotate_types()` 标注后的 AST 在反序列化后仍然保留类型信息。这对治理场景很重要——你可以在 CI 阶段标注类型，在审批阶段直接使用。
+
+---
+
+## 完整治理流水线示例
+
+将以上模块组合起来，构建一个完整的 Spark SQL 变更校验函数：
+
+```python
+import json
+from sqlglot import parse_one
+from sqlglot.schema import MappingSchema
+from sqlglot.lineage import lineage
+from sqlglot.diff import diff, Insert, Remove, Update, Move
+from sqlglot.serde import dump
+from sqlglot.optimizer import annotate_types
+
+def govern_sql_change(
+    old_sql: str,
+    new_sql: str,
+    schema_dict: dict,
+    dialect: str = "spark",
+) -> dict:
+    """校验 Spark SQL 变更，返回治理报告。"""
+
+    # 1. 绑定 schema
+    schema = MappingSchema(schema_dict, dialect=dialect)
+
+    # 2. 解析新旧 AST
+    old_ast = parse_one(old_sql, dialect=dialect)
+    new_ast = parse_one(new_sql, dialect=dialect)
+
+    # 3. 类型标注（用于后续血缘和类型校验）
+    old_typed = annotate_types(old_ast, schema=schema, dialect=dialect)
+    new_typed = annotate_types(new_ast, schema=schema, dialect=dialect)
+
+    # 4. AST diff
+    changes = diff(old_typed, new_typed, delta_only=True)
+
+    report = {
+        "inserts": [],
+        "removes": [],
+        "updates": [],
+        "moves": [],
+        "lineage_changes": {},
+        "schema_violations": [],
+        "ast_snapshot": None,
+    }
+
+    for change in changes:
+        if isinstance(change, Insert):
+            report["inserts"].append(change.expression.sql(dialect=dialect))
+        elif isinstance(change, Remove):
+            report["removes"].append(change.expression.sql(dialect=dialect))
+        elif isinstance(change, Update):
+            report["updates"].append({
+                "from": change.source.sql(dialect=dialect),
+                "to": change.target.sql(dialect=dialect),
+            })
+        elif isinstance(change, Move):
+            report["moves"].append(change.source.sql(dialect=dialect))
+
+    # 5. 新 AST 的列级血缘
+    new_lineage = lineage(column=None, sql=new_ast, schema=schema, dialect=dialect)
+    for col_name, node in new_lineage.items():
+        upstream_cols = [n.name for n in node.walk() if n is not node]
+        report["lineage_changes"][col_name] = upstream_cols
+
+    # 6. Schema 契约校验：检查新 SQL 的输出列是否都在契约中
+    contract_columns = {"user_id", "adjusted_amount"}  # 示例：从契约配置读取
+    new_columns = {sel.alias_or_name for sel in new_ast.selects}
+    violations = new_columns - contract_columns
+    if violations:
+        report["schema_violations"] = [
+            f"输出列 '{c}' 不在 schema 契约中" for c in violations
+        ]
+
+    # 7. 归档新 AST
+    report["ast_snapshot"] = dump(new_typed)
+
+    return report
+```
+
+调用示例：
+
+```python
+schema_dict = {
+    "orders": {
+        "user_id": "BIGINT",
+        "amount": "DECIMAL(10,2)",
+        "status": "STRING",
+        "created_at": "TIMESTAMP",
+    }
+}
+
+result = govern_sql_change(old_sql, new_sql, schema_dict)
+
+print(f"新增 {len(result['inserts'])} 个节点")
+print(f"删除 {len(result['removes'])} 个节点")
+print(f"更新 {len(result['updates'])} 个节点")
+print(f"Schema 违规: {result['schema_violations']}")
+```
+
+---
+
+## 治理检查清单
+
+将以下检查项集成到 CI/CD 流水线中：
+
+```
+□  1. 解析检查：parse_one() 不抛异常（SQL 语法合法）
+□  2. Schema 绑定：所有引用的表都能在 MappingSchema 中找到
+□  3. 列存在性：schema.has_column() 确认所有引用列都存在
+□  4. 类型一致性：annotate_types() 标注后，关键列类型符合契约
+□  5. 血缘完整性：lineage() 能追踪到每个输出列的物理表来源
+□  6. 变更分类：diff() 区分逻辑变更 vs 结构重构
+□  7. 契约符合：输出列集合与 schema 契约一致
+□  8. 审计归档：dump() 序列化 AST 存入审计日志
+```
+
+---
+
+## 关键 API 速查表
+
+| 函数/类 | 模块 | 用途 |
+|---------|------|------|
+| `parse_one(sql, dialect)` | `sqlglot` | SQL → AST |
+| `MappingSchema(schema, dialect)` | `schema.py` | 创建表结构映射 |
+| `schema.add_table(table, column_mapping)` | `schema.py` | 动态注册表 |
+| `schema.get_column_type(table, column)` | `schema.py` | 查询列类型 |
+| `schema.has_column(table, column)` | `schema.py` | 检查列是否存在 |
+| `schema.column_names(table, only_visible)` | `schema.py` | 获取列名列表 |
+| `ensure_schema(schema, dialect)` | `schema.py` | dict → Schema 自动转换 |
+| `lineage(column, sql, schema, sources)` | `lineage.py` | 列级血缘追踪 |
+| `Node.walk()` | `lineage.py` | 遍历血缘链 |
+| `Node.to_html(dialect)` | `lineage.py` | 血缘可视化 |
+| `diff(source, target, delta_only)` | `diff.py` | AST 语义 diff |
+| `Insert / Remove / Update / Move / Keep` | `diff.py` | 编辑操作类型 |
+| `ChangeDistiller(f, t)` | `diff.py` | 底层 diff 算法 |
+| `dump(expression)` | `serde.py` | AST → JSON |
+| `load(payloads)` | `serde.py` | JSON → AST |
+| `annotate_types(expression, schema)` | `optimizer` | 类型推断标注 |


### PR DESCRIPTION
## Summary
- Add `posts/lineage_schema_governance.md`, a governance-oriented guide for data engineers covering column-level lineage tracking, schema binding, semantic AST diff, and AST serialization
- References real APIs from `lineage.py`, `schema.py`, `diff.py`, and `serde.py` with end-to-end Spark SQL examples
- Includes a complete governance pipeline function, 8-item CI/CD checklist, and API quick reference table

## Test plan
- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm all referenced function/class names match current source code
- [ ] Review code examples for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)