### PR TITLE
fix(annotate_types): coerce bigquery date function arg types [CLAUDE]

### DIFF
--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -31,6 +31,8 @@ def _annotate_date_func(self: TypeAnnotator, expression: exp.Expr) -> exp.Expr:
     DATE_ADD('2020-01-01', INTERVAL 1 DAY) -> DATE).
     """
     this = expression.this
+
+    # BigQuery rejects expressions like DATE_ADD(c, ...); it requires the first argument to be a literal
     if isinstance(this, exp.Literal) and this.is_string:
         return self._set_type(expression, _DATE_FUNC_LITERAL_TYPE[type(expression)])
 

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -9,6 +9,34 @@ if t.TYPE_CHECKING:
     from sqlglot.optimizer.annotate_types import TypeAnnotator
 
 
+# DATE_ADD / DATE_SUB / *_TRUNC return the type of their first argument. BigQuery
+# implicitly casts a string literal first arg to the function's own temporal type,
+# so map each to that type (e.g. DATE_ADD('2020-01-01', ...) -> DATE,
+# TIMESTAMP_TRUNC('...') -> TIMESTAMP).
+_DATE_FUNC_LITERAL_TYPE: t.Dict[t.Type[exp.Expr], exp.DType] = {
+    exp.DateAdd: exp.DType.DATE,
+    exp.DateSub: exp.DType.DATE,
+    exp.DateTrunc: exp.DType.DATE,
+    exp.DatetimeTrunc: exp.DType.DATETIME,
+    exp.TimestampTrunc: exp.DType.TIMESTAMPTZ,
+}
+
+
+def _annotate_date_func(self: TypeAnnotator, expression: exp.Expr) -> exp.Expr:
+    """Annotate DATE_ADD / DATE_SUB / *_TRUNC, which return their first arg's type.
+
+    A typed first argument keeps its exact type (e.g. DATE_ADD(DATETIME, ...) ->
+    DATETIME). For a string literal first argument, BigQuery implicitly casts it to
+    the function's own temporal type, so the result is that type (e.g.
+    DATE_ADD('2020-01-01', INTERVAL 1 DAY) -> DATE).
+    """
+    this = expression.this
+    if isinstance(this, exp.Literal) and this.is_string:
+        return self._set_type(expression, _DATE_FUNC_LITERAL_TYPE[type(expression)])
+
+    return self._annotate_by_args(expression, "this")
+
+
 def _annotate_math_functions(self: TypeAnnotator, expression: exp.Expr) -> exp.Expr:
     """
     Many BigQuery math functions such as CEIL, FLOOR etc follow this return type convention:
