### PR TITLE
feat(trino): support inline SQL UDFs (WITH FUNCTION ... SELECT) [CLAUDE]

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2105,7 +2105,7 @@ class StoredProcedure(Expression):
 
 
 class Block(Expression):
-    arg_types = {"expressions": True}
+    arg_types = {"expressions": True, "begin": False}
 
 
 class IfBlock(Expression):
@@ -2118,6 +2118,63 @@ class WhileBlock(Expression):
 
 class EndStatement(Expression):
     arg_types = {}
+
+
+# https://trino.io/docs/current/udf.html
+class FunctionSpecification(Expression):
+    """
+    A SQL user-defined function specification, e.g. an inline UDF declared with
+    `WITH FUNCTION ... SELECT ...` in Trino. `this` is a `UserDefinedFunction`,
+    `properties` holds the `RETURNS` clause and routine characteristics, and
+    `expression` is the routine body (e.g. a `Return` or a `Block`).
+    """
+
+    arg_types = {"this": True, "properties": False, "expression": True}
+
+
+# https://trino.io/docs/current/udf/sql/case.html
+class CaseStatement(Expression):
+    """A procedural `CASE ... END CASE` statement, used in SQL routine bodies."""
+
+    arg_types = {"this": False, "ifs": True, "default": False}
+
+
+# https://trino.io/docs/current/udf/sql/if.html
+class IfStatement(Expression):
+    """A procedural `IF ... THEN ... [ELSEIF ...] [ELSE ...] END IF` statement."""
+
+    arg_types = {"ifs": True, "default": False}
+
+
+# https://trino.io/docs/current/udf/sql/loop.html
+class LoopStatement(Expression):
+    """A procedural `LOOP ... END LOOP` statement; `this` is a `Block`."""
+
+    arg_types = {"this": True, "label": False}
+
+
+# https://trino.io/docs/current/udf/sql/while.html
+class WhileStatement(Expression):
+    """A procedural `WHILE ... DO ... END WHILE` statement; `this` is the condition."""
+
+    arg_types = {"this": True, "body": True, "label": False}
+
+
+# https://trino.io/docs/current/udf/sql/repeat.html
+class RepeatStatement(Expression):
+    """A procedural `REPEAT ... UNTIL ... END REPEAT` statement."""
+
+    arg_types = {"body": True, "until": True, "label": False}
+
+
+# https://trino.io/docs/current/udf/sql/iterate.html
+class Iterate(Expression):
+    """A procedural `ITERATE label` statement, used inside loops."""
+
+
+# https://trino.io/docs/current/udf/sql/leave.html
+class Leave(Expression):
+    """A procedural `LEAVE label` statement, used inside loops."""
 
 
 UNWRAPPED_QUERIES = (Select, SetOperation)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -207,9 +207,11 @@ class Generator:
         exp.JSONBContainsAllTopKeys: lambda self, e: self.binary(e, "?&"),
         exp.JSONBDeleteAtPath: lambda self, e: self.binary(e, "#-"),
         exp.JSONBPathExists: lambda self, e: self.binary(e, "@?"),
+        exp.Iterate: lambda self, e: f"ITERATE {self.sql(e, 'this')}",
         exp.JSONObject: lambda self, e: self._jsonobject_sql(e),
         exp.JSONObjectAgg: lambda self, e: self._jsonobject_sql(e),
         exp.LanguageProperty: lambda self, e: self.naked_property(e),
+        exp.Leave: lambda self, e: f"LEAVE {self.sql(e, 'this')}",
         exp.LocationProperty: lambda self, e: self.naked_property(e),
         exp.LogProperty: lambda _, e: f"{'NO ' if e.args.get('no') else ''}LOG",
         exp.MaskingProperty: lambda *_: "MASKING",
@@ -6211,7 +6213,57 @@ class Generator:
 
     def block_sql(self, expression: exp.Block) -> str:
         expressions = self.expressions(expression, sep="; ", flat=True)
