### PR TITLE
fix(optimizer): Quotation issue in canonicalize_internal_names

### DIFF
--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -255,10 +255,11 @@ def canonicalize_internal_names(expression: E) -> E:
 
         scope_outputs[id(scope_expr)] = output_map
 
-        # Unqualified alias references (ORDER BY a, HAVING a > 5, ...)
+        # Unqualified alias references (ORDER BY a, HAVING a > 5, ...).
         for col in find_all_in_scope(scope_expr, exp.Column):
-            if not col.table and col.name in output_map:
-                _canon(col.this, output_map[col.name])
+            # Only rewrite when the alias is actually being renamed
+            if not col.table and (canon := output_map.get(col.name)) and canon != col.name:
+                _canon(col.this, canon)
 
         # UBN matches branches by original alias. When both branches are internal
         # and aliased to distinct _cN, matching originals land on different slots


### PR DESCRIPTION
`canonicalize_internal_names` was quoting unqualified base column references when its name happened to match the top level output alias.  This produced inconsistent identifier quoting in the canonical output. This violates the rule that base-table column references are part of the data contract and must be preserved verbatim.

The fix narrows the rewrite so it only fires when the alias is actually being renamed.

Query:
```
SELECT a AS a, b AS c, d AS renamed FROM cat.db.t WHERE a > b AND b > 0 AND d < 0
```

| Stage  | Result |
| ------ | ------ |
| Before | SELECT "a" AS a, b AS c, d AS renamed FROM cat.db.t AS "_t0" WHERE "a" > b AND b > 0 AND d < 0 |
| After  | SELECT a AS a, b AS c, d AS renamed FROM cat.db.t AS "_t0" WHERE a > b AND b > 0 AND d < 0 |