### PR TITLE
fix(snowflake): rewrite COUNT(*) FILTER to COUNT_IF [CLAUDE]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -1200,6 +1200,11 @@ class SnowflakeGenerator(generator.Generator):
                 self.unsupported("Unable to rewrite FILTER into the aggregate's arguments")
                 return self.sql(agg)
 
+        # `COUNT(*) FILTER (WHERE cond)` counts qualifying rows, but a star can't be an
+        # IFF argument (`IFF(cond, *, NULL)` is invalid), so use Snowflake's native COUNT_IF.
+        if isinstance(agg, exp.Count) and isinstance(agg_arg, exp.Star):
+            return self.sql(exp.CountIf(this=cond.copy()))
+
         # `DISTINCT` and `ORDER BY` are part of the aggregate's own argument list, so the
         # condition has to wrap the values underneath them rather than the whole clause --
         # `IFF(cond, DISTINCT x, NULL)` is not a call any dialect accepts.

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -367,6 +367,13 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
+            "SELECT COUNT(*) FILTER (WHERE b > 0) FROM t",
+            write={
+                "duckdb": "SELECT COUNT(*) FILTER(WHERE b > 0) FROM t",
+                "snowflake": "SELECT COUNT_IF(b > 0) FROM t",
+            },
+        )
+        self.validate_all(
             "SELECT COUNT(DISTINCT a) FILTER (WHERE b > 0) FROM t",
             write={
                 "duckdb": "SELECT COUNT(DISTINCT a) FILTER(WHERE b > 0) FROM t",


### PR DESCRIPTION
`filter_sql` rewrites an aggregate `FILTER (WHERE cond)` into a conditional
argument by wrapping the aggregate's input in `IFF(cond, input, NULL)`. When the
aggregate is `COUNT(*)`, that input is a star, so the output is
`COUNT(IFF(cond, *, NULL))` — a star isn't a valid `IFF` argument and Snowflake
rejects it.

`COUNT(*) FILTER (WHERE cond)` is just a count of qualifying rows, which is
exactly Snowflake's native `COUNT_IF(cond)`, so emit that instead. Other
aggregates and `COUNT(expr)` / `COUNT(DISTINCT ...)` are untouched.

```
COUNT(*) FILTER (WHERE b > 0)   duckdb -> snowflake
  before: SELECT COUNT(IFF(b > 0, *, NULL)) FROM t   (invalid)
  after:  SELECT COUNT_IF(b > 0) FROM t
```

This completes #7884, which handled the `DISTINCT` / `ORDER BY` argument shapes
but not the star case. Added a regression test alongside the existing
FILTER-rewrite cases in `test_duckdb.py`; `make unit` and `make style` pass.

---
This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug, ran the repro, wrote the test, and wrote this description.
The human account holder reviews every change and is accountable for it. The
verification above is real and re-runnable from the diff. If this isn't the kind
of contribution you want, say so and I'll close it.