+        if expression.args.get("begin"):
+            return f"BEGIN {expressions}; END" if expressions else "BEGIN END"
         return f"{expressions}" if expressions else ""
+
+    def functionspecification_sql(self, expression: exp.FunctionSpecification) -> str:
+        properties = expression.args.get("properties")
+        properties_sql = self.properties(properties, sep=" ", wrapped=False) if properties else ""
+        properties_sql = f" {properties_sql}" if properties_sql else ""
+        body = self.sql(expression, "expression")
+        return f"FUNCTION {self.sql(expression, 'this')}{properties_sql} {body}"
+
+    def casestatement_sql(self, expression: exp.CaseStatement) -> str:
+        this = self.sql(expression, "this")
+        this = f" {this}" if this else ""
+        whens = " ".join(
+            f"WHEN {self.sql(if_, 'this')} THEN {self.sql(if_, 'true')};"
+            for if_ in expression.args["ifs"]
+        )
+        default = self.sql(expression, "default")
+        default = f" ELSE {default};" if default else ""
+        return f"CASE{this} {whens}{default} END CASE"
+
+    def ifstatement_sql(self, expression: exp.IfStatement) -> str:
+        branches = []
+        for i, if_ in enumerate(expression.args["ifs"]):
+            keyword = "IF" if i == 0 else "ELSEIF"
+            branches.append(f"{keyword} {self.sql(if_, 'this')} THEN {self.sql(if_, 'true')};")
+
+        default = self.sql(expression, "default")
+        if default:
+            branches.append(f"ELSE {default};")
+
+        return f"{' '.join(branches)} END IF"
+
+    def statement_label_sql(self, expression: exp.Expr) -> str:
+        label = self.sql(expression, "label")
+        return f"{label}: " if label else ""
+
+    def loopstatement_sql(self, expression: exp.LoopStatement) -> str:
+        label = self.statement_label_sql(expression)
+        return f"{label}LOOP {self.sql(expression, 'this')}; END LOOP"
+
+    def whilestatement_sql(self, expression: exp.WhileStatement) -> str:
+        label = self.statement_label_sql(expression)
+        body = self.sql(expression, "body")
+        return f"{label}WHILE {self.sql(expression, 'this')} DO {body}; END WHILE"
+
+    def repeatstatement_sql(self, expression: exp.RepeatStatement) -> str:
+        label = self.statement_label_sql(expression)
+        body = self.sql(expression, "body")
+        return f"{label}REPEAT {body}; UNTIL {self.sql(expression, 'until')} END REPEAT"
 
     def storedprocedure_sql(self, expression: exp.StoredProcedure) -> str:
         self.unsupported("Unsupported Stored Procedure syntax")

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -13,6 +13,8 @@ from sqlglot.generators.presto import PrestoGenerator, amend_exploded_column_tab
 
 class TrinoGenerator(PrestoGenerator):
     EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = True
+    DECLARE_DEFAULT_ASSIGNMENT = "DEFAULT"
+
     PROPERTIES_LOCATION = {
         **PrestoGenerator.PROPERTIES_LOCATION,
         exp.LocationProperty: exp.Properties.Location.POST_WITH,
@@ -38,6 +40,10 @@ class TrinoGenerator(PrestoGenerator):
                 amend_exploded_column_table,
             ]
         ),
+        exp.SqlSecurityProperty: lambda self, e: f"SECURITY {self.sql(e, 'this')}",
+        exp.StabilityProperty: lambda _, e: (
+            "DETERMINISTIC" if e.name == "IMMUTABLE" else "NOT DETERMINISTIC"
+        ),
         exp.TimeStrToTime: lambda self, e: timestrtotime_sql(self, e, include_precision=True),
         exp.Trim: trim_sql,
     }
@@ -47,6 +53,26 @@ class TrinoGenerator(PrestoGenerator):
         exp.JSONPathRoot,
         exp.JSONPathSubscript,
     }
