### PR TITLE
feat(optimizer)!: annotate unhex for duckdb

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -53,6 +53,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DType.VARBINARY}
         for expr_type in {
             exp.Encode,
+            exp.Unhex,
         }
     },
     exp.DateBin: {"annotator": lambda self, e: self._annotate_by_args(e, "expression")},

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6740,6 +6740,10 @@ ENCODE(tbl.str_col);
 VARBINARY;
 
 # dialect: duckdb
+UNHEX(tbl.str_col);
+VARBINARY;
+
+# dialect: duckdb
 QUARTER(tbl.date_col);
 BIGINT;
 


### PR DESCRIPTION
### **Annotate Unhex for DuckDB**

https://duckdb.org/docs/lts/sql/functions/blob#unhexvalue

Verified the DuckDB UNHEX() function using DuckDB, which returns BLOB as the return type.

<img width="1186" height="418" alt="image" src="https://github.com/user-attachments/assets/1cbd8d50-aecd-40f5-9b99-15e6ca6de720" />

SQLGlot internally normalizes the DuckDB BLOB type to its canonical VARBINARY type.

<img width="1072" height="535" alt="image" src="https://github.com/user-attachments/assets/49e8d00d-116f-4550-ba01-8a2d7b40cfc4" />
