### PR TITLE
fix(presto): respect date part boundary semantics in DATE_DIFF transpilation

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -2041,6 +2041,45 @@ def unit_to_var(expression: exp.Expr, default: str = "DAY") -> exp.Expr | None:
     return exp.Var(this=value) if value else None
 
 
+# Days of week to ISO 8601 day-of-week numbers
+# ISO 8601 standard: Monday=1, Tuesday=2, Wednesday=3, Thursday=4, Friday=5, Saturday=6, Sunday=7
+WEEK_START_DAY_TO_DOW = {
+    "MONDAY": 1,
+    "TUESDAY": 2,
+    "WEDNESDAY": 3,
+    "THURSDAY": 4,
+    "FRIDAY": 5,
+    "SATURDAY": 6,
+    "SUNDAY": 7,
+}
+
+
+def week_unit_to_dow(unit: exp.Expr | None) -> int | None:
+    """
+    Compute the week start day for a week-ish diff unit, e.g BigQuery's WEEK(<day>)
+    or ISOWEEK unit parts.
+
+    Args:
+        unit: The unit expression (Var for WEEK/ISOWEEK or WeekStart)
+
+    Returns:
+        The ISO 8601 day number (Monday=1, Sunday=7 etc) or None if not a week unit or if day is dynamic (not a constant).
+
+        Examples:
+            "WEEK(SUNDAY)" -> 7
+            "WEEK(MONDAY)" -> 1
+            "ISOWEEK" -> 1
+    """
+    if isinstance(unit, exp.Var) and unit.name.upper() in ("WEEK", "ISOWEEK"):
+        return 1
+
+    # Handle WeekStart expressions with explicit day
+    if isinstance(unit, exp.WeekStart):
+        return WEEK_START_DAY_TO_DOW.get(unit.name.upper())
+
+    return None
+
+
 @t.overload
 def map_date_part(part: exp.Expr, dialect: DialectType = Dialect) -> exp.Expr:
     pass

--- a/sqlglot/expressions/temporal.py
+++ b/sqlglot/expressions/temporal.py
@@ -106,7 +106,7 @@ class DatetimeAdd(Expression, Func, IntervalOp):
 
 
 class DatetimeDiff(Expression, Func, TimeUnit):
