### PR TITLE
fix(parser): prioritize parsing parenthesized expressions as Tuple when multi-expression CSV exists

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6841,6 +6841,8 @@ class Parser:
 
         if not this and self._match(TokenType.R_PAREN, advance=False):
             this = self.expression(exp.Tuple())
+        elif len(expressions) > 1 or self._prev.token_type == TokenType.COMMA:
+            this = self.expression(exp.Tuple(expressions=expressions))
         elif isinstance(this, exp.UNWRAPPED_QUERIES):
             this = self._parse_subquery(this=this, parse_alias=False)
         elif isinstance(this, (exp.Subquery, exp.Values)):
@@ -6848,8 +6850,6 @@ class Parser:
                 this=self._parse_query_modifiers(self._parse_set_operations(this)),
                 parse_alias=False,
             )
-        elif len(expressions) > 1 or self._prev.token_type == TokenType.COMMA:
-            this = self.expression(exp.Tuple(expressions=expressions))
         else:
             this = self.expression(exp.Paren(this=this))
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,6 +17,7 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(parse_one("(1)", into=exp.Tuple), exp.Tuple)
         self.assertIsInstance(parse_one("(1,)", into=exp.Tuple), exp.Tuple)
         self.assertIsInstance(parse_one("(x=1)", into=exp.Tuple), exp.Tuple)
+        self.assertIsInstance(parse_one("((SELECT 42), 1)", into=exp.Tuple), exp.Tuple)
 
         self.assertIsInstance(parse_one("select * from t", into=exp.Select), exp.Select)
         self.assertIsInstance(parse_one("select * from t limit 5", into=exp.Select), exp.Select)


### PR DESCRIPTION
When parsing parenthesized expressions where the first item is a subquery (e.g. `((SELECT 42), 1)`), the parser's `_parse_paren` method matches the `isinstance(this, (exp.Subquery, exp.Values))` check first and constructs a `Subquery` object, dropping subsequent items (such as `, 1`).

This PR fixes this by checking if the CSV contains multiple expressions (i.e., `len(expressions) > 1` or a trailing comma) first, which constructs an `exp.Tuple` and correctly preserves all elements.

I have added a unit test verifying that `((SELECT 42), 1)` parses as a `Tuple` successfully.

Closes #7805