### PR TITLE
fix(duckdb): handle ORDER BY and LIMIT for bq ARRAY_CONCAT_AGG

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3463,18 +3463,12 @@ class DuckDBGenerator(generator.Generator):
     def arrayconcatagg_sql(self, expression: exp.ArrayConcatAgg) -> str:
         this = expression.this
 
-        # BigQuery allows a trailing LIMIT and ORDER BY inside the aggregate call, both of
-        # which wrap the aggregated column: ARRAY_CONCAT_AGG(x [ORDER BY ...] [LIMIT n]).
-        # LIMIT has no direct DuckDB equivalent and its LIMIT 0 -> NULL semantics can't be
-        # matched by a plain slice, so it's dropped with a warning.
         if isinstance(this, exp.Limit):
             self.unsupported("LIMIT in ARRAY_CONCAT_AGG cannot be transpiled to DuckDB")
             this = this.this
 
-        # The FILTER predicate references only the aggregated column, so unwrap ORDER BY.
         inner = this.this if isinstance(this, exp.Order) else this
 
-        # FILTER matches BigQuery's NULL semantics (all-NULL / no rows -> NULL).
         return self.func(
             "FLATTEN",
             exp.Filter(

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -3462,11 +3462,24 @@ class DuckDBGenerator(generator.Generator):
 
     def arrayconcatagg_sql(self, expression: exp.ArrayConcatAgg) -> str:
         this = expression.this
+
+        # BigQuery allows a trailing LIMIT and ORDER BY inside the aggregate call, both of
+        # which wrap the aggregated column: ARRAY_CONCAT_AGG(x [ORDER BY ...] [LIMIT n]).
+        # LIMIT has no direct DuckDB equivalent and its LIMIT 0 -> NULL semantics can't be
+        # matched by a plain slice, so it's dropped with a warning.
+        if isinstance(this, exp.Limit):
+            self.unsupported("LIMIT in ARRAY_CONCAT_AGG cannot be transpiled to DuckDB")
+            this = this.this
+
+        # The FILTER predicate references only the aggregated column, so unwrap ORDER BY.
+        inner = this.this if isinstance(this, exp.Order) else this
+
+        # FILTER matches BigQuery's NULL semantics (all-NULL / no rows -> NULL).
         return self.func(
             "FLATTEN",
             exp.Filter(
                 this=exp.ArrayAgg(this=this),
-                expression=exp.Where(this=this.copy().is_(exp.null()).not_()),
+                expression=exp.Where(this=inner.copy().is_(exp.null()).not_()),
             ),
         )
 

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -2133,6 +2133,27 @@ WHERE
             },
         )
         self.validate_all(
+            "SELECT ARRAY_CONCAT_AGG(arr ORDER BY y) FROM (SELECT [1, 2] AS arr, 1 AS y) AS t",
+            write={
+                "bigquery": "SELECT ARRAY_CONCAT_AGG(arr ORDER BY y) FROM (SELECT [1, 2] AS arr, 1 AS y) AS t",
+                "duckdb": "SELECT FLATTEN(ARRAY_AGG(arr ORDER BY y NULLS FIRST) FILTER(WHERE NOT arr IS NULL)) FROM (SELECT [1, 2] AS arr, 1 AS y) AS t",
+            },
+        )
+        self.validate_all(
+            "SELECT ARRAY_CONCAT_AGG(arr LIMIT 2) FROM (SELECT [1, 2] AS arr) AS t",
+            write={
+                "bigquery": "SELECT ARRAY_CONCAT_AGG(arr LIMIT 2) FROM (SELECT [1, 2] AS arr) AS t",
+                "duckdb": UnsupportedError,
+            },
+        )
+        self.validate_all(
+            "SELECT ARRAY_CONCAT_AGG(arr ORDER BY y DESC LIMIT 2) FROM (SELECT [1, 2] AS arr, 1 AS y) AS t",
+            write={
+                "bigquery": "SELECT ARRAY_CONCAT_AGG(arr ORDER BY y DESC LIMIT 2) FROM (SELECT [1, 2] AS arr, 1 AS y) AS t",
+                "duckdb": UnsupportedError,
+            },
+        )
+        self.validate_all(
             "SELECT b'\x61'",
             write={
                 "bigquery": "SELECT b'\x61'",


### PR DESCRIPTION
Handle the transpilation from bq -> duckdb of ARRAY_CONCAT_AGG when `ORDER BY` or `LIMIT` are present.

continued from: https://github.com/tobymao/sqlglot/pull/7891