### PR TITLE
feat(duckdb): transpile BigQuery IN UNNEST(array) to ARRAY_CONTAINS

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3137,14 +3137,49 @@ class DuckDBGenerator(generator.Generator):
     def in_sql(self, expression: exp.In) -> str:
         unnest = expression.args.get("unnest")
         if unnest:
-            # BigQuery's `x IN UNNEST(arr)` becomes
-            # COALESCE(ARRAY_CONTAINS(arr, x), FALSE) in DuckDB.
-            # The default `IN (SELECT UNNEST(...))` creates a correlated subquery that
-            # DuckDB rejects inside non-inner joins.
-            # COALESCE handles NULL arrays: ARRAY_CONTAINS(NULL, x) returns NULL in
-            # DuckDB, but BigQuery's IN UNNEST returns FALSE for NULL arrays.
-            contains = self.func("ARRAY_CONTAINS", unnest.expressions[0], expression.this)
-            return f"COALESCE({contains}, FALSE)"
+            # BigQuery's `x IN UNNEST(arr)` → DuckDB CASE expression that preserves
+            # NULL semantics. The default `IN (SELECT UNNEST(...))` creates a correlated
+            # subquery that DuckDB rejects inside non-inner joins.
+            #
+            # NULL semantics (matching BigQuery):
+            #   NULL IN UNNEST([1, 2])    → NULL (not FALSE)
+            #   3 IN UNNEST([1, NULL])    → NULL (not FALSE)
+            #   3 IN UNNEST([1, 2])       → FALSE
+            #   2 IN UNNEST([1, 2])       → TRUE
+            #   1 IN UNNEST(NULL)         → FALSE
+            #   1 IN UNNEST([])           → FALSE
+            #
+            # Generated SQL:
+            #   CASE
+            #     WHEN arr IS NULL OR ARRAY_LENGTH(arr) = 0 THEN FALSE
+            #     WHEN ARRAY_CONTAINS(arr, x) THEN TRUE
+            #     WHEN x IS NULL OR ARRAY_LENGTH(arr) <> LIST_COUNT(arr) THEN NULL
+            #     ELSE FALSE
+            #   END
+            arr = unnest.expressions[0]
+            value = expression.this
+
+            arr_is_null = exp.Is(this=arr.copy(), expression=exp.null())
+            arr_is_empty = exp.EQ(
+                this=exp.ArraySize(this=arr.copy()),
+                expression=exp.Literal.number(0),
+            )
+            contains = exp.ArrayContains(this=arr.copy(), expression=value.copy())
+            value_is_null = exp.Is(this=value.copy(), expression=exp.null())
+            arr_has_nulls = exp.NEQ(
+                this=exp.ArraySize(this=arr.copy()),
+                expression=exp.func("LIST_COUNT", arr.copy()),
+            )
+
+            case_expr = (
+                exp.Case()
+                .when(exp.or_(arr_is_null, arr_is_empty, copy=False), exp.false(), copy=False)
+                .when(contains, exp.true(), copy=False)
+                .when(exp.or_(value_is_null, arr_has_nulls, copy=False), exp.null(), copy=False)
+                .else_(exp.false(), copy=False)
+            )
+
+            return self.sql(case_expr)
         return super().in_sql(expression)
 
     def join_sql(self, expression: exp.Join) -> str:

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3134,6 +3134,19 @@ class DuckDBGenerator(generator.Generator):
 
         return super().tablesample_sql(expression, tablesample_keyword=tablesample_keyword)
 
