### PR TITLE
fix(optimizer)!: canonicalize numeric-literal GROUP BY to positional ordinal on merge

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -384,14 +384,6 @@ def _merge_joins(outer_scope: Scope, inner_scope: Scope, from_or_join: FromOrJoi
         outer_scope.expression.set("joins", outer_joins)
 
 
-def _projection_ordinal(outer_scope: Scope, name: str) -> int | None:
-    """1-based position of the outer projection named `name`, or None if it isn't projected."""
-    for i, projection in enumerate(t.cast(exp.Select, outer_scope.expression).selects, 1):
-        if projection.alias_or_name == name:
-            return i
-    return None
-
-
 def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> None:
     """
     Merge projections of inner query into outer query.
@@ -422,18 +414,18 @@ def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> No
         is_number = expression.is_number
         last = len(columns_to_replace) - 1
 
-        # A numeric-literal projection can't be inlined into GROUP BY (it would become a
-        # positional reference to a projection); canonicalize to the projection's ordinal to
-        # match qualify. All columns here share `projection_name`, so resolve the ordinal once.
-        group_by_ordinal = _projection_ordinal(outer_scope, projection_name) if is_number else None
-
         for i, column in enumerate(columns_to_replace):
             parent = column.parent
 
+            # A numeric-literal projection can't be inlined into GROUP BY, canonicalize
+            # to the projection's ordinal to match qualify
             if is_number and isinstance(parent, exp.Group):
+                names = [
+                    s.alias_or_name for s in t.cast(exp.Select, outer_scope.expression).selects
+                ]
                 column.replace(
-                    exp.Literal.number(group_by_ordinal)
-                    if group_by_ordinal is not None
+                    exp.Literal.number(names.index(projection_name) + 1)
+                    if projection_name in names
                     else exp.to_identifier(projection_name)
                 )
                 continue

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -174,8 +174,9 @@ def _mergeable(
         )
 
     def _literal_group_alias_collision():
-        """A numeric-literal projection in the outer GROUP BY merges to a bare `GROUP BY a`
-        that can collide with a same-named FROM column."""
+        """A numeric-literal projection in GROUP BY merges to an ordinal when projected in
+        the outer SELECT (no collision possible), or a bare identifier when not projected
+        (collision with a same-named FROM column is possible). This guard blocks the latter."""
         group = outer_scope.expression.args.get("group")
         if not group:
             return False
@@ -414,18 +415,27 @@ def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> No
         is_number = expression.is_number
         last = len(columns_to_replace) - 1
 
+        if is_number and isinstance(outer_scope.expression, exp.Select):
+            # Find the ordinal of the outer SELECT that references this inner projection.
+            for j, s in enumerate(outer_scope.expression.selects):
+                unaliased = s.unalias()
+                if (
+                    isinstance(unaliased, exp.Column)
+                    and unaliased.table == alias
+                    and unaliased.name == projection_name
+                ):
+                    group_ordinal = j + 1
+                    break
+
         for i, column in enumerate(columns_to_replace):
             parent = column.parent
 
             # A numeric-literal projection can't be inlined into GROUP BY, canonicalize
             # to the projection's ordinal to match qualify
             if is_number and isinstance(parent, exp.Group):
-                names = [
-                    s.alias_or_name for s in t.cast(exp.Select, outer_scope.expression).selects
-                ]
                 column.replace(
-                    exp.Literal.number(names.index(projection_name) + 1)
-                    if projection_name in names
+                    exp.Literal.number(group_ordinal)
+                    if group_ordinal is not None
                     else exp.to_identifier(projection_name)
                 )
                 continue

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -415,6 +415,7 @@ def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> No
         is_number = expression.is_number
         last = len(columns_to_replace) - 1
 
+        group_ordinal = None
         if is_number and isinstance(outer_scope.expression, exp.Select):
             # Find the ordinal of the outer SELECT that references this inner projection.
             for j, s in enumerate(outer_scope.expression.selects):

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -384,6 +384,14 @@ def _merge_joins(outer_scope: Scope, inner_scope: Scope, from_or_join: FromOrJoi
         outer_scope.expression.set("joins", outer_joins)
 
 
+def _projection_ordinal(outer_scope: Scope, name: str) -> int | None:
+    """1-based position of the outer projection named `name`, or None if it isn't projected."""
+    for i, projection in enumerate(t.cast(exp.Select, outer_scope.expression).selects, 1):
+        if projection.alias_or_name == name:
+            return i
+    return None
+
+
 def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> None:
     """
     Merge projections of inner query into outer query.
@@ -414,14 +422,20 @@ def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> No
         is_number = expression.is_number
         last = len(columns_to_replace) - 1
 
+        # A numeric-literal projection can't be inlined into GROUP BY (it would become a
+        # positional reference to a projection); canonicalize to the projection's ordinal to
+        # match qualify. All columns here share `projection_name`, so resolve the ordinal once.
+        group_by_ordinal = _projection_ordinal(outer_scope, projection_name) if is_number else None
+
         for i, column in enumerate(columns_to_replace):
             parent = column.parent
 
-            # Ensures that we don't merge literal numbers in GROUP BY as they have positional context
-            # e.g don't trasform `SELECT a FROM (SELECT 6 AS a) GROUP BY a` to `SELECT 6 AS a GROUP BY 6`,
-            # as this would attempt to GROUP BY the 6th projection instead of the column `a`
             if is_number and isinstance(parent, exp.Group):
-                column.replace(exp.to_identifier(column.name))
+                column.replace(
+                    exp.Literal.number(group_by_ordinal)
+                    if group_by_ordinal is not None
+                    else exp.to_identifier(projection_name)
+                )
                 continue
 
             # Ensures we don't alter the intended operator precedence if there's additional

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 from sqlglot import expressions as exp
 from sqlglot.helper import find_new_name, seq_get
 from sqlglot.optimizer.scope import Scope, traverse_scope
-from sqlglot.schema import Schema
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
@@ -15,9 +14,7 @@ if t.TYPE_CHECKING:
     FromOrJoin = t.Union[exp.From, exp.Join]
 
 
-def merge_subqueries(
-    expression: E, leave_tables_isolated: bool = False, schema: Schema | None = None
-) -> E:
+def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
     """
     Rewrite sqlglot AST to merge derived tables into the outer query.
 
@@ -40,12 +37,11 @@ def merge_subqueries(
     Args:
         expression (sqlglot.Expr): expression to optimize
         leave_tables_isolated (bool):
-        schema: database schema used to look up table columns for merge-safety checks.
     Returns:
         sqlglot.Expr: optimized expression
     """
-    expression = merge_ctes(expression, leave_tables_isolated, schema=schema)
-    expression = merge_derived_tables(expression, leave_tables_isolated, schema=schema)
+    expression = merge_ctes(expression, leave_tables_isolated)
+    expression = merge_derived_tables(expression, leave_tables_isolated)
     return expression
 
 
@@ -71,9 +67,7 @@ SAFE_TO_REPLACE_UNWRAPPED = (
 )
 
 
-def merge_ctes(
-    expression: E, leave_tables_isolated: bool = False, schema: Schema | None = None
-) -> E:
+def merge_ctes(expression: E, leave_tables_isolated: bool = False) -> E:
     scopes = traverse_scope(expression)
 
     # All places where we select from CTEs.
@@ -95,7 +89,7 @@ def merge_ctes(
         from_or_join = table.find_ancestor(exp.From, exp.Join)
         if not isinstance(from_or_join, (exp.From, exp.Join)):
             continue
-        if _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join, schema=schema):
+        if _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join):
             alias = table.alias_or_name
             _rename_inner_sources(outer_scope, inner_scope, alias)
             _merge_from(
@@ -111,9 +105,7 @@ def merge_ctes(
     return expression
 
 
-def merge_derived_tables(
-    expression: E, leave_tables_isolated: bool = False, schema: Schema | None = None
-) -> E:
+def merge_derived_tables(expression: E, leave_tables_isolated: bool = False) -> E:
     for outer_scope in traverse_scope(expression):
         for subquery in outer_scope.derived_tables:
             from_or_join = subquery.find_ancestor(exp.From, exp.Join)
@@ -123,9 +115,7 @@ def merge_derived_tables(
             inner_scope = outer_scope.sources[alias]
             if not isinstance(inner_scope, Scope):
                 continue
-            if _mergeable(
-                outer_scope, inner_scope, leave_tables_isolated, from_or_join, schema=schema
-            ):
+            if _mergeable(outer_scope, inner_scope, leave_tables_isolated, from_or_join):
                 _rename_inner_sources(outer_scope, inner_scope, alias)
                 _merge_from(outer_scope, inner_scope, subquery, alias)
                 _merge_expressions(outer_scope, inner_scope, alias)
@@ -143,7 +133,6 @@ def _mergeable(
     inner_scope: Scope,
     leave_tables_isolated: bool,
     from_or_join: FromOrJoin,
-    schema: Schema | None = None,
 ) -> bool:
     """
     Return True if `inner_select` can be merged into outer query.
@@ -173,44 +162,42 @@ def _mergeable(
             for column in outer_scope.columns
         )
 
-    def _literal_group_alias_collision():
-        """A numeric-literal projection in GROUP BY merges to an ordinal when projected in
-        the outer SELECT (no collision possible), or a bare identifier when not projected
-        (collision with a same-named FROM column is possible). This guard blocks the latter."""
+    def _literal_group_unmergeable():
+        """
+        A numeric-literal projection referenced in GROUP BY can't be inlined, because a bare
+        integer literal is positional. A reference that is itself a top-level GROUP BY item
+        can merge as the ordinal of the outer projection that selects it; any other reference,
+        e.g., ROLLUP / CUBE / GROUPING SETS, tuples, expressions, etc, blocks the merge, since
+        ordinals aren't universally supported there, e.g., Presto / Trino only accept columns.
+        """
         group = outer_scope.expression.args.get("group")
         if not group:
             return False
+
         inner_name = from_or_join.alias_or_name
-        grouped = {
-            col.name
-            for e in group.expressions
-            for col in e.find_all(exp.Column)
-            if col.table == inner_name
-        }
+        literal_names = {s.alias_or_name for s in inner_select.selects if s.unalias().is_number}
+        if not literal_names:
+            return False
+
+        grouped = set()
+        top_level_ids = {id(e.unnest()) for e in group.expressions}
+        for col in group.find_all(exp.Column):
+            if col.table != inner_name or col.name not in literal_names:
+                continue
+            if id(col) not in top_level_ids:
+                return True
+            grouped.add(col.name)
+
         if not grouped:
             return False
-        literal_grouped = {
-            s.alias_or_name
-            for s in inner_select.selects
-            if s.alias_or_name in grouped and s.unalias().is_number
-        }
-        if not literal_grouped:
-            return False
-        # `GROUP BY a` resolves against the whole merged FROM: inner sources + outer's others.
-        merged_sources = {
-            src for name, (_, src) in outer_scope.selected_sources.items() if name != inner_name
-        }
-        merged_sources.update(src for _, src in inner_scope.selected_sources.values())
-        for source in merged_sources:
-            if isinstance(source, exp.Table):
-                columns = schema.column_names(source) if schema else None
-                if not columns or literal_grouped & set(columns):
-                    return True
-            elif isinstance(source, Scope) and literal_grouped & set(
-                source.expression.named_selects
-            ):
-                return True
-        return False
+
+        projected = set()
+        for s in outer_scope.expression.selects:
+            unaliased = s.unalias()
+            if isinstance(unaliased, exp.Column) and unaliased.table == inner_name:
+                projected.add(unaliased.name)
+
+        return not grouped <= projected
 
     def _outer_select_joins_on_inner_select_join():
         """
@@ -266,9 +253,9 @@ def _mergeable(
             return False
         inner_name = from_or_join.alias_or_name
         ordered = {
-            o.this.name
+            key.name
             for o in order.expressions
-            if isinstance(o.this, exp.Column) and o.this.table == inner_name
+            if isinstance(key := o.this.unnest(), exp.Column) and key.table == inner_name
         }
         return any(
             s.alias_or_name in ordered and s.unalias().is_number for s in inner_select.selects
@@ -298,7 +285,7 @@ def _mergeable(
         )
         and not _outer_select_joins_on_inner_select_join()
         and not _window_projection_blocks_merge()
-        and not _literal_group_alias_collision()
+        and not _literal_group_unmergeable()
         and not _literal_in_order_by()
         and not _is_recursive()
         and not (inner_select.args.get("order") and outer_scope.is_union)
@@ -400,6 +387,8 @@ def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> No
         if column.table == alias:
             outer_columns[column.name].append(column)
 
+    group = outer_scope.expression.args.get("group")
+
     # Replace columns with the projection expression in the inner query
     for expression in inner_scope.expression.expressions:
         projection_name = expression.alias_or_name
@@ -431,15 +420,14 @@ def _merge_expressions(outer_scope: Scope, inner_scope: Scope, alias: str) -> No
         for i, column in enumerate(columns_to_replace):
             parent = column.parent
 
-            # A numeric-literal projection can't be inlined into GROUP BY, canonicalize
-            # to the projection's ordinal to match qualify
-            if is_number and isinstance(parent, exp.Group):
-                column.replace(
-                    exp.Literal.number(group_ordinal)
-                    if group_ordinal is not None
-                    else exp.to_identifier(projection_name)
-                )
-                continue
+            # A numeric-literal projection can't be inlined into a top-level GROUP BY item
+            # (positional context), canonicalize to the projection's ordinal to match
+            # qualify. _mergeable guarantees the ordinal exists.
+            if is_number and group:
+                item = next((e for e in group.expressions if e.unnest() is column), None)
+                if item is not None:
+                    item.replace(exp.Literal.number(group_ordinal))
+                    continue
 
             # Ensures we don't alter the intended operator precedence if there's additional
             # context surrounding the outer expression (i.e. it's not a simple projection).

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -540,9 +540,9 @@ INNER JOIN (
   ON t0.id = t3.id;
 WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 1 AS id, 'US' AS cid) SELECT t0.id AS id, t3.cid AS cid FROM t0 AS t0 INNER JOIN (SELECT t1.id AS id, t2.cid AS cid FROM t1 AS t1 RIGHT JOIN t2 AS t2 ON t1.cid = t2.cid) AS t3 ON t0.id = t3.id;
 
-# title: Dont replace GROUP and ORDER BY if expression is literal
+# title: Numeric-literal GROUP BY becomes a positional ordinal (matching qualify) while ORDER BY keeps the alias
 WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a;
-WITH t1 AS (SELECT 1 AS col) SELECT 6 AS a, SUM(t1.col) AS b FROM t1 AS t1 GROUP BY a ORDER BY a;
+WITH t1 AS (SELECT 1 AS col) SELECT 6 AS a, SUM(t1.col) AS b FROM t1 AS t1 GROUP BY 1 ORDER BY a;
 
 # title: Literal projection whose alias collides with a base-table column is not merged into GROUP BY
 SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY s.a ORDER BY s.a;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -544,27 +544,54 @@ WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 
 WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a;
 WITH t1 AS (SELECT 1 AS col) SELECT 6 AS a, SUM(t1.col) AS b FROM t1 AS t1 GROUP BY 1 ORDER BY a;
 
-# title: Literal projection not projected in outer SELECT falls back to bare identifier in GROUP BY
-# execute: false
+# title: Literal GROUP BY reference not projected in the outer SELECT blocks the merge
 SELECT MAX(x.b) AS lit FROM x CROSS JOIN (SELECT 6 AS lit FROM z) AS t GROUP BY t.lit;
-SELECT MAX(x.b) AS lit FROM x AS x CROSS JOIN z AS z GROUP BY lit;
+SELECT MAX(x.b) AS lit FROM x AS x CROSS JOIN (SELECT 6 AS lit FROM z AS z) AS t GROUP BY t.lit;
 
-# title: Literal projection whose alias collides with a base-table column is not merged into GROUP BY
+# title: Literal projection whose alias collides with a base-table column merges via ordinal
 SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY s.a ORDER BY s.a;
-SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY s.a ORDER BY a;
+SELECT 6 AS a, SUM(x.b) AS b FROM x AS x GROUP BY 1 ORDER BY a;
 
-# title: Literal projection colliding with an unmergeable-CTE column is not merged into GROUP BY
+# title: Literal projection colliding with an unmergeable-CTE column merges via ordinal
 WITH c AS (SELECT DISTINCT a, b FROM x) SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM c) AS s GROUP BY s.a ORDER BY s.a;
-WITH c AS (SELECT DISTINCT x.a AS a, x.b AS b FROM x AS x) SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s GROUP BY s.a ORDER BY a;
+WITH c AS (SELECT DISTINCT x.a AS a, x.b AS b FROM x AS x) SELECT 6 AS a, SUM(c.b) AS b FROM c AS c GROUP BY 1 ORDER BY a;
 
-# title: Literal projection colliding with an outer joined table column is not merged into GROUP BY
+# title: Literal projection colliding with an outer joined table column merges via ordinal
 WITH c AS (SELECT DISTINCT x.b AS b FROM x) SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM c) AS s CROSS JOIN x GROUP BY s.a ORDER BY s.a;
-WITH c AS (SELECT DISTINCT x.b AS b FROM x AS x) SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s CROSS JOIN x AS x GROUP BY s.a ORDER BY a;
+WITH c AS (SELECT DISTINCT x.b AS b FROM x AS x) SELECT 6 AS a, SUM(c.b) AS b FROM c AS c CROSS JOIN x AS x GROUP BY 1 ORDER BY a;
 
-# title: Literal projection is not merged into GROUP BY when a joined table's schema is unknown
+# title: Literal projection merges via ordinal even when a joined table's schema is unknown
 # execute: false
 SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, y.b AS b FROM y) AS s CROSS JOIN unknown_tbl GROUP BY s.a ORDER BY s.a;
-SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, y.b AS b FROM y AS y) AS s CROSS JOIN unknown_tbl AS unknown_tbl GROUP BY s.a ORDER BY a;
+SELECT 6 AS a, SUM(y.b) AS b FROM y AS y CROSS JOIN unknown_tbl AS unknown_tbl GROUP BY 1 ORDER BY a;
+
+# title: Literal projection referenced in ROLLUP blocks the merge (ordinals are not portable there)
+SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY ROLLUP(s.a) ORDER BY s.a;
+SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY ROLLUP (s.a) ORDER BY a;
+
+# title: Literal projection referenced inside a GROUPING SETS tuple blocks the merge
+SELECT s.a, s.b, COUNT(*) AS c FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY GROUPING SETS ((s.a, s.b)) ORDER BY s.b;
+SELECT s.a AS a, s.b AS b, COUNT(*) AS c FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY GROUPING SETS ((s.a, s.b)) ORDER BY b;
+
+# title: Literal projection referenced inside a tuple GROUP BY item blocks the merge
+SELECT s.a, s.b, COUNT(*) AS c FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY (s.a, s.b) ORDER BY s.b;
+SELECT s.a AS a, s.b AS b, COUNT(*) AS c FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY (s.a, s.b) ORDER BY b;
+
+# title: Paren-wrapped literal GROUP BY reference merges via the projection ordinal
+SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY (s.a) ORDER BY s.a;
+SELECT 6 AS a, SUM(x.b) AS b FROM x AS x GROUP BY 1 ORDER BY a;
+
+# title: Paren-wrapped literal inside a tuple GROUP BY item blocks the merge
+SELECT s.a, s.b, COUNT(*) AS c FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY ((s.a), s.b) ORDER BY s.b;
+SELECT s.a AS a, s.b AS b, COUNT(*) AS c FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY ((s.a), s.b) ORDER BY b;
+
+# title: Literal inside a paren-wrapped tuple GROUP BY item blocks the merge
+SELECT s.a, s.b, COUNT(*) AS c FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY ((s.a, s.b)) ORDER BY s.b;
+SELECT s.a AS a, s.b AS b, COUNT(*) AS c FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY ((s.a, s.b)) ORDER BY b;
+
+# title: Paren-wrapped literal ORDER BY reference blocks the merge
+SELECT s.a FROM (SELECT 6 AS a, b FROM x) AS s ORDER BY (s.a);
+SELECT s.a AS a FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s ORDER BY (s.a);
 
 # title: Window function is not merged when the outer query filters its input rows
 SELECT s.w FROM (SELECT a, ROW_NUMBER() OVER (ORDER BY a) AS w FROM x) AS s WHERE s.a > 5;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -544,6 +544,11 @@ WITH t0 AS (SELECT 5 AS id), t1 AS (SELECT 1 AS id, 'US' AS cid), t2 AS (SELECT 
 WITH t1 AS (SELECT 1 AS col) SELECT a, SUM(b) AS b FROM (SELECT 6 AS a, col AS b FROM t1) AS t GROUP BY a ORDER BY a;
 WITH t1 AS (SELECT 1 AS col) SELECT 6 AS a, SUM(t1.col) AS b FROM t1 AS t1 GROUP BY 1 ORDER BY a;
 
+# title: Literal projection not projected in outer SELECT falls back to bare identifier in GROUP BY
+# execute: false
+SELECT MAX(x.b) AS lit FROM x CROSS JOIN (SELECT 6 AS lit FROM z) AS t GROUP BY t.lit;
+SELECT MAX(x.b) AS lit FROM x AS x CROSS JOIN z AS z GROUP BY lit;
+
 # title: Literal projection whose alias collides with a base-table column is not merged into GROUP BY
 SELECT s.a, SUM(s.b) AS b FROM (SELECT 6 AS a, b FROM x) AS s GROUP BY s.a ORDER BY s.a;
 SELECT s.a AS a, SUM(s.b) AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s GROUP BY s.a ORDER BY a;


### PR DESCRIPTION
When `merge_subqueries` inlines a subquery with a numeric-literal projection (e.g. `6 AS a`), a `GROUP BY` reference to it was rewritten as a bare identifier.  This is non-idempotent and diverges from how `qualify` behaves, which uses a positional ordinal.  This patch aligns the output of the two.

Input Query:
```
WITH unused AS (SELECT 1 AS a), t1 AS (SELECT 1 AS col)
SELECT t.a, SUM(t.b) AS b
FROM (SELECT 6 AS a, t1.col AS b FROM t1) AS t
GROUP BY t.a
```
Before:
```
WITH "_t0" AS (SELECT 1 AS "_c0"), "_t1" AS (SELECT 1 AS "_c1")
SELECT 6 AS "a", SUM("_t1"."_c1") AS "b"
FROM "_t1" AS "_t1"
GROUP BY a
```
After:
```
WITH "_t0" AS (SELECT 1 AS "_c0"), "_t1" AS (SELECT 1 AS "_c1")
SELECT 6 AS "a", SUM("_t1"."_c1") AS "b"
FROM "_t1" AS "_t1"
GROUP BY 1
```