### PR TITLE
fix(tokenizer): escaped quote before closing multi-char delimiter [CLAUDE]

### DIFF
--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -1175,13 +1175,20 @@ class TokenizerCore:
                 escape_follow_chars and self._char == "\\" and self._peek not in escape_follow_chars
             )
 
+            # For multi-char delimiters (e.g """), an escaped quote (e.g \") must be
+            # consumed here, otherwise the quote is picked up by the delimiter check
+            # below and terminates the string early
+            peek_is_delimiter = self._peek == delimiter or (
+                delim_size > 1 and self._peek == delimiter[0]
+            )
+
             if (
                 (string_escapes_allowed_in_raw_strings or not raw_string)
                 and self._char in escapes
-                and (self._peek == delimiter or self._peek in escapes or is_valid_custom_escape)
+                and (peek_is_delimiter or self._peek in escapes or is_valid_custom_escape)
                 and (self._char not in quotes or self._char == self._peek)
             ):
-                if self._peek == delimiter:
+                if peek_is_delimiter:
                     text += self._peek
                 elif is_valid_custom_escape and self._char != self._peek:
                     text += self._peek

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -436,6 +436,14 @@ class TestBigQuery(Validator):
             "x <> ''",
         )
         self.validate_identity(
+            'SELECT """ends with \\"word\\""""',
+            "SELECT 'ends with \"word\"'",
+        )
+        self.validate_identity(
+            "SELECT '''ends with \\'word\\''''",
+            "SELECT 'ends with \\'word\\''",
+        )
+        self.validate_identity(
             "SELECT a overlaps",
             "SELECT a AS overlaps",
         )


### PR DESCRIPTION
In dialects with multi-char string delimiters and escape chars (e.g. BigQuery triple-quoted strings with backslash escapes), an escaped quote immediately before the closing delimiter made the tokenizer end the string one quote early, leaving a dangling quote that failed tokenization:

    SELECT """ends with \"word\""""   -- Error tokenizing

The escape branch in _extract_string only consumed the escape pair when the peeked char equaled the full delimiter, which can never match a multi-char delimiter. Treat a peeked first-delimiter-char as escapable too, which also makes the token text consistent with the single-char delimiter behavior (backslash stripped: 'ends with "word"').