### PR TITLE
fix(postgres): default unitless DATEDIFF to DAY instead of AGE [CLAUDE]

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -78,7 +78,7 @@ def _date_add_sql(kind: str) -> t.Callable[[PostgresGenerator, DATE_ADD_OR_SUB],
 
 
 def _date_diff_sql(self: PostgresGenerator, expression: exp.DateDiff | exp.TsOrDsDiff) -> str:
-    unit = expression.text("unit").upper()
+    unit = expression.text("unit").upper() or "DAY"
     factor = DATE_DIFF_FACTOR.get(unit)
 
     end = f"CAST({self.sql(expression, 'this')} AS TIMESTAMP)"

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -822,6 +822,7 @@ class TestMySQL(Validator):
             write={
                 "exasol": "SELECT DAYS_BETWEEN(x, y)",
                 "mysql": "SELECT DATEDIFF(x, y)",
+                "postgres": "SELECT CAST(EXTRACT(epoch FROM CAST(x AS TIMESTAMP) - CAST(y AS TIMESTAMP)) / 86400 AS BIGINT)",
                 "presto": "SELECT DATE_DIFF('DAY', y, x)",
                 "redshift": "SELECT DATEDIFF(DAY, y, x)",
             },


### PR DESCRIPTION
### Problem

`DATEDIFF(a, b)` transpiled from MySQL to Postgres produces invalid, semantically wrong SQL:

```python
sqlglot.transpile("SELECT DATEDIFF(x, y)", read="mysql", write="postgres")[0]
# SELECT CAST(AGE(CAST(x AS TIMESTAMP), CAST(y AS TIMESTAMP)) AS BIGINT)
```

Two problems with that output:

1. **Invalid SQL** — `AGE(...)` returns an `interval`, and Postgres has no cast from `interval` to `bigint` (`ERROR: cannot cast type interval to bigint`), so the statement won't run.
2. **Wrong semantics** — MySQL `DATEDIFF(a, b)` returns an integer count of days. `AGE` returns a symbolic year/month/day interval, not a total day count.

### Cause

MySQL `DATEDIFF(a, b)` parses to a `DateDiff` node with **no `unit`**. In `_date_diff_sql` (`sqlglot/generators/postgres.py`), `unit` becomes `""`, so `DATE_DIFF_FACTOR.get("")` is `None`, the correct `"DAY": " / 86400"` path is skipped, and control falls through to the `AGE` fallback (which is only meant for `MONTH`/`QUARTER`/`YEAR`).

### Fix

Default the empty unit to `"DAY"` before the factor lookup, matching sqlglot's own `default_unit="DAY"` convention (`dialect.py`). A unitless diff now uses the already-correct epoch path:

```python
sqlglot.transpile("SELECT DATEDIFF(x, y)", read="mysql", write="postgres")[0]
# SELECT CAST(EXTRACT(epoch FROM CAST(x AS TIMESTAMP) - CAST(y AS TIMESTAMP)) / 86400 AS BIGINT)
```

This is exactly what the DuckDB/Presto paths already emit for the same input, so Postgres was the outlier. Explicit `WEEK`/`MONTH`/`QUARTER`/`YEAR` diffs are unchanged and still use `AGE`.

### Testing

- Added the missing `postgres` entry to the existing `SELECT DATEDIFF(x, y)` test in `tests/dialects/test_mysql.py` (the write dict already covered exasol/mysql/presto/redshift but omitted postgres — the broken path was untested). Verified it fails before the fix and passes after.
- Full unit suite passes locally (`SKIP_INTEGRATION=1 python -m unittest`), no regressions.
- `ruff check`, `ruff format --check`, and `mypy` clean on the changed files.

### AI disclosure

Prepared with AI assistance — tool: **Claude Code** (Anthropic), model: **Claude**. The change and tests were reviewed and verified locally by me. Per the contributing guidelines the model is also tagged in the PR title and commit message (`[CLAUDE]`).
