### PR TITLE
fix(optimizer): canonicalize unaliased scalar subquery projections

### DIFF
--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -245,7 +245,8 @@ def canonicalize_internal_names(expression: E) -> E:
         output_map: dict[str, str] = {}
         if isinstance(scope_expr, exp.Select):
             for sel in scope_expr.selects:
-                if isinstance(sel, exp.Alias):
+                # Sets default name for subquery projections, both aliased and unaliased
+                if isinstance(sel, (exp.Alias, exp.Subquery)) and sel.alias:
                     old_alias = sel.alias
                     if is_output_scope:
                         new_name = old_alias

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -176,6 +176,14 @@ SELECT `_t0`.`a` AS `a`, `_t0`.`b` AS `b` FROM `c`.`db`.`x` AS `_t0` QUALIFY ROW
 SELECT x.a, (SELECT MAX(y.c) FROM y) AS m FROM x;
 SELECT "_t1"."a" AS "a", (SELECT MAX("_t0"."c") AS "_c0" FROM "c"."db"."y" AS "_t0") AS "m" FROM "c"."db"."x" AS "_t1";
 
+# title: unaliased scalar subquery in a non-first UNION ALL branch is canonicalized like any other internal column, not left as qualify's default _col_N
+SELECT a, (SELECT MAX(y.c) FROM y) FROM x UNION ALL SELECT a, (SELECT MAX(y.c) FROM y) FROM x;
+SELECT "_t1"."a" AS "a", (SELECT MAX("_t0"."c") AS "_c0" FROM "c"."db"."y" AS "_t0") AS "_col_1" FROM "c"."db"."x" AS "_t1" UNION ALL SELECT "_t3"."a" AS "_c2", (SELECT MAX("_t2"."c") AS "_c1" FROM "c"."db"."y" AS "_t2") AS "_c3" FROM "c"."db"."x" AS "_t3";
+
+# title: unaliased scalar subquery column inside a CTE (non-output scope) is canonicalized like any other internal column
+WITH t AS (SELECT a, (SELECT MAX(y.c) FROM y) FROM x) SELECT a FROM t;
+WITH "_t2" AS (SELECT "_t1"."a" AS "_c1", (SELECT MAX("_t0"."c") AS "_c0" FROM "c"."db"."y" AS "_t0") AS "_c2" FROM "c"."db"."x" AS "_t1") SELECT "_t2"."_c1" AS "a" FROM "_t2" AS "_t2";
+
 # title: distinct on
 # dialect: postgres
 SELECT DISTINCT ON (a) a, b FROM x;


### PR DESCRIPTION
Unaliased scalar subqueries in non-output scopes (CTE bodies, non-first UNION ALL branches) were skipped by `canonicalize_internal_names`, keeping qualify's `_col_N` default instead of a canonical `_cN`.  This fix has `exp.Subquery` outputs (with an alias) canonicalized the same as `exp.Alias`.

Sample input, these should both canonicalize identically:
```
-- Query A (second branch's subquery column unaliased)
SELECT 'x' AS lit, (SELECT COUNT() FROM t) AS cnt
UNION ALL
SELECT 'y', (SELECT COUNT() FROM t2)

-- Query B (same query, second branch's subquery column given an arbitrary alias)
SELECT 'x' AS lit, (SELECT COUNT() FROM t) AS cnt
UNION ALL
SELECT 'y', (SELECT COUNT() FROM t2) AS whatever
```

Previous output, they differ:
```
-- Query A
SELECT 'x' AS lit, (SELECT COUNT() AS _c0 FROM _t0 AS _t0) AS cnt
UNION ALL
SELECT 'y' AS _c2, (SELECT COUNT() AS _c1 FROM _t1 AS _t1) AS _col_1   -- ← not canonicalized

-- Query B
SELECT 'x' AS lit, (SELECT COUNT() AS _c0 FROM _t0 AS _t0) AS cnt
UNION ALL
SELECT 'y' AS _c2, (SELECT COUNT() AS _c1 FROM _t1 AS _t1) AS _c3      -- ← correctly canonicalized
```

After this patch, both are identical:
```
-- Query A
SELECT 'x' AS "lit", (SELECT COUNT() AS "_c0" FROM "_t0" AS "_t0") AS "cnt"
UNION ALL
SELECT 'y' AS "_c2", (SELECT COUNT() AS "_c1" FROM "_t1" AS "_t1") AS "_c3"

-- Query B
SELECT 'x' AS "lit", (SELECT COUNT() AS "_c0" FROM "_t0" AS "_t0") AS "cnt"
UNION ALL
SELECT 'y' AS "_c2", (SELECT COUNT() AS "_c1" FROM "_t1" AS "_t1") AS "_c3"
```