### PR TITLE
fix(starrocks): use native function syntax for MIN_BY/MAX_BY, MAP, ARRAY_CONTAINS_ALL, TRIM

### DIFF
--- a/sqlglot/generators/starrocks.py
+++ b/sqlglot/generators/starrocks.py
@@ -9,6 +9,7 @@ from sqlglot.dialects.dialect import (
     unit_to_str,
     inline_array_sql,
     property_sql,
+    var_map_sql,
 )
 from sqlglot.generators.mysql import MySQLGenerator
 
@@ -86,9 +87,18 @@ class StarRocksGenerator(MySQLGenerator):
     }
 
     TRANSFORMS = {
-        **{k: v for k, v in MySQLGenerator.TRANSFORMS.items() if k is not exp.DateTrunc},
+        # StarRocks uses the native TRIM(str, chars)/LTRIM/RTRIM function form, not
+        # MySQL's TRIM(chars FROM str) syntax, so it falls back to the base generator.
+        **{
+            k: v for k, v in MySQLGenerator.TRANSFORMS.items() if k not in (exp.DateTrunc, exp.Trim)
+        },
+        exp.ArgMax: rename_func("MAX_BY"),
+        exp.ArgMin: rename_func("MIN_BY"),
         exp.Array: inline_array_sql,
         exp.ArrayAgg: rename_func("ARRAY_AGG"),
+        # a <@ b (ArrayContainedBy) is equivalent to ARRAY_CONTAINS_ALL(b, a)
+        exp.ArrayContainedBy: lambda self, e: self.func("ARRAY_CONTAINS_ALL", e.expression, e.this),
+        exp.ArrayContainsAll: rename_func("ARRAY_CONTAINS_ALL"),
         exp.ArrayFilter: rename_func("ARRAY_FILTER"),
         exp.ArrayToString: rename_func("ARRAY_JOIN"),
         exp.ApproxDistinct: approx_count_distinct_sql,
@@ -98,6 +108,9 @@ class StarRocksGenerator(MySQLGenerator):
         exp.Flatten: rename_func("ARRAY_FLATTEN"),
         exp.JSONExtractScalar: arrow_json_extract_sql,
         exp.JSONExtract: arrow_json_extract_sql,
+        # Both MAP forms (two-array MAP([keys], [values]) and variadic MAP(k1, v1, ...))
+        # generate StarRocks' variadic MAP(k1, v1, k2, v2, ...) constructor
+        exp.Map: lambda self, e: var_map_sql(self, e, "MAP"),
         exp.Property: property_sql,
         exp.RegexpLike: rename_func("REGEXP"),
         # Inherited from MySQL, minus operations StarRocks supports natively
@@ -116,6 +129,7 @@ class StarRocksGenerator(MySQLGenerator):
         exp.TimeStrToDate: rename_func("TO_DATE"),
         exp.UnixToStr: lambda self, e: self.func("FROM_UNIXTIME", e.this, self.format_time(e)),
         exp.UnixToTime: rename_func("FROM_UNIXTIME"),
+        exp.VarMap: lambda self, e: var_map_sql(self, e, "MAP"),
     }
 
     # https://docs.starrocks.io/docs/sql-reference/sql-statements/keywords/#reserved-keywords

--- a/sqlglot/parsers/starrocks.py
+++ b/sqlglot/parsers/starrocks.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 
-from sqlglot import exp
+from sqlglot import exp, parser
 from sqlglot.dialects.dialect import build_date_delta_with_interval, build_timestamp_trunc
 from sqlglot.helper import seq_get
 from sqlglot.parsers.mysql import MySQLParser
@@ -28,6 +28,9 @@ class StarRocksParser(MySQLParser):
         ),
         "ARRAY_FLATTEN": exp.Flatten.from_arg_list,
         "REGEXP": exp.RegexpLike.from_arg_list,
