### PR TITLE
feat(optimizer)!: databricks type annotation for REGEXP_COUNT, REGEXP_EXTRACT_ALL

### DIFF
--- a/sqlglot/dialects/databricks.py
+++ b/sqlglot/dialects/databricks.py
@@ -9,11 +9,13 @@ from sqlglot.generators.databricks import DatabricksGenerator
 from sqlglot.parsers.databricks import DatabricksParser
 from sqlglot.tokens import TokenType
 from sqlglot.optimizer.annotate_types import TypeAnnotator
+from sqlglot.typing.databricks import EXPRESSION_METADATA
 
 
 class Databricks(Spark):
     SAFE_DIVISION = False
     COPY_PARAMS_ARE_CSV = False
+    EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
 
     COERCES_TO = defaultdict(set, deepcopy(TypeAnnotator.COERCES_TO))
     for text_type in exp.DataType.TEXT_TYPES:

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -11,5 +11,9 @@ EXPRESSION_METADATA = {
             exp.RegexpCount,
         }
     },
-    exp.RegexpExtractAll: {"returns": exp.DataType.build("ARRAY<STRING>", dialect="databricks")},
+    exp.RegexpExtractAll: {
+        "annotator": lambda self, e: self._set_type(
+            e, exp.DataType.from_str("ARRAY<STRING>", dialect="databricks")
+        )
+    },
 }

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.typing.spark import EXPRESSION_METADATA
+
+EXPRESSION_METADATA = {
+    **EXPRESSION_METADATA,
+    **{
+        exp_type: {"returns": exp.DType.INT}
+        for exp_type in {
+            exp.RegexpCount,
+        }
+    },
+    **{
+        exp_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this", array=True)}
+        for exp_type in {
+            exp.RegexpExtractAll,
+        }
+    },
+}

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -11,5 +11,5 @@ EXPRESSION_METADATA = {
             exp.RegexpCount,
         }
     },
-    exp.RegexpExtractAll: {"returns": exp.DataType.build("ARRAY<TEXT>")},
+    exp.RegexpExtractAll: {"returns": exp.DataType.build("ARRAY<STRING>", dialect="databricks")},
 }

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -11,10 +11,5 @@ EXPRESSION_METADATA = {
             exp.RegexpCount,
         }
     },
-    **{
-        exp_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this", array=True)}
-        for exp_type in {
-            exp.RegexpExtractAll,
-        }
-    },
+    exp.RegexpExtractAll: {"returns": exp.DataType.build("ARRAY<TEXT>")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -970,7 +970,27 @@ BIGINT;
 
 # dialect: spark2, spark, databricks
 tbl.double_col DIV tbl.double_col;
-BIGINT; 
+BIGINT;
+
+# dialect: databricks
+tbl.str_col REGEXP 'pattern';
+BOOLEAN;
+
+# dialect: databricks
+tbl.str_col REGEXP tbl.str_col;
+BOOLEAN;
+
+# dialect: databricks
+REGEXP_COUNT(tbl.str_col, 'l');
+INT;
+
+# dialect: databricks
+REGEXP_COUNT(tbl.str_col, tbl.str_col);
+INT;
+
+# dialect: databricks
+REGEXP_EXTRACT_ALL(tbl.str_col, 'pattern');
+ARRAY<VARCHAR>;
 
 # dialect: hive
 tbl.bigint DIV tbl.bigint;


### PR DESCRIPTION
## Summary

Adds Databricks type inference support for REGEXP_COUNT (INT) and REGEXP_EXTRACT_ALL (ARRAY<TEXT>), and fixture coverage for REGEXP, REGEXP_COUNT, and REGEXP_EXTRACT_ALL.

## Tickets
- RD-1229621 (ADD_MONTHS) — already complete via inheritance, no changes
- RD-1229629 (REGEXP) — fixture entries only
- RD-1229630 (REGEXP_COUNT) — new typing + fixture
- RD-1229631 (REGEXP_EXTRACT) — already complete via inheritance, no changes
- RD-1229632 (REGEXP_EXTRACT_ALL) — new typing + fixture

## Test plan
- [ ] `make style` — PASS
- [ ] `make unit` — PASS