### PR TITLE
fix(duckdb): default missing year to 1970 for BigQuery PARSE_DATE/PARSE_TIMESTAMP

### DIFF
--- a/sqlglot/expressions/temporal.py
+++ b/sqlglot/expressions/temporal.py
@@ -450,11 +450,18 @@ class ParseTime(Expression, Func):
 
 
 class StrToDate(Expression, Func):
-    arg_types = {"this": True, "format": False, "safe": False}
+    arg_types = {"this": True, "format": False, "safe": False, "default_year": False}
 
 
 class StrToTime(Expression, Func):
-    arg_types = {"this": True, "format": True, "zone": False, "safe": False, "target_type": False}
+    arg_types = {
+        "this": True,
+        "format": True,
+        "zone": False,
+        "safe": False,
+        "target_type": False,
+        "default_year": False,
+    }
 
 
 class StrToUnix(Expression, Func):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4087,6 +4087,10 @@ class Generator:
     def strtotime_sql(self, expression: exp.StrToTime) -> str:
         return self.func("STR_TO_TIME", expression.this, expression.args.get("format"))
 
+    # Base implementation that excludes the safe and default_year metadata args
+    def strtodate_sql(self, expression: exp.StrToDate) -> str:
+        return self.func("STR_TO_DATE", expression.this, expression.args.get("format"))
+
     def parsedatetime_sql(self, expression: exp.ParseDatetime) -> str:
         return self.func(
             "PARSE_DATETIME",

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -32,7 +32,6 @@ from sqlglot.dialects.dialect import (
     rename_func,
     remove_from_array_using_filter,
     strposition_sql,
-    str_to_time_sql,
     timestrtotime_sql,
     unit_to_str,
 )
@@ -2751,14 +2750,13 @@ class DuckDBGenerator(generator.Generator):
             exp.DType.TIMESTAMPTZ,
         )
 
-        if expression.args.get("safe"):
-            formatted_time = self.format_time(expression)
-            cast_type = exp.DType.TIMESTAMPTZ if needs_tz else exp.DType.TIMESTAMP
-            return self.sql(
-                exp.cast(self.func("TRY_STRPTIME", expression.this, formatted_time), cast_type)
-            )
+        value, formatted_time = self._strptime_default_year(expression)
 
-        base_sql = str_to_time_sql(self, expression)
+        if expression.args.get("safe"):
+            cast_type = exp.DType.TIMESTAMPTZ if needs_tz else exp.DType.TIMESTAMP
+            return self.sql(exp.cast(self.func("TRY_STRPTIME", value, formatted_time), cast_type))
+
+        base_sql = self.func("STRPTIME", value, formatted_time)
         if needs_tz:
             return self.sql(
                 exp.cast(
@@ -2769,27 +2767,30 @@ class DuckDBGenerator(generator.Generator):
         return base_sql
 
     def strtodate_sql(self, expression: exp.StrToDate) -> str:
-        formatted_time = self.format_time(expression)
+        value, formatted_time = self._strptime_default_year(expression)
         function_name = "STRPTIME" if not expression.args.get("safe") else "TRY_STRPTIME"
         return self.sql(
             exp.cast(
-                self.func(function_name, expression.this, formatted_time),
+                self.func(function_name, value, formatted_time),
                 exp.DataType(this=exp.DType.DATE),
             )
         )
 
+    def _strptime_default_year(
+        self, expression: exp.StrToTime | exp.StrToDate | exp.ParseDatetime
+    ) -> tuple[exp.ExpOrStr, exp.ExpOrStr | None]:
+        value: exp.ExpOrStr = expression.this
+        formatted_time: exp.ExpOrStr | None = self.format_time(expression)
+
+        if default_year := expression.args.get("default_year"):
+            value = exp.DPipe(this=exp.Literal.string(f"{default_year.name} "), expression=value)
+            formatted_time = exp.DPipe(this=exp.Literal.string("%Y "), expression=formatted_time)
+
+        return value, formatted_time
+
     def parsedatetime_sql(self, expression: exp.ParseDatetime) -> str:
-        formatted_time = self.format_time(expression)
-
-        default_year = expression.args.get("default_year")
-        if default_year:
-            year_str = exp.Literal.string(f"{default_year.name} ")
-            fmt_prefix = exp.Literal.string("%Y ")
-            value = exp.DPipe(this=year_str, expression=expression.this)
-            fmt = exp.DPipe(this=fmt_prefix, expression=formatted_time)
-            return self.func("STRPTIME", value, fmt)
-
-        return self.func("STRPTIME", expression.this, formatted_time)
+        value, formatted_time = self._strptime_default_year(expression)
+        return self.func("STRPTIME", value, formatted_time)
 
     def parsetime_sql(self, expression: exp.ParseTime) -> str:
         formatted_time = self.format_time(expression)

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -92,9 +92,16 @@ def _build_levenshtein(args: list) -> exp.Levenshtein:
     )
 
 
+def _build_parse_date(args: list, dialect: Dialect) -> exp.StrToDate:
+    this = build_formatted_time(exp.StrToDate)([seq_get(args, 1), seq_get(args, 0)], dialect)
+    this.set("default_year", exp.Literal.number(1970))
+    return this
+
+
 def _build_parse_timestamp(args: list, dialect: Dialect) -> exp.StrToTime:
     this = build_formatted_time(exp.StrToTime)([seq_get(args, 1), seq_get(args, 0)], dialect)
     this.set("zone", seq_get(args, 2))
+    this.set("default_year", exp.Literal.number(1970))
     return this
 
 
@@ -248,9 +255,7 @@ class BigQueryParser(parser.Parser):
         ),
         "OCTET_LENGTH": exp.ByteLength.from_arg_list,
         "TO_HEX": _build_to_hex,
