### PR TITLE
feat(optimizer)!: parse and annotate duckdb FROM_HEX

### DIFF
--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -129,6 +129,7 @@ class DuckDBParser(parser.Parser):
         ),
         "EPOCH": exp.TimeToUnix.from_arg_list,
         "EPOCH_MS": lambda args: exp.UnixToTime(this=seq_get(args, 0), scale=exp.UnixToTime.MILLIS),
+        "FROM_HEX": exp.Unhex.from_arg_list,
         "GENERATE_SERIES": _build_generate_series(),
         "GET_CURRENT_TIME": exp.CurrentTime.from_arg_list,
         "GET_BIT": lambda args: exp.Getbit(

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -28,6 +28,7 @@ class TestDuckDB(Validator):
             "PIVOT duckdb_functions() ON schema_name USING AVG(LENGTH(function_name))::INTEGER GROUP BY schema_name",
             "PIVOT DUCKDB_FUNCTIONS() ON schema_name USING CAST(AVG(LENGTH(function_name)) AS INT) GROUP BY schema_name",
         )
+        self.validate_identity("FROM_HEX('AA')", "UNHEX('AA')")
         self.validate_identity("SELECT str[0:1]")
         self.validate_identity("SELECT COSH(1.5)")
         self.validate_identity("SELECT MODE(category)")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6744,6 +6744,10 @@ UNHEX(tbl.str_col);
 VARBINARY;
 
 # dialect: duckdb
+FROM_HEX(tbl.str_col);
+VARBINARY;
+
+# dialect: duckdb
 QUARTER(tbl.date_col);
 BIGINT;
 


### PR DESCRIPTION
`UNHEX` and `FROM_HEX` are synonyms in duckdb.

```
memory D SELECT unhex('AA');
┌─────────────┐
│ unhex('AA') │
│    blob     │
├─────────────┤
│ \xAA        │
└─────────────┘
memory D SELECT from_hex('AA');
┌────────────────┐
│ from_hex('AA') │
│      blob      │
├────────────────┤
│ \xAA           │
└────────────────┘
```


**DOCS**
[Duckdb UNHEX/FROM_HEX](https://github.com/tobymao/sqlglot/pull/7930)

ref: https://github.com/tobymao/sqlglot/pull/7930