### PR TITLE
fix(hive): PARSE_JSON and TO_JSON roundtrip

### DIFF
--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -10,7 +10,6 @@ from sqlglot.dialects.dialect import (
     arg_max_or_min_no_count,
     datestrtodate_sql,
     if_sql,
-    is_parse_json,
     left_to_substring_sql,
     max_or_greatest,
     min_or_least,
@@ -115,27 +114,6 @@ def _date_diff_sql(self: HiveGenerator, expression: exp.DateDiff | exp.TsOrDsDif
     return diff_sql
 
 
-def _json_format_sql(self: HiveGenerator, expression: exp.JSONFormat) -> str:
-    this = expression.this
-
-    if is_parse_json(this):
-        if this.this.is_string:
-            # Since FROM_JSON requires a nested type, we always wrap the json string with
-            # an array to ensure that "naked" strings like "'a'" will be handled correctly
-            wrapped_json = exp.Literal.string(f"[{this.this.name}]")
-
-            from_json = self.func(
-                "FROM_JSON", wrapped_json, self.func("SCHEMA_OF_JSON", wrapped_json)
-            )
-            to_json = self.func("TO_JSON", from_json)
-
-            # This strips the [, ] delimiters of the dummy array printed by TO_JSON
-            return self.func("REGEXP_EXTRACT", to_json, "'^.(.*).$'", "1")
-        return self.sql(this)
-
-    return self.func("TO_JSON", this, expression.args.get("options"))
-
-
 @generator.unsupported_args(("expression", "Hive's SORT_ARRAY does not support a comparator."))
 def _array_sort_sql(self: HiveGenerator, expression: exp.ArraySort) -> str:
     return self.func("SORT_ARRAY", expression.this)
@@ -199,7 +177,7 @@ class HiveGenerator(generator.Generator):
     SAFE_JSON_PATH_KEY_RE = re.compile(r"^[_\-a-zA-Z][\-\w]*$")
     SUPPORTS_TO_NUMBER = False
     WITH_PROPERTIES_PREFIX = "TBLPROPERTIES"
-    PARSE_JSON_NAME: str | None = None
+    PARSE_JSON_NAME: str | None = "PARSE_JSON"
     PAD_FILL_PATTERN_IS_REQUIRED = True
     SUPPORTS_MEDIAN = False
     ARRAY_SIZE_NAME = "SIZE"
@@ -265,7 +243,7 @@ class HiveGenerator(generator.Generator):
         exp.IsNan: rename_func("ISNAN"),
         exp.JSONExtract: lambda self, e: self.func("GET_JSON_OBJECT", e.this, e.expression),
         exp.JSONExtractScalar: lambda self, e: self.func("GET_JSON_OBJECT", e.this, e.expression),
-        exp.JSONFormat: _json_format_sql,
+        exp.JSONFormat: rename_func("TO_JSON"),
         exp.Left: left_to_substring_sql,
         exp.Map: var_map_sql,
         exp.Max: max_or_greatest,

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -17,6 +17,27 @@ from sqlglot.transforms import (
 )
 
 
+def _json_format_sql(self: Spark2Generator, expression: exp.JSONFormat) -> str:
+    this = expression.this
+
+    if is_parse_json(this):
+        if this.this.is_string:
+            # Since FROM_JSON requires a nested type, we always wrap the json string with
+            # an array to ensure that "naked" strings like "'a'" will be handled correctly
+            wrapped_json = exp.Literal.string(f"[{this.this.name}]")
+
+            from_json = self.func(
+                "FROM_JSON", wrapped_json, self.func("SCHEMA_OF_JSON", wrapped_json)
+            )
+            to_json = self.func("TO_JSON", from_json)
+
+            # This strips the [, ] delimiters of the dummy array printed by TO_JSON
+            return self.func("REGEXP_EXTRACT", to_json, "'^.(.*).$'", "1")
+        return self.sql(this)
+
+    return self.func("TO_JSON", this, expression.args.get("options"))
+
+
 def _map_sql(self: Spark2Generator, expression: exp.Map) -> str:
     keys = expression.args.get("keys")
     values = expression.args.get("values")
@@ -108,6 +129,7 @@ class Spark2Generator(HiveGenerator):
     NVL2_SUPPORTED = True
     CAN_IMPLEMENT_ARRAY_ANY = True
     ALTER_SET_TYPE = "TYPE"
+    PARSE_JSON_NAME: str | None = None
 
     PROPERTIES_LOCATION = {
         **HiveGenerator.PROPERTIES_LOCATION,
@@ -161,6 +183,7 @@ class Spark2Generator(HiveGenerator):
             exp.FromTimeZone: lambda self, e: self.func(
                 "TO_UTC_TIMESTAMP", e.this, e.args.get("zone")
             ),
+            exp.JSONFormat: _json_format_sql,
             exp.LogicalAnd: rename_func("BOOL_AND"),
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.Map: _map_sql,

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -1024,6 +1024,9 @@ class TestHive(Validator):
             },
         )
 
+        self.validate_identity("""SELECT PARSE_JSON('{"key": 123}')""")
+        self.validate_identity("""SELECT TO_JSON(PARSE_JSON('{"key": 123}'))""")
+
     def test_escapes(self) -> None:
         self.validate_identity("'\n'", "'\\n'")
         self.validate_identity("'\\n'")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1015,6 +1015,10 @@ ARRAY<VARCHAR>;
 TO_JSON(STRUCT(1, 'hello'));
 STRING;
 
+# dialect: hive, databricks
+TO_JSON(PARSE_JSON('{"key": 123}'));
+STRING;
+
 # dialect: hive, spark2, spark, databricks
 GET_JSON_OBJECT('{"a":1}', '$.a');
 STRING;


### PR DESCRIPTION
Preserve roundtrip for (`TO_JSON` is single arg in hive):
```
> SELECT TO_JSON(PARSE_JSON('{"key": 123}'));
+--------------+
|     _c0      |
+--------------+
| {"key":123}  |
+--------------+
```

`PARSE_JSON` returns the `VARIANT` style value like databricks.