### PR TITLE
fix(postgres): preserve ARRAY roundtrip for SET OPS

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -503,7 +503,7 @@ class PostgresGenerator(generator.Generator):
         exprs = expression.expressions
         func_name = self.normalize_func("ARRAY")
 
-        if isinstance(seq_get(exprs, 0), exp.Select):
+        if isinstance(seq_get(exprs, 0), exp.Query):
             return f"{func_name}({self.sql(exprs[0])})"
 
         return f"{func_name}{inline_array_sql(self, expression)}"


### PR DESCRIPTION
On the main the issue with the postgres `ARRAY` roundtrip:
```
input:
WITH pairs AS (SELECT ARRAY[8, 9, 12] AS a, ARRAY[9, 12, 13] AS b)
SELECT ARRAY(SELECT UNNEST(a) EXCEPT SELECT UNNEST(b)) AS r FROM pairs;
> r  
-----
 {8}
(1 row)

output:
WITH pairs AS (SELECT ARRAY[8, 9, 12] AS a, ARRAY[9, 12, 13] AS b)
SELECT ARRAY[SELECT UNNEST(a) EXCEPT SELECT UNNEST(b)] AS r FROM pairs;

> ERROR:  syntax error at or near "SELECT"
LINE 2: SELECT ARRAY[SELECT UNNEST(a) EXCEPT SELECT UNNEST(b)] AS r ...
```
For all the set ops + sub query + select ^ , we need to preserve the `()` and don't generate `[]`.

Note: we can also wrap the expression with parentheses in a subquery, as I tested also this works but I believe keeping the input intact is better.