+
+    def with_sql(self, expression: exp.With) -> str:
+        # Inline UDFs are declared in their own `WITH` clause, which precedes the (optional)
+        # `WITH` clause of the query: https://trino.io/docs/current/udf/sql.html
+        functions = [e for e in expression.expressions if isinstance(e, exp.FunctionSpecification)]
+        if not functions:
+            return super().with_sql(expression)
+
+        functions_sql = self.expressions(sqls=functions, flat=True)
+
+        ctes = [e for e in expression.expressions if not isinstance(e, exp.FunctionSpecification)]
+        if not ctes:
+            return f"WITH {functions_sql}"
+
+        recursive = "RECURSIVE " if expression.args.get("recursive") else ""
+        search = self.sql(expression, "search")
+        search = f" {search}" if search else ""
+        ctes_sql = self.expressions(sqls=ctes, flat=True)
+
+        return f"WITH {functions_sql} WITH {recursive}{ctes_sql}{search}"
 
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -972,21 +972,24 @@ def walk_in_scope(
 
         # Only CTEs and Queries can start child scopes; checking that first lets all
         # other nodes (the vast majority) skip the rest of the boundary checks.
-        if (
-            node is not expression
-            and isinstance(node, (exp.CTE, exp.Query))
-            and (
+        if node is not expression and isinstance(
+            node, (exp.CTE, exp.Query, exp.FunctionSpecification)
+        ):
+            if isinstance(node, exp.FunctionSpecification):
+                # Routine bodies (e.g. Trino inline UDFs) are opaque to the outer scope
+                continue
+
+            if (
                 isinstance(node, exp.CTE)
                 or (isinstance(node.parent, (exp.From, exp.Join)) and _is_derived_table(node))
                 or isinstance(node.parent, exp.UDTF)
                 or isinstance(node, exp.UNWRAPPED_QUERIES)
-            )
-        ):
-            if isinstance(node, (exp.Subquery, exp.UDTF)):
-                for key in ("joins", "laterals", "pivots"):
-                    for arg in node.args.get(key) or []:
-                        yield from walk_in_scope(arg)
-            continue
+            ):
+                if isinstance(node, (exp.Subquery, exp.UDTF)):
+                    for key in ("joins", "laterals", "pivots"):
+                        for arg in node.args.get(key) or []:
+                            yield from walk_in_scope(arg)
+                continue
 
         if prune and prune(node):
             continue

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4059,7 +4059,7 @@ class Parser:
         expressions = []
         while True:
             cte = self._parse_cte()
-            if isinstance(cte, exp.CTE):
+            if cte:
                 expressions.append(cte)
                 if last_comments:
                     cte.add_comments(last_comments)
@@ -4080,7 +4080,7 @@ class Parser:
             comments=comments,
         )
 
-    def _parse_cte(self) -> exp.CTE | None:
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         index = self._index
 
         alias = self._parse_table_alias(self.ID_VAR_TOKENS)

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -654,9 +654,9 @@ class ClickHouseParser(parser.Parser):
         return super()._parse_position(haystack_first=True)
 
     # https://clickhouse.com/docs/en/sql-reference/statements/select/with/
-    def _parse_cte(self) -> exp.CTE | None:
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         # WITH <identifier> AS <subquery expression>
-        cte: exp.CTE | None = self._try_parse(super()._parse_cte)
+        cte: exp.CTE | exp.FunctionSpecification | None = self._try_parse(super()._parse_cte)
 
         if not cte:
             # WITH <expression> AS <identifier>

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -61,3 +61,210 @@ class TrinoParser(PrestoParser):
                 on_condition=self._parse_on_condition(),
             )
         )
