### PR TITLE
fix: preserve leading zeros in subsecond_precision [CLAUDE]

### DIFF
--- a/sqlglot/time.py
+++ b/sqlglot/time.py
@@ -677,7 +677,7 @@ def subsecond_precision(timestamp_literal: str) -> int:
     """
     try:
         parsed = datetime.datetime.fromisoformat(timestamp_literal)
-        subsecond_digit_count = len(str(parsed.microsecond).rstrip("0"))
+        subsecond_digit_count = len(str(parsed.microsecond).zfill(6).rstrip("0"))
         precision = 0
         if subsecond_digit_count > 3:
             precision = 6

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -16,6 +16,8 @@ class TestTime(unittest.TestCase):
 
     def test_subsecond_precision(self):
         self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.123456+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.000123+00:00"))
+        self.assertEqual(6, subsecond_precision("2023-01-01 12:13:14.000001+00:00"))
         self.assertEqual(3, subsecond_precision("2023-01-01 12:13:14.123+00:00"))
         self.assertEqual(0, subsecond_precision("2023-01-01 12:13:14+00:00"))
         self.assertEqual(0, subsecond_precision("2023-01-01 12:13:14"))


### PR DESCRIPTION
`subsecond_precision` computes the digit count with `str(parsed.microsecond)`, which drops leading zeros. `parsed.microsecond` for `.000123` is the integer `123`, so `str(...)` is `"123"` (3 digits) and the function returns precision 3 instead of 6. A fractional second like `.000123` or `.000001` therefore reports millisecond precision, and the generated Trino/MySQL cast becomes `TIMESTAMP(3)` / `DATETIME(3)`, truncating the value to `.000`.

Zero-padding the microsecond to its full 6 digits before stripping trailing zeros fixes the count:

```python
subsecond_digit_count = len(str(parsed.microsecond).zfill(6).rstrip("0"))
```

`.000123` -> `"000123"` -> 6 digits -> precision 6. Existing cases are unchanged: `.010` -> `"010000"` -> `"01"` -> 3, `.123` -> `"123000"` -> `"123"` -> 3, `.123456` -> 6.

Added `.000123` and `.000001` cases to `test_subsecond_precision`.

Disclosure: this fix was found and prepared with LLM assistance; I verified the behavior and reasoning myself.