### PR TITLE
fix(optimizer): incorrect canonical names for certain qualified star queries 

### DIFF
--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -70,9 +70,9 @@ def canonicalize_internal_names(expression: E) -> E:
             columns_by_source.setdefault(table_col.name, []).append(table_col)
 
         # Include qualified stars (e.g. `t.*`)
-        for col in find_all_in_scope(scope_expr, exp.Column):
-            if isinstance(col.this, exp.Star) and col.table:
-                columns_by_source.setdefault(col.table, []).append(col)
+        for star in scope.stars:
+            if isinstance(star, exp.Column) and star.table:
+                columns_by_source.setdefault(star.table, []).append(star)
 
         # source_canon: source's canonical name (used in WITH "_tN" AS, and as
         #   the physical table name in `Table.this`). Shared across every reference

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -69,6 +69,11 @@ def canonicalize_internal_names(expression: E) -> E:
         for table_col in scope.table_columns:
             columns_by_source.setdefault(table_col.name, []).append(table_col)
 
+        # Include qualified stars (e.g. `t.*`)
+        for col in find_all_in_scope(scope_expr, exp.Column):
+            if isinstance(col.this, exp.Star) and col.table:
+                columns_by_source.setdefault(col.table, []).append(col)
+
         # source_canon: source's canonical name (used in WITH "_tN" AS, and as
         #   the physical table name in `Table.this`). Shared across every reference
         #   to the same source within this scope.


### PR DESCRIPTION
In `canonicalize_internal_names`, `columns_by_source` is missing the renaming of certain aliases.

```
SELECT DISTINCT `old`.* FROM t AS `old`
```

Before fix:
```
SELECT DISTINCT `old`.* FROM `_t0` AS `_t0`
```

After fix:
```
SELECT DISTINCT `_t0`.* FROM `_t0` AS `_t0`
```