### PR TITLE
Fix(optimizer): evict mutated projections from the annotator cache

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -236,6 +236,20 @@ class TypeAnnotator:
         self._setop_column_types.clear()
         self._scope_source_selects.clear()
 
+    def uncache(self, expression: exp.Expr, deep: bool = True) -> None:
+        """
+        Evicts `expression` (or its subtree, if `deep`) from the annotation caches. This must
+        be called when an already-annotated tree is about to be mutated, both so that a
+        subsequent annotation pass doesn't skip it and so that the ids of any discarded nodes
+        can't be conflated with new nodes allocated at the same addresses.
+        """
+        nodes: t.Iterable[exp.Expr] = expression.walk() if deep else (expression,)
+        for node in nodes:
+            node_id = id(node)
+            self._visited.discard(node_id)
+            self._null_expressions.pop(node_id, None)
+            self._setop_column_types.pop(node_id, None)
+
     # TODO (mypyc): should be expression: E -> E but mypyc resolves the TypeVar
     # to the isinstance-narrowed type, causing runtime type check failures.
     def _set_type(

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -785,9 +785,10 @@ def _expand_stars(
 
     pivot = t.cast(t.Optional[exp.Pivot], seq_get(scope.pivots, 0))
 
-    if dialect.SUPPORTS_STRUCT_STAR_EXPANSION and any(
+    annotated_ahead = dialect.SUPPORTS_STRUCT_STAR_EXPANSION and any(
         isinstance(col, exp.Dot) for col in scope.stars
-    ):
+    )
+    if annotated_ahead:
         # Found struct expansion, annotate scope ahead of time
         annotator.annotate_scope(scope)
 
@@ -812,19 +813,19 @@ def _expand_stars(
                 _add_rename_columns(expression.this, tables, rename_columns)
                 ilike_pattern = _add_ilike_columns(expression.this)
             elif isinstance(expression, exp.Dot):
-                if (
-                    dialect.SUPPORTS_STRUCT_STAR_EXPANSION
-                    and not dialect.REQUIRES_PARENTHESIZED_STRUCT_ACCESS
-                ):
-                    struct_fields = _expand_struct_stars_no_parens(expression)
-                    if struct_fields:
-                        new_selections.extend(struct_fields)
-                        continue
-                elif dialect.REQUIRES_PARENTHESIZED_STRUCT_ACCESS:
+                if dialect.REQUIRES_PARENTHESIZED_STRUCT_ACCESS:
                     struct_fields = _expand_struct_stars_with_parens(expression)
-                    if struct_fields:
-                        new_selections.extend(struct_fields)
-                        continue
+                elif dialect.SUPPORTS_STRUCT_STAR_EXPANSION:
+                    struct_fields = _expand_struct_stars_no_parens(expression)
+                else:
+                    struct_fields = []
+
+                if struct_fields:
+                    if annotated_ahead:
+                        annotator.uncache(expression)
+
+                    new_selections.extend(struct_fields)
+                    continue
 
         if not tables:
             new_selections.append(expression)
@@ -898,8 +899,16 @@ def _expand_stars(
                         else selection_expr
                     )
 
+        if annotated_ahead:
+            # The star projection was replaced by the expansions above
+            annotator.uncache(expression)
+
     # Ensures we don't overwrite the initial selections with an empty list
     if new_selections and isinstance(scope_expression, exp.Select):
+        if annotated_ahead:
+            # The mutation below would otherwise be skipped by the final annotation pass
+            annotator.uncache(scope_expression, deep=False)
+
         scope_expression.set("expressions", new_selections)
 
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -872,6 +872,30 @@ class TestOptimizer(unittest.TestCase):
                 dialect="snowflake",
             )
 
+    def test_qualify_columns_struct_star_expansion_types(self):
+        # Struct star expansion annotates a scope and then replaces its projections; the
+        # stale annotation caches must not prevent the new projections from being typed
+        qualified = optimizer.qualify.qualify(
+            parse_one(
+                "WITH cte AS (SELECT t.s.* FROM t UNION ALL SELECT t.s.* FROM t) SELECT cte.x FROM cte",
+                read="bigquery",
+            ),
+            schema={"t": {"s": "STRUCT<x INT64, y STRING>"}},
+            dialect="bigquery",
+        )
+
+        union = qualified.find(exp.Union)
+        assert union
+        self.assertEqual(
+            [s.type.sql("bigquery") if s.type else None for s in union.selects],
+            ["INT64", "STRING"],
+        )
+        self.assertEqual(
+            [s.type.sql("bigquery") if s.type else None for s in union.expression.selects],
+            ["INT64", "STRING"],
+        )
+        self.assertEqual(qualified.selects[0].type.sql("bigquery"), "INT64")
+
     def test_qualify_columns__with_invisible(self):
         schema = MappingSchema(self.schema, {"x": {"a"}, "y": {"b"}, "z": {"b"}})
         self.check_file("qualify_columns__with_invisible", qualify_columns, schema=schema)


### PR DESCRIPTION
Context: the failing test in [this PR](https://github.com/tobymao/sqlglot/pull/7867)

