### PR TITLE
Feat(optimizer)!: annotate `to_json` for hive-like dialects

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -27,6 +27,7 @@ EXPRESSION_METADATA = {
             exp.CurrentUser,
             exp.CurrentSchema,
             exp.Hex,
+            exp.JSONExtractScalar,
             exp.JSONFormat,
             exp.NextDay,
             exp.RegexpExtract,

--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -29,6 +29,7 @@ EXPRESSION_METADATA = {
             exp.Hex,
             exp.NextDay,
             exp.RegexpExtract,
+            exp.RegexpReplace,
             exp.Replace,
             exp.Soundex,
         }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -231,12 +231,6 @@ STRING;
 # dialect: spark2, spark, databricks
 REGEXP_EXTRACT(tbl.bin_col, pattern, 0);
 STRING;
-# dialect: spark2, spark, databricks
-REGEXP_REPLACE(tbl.str_col, pattern, replacement);
-VARCHAR;
-# dialect: spark2, spark, databricks
-REGEXP_REPLACE(tbl.bin_col, pattern, replacement);
-VARCHAR;
 
 # dialect: hive, spark2, spark, databricks
 REGEXP_REPLACE(tbl.str_col, pattern, replacement);

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1020,6 +1020,9 @@ ARRAY<VARCHAR>;
 # dialect: hive, spark2, spark, databricks
 TO_JSON(STRUCT(1, 'hello'));
 VARCHAR;
+# dialect: hive, spark2, spark, databricks
+GET_JSON_OBJECT('{"a":1}', '$.a');
+VARCHAR;
 # dialect: hive
 tbl.bigint DIV tbl.bigint;
 BIGINT; 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1011,12 +1011,13 @@ INT;
 REGEXP_EXTRACT_ALL(tbl.str_col, 'pattern');
 ARRAY<VARCHAR>;
 
-# dialect: hive, spark2, spark, databricks
+# dialect: spark2, spark, databricks
 TO_JSON(STRUCT(1, 'hello'));
-VARCHAR;
+STRING;
+
 # dialect: hive, spark2, spark, databricks
 GET_JSON_OBJECT('{"a":1}', '$.a');
-VARCHAR;
+STRING;
 # dialect: hive
 tbl.bigint DIV tbl.bigint;
 BIGINT; 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -231,6 +231,12 @@ STRING;
 # dialect: spark2, spark, databricks
 REGEXP_EXTRACT(tbl.bin_col, pattern, 0);
 STRING;
+# dialect: spark2, spark, databricks
+REGEXP_REPLACE(tbl.str_col, pattern, replacement);
+VARCHAR;
+# dialect: spark2, spark, databricks
+REGEXP_REPLACE(tbl.bin_col, pattern, replacement);
+VARCHAR;
 
 # dialect: spark2, spark, databricks
 CONCAT(tbl.bin_col, tbl.bin_col);


### PR DESCRIPTION
TO_JSON() was returning UNKNOWN instead of VARCHAR during type annotation
in Hive, Spark2, Spark, and Databricks dialects.

JSONFormat was missing from the VARCHAR set in hive.py, same as the
previous RegexpReplace fix. Added it alphabetically.

Added a regression test in annotate_functions.sql for hive, spark2,
spark, and databricks.