### PR TITLE
fix(lineage): handle columns named true/false/null behind a PIVOT alias

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -425,7 +425,15 @@ def to_node(
         elif pivot and pivot.alias_or_name == c.table:
             downstream_columns = []
 
-            column_name = c.name
+            column_this = c.this
+            if isinstance(column_this, (exp.Boolean, exp.Null)):
+                # A column literally named "true", "false" or "null" parses as a keyword
+                # literal instead of an identifier, so recover its identifier form
+                column_this = normalize_identifiers.normalize_identifiers(
+                    exp.to_identifier(column_this.sql().lower()), dialect=dialect
+                )
+
+            column_name = column_this.name
             if column_name in pivot_column_mapping:
                 downstream_columns.extend(pivot_column_mapping[column_name])
             else:
@@ -434,7 +442,7 @@ def to_node(
                 pivot_parent = pivot.parent
                 downstream_columns.append(
                     exp.column(
-                        pivot_renames.get(c.name, c.this),
+                        pivot_renames.get(column_name, column_this),
                         table=pivot_parent.alias_or_name if pivot_parent else None,
                     )
                 )

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -685,6 +685,28 @@ class TestLineage(unittest.TestCase):
         self.assertEqual(node.downstream[0].reference_node_name, "t")
         self.assertEqual(node.downstream[0].downstream[0].name, "quarterly_sales.empid")
 
+    def test_pivot_with_implicit_column_named_like_a_literal(self) -> None:
+        sql = """
+        SELECT p.true AS true_count, p.a
+        FROM loans PIVOT (SUM(loan_id) FOR product IN ('a', 'b')) AS p
+        """
+        schema = {"loans": {"loan_id": "int", "product": "varchar", "true": "boolean"}}
+
+        node = lineage("true_count", sql, schema=schema, dialect="duckdb")
+        self.assertEqual([d.name for d in node.downstream], ["loans.true"])
+
+        node = lineage("true_count", sql, schema=schema, dialect="snowflake")
+        self.assertEqual([d.name for d in node.downstream], ["LOANS.TRUE"])
+
+        sql = """
+        SELECT p.null AS null_count, p.a
+        FROM loans PIVOT (SUM(loan_id) FOR product IN ('a', 'b')) AS p
+        """
+        schema = {"loans": {"loan_id": "int", "product": "varchar", "null": "boolean"}}
+
+        node = lineage("null_count", sql, schema=schema, dialect="duckdb")
+        self.assertEqual([d.name for d in node.downstream], ["loans.null"])
+
     def test_unpivot(self) -> None:
         sql = """
         SELECT id, metric_name, score


### PR DESCRIPTION
# Description

`lineage()` crashes when a query references a column literally named `true`, `false` or `null` through a PIVOT alias.
The parser turns these names into boolean/null literals instead of identifiers, and the pivot branch of `to_node()` passes that raw node into `exp.column()`

```py
from sqlglot.lineage import lineage

sql = """
SELECT p.true AS true_count
FROM loans PIVOT (SUM(loan_id) FOR product IN ('a', 'b')) AS p
"""
schema = {"loans": {"loan_id": "int", "product": "varchar", "true": "boolean"}}

lineage("true_count", sql, schema=schema, dialect="snowflake")
# ValueError: Name needs to be a string or an Identifier, got: <class 'sqlglot.expressions.core.Boolean'>
```

Reproduces on snowflake, databricks, bigquery and duckdb. A schema must be passed to reach it.
Related: this is the column-argument sibling of #5354.
#5363 fixed the `table=` argument of the same `exp.column()` call.

## The fix

Recover the identifier form (dialect-normalized, same as `lineage()` already does for the target column name)
and use the recovered name for the pivot column-mapping lookups.
Regular columns take the exact same path as before.

Note: these column names still fail earlier in `qualify` when there's no pivot (or the pivot source is a CTE/subquery)
pre-existing and unrelated to this crash.

**An LLM helped me with this fix, I reviewed and tested every line and take full responsibility for it.**