### PR TITLE
Fix(presto)!: preserve SHA256/SHA512 digest semantics, render SHA2 as hex string [CLAUDE]

### DIFF
--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -16,7 +16,6 @@ from sqlglot.dialects.dialect import (
     regexp_extract_sql,
     rename_func,
     right_to_substring_sql,
-    sha256_sql,
     strposition_sql,
     struct_extract_sql,
     timestamptrunc_sql,
@@ -385,7 +384,6 @@ class PrestoGenerator(generator.Generator):
         exp.MD5Digest: rename_func("MD5"),
         exp.SHA: rename_func("SHA1"),
         exp.SHA1Digest: rename_func("SHA1"),
-        exp.SHA2: sha256_sql,
         exp.SHA2Digest: sha2_digest_sql,
         exp.Substring: rename_func("SUBSTR"),
     }
@@ -502,6 +500,23 @@ class PrestoGenerator(generator.Generator):
             this = exp.Encode(this=this, charset=exp.Literal.string("utf-8"))
 
         return self.func("LOWER", self.func("TO_HEX", self.func("MD5", self.sql(this))))
+
+    def sha2_sql(self, expression: exp.SHA2) -> str:
+        length = expression.text("length") or "256"
+        if length not in ("256", "512"):
+            self.unsupported(f"SHA{length} is not supported in Presto")
+
+        this = expression.this
+
+        if not this.type:
+            from sqlglot.optimizer.annotate_types import annotate_types
+
+            this = annotate_types(this, dialect=self.dialect)
+
+        if this.is_type(*exp.DataType.TEXT_TYPES):
+            this = exp.Encode(this=this, charset=exp.Literal.string("utf-8"))
+
+        return self.func("LOWER", self.func("TO_HEX", self.func(f"SHA{length}", self.sql(this))))
 
     def strtounix_sql(self, expression: exp.StrToUnix) -> str:
         # Since `TO_UNIXTIME` requires a `TIMESTAMP`, we need to parse the argument into one.

--- a/sqlglot/parsers/presto.py
+++ b/sqlglot/parsers/presto.py
@@ -129,8 +129,12 @@ class PrestoParser(parser.Parser):
             this=seq_get(args, 0), charset=exp.Literal.string("utf-8")
         ),
         "MD5": exp.MD5Digest.from_arg_list,
-        "SHA256": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(256)),
-        "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
+        "SHA256": lambda args: exp.SHA2Digest(
+            this=seq_get(args, 0), length=exp.Literal.number(256)
+        ),
+        "SHA512": lambda args: exp.SHA2Digest(
+            this=seq_get(args, 0), length=exp.Literal.number(512)
+        ),
         "WEEK": exp.WeekOfYear.from_arg_list,
     }
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1173,8 +1173,8 @@ LANGUAGE js AS
                 "clickhouse": "SHA512(x)",
                 "bigquery": "SHA512(x)",
                 "spark2": "SHA2(x, 512)",
-                "presto": "SHA512(x)",
-                "trino": "SHA512(x)",
+                "presto": "LOWER(TO_HEX(SHA512(x)))",
+                "trino": "LOWER(TO_HEX(SHA512(x)))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -754,8 +754,6 @@ class TestExasol(Validator):
             "HASH_SHA256(x)",
             read={
                 "clickhouse": "SHA256(x)",
-                "presto": "SHA256(x)",
-                "trino": "SHA256(x)",
                 "postgres": "SHA256(x)",
                 "duckdb": "SHA256(x)",
             },
@@ -765,9 +763,9 @@ class TestExasol(Validator):
                 "spark2": "SHA2(x, 256)",
                 "clickhouse": "SHA256(x)",
                 "postgres": "SHA256(x)",
-                "presto": "SHA256(x)",
+                "presto": "LOWER(TO_HEX(SHA256(x)))",
                 "redshift": "SHA2(x, 256)",
-                "trino": "SHA256(x)",
+                "trino": "LOWER(TO_HEX(SHA256(x)))",
                 "duckdb": "SHA256(x)",
                 "snowflake": "SHA2(x, 256)",
             },
