### PR TITLE
fix(optimizer): incorrect merge with literal alias collision

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -202,9 +202,8 @@ def _mergeable(
         merged_sources.update(src for _, src in inner_scope.selected_sources.values())
         for source in merged_sources:
             if isinstance(source, exp.Table):
-                if schema is None:
-                    return True
-                if literal_grouped & set(schema.column_names(source)):
+                columns = schema.column_names(source) if schema else None
+                if not columns or literal_grouped & set(columns):
                     return True
             elif isinstance(source, Scope) and literal_grouped & set(
                 source.expression.named_selects

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -166,6 +166,36 @@ def _mergeable(
             for column in unmergable_window_columns
         )
 
+    def _literal_group_alias_collision():
+        """A numeric-literal projection in the outer GROUP BY merges to a bare `GROUP BY a`
+        that can collide with a same-named FROM column."""
+        group = outer_scope.expression.args.get("group")
+        if not group:
+            return False
+        # Only a bare top-level `GROUP BY <col>` key can hit the literal rewrite.
+        inner_name = from_or_join.alias_or_name
+        grouped = {
+            e.name for e in group.expressions if isinstance(e, exp.Column) and e.table == inner_name
+        }
+        if not grouped:
+            return False
+        literal_grouped = {
+            s.alias_or_name
+            for s in inner_select.selects
+            if s.alias_or_name in grouped and s.unalias().is_number
+        }
+        if not literal_grouped:
+            return False
+        # `GROUP BY a` resolves against the whole merged FROM: inner sources + outer's others.
+        merged_sources = [src for name, src in outer_scope.sources.items() if name != inner_name]
+        merged_sources.extend(inner_scope.sources.values())
+        for source in merged_sources:
+            if isinstance(source, exp.Table):
+                return True
+            if isinstance(source, Scope) and literal_grouped & set(source.expression.named_selects):
+                return True
+        return False
+
     def _outer_select_joins_on_inner_select_join():
         """
         All columns from the inner select in the ON clause must be from the first FROM table.

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -157,13 +157,6 @@ def _mergeable(
             and column.name in window_aliases
             and column.find_ancestor(exp.Group, exp.Order, exp.Having, exp.AggFunc)
             for column in outer_scope.columns
-            if column.find_ancestor(
-                exp.Where, exp.Group, exp.Order, exp.Join, exp.Having, exp.AggFunc
-            )
-        ]
-        return any(
-            column.table == inner_select_name and column.name in window_aliases
-            for column in unmergable_window_columns
         )
 
     def _literal_group_alias_collision():
@@ -282,6 +275,7 @@ def _mergeable(
         )
         and not _outer_select_joins_on_inner_select_join()
         and not _window_projection_blocks_merge()
+        and not _literal_group_alias_collision()
         and not _literal_in_order_by()
         and not _is_recursive()
         and not (inner_select.args.get("order") and outer_scope.is_union)

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from sqlglot import expressions as exp
 from sqlglot.helper import find_new_name, seq_get
 from sqlglot.optimizer.scope import Scope, traverse_scope
+from sqlglot.schema import Schema
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
@@ -14,7 +15,9 @@ if t.TYPE_CHECKING:
     FromOrJoin = t.Union[exp.From, exp.Join]
 
 
-def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
+def merge_subqueries(
+    expression: E, leave_tables_isolated: bool = False, schema: Schema | None = None
+) -> E:
     """
     Rewrite sqlglot AST to merge derived tables into the outer query.
 
@@ -37,11 +40,12 @@ def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
     Args:
         expression (sqlglot.Expr): expression to optimize
         leave_tables_isolated (bool):
+        schema: database schema used to look up table columns for merge-safety checks.
     Returns:
         sqlglot.Expr: optimized expression
     """
-    expression = merge_ctes(expression, leave_tables_isolated)
-    expression = merge_derived_tables(expression, leave_tables_isolated)
+    expression = merge_ctes(expression, leave_tables_isolated, schema=schema)
+    expression = merge_derived_tables(expression, leave_tables_isolated, schema=schema)
     return expression
 
 
@@ -67,7 +71,9 @@ SAFE_TO_REPLACE_UNWRAPPED = (
 )
 
 
-def merge_ctes(expression: E, leave_tables_isolated: bool = False) -> E:
+def merge_ctes(
+    expression: E, leave_tables_isolated: bool = False, schema: Schema | None = None
+) -> E:
     scopes = traverse_scope(expression)
 
     # All places where we select from CTEs.
@@ -89,7 +95,7 @@ def merge_ctes(expression: E, leave_tables_isolated: bool = False) -> E:
         from_or_join = table.find_ancestor(exp.From, exp.Join)
         if not isinstance(from_or_join, (exp.From, exp.Join)):
             continue
-        if _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join):
+        if _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join, schema=schema):
             alias = table.alias_or_name
             _rename_inner_sources(outer_scope, inner_scope, alias)
             _merge_from(
@@ -105,7 +111,9 @@ def merge_ctes(expression: E, leave_tables_isolated: bool = False) -> E:
     return expression
 
 
-def merge_derived_tables(expression: E, leave_tables_isolated: bool = False) -> E:
+def merge_derived_tables(
+    expression: E, leave_tables_isolated: bool = False, schema: Schema | None = None
+) -> E:
     for outer_scope in traverse_scope(expression):
         for subquery in outer_scope.derived_tables:
             from_or_join = subquery.find_ancestor(exp.From, exp.Join)
@@ -115,7 +123,9 @@ def merge_derived_tables(expression: E, leave_tables_isolated: bool = False) -> 
             inner_scope = outer_scope.sources[alias]
             if not isinstance(inner_scope, Scope):
                 continue
-            if _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join):
+            if _mergeable(
+                outer_scope, inner_scope, leave_tables_isolated, from_or_join, schema=schema
+            ):
                 _rename_inner_sources(outer_scope, inner_scope, alias)
                 _merge_from(outer_scope, inner_scope, subquery, alias)
                 _merge_expressions(outer_scope, inner_scope, alias)
@@ -129,7 +139,11 @@ def merge_derived_tables(expression: E, leave_tables_isolated: bool = False) -> 
 
 
 def _mergeable(
-    outer_scope: Scope, inner_scope: Scope, leave_tables_isolated: bool, from_or_join: FromOrJoin
+    outer_scope: Scope,
+    inner_scope: Scope,
+    leave_tables_isolated: bool,
+    from_or_join: FromOrJoin,
+    schema: Schema | None = None,
 ) -> bool:
     """
     Return True if `inner_select` can be merged into outer query.
@@ -165,10 +179,12 @@ def _mergeable(
         group = outer_scope.expression.args.get("group")
         if not group:
             return False
-        # Only a bare top-level `GROUP BY <col>` key can hit the literal rewrite.
         inner_name = from_or_join.alias_or_name
         grouped = {
-            e.name for e in group.expressions if isinstance(e, exp.Column) and e.table == inner_name
+            col.name
+            for e in group.expressions
+            for col in e.find_all(exp.Column)
+            if col.table == inner_name
         }
         if not grouped:
             return False
@@ -180,12 +196,19 @@ def _mergeable(
         if not literal_grouped:
             return False
         # `GROUP BY a` resolves against the whole merged FROM: inner sources + outer's others.
-        merged_sources = [src for name, src in outer_scope.sources.items() if name != inner_name]
-        merged_sources.extend(inner_scope.sources.values())
+        merged_sources = {
+            src for name, (_, src) in outer_scope.selected_sources.items() if name != inner_name
+        }
+        merged_sources.update(src for _, src in inner_scope.selected_sources.values())
         for source in merged_sources:
             if isinstance(source, exp.Table):
-                return True
-            if isinstance(source, Scope) and literal_grouped & set(source.expression.named_selects):
+                if schema is None:
+                    return True
+                if literal_grouped & set(schema.column_names(source)):
+                    return True
+            elif isinstance(source, Scope) and literal_grouped & set(
+                source.expression.named_selects
+            ):
                 return True
         return False
 

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -157,6 +157,13 @@ def _mergeable(
             and column.name in window_aliases
             and column.find_ancestor(exp.Group, exp.Order, exp.Having, exp.AggFunc)
             for column in outer_scope.columns
+            if column.find_ancestor(
+                exp.Where, exp.Group, exp.Order, exp.Join, exp.Having, exp.AggFunc
+            )
+        ]
+        return any(
+            column.table == inner_select_name and column.name in window_aliases
+            for column in unmergable_window_columns
         )
 
     def _outer_select_joins_on_inner_select_join():

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -7,7 +7,7 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import OptimizeError, highlight_sql
-from sqlglot.helper import seq_get
+from sqlglot.helper import find_new_name, seq_get
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
 from sqlglot.optimizer.scope import Scope, build_scope, traverse_scope, walk_in_scope
@@ -780,6 +780,23 @@ def _expand_stars(
     rename_columns: dict[int, dict[str, str]] = {}
     ilike_pattern: str | None = None
 
+    # Output names already used by this projection. When this scope feeds another
+    # query (a subquery/CTE), star-expanded columns that would collide (e.g. `id`
+    # from two joined tables that share the column) are aliased uniquely, so the
+    # outer query's by-name references address each column instead of collapsing
+    # onto the first. The outermost query keeps duplicate names since nothing
+    # references its output by name.
+    taken_names: set[str] = set()
+    uniquify_names = scope.parent is not None
+
+    def add_star_selection(selection: exp.Expr, output_name: str) -> None:
+        if uniquify_names and output_name and output_name in taken_names:
+            unique_name = find_new_name(taken_names, output_name)
+            selection = alias(selection.unalias(), unique_name, copy=False)
+            output_name = unique_name
+        taken_names.add(output_name)
+        new_selections.append(selection)
+
     coalesced_columns = set()
     dialect = resolver.dialect
 
@@ -825,10 +842,12 @@ def _expand_stars(
                         annotator.uncache(expression)
 
                     new_selections.extend(struct_fields)
+                    taken_names.update(field.output_name for field in struct_fields)
                     continue
 
         if not tables:
             new_selections.append(expression)
+            taken_names.add(expression.output_name)
             continue
 
         for table in tables:
@@ -863,11 +882,14 @@ def _expand_stars(
                 pivot_columns = pivot.output_columns(columns) or pivot.alias_column_names
 
                 if pivot_columns:
-                    new_selections.extend(
-                        alias(exp.column(name, table=pivot.alias or None), name, copy=False)
-                        for name in pivot_columns
-                        if name not in columns_to_exclude
-                    )
+                    for name in pivot_columns:
+                        if name not in columns_to_exclude:
+                            add_star_selection(
+                                alias(
+                                    exp.column(name, table=pivot.alias or None), name, copy=False
+                                ),
+                                name,
+                            )
                     continue
 
             for name in columns:
@@ -881,8 +903,8 @@ def _expand_stars(
                     using_tables = using_column_tables[name]
                     coalesce_args = [exp.column(name, table=table) for table in using_tables]
 
-                    new_selections.append(
-                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False)
+                    add_star_selection(
+                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False), name
                     )
                 else:
                     alias_ = renamed_columns.get(name, name)
@@ -893,10 +915,11 @@ def _expand_stars(
                     selection_expr = replaced_columns.get(name) or exp.column(
                         name, table=table, quoted=quoted
                     )
-                    new_selections.append(
+                    add_star_selection(
                         alias(selection_expr, alias_, copy=False)
                         if alias_ != name
-                        else selection_expr
+                        else selection_expr,
+                        alias_,
                     )
 
         if annotated_ahead:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -7,7 +7,7 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import OptimizeError, highlight_sql
-from sqlglot.helper import find_new_name, seq_get
+from sqlglot.helper import seq_get
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
 from sqlglot.optimizer.scope import Scope, build_scope, traverse_scope, walk_in_scope
@@ -780,23 +780,6 @@ def _expand_stars(
     rename_columns: dict[int, dict[str, str]] = {}
     ilike_pattern: str | None = None
 
-    # Output names already used by this projection. When this scope feeds another
-    # query (a subquery/CTE), star-expanded columns that would collide (e.g. `id`
-    # from two joined tables that share the column) are aliased uniquely, so the
-    # outer query's by-name references address each column instead of collapsing
-    # onto the first. The outermost query keeps duplicate names since nothing
-    # references its output by name.
-    taken_names: set[str] = set()
-    uniquify_names = scope.parent is not None
-
-    def add_star_selection(selection: exp.Expr, output_name: str) -> None:
-        if uniquify_names and output_name and output_name in taken_names:
-            unique_name = find_new_name(taken_names, output_name)
-            selection = alias(selection.unalias(), unique_name, copy=False)
-            output_name = unique_name
-        taken_names.add(output_name)
-        new_selections.append(selection)
-
     coalesced_columns = set()
     dialect = resolver.dialect
 
@@ -842,12 +825,10 @@ def _expand_stars(
                         annotator.uncache(expression)
 
                     new_selections.extend(struct_fields)
-                    taken_names.update(field.output_name for field in struct_fields)
                     continue
 
         if not tables:
             new_selections.append(expression)
-            taken_names.add(expression.output_name)
             continue
 
         for table in tables:
@@ -882,14 +863,11 @@ def _expand_stars(
                 pivot_columns = pivot.output_columns(columns) or pivot.alias_column_names
 
                 if pivot_columns:
-                    for name in pivot_columns:
-                        if name not in columns_to_exclude:
-                            add_star_selection(
-                                alias(
-                                    exp.column(name, table=pivot.alias or None), name, copy=False
-                                ),
-                                name,
-                            )
+                    new_selections.extend(
+                        alias(exp.column(name, table=pivot.alias or None), name, copy=False)
+                        for name in pivot_columns
+                        if name not in columns_to_exclude
+                    )
                     continue
 
             for name in columns:
@@ -903,8 +881,8 @@ def _expand_stars(
                     using_tables = using_column_tables[name]
                     coalesce_args = [exp.column(name, table=table) for table in using_tables]
 
-                    add_star_selection(
-                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False), name
+                    new_selections.append(
+                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False)
                     )
                 else:
                     alias_ = renamed_columns.get(name, name)
@@ -915,11 +893,10 @@ def _expand_stars(
                     selection_expr = replaced_columns.get(name) or exp.column(
                         name, table=table, quoted=quoted
                     )
-                    add_star_selection(
+                    new_selections.append(
                         alias(selection_expr, alias_, copy=False)
                         if alias_ != name
-                        else selection_expr,
-                        alias_,
+                        else selection_expr
                     )
 
         if annotated_ahead:

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -556,6 +556,11 @@ WITH c AS (SELECT DISTINCT x.a AS a, x.b AS b FROM x AS x) SELECT s.a AS a, SUM(
 WITH c AS (SELECT DISTINCT x.b AS b FROM x) SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM c) AS s CROSS JOIN x GROUP BY s.a ORDER BY s.a;
 WITH c AS (SELECT DISTINCT x.b AS b FROM x AS x) SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s CROSS JOIN x AS x GROUP BY s.a ORDER BY a;
 
+# title: Literal projection is not merged into GROUP BY when a joined table's schema is unknown
+# execute: false
+SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, y.b AS b FROM y) AS s CROSS JOIN unknown_tbl GROUP BY s.a ORDER BY s.a;
+SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, y.b AS b FROM y AS y) AS s CROSS JOIN unknown_tbl AS unknown_tbl GROUP BY s.a ORDER BY a;
+
 # title: Window function is not merged when the outer query filters its input rows
 SELECT s.w FROM (SELECT a, ROW_NUMBER() OVER (ORDER BY a) AS w FROM x) AS s WHERE s.a > 5;
 SELECT s.w AS w FROM (SELECT x.a AS a, ROW_NUMBER() OVER (ORDER BY x.a) AS w FROM x AS x) AS s WHERE s.a > 5;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -544,6 +544,14 @@ WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 
 WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a;
 WITH t1 AS (SELECT 1 AS col) SELECT 6 AS a, SUM(t1.col) AS b FROM t1 AS t1 GROUP BY a ORDER BY a;
 
+# title: Literal projection whose alias collides with a base-table column is not merged into GROUP BY
+SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY s.a ORDER BY s.a;
+SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY s.a ORDER BY a;
+
+# title: Literal projection colliding with an unmergeable-CTE column is not merged into GROUP BY
+WITH c AS (SELECT DISTINCT a, b FROM x) SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM c) AS s GROUP BY s.a ORDER BY s.a;
+WITH c AS (SELECT DISTINCT x.a AS a, x.b AS b FROM x AS x) SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s GROUP BY s.a ORDER BY a;
+
 # title: Window function is not merged when the outer query filters its input rows
 SELECT s.w FROM (SELECT a, ROW_NUMBER() OVER (ORDER BY a) AS w FROM x) AS s WHERE s.a > 5;
 SELECT s.w AS w FROM (SELECT x.a AS a, ROW_NUMBER() OVER (ORDER BY x.a) AS w FROM x AS x) AS s WHERE s.a > 5;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -552,6 +552,10 @@ SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s G
 WITH c AS (SELECT DISTINCT a, b FROM x) SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM c) AS s GROUP BY s.a ORDER BY s.a;
 WITH c AS (SELECT DISTINCT x.a AS a, x.b AS b FROM x AS x) SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s GROUP BY s.a ORDER BY a;
 
+# title: Literal projection colliding with an outer joined table column is not merged into GROUP BY
+WITH c AS (SELECT DISTINCT x.b AS b FROM x) SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM c) AS s CROSS JOIN x GROUP BY s.a ORDER BY s.a;
+WITH c AS (SELECT DISTINCT x.b AS b FROM x AS x) SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s CROSS JOIN x AS x GROUP BY s.a ORDER BY a;
+
 # title: Window function is not merged when the outer query filters its input rows
 SELECT s.w FROM (SELECT a, ROW_NUMBER() OVER (ORDER BY a) AS w FROM x) AS s WHERE s.a > 5;
 SELECT s.w AS w FROM (SELECT x.a AS a, ROW_NUMBER() OVER (ORDER BY x.a) AS w FROM x AS x) AS s WHERE s.a > 5;


### PR DESCRIPTION
Merging a derived table that projects a numeric literal (`6 AS a`) whose alias matches a `FROM` column, and is used in the outer `GROUP BY`, rewrites it to a bare `GROUP BY` a that rebinds to the column instead of the constant.  This changes the query result.  The fix is that `_mergeable` now blocks those merges.

Sample query:
```
SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY s.a;
```
Before, this query will return different results:
```
SELECT 6 AS a, SUM(x.b) AS b FROM x AS x GROUP BY a;
```
After:
```
SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY s.a;
```