### PR TITLE
feat(duckdb): transpile BigQuery ARRAY_CONCAT_AGG to DuckDB

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1624,6 +1624,7 @@ class DuckDBGenerator(generator.Generator):
             exp.ArrayCompact(this=exp.Array(expressions=e.expressions))
         ),
         exp.ArrayConcat: array_concat_sql("LIST_CONCAT"),
+        exp.ArrayConcatAgg: lambda self, e: self.func("FLATTEN", self.func("LIST", e.this)),
         exp.ArrayContains: _array_contains_sql,
         exp.ArrayOverlaps: _array_overlaps_sql,
         exp.ArrayFilter: rename_func("LIST_FILTER"),

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1624,7 +1624,6 @@ class DuckDBGenerator(generator.Generator):
             exp.ArrayCompact(this=exp.Array(expressions=e.expressions))
         ),
         exp.ArrayConcat: array_concat_sql("LIST_CONCAT"),
-        exp.ArrayConcatAgg: lambda self, e: self.arrayconcatagg_sql(e),
         exp.ArrayContains: _array_contains_sql,
         exp.ArrayOverlaps: _array_overlaps_sql,
         exp.ArrayFilter: rename_func("LIST_FILTER"),
@@ -3498,13 +3497,13 @@ class DuckDBGenerator(generator.Generator):
         )
 
     def arrayconcatagg_sql(self, expression: exp.ArrayConcatAgg) -> str:
-        return self.sql(
-            exp.Flatten(
-                this=exp.Filter(
-                    this=exp.ArrayAgg(this=expression.this),
-                    expression=exp.Where(this=expression.this.copy().is_(exp.null()).not_()),
-                )
-            )
+        this = expression.this
+        return self.func(
+            "FLATTEN",
+            exp.Filter(
+                this=exp.ArrayAgg(this=this),
+                expression=exp.Where(this=this.copy().is_(exp.null()).not_()),
+            ),
         )
 
     def arrayunionagg_sql(self, expression: exp.ArrayUnionAgg) -> str:

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1624,7 +1624,7 @@ class DuckDBGenerator(generator.Generator):
             exp.ArrayCompact(this=exp.Array(expressions=e.expressions))
         ),
         exp.ArrayConcat: array_concat_sql("LIST_CONCAT"),
-        exp.ArrayConcatAgg: lambda self, e: self.func("FLATTEN", self.func("LIST", e.this)),
+        exp.ArrayConcatAgg: lambda self, e: self.arrayconcatagg_sql(e),
         exp.ArrayContains: _array_contains_sql,
         exp.ArrayOverlaps: _array_overlaps_sql,
         exp.ArrayFilter: rename_func("LIST_FILTER"),
@@ -3494,6 +3494,16 @@ class DuckDBGenerator(generator.Generator):
             exp.Filter(
                 this=exp.func("LIST", exp.Distinct(expressions=[expression.this])),
                 expression=exp.Where(this=expression.this.copy().is_(exp.null()).not_()),
+            )
+        )
+
+    def arrayconcatagg_sql(self, expression: exp.ArrayConcatAgg) -> str:
+        return self.sql(
+            exp.Flatten(
+                this=exp.Filter(
+                    this=exp.ArrayAgg(this=expression.this),
+                    expression=exp.Where(this=expression.this.copy().is_(exp.null()).not_()),
+                )
             )
         )
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2103,6 +2103,7 @@ WHERE
             write={
                 "snowflake": "SELECT ARRAY_FLATTEN(ARRAY_AGG(1))",
                 "bigquery": "SELECT ARRAY_CONCAT_AGG(1)",
+                "duckdb": "SELECT FLATTEN(LIST(1))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2099,11 +2099,11 @@ WHERE
         )
 
         self.validate_all(
-            "SELECT ARRAY_CONCAT_AGG(1)",
+            "SELECT ARRAY_CONCAT_AGG(arr) FROM (SELECT [1, 2] AS arr) AS t",
             write={
-                "snowflake": "SELECT ARRAY_FLATTEN(ARRAY_AGG(1))",
-                "bigquery": "SELECT ARRAY_CONCAT_AGG(1)",
-                "duckdb": "SELECT FLATTEN(LIST(1))",
+                "bigquery": "SELECT ARRAY_CONCAT_AGG(arr) FROM (SELECT [1, 2] AS arr) AS t",
+                "snowflake": "SELECT ARRAY_FLATTEN(ARRAY_AGG(arr)) FROM (SELECT [1, 2] AS arr) AS t",
+                "duckdb": "SELECT FLATTEN(ARRAY_AGG(arr) FILTER(WHERE NOT arr IS NULL)) FROM (SELECT [1, 2] AS arr) AS t",
             },
         )
         self.validate_all(


### PR DESCRIPTION
## Summary

BigQuery's `ARRAY_CONCAT_AGG(expr)` concatenates arrays into a single flat array. DuckDB has no direct equivalent, but `FLATTEN(LIST(expr))` achieves the same result: `LIST` collects the arrays into a nested list, then `FLATTEN` unnests one level.

### Changes

- Add `ARRAY_CONCAT_AGG` → `FLATTEN(LIST(...))` mapping in `DuckDB.Generator`
- Add transpilation test (BigQuery → DuckDB round-trip)

### Motivation

We use sqlglot to transpile BigQuery SQL models to DuckDB for local testing via [sqlmesh](https://github.com/TobikoData/sqlmesh). `ARRAY_CONCAT_AGG` is used in several of our production models but was not previously transpiled.