### PR TITLE
feat(optimizer)!: annotate encode for duckdb

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -49,6 +49,12 @@ EXPRESSION_METADATA = {
             exp.Decode,
         }
     },
+    **{
+        expr_type: {"returns": exp.DType.VARBINARY}
+        for expr_type in {
+            exp.Encode,
+        }
+    },
     exp.DateBin: {"annotator": lambda self, e: self._annotate_by_args(e, "expression")},
     exp.PercentileDisc: {"annotator": lambda self, e: self._annotate_by_args(e, "this")},
     exp.Localtimestamp: {"returns": exp.DType.TIMESTAMP},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6724,6 +6724,10 @@ DECODE(tbl.str_col);
 VARCHAR;
 
 # dialect: duckdb
+ENCODE(tbl.str_col);
+VARBINARY;
+
+# dialect: duckdb
 QUARTER(tbl.date_col);
 BIGINT;
 


### PR DESCRIPTION
### Annotate encode for duckdb

https://duckdb.org/docs/lts/sql/functions/blob#encodestring

Verified the DuckDB ENCODE() function using DuckDBs Web Shell. The function returns BLOB.

<img width="1251" height="393" alt="image" src="https://github.com/user-attachments/assets/7be1281c-3112-4ae7-9aee-191a76fa83dc" />


SQLGlot internally normalizes DuckDB's BLOB type to its canonical VARBINARY type.

<img width="1116" height="590" alt="image" src="https://github.com/user-attachments/assets/4818c449-09ea-43a0-8803-531d36122cff" />
