### PR TITLE
Fix _KEYWORD_TRIE type annotation: keys are str | int

### DIFF
--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -87,7 +87,7 @@ class _TokenizerBase:
     _ESCAPE_FOLLOW_CHARS: t.ClassVar[set[str]]
     _IDENTIFIER_ESCAPES: t.ClassVar[set[str]]
     _COMMENTS: t.ClassVar[dict[str, str | None]]
-    _KEYWORD_TRIE: t.ClassVar[dict[str, object]]
+    _KEYWORD_TRIE: t.ClassVar[dict[str | int, object]]
 
     @classmethod
     def __init_subclass__(cls, **kwargs: t.Any) -> None:
@@ -208,7 +208,7 @@ class Tokenizer(_TokenizerBase):
     _QUOTES: t.ClassVar[dict[str, str]] = {}
     _STRING_ESCAPES: t.ClassVar[set[str]] = set()
     _BYTE_STRING_ESCAPES: t.ClassVar[set[str]] = set()
-    _KEYWORD_TRIE: t.ClassVar[dict[str, object]] = {}
+    _KEYWORD_TRIE: t.ClassVar[dict[str | int, object]] = {}
     _ESCAPE_FOLLOW_CHARS: t.ClassVar[set[str]] = set()
 
     KEYWORDS: t.ClassVar[dict[str, TokenType]] = {


### PR DESCRIPTION
`new_trie()` stores an integer sentinel (`0`) at each keyword terminal:

```python
>>> new_trie(["bla", "foo"])
{'b': {'l': {'a': {0: True}}}, 'f': {'o': {'o': {0: True}}}}
```

So `_KEYWORD_TRIE`'s keys are `str` (characters) **or** `int` (the terminal marker), not just `str`. This annotates it `dict[str | int, object]` to match reality.

The previous `dict[str, object]` was technically inaccurate about the int keys — mypy accepted it only because `new_trie()` returns a bare `dict`. No runtime or behavioral change; annotation-only.

Surfaced while compiling sqlglot through a strict AOT typed-Python compiler that enforces dict key representations and so rejected the str-keyed annotation holding int keys.