### PR TITLE
fix(optimizer)!: don't normalize quoted derived output aliases in qualify_outputs

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -1033,10 +1033,13 @@ def qualify_outputs(scope_or_expression: Scope | exp.Expr, dialect: Dialect) -> 
                 alias=selection.output_name or f"_col_{i}",
                 copy=False,
             )
-            if isinstance(source_identifier, exp.Identifier) and source_identifier.quoted:
-                # The alias copies the exact spelling of a quoted identifier, so folding it
-                # would desync it from other occurrences of that identifier
-                selection.args["alias"].set("quoted", True)
+            if isinstance(source_identifier, exp.Identifier):
+                # The alias copies the exact spelling of an existing identifier, so folding it
+                # here would desync it from other occurrences of that identifier; its casing
+                # is `normalize_identifiers`' concern, which has already run (or was skipped
+                # deliberately) by this point
+                if source_identifier.quoted:
+                    selection.args["alias"].set("quoted", True)
             else:
                 dialect.normalize_identifier(selection.args["alias"])
         if aliased_column:

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -1027,8 +1027,11 @@ def qualify_outputs(scope_or_expression: Scope | exp.Expr, dialect: Dialect) -> 
                 copy=False,
             )
             if source_quoted:
+                # The alias copies the exact spelling of a quoted identifier, so folding it
+                # would desync it from other occurrences of that identifier
                 selection.args["alias"].set("quoted", True)
-            dialect.normalize_identifier(selection.args["alias"])
+            else:
+                dialect.normalize_identifier(selection.args["alias"])
         if aliased_column:
             selection.set("alias", exp.to_identifier(aliased_column))
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -1020,13 +1020,20 @@ def qualify_outputs(scope_or_expression: Scope | exp.Expr, dialect: Dialect) -> 
                 dialect.normalize_identifier(alias_identifier)
                 selection.set("alias", exp.TableAlias(this=alias_identifier))
         elif not isinstance(selection, (exp.Alias, exp.Aliases)) and not selection.is_star:
-            source_quoted = isinstance(selection, exp.Column) and selection.this.quoted
+            unwrapped = selection.unnest()
+            if isinstance(unwrapped, exp.Column):
+                source_identifier = unwrapped.this
+            elif isinstance(unwrapped, exp.Dot):
+                source_identifier = unwrapped.expression
+            else:
+                source_identifier = None
+
             selection = alias(
                 selection,
                 alias=selection.output_name or f"_col_{i}",
                 copy=False,
             )
-            if source_quoted:
+            if isinstance(source_identifier, exp.Identifier) and source_identifier.quoted:
                 # The alias copies the exact spelling of a quoted identifier, so folding it
                 # would desync it from other occurrences of that identifier
                 selection.args["alias"].set("quoted", True)

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -122,7 +122,7 @@ SELECT _0.a AS a, _0.b AS b FROM (WITH cte1 AS (SELECT 1 AS a, 2 AS b) SELECT ct
 
 # dialect: snowflake
 SELECT OBJECT_CONSTRUCT(*) FROM (SELECT a, b FROM x) AS t;
-SELECT OBJECT_CONSTRUCT(*) AS _COL_0 FROM (SELECT a AS A, b AS B FROM x AS x) AS t;
+SELECT OBJECT_CONSTRUCT(*) AS _COL_0 FROM (SELECT a AS a, b AS b FROM x AS x) AS t;
 
 # dialect: snowflake
 WITH base AS (SELECT 1 AS a, 2 AS b, 3 AS c, 4 AS d) SELECT OBJECT_INSERT(OBJECT_CONSTRUCT(*), 'e', 5) FROM base;
@@ -138,7 +138,7 @@ WITH cte AS (SELECT 1 AS a, 2 AS b) SELECT HASH_AGG(*) AS _COL_0 FROM cte AS cte
 
 # dialect: snowflake
 WITH cte AS (SELECT a, b FROM x) SELECT COUNT(* EXCLUDE a) FROM cte;
-WITH cte AS (SELECT a AS A, b AS B FROM x AS x) SELECT COUNT(* EXCLUDE (a)) AS _COL_0 FROM cte AS cte;
+WITH cte AS (SELECT a AS a, b AS b FROM x AS x) SELECT COUNT(* EXCLUDE (a)) AS _COL_0 FROM cte AS cte;
 
 WITH cte1 AS (SELECT a, SUM(b) AS sale FROM x GROUP BY a), cte2 AS (SELECT cte1.a, COUNT(*) AS cnt FROM cte1 GROUP BY cte1.a) SELECT a, cnt FROM cte2;
 WITH cte1 AS (SELECT x.a AS a FROM x AS x GROUP BY x.a), cte2 AS (SELECT cte1.a AS a, COUNT(*) AS cnt FROM cte1 AS cte1 GROUP BY cte1.a) SELECT cte2.a AS a, cte2.cnt AS cnt FROM cte2 AS cte2;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -529,6 +529,19 @@ class TestOptimizer(unittest.TestCase):
             "SELECT y AS y FROM x",
         )
 
+        # Aliases derived from quoted projections keep their exact spelling, even for
+        # dialects that fold quoted identifiers (e.g. Trino), so that running this rule
+        # without `normalize_identifiers` doesn't desync the alias from its source
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
+                parse_one('SELECT "C1" FROM t', read="trino"),
+                schema={},
+                infer_schema=False,
+                dialect="trino",
+            ).sql(dialect="trino"),
+            'SELECT "C1" AS "C1" FROM t',
+        )
+
         self.assertEqual(
             optimizer.qualify.qualify(
                 parse_one(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -561,6 +561,18 @@ class TestOptimizer(unittest.TestCase):
             'SELECT t.s."Ff" AS "Ff" FROM t',
         )
 
+        # Same for unquoted identifiers: folding only the derived alias would leave the
+        # outer scope unable to resolve (and qualify) references to the inner output
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
+                parse_one("SELECT Cc FROM (SELECT Cc FROM t) AS s", read="snowflake"),
+                schema={},
+                infer_schema=False,
+                dialect="snowflake",
+            ).sql(dialect="snowflake"),
+            "SELECT s.Cc AS Cc FROM (SELECT Cc AS Cc FROM t) AS s",
+        )
+
         self.assertEqual(
             optimizer.qualify.qualify(
                 parse_one(

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -543,6 +543,25 @@ class TestOptimizer(unittest.TestCase):
         )
 
         self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
+                parse_one('SELECT ("C1") FROM t', read="trino"),
+                schema={},
+                infer_schema=False,
+                dialect="trino",
+            ).sql(dialect="trino"),
+            'SELECT ("C1") AS "C1" FROM t',
+        )
+
+        self.assertEqual(
+            optimizer.qualify_columns.qualify_columns(
+                parse_one('SELECT t.s."Ff" FROM t', read="duckdb"),
+                schema={"t": {"s": 'STRUCT("Ff" INT)'}},
+                dialect="duckdb",
+            ).sql(dialect="duckdb"),
+            'SELECT t.s."Ff" AS "Ff" FROM t',
+        )
+
+        self.assertEqual(
             optimizer.qualify.qualify(
                 parse_one(
                     "WITH X AS (SELECT Y.A FROM DB.y CROSS JOIN a.b.INFORMATION_SCHEMA.COLUMNS) SELECT `A` FROM X",


### PR DESCRIPTION
Fixes #7919 
