### PR TITLE
feat(dremio): support AT SNAPSHOT and AT TIMESTAMP time travel [CLAUDE]

### DIFF
--- a/sqlglot/dialects/dremio.py
+++ b/sqlglot/dialects/dremio.py
@@ -67,6 +67,12 @@ class Dremio(Dialect):
     class Tokenizer(tokens.Tokenizer):
         COMMENTS = ["--", "//", ("/*", "*/")]
 
+        KEYWORDS = {
+            **tokens.Tokenizer.KEYWORDS,
+            "AT SNAPSHOT": tokens.TokenType.VERSION_SNAPSHOT,
+            "AT TIMESTAMP": tokens.TokenType.TIMESTAMP_SNAPSHOT,
+        }
+
     Parser = DremioParser
 
     Generator = DremioGenerator

--- a/sqlglot/generators/dremio.py
+++ b/sqlglot/generators/dremio.py
@@ -72,6 +72,14 @@ class DremioGenerator(generator.Generator):
         exp.GenerateSeries: rename_func("ARRAY_GENERATE_RANGE"),
     }
 
+    def version_sql(self, expression: exp.Version) -> str:
+        if expression.text("kind") == "AS OF":
+            this = "SNAPSHOT" if expression.name == "VERSION" else expression.name
+            return f"AT {this} {self.sql(expression, 'expression')}"
+
+        self.unsupported("Historical data syntax is not supported in Dremio")
+        return super().version_sql(expression)
+
     def datatype_sql(self, expression: exp.DataType) -> str:
         """
         Reject time-zone-aware TIMESTAMPs, which Dremio does not accept

--- a/sqlglot/generators/dremio.py
+++ b/sqlglot/generators/dremio.py
@@ -77,7 +77,7 @@ class DremioGenerator(generator.Generator):
             this = "SNAPSHOT" if expression.name == "VERSION" else expression.name
             return f"AT {this} {self.sql(expression, 'expression')}"
 
-        self.unsupported("Historical data syntax is not supported in Dremio")
+        self.unsupported("Range time travel is not supported in Dremio")
         return super().version_sql(expression)
 
     def datatype_sql(self, expression: exp.DataType) -> str:

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -74,6 +74,39 @@ class TestDremio(Validator):
             "SELECT * FROM t ORDER BY a DESC NULLS FIRST",
         )
 
+    def test_time_travel(self):
+        self.validate_identity("SELECT * FROM t AT SNAPSHOT '4132119532727284872'")
+        self.validate_identity("SELECT * FROM t AT TIMESTAMP '2024-01-01 12:00:00.000'")
+        self.validate_identity("SELECT * FROM t AT SNAPSHOT '4132119532727284872' AS a")
+
+        self.validate_all(
+            "SELECT * FROM t AT SNAPSHOT '123'",
+            read={
+                "spark": "SELECT * FROM t VERSION AS OF '123'",
+                "trino": "SELECT * FROM t FOR VERSION AS OF '123'",
+            },
+            write={
+                "spark": "SELECT * FROM t VERSION AS OF '123'",
+                "trino": "SELECT * FROM t FOR VERSION AS OF '123'",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM t AT TIMESTAMP '2024-01-01'",
+            read={
+                "spark": "SELECT * FROM t TIMESTAMP AS OF '2024-01-01'",
+            },
+            write={
+                "spark": "SELECT * FROM t TIMESTAMP AS OF '2024-01-01'",
+            },
+        )
+
+        with self.assertRaises(UnsupportedError):
+            transpile(
+                "SELECT * FROM t FOR VERSION BETWEEN '1' AND '2'",
+                write="dremio",
+                unsupported_level=ErrorLevel.IMMEDIATE,
+            )
+
     def test_convert_timezone(self):
         self.validate_all(
             "SELECT CONVERT_TIMEZONE('America/Chicago', DateColumn)",


### PR DESCRIPTION
Dremio queries Iceberg tables at a point in time with FROM t AT SNAPSHOT '<id>' and FROM t AT TIMESTAMP '<ts>', which map to sqlglot's exp.Version (VERSION AS OF / TIMESTAMP AS OF), enabling transpilation to and from Spark, Trino, etc.

Tokenize the AT clauses as VERSION_SNAPSHOT / TIMESTAMP_SNAPSHOT so the base parser handles them, and override version_sql to generate the AT syntax, warning on range kinds (FROM/BETWEEN) Dremio cannot express.

https://docs.dremio.com/current/reference/sql/commands/SELECT-statements/#examples-for-iceberg-tables