@@ -175,9 +203,6 @@ EXPRESSION_METADATA = {
         for expr_type in {
             exp.ArgMax,
             exp.ArgMin,
-            exp.DateAdd,
-            exp.DateTrunc,
-            exp.DatetimeTrunc,
             exp.GroupConcat,
             exp.IgnoreNulls,
             exp.JSONExtract,
@@ -197,10 +222,19 @@ EXPRESSION_METADATA = {
             exp.SafeNegate,
             exp.Sign,
             exp.Substring,
-            exp.TimestampTrunc,
             exp.Translate,
             exp.Trim,
             exp.Upper,
+        }
+    },
+    **{
+        expr_type: {"annotator": lambda self, e: _annotate_date_func(self, e)}
+        for expr_type in {
+            exp.DateAdd,
+            exp.DateSub,
+            exp.DateTrunc,
+            exp.DatetimeTrunc,
+            exp.TimestampTrunc,
         }
     },
     **{

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -231,13 +231,7 @@ EXPRESSION_METADATA = {
     },
     **{
         expr_type: {"annotator": lambda self, e: _annotate_date_func(self, e)}
-        for expr_type in {
-            exp.DateAdd,
-            exp.DateSub,
-            exp.DateTrunc,
-            exp.DatetimeTrunc,
-            exp.TimestampTrunc,
-        }
+        for expr_type in _DATE_FUNC_LITERAL_TYPE
     },
     **{
         expr_type: {"returns": exp.DType.BIGINT}

--- a/sqlglot/typing/bigquery.py
+++ b/sqlglot/typing/bigquery.py
@@ -13,7 +13,7 @@ if t.TYPE_CHECKING:
 # implicitly casts a string literal first arg to the function's own temporal type,
 # so map each to that type (e.g. DATE_ADD('2020-01-01', ...) -> DATE,
 # TIMESTAMP_TRUNC('...') -> TIMESTAMP).
-_DATE_FUNC_LITERAL_TYPE: t.Dict[t.Type[exp.Expr], exp.DType] = {
+_DATE_FUNC_LITERAL_TYPE: dict[type[exp.Expr], exp.DType] = {
     exp.DateAdd: exp.DType.DATE,
     exp.DateSub: exp.DType.DATE,
     exp.DateTrunc: exp.DType.DATE,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -2449,6 +2449,74 @@ DATE_ADD(DATETIME '2008-12-25 15:30:00', INTERVAL 30 MINUTE);
 DATETIME;
 
 # dialect: bigquery
+DATE_ADD('2008-12-25', INTERVAL 5 DAY);
+DATE;
+
+# dialect: bigquery
+DATE_TRUNC('2008-12-25', MONTH);
+DATE;
+
+# dialect: bigquery
+DATETIME_TRUNC('2008-12-25', DAY);
+DATETIME;
+
+# dialect: bigquery
+DATETIME_TRUNC('2008-12-25 15:30:00', DAY);
+DATETIME;
+
+# dialect: bigquery
+TIMESTAMP_TRUNC('2008-12-25 15:30:00', DAY);
+TIMESTAMP;
+
+# dialect: bigquery
+TIMESTAMP_TRUNC('2008-12-25', DAY);
+TIMESTAMP;
+
+# dialect: bigquery
+DATE_SUB('2008-12-25', INTERVAL 1 MONTH);
+DATE;
+
+# dialect: bigquery
+DATE_SUB(DATE '2008-12-25', INTERVAL 1 MONTH);
+DATE;
+
+# dialect: bigquery
+DATE_SUB(DATETIME '2008-12-25 15:30:00', INTERVAL 1 DAY);
+DATETIME;
+
+# dialect: bigquery
+DATE_SUB(TIMESTAMP '2008-12-25 15:30:00', INTERVAL 1 HOUR);
+TIMESTAMP;
+
+# dialect: bigquery
+DATETIME_ADD('2008-12-25 15:30:00', INTERVAL 1 DAY);
+DATETIME;
+
+# dialect: bigquery
+DATETIME_SUB('2008-12-25 15:30:00', INTERVAL 1 DAY);
+DATETIME;
+
+# dialect: bigquery
+TIMESTAMP_ADD('2008-12-25 15:30:00', INTERVAL 1 HOUR);
+TIMESTAMP;
+
+# dialect: bigquery
+TIMESTAMP_SUB('2008-12-25 15:30:00', INTERVAL 1 HOUR);
+TIMESTAMP;
+
+# dialect: bigquery
+TIME_ADD('08:50:48', INTERVAL 1 HOUR);
+TIME;
+
+# dialect: bigquery
+TIME_SUB('08:50:48', INTERVAL 1 HOUR);
+TIME;
+
+# dialect: bigquery
+TIME_TRUNC('08:50:48', HOUR);
+TIME;
+
+# dialect: bigquery
 UNIX_DATE(tbl.date_col);
 BIGINT;
 


### PR DESCRIPTION
In BigQuery these functions return the type of their first argument. They were annotated via `_annotate_by_args("this")` (`DATE_ADD`, `DATE_TRUNC`, `DATETIME_TRUNC`, `TIMESTAMP_TRUNC`), which copies the first arg's type verbatim. For a date/datetime string-literal first arg that type is the literal's `VARCHAR`, so e.g. `DATE_ADD('2020-01-01', INTERVAL 1 DAY)` was annotated as `VARCHAR` instead of `DATE`.

`DATE_SUB` was separately annotated via the base `_annotate_timeunit`, which handled the string-literal case but mis-annotated a `TIMESTAMP` first arg as `DATETIME` (e.g. `DATE_SUB(TIMESTAMP '...', INTERVAL 1 HOUR)` -> `DATETIME` instead of `TIMESTAMP`).

Route all five through a new bigquery `_annotate_date_func`: a typed first arg keeps its exact type (via `_annotate_by_args`), and a string-literal first arg is coerced to the function's own temporal type (`DATE_ADD`/`DATE_SUB`/`DATE_TRUNC` -> `DATE`, `DATETIME_TRUNC` -> `DATETIME`, `TIMESTAMP_TRUNC` -> `TIMESTAMP`), matching BigQuery's implicit coercion. Verified against BigQuery for the whole date/time arithmetic family; the change is bigquery-only and does not affect other dialects.