### PR TITLE
Fix(bigquery)!: map native SHA512 to SHA2Digest, mirroring SHA256 [CLAUDE]

### DIFF
--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -24,7 +24,6 @@ from sqlglot.dialects.dialect import (
     unit_to_str,
     sequence_sql,
     explode_to_unnest_sql,
-    sha2_digest_sql,
 )
 from sqlglot.dialects.hive import Hive
 from sqlglot.generator import unsupported_args
@@ -32,6 +31,19 @@ from sqlglot.optimizer.scope import find_all_in_scope
 from sqlglot.transforms import unqualify_columns
 
 DATE_ADD_OR_SUB = t.Union[exp.DateAdd, exp.TimestampAdd, exp.DateSub]
+
+
+def _sha2_digest_sql(self: PrestoGenerator, expression: exp.SHA2Digest) -> str:
+    length = expression.text("length") or "256"
+    if length not in ("256", "512"):
+        self.unsupported(f"SHA{length} is not supported in Presto")
+
+    this = expression.this
+    if this.is_type(*exp.DataType.TEXT_TYPES):
+        # the native digest takes VARBINARY, so a text-typed argument needs encoding
+        this = exp.Encode(this=this, charset=exp.Literal.string("utf-8"))
+
+    return self.func(f"SHA{length}", this)
 
 
 def _initcap_sql(self: PrestoGenerator, expression: exp.Initcap) -> str:
@@ -384,7 +396,7 @@ class PrestoGenerator(generator.Generator):
         exp.MD5Digest: rename_func("MD5"),
         exp.SHA: rename_func("SHA1"),
         exp.SHA1Digest: rename_func("SHA1"),
-        exp.SHA2Digest: sha2_digest_sql,
+        exp.SHA2Digest: _sha2_digest_sql,
         exp.Substring: rename_func("SUBSTR"),
     }
 

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -270,7 +270,9 @@ class BigQueryParser(parser.Parser):
         "SHA256": lambda args: exp.SHA2Digest(
             this=seq_get(args, 0), length=exp.Literal.number(256)
         ),
-        "SHA512": lambda args: exp.SHA2(this=seq_get(args, 0), length=exp.Literal.number(512)),
+        "SHA512": lambda args: exp.SHA2Digest(
+            this=seq_get(args, 0), length=exp.Literal.number(512)
+        ),
         "SIMILARITY": exp.AISimilarity.from_arg_list,
         "SPLIT": lambda args: exp.Split(
             # https://cloud.google.com/bigquery/docs/reference/standard-sql/string_functions#split

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -27,7 +27,7 @@ class TestBigQuery(Validator):
         # Presto's SHA512 takes VARBINARY, so annotated string args are wrapped in TO_UTF8
         expr = self.parse_one("SELECT SHA512('foo')")
         annotated = annotate_types(expr, dialect="bigquery")
-        self.assertEqual(annotated.sql("presto"), "SELECT LOWER(TO_HEX(SHA512(TO_UTF8('foo'))))")
+        self.assertEqual(annotated.sql("presto"), "SELECT SHA512(TO_UTF8('foo'))")
 
         self.validate_identity(
             "SELECT 'foo' 'bar'",
@@ -1181,8 +1181,8 @@ LANGUAGE js AS
                 "clickhouse": "SHA512(x)",
                 "bigquery": "SHA512(x)",
                 "spark2": "SHA2(x, 512)",
-                "presto": "LOWER(TO_HEX(SHA512(x)))",
-                "trino": "LOWER(TO_HEX(SHA512(x)))",
+                "presto": "SHA512(x)",
+                "trino": "SHA512(x)",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Follow-up agreed in #7824: the bigquery parser mapped `SHA256` to `exp.SHA2Digest` but `SHA512` to `exp.SHA2`, while BigQuery returns BYTES for both.

Changes:

- The bigquery parser now maps native `SHA512` to `exp.SHA2Digest`, mirroring the `SHA256` line above it.
- Presto/Trino render `exp.SHA2Digest` through a dialect-specific function that encodes text-typed arguments (`SHA512(TO_UTF8(x))`), since the native digests take VARBINARY. Same convention as `sha2_sql` after the #7824 review: `is_type` only, type inference is assumed to have run separately. Unsupported lengths raise the usual warning.
- Clickhouse already wires `exp.SHA2Digest` on main, so BYTES semantics survive there with no change.

Test updates in test_bigquery.py:

- The annotated-types test now expects `SELECT SHA512(TO_UTF8('foo'))` on presto: BigQuery's SHA512 returns BYTES, so digest-to-digest is the value-preserving translation rather than the hex-string form.
- The SHA512 write block's presto/trino entries move to `SHA512(x)` for the same reason; spark2/clickhouse/bigquery entries are unchanged.

DuckDB renders 512-bit digests as `UNHEX(SHA256(x))` behind the existing "only supports SHA256" unsupported-warning; that fallback predates this change and is left as is.

Full dialect suite: 742 passed, 11174 subtests.
