### PR TITLE
fix(snowflake): transpile FROM_ISO8601_TIMESTAMP to cast

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3738,6 +3738,9 @@ class Generator:
         zone = self.sql(expression, "zone")
         return f"{this} AT TIME ZONE {zone} AT TIME ZONE 'UTC'"
 
+    def fromiso8601timestamp_sql(self, expression: exp.FromISO8601Timestamp) -> str:
+        return self.sql(exp.cast(expression.this, exp.DType.TIMESTAMPTZ))
+
     def add_sql(self, expression: exp.Add) -> str:
         return self.binary(expression, "+")
 

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -2471,9 +2471,6 @@ class DuckDBGenerator(generator.Generator):
         )
         return self.function_fallback_sql(expression)
 
-    def fromiso8601timestamp_sql(self, expression: exp.FromISO8601Timestamp) -> str:
-        return self.sql(exp.cast(expression.this, exp.DType.TIMESTAMPTZ))
-
     def strposition_sql(self, expression: exp.StrPosition) -> str:
         this = expression.this
         substr = expression.args.get("substr")

--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -308,6 +308,7 @@ class PrestoGenerator(generator.Generator):
         exp.Encode: lambda self, e: encode_decode_sql(self, e, "TO_UTF8"),
         exp.FileFormatProperty: lambda self, e: f"format={self.sql(exp.Literal.string(e.name))}",
         exp.First: _first_last_sql,
+        exp.FromISO8601Timestamp: rename_func("FROM_ISO8601_TIMESTAMP"),
         exp.FromTimeZone: lambda self, e: (
             f"WITH_TIMEZONE({self.sql(e, 'this')}, {self.sql(e, 'zone')}) AT TIME ZONE 'UTC'"
         ),

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -38,6 +38,11 @@ class TestPresto(Validator):
             write={
                 "duckdb": "SELECT CAST('2020-05-11T11:15:05' AS TIMESTAMPTZ)",
                 "presto": "SELECT FROM_ISO8601_TIMESTAMP('2020-05-11T11:15:05')",
+                "trino": "SELECT FROM_ISO8601_TIMESTAMP('2020-05-11T11:15:05')",
+                "snowflake": "SELECT CAST('2020-05-11T11:15:05' AS TIMESTAMPTZ)",
+                "spark": "SELECT CAST('2020-05-11T11:15:05' AS TIMESTAMP)",
+                "databricks": "SELECT CAST('2020-05-11T11:15:05' AS TIMESTAMP)",
+                "bigquery": "SELECT CAST('2020-05-11T11:15:05' AS TIMESTAMP)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #7775

`FROM_ISO8601_TIMESTAMP` is a Presto/Trino function that parses an ISO 8601 string into a timestamp **with timezone**. Previously it was only transpiled for DuckDB; every other dialect emitted the literal `FROM_ISO8601_TIMESTAMP(...)`, which is invalid outside Presto/Trino:

```python
>>> sqlglot.parse_one("SELECT FROM_ISO8601_TIMESTAMP('2022-07-01T07:00:00+00:00')", "trino").sql("snowflake")
"SELECT FROM_ISO8601_TIMESTAMP('2022-07-01T07:00:00+00:00')"   # before
"SELECT CAST('2022-07-01T07:00:00+00:00' AS TIMESTAMPTZ)"      # after
```

### Change
- Move DuckDB's `fromiso8601timestamp_sql` (cast to `TIMESTAMPTZ`) into the base `Generator`, so all dialects transpile it correctly (Snowflake, Spark, BigQuery, Redshift, …).
- Add an explicit `exp.FromISO8601Timestamp` transform to the Presto generator so Presto/Trino keep emitting the native function.

### Why a cast rather than `TO_TIMESTAMP` for Snowflake
Snowflake's own `TO_TIMESTAMP('literal')` already parses into a cast in sqlglot, so `CAST(... AS TIMESTAMPTZ)` is the canonical representation. It also preserves the timezone offset (plain `TO_TIMESTAMP` defaults to `TIMESTAMP_NTZ`), and matches the pre-existing DuckDB behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)