### PR TITLE
fix(postgres): preserve contained-by operator direction CODEX

### DIFF
--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -114,6 +114,10 @@ class ArrayContainsAll(Expression, Binary, Func):
     _sql_names = ["ARRAY_CONTAINS_ALL", "ARRAY_HAS_ALL"]
 
 
+class ArrayContainedBy(Expression, Binary, Func):
+    _sql_names = ["ARRAY_CONTAINED_BY"]
+
+
 class ArrayExcept(Expression, Func):
     arg_types = {"this": True, "expression": True, "is_multiset": False}
 

--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -115,7 +115,7 @@ class ArrayContainsAll(Expression, Binary, Func):
 
 
 class ArrayContainedBy(Expression, Binary, Func):
-    _sql_names = ["ARRAY_CONTAINED_BY"]
+    pass
 
 
 class ArrayExcept(Expression, Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -140,6 +140,7 @@ class Generator:
         ),
         exp.AnalyzeColumns: lambda self, e: self.sql(e, "this"),
         exp.AnalyzeWith: lambda self, e: self.expressions(e, prefix="WITH ", sep=" "),
+        exp.ArrayContainedBy: lambda self, e: self.binary(e, "<@"),
         exp.ArrayContainsAll: lambda self, e: self.binary(e, "@>"),
         exp.ArrayOverlaps: lambda self, e: self.binary(e, "&&"),
         exp.AssumeColumnConstraint: lambda self, e: f"ASSUME ({self.sql(e, 'this')})",

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -653,6 +653,10 @@ class MySQLGenerator(generator.Generator):
         self.unsupported("Array operations are not supported by MySQL")
         return self.function_fallback_sql(expression)
 
+    def arraycontainedby_sql(self, expression: exp.ArrayContainedBy) -> str:
+        self.unsupported("Array operations are not supported by MySQL")
+        return self.function_fallback_sql(expression)
+
     def dpipe_sql(self, expression: exp.DPipe) -> str:
         return self.func("CONCAT", *expression.flatten())
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1192,7 +1192,7 @@ class Parser:
         TokenType.IRLIKE: binary_range_parser(exp.RegexpILike),
         TokenType.IS: lambda self, this: self._parse_is(this),
         TokenType.LIKE: binary_range_parser(exp.Like),
-        TokenType.LT_AT: binary_range_parser(exp.ArrayContainsAll, reverse_args=True),
+        TokenType.LT_AT: binary_range_parser(exp.ArrayContainedBy),
         TokenType.OVERLAPS: binary_range_parser(exp.Overlaps),
         TokenType.RLIKE: binary_range_parser(exp.RegexpLike),
         TokenType.SIMILAR_TO: binary_range_parser(exp.SimilarTo),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1350,8 +1350,8 @@ class TestDuckDB(Validator):
         self.validate_identity("a ** b", "POWER(a, b)")
         self.validate_identity("a ~~~ b", "a GLOB b")
         self.validate_identity("a ~~ b", "a LIKE b")
-        self.validate_identity("a @> b")
-        self.validate_identity("a <@ b", "b @> a")
+        self.validate_identity("a @> b").assert_is(exp.ArrayContainsAll)
+        self.validate_identity("a <@ b").assert_is(exp.ArrayContainedBy)
         self.validate_identity("a && b").assert_is(exp.ArrayOverlaps)
         self.validate_identity("a ^@ b", "STARTS_WITH(a, b)")
         self.validate_identity(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -213,9 +213,8 @@ class TestPostgres(Validator):
             "SELECT SUBSTRING('Thomas' FOR 3 FROM 2)",
             "SELECT SUBSTRING('Thomas' FROM 2 FOR 3)",
         )
-        self.validate_identity(
-            "SELECT ARRAY[1, 2, 3] <@ ARRAY[1, 2]",
-            "SELECT ARRAY[1, 2] @> ARRAY[1, 2, 3]",
+        self.validate_identity("SELECT ARRAY[1, 2, 3] <@ ARRAY[1, 2]").expressions[0].assert_is(
+            exp.ArrayContainedBy
         )
         self.validate_identity(
             "SELECT DATE_PART('isodow'::varchar(6), current_date)",


### PR DESCRIPTION
## Summary

Preserve `<@` as a distinct contained-by expression instead of commuting it into reversed `@>`.

Previously, Postgres and DuckDB parsed `<@` successfully, but SQL generation normalized it by reversing the operands and rendering `@>`. This caused round-trip/render mismatches for operator-sensitive checks. This PR keeps the original operator direction in the AST and generated SQL.

## Changes

- Add `ArrayContainedBy` expression for `<@`
- Parse `TokenType.LT_AT` into `ArrayContainedBy` instead of reversed `ArrayContainsAll`
- Generate `ArrayContainedBy` as `<@`
- Preserve existing MySQL unsupported-array behavior for the new expression
- Update Postgres and DuckDB tests to assert `<@` round-trips directly

## Verification

- `python -m unittest tests.dialects.test_postgres.TestPostgres.test_postgres tests.dialects.test_duckdb.TestDuckDB.test_duckdb`
- `uv run ruff check sqlglot/expressions/array.py sqlglot/parser.py sqlglot/generator.py sqlglot/generators/mysql.py tests/dialects/test_postgres.py tests/dialects/test_duckdb.py`

## Contributor's Note

I am working through Postgres support gaps in small, focused PRs (the previous one was #7766).