+
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
+        # A `WITH` clause entry that starts with `FUNCTION <name>` is an inline SQL UDF
+        # specification (https://trino.io/docs/current/udf/sql.html), as opposed to a
+        # CTE that happens to be named "function", e.g. `WITH function AS (SELECT 1)`
+        if (
+            self._curr.token_type == TokenType.FUNCTION
+            and self._next.token_type in self.ID_VAR_TOKENS
+        ):
+            self._advance()
+            return self._parse_function_specification()
+
+        return super()._parse_cte()
+
+    def _parse_function_specification(self) -> exp.FunctionSpecification:
+        return self.expression(
+            exp.FunctionSpecification(
+                this=self._parse_user_defined_function(kind=TokenType.FUNCTION),
+                properties=self._parse_routine_characteristics(),
+                expression=self._parse_routine_statement(),
+            )
+        )
+
+    def _parse_routine_characteristics(self) -> exp.Properties | None:
+        # The `RETURNS` clause, followed by any routine characteristics:
+        # https://trino.io/docs/current/udf/function.html
+        properties: list[exp.Expr] = []
+        while True:
+            if self._match_text_seq("NOT", "DETERMINISTIC"):
+                prop: exp.Expr = self.expression(
+                    exp.StabilityProperty(this=exp.Literal.string("VOLATILE"))
+                )
+            elif self._match_texts(
+                ("RETURNS", "LANGUAGE", "DETERMINISTIC", "CALLED", "SECURITY", "COMMENT")
+            ):
+                prop = self.PROPERTY_PARSERS[self._prev.text.upper()](self)
+            else:
+                break
+
+            properties.append(prop)
+
+        return self.expression(exp.Properties(expressions=properties)) if properties else None
+
+    def _parse_routine_statement(self) -> exp.Expr | None:
+        # https://trino.io/docs/current/udf/sql.html
+        if self._match(TokenType.BEGIN):
+            statements = self._parse_routine_statements({"END"})
+            self._match(TokenType.END)
+            return self.expression(exp.Block(expressions=statements, begin=True))
+
+        if self._match(TokenType.CASE):
+            return self._parse_case_statement()
+
+        if self._match_text_seq("IF"):
+            return self._parse_if_statement()
+
+        if self._match_text_seq("RETURN"):
+            return self.expression(exp.Return(this=self._parse_disjunction()))
+
+        if self._match(TokenType.SET):
+            return self._parse_set()
+
+        if self._match_text_seq("DECLARE"):
+            declaration = self._parse_declareitem()
+            if not declaration:
+                self.raise_error("Expected variable declaration")
+            return self.expression(exp.Declare(expressions=[declaration]))
+
+        if self._match_text_seq("ITERATE"):
+            return self.expression(exp.Iterate(this=self._parse_id_var()))
+
+        if self._match_text_seq("LEAVE"):
+            return self.expression(exp.Leave(this=self._parse_id_var()))
+
+        label = None
+        if self._next.token_type == TokenType.COLON:
+            label = self._parse_id_var()
+            self._match(TokenType.COLON)
+
+        if self._match_text_seq("LOOP"):
+            statements = self._parse_routine_statements({"END"})
+            self._match(TokenType.END)
+            self._expect_text("LOOP")
+            return self.expression(
+                exp.LoopStatement(
+                    this=self.expression(exp.Block(expressions=statements)), label=label
+                )
+            )
+
+        if self._match_text_seq("WHILE"):
+            condition = self._parse_disjunction()
+            self._expect_text("DO")
+            statements = self._parse_routine_statements({"END"})
+            self._match(TokenType.END)
+            self._expect_text("WHILE")
+            return self.expression(
+                exp.WhileStatement(
+                    this=condition,
+                    body=self.expression(exp.Block(expressions=statements)),
+                    label=label,
+                )
+            )
+
+        if self._match_text_seq("REPEAT"):
+            statements = self._parse_routine_statements({"UNTIL"})
+            self._match_text_seq("UNTIL")
+            until = self._parse_disjunction()
+            if not self._match(TokenType.END):
+                self.raise_error("Expected END REPEAT")
+            self._expect_text("REPEAT")
+            return self.expression(
+                exp.RepeatStatement(
+                    body=self.expression(exp.Block(expressions=statements)),
+                    until=until,
+                    label=label,
+                )
+            )
+
+        self.raise_error("Expected routine statement")
+        return None
+
+    def _parse_routine_statements(self, terminators: set[str]) -> list[exp.Expr]:
+        statements: list[exp.Expr] = []
+        while True:
+            if not self._curr:
+                # Routine statements are separated by semicolons, which also delimit the
+                # chunks produced in `_parse`, so the routine body continues in the next chunk
+                if self._chunk_index >= len(self._chunks):
+                    self.raise_error("Unexpected end of routine body", token=self._prev)
+                    break
+
+                self._advance_chunk()
+                continue
+
+            if self._curr.token_type == TokenType.SEMICOLON:
+                # A semicolon that carries comments is kept as a standalone chunk
+                self._advance()
+                continue
+
+            if self._curr.text.upper() in terminators:
+                break
+
+            statement = self._parse_routine_statement()
+            if not statement:
+                break
+
+            statements.append(statement)
+
+        return statements
+
+    def _parse_case_statement(self) -> exp.CaseStatement:
+        this = None if self._curr.token_type == TokenType.WHEN else self._parse_disjunction()
+
+        ifs = []
+        while self._match(TokenType.WHEN):
+            condition = self._parse_disjunction()
+            self._expect_text("THEN")
+            statements = self._parse_routine_statements({"WHEN", "ELSE", "END"})
+            ifs.append(
+                self.expression(
+                    exp.If(
+                        this=condition,
+                        true=self.expression(exp.Block(expressions=statements)),
+                    )
+                )
+            )
+
+        default = self._parse_statements_after_else()
+
+        self._match(TokenType.END)
+        self._expect_text("CASE")
+        return self.expression(exp.CaseStatement(this=this, ifs=ifs, default=default))
+
+    def _parse_if_statement(self) -> exp.IfStatement:
+        ifs = []
+        while True:
+            condition = self._parse_disjunction()
+            self._expect_text("THEN")
+            statements = self._parse_routine_statements({"ELSEIF", "ELSE", "END"})
+            ifs.append(
+                self.expression(
+                    exp.If(
+                        this=condition,
+                        true=self.expression(exp.Block(expressions=statements)),
+                    )
+                )
+            )
+
+            if not self._match_text_seq("ELSEIF"):
+                break
+
+        default = self._parse_statements_after_else()
+
+        self._match(TokenType.END)
+        self._expect_text("IF")
+        return self.expression(exp.IfStatement(ifs=ifs, default=default))
+
+    def _parse_statements_after_else(self) -> exp.Block | None:
+        if not self._match(TokenType.ELSE):
+            return None
+
+        statements = self._parse_routine_statements({"END"})
+        return self.expression(exp.Block(expressions=statements))
+
+    def _expect_text(self, text: str) -> None:
+        if not self._match_text_seq(text):
+            self.raise_error(f"Expected {text}")

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -1,3 +1,6 @@
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import ParseError
 from tests.dialects.test_dialect import Validator
 
 