@@ -776,16 +774,14 @@ class TestExasol(Validator):
             "HASH_SHA512(x)",
             read={
                 "clickhouse": "SHA512(x)",
-                "presto": "SHA512(x)",
-                "trino": "SHA512(x)",
             },
             write={
                 "exasol": "HASH_SHA512(x)",
                 "clickhouse": "SHA512(x)",
                 "bigquery": "SHA512(x)",
                 "spark2": "SHA2(x, 512)",
-                "presto": "SHA512(x)",
-                "trino": "SHA512(x)",
+                "presto": "LOWER(TO_HEX(SHA512(x)))",
+                "trino": "LOWER(TO_HEX(SHA512(x)))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -710,6 +710,47 @@ class TestPresto(Validator):
             "LOWER(TO_HEX(MD5(TO_UTF8(CONCAT(CAST(x AS VARCHAR), CAST('s' AS VARCHAR))))))",
         )
 
+        self.assertEqual(
+            exp.func("sha2", exp.cast("x", "text"), exp.Literal.number(256)).sql(dialect="presto"),
+            "LOWER(TO_HEX(SHA256(TO_UTF8(CAST(x AS VARCHAR)))))",
+        )
+
+        # native SHA256/SHA512 take and return VARBINARY, so they parse as
+        # SHA2Digest and round-trip untouched, mirroring MD5 -> MD5Digest
+        self.validate_all(
+            "SELECT SHA256(x)",
+            write={
+                "presto": "SELECT SHA256(x)",
+                "trino": "SELECT SHA256(x)",
+                "duckdb": "SELECT UNHEX(SHA256(x))",
+                "bigquery": "SELECT SHA256(x)",
+            },
+        )
+        self.validate_all(
+            "SELECT SHA512(x)",
+            write={
+                "presto": "SELECT SHA512(x)",
+                "trino": "SELECT SHA512(x)",
+                "bigquery": "SELECT SHA512(x)",
+            },
+        )
+
+        # string-semantics SHA2 renders hex output like md5_sql does for MD5
+        self.validate_all(
+            "SELECT SHA2(x, 256)",
+            write={
+                "presto": "SELECT LOWER(TO_HEX(SHA256(x)))",
+                "trino": "SELECT LOWER(TO_HEX(SHA256(x)))",
+            },
+        )
+        self.validate_all(
+            "SELECT SHA2(x, 512)",
+            write={
+                "presto": "SELECT LOWER(TO_HEX(SHA512(x)))",
+                "trino": "SELECT LOWER(TO_HEX(SHA512(x)))",
+            },
+        )
+
         with self.assertLogs(helper_logger):
             self.validate_all(
                 "SELECT COALESCE(ELEMENT_AT(MAP_FROM_ENTRIES(ARRAY[(51, '1')]), id), quantity) FROM my_table",


### PR DESCRIPTION
Presto and Trino's native `SHA256`/`SHA512` take and return `VARBINARY`, but the parser mapped them to `exp.SHA2`, the string-to-hex-string expression that MySQL and Spark use. The codebase already models this split with `exp.MD5` and `exp.MD5Digest`, and the presto parser maps native `MD5` to `MD5Digest` one line above the SHA mappings, so this looked like an oversight rather than a decision.

Two changes, both mirroring the MD5 precedent:

- The parser now maps native `SHA256`/`SHA512` to `exp.SHA2Digest`. Digests survive a round trip and transpile to other digest functions: Trino `SHA256(x)` becomes `UNHEX(SHA256(x))` in DuckDB and stays `SHA256(x)` in BigQuery, instead of silently turning into a hex-string function.
- The generator renders `exp.SHA2` the way `md5_sql` renders `exp.MD5`: `LOWER(TO_HEX(SHA256(TO_UTF8(x))))`, with the UTF8 encode applied when the argument is typed as text. Spark's `SHA2(x, 256)` now produces the same value on Trino that it produces on Spark. SHA224/SHA384 raise the usual unsupported warning since Presto has no equivalents.

Updated the bigquery and exasol expectations that encoded the old equivalence. Exasol's `HASH_SHA256` returns a hex string, so `LOWER(TO_HEX(SHA256(x)))` is the value-preserving translation there; its presto/trino read entries asserted that a digest function and a hex-string function were the same thing, which is the bug this fixes, so those two entries are removed.

Found while chasing a surrogate key mismatch in SQLMesh on Trino (TobikoData/sqlmesh#5871): MD5-based keys transpile correctly, SHA256-based keys silently change value.

One adjacent inconsistency deliberately left alone: the bigquery parser maps `SHA256` to `SHA2Digest` but `SHA512` to `SHA2`, while BigQuery returns `BYTES` for both. Happy to follow up separately if that is wanted.
