### PR TITLE
feat(optimizer)!: annotate encode for duckdb

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -49,6 +49,12 @@ EXPRESSION_METADATA = {
             exp.Decode,
         }
     },
+    **{
+        expr_type: {"returns": exp.DType.VARBINARY}
+        for expr_type in {
+            exp.Encode,
+        }
+    },
     exp.DateBin: {"annotator": lambda self, e: self._annotate_by_args(e, "expression")},
     exp.PercentileDisc: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
     exp.Localtimestamp: {"returns": exp.DType.TIMESTAMP},

--- a/test.py
+++ b/test.py
@@ -1,0 +1,12 @@
+from sqlglot import parse_one
+from sqlglot.optimizer.annotate_types import annotate_types
+
+dialect="duckdb"
+
+sql = "encode('my_string_with_ü')"
+
+ast = parse_one(sql,dialect=dialect)
+
+annotated = annotate_types(ast,dialect=dialect)
+
+print(repr(annotated))

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6724,6 +6724,10 @@ DECODE(tbl.str_col);
 VARCHAR;
 
 # dialect: duckdb
+ENCODE(tbl.str_col);
+VARBINARY;
+
+# dialect: duckdb
 QUARTER(tbl.date_col);
 BIGINT;
 


### PR DESCRIPTION
**Annotate encode for duckdb**

https://duckdb.org/docs/lts/sql/functions/blob#encodestring

Verified the DuckDB ENCODE() function using DuckDB. The function returns BLOB.

<img width="1853" height="483" alt="image" src="https://github.com/user-attachments/assets/13385909-076f-4d7f-a3ef-684ef3bcb0f0" />


SQLGlot internally normalizes DuckDB's BLOB type to its canonical VARBINARY type.

<img width="1116" height="590" alt="image" src="https://github.com/user-attachments/assets/af3f1086-8991-488f-a4ad-c4dd36c70f2d" />

