### PR TITLE
perf(optimizer): memoize UNNEST/EXPLODE column-type resolution [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/resolver.py
+++ b/sqlglot/optimizer/resolver.py
@@ -30,6 +30,7 @@ class Resolver:
         self._all_columns: set[str] | None = None
         self._infer_schema: bool = infer_schema
         self._get_source_columns_cache: dict[tuple[str, bool], Sequence[str]] = {}
+        self._column_type_from_scope_cache: dict[tuple[int, str], exp.DataType | None] = {}
 
     def get_table(self, column: str | exp.Column) -> exp.Identifier | None:
         """
@@ -404,16 +405,28 @@ class Resolver:
         Returns:
             The DataType of the column, or None if not found.
         """
+        # A single source can be reachable through many paths of a scope DAG (e.g. a CTE
+        # referenced by several other CTEs). The schema and scope are immutable during
+        # qualification, so the type of `column` under `source` depends only on
+        # `(source, column name)`; memoize it to walk each source once.
+        cache_key = (id(source), column.name)
+        if cache_key in self._column_type_from_scope_cache:
+            return self._column_type_from_scope_cache[cache_key]
+
+        # None is a valid result if DataType could not be determined!
+        result: exp.DataType | None = None
         if isinstance(source, exp.Table):
             # base table - get the column type from schema
-            col_type: exp.DataType | None = self.schema.get_column_type(source, column)
+            col_type = self.schema.get_column_type(source, column)
             if col_type and not col_type.is_type(exp.DType.UNKNOWN):
-                return col_type
+                result = col_type
         elif isinstance(source, Scope):
             # iterate over all sources in the scope
-            for source_name, nested_source in source.sources.items():
-                col_type = self._get_column_type_from_scope(nested_source, column)
-                if col_type and not col_type.is_type(exp.DType.UNKNOWN):
-                    return col_type
+            for nested_source in source.sources.values():
+                nested_type = self._get_column_type_from_scope(nested_source, column)
+                if nested_type and not nested_type.is_type(exp.DType.UNKNOWN):
+                    result = nested_type
+                    break
 
-        return None
+        self._column_type_from_scope_cache[cache_key] = result
+        return result

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -741,6 +741,53 @@ class TestOptimizer(unittest.TestCase):
             "IN ((`produce`.`q1`, `produce`.`q2`) AS 'h1', (`produce`.`q3`, `produce`.`q4`) AS 'h2')) AS `produce`",
         )
 
+    def test_unnest_type_trace_is_memoized(self):
+        """Tracing an UNNEST's element type must not re-walk shared parts of the scope graph.
+
+        qualify resolves an unnested column's type by walking it back to a base table
+        (Resolver._get_column_type_from_scope). Each order_attrs_k joins order_attrs_{k-1}
+        back to the shared `orders` CTE, which does not hold `attrs`, so the walk cannot
+        short-circuit and revisits it through every path. Without memoization the trace is
+        called ~93k times at 12 levels; with it, ~90.
+        """
+        from sqlglot.optimizer import resolver as resolver_module
+
+        n_levels = 12
+        ctes = [
+            "order_attrs0 AS (SELECT id, [STRUCT('color' AS key, 'red' AS value)] AS attrs FROM orders)"
+        ]
+        for k in range(1, n_levels):
+            prev = f"order_attrs{k - 1}"
+            ctes.append(
+                f"order_attrs{k} AS (SELECT a.id AS id, "
+                f"array_concat(a.attrs, [STRUCT('size' AS key, 'large' AS value)]) AS attrs "
+                f"FROM {prev} AS a JOIN orders AS o ON a.id = o.id)"
+            )
+        ctes.append(
+            f"non_null_attrs AS (SELECT ARRAY(SELECT x FROM UNNEST(attrs) AS x "
+            f"WHERE NOT x.value IS NULL) AS attrs FROM order_attrs{n_levels - 1})"
+        )
+        sql = "WITH " + ", ".join(ctes) + " SELECT * FROM non_null_attrs"
+
+        original = resolver_module.Resolver._get_column_type_from_scope
+        with patch.object(
+            resolver_module.Resolver,
+            "_get_column_type_from_scope",
+            autospec=True,
+            side_effect=original,
+        ) as traced:
+            optimizer.qualify.qualify(
+                parse_one(sql, dialect="bigquery"),
+                schema={"orders": {"id": "INT64"}},
+                dialect="bigquery",
+            )
+
+        self.assertLess(
+            traced.call_count,
+            1000,
+            f"got {traced.call_count} trace calls -- memoization may be broken",
+        )
+
     def test_validate_columns(self):
         with self.assertRaisesRegex(
             OptimizeError, "Column 'foo' could not be resolved. Line: 1, Col: 10"


### PR DESCRIPTION
(Code by Claude, reviewed by me)

`Resolver._get_column_type_from_scope` resolves the element type of an unnested/exploded column by recursing over the sources of each scope. It had no memoization, so when the same CTE is reachable through several paths of the scope graph, its subtree was re-walked once per path. Qualifying a query whose CTEs reconverge on a shared upstream CTE was therefore exponential in the depth of the graph, for a single UNNEST/EXPLODE. On a real query this reached ~3.8M calls (~4s) into the trace.

The scope and schema are immutable during qualification, so the type of a column under a given source depends only on `(source, column name)`. Cache the result on that key so each source is walked once, which makes the trace roughly linear in the size of the scope graph. Qualified output is unchanged.

Verified on BigQuery `UNNEST(col)` and Claude tells me it's also reached by Spark/Hive `LATERAL VIEW EXPLODE(col)` (this part I did _not_ verify).

Closes #7821