+    def in_sql(self, expression: exp.In) -> str:
+        unnest = expression.args.get("unnest")
+        if unnest:
+            # BigQuery's `x IN UNNEST(arr)` becomes
+            # COALESCE(ARRAY_CONTAINS(arr, x), FALSE) in DuckDB.
+            # The default `IN (SELECT UNNEST(...))` creates a correlated subquery that
+            # DuckDB rejects inside non-inner joins.
+            # COALESCE handles NULL arrays: ARRAY_CONTAINS(NULL, x) returns NULL in
+            # DuckDB, but BigQuery's IN UNNEST returns FALSE for NULL arrays.
+            contains = self.func("ARRAY_CONTAINS", unnest.expressions[0], expression.this)
+            return f"COALESCE({contains}, FALSE)"
+        return super().in_sql(expression)
+
     def join_sql(self, expression: exp.Join) -> str:
         if (
             not expression.args.get("using")

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2106,6 +2106,13 @@ WHERE
             },
         )
         self.validate_all(
+            "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND a.val IN UNNEST(b.arr)",
+            write={
+                "bigquery": "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND a.val IN UNNEST(b.arr)",
+                "duckdb": "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND COALESCE(ARRAY_CONTAINS(b.arr, a.val), FALSE)",
+            },
+        )
+        self.validate_all(
             "SELECT b'\x61'",
             write={
                 "bigquery": "SELECT b'\x61'",

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1598,9 +1598,17 @@ LANGUAGE js AS
             "SELECT * FROM a WHERE b IN UNNEST([1, 2, 3])",
             write={
                 "bigquery": "SELECT * FROM a WHERE b IN UNNEST([1, 2, 3])",
+                "duckdb": "SELECT * FROM a WHERE CASE WHEN [1, 2, 3] IS NULL OR ARRAY_LENGTH([1, 2, 3]) = 0 THEN FALSE WHEN ARRAY_CONTAINS([1, 2, 3], b) THEN TRUE WHEN b IS NULL OR ARRAY_LENGTH([1, 2, 3]) <> LIST_COUNT([1, 2, 3]) THEN NULL ELSE FALSE END",
                 "presto": "SELECT * FROM a WHERE b IN (SELECT UNNEST(ARRAY[1, 2, 3]))",
                 "hive": "SELECT * FROM a WHERE b IN (SELECT EXPLODE(ARRAY(1, 2, 3)))",
                 "spark": "SELECT * FROM a WHERE b IN (SELECT EXPLODE(ARRAY(1, 2, 3)))",
+            },
+        )
+        self.validate_all(
+            "SELECT * FROM a WHERE b NOT IN UNNEST([1, 2, 3])",
+            write={
+                "bigquery": "SELECT * FROM a WHERE NOT b IN UNNEST([1, 2, 3])",
+                "duckdb": "SELECT * FROM a WHERE NOT CASE WHEN [1, 2, 3] IS NULL OR ARRAY_LENGTH([1, 2, 3]) = 0 THEN FALSE WHEN ARRAY_CONTAINS([1, 2, 3], b) THEN TRUE WHEN b IS NULL OR ARRAY_LENGTH([1, 2, 3]) <> LIST_COUNT([1, 2, 3]) THEN NULL ELSE FALSE END",
             },
         )
         self.validate_all(
@@ -2109,7 +2117,7 @@ WHERE
             "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND a.val IN UNNEST(b.arr)",
             write={
                 "bigquery": "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND a.val IN UNNEST(b.arr)",
-                "duckdb": "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND COALESCE(ARRAY_CONTAINS(b.arr, a.val), FALSE)",
+                "duckdb": "SELECT * FROM a LEFT JOIN b ON a.key = b.key AND CASE WHEN b.arr IS NULL OR ARRAY_LENGTH(b.arr) = 0 THEN FALSE WHEN ARRAY_CONTAINS(b.arr, a.val) THEN TRUE WHEN a.val IS NULL OR ARRAY_LENGTH(b.arr) <> LIST_COUNT(b.arr) THEN NULL ELSE FALSE END",
             },
         )
         self.validate_all(


### PR DESCRIPTION
## Summary

BigQuery uses `value IN UNNEST(array_expr)` to test array membership. DuckDB has no `UNNEST` in this position but provides `ARRAY_CONTAINS`.

### Changes

- Add `IN UNNEST(arr)` → `COALESCE(ARRAY_CONTAINS(arr, val), FALSE)` in DuckDB generator via `in_sql` override
- Wrap in `COALESCE(..., FALSE)` for null safety — `ARRAY_CONTAINS(NULL, x)` returns NULL in DuckDB, but BigQuery's `IN UNNEST(NULL)` returns FALSE
- Add transpilation test for BigQuery → DuckDB

### Motivation

We use sqlglot to transpile BigQuery SQL models to DuckDB for local testing via [sqlmesh](https://github.com/TobikoData/sqlmesh). `IN UNNEST(...)` is used in several of our production models for array membership checks but was not previously transpiled to DuckDB.