### PR TITLE
fix(druid): add JSON_VALUE RETURNING support

### DIFF
--- a/sqlglot/parsers/druid.py
+++ b/sqlglot/parsers/druid.py
@@ -4,4 +4,7 @@ from sqlglot.parser import Parser
 
 
 class DruidParser(Parser):
-    pass
+    FUNCTION_PARSERS = {
+        **Parser.FUNCTION_PARSERS,
+        "JSON_VALUE": lambda self: self._parse_json_value(),
+    }

--- a/tests/dialects/test_druid.py
+++ b/tests/dialects/test_druid.py
@@ -22,3 +22,9 @@ class TestDruid(Validator):
             "FLOOR(__time TO WEEK)",
             write=write,
         )
+
+    def test_json_value(self):
+        json_doc = """'{"item": "shoes", "price": "49.95"}'"""
+        self.validate_identity(f"SELECT JSON_VALUE({json_doc}, '$.item')")
+        self.validate_identity(f"SELECT JSON_VALUE({json_doc}, '$.price' RETURNING DOUBLE)")
+        self.validate_identity("SELECT JSON_VALUE(x, '$.a' RETURNING BIGINT) FROM t")


### PR DESCRIPTION
## Description

Adds `JSON_VALUE` to Druid's `FUNCTION_PARSERS` so the `RETURNING <type>` clause is parsed instead of falling through to the generic function-call parser, which can't handle it.

The base `Parser._parse_json_value` already handles `RETURNING` (and `ON EMPTY` / `ON ERROR`) correctly — it just wasn't routed for the Druid dialect. MySQL, Trino, and Exasol register `JSON_VALUE` the same way.

### Before

```
>>> import sqlglot
>>> sqlglot.parse_one("SELECT JSON_VALUE(x, '$.a' RETURNING BIGINT) FROM t", dialect="druid")
sqlglot.errors.ParseError: Expecting ). Line 1, Col: 36.
```

### After

```
>>> sqlglot.parse_one("SELECT JSON_VALUE(x, '$.a' RETURNING BIGINT) FROM t", dialect="druid").sql(dialect="druid")
"SELECT JSON_VALUE(x, '$.a' RETURNING BIGINT) FROM t"
```

## Related

Surfaced via [apache/superset#36954](https://github.com/apache/superset/issues/36954) — Superset users on Druid datasets currently can't run any query using `json_value(..., '$.x' RETURNING <type>)` because the SQL fails sanitize/format before being sent to the engine.

## Tests

Added `test_json_value` to `tests/dialects/test_druid.py` covering plain `JSON_VALUE`, `RETURNING DOUBLE`, and the exact failure case from the linked issue. Full suite (`python -m unittest`) green locally.