### PR TITLE
fix(optimizer)!: dedupe colliding star expanded aliases

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -60,10 +60,7 @@ def qualify_columns(
     dialect = schema.dialect or Dialect()
     pseudocolumns = dialect.PSEUDOCOLUMNS
 
-    scopes = traverse_scope(expression)
-    star_referenced_sources = _star_referenced_source_ids(scopes)
-
-    for scope in scopes:
+    for scope in traverse_scope(expression):
         if dialect.PREFER_CTE_ALIAS_COLUMN:
             pushdown_cte_alias_columns(scope)
 
@@ -103,7 +100,6 @@ def qualify_columns(
                     using_column_tables,
                     pseudocolumns,
                     annotator,
-                    star_referenced_sources,
                 )
             qualify_outputs(scope, dialect=dialect)
 
@@ -117,29 +113,6 @@ def qualify_columns(
             annotator.annotate_scope(scope)
 
     return expression
-
-
-def _star_referenced_source_ids(scopes: list[Scope]) -> set[int]:
-    """ids of sources exposed to some other scope via `SELECT *` or `alias.*`."""
-    referenced: set[int] = set()
-
-    for scope in scopes:
-        scope_expression = scope.expression
-        if not isinstance(scope_expression, exp.Select):
-            continue
-
-        for projection in scope_expression.selects:
-            if isinstance(projection, exp.Star):
-                # Bare, unqualified `*` exposes every source in this scope.
-                for _, source in scope.selected_sources.values():
-                    referenced.add(id(source))
-            elif isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star):
-                # Qualified `alias.*` exposes only that one source.
-                qualified_source = scope.sources.get(projection.table)
-                if qualified_source is not None:
-                    referenced.add(id(qualified_source))
-
-    return referenced
 
 
 def validate_qualify_columns(expression: E, sql: str | None = None) -> E:
@@ -817,7 +790,6 @@ def _expand_stars(
     using_column_tables: dict[str, t.Any],
     pseudocolumns: set[str],
     annotator: TypeAnnotator,
-    star_referenced_sources: set[int],
 ) -> None:
     """Expand stars to lists of column selections"""
 
@@ -882,6 +854,12 @@ def _expand_stars(
             source = scope.sources.get(table)
             if source is None:
                 raise OptimizeError(f"Unknown table: {table}")
+
+            # This source is being re-exposed via a star, so uniquify any duplicate output
+            # names (e.g. same-named columns from a join) before it's expanded below,
+            # otherwise the duplicates would collapse onto a single column reference.
+            if isinstance(source, Scope) and isinstance(source.expression, exp.Select):
+                _uniquify_output_names(source.expression)
 
             columns = resolver.get_source_columns(table, only_visible=True)
             columns = columns or scope.outer_columns
@@ -950,11 +928,6 @@ def _expand_stars(
             # The star projection was replaced by the expansions above
             annotator.uncache(expression)
 
-    # If this scope is re-exposed to another scope via a star, colliding output names
-    # must be made unique so the outer star expansion can't collapse them onto one column
-    if id(scope) in star_referenced_sources:
-        _uniquify_output_names(new_selections)
-
     # Ensures we don't overwrite the initial selections with an empty list
     if new_selections and isinstance(scope_expression, exp.Select):
         if annotated_ahead:
@@ -964,16 +937,24 @@ def _expand_stars(
         scope_expression.set("expressions", new_selections)
 
 
-def _uniquify_output_names(selections: list[exp.Expr]) -> None:
-    """Rename projections whose output name repeats, so a parent scope re-exposing
-    them via a star can't collapse the duplicates onto a single column reference."""
+def _uniquify_output_names(select: exp.Select) -> None:
+    """Rename projections whose output name repeats, so a scope re-exposing them via a
+    star can't collapse the duplicates onto a single column reference."""
     taken: set[str] = set()
-    for i, selection in enumerate(selections):
+    new_selections: list[exp.Expr] = []
+    changed = False
+
+    for selection in select.selects:
         name = selection.output_name
         if name and name in taken:
             name = find_new_name(taken, name)
-            selections[i] = alias(selection.unalias(), name, copy=False)
+            selection = alias(selection.unalias(), name, copy=False)
+            changed = True
         taken.add(name)
+        new_selections.append(selection)
+
+    if changed:
+        select.set("expressions", new_selections)
 
 
 def _output_identifier_quoted(selection: exp.Expr) -> bool:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -827,19 +827,6 @@ def _expand_stars(
     rename_columns: dict[int, dict[str, str]] = {}
     ilike_pattern: str | None = None
 
-    # Output names already used by this projection. Star-expanded columns that would
-    # collide are only aliased uniquely if this scope is exposed to another scope
-    taken_names: set[str] = set()
-    uniquify_names = id(scope) in star_referenced_sources
-
-    def add_star_selection(selection: exp.Expr, output_name: str) -> None:
-        if uniquify_names and output_name and output_name in taken_names:
-            unique_name = find_new_name(taken_names, output_name)
-            selection = alias(selection.unalias(), unique_name, copy=False)
-            output_name = unique_name
-        taken_names.add(output_name)
-        new_selections.append(selection)
-
     coalesced_columns = set()
     dialect = resolver.dialect
 
@@ -885,12 +872,10 @@ def _expand_stars(
                         annotator.uncache(expression)
 
                     new_selections.extend(struct_fields)
-                    taken_names.update(field.output_name for field in struct_fields)
                     continue
 
         if not tables:
             new_selections.append(expression)
-            taken_names.add(expression.output_name)
             continue
 
         for table in tables:
@@ -925,14 +910,11 @@ def _expand_stars(
                 pivot_columns = pivot.output_columns(columns) or pivot.alias_column_names
 
                 if pivot_columns:
-                    for name in pivot_columns:
-                        if name not in columns_to_exclude:
-                            add_star_selection(
-                                alias(
-                                    exp.column(name, table=pivot.alias or None), name, copy=False
-                                ),
-                                name,
-                            )
+                    new_selections.extend(
+                        alias(exp.column(name, table=pivot.alias or None), name, copy=False)
+                        for name in pivot_columns
+                        if name not in columns_to_exclude
+                    )
                     continue
 
             for name in columns:
@@ -946,8 +928,8 @@ def _expand_stars(
                     using_tables = using_column_tables[name]
                     coalesce_args = [exp.column(name, table=table) for table in using_tables]
 
-                    add_star_selection(
-                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False), name
+                    new_selections.append(
+                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False)
                     )
                 else:
                     alias_ = renamed_columns.get(name, name)
@@ -958,16 +940,20 @@ def _expand_stars(
                     selection_expr = replaced_columns.get(name) or exp.column(
                         name, table=table, quoted=quoted
                     )
-                    add_star_selection(
+                    new_selections.append(
                         alias(selection_expr, alias_, copy=False)
                         if alias_ != name
-                        else selection_expr,
-                        alias_,
+                        else selection_expr
                     )
 
         if annotated_ahead:
             # The star projection was replaced by the expansions above
             annotator.uncache(expression)
+
+    # If this scope is re-exposed to another scope via a star, colliding output names
+    # must be made unique so the outer star expansion can't collapse them onto one column
+    if id(scope) in star_referenced_sources:
+        _uniquify_output_names(new_selections)
 
     # Ensures we don't overwrite the initial selections with an empty list
     if new_selections and isinstance(scope_expression, exp.Select):
@@ -976,6 +962,18 @@ def _expand_stars(
             annotator.uncache(scope_expression, deep=False)
 
         scope_expression.set("expressions", new_selections)
+
+
+def _uniquify_output_names(selections: list[exp.Expr]) -> None:
+    """Rename projections whose output name repeats, so a parent scope re-exposing
+    them via a star can't collapse the duplicates onto a single column reference."""
+    taken: set[str] = set()
+    for i, selection in enumerate(selections):
+        name = selection.output_name
+        if name and name in taken:
+            name = find_new_name(taken, name)
+            selections[i] = alias(selection.unalias(), name, copy=False)
+        taken.add(name)
 
 
 def _output_identifier_quoted(selection: exp.Expr) -> bool:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -850,21 +850,10 @@ def _expand_stars(
             new_selections.append(expression)
             continue
 
-        star_start = len(new_selections)
-
         for table in tables:
             source = scope.sources.get(table)
             if source is None:
                 raise OptimizeError(f"Unknown table: {table}")
-
-            if isinstance(source, Scope) and isinstance(source.expression, exp.Select):
-                # This source is being re-exposed via a star, check for duplicate output
-                # and restore the star if found.
-                if _has_duplicate_output_names(source.expression):
-                    source.expression.set("expressions", [exp.Star()])
-                    del new_selections[star_start:]
-                    new_selections.append(expression)
-                    break
 
             columns = resolver.get_source_columns(table, only_visible=True)
             columns = columns or scope.outer_columns
@@ -872,7 +861,10 @@ def _expand_stars(
             if pseudocolumns and dialect.EXCLUDES_PSEUDOCOLUMNS_FROM_STAR:
                 columns = [name for name in columns if name.upper() not in pseudocolumns]
 
-            if not columns or "*" in columns:
+            # If a source exposes duplicate output names (e.g. a derived table re-exposing
+            # colliding star-expanded columns), expanding this star would produce ambiguous
+            # projections, so we leave it unexpanded.
+            if not columns or "*" in columns or len(columns) != len(set(columns)):
                 return
 
             table_id = id(table)
@@ -940,16 +932,6 @@ def _expand_stars(
             annotator.uncache(scope_expression, deep=False)
 
         scope_expression.set("expressions", new_selections)
-
-
-def _has_duplicate_output_names(select: exp.Select) -> bool:
-    seen: set[str] = set()
-    for selection in select.selects:
-        name = selection.output_name
-        if name and name in seen:
-            return True
-        seen.add(name)
-    return False
 
 
 def _output_identifier_quoted(selection: exp.Expr) -> bool:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -7,7 +7,7 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import OptimizeError, highlight_sql
-from sqlglot.helper import find_new_name, seq_get
+from sqlglot.helper import seq_get
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
 from sqlglot.optimizer.scope import Scope, build_scope, traverse_scope, walk_in_scope
@@ -850,14 +850,21 @@ def _expand_stars(
             new_selections.append(expression)
             continue
 
+        star_start = len(new_selections)
+
         for table in tables:
             source = scope.sources.get(table)
             if source is None:
                 raise OptimizeError(f"Unknown table: {table}")
 
-            # This source is being re-exposed via a star, so uniquify any duplicate output
             if isinstance(source, Scope) and isinstance(source.expression, exp.Select):
-                _uniquify_output_names(source.expression)
+                # This source is being re-exposed via a star, check for duplicate output
+                # and restore the star if found.
+                if _has_duplicate_output_names(source.expression):
+                    source.expression.set("expressions", [exp.Star()])
+                    del new_selections[star_start:]
+                    new_selections.append(expression)
+                    break
 
             columns = resolver.get_source_columns(table, only_visible=True)
             columns = columns or scope.outer_columns
@@ -935,24 +942,14 @@ def _expand_stars(
         scope_expression.set("expressions", new_selections)
 
 
-def _uniquify_output_names(select: exp.Select) -> None:
-    """Rename projections whose output name repeats, so a scope re-exposing them via a
-    star can't collapse the duplicates onto a single column reference."""
-    taken: set[str] = set()
-    new_selections: list[exp.Expr] = []
-    changed = False
-
+def _has_duplicate_output_names(select: exp.Select) -> bool:
+    seen: set[str] = set()
     for selection in select.selects:
         name = selection.output_name
-        if name and name in taken:
-            name = find_new_name(taken, name)
-            selection = alias(selection.unalias(), name, copy=False)
-            changed = True
-        taken.add(name)
-        new_selections.append(selection)
-
-    if changed:
-        select.set("expressions", new_selections)
+        if name and name in seen:
+            return True
+        seen.add(name)
+    return False
 
 
 def _output_identifier_quoted(selection: exp.Expr) -> bool:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -856,8 +856,6 @@ def _expand_stars(
                 raise OptimizeError(f"Unknown table: {table}")
 
             # This source is being re-exposed via a star, so uniquify any duplicate output
-            # names (e.g. same-named columns from a join) before it's expanded below,
-            # otherwise the duplicates would collapse onto a single column reference.
             if isinstance(source, Scope) and isinstance(source.expression, exp.Select):
                 _uniquify_output_names(source.expression)
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -7,7 +7,7 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import OptimizeError, highlight_sql
-from sqlglot.helper import seq_get
+from sqlglot.helper import find_new_name, seq_get
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
 from sqlglot.optimizer.scope import Scope, build_scope, traverse_scope, walk_in_scope
@@ -60,7 +60,10 @@ def qualify_columns(
     dialect = schema.dialect or Dialect()
     pseudocolumns = dialect.PSEUDOCOLUMNS
 
-    for scope in traverse_scope(expression):
+    scopes = traverse_scope(expression)
+    star_referenced_sources = _star_referenced_source_ids(scopes)
+
+    for scope in scopes:
         if dialect.PREFER_CTE_ALIAS_COLUMN:
             pushdown_cte_alias_columns(scope)
 
@@ -100,6 +103,7 @@ def qualify_columns(
                     using_column_tables,
                     pseudocolumns,
                     annotator,
+                    star_referenced_sources,
                 )
             qualify_outputs(scope, dialect=dialect)
 
@@ -113,6 +117,29 @@ def qualify_columns(
             annotator.annotate_scope(scope)
 
     return expression
+
+
+def _star_referenced_source_ids(scopes: list[Scope]) -> set[int]:
+    """ids of sources exposed to some other scope via `SELECT *` or `alias.*`."""
+    referenced: set[int] = set()
+
+    for scope in scopes:
+        scope_expression = scope.expression
+        if not isinstance(scope_expression, exp.Select):
+            continue
+
+        for projection in scope_expression.selects:
+            if isinstance(projection, exp.Star):
+                # Bare, unqualified `*` exposes every source in this scope.
+                for _, source in scope.selected_sources.values():
+                    referenced.add(id(source))
+            elif isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star):
+                # Qualified `alias.*` exposes only that one source.
+                qualified_source = scope.sources.get(projection.table)
+                if qualified_source is not None:
+                    referenced.add(id(qualified_source))
+
+    return referenced
 
 
 def validate_qualify_columns(expression: E, sql: str | None = None) -> E:
@@ -790,6 +817,7 @@ def _expand_stars(
     using_column_tables: dict[str, t.Any],
     pseudocolumns: set[str],
     annotator: TypeAnnotator,
+    star_referenced_sources: set[int],
 ) -> None:
     """Expand stars to lists of column selections"""
 
@@ -798,6 +826,19 @@ def _expand_stars(
     replace_columns: dict[int, dict[str, exp.Alias]] = {}
     rename_columns: dict[int, dict[str, str]] = {}
     ilike_pattern: str | None = None
+
+    # Output names already used by this projection. Star-expanded columns that would
+    # collide are only aliased uniquely if this scope is exposed to another scope
+    taken_names: set[str] = set()
+    uniquify_names = id(scope) in star_referenced_sources
+
+    def add_star_selection(selection: exp.Expr, output_name: str) -> None:
+        if uniquify_names and output_name and output_name in taken_names:
+            unique_name = find_new_name(taken_names, output_name)
+            selection = alias(selection.unalias(), unique_name, copy=False)
+            output_name = unique_name
+        taken_names.add(output_name)
+        new_selections.append(selection)
 
     coalesced_columns = set()
     dialect = resolver.dialect
@@ -844,10 +885,12 @@ def _expand_stars(
                         annotator.uncache(expression)
 
                     new_selections.extend(struct_fields)
+                    taken_names.update(field.output_name for field in struct_fields)
                     continue
 
         if not tables:
             new_selections.append(expression)
+            taken_names.add(expression.output_name)
             continue
 
         for table in tables:
@@ -882,11 +925,14 @@ def _expand_stars(
                 pivot_columns = pivot.output_columns(columns) or pivot.alias_column_names
 
                 if pivot_columns:
-                    new_selections.extend(
-                        alias(exp.column(name, table=pivot.alias or None), name, copy=False)
-                        for name in pivot_columns
-                        if name not in columns_to_exclude
-                    )
+                    for name in pivot_columns:
+                        if name not in columns_to_exclude:
+                            add_star_selection(
+                                alias(
+                                    exp.column(name, table=pivot.alias or None), name, copy=False
+                                ),
+                                name,
+                            )
                     continue
 
             for name in columns:
@@ -900,8 +946,8 @@ def _expand_stars(
                     using_tables = using_column_tables[name]
                     coalesce_args = [exp.column(name, table=table) for table in using_tables]
 
-                    new_selections.append(
-                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False)
+                    add_star_selection(
+                        alias(exp.func("coalesce", *coalesce_args), alias=name, copy=False), name
                     )
                 else:
                     alias_ = renamed_columns.get(name, name)
@@ -912,10 +958,11 @@ def _expand_stars(
                     selection_expr = replaced_columns.get(name) or exp.column(
                         name, table=table, quoted=quoted
                     )
-                    new_selections.append(
+                    add_star_selection(
                         alias(selection_expr, alias_, copy=False)
                         if alias_ != name
-                        else selection_expr
+                        else selection_expr,
+                        alias_,
                     )
 
         if annotated_ahead:

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -1057,8 +1057,22 @@ SELECT _0.a AS a, _0.b AS b, _1.b AS b, _1.c AS c FROM ((SELECT x.a AS a, x.b AS
 # title: outer star over derived table with duplicate output names is left unexpanded
 # execute: false
 SELECT * FROM (SELECT * FROM x CROSS JOIN y) AS s;
-SELECT * FROM (SELECT * FROM x AS x CROSS JOIN y AS y) AS s;
+SELECT * FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c FROM x AS x CROSS JOIN y AS y) AS s;
 
+# title: qualified outer star over derived table with duplicate output names is left unexpanded
+# execute: false
+SELECT s.* FROM (SELECT * FROM x CROSS JOIN y) AS s;
+SELECT s.* FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c FROM x AS x CROSS JOIN y AS y) AS s;
+
+# title: user-authored duplicate aliases in a derived table are preserved, not clobbered
+# execute: false
+SELECT * FROM (SELECT a AS k, a AS k FROM x) AS s;
+SELECT * FROM (SELECT x.a AS k, x.a AS k FROM x AS x) AS s;
+
+# title: mixed star and explicit projection in a derived table with duplicate output names is preserved
+# execute: false
+SELECT * FROM (SELECT *, a AS extra FROM x CROSS JOIN y) AS s;
+SELECT * FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c, x.a AS extra FROM x AS x CROSS JOIN y AS y) AS s;
 
 SELECT b FROM ((SELECT a FROM x) INNER JOIN y ON a = b);
 SELECT y.b AS b FROM ((SELECT x.a AS a FROM x AS x) AS _0 INNER JOIN y AS y ON _0.a = y.b);

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -1055,22 +1055,26 @@ SELECT * FROM ((SELECT * FROM x) INNER JOIN (SELECT * FROM y) ON a = c);
 SELECT _0.a AS a, _0.b AS b, _1.b AS b, _1.c AS c FROM ((SELECT x.a AS a, x.b AS b FROM x AS x) AS _0 INNER JOIN (SELECT y.b AS b, y.c AS c FROM y AS y) AS _1 ON _0.a = _1.c);
 
 # title: outer star over derived table with duplicate output names is left unexpanded
-# execute: false
 SELECT * FROM (SELECT * FROM x CROSS JOIN y) AS s;
 SELECT * FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c FROM x AS x CROSS JOIN y AS y) AS s;
 
 # title: qualified outer star over derived table with duplicate output names is left unexpanded
-# execute: false
 SELECT s.* FROM (SELECT * FROM x CROSS JOIN y) AS s;
 SELECT s.* FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c FROM x AS x CROSS JOIN y AS y) AS s;
 
+# title: outer star over derived table with distinct output names is expanded normally
+SELECT * FROM (SELECT a, c FROM x CROSS JOIN y) AS s;
+SELECT s.a AS a, s.c AS c FROM (SELECT x.a AS a, y.c AS c FROM x AS x CROSS JOIN y AS y) AS s;
+
+# title: nested outer stars over duplicate output names are left unexpanded at each level
+SELECT * FROM (SELECT * FROM (SELECT * FROM x CROSS JOIN y) AS s) AS t;
+SELECT * FROM (SELECT * FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c FROM x AS x CROSS JOIN y AS y) AS s) AS t;
+
 # title: user-authored duplicate aliases in a derived table are preserved, not clobbered
-# execute: false
 SELECT * FROM (SELECT a AS k, a AS k FROM x) AS s;
 SELECT * FROM (SELECT x.a AS k, x.a AS k FROM x AS x) AS s;
 
 # title: mixed star and explicit projection in a derived table with duplicate output names is preserved
-# execute: false
 SELECT * FROM (SELECT *, a AS extra FROM x CROSS JOIN y) AS s;
 SELECT * FROM (SELECT x.a AS a, x.b AS b, y.b AS b, y.c AS c, x.a AS extra FROM x AS x CROSS JOIN y AS y) AS s;
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -1054,6 +1054,12 @@ SELECT x.a AS a, y.b AS b, z.c AS c FROM x AS x LEFT JOIN (y AS y INNER JOIN z A
 SELECT * FROM ((SELECT * FROM x) INNER JOIN (SELECT * FROM y) ON a = c);
 SELECT _0.a AS a, _0.b AS b, _1.b AS b, _1.c AS c FROM ((SELECT x.a AS a, x.b AS b FROM x AS x) AS _0 INNER JOIN (SELECT y.b AS b, y.c AS c FROM y AS y) AS _1 ON _0.a = _1.c);
 
+# title: outer star over derived table with duplicate output names is left unexpanded
+# execute: false
+SELECT * FROM (SELECT * FROM x CROSS JOIN y) AS s;
+SELECT * FROM (SELECT * FROM x AS x CROSS JOIN y AS y) AS s;
+
+
 SELECT b FROM ((SELECT a FROM x) INNER JOIN y ON a = b);
 SELECT y.b AS b FROM ((SELECT x.a AS a FROM x AS x) AS _0 INNER JOIN y AS y ON _0.a = y.b);
 


### PR DESCRIPTION
When `qualify_columns` expands a `SELECT *` over sources with overlapping column names (e.g. two joined tables that both have an `id` column), it causes problems:

1. it produces duplicate output aliases in the projection list,
2. it can canonicalize into the wrong query,
3. it can cause different queries to collide on the same output

This is a problem when that expanded scope is itself re-exposed to an outer scope via another `table.*` or `alias.*`, since duplicate aliases at that point collapse distinct columns under the same name.

Sample Query (wrong canonicalization)
```
Schema: {"x": {"id": "INT", "name": "TEXT"}, "y": {"id": "INT", "name": "TEXT"}}
SELECT * FROM x CROSS JOIN (SELECT * FROM y AS a CROSS JOIN x AS b) AS w;
```
Output (before fix), this is a different query (vs input):
```
WITH "w" AS (SELECT "a"."id" AS "id", "a"."name" AS "name", "b"."id" AS "id", "b"."name" AS "name" FROM "y" AS "a" CROSS JOIN "x" AS "b") SELECT "x"."id" AS "id", "x"."name" AS "name", "w"."id" AS "id", "w"."name" AS "name", "w"."id" AS "id", "w"."name" AS "name" FROM "x" AS "x" CROSS JOIN "w" AS "w";
```
Expected output (after fix), same query as input:
```
SELECT "s"."id" AS "id", "s"."name" AS "name", "s"."id_2" AS "id_2", "s"."name_2" AS "name_2" FROM (SELECT "x"."id" AS "id", "x"."name" AS "name", "y"."id" AS "id_2", "y"."name" AS "name_2" FROM "x" AS "x" CROSS JOIN "y" AS "y") AS "s";
```


Sample Queries (for query collision):
```
Schema: {"u": {"v": "INT"}, "w": {"v": "INT"}}
Q_1: SELECT s.v, s.v FROM (SELECT a.v AS v, b.v AS v FROM u AS a CROSS JOIN w AS b) AS s;
Q_2: SELECT * FROM (SELECT * FROM u AS a CROSS JOIN w AS b) AS s;
```
These are different queries that return different data, but they both collide into:
```
SELECT "s"."v" AS "v", "s"."v" AS "v" FROM (SELECT "a"."v" AS "v", "b"."v" AS "v" FROM "u" AS "a" CROSS JOIN "w" AS "b") AS "s";
```
Expected output:
```
Q_1: SELECT "s"."v" AS "v", "s"."v" AS "v" FROM (SELECT "a"."v" AS "v", "b"."v" AS "v" FROM "u" AS "a" CROSS JOIN "w" AS "b") AS "s";
Q_2: SELECT "s"."v" AS "v", "s"."v_2" AS "v_2" FROM (SELECT "a"."v" AS "v", "b"."v" AS "v_2" FROM "u" AS "a" CROSS JOIN "w" AS "b") AS "s";
```