### PR TITLE
feat(executor): support window functions [CLAUDE]

### DIFF
--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -1,4 +1,5 @@
 import collections
+import functools
 import itertools
 import math
 
@@ -9,6 +10,15 @@ from sqlglot.executor.context import Context
 from sqlglot.executor.env import ENV
 from sqlglot.executor.table import RowReader, Table
 from sqlglot.generators.python import PythonGenerator
+
+_MISSING = object()
+
+AGG_FUNCS = {
+    exp.Sum: "SUM",
+    exp.Avg: "AVG",
+    exp.Min: "MIN",
+    exp.Max: "MAX",
+}
 
 
 class PythonExecutor:
@@ -39,6 +49,8 @@ class PythonExecutor:
                     contexts[node] = self.aggregate(node, context)
                 elif isinstance(node, planner.Join):
                     contexts[node] = self.join(node, context)
+                elif isinstance(node, planner.Window):
+                    contexts[node] = self.window(node, context)
                 elif isinstance(node, planner.Sort):
                     contexts[node] = self.sort(node, context)
                 elif isinstance(node, planner.SetOperation):
@@ -277,6 +289,220 @@ class PythonExecutor:
         if step.projections or step.condition:
             return self.scan(step, context)
         return context
+
+    def window(self, step, context):
+        table = context.table
+        # Unqualified columns compile to scope[None], so expose the source table
+        # under None while the window values are computed.
+        source = self.context({None: table, **context.tables})
+
+        computed = [
+            (projection.alias, self.compute_window(projection.this, source))
+            for projection in step.windows
+        ]
+
+        for name, values in computed:
+            table.add_columns(name)
+            table.rows = [row + (value,) for row, value in zip(table.rows, values)]
+
+        tables = {None: table, step.name: table}
+        tables.update({name: table for name in context.tables})
+        context = self.context(tables)
+
+        if step.projections or step.condition:
+            return self.scan(step, context)
+        return context
+
+    def compute_window(self, window, context):
+        length = len(context.table.rows)
+        if not length:
+            return []
+
+        partition_codes = self.generate_tuple(window.args.get("partition_by") or [])
+        ordering = window.args.get("order")
+        orderings = ordering.expressions if ordering else []
+        order_codes = self.generate_tuple([o.this for o in orderings])
+        descending = [bool(o.args.get("desc")) for o in orderings]
+
+        partition_keys = self._window_rows(context, partition_codes, length)
+        order_keys = self._window_rows(context, order_codes, length)
+
+        func = window.this
+        arg = (
+            func.this
+            if isinstance(
+                func,
+                (exp.Lag, exp.Lead, exp.FirstValue, exp.LastValue, exp.NthValue, exp.AggFunc),
+            )
+            else None
+        )
+        if isinstance(arg, exp.Star):
+            arg = None
+        arg_values = (
+            [row[0] for row in self._window_rows(context, (self.generate(arg),), length)]
+            if arg is not None
+            else None
+        )
+
+        spec = window.args.get("spec")
+        partitions: dict = collections.OrderedDict()
+        for i in range(length):
+            partitions.setdefault(partition_keys[i], []).append(i)
+
+        result: list = [None] * length
+        for indices in partitions.values():
+            ordered = self._order_partition(indices, order_keys, descending)
+            self._apply_window(func, spec, ordered, order_keys, arg_values, descending, result)
+
+        return result
+
+    def _window_rows(self, context, codes, length):
+        if not codes:
+            return [()] * length
+
+        rows = []
+        for i in range(length):
+            context.set_index(i)
+            rows.append(context.eval_tuple(codes))
+        return rows
+
+    def _order_partition(self, indices, order_keys, descending):
+        if not descending:
+            return list(indices)
+
+        def compare(a, b):
+            for column, desc in enumerate(descending):
+                left = order_keys[a][column]
+                right = order_keys[b][column]
+                if left == right:
+                    continue
+                if left is None:
+                    return -1
+                if right is None:
+                    return 1
+                order = 1 if left > right else -1
+                return -order if desc else order
+            return 0
+
+        return sorted(indices, key=functools.cmp_to_key(compare))
+
+    def _apply_window(self, func, spec, ordered, order_keys, arg_values, descending, result):
+        count = len(ordered)
+
+        if isinstance(func, exp.RowNumber):
+            for position, index in enumerate(ordered):
+                result[index] = position + 1
+        elif isinstance(func, (exp.Rank, exp.DenseRank)):
+            dense = isinstance(func, exp.DenseRank)
+            rank = 0
+            previous = _MISSING
+            for position, index in enumerate(ordered):
+                key = order_keys[index]
+                if key != previous:
+                    rank = rank + 1 if dense else position + 1
+                    previous = key
+                result[index] = rank
+        elif isinstance(func, exp.Ntile):
+            buckets = int(func.this.name)
+            base, remainder = divmod(count, buckets)
+            position = 0
+            for bucket in range(buckets):
+                for _ in range(base + (1 if bucket < remainder else 0)):
+                    if position < count:
+                        result[ordered[position]] = bucket + 1
+                        position += 1
+        elif isinstance(func, (exp.Lag, exp.Lead)):
+            offset_arg = func.args.get("offset")
+            offset = int(offset_arg.name) if offset_arg else 1
+            default = self._window_literal(func.args.get("default"))
+            for position, index in enumerate(ordered):
+                source = position + offset if isinstance(func, exp.Lead) else position - offset
+                result[index] = arg_values[ordered[source]] if 0 <= source < count else default
+        else:
+            # FIRST_VALUE, LAST_VALUE, NTH_VALUE and the aggregates are all
+            # evaluated over the window frame.
+            frames = self._window_frames(spec, ordered, order_keys, descending)
+            for position, index in enumerate(ordered):
+                low, high = frames[position]
+                result[index] = self._frame_value(func, ordered, arg_values, low, high)
+
+    def _window_frames(self, spec, ordered, order_keys, descending):
+        count = len(ordered)
+
+        # Peer groups: rows that share an ORDER BY value.
+        first_peer = list(range(count))
+        last_peer = list(range(count))
+        start = 0
+        while start < count:
+            end = start
+            while end < count and order_keys[ordered[end]] == order_keys[ordered[start]]:
+                end += 1
+            for position in range(start, end):
+                first_peer[position] = start
+                last_peer[position] = end - 1
+            start = end
+
+        if spec is None:
+            if not descending:
+                return [(0, count - 1)] * count
+            # Default frame with an ORDER BY: RANGE UNBOUNDED PRECEDING to CURRENT ROW.
+            return [(0, last_peer[position]) for position in range(count)]
+
+        rows = spec.text("kind") == "ROWS"
+        # A RANGE offset measures distance against the single ordering column.
+        values = [order_keys[ordered[p]][0] for p in range(count)] if descending else []
+        desc = descending[0] if descending else False
+
+        def bound(position, value, side, is_start):
+            if value == "UNBOUNDED":
+                return 0 if side == "PRECEDING" else count - 1
+            if value == "CURRENT ROW":
+                if rows:
+                    return position
+                return first_peer[position] if is_start else last_peer[position]
+            offset = int(value)
+            if rows:
+                return position - offset if side == "PRECEDING" else position + offset
+            current = values[position]
+            if desc:
+                limit = current + offset if side == "PRECEDING" else current - offset
+                if is_start:
+                    return next((q for q in range(count) if values[q] <= limit), count)
+                return next((q for q in reversed(range(count)) if values[q] >= limit), -1)
+            limit = current - offset if side == "PRECEDING" else current + offset
+            if is_start:
+                return next((q for q in range(count) if values[q] >= limit), count)
+            return next((q for q in reversed(range(count)) if values[q] <= limit), -1)
+
+        frames = []
+        for position in range(count):
+            low = bound(position, spec.text("start"), spec.text("start_side"), True)
+            high = bound(position, spec.text("end"), spec.text("end_side"), False)
+            frames.append((max(0, low), min(count - 1, high)))
+        return frames
+
+    def _frame_value(self, func, ordered, arg_values, low, high):
+        if isinstance(func, exp.FirstValue):
+            return arg_values[ordered[low]] if low <= high else None
+        if isinstance(func, exp.LastValue):
+            return arg_values[ordered[high]] if low <= high else None
+        if isinstance(func, exp.NthValue):
+            index = low + int(func.args["offset"].name) - 1
+            return arg_values[ordered[index]] if low <= index <= high else None
+
+        frame = range(low, high + 1) if low <= high else range(0)
+        if isinstance(func, exp.Count):
+            if isinstance(func.this, exp.Star):
+                return len(frame)
+            return sum(1 for position in frame if arg_values[ordered[position]] is not None)
+        return self.env[AGG_FUNCS[type(func)]](
+            [arg_values[ordered[position]] for position in frame]
+        )
+
+    def _window_literal(self, expression):
+        if expression is None:
+            return None
+        return eval(self.generate(expression), {**self.env, "scope": {}})
 
     def sort(self, step, context):
         projections = self.generate_tuple(step.projections)

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -147,6 +147,19 @@ class Step:
             step.operands = tuple(alias(operand, alias_) for operand, alias_ in operands.items())
             step.aggregations = list(aggregations)
 
