### PR TITLE
feat(optimizer)!: Annotate Typeof for Spark/DBX

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -24,6 +24,7 @@ EXPRESSION_METADATA = {
             exp.Collation,
             exp.CurrentTimezone,
             exp.Randstr,
+            exp.Typeof,
         }
     },
     **{
@@ -35,7 +36,6 @@ EXPRESSION_METADATA = {
             exp.BitwiseOrAgg,
             exp.BitwiseXorAgg,
             exp.Overlay,
-            exp.Typeof,
         }
     },
     exp.BitmapCount: {"returns": exp.DType.BIGINT},

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -35,6 +35,7 @@ EXPRESSION_METADATA = {
             exp.BitwiseOrAgg,
             exp.BitwiseXorAgg,
             exp.Overlay,
+            exp.Typeof,
         }
     },
     exp.BitmapCount: {"returns": exp.DType.BIGINT},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -949,6 +949,18 @@ ARRAY<STRING>;
 MINUTE('2024-01-01 12:30:00');
 INT;
 
+# dialect: spark, databricks
+TYPEOF(tbl.int_col);
+INT;
+
+# dialect: spark, databricks
+TYPEOF(tbl.double_col);
+DOUBLE;
+
+# dialect: spark, databricks
+TYPEOF(tbl.str_col);
+STRING;
+
 --------------------------------------
 -- BigQuery
 --------------------------------------

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -951,15 +951,15 @@ INT;
 
 # dialect: spark, databricks
 TYPEOF(tbl.int_col);
-INT;
+VARCHAR;
 
 # dialect: spark, databricks
 TYPEOF(tbl.double_col);
-DOUBLE;
+VARCHAR;
 
 # dialect: spark, databricks
 TYPEOF(tbl.str_col);
-STRING;
+VARCHAR;
 
 --------------------------------------
 -- BigQuery


### PR DESCRIPTION
## This PR annotate the function `Typeof` for Spark/DBX

https://docs.databricks.com/aws/en/sql/language-manual/functions/typeof
https://spark.apache.org/docs/latest/api/sql/index.html#typeof