### PR TITLE
Fix RegexpReplace type inference returning UNKNOWN for Hive/Spark/Databricks

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -29,6 +29,7 @@ EXPRESSION_METADATA = {
             exp.Hex,
             exp.NextDay,
             exp.RegexpExtract,
+            exp.RegexpReplace,
             exp.Replace,
             exp.Soundex,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -231,6 +231,12 @@ STRING;
 # dialect: spark2, spark, databricks
 REGEXP_EXTRACT(tbl.bin_col, pattern, 0);
 STRING;
+# dialect: spark2, spark, databricks
+REGEXP_REPLACE(tbl.str_col, pattern, replacement);
+VARCHAR;
+# dialect: spark2, spark, databricks
+REGEXP_REPLACE(tbl.bin_col, pattern, replacement);
+VARCHAR;
 
 # dialect: spark2, spark, databricks
 CONCAT(tbl.bin_col, tbl.bin_col);


### PR DESCRIPTION
REGEXP_REPLACE() was returning UNKNOWN instead of VARCHAR in Spark, Spark2,
Hive, and Databricks dialects.

RegexpReplace was just missing from the VARCHAR set in hive.py, right next to RegexpExtract and Replace which were already there. Added it, and since Spark inherits from Hive, all dialects are fixed with one line.

Also added regression tests in annotate_functions.sql for spark2, spark and databricks.