### PR TITLE
fix(postgres)!: more robust date formats

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -52,7 +52,6 @@ class DuckDB(Dialect):
         "%f_seven": "%n",
         "%f_eight": "%n",
         "%f_nine": "%n",
-        "%benupper": "%b",
     }
 
     def to_json_path(self, path: exp.Expr | None) -> exp.Expr | None:

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -52,6 +52,7 @@ class DuckDB(Dialect):
         "%f_seven": "%n",
         "%f_eight": "%n",
         "%f_nine": "%n",
+        "%benupper": "%b",
     }
 
     def to_json_path(self, path: exp.Expr | None) -> exp.Expr | None:

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -51,18 +51,8 @@ class Postgres(Dialect):
         "TMDy": "%a",
         "TMMon": "%b",  # Sep
         "TMMonth": "%B",  # September
-        "Day": "%Aen",  # Tuesday
         "day": "%Aenlower",  # tuesday
-        "DAY": "%Aenupper",  # TUESDAY
-        "Dy": "%aen",  # Tue
         "dy": "%aenlower",  # tue
-        "DY": "%aenupper",  # TUE
-        "Month": "%Ben",  # September
-        "month": "%Benlower",  # september
-        "MONTH": "%Benupper",  # SEPTEMBER
-        "Mon": "%ben",  # Sep
-        "mon": "%benlower",  # sep
-        "MON": "%benupper",  # SEP
         "TZ": "%Z",  # uppercase timezone name
         "US": "%f",  # zero padded microsecond
         "ww": "%U",  # 1-based week of year

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -51,12 +51,26 @@ class Postgres(Dialect):
         "TMDy": "%a",
         "TMMon": "%b",  # Sep
         "TMMonth": "%B",  # September
+        "Day": "%Aen",  # Tuesday
+        "day": "%Aenlower",  # tuesday
+        "DAY": "%Aenupper",  # TUESDAY
+        "Dy": "%aen",  # Tue
+        "dy": "%aenlower",  # tue
+        "DY": "%aenupper",  # TUE
+        "Month": "%Ben",  # September
+        "month": "%Benlower",  # september
+        "MONTH": "%Benupper",  # SEPTEMBER
+        "Mon": "%ben",  # Sep
+        "mon": "%benlower",  # sep
+        "MON": "%benupper",  # SEP
         "TZ": "%Z",  # uppercase timezone name
         "US": "%f",  # zero padded microsecond
         "ww": "%U",  # 1-based week of year
         "WW": "%U",  # 1-based week of year
         "yy": "%y",  # 15
         "YY": "%y",  # 15
+        "yyy": "%Ythree",  # 015
+        "YYY": "%Ythree",  # 015
         "yyyy": "%Y",  # 2015
         "YYYY": "%Y",  # 2015
     }

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -25,6 +25,12 @@ class Redshift(Postgres):
     # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
 
+    TIME_MAPPING = {
+        **Postgres.TIME_MAPPING,
+        "MON": "%b",
+        "MONTH": "%B",
+    }
+
     Parser = RedshiftParser
 
     class Tokenizer(Postgres.Tokenizer):

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -25,12 +25,6 @@ class Redshift(Postgres):
     # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html
     TIME_FORMAT = "'YYYY-MM-DD HH24:MI:SS'"
 
-    TIME_MAPPING = {
-        **Postgres.TIME_MAPPING,
-        "MON": "%b",
-        "MONTH": "%B",
-    }
-
     Parser = RedshiftParser
 
     class Tokenizer(Postgres.Tokenizer):


### PR DESCRIPTION
This PR fixes the following roundtrip postgres/redshift issue:

```
-- On main (parsed %d and then the rest of the format for example `dy`-> format `%dy`) --
input:
SELECT TO_CHAR(DATE '2024-07-09', 'dy');
> 'tue'
output:
SELECT TO_CHAR(CAST('2024-07-09' AS DATE), 'Dy')
> 'Tue'

input:
SELECT TO_CHAR(DATE '2024-07-09', 'day');
> 'tuesday'
output (roundtrip):
SELECT TO_CHAR(CAST('2024-07-09' AS DATE), 'Day')
> 'Tuesday'

input:
SELECT TO_CHAR(DATE '2024-07-09', 'yyymmdd');
> '0240709'
output (roundtrip):
SELECT TO_CHAR(CAST('2024-07-09' AS DATE), 'YYymmDD')
> '2440709
```

**DOCS**
[Postgres format docs](https://www.postgresql.org/docs/current/functions-formatting.html)
[Redshift format docs](https://docs.aws.amazon.com/redshift/latest/dg/r_FORMAT_strings.html)