### PR TITLE
Fix(parser)!: delimited text incorrectly consumed by `_match_text*`

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -37,6 +37,10 @@ logger = logging.getLogger("sqlglot")
 
 OPTIONS_TYPE = dict[str, Sequence[t.Union[Sequence[str], str]]]
 
+# Excludes bare strings, which are also collections of strings, so that a single keyword
+# can't accidentally be matched with substring semantics (e.g. _match_texts("FOO"))
+TEXTS_TYPE = t.Union[tuple[str, ...], list[str], t.AbstractSet[str], t.Mapping[str, t.Any]]
+
 # Used to detect alphabetical characters and +/- in timestamp literals
 TIME_ZONE_RE: Pattern[str] = re.compile(r":.*?[a-zA-Z\+\-]")
 
@@ -614,6 +618,22 @@ class Parser:
         *Tokenizer.SINGLE_TOKENS.values(),
         TokenType.SELECT,
     } - {TokenType.IDENTIFIER}
+
+    # Tokens whose text is extracted from delimited source text (e.g. quoted identifiers,
+    # string literals), so they must never be treated as keywords when matching by text
+    TEXT_MATCH_EXCLUDED_TOKENS: t.ClassVar[frozenset] = frozenset(
+        {
+            TokenType.BIT_STRING,
+            TokenType.BYTE_STRING,
+            TokenType.HEREDOC_STRING,
+            TokenType.HEX_STRING,
+            TokenType.IDENTIFIER,
+            TokenType.NATIONAL_STRING,
+            TokenType.RAW_STRING,
+            TokenType.STRING,
+            TokenType.UNICODE_STRING,
+        }
+    )
 
     DB_CREATABLES: t.ClassVar = {
         TokenType.DATABASE,
@@ -1955,8 +1975,11 @@ class Parser:
             return True
         return False
 
-    def _match_texts(self, texts: t.Collection[str], advance: bool = True) -> bool:
-        if self._curr.token_type != TokenType.STRING and self._curr.text.upper() in texts:
+    def _match_texts(self, texts: TEXTS_TYPE, advance: bool = True) -> bool:
+        if (
+            self._curr.token_type not in self.TEXT_MATCH_EXCLUDED_TOKENS
+            and self._curr.text.upper() in texts
+        ):
             if advance:
                 self._advance()
             return True
@@ -1964,9 +1987,9 @@ class Parser:
 
     def _match_text_seq(self, *texts: str, advance: bool = True) -> bool:
         index = self._index
-        string_type = TokenType.STRING
+        excluded_tokens = self.TEXT_MATCH_EXCLUDED_TOKENS
         for text in texts:
-            if self._curr.token_type != string_type and self._curr.text.upper() == text:
+            if self._curr.token_type not in excluded_tokens and self._curr.text.upper() == text:
                 self._advance()
             else:
                 self._retreat(index)
@@ -7492,9 +7515,7 @@ class Parser:
 
         return constraints
 
-    def _parse_unnamed_constraint(
-        self, constraints: t.Collection[str] | None = None
-    ) -> exp.Expr | None:
+    def _parse_unnamed_constraint(self, constraints: TEXTS_TYPE | None = None) -> exp.Expr | None:
         index = self._index
 
         if self._match(TokenType.IDENTIFIER, advance=False) or not self._match_texts(
@@ -9067,7 +9088,7 @@ class Parser:
         elif self._match(TokenType.FOR):
             if self._match_text_seq("ALL", "COLUMNS"):
                 this = "FOR ALL COLUMNS"
-            if self._match_texts("COLUMNS"):
+            if self._match_text_seq("COLUMNS"):
                 this = "FOR COLUMNS"
                 expressions = self._parse_csv(self._parse_column_reference)
         elif self._match_text_seq("SAMPLE"):
@@ -9297,7 +9318,9 @@ class Parser:
             return None
 
         option = start.text.upper()
-        continuations = options.get(option)
+        continuations = (
+            None if start.token_type in self.TEXT_MATCH_EXCLUDED_TOKENS else options.get(option)
+        )
 
         index = self._index
         self._advance()

--- a/sqlglot/parsers/exasol.py
+++ b/sqlglot/parsers/exasol.py
@@ -153,7 +153,7 @@ class ExasolParser(parser.Parser):
 
         expression = exp.JSONExtract(expressions=args)
 
-        if self._match_texts("EMITS"):
+        if self._match_text_seq("EMITS"):
             expression.set("emits", self._parse_schema())
 
         return expression

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -1393,10 +1393,10 @@ class SnowflakeParser(parser.Parser):
 
     def _parse_window(self, this: exp.Expr | None, alias: bool = False) -> exp.Expr | None:
         if isinstance(this, exp.NthValue):
-            if self._match_text_seq("FROM"):
-                if self._match_texts(("FIRST", "LAST")):
-                    from_first = self._prev.text.upper() == "FIRST"
-                    this.set("from_first", from_first)
+            if self._match_text_seq("FROM", "FIRST"):
+                this.set("from_first", True)
+            elif self._match_text_seq("FROM", "LAST"):
+                this.set("from_first", False)
 
         result = super()._parse_window(this, alias)
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -910,6 +910,10 @@ class TestExasol(Validator):
         self.validate_identity(
             """SELECT JSON_EXTRACT('{"firstname" : "Ann", "surname" : "Smith", "age" : 29}', '$.firstname', '$.surname', '$.age') EMITS (firstname VARCHAR(100), surname VARCHAR(100), age INT)"""
         )
+        self.validate_identity(
+            "SELECT JSON_EXTRACT(x, '$.a') s FROM t",
+            "SELECT JSON_EXTRACT(x, '$.a') AS s FROM t",
+        )
 
     def test_group_by_all(self):
         self.validate_all(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1525,6 +1525,9 @@ class TestSnowflake(Validator):
             },
         )
 
+        # FROM here is the query's FROM clause, not the FROM FIRST | LAST modifier
+        self.validate_identity("SELECT NTH_VALUE(a, 2) FROM t")
+
         # NTH_VALUE FROM FIRST not supported in DuckDB
         self.validate_all(
             "SELECT NTH_VALUE(is_deleted, 2) FROM FIRST IGNORE NULLS OVER (PARTITION BY id) AS nth_is_deleted FROM my_table",

--- a/tests/fixtures/identity.sql
+++ b/tests/fixtures/identity.sql
@@ -953,3 +953,27 @@ SELECT UNIFORM(1, 10)
 SELECT CURRENT_TIMEZONE()
 SELECT NUMRANGE(1.1, 2.2) -|- NUMRANGE(2.2, 3.3)
 CREATE TABLE t (a VARCHAR, check INT)
+CREATE TABLE "if" (x INT)
+DROP TABLE "if"
+SELECT TRIM("both") FROM t
+"while"
+DROP INDEX "concurrently"
+CREATE INDEX "concurrently" ON t(x)
+CREATE TABLE t AS "minvalue"
+CREATE TABLE t AS "increment"
+CREATE TABLE t AS "start"
+CREATE TABLE t AS "cache"
+CREATE TABLE t AS "sample"
+DESCRIBE "history"
+SELECT * FROM t CONNECT BY "nocycle" = 1
+SELECT a BETWEEN "symmetric" AND b FROM t
+SELECT JSON_OBJECT("key": 1)
+SELECT JSON_OBJECT('a': "value")
+CREATE INDEX i ON t(c "nulls")
+GRANT SELECT ON TABLE t TO "role"
+ANALYZE "verbose"
+ANALYZE "tables"
+ANALYZE "database"
+CREATE TABLE t (a INT, UNIQUE "key" (a))
+USE "role"
+SELECT MATCH("table") AGAINST('x') FROM t

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -109,6 +109,108 @@ class TestParser(unittest.TestCase):
         self.assertIsInstance(cast.this, exp.Column)
         self.assertEqual(cast.this.name, "current_user")
 
+    def test_text_match_excludes_delimited_tokens(self):
+        # Tokens whose delimiters are stripped during tokenization (quoted identifiers,
+        # heredoc/national strings, etc.) must not be matched as keywords by text.
+        # Base-dialect roundtrip cases live in identity.sql; these are the dialect-specific
+        # and non-roundtripping ones
+        for dialect, sql, expected in [
+            ("postgres", "SELECT TRIM($$leading$$)", "SELECT TRIM('leading')"),
+            ("tsql", "SELECT TRIM(N'both')", "SELECT TRIM(N'both')"),
+            ("postgres", 'SELECT TRIM("leading" FROM x)', 'SELECT TRIM("leading" FROM x)'),
+            ("mysql", "INSERT `local` (a) VALUES (1)", "INSERT INTO `local` (a) VALUES (1)"),
+            (
+                "mysql",
+                "INSERT `directory` (a) VALUES (1)",
+                "INSERT INTO `directory` (a) VALUES (1)",
+            ),
+            ("mysql", "SELECT `high_priority` FROM t", "SELECT `high_priority` FROM t"),
+            ("postgres", 'SELECT * INTO "unlogged" FROM t', 'SELECT * INTO "unlogged" FROM t'),
+            (
+                "oracle",
+                'SELECT XMLELEMENT("name", x) FROM t',
+                'SELECT XMLELEMENT(NAME "name", x) FROM t',
+            ),
+            (
+                "postgres",
+                'SELECT c::INT "unsigned" FROM t',
+                'SELECT CAST(c AS INT) AS "unsigned" FROM t',
+            ),
+            (
+                "oracle",
+                "SELECT INTERVAL '1' DAY \"to\" FROM t",
+                "SELECT INTERVAL '1' DAY AS \"to\" FROM t",
+            ),
+            (
+                "clickhouse",
+                "CREATE TABLE t (j JSON(`skip` String))",
+                'CREATE TABLE t (j JSON("skip" String))',
+            ),
+            (
+                "clickhouse",
+                'ALTER TABLE t DROP PARTITION "id"',
+                'ALTER TABLE t DROP PARTITION "id"',
+            ),
+            ("databricks", "DECLARE `var` INT", "DECLARE `var` INT"),
+            (
+                "redshift",
+                'ALTER TABLE t ALTER "sortkey" TYPE INT',
+                'ALTER TABLE t ALTER COLUMN "sortkey" TYPE INTEGER',
+            ),
+            (
+                "duckdb",
+                'ALTER TABLE t ADD "columns" INT',
+                'ALTER TABLE t ADD COLUMN "columns" INT',
+            ),
+            (
+                "postgres",
+                'ALTER TABLE "only" ADD COLUMN x INT',
+                'ALTER TABLE "only" ADD COLUMN x INT',
+            ),
+            ("duckdb", 'SELECT MAX("lambda") FROM t', 'SELECT MAX("lambda") FROM t'),
+            ("duckdb", 'CREATE MACRO m() AS "return"', 'CREATE MACRO m() AS "return"'),
+            ("mysql", "ALTER TABLE t RENAME `index`", "ALTER TABLE t RENAME `index`"),
+            (
+                "mysql",
+                "CREATE TABLE t (x TEXT, FULLTEXT `index` (x))",
+                "CREATE TABLE t (x TEXT, FULLTEXT INDEX `index` (x))",
+            ),
+            ("mysql", "SHOW CREATE TABLE `json`", "SHOW CREATE TABLE `json`"),
+            (
+                "snowflake",
+                'WITH "identifier" (c) AS (SELECT 1) SELECT c FROM "identifier"',
+                'WITH "identifier"(c) AS (SELECT 1) SELECT c FROM "identifier"',
+            ),
+            (
+                "snowflake",
+                'SELECT * FROM t AS "identifier"(a, b)',
+                'SELECT * FROM t AS "identifier"(a, b)',
+            ),
+            (
+                "bigquery",
+                "SELECT ML.PREDICT(MODEL m, `table`)",
+                "SELECT ML.PREDICT(MODEL m, TABLE `table`)",
+            ),
+            (
+                "spark",
+                "ALTER TABLE t CHANGE COLUMN a `type` INT",
+                "ALTER TABLE t RENAME COLUMN a TO `type`",
+            ),
+            (
+                "exasol",
+                "SELECT JSON_EXTRACT(x, '$.a') \"emits\" FROM t",
+                "SELECT JSON_EXTRACT(x, '$.a') AS \"emits\" FROM t",
+            ),
+            ("trino", "SELECT U&'abc' \"uescape\"", "SELECT U&'abc' AS \"uescape\""),
+            (
+                "snowflake",
+                'SELECT * FROM t MATCH_RECOGNIZE(MEASURES "final" AS f PATTERN (a) DEFINE a AS TRUE)',
+                'SELECT * FROM t MATCH_RECOGNIZE ( MEASURES "final" AS f PATTERN (a) DEFINE a AS TRUE)',
+            ),
+        ]:
+            with self.subTest(f"{dialect}: {sql}"):
+                self.assertEqual(parse_one(sql, dialect=dialect).sql(dialect), expected)
+
     def test_tuple(self):
         parse_one("(a,)").assert_is(exp.Tuple)
 


### PR DESCRIPTION
This patch was motivated by this issue: https://github.com/tobymao/sqlglot/issues/7837, which was fixed [here](https://github.com/tobymao/sqlglot/commit/f37c71e762321625350f16c1c358e12e28fa6380).

I realized that the bug family is broader and not limited to `PROJECTION`, so I had Claude analyze the codebase and it seems like it did a good job, as the same flavor of the bug existed in many places that depended on `_match_texts` and `_match_text_seq`.
