### PR TITLE
feat!: preserve line breaks between consecutive comments in pretty mode

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1007,14 +1007,14 @@ class Generator:
         if not comments or isinstance(expression, self.EXCLUDE_COMMENTS):
             return sql
 
-        comments_sql = " ".join(
-            f"/*{self.sanitize_comment(comment)}*/" for comment in comments if comment
+        comments_sql = self.sep().join(
+            f"/*{self._replace_line_breaks(self.sanitize_comment(comment))}*/"
+            for comment in comments
+            if comment
         )
 
         if not comments_sql:
             return sql
-
-        comments_sql = self._replace_line_breaks(comments_sql)
 
         if separated or isinstance(expression, self.WITH_SEPARATED_COMMENTS):
             return (

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1007,23 +1007,24 @@ class Generator:
         if not comments or isinstance(expression, self.EXCLUDE_COMMENTS):
             return sql
 
-        comments_sql = self.sep().join(
+        comments_list = [
             f"/*{self._replace_line_breaks(self.sanitize_comment(comment))}*/"
             for comment in comments
             if comment
-        )
+        ]
 
-        if not comments_sql:
+        if not comments_list:
             return sql
 
         if separated or isinstance(expression, self.WITH_SEPARATED_COMMENTS):
+            comments_sql = self.sep().join(comments_list)
             return (
                 f"{self.sep()}{comments_sql}{sql}"
                 if not sql or sql[0].isspace()
                 else f"{comments_sql}{self.sep()}{sql}"
             )
 
-        return f"{sql} {comments_sql}"
+        return f"{sql} {' '.join(comments_list)}"
 
     def wrap(self, expression: exp.Expr | str) -> str:
         this_sql = (

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -242,8 +242,7 @@ line3*/ /*another comment*/ where 1=1 -- comment at the end""",
   *
 FROM tbl /* line1
 line2
-line3 */
-/* another comment */
+line3 */ /* another comment */
 WHERE
   1 = 1 /* comment at the end */""",
             pretty=True,
@@ -397,9 +396,7 @@ SELECT
   c
 FROM tb_01
 WHERE
-  a /* comment5 */ = 1 AND b = 2 /* comment6 */
-  /* and c = 1 */
-  /* comment7 */""",
+  a /* comment5 */ = 1 AND b = 2 /* comment6 */ /* and c = 1 */ /* comment7 */""",
             pretty=True,
         )
         self.validate(
@@ -443,8 +440,7 @@ LEFT OUTER JOIN b""",
         self.validate(
             "SELECT\n  a /* sqlglot.meta case_sensitive */ -- noqa\nFROM tbl",
             """SELECT
-  a /* sqlglot.meta case_sensitive */
-  /* noqa */
+  a /* sqlglot.meta case_sensitive */ /* noqa */
 FROM tbl""",
             pretty=True,
         )
@@ -645,8 +641,27 @@ WHERE
     FROM t
   ) /* f */
 ORDER BY
-  n /* g */
-  /* h */""",
+  n /* g */ /* h */""",
+            pretty=True,
+        )
+
+        # Round-trip stress: multiple trailing comments on the same expression must
+        # stay space-separated (same line) in pretty mode. Re-parsing would otherwise
+        # detach the later ones onto the next token.
+        self.validate(
+            "SELECT a /* foo */ /* bar */ FROM tbl",
+            """SELECT
+  a /* foo */ /* bar */
+FROM tbl""",
+            pretty=True,
+        )
+        self.validate(
+            "SELECT x FROM t WHERE x = 1 /* a */ /* b */ /* c */",
+            """SELECT
+  x
+FROM t
+WHERE
+  x = 1 /* a */ /* b */ /* c */""",
             pretty=True,
         )
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -216,7 +216,9 @@ SELECT * FROM foo
 -- comment 2
 -- comment 3
 SELECT * FROM foo""",
-            """/* comment 1 */ /* comment 2 */ /* comment 3 */
+            """/* comment 1 */
+/* comment 2 */
+/* comment 3 */
 SELECT
   *
 FROM foo""",
@@ -240,7 +242,8 @@ line3*/ /*another comment*/ where 1=1 -- comment at the end""",
   *
 FROM tbl /* line1
 line2
-line3 */ /* another comment */
+line3 */
+/* another comment */
 WHERE
   1 = 1 /* comment at the end */""",
             pretty=True,
@@ -367,7 +370,9 @@ FROM v""",
             -- comment3
             DROP TABLE IF EXISTS db.tba
             """,
-            """/* comment1 */ /* comment2 */ /* comment3 */
+            """/* comment1 */
+/* comment2 */
+/* comment3 */
 DROP TABLE IF EXISTS db.tba""",
             pretty=True,
         )
@@ -392,7 +397,9 @@ SELECT
   c
 FROM tb_01
 WHERE
-  a /* comment5 */ = 1 AND b = 2 /* comment6 */ /* and c = 1 */ /* comment7 */""",
+  a /* comment5 */ = 1 AND b = 2 /* comment6 */
+  /* and c = 1 */
+  /* comment7 */""",
             pretty=True,
         )
         self.validate(
@@ -428,14 +435,16 @@ INNER JOIN b""",
             """SELECT
   *
 FROM a
-/* comment 1 */ /* comment 2 */
+/* comment 1 */
+/* comment 2 */
 LEFT OUTER JOIN b""",
             pretty=True,
         )
         self.validate(
             "SELECT\n  a /* sqlglot.meta case_sensitive */ -- noqa\nFROM tbl",
             """SELECT
-  a /* sqlglot.meta case_sensitive */ /* noqa */
+  a /* sqlglot.meta case_sensitive */
+  /* noqa */
 FROM tbl""",
             pretty=True,
         )
@@ -619,7 +628,8 @@ FROM tbl1""",
   SELECT
     2 AS n /* b */
   FROM (
-    /* c */ /* c2 */
+    /* c */
+    /* c2 */
     SELECT
       a /* d */
     FROM t
@@ -635,7 +645,8 @@ WHERE
     FROM t
   ) /* f */
 ORDER BY
-  n /* g */ /* h */""",
+  n /* g */
+  /* h */""",
             pretty=True,
         )
 


### PR DESCRIPTION
When multiple comments are attached to the same expression (e.g., from consecutive `--` comment lines before a `SELECT`), they were joined with spaces even in pretty mode. Now they are joined with the generator's separator (newline in pretty mode, space otherwise).

Additionally, `_replace_line_breaks` is applied per-comment content rather than post-join, so newlines between separate comments get proper SQL indentation while newlines within a single multi-line comment remain as sentinels to prevent extra indentation.

Closes #7764