### PR TITLE
fix(optimizer): stacked decorators bug

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -84,7 +84,9 @@ def catch(*exceptions):
             try:
                 return func(expression, *args, **kwargs)
             except exceptions:
-                return expression
+                # When stacked under @annotate_types_on_change, that decorator calls func(self, expression)
+                # directly, so `expression` here is the Simplifier instance and the SQL node is args[0].
+                return args[0] if args else expression
 
         return wrapped
 

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -80,13 +80,11 @@ def catch(*exceptions):
     """Decorator that ignores a simplification function if any of `exceptions` are raised"""
 
     def decorator(func):
-        def wrapped(expression, *args, **kwargs):
+        def wrapped(self, expression, *args, **kwargs):
             try:
-                return func(expression, *args, **kwargs)
+                return func(self, expression, *args, **kwargs)
             except exceptions:
-                # When stacked under @annotate_types_on_change, that decorator calls func(self, expression)
-                # directly, so `expression` here is the Simplifier instance and the SQL node is args[0].
-                return args[0] if args else expression
+                return expression
 
         return wrapped
 


### PR DESCRIPTION
Fixes a crash in `pushdown_predicates` triggered by `TIMESTAMP_TRUNC` equality comparisons with sub-day units like `HOUR`.

Cause

`simplify_datetrunc` and `simplify_equality` are wrapped by two stacked decorators: `@annotate_types_on_change` (outer) and `@catch` (inner). The outer decorator calls the inner one directly, bypassing Python's normal method binding. This causes the `@catch` decorator to receive the Simplifier instance where it expects the SQL expression node. When `date_floor` raises `UnsupportedUnit` for unsupported units like `HOUR`, `@catch` returns the Simplifier object instead of the original expression. The downstream `_annotate_expression` then calls `.type` on it, producing `AttributeError: 'Simplifier' object has no attribute 'type'`.

Fix

One-line change in the `catch` in `simplify.py`