### PR TITLE
fix: fetch fork PR heads in benchmark workflow

### DIFF
--- a/.github/workflows/benchmark-sqlglot.yml
+++ b/.github/workflows/benchmark-sqlglot.yml
@@ -24,9 +24,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER=${{ github.event.issue.number }}
-          PR_HEAD=$(gh pr view $PR_NUMBER --json headRefName -q .headRefName)
-          git fetch origin "$PR_HEAD"
-          git checkout "$PR_HEAD"
+          PR_HEAD_REPO=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.repo.clone_url')
+          PR_HEAD_REF=$(gh api "repos/${{ github.repository }}/pulls/$PR_NUMBER" --jq '.head.ref')
+          git fetch "$PR_HEAD_REPO" "$PR_HEAD_REF"
+          git checkout FETCH_HEAD
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Description:

Issue #7762 reported that the benchmark workflow fails for fork pull requests because it resolves the PR head ref and then tries to fetch that branch from `origin`, which only contains branches from `tobymao/sqlglot`.

This PR updates `.github/workflows/benchmark-sqlglot.yml` to resolve the PR head repository clone URL and head ref from the pull request API, then fetches that ref directly and checks out `FETCH_HEAD`.

This keeps the workflow behavior the same for same-repository pull requests and fixes the checkout path for fork pull requests.

Closes #7762.

## Checklist:

- [x] I have verified the failure locally against a fork pull request by reproducing `git fetch origin "$PR_HEAD"` failing for PR #7670.
- [x] I have verified the fix locally by fetching the PR head repository clone URL and ref from the pull request API and checking out `FETCH_HEAD` successfully.
- [x] I have run validation with `make check`.