-    arg_types = {"this": True, "expression": True, "unit": False}
+    arg_types = {"this": True, "expression": True, "unit": False, "date_part_boundary": False}
 
 
 class DatetimeSub(Expression, Func, IntervalOp):

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -34,6 +34,8 @@ from sqlglot.dialects.dialect import (
     strposition_sql,
     timestrtotime_sql,
     unit_to_str,
+    week_unit_to_dow,
+    WEEK_START_DAY_TO_DOW,
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import find_new_name, is_date_unit, seq_get
@@ -66,18 +68,6 @@ WS_CONTROL_CHARS_TO_DUCK = {
     "\u001d": 29,
     "\u001e": 30,
     "\u001f": 31,
-}
-
-# Days of week to ISO 8601 day-of-week numbers
-# ISO 8601 standard: Monday=1, Tuesday=2, Wednesday=3, Thursday=4, Friday=5, Saturday=6, Sunday=7
-WEEK_START_DAY_TO_DOW = {
-    "MONDAY": 1,
-    "TUESDAY": 2,
-    "WEDNESDAY": 3,
-    "THURSDAY": 4,
-    "FRIDAY": 5,
-    "SATURDAY": 6,
-    "SUNDAY": 7,
 }
 
 MAX_BIT_POSITION = exp.Literal.number(32768)
@@ -905,33 +895,6 @@ def _implicit_datetime_cast(
     return arg
 
 
-def _week_unit_to_dow(unit: exp.Expr | None) -> int | None:
-    """
-    Compute the Monday-based day shift to align DATE_DIFF('WEEK', ...) coming
-    from other dialects, e.g BigQuery's WEEK(<day>) or ISOWEEK unit parts.
-
-    Args:
-        unit: The unit expression (Var for ISOWEEK or WeekStart)
-
-    Returns:
-        The ISO 8601 day number (Monday=1, Sunday=7 etc) or None if not a week unit or if day is dynamic (not a constant).
-
-        Examples:
-            "WEEK(SUNDAY)" -> 7
-            "WEEK(MONDAY)" -> 1
-            "ISOWEEK" -> 1
-    """
-    # Handle plain Var expressions for ISOWEEK only
-    if isinstance(unit, exp.Var) and unit.name.upper() in "ISOWEEK":
-        return 1
-
-    # Handle WeekStart expressions with explicit day
-    if isinstance(unit, exp.WeekStart):
-        return WEEK_START_DAY_TO_DOW.get(unit.name.upper())
-
-    return None
-
-
 def _build_week_trunc_expression(
     date_expr: exp.Expr,
     start_dow: int,
@@ -988,7 +951,7 @@ def _date_diff_sql(self: DuckDBGenerator, expression: exp.DateDiff | exp.Datetim
     date_part_boundary = expression.args.get("date_part_boundary")
 
     # Extract week start day; returns None if day is dynamic (column/placeholder)
-    week_start = _week_unit_to_dow(unit)
+    week_start = week_unit_to_dow(unit)
     if date_part_boundary and week_start and this and expr:
         expression.set("unit", exp.Literal.string("WEEK"))
 
@@ -4389,7 +4352,7 @@ class DuckDBGenerator(generator.Generator):
         unit = expression.args.get("unit")
         date = expression.this
 
-        week_start = _week_unit_to_dow(unit)
+        week_start = week_unit_to_dow(unit)
         unit = unit_to_str(expression)
 
         if week_start:

--- a/sqlglot/generators/presto.py
+++ b/sqlglot/generators/presto.py
@@ -22,6 +22,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     ts_or_ds_add_cast,
     unit_to_str,
+    week_unit_to_dow,
     sequence_sql,
     explode_to_unnest_sql,
 )
@@ -173,7 +174,33 @@ def _date_diff_sql(
 ) -> str:
     # Presto/Trino only expose date_diff(unit, ts1, ts2); it returns ts2 - ts1, so the
     # operands are emitted as (expression, this) to preserve `this - expression` semantics.
-    return self.func("DATE_DIFF", unit_to_str(expression), expression.expression, expression.this)
+    this: exp.Expr = expression.this
+    expr: exp.Expr = expression.expression
+    unit = unit_to_str(expression)
+
+    # DATE_DIFF counts complete units between its operands, whereas dialects that set
+    # date_part_boundary count unit boundary crossings, so the operands are truncated
+    # down to the unit to make the two coincide
+    if unit and expression.args.get("date_part_boundary"):
+        raw_unit = expression.args.get("unit")
+        dow = week_unit_to_dow(raw_unit)
+
+        if dow is not None:
+            unit = exp.Literal.string("WEEK")
+
+            # DATE_TRUNC('WEEK', ...) is Monday-based; shifting both operands by the same
+            # delta realigns it to the requested week start without changing the diff
+            shift_days = 1 if dow == 7 else 1 - dow
+            if shift_days:
+                delta = exp.Interval(this=exp.Literal.string(str(shift_days)), unit=exp.var("DAY"))
+                this = exp.Add(this=this, expression=delta)
+                expr = exp.Add(this=expr, expression=delta.copy())
+
+        if not isinstance(raw_unit, exp.WeekStart) or dow is not None:
+            this = exp.DateTrunc(unit=unit.copy(), this=this)
+            expr = exp.DateTrunc(unit=unit.copy(), this=expr)
+
+    return self.func("DATE_DIFF", unit, expr, this)
 
 
 def _explode_to_unnest_sql(self: PrestoGenerator, expression: exp.Lateral) -> str:

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -28,19 +28,24 @@ def _build_date(args: list) -> exp.Date | exp.DateFromParts:
     return expr_type.from_arg_list(args)
 
 
-def build_date_diff(args: list) -> exp.Expr:
-    expr = exp.DateDiff(
-        this=seq_get(args, 0),
-        expression=seq_get(args, 1),
-        unit=seq_get(args, 2),
-        date_part_boundary=True,
-    )
+def build_date_diff(
+    expr_type: type[exp.DateDiff | exp.DatetimeDiff],
+) -> t.Callable[[list], exp.Expr]:
+    def _builder(args: list) -> exp.Expr:
+        expr = expr_type(
+            this=seq_get(args, 0),
+            expression=seq_get(args, 1),
+            unit=seq_get(args, 2),
+            date_part_boundary=True,
+        )
 
-    unit = expr.args.get("unit")
-    if isinstance(unit, exp.Var) and unit.name.upper() == "WEEK":
-        expr.set("unit", exp.WeekStart(this=exp.var("SUNDAY")))
+        unit = expr.args.get("unit")
+        if isinstance(unit, exp.Var) and unit.name.upper() == "WEEK":
+            expr.set("unit", exp.WeekStart(this=exp.var("SUNDAY")))
 
-    return expr
+        return expr
+
+    return _builder
 
 
 def _build_datetime(args: list) -> exp.Func:
@@ -222,7 +227,7 @@ class BigQueryParser(parser.Parser):
         "CONTAINS_SUBSTR": _build_contains_substring,
         "DATE": _build_date,
         "DATE_ADD": build_date_delta_with_interval(exp.DateAdd),
-        "DATE_DIFF": build_date_diff,
+        "DATE_DIFF": build_date_diff(exp.DateDiff),
         "DATE_SUB": build_date_delta_with_interval(exp.DateSub),
         "DATE_TRUNC": lambda args: exp.DateTrunc(
             unit=seq_get(args, 1),
@@ -231,6 +236,7 @@ class BigQueryParser(parser.Parser):
         ),
         "DATETIME": _build_datetime,
         "DATETIME_ADD": build_date_delta_with_interval(exp.DatetimeAdd),
+        "DATETIME_DIFF": build_date_diff(exp.DatetimeDiff),
         "DATETIME_SUB": build_date_delta_with_interval(exp.DatetimeSub),
         "DIV": binary_from_function(exp.IntDiv),
         "EDIT_DISTANCE": _build_levenshtein,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -954,6 +954,28 @@ LANGUAGE js AS
                 },
             ),
         )
