### PR TITLE
Feat(mysql): support INSERT ... SET ... syntax

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -3542,6 +3542,38 @@ class Parser:
 
             this = self._parse_function() if is_function else self._parse_insert_table()
 
+        # MySQL's INSERT ... SET is normalized into the INSERT ... (cols) VALUES (vals) variant
+        set_values = None
+        if self._match(TokenType.SET):
+            columns = []
+            values = []
+
+            def _parse_set_assignment() -> exp.Expr | None:
+                target = self._parse_column()
+                if isinstance(target, exp.Column) and self._match(TokenType.EQ):
+                    if self.dialect.SUPPORTS_VALUES_DEFAULT and self._match(TokenType.DEFAULT):
+                        value: exp.Expr | None = exp.var(self._prev.text.upper())
+                    else:
+                        value = self._parse_disjunction()
+
+                    if value:
+                        columns.append(target.this)
+                        values.append(value)
+                        return value
+
+                self.raise_error("Expected column assignment in INSERT ... SET")
+                return None
+
+            self._parse_csv(_parse_set_assignment)
+
+            this = self.expression(exp.Schema(this=this, expressions=columns))
+            set_values = self.expression(
+                exp.Values(
+                    expressions=[exp.Tuple(expressions=values)],
+                    alias=self._parse_table_alias(),
+                )
+            )
+
         returning = self._parse_returning()  # TSQL allows RETURNING before source
 
         return self.expression(
@@ -3557,7 +3589,9 @@ class Parser:
                 partition=self._match(TokenType.PARTITION_BY) and self._parse_partitioned_by(),
                 settings=self._match_text_seq("SETTINGS") and self._parse_settings_property(),
                 default=self._match_text_seq("DEFAULT", "VALUES"),
-                expression=self._parse_derived_table_values() or self._parse_ddl_select(),
+                expression=set_values
+                or self._parse_derived_table_values()
+                or self._parse_ddl_select(),
                 conflict=self._parse_on_conflict(),
                 returning=returning or self._parse_returning(),
                 overwrite=overwrite,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -120,6 +120,14 @@ class TestMySQL(Validator):
             "INSERT INTO x VALUES (1, 'a', 2.0) ON DUPLICATE KEY UPDATE x.id = 1"
         )
         self.validate_identity(
+            "INSERT INTO `test_table` SET `test_col_1` = 123, `test_col_2` = '456'",
+            "INSERT INTO `test_table` (`test_col_1`, `test_col_2`) VALUES (123, '456')",
+        )
+        self.validate_identity(
+            "INSERT INTO t SET a = DEFAULT, b = 2 AS new ON DUPLICATE KEY UPDATE a = new.a + 1",
+            "INSERT INTO t (a, b) VALUES (DEFAULT, 2) AS new ON DUPLICATE KEY UPDATE a = new.a + 1",
+        )
+        self.validate_identity(
             "CREATE OR REPLACE VIEW my_view AS SELECT column1 AS `boo`, column2 AS `foo` FROM my_table WHERE column3 = 'some_value' UNION SELECT q.* FROM fruits_table, JSON_TABLE(Fruits, '$[*]' COLUMNS(id VARCHAR(255) PATH '$.$id', value VARCHAR(255) PATH '$.value')) AS q",
         )
         self.validate_identity(


### PR DESCRIPTION
Closes #7927

MySQL's `INSERT ... SET` form is documented as equivalent to the standard column-list form, so we normalize it at parse time into the canonical `Schema` + `Values` AST rather than introducing a new representation. Besides preserving semantics, this also easily enables transpilation towards other dialects. Column qualifiers on assignment targets (`SET t.a = 1`) are dropped since MySQL only accepts qualifiers that resolve to the single insert target, making them redundant.
