### PR TITLE
fix(redshift): transpile TIMESTAMPDIFF to DATEDIFF [CLAUDE]

### DIFF
--- a/sqlglot/generators/redshift.py
+++ b/sqlglot/generators/redshift.py
@@ -78,6 +78,7 @@ class RedshiftGenerator(PostgresGenerator):
         exp.CurrentUserId: lambda *_: "CURRENT_USER_ID",
         exp.DateAdd: date_delta_sql("DATEADD"),
         exp.DateDiff: date_delta_sql("DATEDIFF"),
+        exp.TimestampDiff: date_delta_sql("DATEDIFF"),
         exp.DistKeyProperty: lambda self, e: self.func("DISTKEY", e.this),
         exp.DistStyleProperty: lambda self, e: self.naked_property(e),
         exp.Explode: lambda self, e: self.explode_sql(e),

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -298,6 +298,13 @@ class TestRedshift(Validator):
             },
         )
         self.validate_all(
+            # Redshift has no TIMESTAMPDIFF; it must become DATEDIFF(unit, start, end).
+            "DATEDIFF(SECOND, a, b)",
+            read={
+                "mysql": "TIMESTAMPDIFF(SECOND, a, b)",
+            },
+        )
+        self.validate_all(
             "SELECT DATEADD(month, 18, '2008-02-28')",
             write={
                 "bigquery": "SELECT DATE_ADD(CAST('2008-02-28' AS DATETIME), INTERVAL 18 MONTH)",


### PR DESCRIPTION
**Problem**

`TIMESTAMPDIFF` transpiled from MySQL to Redshift produces invalid SQL:

```python
sqlglot.transpile("SELECT TIMESTAMPDIFF(SECOND, start_ts, end_ts)", read="mysql", write="redshift")[0]
# -> SELECT TIMESTAMPDIFF(end_ts, start_ts, SECOND)
```

Redshift has no `TIMESTAMPDIFF` function, and the arguments come out in raw AST order (the unit last), so the statement fails to run.

**Cause**

MySQL's `TIMESTAMPDIFF` parses to `exp.TimestampDiff`, but `RedshiftGenerator.TRANSFORMS` had no entry for it, so it fell back to the default function rendering.

**Fix**

Redshift already renders the sibling `exp.DateDiff` with `date_delta_sql("DATEDIFF")`. Wiring `exp.TimestampDiff` to the same handler produces `DATEDIFF(unit, start, end)`, which matches Redshift's builtin and preserves the `end - start` semantics.

```python
# -> SELECT DATEDIFF(SECOND, start_ts, end_ts)
```

**Testing**

Added a read-direction case in `test_redshift.py` (fails on `main`, passes here). `tests/dialects/` full suite: 748 passed, no regressions. `ruff check` / `ruff format` clean.

*Disclosure: authored by an AI coding agent (Claude Code) on my account — it found the bug, ran the repro, wrote the test and this description. I review every change and am accountable for it; the verification is real and re-runnable from the diff.*
