### PR TITLE
feat(optimizer)!: annotate DIV for Spark/DBX

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -37,8 +37,9 @@ EXPRESSION_METADATA = {
     **{
         expr_type: {"returns": exp.DType.BIGINT}
         for expr_type in {
-            exp.StrToUnix,
             exp.Factorial,
+            exp.IntDiv,
+            exp.StrToUnix,
         }
     },
     **{

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -10,7 +10,6 @@ EXPRESSION_METADATA = {
         exp_type: {"returns": exp.DType.BIGINT}
         for exp_type in {
             exp.BitmapCount,
-            exp.IntDiv,
         }
     },
     **{

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -7,6 +7,13 @@ from sqlglot.typing.spark2 import EXPRESSION_METADATA
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
+        exp_type: {"returns": exp.DType.BIGINT}
+        for exp_type in {
+            exp.BitmapCount,
+            exp.IntDiv,
+        }
+    },
+    **{
         exp_type: {"returns": exp.DType.DOUBLE}
         for exp_type in {
             exp.Sec,
@@ -37,7 +44,6 @@ EXPRESSION_METADATA = {
             exp.Overlay,
         }
     },
-    exp.BitmapCount: {"returns": exp.DType.BIGINT},
     exp.Localtimestamp: {"returns": exp.DType.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DType.BINARY},
     exp.DateFromUnixDate: {"returns": exp.DType.DATE},

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -7,12 +7,6 @@ from sqlglot.typing.spark2 import EXPRESSION_METADATA
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
-        exp_type: {"returns": exp.DType.BIGINT}
-        for exp_type in {
-            exp.BitmapCount,
-        }
-    },
-    **{
         exp_type: {"returns": exp.DType.DOUBLE}
         for exp_type in {
             exp.Sec,
@@ -43,6 +37,7 @@ EXPRESSION_METADATA = {
             exp.Overlay,
         }
     },
+    exp.BitmapCount: {"returns": exp.DType.BIGINT},
     exp.Localtimestamp: {"returns": exp.DType.TIMESTAMPNTZ},
     exp.ToBinary: {"returns": exp.DType.BINARY},
     exp.DateFromUnixDate: {"returns": exp.DType.DATE},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -964,12 +964,16 @@ VARCHAR;
 TYPEOF(foo);
 VARCHAR;
 
-# dialect: spark, databricks
+# dialect: spark2, spark, databricks
 tbl.int_col DIV tbl.int_col;
 BIGINT;
 
-# dialect: spark, databricks
+# dialect: spark2, spark, databricks
 tbl.double_col DIV tbl.double_col;
+BIGINT; 
+
+# dialect: hive
+tbl.bigint DIV tbl.bigint;
 BIGINT; 
 
 --------------------------------------

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -964,6 +964,14 @@ VARCHAR;
 TYPEOF(foo);
 VARCHAR;
 
+# dialect: spark, databricks
+tbl.int_col DIV tbl.int_col;
+BIGINT;
+
+# dialect: spark, databricks
+tbl.double_col DIV tbl.double_col;
+BIGINT; 
+
 --------------------------------------
 -- BigQuery
 --------------------------------------


### PR DESCRIPTION
### This PR annotate DIV for Spark/DBX

```sql
SELECT typeof(3 div 2)
```

```
+-----------------+
|typeof((3 div 2))|
+-----------------+
|           bigint|
+-----------------+
```

https://spark.apache.org/docs/latest/api/sql/index.html#div
https://docs.databricks.com/aws/en/sql/language-manual/functions/div#returns