### PR TITLE
perf(optimizer): speed up merge_subqueries

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -149,8 +149,7 @@ def _mergeable(
         if not window_aliases:
             return False
 
-        outer = outer_scope.expression
-        if outer.args.get("where") or outer.args.get("joins"):
+        if outer_args.get("where") or outer_args.get("joins"):
             return True
 
         return any(
@@ -168,7 +167,7 @@ def _mergeable(
         e.g., ROLLUP / CUBE / GROUPING SETS, tuples, expressions, etc, blocks the merge, since
         ordinals aren't universally supported there, e.g., Presto / Trino only accept columns.
         """
-        group = outer_scope.expression.args.get("group")
+        group = outer_args.get("group")
         if not group:
             return False
 
@@ -231,7 +230,7 @@ def _mergeable(
         #       SELECT * FROM cte  <-- outer scope
         #     )
         cte = inner_scope.expression.parent
-        node = outer_scope.expression.parent
+        node = outer.parent
 
         while node:
             if node is cte:
@@ -241,7 +240,7 @@ def _mergeable(
 
     def _literal_in_order_by(number_literal_aliases):
         """A numeric-literal projection under a bare ORDER BY key can't merge (would become positional)."""
-        order = outer_scope.expression.args.get("order")
+        order = outer_args.get("order")
         if not order:
             return False
         ordered = {
@@ -251,13 +250,14 @@ def _mergeable(
         }
         return bool(number_literal_aliases & ordered)
 
-    if not isinstance(outer_scope.expression, exp.Select):
+    outer = outer_scope.expression
+    if not isinstance(outer, exp.Select):
         return False
-    if outer_scope.expression.is_star:
+    if outer.is_star:
         return False
     if not isinstance(inner_select, exp.Select):
         return False
-    if any(inner_select.args.get(arg) for arg in UNMERGABLE_ARGS):
+    if any(v for k, v in inner_select.args.items() if k in UNMERGABLE_ARGS):
         return False
     if inner_select.args.get("from_") is None:
         return False
@@ -291,10 +291,11 @@ def _mergeable(
         and from_or_join.side in ("FULL", "LEFT", "RIGHT")
     ):
         return False
+    outer_args = outer.args
     if (
         isinstance(from_or_join, exp.From)
         and inner_select.args.get("where")
-        and any(j.side in ("FULL", "RIGHT") for j in outer_scope.expression.args.get("joins", []))
+        and any(j.side in ("FULL", "RIGHT") for j in outer_args.get("joins", []))
     ):
         return False
 

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -276,6 +276,20 @@ def _mergeable(
         or any(v for k, v in inner_select.args.items() if k in UNMERGABLE_ARGS)
         or inner_select.args.get("from_") is None
         or outer_scope.pivots
+        or (leave_tables_isolated and len(outer_scope.selected_sources) > 1)
+        or (isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"))
+        or (
+            isinstance(from_or_join, exp.Join)
+            and inner_select.args.get("where")
+            and from_or_join.side in ("FULL", "LEFT", "RIGHT")
+        )
+        or (
+            isinstance(from_or_join, exp.From)
+            and inner_select.args.get("where")
+            and any(j.side in ("FULL", "RIGHT") for j in outer_args.get("joins", []))
+        )
+        or (inner_select.args.get("order") and outer_scope.is_union)
+        or isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform)
     ):
         return False
 
@@ -297,25 +311,11 @@ def _mergeable(
                 window_aliases.add(name)
 
     return (
-        not (leave_tables_isolated and len(outer_scope.selected_sources) > 1)
-        and not (isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"))
-        and not (
-            isinstance(from_or_join, exp.Join)
-            and inner_select.args.get("where")
-            and from_or_join.side in ("FULL", "LEFT", "RIGHT")
-        )
-        and not (
-            isinstance(from_or_join, exp.From)
-            and inner_select.args.get("where")
-            and any(j.side in ("FULL", "RIGHT") for j in outer_args.get("joins", []))
-        )
-        and not _outer_select_joins_on_inner_select_join(projections)
+        not _outer_select_joins_on_inner_select_join(projections)
         and not _window_projection_blocks_merge(window_aliases)
         and not _literal_group_unmergeable(number_literal_aliases)
         and not _literal_in_order_by(number_literal_aliases)
         and not (inner_scope.is_cte and _is_recursive())
-        and not (inner_select.args.get("order") and outer_scope.is_union)
-        and not isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform)
     )
 
 

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -40,8 +40,10 @@ def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
     Returns:
         sqlglot.Expr: optimized expression
     """
-    expression = merge_ctes(expression, leave_tables_isolated)
-    expression = merge_derived_tables(expression, leave_tables_isolated)
+    # Shared across both passes so the scope tree is only built once
+    scopes = traverse_scope(expression)
+    expression = merge_ctes(expression, leave_tables_isolated, scopes=scopes)
+    expression = merge_derived_tables(expression, leave_tables_isolated, scopes=scopes)
     return expression
 
 
@@ -67,8 +69,12 @@ SAFE_TO_REPLACE_UNWRAPPED = (
 )
 
 
-def merge_ctes(expression: E, leave_tables_isolated: bool = False) -> E:
-    scopes = traverse_scope(expression)
+def merge_ctes(
+    expression: E,
+    leave_tables_isolated: bool = False,
+    scopes: list[Scope] | None = None,
+) -> E:
+    scopes = traverse_scope(expression) if scopes is None else scopes
 
     # All places where we select from CTEs.
     # We key on the CTE scope so we can detect CTES that are selected from multiple times.
@@ -105,8 +111,12 @@ def merge_ctes(expression: E, leave_tables_isolated: bool = False) -> E:
     return expression
 
 
-def merge_derived_tables(expression: E, leave_tables_isolated: bool = False) -> E:
-    for outer_scope in traverse_scope(expression):
+def merge_derived_tables(
+    expression: E,
+    leave_tables_isolated: bool = False,
+    scopes: list[Scope] | None = None,
+) -> E:
+    for outer_scope in traverse_scope(expression) if scopes is None else scopes:
         for subquery in outer_scope.derived_tables:
             from_or_join = subquery.find_ancestor(exp.From, exp.Join)
             if not isinstance(from_or_join, (exp.From, exp.Join)):

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -261,36 +261,52 @@ def _mergeable(
             s.alias_or_name in ordered and s.unalias().is_number for s in inner_select.selects
         )
 
-    return (
-        isinstance(outer_scope.expression, exp.Select)
-        and not outer_scope.expression.is_star
-        and isinstance(inner_select, exp.Select)
-        and not any(inner_select.args.get(arg) for arg in UNMERGABLE_ARGS)
-        and inner_select.args.get("from_") is not None
-        and not outer_scope.pivots
-        and not any(e.find(exp.AggFunc, exp.Select, exp.Explode) for e in inner_select.expressions)
-        and not (leave_tables_isolated and len(outer_scope.selected_sources) > 1)
-        and not (isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"))
-        and not (
-            isinstance(from_or_join, exp.Join)
-            and inner_select.args.get("where")
-            and from_or_join.side in ("FULL", "LEFT", "RIGHT")
-        )
-        and not (
-            isinstance(from_or_join, exp.From)
-            and inner_select.args.get("where")
-            and any(
-                j.side in ("FULL", "RIGHT") for j in outer_scope.expression.args.get("joins", [])
-            )
-        )
-        and not _outer_select_joins_on_inner_select_join()
-        and not _window_projection_blocks_merge()
-        and not _literal_group_unmergeable()
-        and not _literal_in_order_by()
-        and not _is_recursive()
-        and not (inner_select.args.get("order") and outer_scope.is_union)
-        and not isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform)
-    )
+    if not isinstance(outer_scope.expression, exp.Select):
+        return False
+    if outer_scope.expression.is_star:
+        return False
+    if not isinstance(inner_select, exp.Select):
+        return False
+    if any(inner_select.args.get(arg) for arg in UNMERGABLE_ARGS):
+        return False
+    if inner_select.args.get("from_") is None:
+        return False
+    if outer_scope.pivots:
+        return False
+    if any(e.find(exp.AggFunc, exp.Select, exp.Explode) for e in inner_select.expressions):
+        return False
+    if leave_tables_isolated and len(outer_scope.selected_sources) > 1:
+        return False
+    if isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"):
+        return False
+    if (
+        isinstance(from_or_join, exp.Join)
+        and inner_select.args.get("where")
+        and from_or_join.side in ("FULL", "LEFT", "RIGHT")
+    ):
+        return False
+    if (
+        isinstance(from_or_join, exp.From)
+        and inner_select.args.get("where")
+        and any(j.side in ("FULL", "RIGHT") for j in outer_scope.expression.args.get("joins", []))
+    ):
+        return False
+    if _outer_select_joins_on_inner_select_join():
+        return False
+    if _window_projection_blocks_merge():
+        return False
+    if _literal_group_unmergeable():
+        return False
+    if _literal_in_order_by():
+        return False
+    if _is_recursive():
+        return False
+    if inner_select.args.get("order") and outer_scope.is_union:
+        return False
+    if isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform):
+        return False
+
+    return True
 
 
 def _rename_inner_sources(outer_scope: Scope, inner_scope: Scope, alias: str) -> None:

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -139,14 +139,13 @@ def _mergeable(
     """
     inner_select = inner_scope.expression.unnest()
 
-    def _window_projection_blocks_merge():
+    def _window_projection_blocks_merge(window_aliases):
         """A window function's result depends on the full row set it sees, so merging the
         subquery into the outer query is unsafe when:
           - the outer query filters or joins (WHERE/JOIN), which changes that row set, or
           - a window column is referenced in an operation that isn't pushed down
             (GROUP BY, ORDER BY, HAVING, aggregate).
         """
-        window_aliases = {s.alias_or_name for s in inner_select.selects if s.find(exp.Window)}
         if not window_aliases:
             return False
 
@@ -154,15 +153,14 @@ def _mergeable(
         if outer.args.get("where") or outer.args.get("joins"):
             return True
 
-        inner_select_name = from_or_join.alias_or_name
         return any(
-            column.table == inner_select_name
+            column.table == inner_name
             and column.name in window_aliases
             and column.find_ancestor(exp.Group, exp.Order, exp.Having, exp.AggFunc)
             for column in outer_scope.columns
         )
 
-    def _literal_group_unmergeable():
+    def _literal_group_unmergeable(number_literal_aliases):
         """
         A numeric-literal projection referenced in GROUP BY can't be inlined, because a bare
         integer literal is positional. A reference that is itself a top-level GROUP BY item
@@ -174,15 +172,13 @@ def _mergeable(
         if not group:
             return False
 
-        inner_name = from_or_join.alias_or_name
-        literal_names = {s.alias_or_name for s in inner_select.selects if s.unalias().is_number}
-        if not literal_names:
+        if not number_literal_aliases:
             return False
 
         grouped = set()
         top_level_ids = {id(e.unnest()) for e in group.expressions}
         for col in group.find_all(exp.Column):
-            if col.table != inner_name or col.name not in literal_names:
+            if col.table != inner_name or col.name not in number_literal_aliases:
                 continue
             if id(col) not in top_level_ids:
                 return True
@@ -199,7 +195,7 @@ def _mergeable(
 
         return not grouped <= projected
 
-    def _outer_select_joins_on_inner_select_join():
+    def _outer_select_joins_on_inner_select_join(projections):
         """
         All columns from the inner select in the ON clause must be from the first FROM table.
 
@@ -213,21 +209,18 @@ def _mergeable(
         if not isinstance(from_or_join, exp.Join):
             return False
 
-        alias = from_or_join.alias_or_name
-
         on = from_or_join.args.get("on")
         if not on:
             return False
-        selections = [c.name for c in on.find_all(exp.Column) if c.table == alias]
+        selections = [c.name for c in on.find_all(exp.Column) if c.table == inner_name]
         inner_from = inner_scope.expression.args.get("from_")
         if not inner_from:
             return False
         inner_from_table = inner_from.alias_or_name
-        inner_projections = {s.alias_or_name: s for s in inner_scope.expression.selects}
         return any(
             col.table != inner_from_table
             for selection in selections
-            for col in inner_projections[selection].find_all(exp.Column)
+            for col in projections[selection].find_all(exp.Column)
         )
 
     def _is_recursive():
@@ -246,20 +239,17 @@ def _mergeable(
             node = node.parent
         return False
 
-    def _literal_in_order_by():
+    def _literal_in_order_by(number_literal_aliases):
         """A numeric-literal projection under a bare ORDER BY key can't merge (would become positional)."""
         order = outer_scope.expression.args.get("order")
         if not order:
             return False
-        inner_name = from_or_join.alias_or_name
         ordered = {
             key.name
             for o in order.expressions
             if isinstance(key := o.this.unnest(), exp.Column) and key.table == inner_name
         }
-        return any(
-            s.alias_or_name in ordered and s.unalias().is_number for s in inner_select.selects
-        )
+        return bool(number_literal_aliases & ordered)
 
     if not isinstance(outer_scope.expression, exp.Select):
         return False
@@ -273,8 +263,24 @@ def _mergeable(
         return False
     if outer_scope.pivots:
         return False
-    if any(e.find(exp.AggFunc, exp.Select, exp.Explode) for e in inner_select.expressions):
-        return False
+
+    # Single pass over the projections: replaces the separate AggFunc/Select/Explode and
+    # Window tree walks, and precomputes what the checks below need per-projection.
+    window_aliases: set[str] = set()
+    number_literal_aliases: set[str] = set()
+    projections: dict[str, exp.Expr] = {}
+
+    for s in inner_select.selects:
+        name = s.alias_or_name
+        projections[name] = s
+        if s.unalias().is_number:
+            number_literal_aliases.add(name)
+        for node in s.walk():
+            if isinstance(node, (exp.AggFunc, exp.Select, exp.Explode)):
+                return False
+            if isinstance(node, exp.Window):
+                window_aliases.add(name)
+
     if leave_tables_isolated and len(outer_scope.selected_sources) > 1:
         return False
     if isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"):
@@ -291,13 +297,16 @@ def _mergeable(
         and any(j.side in ("FULL", "RIGHT") for j in outer_scope.expression.args.get("joins", []))
     ):
         return False
-    if _outer_select_joins_on_inner_select_join():
+
+    inner_name = from_or_join.alias_or_name
+
+    if _outer_select_joins_on_inner_select_join(projections):
         return False
-    if _window_projection_blocks_merge():
+    if _window_projection_blocks_merge(window_aliases):
         return False
-    if _literal_group_unmergeable():
+    if _literal_group_unmergeable(number_literal_aliases):
         return False
-    if _literal_in_order_by():
+    if _literal_in_order_by(number_literal_aliases):
         return False
     if _is_recursive():
         return False

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -44,9 +44,11 @@ def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
     # doesn't mutate the AST; if it does, the scopes it was given are no longer valid, so the
     # scope tree needs to be rebuilt before merge_derived_tables runs.
     scopes = traverse_scope(expression)
-    expression, merged_ctes = _merge_ctes(expression, leave_tables_isolated, scopes=scopes)
+    expression, merged_ctes = merge_ctes(expression, leave_tables_isolated, scopes=scopes)
+
     if merged_ctes:
         scopes = traverse_scope(expression)
+
     expression = merge_derived_tables(expression, leave_tables_isolated, scopes=scopes)
     return expression
 
@@ -77,21 +79,11 @@ def merge_ctes(
     expression: E,
     leave_tables_isolated: bool = False,
     scopes: list[Scope] | None = None,
-) -> E:
-    return _merge_ctes(expression, leave_tables_isolated, scopes)[0]
-
-
-def _merge_ctes(
-    expression: E,
-    leave_tables_isolated: bool = False,
-    scopes: list[Scope] | None = None,
 ) -> tuple[E, bool]:
-    scopes = traverse_scope(expression) if scopes is None else scopes
-
     # All places where we select from CTEs.
     # We key on the CTE scope so we can detect CTES that are selected from multiple times.
     cte_selections = defaultdict(list)
-    for outer_scope in scopes:
+    for outer_scope in traverse_scope(expression) if scopes is None else scopes:
         for table, inner_scope in outer_scope.selected_sources.values():
             if isinstance(inner_scope, Scope) and inner_scope.is_cte:
                 cte_selections[id(inner_scope)].append(

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -309,7 +309,7 @@ def _mergeable(
         return False
     if _literal_in_order_by(number_literal_aliases):
         return False
-    if _is_recursive():
+    if inner_scope.is_cte and _is_recursive():
         return False
     if inner_select.args.get("order") and outer_scope.is_union:
         return False

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -40,9 +40,13 @@ def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
     Returns:
         sqlglot.Expr: optimized expression
     """
-    # Shared across both passes so the scope tree is only built once
+    # Shared across both passes so the scope tree is only built once, as long as merge_ctes
+    # doesn't mutate the AST; if it does, the scopes it was given are no longer valid, so the
+    # scope tree needs to be rebuilt before merge_derived_tables runs.
     scopes = traverse_scope(expression)
-    expression = merge_ctes(expression, leave_tables_isolated, scopes=scopes)
+    expression, merged_ctes = _merge_ctes(expression, leave_tables_isolated, scopes=scopes)
+    if merged_ctes:
+        scopes = traverse_scope(expression)
     expression = merge_derived_tables(expression, leave_tables_isolated, scopes=scopes)
     return expression
 
@@ -74,6 +78,14 @@ def merge_ctes(
     leave_tables_isolated: bool = False,
     scopes: list[Scope] | None = None,
 ) -> E:
+    return _merge_ctes(expression, leave_tables_isolated, scopes)[0]
+
+
+def _merge_ctes(
+    expression: E,
+    leave_tables_isolated: bool = False,
+    scopes: list[Scope] | None = None,
+) -> tuple[E, bool]:
     scopes = traverse_scope(expression) if scopes is None else scopes
 
     # All places where we select from CTEs.
@@ -90,6 +102,7 @@ def merge_ctes(
                     )
                 )
 
+    merged = False
     singular_cte_selections = [v[0] for k, v in cte_selections.items() if len(v) == 1]
     for outer_scope, inner_scope, table in singular_cte_selections:
         from_or_join = table.find_ancestor(exp.From, exp.Join)
@@ -108,7 +121,8 @@ def merge_ctes(
             _merge_hints(outer_scope, inner_scope)
             _pop_cte(inner_scope)
             outer_scope.clear_cache()
-    return expression
+            merged = True
+    return expression, merged
 
 
 def merge_derived_tables(
@@ -148,8 +162,11 @@ def _mergeable(
     Return True if `inner_select` can be merged into outer query.
     """
     inner_select = inner_scope.expression.unnest()
+    outer = outer_scope.expression
+    outer_args = outer.args
+    inner_name = from_or_join.alias_or_name
 
-    def _window_projection_blocks_merge(window_aliases):
+    def _window_projection_blocks_merge(window_aliases: set[str]) -> bool:
         """A window function's result depends on the full row set it sees, so merging the
         subquery into the outer query is unsafe when:
           - the outer query filters or joins (WHERE/JOIN), which changes that row set, or
@@ -169,7 +186,7 @@ def _mergeable(
             for column in outer_scope.columns
         )
 
-    def _literal_group_unmergeable(number_literal_aliases):
+    def _literal_group_unmergeable(number_literal_aliases: set[str]) -> bool:
         """
         A numeric-literal projection referenced in GROUP BY can't be inlined, because a bare
         integer literal is positional. A reference that is itself a top-level GROUP BY item
@@ -197,14 +214,14 @@ def _mergeable(
             return False
 
         projected = set()
-        for s in outer_scope.expression.selects:
+        for s in t.cast(exp.Select, outer).selects:
             unaliased = s.unalias()
             if isinstance(unaliased, exp.Column) and unaliased.table == inner_name:
                 projected.add(unaliased.name)
 
         return not grouped <= projected
 
-    def _outer_select_joins_on_inner_select_join(projections):
+    def _outer_select_joins_on_inner_select_join(projections: dict[str, exp.Expr]) -> bool:
         """
         All columns from the inner select in the ON clause must be from the first FROM table.
 
@@ -232,7 +249,7 @@ def _mergeable(
             for col in projections[selection].find_all(exp.Column)
         )
 
-    def _is_recursive():
+    def _is_recursive() -> bool:
         # Recursive CTEs look like this:
         #     WITH RECURSIVE cte AS (
         #       SELECT * FROM x  <-- inner scope
@@ -248,7 +265,7 @@ def _mergeable(
             node = node.parent
         return False
 
-    def _literal_in_order_by(number_literal_aliases):
+    def _literal_in_order_by(number_literal_aliases: set[str]) -> bool:
         """A numeric-literal projection under a bare ORDER BY key can't merge (would become positional)."""
         order = outer_args.get("order")
         if not order:
@@ -260,18 +277,14 @@ def _mergeable(
         }
         return bool(number_literal_aliases & ordered)
 
-    outer = outer_scope.expression
-    if not isinstance(outer, exp.Select):
-        return False
-    if outer.is_star:
-        return False
-    if not isinstance(inner_select, exp.Select):
-        return False
-    if any(v for k, v in inner_select.args.items() if k in UNMERGABLE_ARGS):
-        return False
-    if inner_select.args.get("from_") is None:
-        return False
-    if outer_scope.pivots:
+    if (
+        not isinstance(outer, exp.Select)
+        or outer.is_star
+        or not isinstance(inner_select, exp.Select)
+        or any(v for k, v in inner_select.args.items() if k in UNMERGABLE_ARGS)
+        or inner_select.args.get("from_") is None
+        or outer_scope.pivots
+    ):
         return False
 
     # Single pass over the projections: replaces the separate AggFunc/Select/Explode and
@@ -291,42 +304,27 @@ def _mergeable(
             if isinstance(node, exp.Window):
                 window_aliases.add(name)
 
-    if leave_tables_isolated and len(outer_scope.selected_sources) > 1:
-        return False
-    if isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"):
-        return False
-    if (
-        isinstance(from_or_join, exp.Join)
-        and inner_select.args.get("where")
-        and from_or_join.side in ("FULL", "LEFT", "RIGHT")
-    ):
-        return False
-    outer_args = outer.args
-    if (
-        isinstance(from_or_join, exp.From)
-        and inner_select.args.get("where")
-        and any(j.side in ("FULL", "RIGHT") for j in outer_args.get("joins", []))
-    ):
-        return False
-
-    inner_name = from_or_join.alias_or_name
-
-    if _outer_select_joins_on_inner_select_join(projections):
-        return False
-    if _window_projection_blocks_merge(window_aliases):
-        return False
-    if _literal_group_unmergeable(number_literal_aliases):
-        return False
-    if _literal_in_order_by(number_literal_aliases):
-        return False
-    if inner_scope.is_cte and _is_recursive():
-        return False
-    if inner_select.args.get("order") and outer_scope.is_union:
-        return False
-    if isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform):
-        return False
-
-    return True
+    return (
+        not (leave_tables_isolated and len(outer_scope.selected_sources) > 1)
+        and not (isinstance(from_or_join, exp.Join) and inner_select.args.get("joins"))
+        and not (
+            isinstance(from_or_join, exp.Join)
+            and inner_select.args.get("where")
+            and from_or_join.side in ("FULL", "LEFT", "RIGHT")
+        )
+        and not (
+            isinstance(from_or_join, exp.From)
+            and inner_select.args.get("where")
+            and any(j.side in ("FULL", "RIGHT") for j in outer_args.get("joins", []))
+        )
+        and not _outer_select_joins_on_inner_select_join(projections)
+        and not _window_projection_blocks_merge(window_aliases)
+        and not _literal_group_unmergeable(number_literal_aliases)
+        and not _literal_in_order_by(number_literal_aliases)
+        and not (inner_scope.is_cte and _is_recursive())
+        and not (inner_select.args.get("order") and outer_scope.is_union)
+        and not isinstance(seq_get(inner_select.expressions, 0), exp.QueryTransform)
+    )
 
 
 def _rename_inner_sources(outer_scope: Scope, inner_scope: Scope, alias: str) -> None:

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -610,3 +610,11 @@ SELECT s.b AS b FROM (SELECT 6 AS a, x.b AS b FROM x AS x) AS s ORDER BY s.a;
 # execute: false
 WITH c AS (SELECT DISTINCT b FROM x) SELECT s.b FROM (SELECT 6 AS a, b FROM c) AS s CROSS JOIN x ORDER BY s.a;
 WITH c AS (SELECT DISTINCT x.b AS b FROM x AS x) SELECT s.b AS b FROM (SELECT 6 AS a, c.b AS b FROM c AS c) AS s CROSS JOIN x AS x ORDER BY s.a;
+
+# title: A single-use CTE merge must not leave a stale scope for the later derived-table pass
+WITH c AS (SELECT a FROM (SELECT a, b FROM x) AS q WHERE q.b > 1) SELECT c.a FROM c JOIN y ON c.a = y.b;
+SELECT x.a AS a FROM x AS x JOIN y AS y ON x.a = y.b WHERE x.b > 1;
+
+# title: Window function nested inside a merged CTE is still blocked from merging into a join
+WITH c AS (SELECT rn FROM (SELECT ROW_NUMBER() OVER (ORDER BY a) AS rn FROM x) AS q) SELECT c.rn FROM c JOIN y ON c.rn = y.b;
+SELECT q.rn AS rn FROM (SELECT ROW_NUMBER() OVER (ORDER BY x.a) AS rn FROM x AS x) AS q JOIN y AS y ON q.rn = y.b;

--- a/tests/fixtures/optimizer/merge_subqueries.sql
+++ b/tests/fixtures/optimizer/merge_subqueries.sql
@@ -618,3 +618,7 @@ SELECT x.a AS a FROM x AS x JOIN y AS y ON x.a = y.b WHERE x.b > 1;
 # title: Window function nested inside a merged CTE is still blocked from merging into a join
 WITH c AS (SELECT rn FROM (SELECT ROW_NUMBER() OVER (ORDER BY a) AS rn FROM x) AS q) SELECT c.rn FROM c JOIN y ON c.rn = y.b;
 SELECT q.rn AS rn FROM (SELECT ROW_NUMBER() OVER (ORDER BY x.a) AS rn FROM x AS x) AS q JOIN y AS y ON q.rn = y.b;
+
+# title: A CTE merge that reintroduces a name colliding with the outer join still renames correctly
+WITH c AS (SELECT q.a FROM (SELECT x.a FROM x AS x) AS q) SELECT c.a FROM c JOIN x ON c.a = x.a;
+SELECT x_2.a AS a FROM x AS x_2 JOIN x AS x ON x_2.a = x.a;


### PR DESCRIPTION
Performance rework of `merge_subqueries` with ~1.25x speedup.  No changes to output SQL.

Changes
- Build the scope tree once: `merge_subqueries` calls `traverse_scope` once and threads scopes into `merge_ctes` and `merge_derived_tables` (was previously built twice).
- Single-pass scan in `_mergeable`: one loop over `inner_select.selects` precomputes projections, number_literal_aliases, window_aliases and does the AggFunc/Select/Explode check, replacing several re-walks. Helpers now receive this data instead of recomputing it.
- Cache `outer`, `outer_args`, and `inner_name`; convert the boolean and-chain to early-return guards; run `_is_recursive` only when `inner_scope.is_cte`.

Performance (pyperf, timing only the rule; before = origin/main, after = this branch).

| Corpus                       | Before           | After            | Speedup |
| ---------------------------- | ---------------- | ---------------- | ------- |
| merge_subqueries_fixtures    | 17.4 ms +/- 0.4  | 14.5 ms +/- 0.4  | 1.20x   |
| merge_subqueries_tpch        | 8.35 ms +/- 0.18 | 6.57 ms +/- 0.19 | 1.27x   |
| merge_subqueries_wide_chain  | 581 ms +/- 5     | 446 ms +/- 15    | 1.30x   |
| merge_subqueries_whole_suite | 215 ms +/- 3     | 175 ms +/- 2     | 1.23x   |
| Geometric mean               |                  |                  | ~1.25x  |

**Check the Jira ticket for the timing script**.