-        "PARSE_DATE": lambda args, dialect: build_formatted_time(exp.StrToDate)(
-            [seq_get(args, 1), seq_get(args, 0)], dialect
-        ),
+        "PARSE_DATE": _build_parse_date,
         "PARSE_TIME": lambda args, dialect: build_formatted_time(exp.ParseTime)(
             [seq_get(args, 1), seq_get(args, 0)], dialect
         ),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -546,7 +546,7 @@ LANGUAGE js AS
             "PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E6S%z', x)",
             write={
                 "bigquery": "PARSE_TIMESTAMP('%FT%H:%M:%E6S%z', x)",
-                "duckdb": "STRPTIME(x, '%Y-%m-%dT%H:%M:%S.%f%z')",
+                "duckdb": "STRPTIME('1970 ' || x, '%Y ' || '%Y-%m-%dT%H:%M:%S.%f%z')",
             },
         )
         self.validate_all(
@@ -620,7 +620,7 @@ LANGUAGE js AS
             "PARSE_TIMESTAMP('%Y-%m-%dT%H:%M:%E6S%z', x)",
             write={
                 "bigquery": "PARSE_TIMESTAMP('%FT%H:%M:%E6S%z', x)",
-                "duckdb": "STRPTIME(x, '%Y-%m-%dT%H:%M:%S.%f%z')",
+                "duckdb": "STRPTIME('1970 ' || x, '%Y ' || '%Y-%m-%dT%H:%M:%S.%f%z')",
             },
         )
         self.validate_all(
@@ -1799,15 +1799,29 @@ WHERE
             "SELECT PARSE_DATE('%A %b %e %Y', 'Thursday Dec 25 2008')",
             write={
                 "bigquery": "SELECT PARSE_DATE('%A %b %e %Y', 'Thursday Dec 25 2008')",
-                "duckdb": "SELECT CAST(STRPTIME('Thursday Dec 25 2008', '%A %b %-d %Y') AS DATE)",
+                "duckdb": "SELECT CAST(STRPTIME('1970 ' || 'Thursday Dec 25 2008', '%Y ' || '%A %b %-d %Y') AS DATE)",
             },
         )
         self.validate_all(
             "SELECT PARSE_DATE('%Y%m%d', '20081225')",
             write={
                 "bigquery": "SELECT PARSE_DATE('%Y%m%d', '20081225')",
-                "duckdb": "SELECT CAST(STRPTIME('20081225', '%Y%m%d') AS DATE)",
+                "duckdb": "SELECT CAST(STRPTIME('1970 ' || '20081225', '%Y ' || '%Y%m%d') AS DATE)",
                 "snowflake": "SELECT DATE('20081225', 'yyyymmDD')",
+            },
+        )
+        self.validate_all(
+            "SELECT PARSE_DATE('%m-%d', '12-25')",
+            write={
+                "duckdb": "SELECT CAST(STRPTIME('1970 ' || '12-25', '%Y ' || '%m-%d') AS DATE)",
+                "mysql": "SELECT STR_TO_DATE('12-25', '%m-%d')",
+            },
+        )
+        self.validate_all(
+            "SELECT PARSE_TIMESTAMP('%m-%d %H:%M:%S', '12-25 07:30:00')",
+            write={
+                "duckdb": "SELECT STRPTIME('1970 ' || '12-25 07:30:00', '%Y ' || '%m-%d %H:%M:%S')",
+                "mysql": "SELECT STR_TO_DATE('12-25 07:30:00', '%m-%d %T')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -1826,7 +1826,7 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
-            "SELECT CAST(CAST(STRPTIME('05/06/2020', '%m/%d/%Y') AS DATE) AS DATE)",
+            "SELECT CAST(CAST(STRPTIME('1970 ' || '05/06/2020', '%Y ' || '%m/%d/%Y') AS DATE) AS DATE)",
             read={
                 "bigquery": "SELECT DATE(PARSE_DATE('%m/%d/%Y', '05/06/2020'))",
             },


### PR DESCRIPTION
BigQuery defaults an unspecified year to 1970; DuckDB's STRPTIME defaults to 1900. #7704 taught the DuckDB generator to compensate, but only for PARSE_DATETIME. The symmetric builders PARSE_DATE (StrToDate) and PARSE_TIMESTAMP (StrToTime) were left unmirrored, so a yearless `PARSE_DATE('%m-%d', '12-25')` transpiles to DuckDB and returns 1900-12-25 instead of 1970-12-25 — a silent 70-year error.

The fix reuses #7704's mechanism: a `default_year` flag set only by the BigQuery PARSE_* builders, applied via the same `'1970 ' || ...` prefix in DuckDB's strtodate/strtotime. Other dialects are untouched, and an explicit year still wins. Verified both ways on a real duckdb engine (1900 before, 1970 after); full suite 1106 passed.