### PR TITLE
fix(spark): parse SQL scripting compound blocks

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2105,7 +2105,7 @@ class StoredProcedure(Expression):
 
 
 class Block(Expression):
-    arg_types = {"expressions": True}
+    arg_types = {"expressions": True, "wrapped": False}
 
 
 class IfBlock(Expression):

--- a/sqlglot/generators/spark.py
+++ b/sqlglot/generators/spark.py
@@ -186,6 +186,10 @@ class SparkGenerator(Spark2Generator):
         parquet_file = expression.expressions[0]
         return f"parquet.`{parquet_file.name}`"
 
+    def block_sql(self, expression: exp.Block) -> str:
+        sql = super().block_sql(expression)
+        return f"BEGIN {sql}" if expression.args.get("wrapped") else sql
+
     def ifblock_sql(self, expression: exp.IfBlock) -> str:
         condition = expression.this
         true_block = expression.args.get("true")

--- a/sqlglot/parsers/spark.py
+++ b/sqlglot/parsers/spark.py
@@ -123,8 +123,14 @@ class SparkParser(Spark2Parser):
 
     STATEMENT_PARSERS = {
         **Spark2Parser.STATEMENT_PARSERS,
+        TokenType.BEGIN: lambda self: self._parse_scripting_block(),
         TokenType.DECLARE: lambda self: self._parse_declare(),
     }
+
+    def _parse_scripting_block(self) -> exp.Block:
+        block = self._parse_block()
+        block.set("wrapped", True)
+        return block
 
     def _parse_generated_as_identity(
         self,

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -9,6 +9,17 @@ from tests.dialects.test_dialect import Validator
 class TestSpark(Validator):
     dialect = "spark"
 
+    def test_sql_scripting(self):
+        self.validate_identity(
+            """
+            BEGIN
+              SELECT 1;
+              SELECT 2;
+            END;
+            """,
+            "BEGIN SELECT 1; SELECT 2; END",
+        ).assert_is(exp.Block)
+
     def test_ddl(self):
         self.validate_identity("DAYOFWEEK(TO_DATE(x))")
         self.validate_identity("DAYOFMONTH(TO_DATE(x))")


### PR DESCRIPTION
This is a proposed fix to https://github.com/tobymao/sqlglot/issues/7838. I appreciate that this does not fundamentally fix the underlying lack of mature support for imperative SQL. However, it does allow SQL script blocks to roundtrip. I can also understand that this doesn't _really_ solve the issue for transpiling between dialects which is a core `sqlglot` functionality. So based on that please feel free to close - I figured the approach _might_ spark some idea in someone else.