### PR TITLE
fix(optimizer): do not push predicates into a subquery with LIMIT/OFFSET [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -241,6 +241,10 @@ def nodes_for_predicate(
                 not node.args.get("group")
                 and scope_ref_count[id(source)] < 2
                 and not has_window_expression
+                # A LIMIT/OFFSET picks rows before the outer predicate runs, so pushing
+                # the predicate in would filter first and change which rows survive.
+                and not node.args.get("limit")
+                and not node.args.get("offset")
             ):
                 nodes[table] = node
     return nodes

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -79,3 +79,11 @@ SELECT a.id, b.val, c.name FROM t_a AS a INNER JOIN t_b AS b ON a.id = b.a_id IN
 -- DNF: single-table predicate is pushed to its own JOIN regardless of join order
 SELECT a.id, b.val FROM t_a AS a INNER JOIN t_b AS b ON b.a_id = a.id WHERE (b.flag = 1 AND b.active = 1) OR (b.flag = 2 AND b.active = 0);
 SELECT a.id, b.val FROM t_a AS a INNER JOIN t_b AS b ON ((b.active = 0 AND b.flag = 2) OR (b.active = 1 AND b.flag = 1)) AND a.id = b.a_id WHERE (b.active = 0 AND b.flag = 2) OR (b.active = 1 AND b.flag = 1);
+
+-- Predicate is not pushed into a subquery with LIMIT: filtering before the limit changes which rows the limit keeps
+SELECT s.a FROM (SELECT a, b FROM x ORDER BY a LIMIT 10) AS s WHERE s.b = 1;
+SELECT s.a FROM (SELECT a, b FROM x ORDER BY a LIMIT 10) AS s WHERE s.b = 1;
+
+-- Predicate is not pushed into a subquery with OFFSET: filtering before the offset changes which rows are skipped
+SELECT s.a FROM (SELECT a, b FROM x ORDER BY a OFFSET 3) AS s WHERE s.b = 1;
+SELECT s.a FROM (SELECT a, b FROM x ORDER BY a OFFSET 3) AS s WHERE s.b = 1;


### PR DESCRIPTION
`pushdown_predicates` already refuses to push a predicate into a single-table
subquery that carries a `GROUP BY` or a window function, since either would
change the result. `LIMIT` / `OFFSET` has the same issue: it selects rows
*before* the outer predicate runs, so pushing the filter in changes which rows
survive the limit.

```
SELECT s.x FROM (SELECT x, y FROM t ORDER BY x LIMIT 10) AS s WHERE s.y > 5
  before: ... (SELECT ... FROM t WHERE y > 5 ORDER BY x LIMIT 10) ... WHERE TRUE
```

The rewrite filters `y > 5` before the `LIMIT 10`, so it returns rows the
original query would never see — a silent change of results. The same happens
with a bare `OFFSET`.

Extended the existing guard to also bail when the subquery has a `limit` or
`offset`. Subqueries without either still get the predicate pushed down as
before. Added two fixture cases (LIMIT and OFFSET) that assert the query is
left unchanged; `make unit` passes.

---
This PR was authored by an AI coding agent (Claude Code) running on this account:
the AI found the bug, ran the repro, wrote the tests, and wrote this description.
The human account holder reviews every change and is accountable for it. The
verification above is real and re-runnable from the diff. If this isn't the kind
of contribution you want, say so and I'll close it.
