### PR TITLE
feat(typing)!: annotate str_to_map for hive-like dialects

### DIFF
--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -76,4 +76,5 @@ EXPRESSION_METADATA = {
     exp.If: {"annotator": lambda self, e: self._annotate_by_args(e, "true", "false", promote=True)},
     exp.Quantile: {"annotator": lambda self, e: self._annotate_by_args(e, "quantile")},
     exp.RegexpSplit: {"returns": exp.DataType.from_str("ARRAY<STRING>")},
+    exp.StrToMap: {"returns": exp.DataType.from_str("MAP<STRING, STRING>")},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1022,9 +1022,11 @@ STRING;
 # dialect: hive, spark2, spark, databricks
 GET_JSON_OBJECT('{"a":1}', '$.a');
 STRING;
+
 # dialect: hive, spark2, spark, databricks
 STR_TO_MAP('a:1,b:2', ',', ':');
 MAP<STRING, STRING>;
+
 # dialect: hive
 tbl.bigint DIV tbl.bigint;
 BIGINT; 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -1022,6 +1022,9 @@ STRING;
 # dialect: hive, spark2, spark, databricks
 GET_JSON_OBJECT('{"a":1}', '$.a');
 STRING;
+# dialect: hive, spark2, spark, databricks
+STR_TO_MAP('a:1,b:2', ',', ':');
+MAP<STRING, STRING>;
 # dialect: hive
 tbl.bigint DIV tbl.bigint;
 BIGINT; 


### PR DESCRIPTION
str_to_map() was returning UNKNOWN instead of MAP<STRING, STRING>.
Added StrToMap to hive.py using the same pattern as RegexpSplit.
Since Spark, Spark2, and Databricks inherit from Hive, all dialects
are fixed with one line. Added a fixture test for all 4 dialects.