### PR TITLE
fix(databricks)!: json extract with : roundtrip

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1791,6 +1791,10 @@ class Parser:
     # Whether the `:` operator is used to extract a value from a VARIANT column
     COLON_IS_VARIANT_EXTRACT: t.ClassVar = False
 
+    # Whether a chain of colon extractions (x:y:z) is a single extraction with a merged
+    # path (x:y.z, e.g. Snowflake) or each colon extracts from the previous result (e.g. Databricks)
+    COLON_CHAIN_IS_SINGLE_EXTRACT: t.ClassVar = True
+
     # Whether or not a VALUES keyword needs to be followed by '(' to form a VALUES clause.
     # If this is True and '(' is not found, the keyword will be treated as an identifier
     VALUES_FOLLOWED_BY_PAREN: t.ClassVar = True
@@ -6685,6 +6689,10 @@ class Parser:
         escape = None
 
         while self._match(TokenType.COLON):
+            if not self.COLON_CHAIN_IS_SINGLE_EXTRACT:
+                this, path_parts = self._build_json_extract(this, path_parts, escape)
+                escape = None
+
             key = self._parse_id_var(any_token=True, tokens=(TokenType.SELECT,))
 
             if key:

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -11,6 +11,7 @@ class DatabricksParser(SparkParser):
     LOG_DEFAULTS_TO_LN = True
     STRICT_CAST = True
     COLON_IS_VARIANT_EXTRACT = True
+    COLON_CHAIN_IS_SINGLE_EXTRACT = False
 
     FUNCTIONS = {
         **SparkParser.FUNCTIONS,


### PR DESCRIPTION
This PR avoids parsing jsonextract chains like `x:y:z` into a single path and generate `x:y.z`.

In cases where the y is a json string this fails

```

SELECT
  s:a:b AS res1, s:a.b AS res2
FROM (
  SELECT
    TO_JSON(STRUCT(TO_JSON(STRUCT(1 AS b)) AS a)) AS s
)

res1  res2
1       NULL
```