### PR TITLE
Don't leak ARRAY_AGG's inline ORDER BY into the generated NULL filter [CLAUDE]

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -5668,7 +5668,12 @@ class Generator:
 
     def arrayagg_sql(self, expression: exp.ArrayAgg) -> str:
         array_agg = self.function_fallback_sql(expression)
-        return self._add_arrayagg_null_filter(array_agg, expression, expression.this)
+        # The NULL filter must be built from the column itself, not the ORDER BY
+        # wrapping it (an inline ORDER BY makes ArrayAgg.this an exp.Order).
+        column = expression.this
+        if isinstance(column, exp.Order):
+            column = column.this
+        return self._add_arrayagg_null_filter(array_agg, expression, column)
 
     def slice_sql(self, expression: exp.Slice) -> str:
         step = self.sql(expression, "step")

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -492,6 +492,14 @@ TBLPROPERTIES (
                 "spark": "SELECT COLLECT_LIST(x) FILTER(WHERE x = 5) FROM (SELECT 1 UNION ALL SELECT NULL) AS t(x)",
             },
         )
+        # An inline ORDER BY must not leak into the generated NULL FILTER.
+        self.validate_all(
+            "SELECT ARRAY_AGG(x ORDER BY y) FROM t",
+            write={
+                "presto": "SELECT ARRAY_AGG(x ORDER BY y NULLS FIRST) FILTER(WHERE x IS NOT NULL) FROM t",
+                "postgres": "SELECT ARRAY_AGG(x ORDER BY y NULLS FIRST) FILTER(WHERE x IS NOT NULL) FROM t",
+            },
+        )
         self.validate_all(
             "SELECT ARRAY_AGG(1)",
             write={


### PR DESCRIPTION
When ARRAY_AGG is transpiled from a null-excluding dialect (e.g. Spark) to one that includes nulls, sqlglot adds a `FILTER(WHERE col IS NOT NULL)` to preserve the semantics. If the ARRAY_AGG has an inline `ORDER BY`, `ArrayAgg.this` is an `exp.Order`, so the filter was generated as `FILTER(WHERE x ORDER BY y ... IS NOT NULL)` — invalid SQL that no target dialect can parse back.

The fix unwraps the `Order` so the filter is built from the column itself, which is what `_add_arrayagg_null_filter` documents it expects ("before ORDER BY wrapping") and what the DuckDB path already does. Cases without an inline ORDER BY are unchanged.

Verified against the full unit suite (1243 tests) with an added Spark→Presto/Postgres test.

Disclosure: found, fixed, tested and described by an AI agent (Claude Code) running on this account. The account holder reviews every change and is accountable for it.
