### PR TITLE
fix(postgres): 1 arg UUID roundtrip

### DIFF
--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -134,6 +134,7 @@ class PostgresParser(parser.Parser):
             if len(args) == 2
             else exp.WidthBucket.from_arg_list(args)
         ),
+        "UUID": lambda args: exp.cast(args[0], exp.DType.UUID) if args else exp.Uuid(),
     }
 
     NO_PAREN_FUNCTION_PARSERS = {


### PR DESCRIPTION
```
postgres=# select uuid('14a36fcb-8743-4faa-bd7a-f02b1e928843');
                 uuid                 
--------------------------------------
 14a36fcb-8743-4faa-bd7a-f02b1e928843
(1 row)

postgres=# select cast('14a36fcb-8743-4faa-bd7a-f02b1e928843' as uuid);
                 uuid                 
--------------------------------------
 14a36fcb-8743-4faa-bd7a-f02b1e928843
(1 row)
```