### PR TITLE
fix(clickhouse): parse camelCase dateTrunc, not just date_trunc [CLAUDE]

### DIFF
--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -287,6 +287,7 @@ class ClickHouseParser(parser.Parser):
         "DATE_FORMAT": _build_datetime_format(exp.TimeToStr),
         "DATE_SUB": build_date_delta(exp.DateSub, default_unit=None),
         "DATESUB": build_date_delta(exp.DateSub, default_unit=None),
+        "DATETRUNC": exp.DateTrunc.from_arg_list,
         "FORMATDATETIME": _build_datetime_format(exp.TimeToStr),
         "HAS": exp.ArrayContains.from_arg_list,
         "ILIKE": build_like(exp.ILike),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1832,6 +1832,21 @@ LIFETIME(MIN 0 MAX 0)""",
             },
         )
 
+        # camelCase dateTrunc is emitted by this dialect, so it must parse back
+        self.validate_all(
+            "dateTrunc('MONTH', x)",
+            read={
+                "clickhouse": "dateTrunc('MONTH', x)",
+            },
+            write={
+                "clickhouse": "dateTrunc('MONTH', x)",
+                "databricks": "TRUNC(x, 'MONTH')",
+                "duckdb": "DATE_TRUNC('MONTH', x)",
+                "presto": "DATE_TRUNC('MONTH', x)",
+                "spark": "TRUNC(x, 'MONTH')",
+            },
+        )
+
         self.validate_all(
             "date_trunc('WEEK', today())",
             write={


### PR DESCRIPTION
### Problem

ClickHouse's `dateTrunc` (camelCase) doesn't parse, so transpiling it out of ClickHouse produces a bare `DATETRUNC(...)` that is invalid in every other dialect:

```python
sqlglot.transpile("SELECT dateTrunc('month', ts)", read="clickhouse", write="presto")[0]
# SELECT DATETRUNC('month', ts)     <- no such function
sqlglot.transpile("SELECT dateTrunc('month', ts)", read="clickhouse", write="duckdb")[0]
# SELECT DATETRUNC('month', ts)
```

The snake_case alias is fine, which is what makes this look like a lookup gap rather than missing support:

```python
sqlglot.transpile("SELECT date_trunc('month', ts)", read="clickhouse", write="presto")[0]
# SELECT DATE_TRUNC('MONTH', ts)
```

It also breaks a round trip through sqlglot's own output: the ClickHouse generator *emits* `dateTrunc` (`generators/clickhouse.py`, covered by `test_clickhouse.py`), but the ClickHouse parser can't read that back — `date_trunc('WEEK', x)` generates `dateTrunc('WEEK', x)`, which re-parses to `Anonymous` instead of `DateTrunc`.

### Cause

`ClickHouseParser.FUNCTIONS` inherits the `DATE_TRUNC` key, but function lookup is on the uppercased name, so `dateTrunc` → `DATETRUNC` misses the dict and falls through to `exp.Anonymous`:

```python
parse_one("SELECT dateTrunc('month', ts)", read="clickhouse").selects[0]   # Anonymous
parse_one("SELECT date_trunc('month', ts)", read="clickhouse").selects[0]  # DateTrunc
```

### Fix

Register `DATETRUNC` to the same builder as the inherited `DATE_TRUNC`, so both spellings of the same ClickHouse function parse identically:

```python
sqlglot.transpile("SELECT dateTrunc('MONTH', ts)", read="clickhouse", write="presto")[0]
# SELECT DATE_TRUNC('MONTH', ts)
```

ClickHouse output is unchanged (`dateTrunc('MONTH', ts)`), so this is purely additive to the parser.

One judgement call worth flagging for review: `dateTrunc` is arguably closer to `exp.TimestampTrunc` (what `toStartOfXxx` maps to since #6268) than to `exp.DateTrunc`. I mapped it to `DateTrunc` deliberately — it keeps `dateTrunc` and its own `date_trunc` alias parsing to the same node. Splitting the two aliases across different expression types seemed like a semantic change that should be your call, not a side effect of a parser fix. Happy to switch if you'd prefer `TimestampTrunc`.

### Testing

- Added a `dateTrunc('MONTH', x)` case to `test_to_start_of` in `tests/dialects/test_clickhouse.py`, covering read-back plus writes to clickhouse/databricks/duckdb/presto/spark. Verified red before the fix (all 4 cross-dialect subtests emit `DATETRUNC('MONTH', x)`) and green after.
- Full suite passes locally: 1131 passed, 18556 subtests. The only failure is the pre-existing `test_lazy_load`, which fails identically on an unmodified `main` in my environment (it shells out to a `python` binary that isn't on PATH here) and is unrelated to this change.
- `ruff check` and `ruff format --check` clean on both changed files.

### AI disclosure

Prepared with AI assistance — tool: **Claude Code** (Anthropic), model: **Claude**. I reproduced the bug against the unmodified module, verified the fix and tests locally, and take responsibility for the change. Per the contributing guidelines the model is also tagged in the PR title and commit message (`[CLAUDE]`).
