### PR TITLE
Fix Presto LOG(b, x) argument order on round-trip [CLAUDE]

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -82,7 +82,7 @@ def build_logarithm(args: BuilderArgs, dialect: Dialect) -> exp.Func:
     expression = seq_get(args, 1)
 
     if expression:
-        if not dialect.LOG_BASE_FIRST:
+        if dialect.LOG_BASE_FIRST is False:
             this, expression = expression, this
         return exp.Log(this=this, expression=expression)
 

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -715,6 +715,10 @@ class TestPresto(Validator):
             "LOWER(TO_HEX(SHA256(TO_UTF8(CAST(x AS VARCHAR)))))",
         )
 
+        # Presto LOG(b, x) is log base b of x; the two arguments must not be swapped on round-trip.
+        self.validate_identity("SELECT LOG(x, y)")
+        self.validate_identity("SELECT LOG(3, 9)")
+
         # native SHA256/SHA512 take and return VARBINARY, so they parse as
         # SHA2Digest and round-trip untouched, mirroring MD5 -> MD5Digest
         self.validate_all(


### PR DESCRIPTION
Presto's `LOG(b, x)` is the logarithm of `x` to base `b`, but round-tripping it through the Presto dialect silently swaps the two arguments: `LOG(3, 9)` (log base 3 of 9, = 2) comes back out as `LOG(9, 3)` (= 0.5). The SQL still looks valid, so the wrong value is easy to miss.

The cause is an inconsistency around the tri-state `LOG_BASE_FIRST` flag. Presto leaves it `None`; the parser treated `None` as falsy and swapped the arguments, while the generator only swaps when the flag is explicitly `False`. Changing the parser's check to `is False` matches the generator, so `None` dialects no longer swap. Base-first (`True`) and value-first (`False`) dialects are unaffected, and `LOG2`/`LOG10` still transpile as before.

Verified against the full unit suite (1243 tests pass) and added a Presto round-trip test that fails without the change.

Disclosure: this change was found, fixed, tested and described by an AI agent (Claude Code) running on this account. The account holder reviews every change and is accountable for it.
