### PR TITLE
fix(presto): transpile FROM_ISO8601_TIMESTAMP_NANOS to cast

### DIFF
--- a/sqlglot/expressions/temporal.py
+++ b/sqlglot/expressions/temporal.py
@@ -441,6 +441,10 @@ class FromISO8601Date(Expression, Func):
     _sql_names = ["FROM_ISO8601_DATE"]
 
 
+class FromISO8601TimestampNanos(Expression, Func):
+    _sql_names = ["FROM_ISO8601_TIMESTAMP_NANOS"]
+
+
 class ParseDatetime(Expression, Func):
     arg_types = {"this": True, "format": False, "zone": False, "default_year": False}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4008,6 +4008,9 @@ class Generator:
     def fromiso8601timestamp_sql(self, expression: exp.FromISO8601Timestamp) -> str:
         return self.sql(exp.cast(expression.this, exp.DType.TIMESTAMPTZ))
 
+    def fromiso8601timestampnanos_sql(self, expression: exp.FromISO8601TimestampNanos) -> str:
+        return self.sql(exp.cast(expression.this, exp.DType.TIMESTAMPTZ))
+
     def add_sql(self, expression: exp.Add) -> str:
         return self.binary(expression, "+")
 

--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -306,6 +306,7 @@ class PrestoGenerator(generator.Generator):
         exp.First: _first_last_sql,
         exp.FromISO8601Date: rename_func("FROM_ISO8601_DATE"),
         exp.FromISO8601Timestamp: rename_func("FROM_ISO8601_TIMESTAMP"),
+        exp.FromISO8601TimestampNanos: rename_func("FROM_ISO8601_TIMESTAMP_NANOS"),
         exp.FromTimeZone: lambda self, e: (
             f"WITH_TIMEZONE({self.sql(e, 'this')}, {self.sql(e, 'zone')}) AT TIME ZONE 'UTC'"
         ),

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -58,6 +58,18 @@ class TestPresto(Validator):
             },
         )
         self.validate_all(
+            "SELECT FROM_ISO8601_TIMESTAMP_NANOS('2020-05-11T11:15:05.000000000')",
+            write={
+                "duckdb": "SELECT CAST('2020-05-11T11:15:05.000000000' AS TIMESTAMPTZ)",
+                "presto": "SELECT FROM_ISO8601_TIMESTAMP_NANOS('2020-05-11T11:15:05.000000000')",
+                "trino": "SELECT FROM_ISO8601_TIMESTAMP_NANOS('2020-05-11T11:15:05.000000000')",
+                "snowflake": "SELECT CAST('2020-05-11T11:15:05.000000000' AS TIMESTAMPTZ)",
+                "spark": "SELECT CAST('2020-05-11T11:15:05.000000000' AS TIMESTAMP)",
+                "databricks": "SELECT CAST('2020-05-11T11:15:05.000000000' AS TIMESTAMP)",
+                "bigquery": "SELECT CAST('2020-05-11T11:15:05.000000000' AS TIMESTAMP)",
+            },
+        )
+        self.validate_all(
             "CAST(x AS INTERVAL YEAR TO MONTH)",
             write={
                 "oracle": "CAST(x AS INTERVAL YEAR TO MONTH)",


### PR DESCRIPTION
Presto/Trino has three `from_iso8601_*` functions. `FROM_ISO8601_TIMESTAMP` (#7776) and `FROM_ISO8601_DATE` (#7778) now parse into dedicated expressions and transpile to a cast, but `FROM_ISO8601_TIMESTAMP_NANOS` is still parsed as an anonymous function. Transpiling it to a dialect that doesn't have it (duckdb, snowflake, ...) emits a call to a function that doesn't exist there.

This adds `FromISO8601TimestampNanos` and handles it the same way as `FROM_ISO8601_TIMESTAMP`: it round-trips in presto/trino and casts to a timestamp with time zone in other dialects.

Ref: https://trino.io/docs/current/functions/datetime.html#from_iso8601_timestamp_nanos