+        # StarRocks' MAP() is a variadic constructor: MAP(k1, v1, k2, v2, ...)
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/map-functions/map/
+        "MAP": parser.build_var_map,
     }
 
     PROPERTY_PARSERS = {

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -30,6 +30,100 @@ class TestStarrocks(Validator):
         self.validate_identity("SELECT t1.id FROM t1 LEFT ANTI JOIN t2 ON t1.id = t2.id")
         self.validate_identity("SELECT t1.id FROM t1 LEFT SEMI JOIN t2 ON t1.id = t2.id")
 
+    def test_min_max_by(self):
+        # StarRocks has MIN_BY/MAX_BY, but no ARG_MIN/ARG_MAX
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/aggregate-functions/min_by/
+        self.validate_identity("SELECT MIN_BY(name, ts) FROM t")
+        self.validate_identity("SELECT MAX_BY(name, ts) FROM t")
+        self.validate_identity("SELECT MIN_BY(x, y) OVER (PARTITION BY z) FROM t")
+
+        self.validate_all(
+            "SELECT MAX_BY(a, b), MIN_BY(a, b) FROM t",
+            read={
+                "clickhouse": "SELECT argMax(a, b), argMin(a, b) FROM t",
+                "presto": "SELECT MAX_BY(a, b), MIN_BY(a, b) FROM t",
+                "spark": "SELECT MAX_BY(a, b), MIN_BY(a, b) FROM t",
+            },
+            write={"starrocks": "SELECT MAX_BY(a, b), MIN_BY(a, b) FROM t"},
+        )
+
+    def test_map(self):
+        # StarRocks' MAP() is a variadic constructor: MAP(k1, v1, k2, v2, ...)
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/map-functions/map/
+        self.validate_identity("SELECT MAP('a', 1, 'b', 2)")
+        self.validate_identity("SELECT MAP('a', 1, 'b', 2)['a']")
+
+        self.validate_all(
+            "SELECT MAP('a', 1, 'b', 2)",
+            read={
+                "hive": "SELECT MAP('a', 1, 'b', 2)",
+                "spark": "SELECT MAP('a', 1, 'b', 2)",
+            },
+            write={
+                "starrocks": "SELECT MAP('a', 1, 'b', 2)",
+                "duckdb": "SELECT MAP(['a', 'b'], [1, 2])",
+            },
+        )
+
+        # The two-array MAP([keys], [values]) form must also produce StarRocks' variadic MAP
+        self.validate_all(
+            "SELECT MAP('a', 1, 'b', 2)",
+            read={
+                "duckdb": "SELECT MAP(['a', 'b'], [1, 2])",
+                "presto": "SELECT MAP(ARRAY['a', 'b'], ARRAY[1, 2])",
+            },
+            write={"starrocks": "SELECT MAP('a', 1, 'b', 2)"},
+        )
+
+    def test_array_contains_all(self):
+        # StarRocks uses ARRAY_CONTAINS_ALL, not the Postgres `@>` operator
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/array-functions/array_contains_all/
+        self.validate_identity("SELECT ARRAY_CONTAINS_ALL([1, 2, 3], [1, 2])")
+
+        self.validate_all(
+            "SELECT ARRAY_CONTAINS_ALL([1, 2, 3], [1, 2])",
+            read={
+                "duckdb": "SELECT [1, 2, 3] @> [1, 2]",
+                "postgres": "SELECT ARRAY[1, 2, 3] @> ARRAY[1, 2]",
+            },
+            write={"starrocks": "SELECT ARRAY_CONTAINS_ALL([1, 2, 3], [1, 2])"},
+        )
+
+        # The inverse `a <@ b` (ArrayContainedBy) is ARRAY_CONTAINS_ALL(b, a)
+        self.validate_all(
+            "SELECT ARRAY_CONTAINS_ALL([1, 2, 3], [1, 2])",
+            read={
+                "duckdb": "SELECT [1, 2] <@ [1, 2, 3]",
+                "postgres": "SELECT ARRAY[1, 2] <@ ARRAY[1, 2, 3]",
+            },
+            write={"starrocks": "SELECT ARRAY_CONTAINS_ALL([1, 2, 3], [1, 2])"},
+        )
+
+    def test_trim(self):
+        # StarRocks uses the function form TRIM(str, chars)/LTRIM/RTRIM,
+        # not MySQL's TRIM(chars FROM str) syntax
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/string-functions/trim/
+        self.validate_identity("SELECT TRIM('  hi  ')")
+        self.validate_identity("SELECT TRIM('--hi--', '-')")
+        self.validate_identity("SELECT LTRIM('xxhi', 'x')")
+        self.validate_identity("SELECT RTRIM('hixx', 'x')")
+
+        self.validate_all(
+            "SELECT TRIM('--hi--', '-')",
+            read={"": "SELECT TRIM('-' FROM '--hi--')"},
+            write={"starrocks": "SELECT TRIM('--hi--', '-')"},
+        )
+        self.validate_all(
+            "SELECT LTRIM('xxhi', 'x')",
+            read={"": "SELECT TRIM(LEADING 'x' FROM 'xxhi')"},
+            write={"starrocks": "SELECT LTRIM('xxhi', 'x')"},
+        )
+        self.validate_all(
+            "SELECT RTRIM('hixx', 'x')",
+            read={"": "SELECT TRIM(TRAILING 'x' FROM 'hixx')"},
+            write={"starrocks": "SELECT RTRIM('hixx', 'x')"},
+        )
+
     def test_distinct_on(self):
         self.validate_identity(
             "SELECT DISTINCT ON (a) a, b FROM x ORDER BY c DESC",


### PR DESCRIPTION
StarRocks inherited several function generations from MySQL / the base dialect
  that produce SQL StarRocks rejects. Each fix below was verified against a real
  StarRocks 3.5.16 instance. 
  
  - **MIN_BY / MAX_BY** — StarRocks has `min_by`/`max_by` but no `arg_min`/`arg_max`,
    so emit `MAX_BY`/`MIN_BY` instead of `ARG_MAX`/`ARG_MIN` (incl. the window form).
  - **MAP** — StarRocks' `MAP()` is a variadic constructor `MAP(k1, v1, k2, v2, ...)`.
    Parse via `build_var_map` and generate both `exp.Map` (the two-array form read
    from duckdb/presto/snowflake) and `exp.VarMap` back to the variadic form, 
    mirroring `hive.py`/`snowflake.py`. Previously raised a `ParseError`.
  - **ARRAY_CONTAINS_ALL** — emit `ARRAY_CONTAINS_ALL(a, b)` instead of the Postgres
    `@>` operator; also map the inverse `a <@ b` to `ARRAY_CONTAINS_ALL(b, a)`.
  - **TRIM** — use the native function form `TRIM(str, chars)`/`LTRIM`/`RTRIM`
    instead of MySQL's `TRIM(chars FROM str)` syntax.
    
  Tests added in `tests/dialects/test_starrocks.py` cover round-trips and
  cross-dialect read/write; all asserted StarRocks outputs were executed against
  a live StarRocks 3.5.16 instance.