### PR TITLE
Fix(tokenizer)!: handle escaped quote before closing multi-char delimiter, preserve escapes in raw strings

### DIFF
--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -1175,14 +1175,22 @@ class TokenizerCore:
                 escape_follow_chars and self._char == "\\" and self._peek not in escape_follow_chars
             )
 
+            # An escaped quote before the closing delimiter (e.g. \" in """a\"""") must be
+            # consumed here, otherwise it'd be picked up by the delimiter check below and
+            # terminate the string early. This is only relevant for multi-char delimiters
+            # made up of quote chars, e.g. it shouldn't apply to Snowflake's $$ strings
+            escaped_delimiter = self._peek == delimiter or (
+                delim_size > 1 and self._peek == delimiter[0] and self._peek in quotes
+            )
+
             if (
                 (string_escapes_allowed_in_raw_strings or not raw_string)
                 and self._char in escapes
-                and (self._peek == delimiter or self._peek in escapes or is_valid_custom_escape)
+                and (escaped_delimiter or self._peek in escapes or is_valid_custom_escape)
                 and (self._char not in quotes or self._char == self._peek)
             ):
-                if self._peek == delimiter:
-                    text += self._peek
+                if escaped_delimiter:
+                    text += self._peek if not raw_string else self._char + self._peek
                 elif is_valid_custom_escape and self._char != self._peek:
                     text += self._peek
                 else:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -436,6 +436,26 @@ class TestBigQuery(Validator):
             "x <> ''",
         )
         self.validate_identity(
+            'SELECT """ends with \\"word\\""""',
+            "SELECT 'ends with \"word\"'",
+        )
+        self.validate_identity(
+            "SELECT '''ends with \\'word\\''''",
+            "SELECT 'ends with \\'word\\''",
+        )
+        self.validate_identity(
+            'SELECT """a\\"b"""',
+            "SELECT 'a\"b'",
+        )
+        self.validate_identity(
+            'SELECT r"""ends with \\""""',
+            "SELECT 'ends with \\\\\"'",
+        )
+        self.validate_identity(
+            'SELECT r"""a\\"b"""',
+            "SELECT 'a\\\\\"b'",
+        )
+        self.validate_identity(
             "SELECT a overlaps",
             "SELECT a AS overlaps",
         )
@@ -1285,8 +1305,9 @@ LANGUAGE js AS
         self.validate_all(
             "r'x\\''",
             write={
-                "bigquery": "'x\\''",
-                "hive": "'x\\''",
+                "bigquery": "'x\\\\\\''",
+                "duckdb": "'x\\'''",
+                "hive": "'x\\\\\\''",
             },
         )
 

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -22,6 +22,11 @@ class TestClickhouse(Validator):
             "CAST(CASE WHEN notEmpty(report_task_id) THEN report_task_id ELSE '-1' END AS String)",
         )
 
+        self.validate_identity(
+            r"SELECT $$a\$b$$",
+            r"SELECT 'a\\$b'",
+        )
+
         expr = quote_identifiers(self.parse_one("{start_date:String}"), dialect="clickhouse")
         self.assertEqual(expr.sql("clickhouse"), "{start_date: String}")
 

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -1035,6 +1035,14 @@ class TestSnowflake(Validator):
             r"SELECT 'a \' \\ \\t \\x21 z $ '",
         )
         self.validate_identity(
+            r"SELECT $$a\$b$$",
+            r"SELECT 'a\\$b'",
+        )
+        self.validate_identity(
+            r"SELECT $$a\$$",
+            r"SELECT 'a\\'",
+        )
+        self.validate_identity(
             "SELECT {'test': 'best'}::VARIANT",
             "SELECT CAST(OBJECT_CONSTRUCT('test', 'best') AS VARIANT)",
         )


### PR DESCRIPTION
See https://github.com/tobymao/sqlglot/pull/7864.