### PR TITLE
fix(tsql): parse EXEC return status parameter (CLAUDE)

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -432,7 +432,7 @@ class NextValueFor(Expression, Func):
 
 
 class Execute(Expression):
-    arg_types = {"this": True, "expressions": False}
+    arg_types = {"this": True, "expressions": False, "return_status": False}
 
     @property
     def name(self) -> str:

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -640,7 +640,9 @@ class TSQLGenerator(generator.Generator):
         this = self.sql(expression, "this")
         expressions = self.expressions(expression)
         expressions = f" {expressions}" if expressions else ""
-        return f"EXECUTE {this}{expressions}"
+        return_status = self.sql(expression, "return_status")
+        return_status = f"{return_status} = " if return_status else ""
+        return f"EXECUTE {return_status}{this}{expressions}"
 
     def executesql_sql(self, expression: exp.ExecuteSql) -> str:
         return self.execute_sql(expression)

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -451,10 +451,20 @@ class TSQLParser(parser.Parser):
     }
 
     def _parse_execute(self) -> exp.Execute:
+        return_status = None
+        index = self._index
+        if self._match(TokenType.PARAMETER):
+            param = self._parse_parameter()
+            if self._match(TokenType.EQ):
+                return_status = param
+            else:
+                self._retreat(index)
+
         execute = self.expression(
             exp.Execute(
                 this=self._parse_table(schema=True),
                 expressions=self._parse_csv(self._parse_expression),
+                return_status=return_status,
             )
         )
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -33,6 +33,11 @@ class TestTSQL(Validator):
             "EXEC MyProc @id = 7, @name = 'Lochristi'",
             "EXECUTE MyProc @id = 7, @name = 'Lochristi'",
         )
+        self.validate_identity("EXECUTE @return_status = dbo.MyProc @a, @b")
+        self.validate_identity(
+            "EXEC @RC = dbo.MyProc @id = 7",
+            "EXECUTE @RC = dbo.MyProc @id = 7",
+        )
         self.validate_identity("SELECT TRIM('     test    ') AS Result")
         self.validate_identity("SELECT TRIM('.,! ' FROM '     #     test    .') AS Result")
         self.validate_identity("SELECT * FROM t TABLESAMPLE (10 PERCENT)")


### PR DESCRIPTION
Fixes #7834

T-SQL `EXECUTE`/`EXEC` allows capturing a procedure's return status: `EXEC @return_status = dbo.MyProc @a, @b`. `_parse_execute` parsed the first token as the procedure name via `_parse_table`, so `@return_status` was taken as the target and the following `=` raised `ParseError: Required keyword: 'this' missing for EQ`.

This optionally consumes a leading `@param =` as the return-status target before parsing the procedure. If a parameter is present but not followed by `=`, the parser retreats so the existing `EXEC @param` forms are unaffected. The new `return_status` arg is emitted by the T-SQL generator, so the statement round-trips.

Verified round-trips (and that the plain forms are unchanged):

```
EXEC @RC = dbo.MyProc @a, @b        -> EXECUTE @RC = dbo.MyProc @a, @b
EXECUTE @return_status = dbo.MyProc -> EXECUTE @return_status = dbo.MyProc
EXEC dbo.MyProc @a, @b              -> EXECUTE dbo.MyProc @a, @b
EXEC sp_executesql @stmt           -> EXECUTE sp_executesql @stmt
```

`tests/dialects/test_tsql.py` and `tests/test_parser.py` / `tests/test_generator.py` pass.