+        # DATETIME_DIFF counts unit boundary crossings, so Presto/Trino's date_diff (which
+        # counts complete units) must truncate its operands: both dates below are 1 day
+        # apart but cross a month boundary
+        self.validate_all(
+            "SELECT DATETIME_DIFF(DATETIME '2021-02-01 00:00:00', DATETIME '2021-01-31 00:00:00', MONTH)",
+            write={
+                "bigquery": "SELECT DATETIME_DIFF(CAST('2021-02-01 00:00:00' AS DATETIME), CAST('2021-01-31 00:00:00' AS DATETIME), MONTH)",
+                "presto": "SELECT DATE_DIFF('MONTH', DATE_TRUNC('MONTH', CAST('2021-01-31 00:00:00' AS TIMESTAMP)), DATE_TRUNC('MONTH', CAST('2021-02-01 00:00:00' AS TIMESTAMP)))",
+                "trino": "SELECT DATE_DIFF('MONTH', DATE_TRUNC('MONTH', CAST('2021-01-31 00:00:00' AS TIMESTAMP)), DATE_TRUNC('MONTH', CAST('2021-02-01 00:00:00' AS TIMESTAMP)))",
+            },
+        )
+        # BigQuery weeks start on Sunday: 2017-10-14 (Saturday) -> 2017-10-15 (Sunday)
+        # crosses a week boundary, so the Monday-based DATE_TRUNC('WEEK') is shifted
+        self.validate_all(
+            "SELECT DATETIME_DIFF(DATETIME '2017-10-15 00:00:00', DATETIME '2017-10-14 00:00:00', WEEK)",
+            write={
+                "bigquery": "SELECT DATETIME_DIFF(CAST('2017-10-15 00:00:00' AS DATETIME), CAST('2017-10-14 00:00:00' AS DATETIME), WEEK)",
+                "duckdb": "SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2017-10-14 00:00:00' AS TIMESTAMP) + INTERVAL '1' DAY), DATE_TRUNC('WEEK', CAST('2017-10-15 00:00:00' AS TIMESTAMP) + INTERVAL '1' DAY))",
+                "presto": "SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2017-10-14 00:00:00' AS TIMESTAMP) + INTERVAL '1' DAY), DATE_TRUNC('WEEK', CAST('2017-10-15 00:00:00' AS TIMESTAMP) + INTERVAL '1' DAY))",
+                "trino": "SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2017-10-14 00:00:00' AS TIMESTAMP) + INTERVAL '1' DAY), DATE_TRUNC('WEEK', CAST('2017-10-15 00:00:00' AS TIMESTAMP) + INTERVAL '1' DAY))",
+            },
+        )
         (
             self.validate_all(
                 "SELECT DATETIME_ADD('2023-01-01T00:00:00', INTERVAL 1 MILLISECOND)",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -823,7 +823,7 @@ class TestMySQL(Validator):
                 "exasol": "SELECT DAYS_BETWEEN(x, y)",
                 "mysql": "SELECT DATEDIFF(x, y)",
                 "postgres": "SELECT (CAST(x AS DATE) - CAST(y AS DATE))",
-                "presto": "SELECT DATE_DIFF('DAY', y, x)",
+                "presto": "SELECT DATE_DIFF('DAY', DATE_TRUNC('DAY', y), DATE_TRUNC('DAY', x))",
                 "redshift": "SELECT DATEDIFF(DAY, y, x)",
             },
         )


### PR DESCRIPTION
Fixes BigQuery `DATETIME_DIFF` (and improves `DATE_DIFF` Snowflake, MySQL diffs) transpilation to Presto/Trino. Presto's `DATE_DIFF` counts complete units while BigQuery, Snowflake, MySQL count boundary crossings, so the Presto generator now truncates both operands to the unit when `date_part_boundary` is set, with a day-shift to realign Presto's Monday-based `DATE_TRUNC('WEEK')` to the requested week start.
