### PR TITLE
chore: remove stray raise in simplify

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -710,9 +710,6 @@ class Simplifier:
             if node is not original:
                 original.replace(node)
 
-            for n in node.iter_expressions(reverse=True):
-                if n.meta_get(FINAL):
-                    raise
             pre_transformation_stack.extend(
                 n for n in node.iter_expressions(reverse=True) if not n.meta_get(FINAL)
             )


### PR DESCRIPTION
Seems like this loop was used for debugging purposes during the `simplify` refactor:

1. It's a bare `raise` outside any except block. If it ever fired, Python wouldn't raise anything meaningful.
2. It came from #6351.
3. It appears to be unreachable. `FINAL` is only ever set in `simplify()` (L635/640/648/663) on `GROUP BY` clauses, grouped projections, HAVING, and Snowflake `match_condition`, all of which hang off `Select`/`Join` nodes. But `_simplify` only ever runs on `Condition` trees and any nested `exp.Query` hit inside the pre-transformation loop is recursed into separately and continued at line 693–696, so its children never enter the stack. Meanwhile the check does a full extra `iter_expressions` pass over every node's children on every `while_changing` iteration, duplicating the iteration that the extend right below already does.