### PR TITLE
fix: render FOR VERSION/TIMESTAMP FROM/BETWEEN bounds, not a tuple [CLAUDE]

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2608,6 +2608,12 @@ class Generator:
         this = f"FOR {expression.name}"
         kind = expression.text("kind")
         expr = self.sql(expression, "expression")
+        if kind in ("FROM", "BETWEEN"):
+            # the two range bounds are stored as a Tuple; render them as
+            # "<start> TO/AND <end>", not as a "(start, end)" tuple literal
+            bounds = expression.args["expression"].expressions
+            sep = "AND" if kind == "BETWEEN" else "TO"
+            expr = f"{self.sql(bounds[0])} {sep} {self.sql(bounds[1])}"
         return f"{this} {kind} {expr}"
 
     def tuple_sql(self, expression: exp.Tuple) -> str:

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -797,6 +797,8 @@ class TestPresto(Validator):
         self.validate_identity(
             "SELECT * FROM example.testdb.customer_orders FOR TIMESTAMP AS OF CAST('2022-03-23 09:59:29.803 Europe/Vienna' AS TIMESTAMP)"
         )
+        self.validate_identity("SELECT * FROM t FOR VERSION BETWEEN '1' AND '2'")
+        self.validate_identity("SELECT * FROM t FOR TIMESTAMP FROM '2024-01-01' TO '2024-02-01'")
         self.validate_identity(
             "SELECT origin_state, destination_state, origin_zip, SUM(package_weight) FROM shipping GROUP BY ALL CUBE (origin_state, destination_state), ROLLUP (origin_state, origin_zip)"
         )


### PR DESCRIPTION
The base `version_sql` renders a `FROM`/`BETWEEN` time-travel range straight from its `Tuple`, so a valid range comes back as a tuple literal:

```
>>> sqlglot.parse_one("SELECT * FROM t FOR VERSION BETWEEN '1' AND '2'", read="trino").sql("trino")
"SELECT * FROM t FOR VERSION BETWEEN ('1', '2')"
```

`FROM '1' TO '2'` is affected the same way. The parser stores the two bounds as a `Tuple`, but for these two kinds they need to be joined by `AND`/`TO` rather than emitted as `(start, end)`. `CONTAINED IN (...)`, `AS OF` and `ALL` are unchanged.

Added two identity cases to the Presto tests; both fail on `main` and pass here. Full suite green.

Disclosure: found and fixed with Claude Code — the AI hit the round-trip mismatch, wrote the fix and the tests. I review every change and am responsible for it; the fail-before/pass-after tests re-run from the diff.