+        # Window functions are computed after grouping, so pull them out of the
+        # projections before the aggregate operands are collected. Otherwise an
+        # aggregate nested in an OVER clause (e.g. SUM(x) OVER ()) would be
+        # mistaken for a grouped aggregation.
+        windows: list[exp.Expr] = []
+        next_window_name = name_sequence("_w_")
+
+        for e in expression.expressions:
+            for window in reversed(list(e.find_all(exp.Window))):
+                window_name = next_window_name()
+                windows.append(alias(window.copy(), window_name, quoted=True))
+                window.replace(exp.column(window_name, quoted=True))
+
         for e in expression.expressions:
             if e.find(exp.AggFunc):
                 projections.append(exp.column(e.alias_or_name, step.name, quoted=True))
@@ -203,6 +216,14 @@ class Step:
             step = aggregate
         else:
             aggregate = None
+
+        if windows:
+            window = Window()
+            window.source = step.name
+            window.name = step.name
+            window.windows = windows
+            window.add_dependency(step)
+            step = window
 
         order: exp.Order | None = expression.args.get("order")
 
@@ -388,6 +409,21 @@ class Aggregate(Step):
             lines.append(f"{indent}Operands:")
             for expression in self.operands:
                 lines.append(f"{indent}  - {expression.sql()}")
