### PR TITLE
fix(postgres): support jsonpath @? operator CODEX

### DIFF
--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -75,6 +75,7 @@ class Postgres(Dialect):
             **tokens.Tokenizer.KEYWORDS,
             "~": TokenType.RLIKE,
             "@@": TokenType.DAT,
+            "@?": TokenType.AT_QMARK,
             "@>": TokenType.AT_GT,
             "<@": TokenType.LT_AT,
             "?&": TokenType.QMARK_AMP,

--- a/sqlglot/expressions/json.py
+++ b/sqlglot/expressions/json.py
@@ -62,6 +62,10 @@ class JSONBDeleteAtPath(Expression, Binary, Func):
     pass
 
 
+class JSONBPathExists(Expression, Binary, Predicate, Func):
+    pass
+
+
 class JSONBExists(Expression, Func):
     arg_types = {"this": True, "path": True}
     _sql_names = ["JSONB_EXISTS"]

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -203,6 +203,7 @@ class Generator:
         exp.JSONBContainsAnyTopKeys: lambda self, e: self.binary(e, "?|"),
         exp.JSONBContainsAllTopKeys: lambda self, e: self.binary(e, "?&"),
         exp.JSONBDeleteAtPath: lambda self, e: self.binary(e, "#-"),
+        exp.JSONBPathExists: lambda self, e: self.binary(e, "@?"),
         exp.JSONObject: lambda self, e: self._jsonobject_sql(e),
         exp.JSONObjectAgg: lambda self, e: self._jsonobject_sql(e),
         exp.LanguageProperty: lambda self, e: self.naked_property(e),

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1200,6 +1200,7 @@ class Parser:
         TokenType.QMARK_AMP: binary_range_parser(exp.JSONBContainsAllTopKeys),
         TokenType.QMARK_PIPE: binary_range_parser(exp.JSONBContainsAnyTopKeys),
         TokenType.HASH_DASH: binary_range_parser(exp.JSONBDeleteAtPath),
+        TokenType.AT_QMARK: binary_range_parser(exp.JSONBPathExists),
         TokenType.ADJACENT: binary_range_parser(exp.Adjacent),
         TokenType.OPERATOR: lambda self, this: self._parse_operator(this),
         TokenType.AMP_LT: binary_range_parser(exp.ExtendsLeft),

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -64,6 +64,7 @@ class TokenType(IntEnum):
     LR_ARROW = auto()
     LLRR_ARROW = auto()
     DAT = auto()
+    AT_QMARK = auto()
     LT_AT = auto()
     AT_GT = auto()
     DOLLAR = auto()

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -42,6 +42,8 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT x FROM t WHERE CAST($1 AS TEXT) = 'ok'")
         self.validate_identity("SELECT * FROM t TABLESAMPLE SYSTEM (50) REPEATABLE (55)")
         self.validate_identity("x @@ y")
+        self.validate_identity("doc @? '$.a[*] ? (@ > 2)'")
+        self.validate_identity("SELECT * FROM events WHERE doc @? '$.a[*] ? (@ > 2)'")
         self.validate_identity("CAST(x AS MONEY)")
         self.validate_identity("CAST(x AS INT4RANGE)")
         self.validate_identity("CAST(x AS INT4MULTIRANGE)")


### PR DESCRIPTION
## Summary
- tokenize and parse Postgres `@?` as a JSONB JSONPath predicate operator
- add `JSONBPathExists` expression support and generate it back as `@?`
- add Postgres round-trip tests

## Tests
- `ruff check sqlglot/tokenizer_core.py sqlglot/dialects/postgres.py sqlglot/expressions/json.py sqlglot/parser.py sqlglot/generator.py tests/dialects/test_postgres.py`
- `make unit`
- `make unitc`
