### PR TITLE
fix(optimizer)!: merge_subqueries issue with numeric literal ORDER BY

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -206,6 +206,21 @@ def _mergeable(
             node = node.parent
         return False
 
+    def _literal_in_order_by():
+        """A numeric-literal projection under a bare ORDER BY key can't merge (would become positional)."""
+        order = outer_scope.expression.args.get("order")
+        if not order:
+            return False
+        inner_name = from_or_join.alias_or_name
+        ordered = {
+            o.this.name
+            for o in order.expressions
+            if isinstance(o.this, exp.Column) and o.this.table == inner_name
+        }
+        return any(
+            s.alias_or_name in ordered and s.unalias().is_number for s in inner_select.selects
+        )
+
     return (
         isinstance(outer_scope.expression, exp.Select)
         and not outer_scope.expression.is_star
@@ -230,6 +245,7 @@ def _mergeable(
         )
         and not _outer_select_joins_on_inner_select_join()
         and not _window_projection_blocks_merge()
+        and not _literal_in_order_by()
         and not _is_recursive()
         and not (inner_select.args.get("order") and outer_scope.is_union)
         and not isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform)

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -551,3 +551,13 @@ SELECT s.w AS w FROM (SELECT x.a AS a, ROW_NUMBER() OVER (ORDER BY x.a) AS w FRO
 # title: Window function is not merged when the outer query joins, changing its input rows
 SELECT s.w FROM (SELECT b, ROW_NUMBER() OVER (ORDER BY b) AS w FROM x) AS s JOIN y ON s.b = y.b;
 SELECT s.w AS w FROM (SELECT x.b AS b, ROW_NUMBER() OVER (ORDER BY x.b) AS w FROM x AS x) AS s JOIN y AS y ON s.b = y.b;
+
+# title: Numeric-literal projection referenced in ORDER BY is not merged into a positional ORDER BY
+# execute: false
+SELECT s.b FROM (SELECT 6 AS a, b FROM x) AS s ORDER BY s.a;
+SELECT s.b AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s ORDER BY s.a;
+
+# title: Numeric-literal ORDER BY key is not merged when a join is present
+# execute: false
+WITH c AS (SELECT DISTINCT b FROM x) SELECT s.b FROM (SELECT 6 AS a, b FROM c) AS s CROSS JOIN x ORDER BY s.a;
+WITH c AS (SELECT DISTINCT x.b AS b FROM x AS x) SELECT s.b AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s CROSS JOIN x AS x ORDER BY s.a;


### PR DESCRIPTION
Merging a derived table with a numeric literal projection (e.g. `6 AS a`) referenced by an `ORDER BY` was substituting the literal directly, producing a positional resut (e.g.  `ORDER BY 6`, the 6th output column).  This generally results in either a runtime error or wrong ordering. Added guard to `_mergeable` to block that merge.

Sample input:
```
SELECT s.b FROM (SELECT 6 AS a, b FROM x) AS s ORDER BY s.a;
```
Previous:
```
SELECT x.b AS b FROM x AS x ORDER BY 6;
```
Fixed
```
SELECT s.b AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s ORDER BY s.a;
```