### PR TITLE
fix(clickhouse): support arrayMap and arrayFilter roundtrips [CODEX]

### DIFF
--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -280,6 +280,7 @@ class ClickHouseGenerator(generator.Generator):
         exp.ArrayConcat: rename_func("arrayConcat"),
         exp.ArrayContains: rename_func("has"),
         exp.ArrayFilter: lambda self, e: self.func("arrayFilter", e.expression, e.this),
+        exp.Transform: lambda self, e: self.func("arrayMap", e.expression, e.this),
         exp.ArrayRemove: remove_from_array_using_filter,
         exp.ArrayReverse: rename_func("arrayReverse"),
         exp.ArraySlice: rename_func("arraySlice"),

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -262,8 +262,6 @@ class ClickHouseParser(parser.Parser):
         "ARRAYMIN": exp.ArrayMin.from_arg_list,
         "ARRAYREVERSE": exp.ArrayReverse.from_arg_list,
         "ARRAYSLICE": exp.ArraySlice.from_arg_list,
-        # ClickHouse higher-order array functions: the lambda comes first, the array second.
-        # This is the opposite of exp.ArrayFilter(this=array, expression=lambda) convention.
         "ARRAYFILTER": lambda args: exp.ArrayFilter(
             this=seq_get(args, 1), expression=seq_get(args, 0)
         ),

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -267,9 +267,7 @@ class ClickHouseParser(parser.Parser):
         "ARRAYFILTER": lambda args: exp.ArrayFilter(
             this=seq_get(args, 1), expression=seq_get(args, 0)
         ),
-        "ARRAYMAP": lambda args: exp.Transform(
-            this=seq_get(args, 1), expression=seq_get(args, 0)
-        ),
+        "ARRAYMAP": lambda args: exp.Transform(this=seq_get(args, 1), expression=seq_get(args, 0)),
         "CURRENTDATABASE": exp.CurrentDatabase.from_arg_list,
         "CURRENTSCHEMAS": exp.CurrentSchemas.from_arg_list,
         "COUNTIF": _build_count_if,

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -262,6 +262,14 @@ class ClickHouseParser(parser.Parser):
         "ARRAYMIN": exp.ArrayMin.from_arg_list,
         "ARRAYREVERSE": exp.ArrayReverse.from_arg_list,
         "ARRAYSLICE": exp.ArraySlice.from_arg_list,
+        # ClickHouse higher-order array functions: the lambda comes first, the array second.
+        # This is the opposite of exp.ArrayFilter(this=array, expression=lambda) convention.
+        "ARRAYFILTER": lambda args: exp.ArrayFilter(
+            this=seq_get(args, 1), expression=seq_get(args, 0)
+        ),
+        "ARRAYMAP": lambda args: exp.Transform(
+            this=seq_get(args, 1), expression=seq_get(args, 0)
+        ),
         "CURRENTDATABASE": exp.CurrentDatabase.from_arg_list,
         "CURRENTSCHEMAS": exp.CurrentSchemas.from_arg_list,
         "COUNTIF": _build_count_if,

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1768,6 +1768,28 @@ LIFETIME(MIN 0 MAX 0)""",
         self.validate_identity(
             "SELECT TRANSFORM(foo, [1, 2], ['first', 'second'], 'default') FROM table"
         )
+        self.validate_all(
+            "SELECT arrayMap(x -> x + 1, arr) FROM t",
+            read={
+                "duckdb": "SELECT LIST_TRANSFORM(arr, x -> x + 1) FROM t",
+                "spark": "SELECT TRANSFORM(arr, x -> x + 1) FROM t",
+            },
+            write={
+                "clickhouse": "SELECT arrayMap(x -> x + 1, arr) FROM t",
+                "duckdb": "SELECT LIST_TRANSFORM(arr, x -> x + 1) FROM t",
+                "spark": "SELECT TRANSFORM(arr, x -> x + 1) FROM t",
+            },
+        )
+        self.validate_all(
+            "SELECT arrayFilter(x -> x > 0, arr) FROM t",
+            read={
+                "duckdb": "SELECT LIST_FILTER(arr, x -> x > 0) FROM t",
+            },
+            write={
+                "clickhouse": "SELECT arrayFilter(x -> x > 0, arr) FROM t",
+                "duckdb": "SELECT LIST_FILTER(arr, x -> x > 0) FROM t",
+            },
+        )
 
     def test_array_offset(self):
         with self.assertLogs(helper_logger) as cm:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1768,28 +1768,8 @@ LIFETIME(MIN 0 MAX 0)""",
         self.validate_identity(
             "SELECT TRANSFORM(foo, [1, 2], ['first', 'second'], 'default') FROM table"
         )
-        self.validate_all(
-            "SELECT arrayMap(x -> x + 1, arr) FROM t",
-            read={
-                "duckdb": "SELECT LIST_TRANSFORM(arr, x -> x + 1) FROM t",
-                "spark": "SELECT TRANSFORM(arr, x -> x + 1) FROM t",
-            },
-            write={
-                "clickhouse": "SELECT arrayMap(x -> x + 1, arr) FROM t",
-                "duckdb": "SELECT LIST_TRANSFORM(arr, x -> x + 1) FROM t",
-                "spark": "SELECT TRANSFORM(arr, x -> x + 1) FROM t",
-            },
-        )
-        self.validate_all(
-            "SELECT arrayFilter(x -> x > 0, arr) FROM t",
-            read={
-                "duckdb": "SELECT LIST_FILTER(arr, x -> x > 0) FROM t",
-            },
-            write={
-                "clickhouse": "SELECT arrayFilter(x -> x > 0, arr) FROM t",
-                "duckdb": "SELECT LIST_FILTER(arr, x -> x > 0) FROM t",
-            },
-        )
+        self.validate_identity("arrayMap(x -> x + 1, arr)").assert_is(exp.Transform)
+        self.validate_identity("arrayFilter(x -> x > 0, arr)").assert_is(exp.ArrayFilter)
 
     def test_array_offset(self):
         with self.assertLogs(helper_logger) as cm:


### PR DESCRIPTION
## Problem

ClickHouse higher-order array functions `arrayMap(lambda, arr)` and `arrayFilter(lambda, arr)` were parsed as generic/unsupported function expressions instead of SQLGlot's semantic array function nodes.

This made ClickHouse -> ClickHouse roundtrips lossy for these functions, and it also meant `arrayMap` did not use the existing `exp.Transform` representation.

## Fix

- Add ClickHouse parser mappings for `ARRAYMAP` and `ARRAYFILTER`.
- Preserve ClickHouse's argument order by mapping `arrayMap(lambda, array)` to `exp.Transform(this=array, expression=lambda)` and `arrayFilter(lambda, array)` to `exp.ArrayFilter(this=array, expression=lambda)`.
- Add a ClickHouse generator transform for `exp.Transform` so `arrayMap` roundtrips back to ClickHouse syntax.

## Tests

Added focused ClickHouse identity tests:

- `arrayMap(x -> x + 1, arr)` roundtrips and parses as `exp.Transform`.
- `arrayFilter(x -> x > 0, arr)` roundtrips and parses as `exp.ArrayFilter`.

Local verification:

```text
python -m unittest tests.dialects.test_clickhouse.TestClickhouse.test_functions
python -m ruff check sqlglot/parsers/clickhouse.py sqlglot/generators/clickhouse.py tests/dialects/test_clickhouse.py
python -m ruff format --check sqlglot/parsers/clickhouse.py sqlglot/generators/clickhouse.py tests/dialects/test_clickhouse.py
```

---

This pull request was prepared with the assistance of AI, under my direction and review.