@@ -176,3 +179,132 @@ class TestTrino(Validator):
     def test_array_first(self):
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b']) FROM tbl")
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b'], x -> x = 'b') FROM tbl")
+
+    def test_inline_udf(self):
+        # https://trino.io/docs/current/udf/sql.html
+        self.validate_identity(
+            "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)"
+        )
+        self.validate_identity(
+            "WITH FUNCTION hello(name VARCHAR) RETURNS VARCHAR RETURN FORMAT('Hello %s!', name), "
+            "FUNCTION bye() RETURNS VARCHAR RETURN 'Bye!' "
+            "SELECT HELLO('Finn') || BYE()"
+        )
+        self.validate_identity(
+            "WITH FUNCTION meaning_of_life() RETURNS TINYINT "
+            "BEGIN "
+            "DECLARE a TINYINT DEFAULT CAST(6 AS TINYINT); "
+            "DECLARE b TINYINT DEFAULT CAST(7 AS TINYINT); "
+            "RETURN a * b; "
+            "END "
+            "SELECT MEANING_OF_LIFE()"
+        )
+
+        # routine characteristics
+        self.validate_identity(
+            "WITH FUNCTION f(x INTEGER) RETURNS INTEGER LANGUAGE SQL DETERMINISTIC "
+            "RETURNS NULL ON NULL INPUT RETURN x SELECT F(1)"
+        )
+        self.validate_identity(
+            "WITH FUNCTION f(x INTEGER) RETURNS INTEGER NOT DETERMINISTIC CALLED ON NULL INPUT "
+            "RETURN x SELECT F(1)"
+        )
+        self.validate_identity(
+            "WITH FUNCTION f() RETURNS INTEGER SECURITY INVOKER COMMENT 'meaning of life' "
+            "RETURN 42 SELECT F()"
+        )
+
+        # control statements
+        self.validate_identity(
+            "WITH FUNCTION simple_case(a BIGINT) RETURNS VARCHAR "
+            "BEGIN "
+            "CASE a WHEN 0 THEN RETURN 'zero'; WHEN 1 THEN RETURN 'one'; ELSE RETURN 'more'; END CASE; "
+            "RETURN NULL; "
+            "END "
+            "SELECT SIMPLE_CASE(x) FROM t"
+        )
+        self.validate_identity(
+            "WITH FUNCTION searched_case(a BIGINT) RETURNS VARCHAR "
+            "BEGIN "
+            "CASE WHEN a < 0 THEN RETURN 'negative'; WHEN a = 0 THEN RETURN 'zero'; END CASE; "
+            "RETURN 'positive'; "
+            "END "
+            "SELECT SEARCHED_CASE(x) FROM t"
+        )
+        self.validate_identity(
+            "WITH FUNCTION classify(a BIGINT) RETURNS VARCHAR "
+            "BEGIN "
+            "IF (a > 100) THEN RETURN 'big'; ELSEIF a > 0 THEN RETURN 'small'; ELSE RETURN 'negative'; END IF; "
+            "END "
+            "SELECT CLASSIFY(x) FROM t"
+        )
+        self.validate_identity(
+            "WITH FUNCTION count_up(a BIGINT) RETURNS VARCHAR "
+            "BEGIN "
+            "WHILE a < 100 DO SET a = a + 1; END WHILE; "
+            "RETURN IF(a = 100, 'hundred', 'other'); "
+            "END "
+            "SELECT COUNT_UP(x) FROM t"
+        )
+        self.validate_identity(
+            "WITH FUNCTION with_loops(p INTEGER) RETURNS INTEGER "
+            "BEGIN "
+            "DECLARE r INTEGER DEFAULT 0; "
+            "top: REPEAT SET r = r + 1; ITERATE top; UNTIL r >= p END REPEAT; "
+            "abc: LOOP LEAVE abc; END LOOP; "
+            "RETURN r; "
+            "END "
+            "SELECT WITH_LOOPS(3)"
+        )
+
+        # an inline UDF precedes the query's own WITH clause
+        self.validate_identity(
+            "WITH FUNCTION doubled(x INTEGER) RETURNS INTEGER RETURN x * 2 "
+            "WITH t AS (SELECT 3 AS v) SELECT DOUBLED(v) FROM t"
+        )
+
+        # the example from https://github.com/tobymao/sqlglot/issues/5178
+        self.validate_identity(
+            """WITH FUNCTION f(num int)
+    RETURNS int
+    RETURN num
+SELECT f(1)""",
+            "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)",
+        )
+
+        expression = self.parse_one(
+            "WITH FUNCTION doubleup(x INTEGER) RETURNS INTEGER BEGIN RETURN x * 2; END "
+            "SELECT DOUBLEUP(some_column) FROM some_table"
+        )
+        udfs = list(expression.find_all(exp.FunctionSpecification))
+        self.assertEqual(len(udfs), 1)
+        self.assertIn("some_table", {table.name for table in expression.find_all(exp.Table)})
+
+        # semicolons inside a routine body must not split the surrounding statement
+        statements = sqlglot.parse(
+            "WITH FUNCTION f() RETURNS INTEGER BEGIN RETURN 1; END SELECT F(); SELECT 2",
+            dialect="trino",
+        )
+        self.assertEqual(len(statements), 2)
+        self.assertEqual(statements[1].sql(dialect="trino"), "SELECT 2")
+
+        # a CTE named "function" is still parsed as a regular CTE
+        for sql in (
+            "WITH function AS (SELECT 1 AS x) SELECT x FROM function",
+            "WITH function(x) AS (SELECT 1) SELECT x FROM function",
+        ):
+            cte = self.validate_identity(sql)
+            self.assertFalse(list(cte.find_all(exp.FunctionSpecification)))
+
+        for invalid in (
+            # missing END
+            "WITH FUNCTION f() RETURNS INTEGER BEGIN RETURN 1; SELECT F()",
+            # missing routine body
+            "WITH FUNCTION f() RETURNS INTEGER SELECT F()",
+            # missing END IF
+            "WITH FUNCTION f() RETURNS INTEGER BEGIN IF a THEN RETURN 1; END SELECT 1",
+            # missing RETURN expression
+            "WITH FUNCTION f() RETURNS INTEGER RETURN",
+        ):
+            with self.assertRaises(ParseError):
+                sqlglot.parse(invalid, dialect="trino")


