### PR TITLE
Cast REAL to numeric before ROUND in Postgres [CLAUDE]

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -222,7 +222,7 @@ def _round_sql(self: PostgresGenerator, expression: exp.Round) -> str:
 
     # ROUND(double precision, integer) is not permitted in Postgres
     # so it's necessary to cast to decimal before rounding.
-    if expression.this.is_type(exp.DType.DOUBLE):
+    if expression.this.is_type(*exp.DataType.FLOAT_TYPES):
         decimal_type = exp.DType.DECIMAL.into_expr(expressions=expression.expressions)
         this = self.sql(exp.Cast(this=this, to=decimal_type))
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1798,6 +1798,11 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
                 "bigquery": "ROUND(x::DOUBLE, 4)",
             },
         )
+        # ROUND(real, integer) is not permitted in Postgres either, so REAL must be cast too.
+        self.validate_all(
+            "ROUND(CAST(CAST(x AS REAL) AS DECIMAL), 4)",
+            read={"postgres": "ROUND(x::REAL, 4)"},
+        )
         self.validate_all(
             "ROUND(CAST(x AS DECIMAL(18, 3)), 4)", read={"duckdb": "ROUND(x::DECIMAL, 4)"}
         )


### PR DESCRIPTION
Postgres has no `ROUND(real, integer)` any more than it has `ROUND(double precision, integer)` — both raise `function round(...) does not exist`. The Postgres generator already casts double-typed arguments to numeric before rounding, but it only checked for `DOUBLE`, so a `REAL` argument was emitted unchanged as `ROUND(real, integer)`, which Postgres rejects.

This widens the guard from `DOUBLE` to `FLOAT_TYPES` (which also covers `REAL`), so a real argument is cast to numeric before rounding. Decimal, numeric and integer arguments are unaffected.

Verified against the full unit suite (1243 tests) with an added round-trip test.

Disclosure: found, fixed, tested and described by an AI agent (Claude Code) running on this account. The account holder reviews every change and is accountable for it.
