### PR TITLE
fix(optimizer)!: annotate type for databricks REGR_AVGY, REGR_COUNT, REGR_INTERCEPT, REGR_R2, REGR_SLOPE

### DIFF
--- a/sqlglot/expressions/aggregate.py
+++ b/sqlglot/expressions/aggregate.py
@@ -256,19 +256,19 @@ class RegrAvgy(Expression, AggFunc):
 
 
 class RegrCount(Expression, AggFunc):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": False}
 
 
 class RegrIntercept(Expression, AggFunc):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": False}
 
 
 class RegrR2(Expression, AggFunc):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": False}
 
 
 class RegrSlope(Expression, AggFunc):
-    arg_types = {"this": True, "expression": True}
+    arg_types = {"this": True, "expression": False}
 
 
 class RegrSxx(Expression, AggFunc):

--- a/sqlglot/generators/databricks.py
+++ b/sqlglot/generators/databricks.py
@@ -109,6 +109,14 @@ class DatabricksGenerator(SparkGenerator):
 
         return self.func("UNIFORM", expression.this, expression.expression, seed)
 
+    def regravgx_sql(self, expression: exp.RegrAvgx) -> str:
+        x = expression.expression
+        if isinstance(x, exp.Distinct):
+            return self.func(
+                "REGR_AVGX", exp.Distinct(expressions=[expression.this]), *x.expressions
+            )
+        return self.func("REGR_AVGX", expression.this, x)
+
     def clusterproperty_sql(self, expression):
         this = self.sql(expression, "this") or f"({self.expressions(expression, flat=True)})"
         return f"CLUSTER BY {this}"

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -31,6 +31,16 @@ class DatabricksParser(SparkParser):
         "CURDATE": lambda self: self._parse_curdate(),
     }
 
