### PR TITLE
fix(optimizer): keep columns a recursive CTE reads from itself [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -25,6 +25,16 @@ SELECT_ALL = object()
 SET_RETURNING_FUNCTIONS = (exp.Explode, exp.Inline, exp.Unnest)
 
 
+def _is_self_referencing_cte(scope: Scope) -> bool:
+    cte = scope.expression.parent
+    return (
+        isinstance(cte, exp.CTE)
+        and isinstance(cte.parent, exp.With)
+        and cte.parent.recursive
+        and any(table.name == cte.alias for table in scope.expression.find_all(exp.Table))
+    )
+
+
 # Selection to use if selection list is empty
 def default_selection(is_agg: bool) -> exp.Alias:
     return alias(exp.Max(this=exp.Literal.number(1)) if is_agg else "1", "_").assert_is(exp.Alias)
@@ -66,6 +76,11 @@ def pushdown_projections(
 
         # We can't remove columns SELECT DISTINCT nor UNION DISTINCT.
         if scope.expression.args.get("distinct"):
+            parent_selections = {SELECT_ALL}
+
+        # A recursive CTE's body reads the CTE's own output, so its projections
+        # can't be pruned based only on what the enclosing query selects.
+        if _is_self_referencing_cte(scope):
             parent_selections = {SELECT_ALL}
 
         if isinstance(scope.expression, exp.SetOperation):

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2490,6 +2490,28 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         self.assertEqual(set(scope_t.cte_sources), {"t"})
         self.assertEqual(set(scope_y.cte_sources), {"t", "y"})
 
+    def test_pushdown_projections_keeps_recursive_cte_self_referenced_columns(self):
+        # The recursive term joins on t.link, which the outer query never
+        # selects; pruning it used to corrupt the CTE and crash merge_subqueries
+        optimized = optimizer.optimize(
+            parse_one(
+                """
+                WITH RECURSIVE t AS (
+                  SELECT id, link FROM graph WHERE id = 1
+                  UNION ALL
+                  SELECT g.id, g.link FROM graph AS g, t WHERE g.id = t.link
+                )
+                SELECT id FROM t
+                """,
+                read="postgres",
+            ),
+            schema={"graph": {"id": "INT", "link": "INT"}},
+            dialect="postgres",
+        )
+
+        cte = optimized.find(exp.CTE)
+        self.assertIn("link", {select.alias_or_name for select in cte.this.selects})
+
     def test_schema_with_spaces(self):
         schema = {
             "a": {


### PR DESCRIPTION
Fixes `optimizer.optimize` crashing (or silently producing invalid SQL) on a self-referencing recursive CTE when the enclosing query doesn't select every CTE column.

**Repro on current main:**

```python
from sqlglot import parse_one
from sqlglot.optimizer import optimize

sql = """
WITH RECURSIVE t AS (
  SELECT id, link FROM graph WHERE id = 1
  UNION ALL
  SELECT g.id, g.link FROM graph AS g, t WHERE g.id = t.link
)
SELECT id FROM t
"""
optimize(parse_one(sql, read="postgres"), schema={"graph": {"id": "INT", "link": "INT"}}, dialect="postgres")
# KeyError: 'link'  (merge_subqueries.py)
```

**Root cause:** `_traverse_ctes` gives the CTE body a throwaway branch scope to resolve the recursive term's self-reference. `pushdown_projections` records the self-reference's column usage (`t.link` above) against that throwaway scope, so it is lost, and the projections the recursive term still joins on get pruned from the CTE. `merge_subqueries` then crashes on the missing projection; depending on the query the pruning can also survive silently as invalid SQL. Remapping the usage to the real scope wouldn't help on its own, because the reversed-postorder pass visits the union before the recursive term, making the self-reference a back-edge.

**Fix:** treat self-referencing recursive CTEs conservatively and skip pruning their projections, mirroring the existing `DISTINCT` guard in the same loop. `merge_subqueries._is_recursive` and `pushdown_predicates` already special-case recursive CTEs the same way; `pushdown_projections` was the one rule missing the guard.

Added a regression test that asserts the optimized CTE keeps the column its recursive term joins on (it fails with a `KeyError` without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
