### PR TITLE
fix(optimizer): resolve columns of a LATERAL subquery in the outer scope [CLAUDE]

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -105,7 +105,12 @@ class UDTF(DerivedTable):
     @property
     def selects(self) -> list[Expr]:
         alias = self.args.get("alias")
-        return alias.columns if alias else []
+        if alias and alias.columns:
+            return alias.columns
+
+        # A UDTF without explicit alias columns (e.g. `LATERAL (<subquery>)`) exposes the
+        # columns produced by the query it wraps, so fall back to those.
+        return super().selects
 
 
 @trait

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -464,6 +464,20 @@ class TestOptimizer(unittest.TestCase):
             "SELECT `test`.`bar_bazfoo_$id` AS `bar_bazfoo_$id` FROM `test` AS `test`",
         )
 
+        # A LATERAL subquery exposes the columns of the query it wraps, so the outer
+        # scope must be able to resolve them (e.g. the WITH ORDINALITY column `pos`).
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(
+                    "SELECT pos, val FROM t CROSS JOIN LATERAL (SELECT pos - 1 AS pos, val FROM UNNEST(t.arr) WITH ORDINALITY AS _t0(val, pos))",
+                    read="duckdb",
+                ),
+                schema={"t": {"arr": "ARRAY<VARCHAR>"}},
+                dialect="duckdb",
+            ).sql(dialect="duckdb"),
+            'SELECT "_0"."pos" AS "pos", "_0"."val" AS "val" FROM "t" AS "t" CROSS JOIN LATERAL (SELECT "_t0"."pos" - 1 AS "pos", "_t0"."val" AS "val" FROM UNNEST("t"."arr") WITH ORDINALITY AS "_t0"("val", pos)) AS "_0"',
+        )
+
         qualified = optimizer.qualify.qualify(
             parse_one("WITH t AS (SELECT 1 AS c) (SELECT c FROM t)")
         )


### PR DESCRIPTION

Closes #7799.

**Bug.** `qualify()` could not resolve columns produced by a `LATERAL (<subquery>)`
source. This surfaced when transpiling Spark `LATERAL VIEW POSEXPLODE` to DuckDB:

```py
sql = "SELECT pos, val FROM t LATERAL VIEW POSEXPLODE(t.arr) AS pos, val"
generated = parse_one(sql, read="spark").sql(dialect="duckdb")
# SELECT pos, val FROM t CROSS JOIN LATERAL
#   (SELECT pos - 1 AS pos, val FROM UNNEST(t.arr) WITH ORDINALITY AS _t0(val, pos))

qualify(parse_one(generated, read="duckdb"), dialect="duckdb",
        schema={"t": {"arr": "ARRAY<VARCHAR>"}})
# -> OptimizeError: Column 'pos' could not be resolved.
```

DuckDB itself resolves the query fine.

**Root cause.** In the generated SQL the lateral is `Lateral(this=Subquery(...))`
with no alias columns of its own. The optimizer derives a source's columns from
`UDTF.selects`, which only returned `alias.columns`:

```py
class UDTF(DerivedTable):
    @property
    def selects(self):
        alias = self.args.get("alias")
        return alias.columns if alias else []
```

Because the `Lateral` has no alias columns, `selects` (and therefore
`named_selects`) was empty, so in the outer scope the lateral source resolved to
*no* columns and `pos`/`val` could not be qualified. The inner `UNNEST ... WITH
ORDINALITY AS _t0(val, pos)` resolved correctly only because `Unnest.selects`
already special-cases the ordinality/offset column.

**Fix.** When a UDTF has no explicit alias columns, fall back to the columns of
the query it wraps (`DerivedTable.selects`, i.e. the inner `Subquery`/`Query`'s
selects). This is general: it works regardless of alias names or column order,
and it leaves the existing aliased path (e.g. `UNNEST(...) AS t(a, b)`,
`LATERAL VIEW EXPLODE(...) v AS x`) and `Unnest.selects` (which calls
`super().selects`) untouched, since those still have alias columns.

# Tests

- Added a regression test in `tests/test_optimizer.py::test_qualify_columns`
  using the exact repro from the issue. It fails before the fix
  (`OptimizeError: Column 'pos' could not be resolved`) and passes after,
  producing correctly-qualified SQL.
- Full suite passes (`tests/test_optimizer.py`, `tests/test_expressions.py`,
  `tests/test_build.py`, `tests/dialects/`, `tests/test_transpile.py`,
  `tests/test_lineage.py`), and `ruff check` / `ruff format --check` are clean.
