### PR TITLE
fix(generator): emit LIMIT 1 for countless FETCH FIRST ROWS ONLY CLAUDE

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3243,7 +3243,12 @@ class Generator:
         limit = expression.args.get("limit")
 
         if self.LIMIT_FETCH == "LIMIT" and isinstance(limit, exp.Fetch):
-            limit = exp.Limit(expression=exp.maybe_copy(limit.args.get("count")))
+            count = limit.args.get("count")
+            # "FETCH FIRST ROWS ONLY" without a count means one row per the SQL
+            # standard; emitting a bare "LIMIT" here would produce invalid SQL.
+            limit = exp.Limit(
+                expression=exp.maybe_copy(count) if count is not None else exp.Literal.number(1)
+            )
         elif self.LIMIT_FETCH == "FETCH" and isinstance(limit, exp.Limit):
             limit = exp.Fetch(direction="FIRST", count=exp.maybe_copy(limit.expression))
 

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -2746,6 +2746,48 @@ class TestDialect(Validator):
             "CAST(x AS DECIMAL) / NULLIF(y, 0)",
         )
 
+    def test_fetch_first_implicit_count(self):
+        # "FETCH FIRST ROWS ONLY" without an explicit count selects one row per
+        # the SQL standard. Dialects that render FETCH as LIMIT previously emitted
+        # a bare "LIMIT", which is invalid SQL and fails to re-parse.
+        self.validate_all(
+            "SELECT * FROM t FETCH FIRST ROWS ONLY",
+            write={
+                "postgres": "SELECT * FROM t FETCH FIRST ROWS ONLY",
+                "presto": "SELECT * FROM t FETCH FIRST ROWS ONLY",
+                "oracle": "SELECT * FROM t FETCH FIRST ROWS ONLY",
+                "mysql": "SELECT * FROM t LIMIT 1",
+                "sqlite": "SELECT * FROM t LIMIT 1",
+                "duckdb": "SELECT * FROM t LIMIT 1",
+                "bigquery": "SELECT * FROM t LIMIT 1",
+                "spark": "SELECT * FROM t LIMIT 1",
+                "hive": "SELECT * FROM t LIMIT 1",
+                "redshift": "SELECT * FROM t LIMIT 1",
+                "starrocks": "SELECT * FROM t LIMIT 1",
+                "doris": "SELECT * FROM t LIMIT 1",
+            },
+        )
+
+        # An explicit count must be preserved, not defaulted to one.
+        self.validate_all(
+            "SELECT * FROM t FETCH FIRST 10 ROWS ONLY",
+            write={
+                "mysql": "SELECT * FROM t LIMIT 10",
+                "oracle": "SELECT * FROM t FETCH FIRST 10 ROWS ONLY",
+            },
+        )
+
+        # The generated SQL must round-trip (be re-parseable and idempotent) in
+        # every LIMIT-based dialect.
+        for dialect in ("mysql", "sqlite", "duckdb", "bigquery", "spark", "redshift"):
+            with self.subTest(dialect=dialect):
+                once = parse_one("SELECT * FROM t FETCH FIRST ROWS ONLY", read=dialect).sql(
+                    dialect=dialect
+                )
+                self.assertEqual(once, "SELECT * FROM t LIMIT 1")
+                twice = parse_one(once, read=dialect).sql(dialect=dialect)
+                self.assertEqual(once, twice)
+
     def test_limit(self):
         self.validate_identity("WITH t AS (SELECT 1 AS all) SELECT 1 FROM t LIMIT all")
         self.validate_all(


### PR DESCRIPTION
### Problem

When a dialect renders `FETCH` as `LIMIT` (`LIMIT_FETCH == "LIMIT"`), a `FETCH`
clause with no explicit count is converted to a bare `exp.Limit` with no
expression. `FETCH FIRST ROWS ONLY` (no number) is valid SQL and selects one
row per the SQL standard, but the generated output is invalid and no longer
re-parses:

```python
>>> import sqlglot
>>> sqlglot.transpile("SELECT * FROM t FETCH FIRST ROWS ONLY", read="oracle", write="mysql")
['SELECT * FROM t LIMIT']          # invalid SQL
```

This affects every LIMIT-based dialect: mysql, sqlite, duckdb, bigquery, spark,
hive, redshift, starrocks, doris.

### Fix

Default the count to `1` when it is absent, matching the SQL-standard meaning of
a countless `FETCH FIRST ROWS ONLY`. An explicit count is still preserved
unchanged.

### Tests

`test_fetch_first_implicit_count` validates the countless case across the FETCH
dialects (which keep `FETCH FIRST ROWS ONLY`) and the LIMIT dialects (which now
emit `LIMIT 1`), checks that an explicit count is preserved, and round-trips the
generated SQL for idempotence in each LIMIT dialect.

`pytest tests/dialects/ tests/test_generator.py tests/test_expressions.py` →
818 passed, 11196 subtests passed. `ruff check` / `ruff format --check` clean.