### PR DESCRIPTION
Howdy! I was fixing an Issue on [Superset](https://superset.apache.org/), and it was suggested I file the fix "upstream"  so here we go!

Trino supports declaring SQL UDFs inline, in a `WITH` clause that precedes the query (https://trino.io/docs/current/udf/sql.html):

```sql
WITH FUNCTION meaning_of_life()
  RETURNS tinyint
  BEGIN
    DECLARE a tinyint DEFAULT CAST(6 AS tinyint);
    DECLARE b tinyint DEFAULT CAST(7 AS tinyint);
    RETURN a * b;
  END
SELECT meaning_of_life()
```

These fail to parse (`Expecting (`), and the semicolons inside `BEGIN ... END` bodies additionally split the statement in `sqlglot.parse`. #5178 was closed as low priority with an invitation for a well-tested PR, so here's an attempt. The same gap bit us over in Apache Superset (apache/superset#26162), and I'd rather fix it here than carry a custom dialect downstream.

Parsing follows the `functionSpecification` / `controlStatement` grammar from Trino's SqlBase.g4. `TrinoParser._parse_cte` recognizes `FUNCTION <name>` entries and parses them into a new `exp.FunctionSpecification` node (a CTE literally named `function` still parses as a CTE). Routine bodies support the full control statement grammar (`RETURN`, `BEGIN`, `DECLARE`, `SET`, `CASE`, `IF`/`ELSEIF`, `LOOP`, `WHILE`, `REPEAT`/`UNTIL`, `ITERATE`, `LEAVE`, loop labels), reusing `Declare`/`Set`/`Return`/`Block` where they fit and adding statement-level expressions for the rest. Since routine statements are semicolon-separated, the body parser continues across the chunks produced in `Parser._parse`, the same way `_parse_block` already does for procedures, so multi-statement scripts still split correctly around the UDF query.

Routine characteristics reuse the existing property machinery, with Trino generator fixes so they round-trip: `DETERMINISTIC` instead of `IMMUTABLE`, `SECURITY INVOKER` instead of `SQL SECURITY INVOKER`, and `DECLARE ... DEFAULT` instead of `=`. Per the grammar, inline functions can't be comma-mixed with named queries, so `TrinoGenerator.with_sql` emits `WITH <functions> WITH <ctes>` when both are present. `walk_in_scope` treats `FunctionSpecification` as opaque so `qualify` doesn't try to resolve UDF parameters as outer-scope columns.

Not covered: `AS $$...$$` bodies for `LANGUAGE PYTHON` UDFs (would need `$$` tokenizer support in Trino), and `CREATE FUNCTION` with a `BEGIN` body, which still splits on inner semicolons today. Happy to follow up on either if there's interest.

Disclosure: implemented with Claude Code, but reviewed, tested (`make unit`, `make unitc`, `make style`) and understood by me. [Edit: it's true, I really look at stuff]
