### PR TITLE
feat(snowflake): support properties before column definitions in `CREATE` statements

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4,7 +4,9 @@ import itertools
 import logging
 import re
 import typing as t
+from builtins import type as Type
 from collections import defaultdict
+from collections.abc import Sequence
 
 from sqlglot import exp
 from sqlglot.errors import (
@@ -17,19 +19,16 @@ from sqlglot.errors import (
 )
 from sqlglot.expressions import apply_index_offset
 from sqlglot.helper import ensure_list, i64, seq_get
-from sqlglot.trie import new_trie
 from sqlglot.time import format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
-from sqlglot.trie import TrieResult, in_trie
-from collections.abc import Sequence
-from builtins import type as Type
+from sqlglot.trie import TrieResult, in_trie, new_trie
 
 if t.TYPE_CHECKING:
-    from sqlglot.expressions import ExpOrStr
-    from sqlglot._typing import E, BuilderArgs
-    from sqlglot.dialects.dialect import Dialect, DialectType
-
     from re import Pattern
+
+    from sqlglot._typing import BuilderArgs, E
+    from sqlglot.dialects.dialect import Dialect, DialectType
+    from sqlglot.expressions import ExpOrStr
 
     T = t.TypeVar("T")
     TCeilFloor = t.TypeVar("TCeilFloor", exp.Ceil, exp.Floor)
@@ -2812,6 +2811,12 @@ class Parser:
             return seq_props
 
         self._retreat(index)
+        return self._parse_key_value_property()
+
+    def _parse_key_value_property(
+        self, parse_value: t.Callable[[], exp.Expr | None] | None = None
+    ) -> exp.Property | None:
+        index = self._index
         key = self._parse_column()
 
         if not self._match(TokenType.EQ):
@@ -2822,7 +2827,11 @@ class Parser:
         if isinstance(key, exp.Column):
             key = key.to_dot() if len(key.parts) > 1 else exp.var(key.name)
 
-        value = self._parse_bitwise() or self._parse_var(any_token=True)
+        value = (
+            parse_value()
+            if parse_value
+            else self._parse_bitwise() or self._parse_var(any_token=True)
+        )
 
         # Transform the value to exp.Var if it was parsed as exp.Column(exp.Identifier())
         if isinstance(value, exp.Column):

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -3,24 +3,25 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp, parser
-from sqlglot.trie import new_trie
 from sqlglot.dialects.dialect import (
     Dialect,
+    binary_from_function,
     build_default_decimal_type,
     build_formatted_time,
     build_like,
     build_replace_with_optional_replacement,
     build_timetostr_or_tochar,
     build_trunc,
-    binary_from_function,
     date_trunc_to_time,
     map_date_part,
 )
 from sqlglot.helper import is_date_unit, is_int, seq_get
 from sqlglot.tokens import TokenType
+from sqlglot.trie import new_trie
 
 if t.TYPE_CHECKING:
     from collections.abc import Collection
+
     from sqlglot._typing import B, E
     from sqlglot.dialects.dialect import Dialect
 
@@ -975,6 +976,21 @@ class SnowflakeParser(parser.Parser):
 
     def _parse_tag(self) -> exp.Tags:
         return self.expression(exp.Tags(expressions=self._parse_wrapped_csv(self._parse_property)))
+
+    def _parse_property_before(self) -> exp.Expr | list[exp.Expr] | None:
+        prop = super()._parse_property_before()
+        if prop:
+            return prop
+
+        if self._next and self._next.token_type == TokenType.EQ:
+            # Snowflake allows `KEY = VALUE` properties to precede the column list, e.g.
+            # `CREATE TABLE t CHANGE_TRACKING=TRUE (id INT)`, so we parse them here. The
+            # value is parsed greedily, so an unquoted value would swallow the following
+            # column list (`VALUE (...)` read as a function call). No real property uses
+            # such a value, but we wrap it in `_try_parse` to back off instead of raising.
+            return self._try_parse(self._parse_property)
+
+        return None
 
     def _parse_with_constraint(self) -> exp.Expr | None:
         if self._prev.token_type != TokenType.WITH:

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -978,30 +978,16 @@ class SnowflakeParser(parser.Parser):
         return self.expression(exp.Tags(expressions=self._parse_wrapped_csv(self._parse_property)))
 
     def _parse_property_before(self) -> exp.Expr | list[exp.Expr] | None:
-        index = self._index
         prop = super()._parse_property_before()
         if prop:
             return prop
 
-        if self._index != index or not self._next or self._next.token_type != TokenType.EQ:
+        if not self._next or self._next.token_type != TokenType.EQ:
             return None
 
-        seq_props = self._parse_sequence_properties()
-        if seq_props:
-            return seq_props
-
-        key = self._parse_column()
-        self._match(TokenType.EQ)
-        value = self._parse_primary_or_var()
-
-        if key and value:
-            if isinstance(key, exp.Column):
-                key = key.to_dot() if len(key.parts) > 1 else exp.var(key.name)
-
-            return self.expression(exp.Property(this=key, value=value))
-
-        self._retreat(index)
-        return None
+        return self._parse_sequence_properties() or self._parse_key_value_property(
+            self._parse_primary_or_var
+        )
 
     def _parse_with_constraint(self) -> exp.Expr | None:
         if self._prev.token_type != TokenType.WITH:

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -978,18 +978,29 @@ class SnowflakeParser(parser.Parser):
         return self.expression(exp.Tags(expressions=self._parse_wrapped_csv(self._parse_property)))
 
     def _parse_property_before(self) -> exp.Expr | list[exp.Expr] | None:
+        index = self._index
         prop = super()._parse_property_before()
         if prop:
             return prop
 
-        if self._next and self._next.token_type == TokenType.EQ:
-            # Snowflake allows `KEY = VALUE` properties to precede the column list, e.g.
-            # `CREATE TABLE t CHANGE_TRACKING=TRUE (id INT)`, so we parse them here. The
-            # value is parsed greedily, so an unquoted value would swallow the following
-            # column list (`VALUE (...)` read as a function call). No real property uses
-            # such a value, but we wrap it in `_try_parse` to back off instead of raising.
-            return self._try_parse(self._parse_property)
+        if self._index != index or not self._next or self._next.token_type != TokenType.EQ:
+            return None
 
+        seq_props = self._parse_sequence_properties()
+        if seq_props:
+            return seq_props
+
+        key = self._parse_column()
+        self._match(TokenType.EQ)
+        value = self._parse_primary_or_var()
+
+        if key and value:
+            if isinstance(key, exp.Column):
+                key = key.to_dot() if len(key.parts) > 1 else exp.var(key.name)
+
+            return self.expression(exp.Property(this=key, value=value))
+
+        self._retreat(index)
         return None
 
     def _parse_with_constraint(self) -> exp.Expr | None:

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4305,6 +4305,10 @@ class TestSnowflake(Validator):
             "CREATE DYNAMIC TABLE product (pre_tax_profit, taxes, after_tax_profit) TARGET_LAG='20 minutes' WAREHOUSE=mywh AS SELECT revenue - cost, (revenue - cost) * tax_rate, (revenue - cost) * (1.0 - tax_rate) FROM staging_table"
         )
         self.validate_identity(
+            "CREATE DYNAMIC TABLE dt TARGET_LAG='1 minute' WAREHOUSE=my_wh (id) AS SELECT * FROM bla",
+            "CREATE DYNAMIC TABLE dt (id) TARGET_LAG='1 minute' WAREHOUSE=my_wh AS SELECT * FROM bla",
+        )
+        self.validate_identity(
             "ALTER TABLE db_name.schmaName.tblName ADD COLUMN_1 VARCHAR NOT NULL TAG (key1='value_1')"
         )
         self.validate_identity(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4266,8 +4266,8 @@ class TestSnowflake(Validator):
         self.validate_identity("CREATE TABLE geospatial_table (id INT, g GEOGRAPHY)")
         self.validate_identity("CREATE TABLE t (id INT) CHANGE_TRACKING=TRUE")
         self.validate_identity(
-            "CREATE TABLE t CHANGE_TRACKING=TRUE (id INT)",
-            "CREATE TABLE t (id INT) CHANGE_TRACKING=TRUE",
+            "CREATE TABLE t CHANGE_TRACKING=TRUE DATA_RETENTION_TIME_IN_DAYS=1 (id INT)",
+            "CREATE TABLE t (id INT) CHANGE_TRACKING=TRUE DATA_RETENTION_TIME_IN_DAYS=1",
         )
         self.validate_identity("CREATE MATERIALIZED VIEW a COMMENT='...' AS SELECT 1 FROM x")
         self.validate_identity("CREATE DATABASE mytestdb_clone CLONE mytestdb")

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4264,6 +4264,11 @@ class TestSnowflake(Validator):
         self.validate_identity("CREATE SECURE VIEW table1 AS (SELECT a FROM table2)")
         self.validate_identity("CREATE OR REPLACE VIEW foo (uid) COPY GRANTS AS (SELECT 1)")
         self.validate_identity("CREATE TABLE geospatial_table (id INT, g GEOGRAPHY)")
+        self.validate_identity("CREATE TABLE t (id INT) CHANGE_TRACKING=TRUE")
+        self.validate_identity(
+            "CREATE TABLE t CHANGE_TRACKING=TRUE (id INT)",
+            "CREATE TABLE t (id INT) CHANGE_TRACKING=TRUE",
+        )
         self.validate_identity("CREATE MATERIALIZED VIEW a COMMENT='...' AS SELECT 1 FROM x")
         self.validate_identity("CREATE DATABASE mytestdb_clone CLONE mytestdb")
         self.validate_identity("CREATE SCHEMA mytestschema_clone CLONE testschema")
@@ -5956,6 +5961,13 @@ SINGLE = TRUE""",
         self.validate_identity("CREATE OR REPLACE VIEW FOO (A, B) AS SELECT A, B FROM TBL")
         self.validate_identity(
             "CREATE OR REPLACE MATERIALIZED VIEW FOO (A, B) AS SELECT A, B FROM TBL"
+        )
+
+    def test_create_view_change_tracking(self):
+        self.validate_identity("CREATE VIEW v (c) CHANGE_TRACKING=TRUE AS SELECT 1 AS c")
+        self.validate_identity(
+            "CREATE VIEW my_view CHANGE_TRACKING=TRUE (id) AS SELECT * FROM my_table",
+            "CREATE VIEW my_view (id) CHANGE_TRACKING=TRUE AS SELECT * FROM my_table",
         )
 
     def test_create_view_row_access_policy(self):


### PR DESCRIPTION
## Summary

Snowflake, in `CREATE` statements, accepts `KEY = VALUE` properties both after and before the column definitions, example:

```
CREATE TABLE t CHANGE_TRACKING=TRUE (id INT);
CREATE TABLE t (id INT) CHANGE_TRACKING=TRUE;
```

Both versions of the above example are valid, but currently passing parameters before column definitions fail to parse. This PR aims to fix this by overriding `_parse_property_before` to parse such properties.

As usual, happy to receive feedback and guidance to follow up.