### PR TITLE
fix(oracle): unrecognized WITH hangs the parser [CLAUDE]

### DIFF
--- a/sqlglot/parsers/oracle.py
+++ b/sqlglot/parsers/oracle.py
@@ -4,7 +4,7 @@ import typing as t
 
 from sqlglot import exp, parser
 from sqlglot.dialects.dialect import build_formatted_time, build_timetostr_or_tochar, build_trunc
-from sqlglot.helper import seq_get
+from sqlglot.helper import ensure_list, seq_get
 from sqlglot.parser import OPTIONS_TYPE, build_coalesce
 from sqlglot.tokens import TokenType
 
@@ -77,7 +77,10 @@ class OracleParser(parser.Parser):
     QUERY_MODIFIER_PARSERS = {
         **parser.Parser.QUERY_MODIFIER_PARSERS,
         TokenType.ORDER_SIBLINGS_BY: lambda self: ("order", self._parse_order()),
-        TokenType.WITH: lambda self: ("options", [self._parse_query_restrictions()]),
+        TokenType.WITH: lambda self: (
+            "options",
+            ensure_list(self._parse_query_restrictions()),
+        ),
     }
 
     TYPE_LITERAL_PARSERS = {

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -1,4 +1,4 @@
-from sqlglot import exp, UnsupportedError, ParseError, parse, parse_one
+from sqlglot import exp, ErrorLevel, UnsupportedError, ParseError, parse, parse_one
 from tests.dialects.test_dialect import Validator
 from sqlglot.optimizer.qualify import qualify
 
@@ -633,6 +633,24 @@ CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4"""
                     self.validate_identity(
                         f"CREATE VIEW view AS SELECT * FROM tbl WITH {restriction}{constraint_name}"
                     )
+
+    def test_unrecognized_query_restriction(self):
+        """An unrecognized WITH must error, not spin in _parse_query_modifiers.
+
+        _parse_query_restrictions returns None when WITH isn't followed by a
+        recognized restriction. Wrapping that in a list literal made it the
+        truthy [None], which passed the modifier loop's `if expression:` guard
+        without ever consuming the WITH token.
+        """
+        for sql in (
+            "SELECT * FROM tbl WITH",
+            "SELECT * FROM tbl WITH READ",
+            "SELECT * FROM tbl WITH GRANT OPTION",
+            "SELECT * FROM t WITH x AS (SELECT 1) SELECT * FROM x",
+        ):
+            with self.subTest(sql):
+                with self.assertRaises(ParseError):
+                    parse_one(sql, read="oracle", error_level=ErrorLevel.RAISE)
 
     def test_multitable_inserts(self):
         self.maxDiff = None


### PR DESCRIPTION
An unrecognized `WITH` makes the Oracle parser spin forever:

```python
sqlglot.parse_one("SELECT * FROM tbl WITH", read="oracle", error_level=ErrorLevel.RAISE)
# never returns; self.errors grows without bound
```

Postgres and DuckDB raise a `ParseError` on the same input.

## Cause

Oracle's `WITH` query modifier wraps its result in a list literal:

```python
TokenType.WITH: lambda self: ("options", [self._parse_query_restrictions()]),
```

`_parse_query_restrictions` returns `None` when `WITH` isn't followed by `READ ONLY` or `CHECK OPTION` (it `_retreat`s and gives up). The lambda turns that into `[None]` — **truthy** — which passes the `if expression:` guard in `_parse_query_modifiers`. The `WITH` token is never consumed, so the enclosing `while True` re-enters on the same token forever.

It is the **only** entry among the 25 `QUERY_MODIFIER_PARSERS` (base, Oracle, ClickHouse, T-SQL) that wraps in a list literal — every other returns the parse result directly, so the guard works for them.

Only `ErrorLevel.IMMEDIATE` escapes, and only incidentally, because `raise_error` raises before the `continue`. **IMMEDIATE is the default**, which is why this went unnoticed. `IGNORE`, `WARN` and `RAISE` all hang — and those are exactly the levels a linter or IDE parsing untrusted SQL would use, where a silent hang is worse than an error.

## Fix

Use `ensure_list`, which yields a falsy `[]` for `None` so the existing guard breaks the loop, and `[x]` otherwise — preserving the list shape `options` expects. Valid restrictions are unaffected; `WITH READ ONLY` and `WITH CHECK OPTION` round-trip byte-identically.

## Reachability

Hanging inputs include a realistic one — a script missing a semicolon before a CTE:

```
SELECT * FROM t WITH x AS (SELECT 1) SELECT * FROM x
```

plus truncated restrictions (`WITH READ`, `WITH CHECK`) and `WITH GRANT OPTION`. Oracle permits only `WITH READ ONLY` and `WITH CHECK OPTION` as query restrictions ([SELECT, 19c SQL Language Reference](https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/SELECT.html)), matching `QUERY_RESTRICTIONS` — anything else is malformed and must error, not hang.

## Tests

Four previously-hanging inputs now assert `ParseError` under `ErrorLevel.RAISE`. `test_query_restrictions` covers only the two valid restrictions, so the unrecognized path was untested.

- `pytest tests/dialects/test_oracle.py` — 26 passed, 219 subtests
- `pytest tests/` — 1132 passed, 18561 subtests. The one failure (`test_lazy_load`) needs a `python` binary on PATH and fails identically on a clean checkout — verified with `git stash`.
- `ruff check` / `ruff format --check` clean.

---

AI disclosure: drafted with Claude Code (Opus 4.8), including the root-cause trace and the tests. I ran the repro and the full suite locally and reviewed the diff before opening. Model tag is in the title and commit per CLAUDE.md.