+    FUNCTION_PARSERS = {
+        **SparkParser.FUNCTION_PARSERS,
+        "REGR_AVGX": lambda self: self._parse_quantile_function(exp.RegrAvgx),
+        "REGR_AVGY": lambda self: self._parse_quantile_function(exp.RegrAvgy),
+        "REGR_COUNT": lambda self: self._parse_regr_count(),
+        "REGR_INTERCEPT": lambda self: self._parse_quantile_function(exp.RegrIntercept),
+        "REGR_R2": lambda self: self._parse_quantile_function(exp.RegrR2),
+        "REGR_SLOPE": lambda self: self._parse_quantile_function(exp.RegrSlope),
+    }
+
     FACTOR = {
         **SparkParser.FACTOR,
         TokenType.COLON: exp.JSONExtract,
@@ -54,6 +64,13 @@ class DatabricksParser(SparkParser):
         if self._match(TokenType.L_PAREN):
             self._match_r_paren()
         return self.expression(exp.CurrentDate())
+
+    def _parse_regr_count(self) -> exp.RegrCount:
+        if self._match(TokenType.DISTINCT):
+            return exp.RegrCount(this=exp.Distinct(expressions=self._parse_function_args()))
+        self._match(TokenType.ALL)
+        args = self._parse_function_args()
+        return self.expression(exp.RegrCount(this=seq_get(args, 0), expression=seq_get(args, 1)))
 
     def _parse_cluster_property(self):
         if self._match_texts(("AUTO", "NONE")):

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -35,10 +35,6 @@ class DatabricksParser(SparkParser):
         **SparkParser.FUNCTION_PARSERS,
         "REGR_AVGX": lambda self: self._parse_quantile_function(exp.RegrAvgx),
         "REGR_AVGY": lambda self: self._parse_quantile_function(exp.RegrAvgy),
-        "REGR_COUNT": lambda self: self._parse_regr_count(),
-        "REGR_INTERCEPT": lambda self: self._parse_quantile_function(exp.RegrIntercept),
-        "REGR_R2": lambda self: self._parse_quantile_function(exp.RegrR2),
-        "REGR_SLOPE": lambda self: self._parse_quantile_function(exp.RegrSlope),
     }
 
     FACTOR = {
@@ -64,13 +60,6 @@ class DatabricksParser(SparkParser):
         if self._match(TokenType.L_PAREN):
             self._match_r_paren()
         return self.expression(exp.CurrentDate())
-
-    def _parse_regr_count(self) -> exp.RegrCount:
-        if self._match(TokenType.DISTINCT):
-            return exp.RegrCount(this=exp.Distinct(expressions=self._parse_function_args()))
-        self._match(TokenType.ALL)
-        args = self._parse_function_args()
-        return self.expression(exp.RegrCount(this=seq_get(args, 0), expression=seq_get(args, 1)))
 
     def _parse_cluster_property(self):
         if self._match_texts(("AUTO", "NONE")):

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -33,8 +33,8 @@ class DatabricksParser(SparkParser):
 
     FUNCTION_PARSERS = {
         **SparkParser.FUNCTION_PARSERS,
-        "REGR_AVGX": lambda self: self._parse_quantile_function(exp.RegrAvgx),
-        "REGR_AVGY": lambda self: self._parse_quantile_function(exp.RegrAvgy),
+        "REGR_AVGX": lambda self: self._parse_distinct_arg_function(exp.RegrAvgx, distinct_index=1),
+        "REGR_AVGY": lambda self: self._parse_distinct_arg_function(exp.RegrAvgy),
     }
 
     FACTOR = {

--- a/sqlglot/parsers/hive.py
+++ b/sqlglot/parsers/hive.py
@@ -63,8 +63,8 @@ class HiveParser(parser.Parser):
 
     FUNCTION_PARSERS = {
         **parser.Parser.FUNCTION_PARSERS,
-        "PERCENTILE": lambda self: self._parse_quantile_function(exp.Quantile),
-        "PERCENTILE_APPROX": lambda self: self._parse_quantile_function(exp.ApproxQuantile),
+        "PERCENTILE": lambda self: self._parse_distinct_arg_function(exp.Quantile),
+        "PERCENTILE_APPROX": lambda self: self._parse_distinct_arg_function(exp.ApproxQuantile),
     }
 
     FUNCTIONS = {
@@ -178,18 +178,18 @@ class HiveParser(parser.Parser):
             )
         )
 
-    def _parse_quantile_function(self, func: type[F]) -> F:
-        if self._match(TokenType.DISTINCT):
-            first_arg: exp.Expr | None = self.expression(
-                exp.Distinct(expressions=[self._parse_lambda()])
-            )
-        else:
+    def _parse_distinct_arg_function(self, func: type[F], distinct_index: int = 0) -> F:
+        is_distinct = self._match(TokenType.DISTINCT)
+        if not is_distinct:
             self._match(TokenType.ALL)
-            first_arg = self._parse_lambda()
 
-        args = [first_arg]
+        args = [self._parse_lambda()]
         if self._match(TokenType.COMMA):
             args.extend(self._parse_function_args())
+
+        target = seq_get(args, distinct_index)
+        if is_distinct and target:
+            args[distinct_index] = self.expression(exp.Distinct(expressions=[target]))
 
         return func.from_arg_list(args)
 

--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -80,7 +80,7 @@ class Spark2Parser(HiveParser):
 
     FUNCTION_PARSERS = {
         **HiveParser.FUNCTION_PARSERS,
-        "APPROX_PERCENTILE": lambda self: self._parse_quantile_function(exp.ApproxQuantile),
+        "APPROX_PERCENTILE": lambda self: self._parse_distinct_arg_function(exp.ApproxQuantile),
         "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
         "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
         "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -9,6 +9,10 @@ EXPRESSION_METADATA = {
         exp_type: {"returns": exp.DType.DOUBLE}
         for exp_type in {
             exp.RegrAvgx,
+            exp.RegrAvgy,
+            exp.RegrIntercept,
+            exp.RegrR2,
+            exp.RegrSlope,
         }
     },
     **{
@@ -19,6 +23,7 @@ EXPRESSION_METADATA = {
         }
     },
     exp.RegexpSubstr: {"returns": exp.DType.VARCHAR},
+    exp.RegrCount: {"returns": exp.DType.BIGINT},
     exp.RegexpExtractAll: {
         "annotator": lambda self, e: self._set_type(
             e, exp.DataType.from_str("ARRAY<STRING>", dialect="databricks")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4247,6 +4247,10 @@ DOUBLE;
 REGR_AVGX(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
 
+# dialect: databricks
+REGR_AVGX(DISTINCT tbl.double_col, tbl.double_col);
+DOUBLE;
+
 # dialect: snowflake
 REGR_AVGY(tbl.double_col, tbl.double_col);
 DOUBLE;
@@ -4265,6 +4269,18 @@ DOUBLE;
 
 # dialect: databricks
 REGR_AVGY(tbl.int_col, tbl.int_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_AVGY(ALL tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_AVGY(DISTINCT tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_AVGY(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
 DOUBLE;
 
 # dialect: snowflake
@@ -4291,6 +4307,18 @@ BIGINT;
 REGR_COUNT(tbl.int_col, tbl.int_col);
 BIGINT;
 
+# dialect: databricks
+REGR_COUNT(ALL tbl.double_col, tbl.double_col);
+BIGINT;
+
+# dialect: databricks
+REGR_COUNT(DISTINCT tbl.double_col, tbl.double_col);
+BIGINT;
+
+# dialect: databricks
+REGR_COUNT(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
+BIGINT;
+
 # dialect: snowflake
 REGR_INTERCEPT(tbl.double_col, tbl.double_col);
 DOUBLE;
@@ -4315,6 +4343,18 @@ DOUBLE;
 REGR_INTERCEPT(tbl.int_col, tbl.int_col);
 DOUBLE;
 
+# dialect: databricks
+REGR_INTERCEPT(ALL tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_INTERCEPT(DISTINCT tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_INTERCEPT(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
+DOUBLE;
+
 # dialect: snowflake
 REGR_R2(tbl.double_col, tbl.double_col);
 DOUBLE;
@@ -4337,6 +4377,18 @@ DOUBLE;
 
 # dialect: databricks
 REGR_R2(tbl.int_col, tbl.int_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_R2(ALL tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_R2(DISTINCT tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_R2(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
 DOUBLE;
 
 # dialect: snowflake
@@ -4409,6 +4461,18 @@ DOUBLE;
 
 # dialect: databricks
 REGR_SLOPE(tbl.int_col, tbl.int_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_SLOPE(ALL tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_SLOPE(DISTINCT tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_SLOPE(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
 DOUBLE;
 
 # dialect: snowflake

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4259,6 +4259,14 @@ DOUBLE;
 REGR_AVGY(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
 
+# dialect: databricks
+REGR_AVGY(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_AVGY(tbl.int_col, tbl.int_col);
+DOUBLE;
+
 # dialect: snowflake
 REGR_COUNT(tbl.double_col, tbl.double_col);
 DOUBLE;
@@ -4274,6 +4282,14 @@ DOUBLE;
 # dialect: snowflake
 REGR_COUNT(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
+
+# dialect: databricks
+REGR_COUNT(tbl.double_col, tbl.double_col);
+BIGINT;
+
+# dialect: databricks
+REGR_COUNT(tbl.int_col, tbl.int_col);
+BIGINT;
 
 # dialect: snowflake
 REGR_INTERCEPT(tbl.double_col, tbl.double_col);
@@ -4291,6 +4307,14 @@ DOUBLE;
 REGR_INTERCEPT(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
 
+# dialect: databricks
+REGR_INTERCEPT(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_INTERCEPT(tbl.int_col, tbl.int_col);
+DOUBLE;
+
 # dialect: snowflake
 REGR_R2(tbl.double_col, tbl.double_col);
 DOUBLE;
@@ -4306,6 +4330,14 @@ DOUBLE;
 # dialect: snowflake
 REGR_R2(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
+
+# dialect: databricks
+REGR_R2(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_R2(tbl.int_col, tbl.int_col);
+DOUBLE;
 
 # dialect: snowflake
 REGR_SXX(tbl.double_col, tbl.double_col);
@@ -4370,6 +4402,14 @@ DOUBLE;
 # dialect: snowflake
 REGR_SLOPE(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
+
+# dialect: databricks
+REGR_SLOPE(tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
+REGR_SLOPE(tbl.int_col, tbl.int_col);
+DOUBLE;
 
 # dialect: snowflake
 REGR_VALX(NULL, 2.0);

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1052,6 +1052,10 @@ REGR_AVGX(ALL tbl.double_col, tbl.double_col);
 DOUBLE;
 
 # dialect: databricks
+REGR_AVGX(DISTINCT tbl.double_col, tbl.double_col);
+DOUBLE;
+
+# dialect: databricks
 REGR_AVGX(tbl.double_col, tbl.double_col) OVER (PARTITION BY 1);
 DOUBLE;
 
@@ -4246,10 +4250,6 @@ DOUBLE;
 # dialect: snowflake
 REGR_AVGX(tbl.decfloat_col, tbl.decfloat_col);
 DECFLOAT;
-
-# dialect: databricks
-REGR_AVGX(DISTINCT tbl.double_col, tbl.double_col);
-DOUBLE;
 
 # dialect: snowflake
 REGR_AVGY(tbl.double_col, tbl.double_col);


### PR DESCRIPTION
## Summary

Adds Databricks type inference support for REGR_AVGY (DOUBLE), REGR_COUNT (BIGINT), REGR_INTERCEPT (DOUBLE), REGR_R2 (DOUBLE), and REGR_SLOPE (DOUBLE), plus fixture coverage for all five functions.

**Issue:** REGR_FUNC(DISTINCT col1, col2) raised a parse error in Databricks because the base parser's DISTINCT handler consumed all comma-separated arguments into a single node, leaving the second required argument missing.

**Fix:** Added a custom parser method in DatabricksParser that reads only the first argument under DISTINCT, then parses the rest normally.

## Tickets
- RD-1229638 (REGR_AVGY) — DOUBLE
- RD-1229639 (REGR_COUNT) — BIGINT
- RD-1229640 (REGR_INTERCEPT) — DOUBLE
- RD-1229641 (REGR_R2) — DOUBLE
- RD-1229642 (REGR_SLOPE) — DOUBLE

## Test plan

```
python3 -c "import sqlglot; print(repr(sqlglot.parse_one('SELECT REGR_AVGY(DISTINCT tbl.double_col, tbl.double_col) FROM tbl', dialect='databricks').expressions[0]))"


RegrAvgy(
  this=Distinct(
    expressions=[
      Column(
        this=Identifier(this=double_col, quoted=False),
        table=Identifier(this=tbl, quoted=False))]),
  expression=Column(
    this=Identifier(this=double_col, quoted=False),
    table=Identifier(this=tbl, quoted=False))

```
- [ ] `make style` — PASS
- [ ] `make unit` — PASS