+
+        return lines
+
+
+class Window(Step):
+    def __init__(self) -> None:
+        super().__init__()
+        self.windows: list[exp.Expr] = []
+        self.source: str | None = None
+
+    def _to_s(self, indent: str) -> list[str]:
+        lines = [f"{indent}Windows:"]
+
+        for expression in self.windows:
+            lines.append(f"{indent}  - {expression.sql()}")
 
         return lines
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -296,6 +296,53 @@ class TestExecutor(unittest.TestCase):
                 self.assertEqual(result.columns, tuple(cols))
                 self.assertEqual(result.rows, rows)
 
+    def test_window_functions(self):
+        table = [
+            {"g": "a", "v": 10, "n": 1},
+            {"g": "a", "v": 20, "n": 2},
+            {"g": "a", "v": 20, "n": 3},
+            {"g": "a", "v": 40, "n": 4},
+            {"g": "b", "v": 5, "n": 5},
+            {"g": "b", "v": 15, "n": 6},
+            {"g": "b", "v": 25, "n": 7},
+        ]
+
+        conn = duckdb.connect()
+        conn.execute("CREATE TABLE t (g VARCHAR, v INT, n INT)")
+        conn.executemany(
+            "INSERT INTO t VALUES (?, ?, ?)", [(r["g"], r["v"], r["n"]) for r in table]
+        )
+
+        for sql in [
+            "SELECT n, ROW_NUMBER() OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, RANK() OVER (PARTITION BY g ORDER BY v) AS w FROM t",
+            "SELECT n, DENSE_RANK() OVER (PARTITION BY g ORDER BY v) AS w FROM t",
+            "SELECT n, NTILE(2) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, LAG(v, 2, -1) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, LEAD(v) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, FIRST_VALUE(v) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, LAST_VALUE(v) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, NTH_VALUE(v, 2) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, SUM(v) OVER (PARTITION BY g) AS w FROM t",
+            "SELECT n, SUM(v) OVER (PARTITION BY g ORDER BY v) AS w FROM t",
+            "SELECT n, AVG(v) OVER (PARTITION BY g ORDER BY n) AS w FROM t",
+            "SELECT n, COUNT(*) OVER (PARTITION BY g ORDER BY v) AS w FROM t",
+            "SELECT n, SUM(v) OVER "
+            "(PARTITION BY g ORDER BY n ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING) AS w FROM t",
+            "SELECT n, LAST_VALUE(v) OVER "
+            "(PARTITION BY g ORDER BY n ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) "
+            "AS w FROM t",
+            "SELECT n, SUM(v) OVER "
+            "(PARTITION BY g ORDER BY v RANGE BETWEEN 10 PRECEDING AND 10 FOLLOWING) AS w FROM t",
+        ]:
+            with self.subTest(sql):
+                expected = conn.execute(transpile(sql, write="duckdb")[0]).fetchall()
+                result = execute(sql, tables={"t": table}).rows
+                self.assertEqual(
+                    sorted(result, key=lambda row: row[0]),
+                    sorted((tuple(row) for row in expected), key=lambda row: row[0]),
+                )
+
     def test_set_operations(self):
         tables = {
             "x": [


### PR DESCRIPTION
The Python executor raised `ExecuteError` on any query containing an `OVER` clause (#3346). This implements window function evaluation.

`PARTITION BY` and `ORDER BY` are supported for:
- ranking: `ROW_NUMBER`, `RANK`, `DENSE_RANK`, `NTILE`
- navigation: `LAG`, `LEAD`, `FIRST_VALUE`, `LAST_VALUE`, `NTH_VALUE`
- aggregates: `SUM`, `COUNT`, `AVG`, `MIN`, `MAX`

Aggregates and value functions are evaluated over the window frame, covering the default frame, explicit `ROWS` frames, and `RANGE` frames (including value-based numeric offsets and order-by peers).

Implemented as a `Window` planning step plus a matching executor pass. Results are verified against DuckDB in `tests/test_executor.py`.