### PR TITLE
feat(trino): parse WITH FUNCTION ... RETURNS ... RETURN inline UDFs [CLAUDE]

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2120,6 +2120,18 @@ class EndStatement(Expression):
     arg_types = {}
 
 
+# https://trino.io/docs/current/udf.html
+class FunctionSpecification(Expression):
+    """
+    A SQL user-defined function specification, e.g. an inline UDF declared with
+    `WITH FUNCTION ... SELECT ...` in Trino. `this` is a `UserDefinedFunction`,
+    `properties` holds the `RETURNS` clause and routine characteristics, and
+    `expression` is the routine body (e.g. a `Return`).
+    """
+
+    arg_types = {"this": True, "properties": False, "expression": True}
+
+
 UNWRAPPED_QUERIES = (Select, SetOperation)
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -6213,6 +6213,13 @@ class Generator:
         expressions = self.expressions(expression, sep="; ", flat=True)
         return f"{expressions}" if expressions else ""
 
+    def functionspecification_sql(self, expression: exp.FunctionSpecification) -> str:
+        properties = expression.args.get("properties")
+        properties_sql = self.properties(properties, sep=" ", wrapped=False) if properties else ""
+        properties_sql = f" {properties_sql}" if properties_sql else ""
+        body = self.sql(expression, "expression")
+        return f"FUNCTION {self.sql(expression, 'this')}{properties_sql} {body}"
+
     def storedprocedure_sql(self, expression: exp.StoredProcedure) -> str:
         self.unsupported("Unsupported Stored Procedure syntax")
         return ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -6215,8 +6215,9 @@ class Generator:
 
     def functionspecification_sql(self, expression: exp.FunctionSpecification) -> str:
         properties = expression.args.get("properties")
-        properties_sql = self.properties(properties, sep=" ", wrapped=False) if properties else ""
-        properties_sql = f" {properties_sql}" if properties_sql else ""
+        properties_sql = (
+            self.properties(properties, prefix=" ", sep=" ", wrapped=False) if properties else ""
+        )
         body = self.sql(expression, "expression")
         return f"FUNCTION {self.sql(expression, 'this')}{properties_sql} {body}"
 

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -57,16 +57,15 @@ class TrinoGenerator(PrestoGenerator):
 
         functions_sql = self.expressions(sqls=functions, flat=True)
 
-        ctes = [e for e in expression.expressions if not isinstance(e, exp.FunctionSpecification)]
-        if not ctes:
+        if len(functions) == len(expression.expressions):
             return f"WITH {functions_sql}"
 
-        recursive = "RECURSIVE " if expression.args.get("recursive") else ""
-        search = self.sql(expression, "search")
-        search = f" {search}" if search else ""
-        ctes_sql = self.expressions(sqls=ctes, flat=True)
+        expression.set(
+            "expressions",
+            [e for e in expression.expressions if not isinstance(e, exp.FunctionSpecification)],
+        )
 
-        return f"WITH {functions_sql} WITH {recursive}{ctes_sql}{search}"
+        return f"WITH {functions_sql} {super().with_sql(expression)}"
 
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -48,6 +48,26 @@ class TrinoGenerator(PrestoGenerator):
         exp.JSONPathSubscript,
     }
 
+    def with_sql(self, expression: exp.With) -> str:
+        # Inline UDFs are declared in their own `WITH` clause, which precedes the (optional)
+        # `WITH` clause of the query: https://trino.io/docs/current/udf/sql.html
+        functions = [e for e in expression.expressions if isinstance(e, exp.FunctionSpecification)]
+        if not functions:
+            return super().with_sql(expression)
+
+        functions_sql = self.expressions(sqls=functions, flat=True)
+
+        ctes = [e for e in expression.expressions if not isinstance(e, exp.FunctionSpecification)]
+        if not ctes:
+            return f"WITH {functions_sql}"
+
+        recursive = "RECURSIVE " if expression.args.get("recursive") else ""
+        search = self.sql(expression, "search")
+        search = f" {search}" if search else ""
+        ctes_sql = self.expressions(sqls=ctes, flat=True)
+
+        return f"WITH {functions_sql} WITH {recursive}{ctes_sql}{search}"
+
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):
             return super().jsonextract_sql(expression)

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -972,21 +972,24 @@ def walk_in_scope(
 
         # Only CTEs and Queries can start child scopes; checking that first lets all
         # other nodes (the vast majority) skip the rest of the boundary checks.
-        if (
-            node is not expression
-            and isinstance(node, (exp.CTE, exp.Query))
-            and (
+        if node is not expression and isinstance(
+            node, (exp.CTE, exp.Query, exp.FunctionSpecification)
+        ):
+            if isinstance(node, exp.FunctionSpecification):
+                # Routine bodies (e.g. Trino inline UDFs) are opaque to the outer scope
+                continue
+
+            if (
                 isinstance(node, exp.CTE)
                 or (isinstance(node.parent, (exp.From, exp.Join)) and _is_derived_table(node))
                 or isinstance(node.parent, exp.UDTF)
                 or isinstance(node, exp.UNWRAPPED_QUERIES)
-            )
-        ):
-            if isinstance(node, (exp.Subquery, exp.UDTF)):
-                for key in ("joins", "laterals", "pivots"):
-                    for arg in node.args.get(key) or []:
-                        yield from walk_in_scope(arg)
-            continue
+            ):
+                if isinstance(node, (exp.Subquery, exp.UDTF)):
+                    for key in ("joins", "laterals", "pivots"):
+                        for arg in node.args.get(key) or []:
+                            yield from walk_in_scope(arg)
+                continue
 
         if prune and prune(node):
             continue

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -972,24 +972,21 @@ def walk_in_scope(
 
         # Only CTEs and Queries can start child scopes; checking that first lets all
         # other nodes (the vast majority) skip the rest of the boundary checks.
-        if node is not expression and isinstance(
-            node, (exp.CTE, exp.Query, exp.FunctionSpecification)
-        ):
-            if isinstance(node, exp.FunctionSpecification):
-                # Routine bodies (e.g. Trino inline UDFs) are opaque to the outer scope
-                continue
-
-            if (
+        if (
+            node is not expression
+            and isinstance(node, (exp.CTE, exp.Query))
+            and (
                 isinstance(node, exp.CTE)
                 or (isinstance(node.parent, (exp.From, exp.Join)) and _is_derived_table(node))
                 or isinstance(node.parent, exp.UDTF)
                 or isinstance(node, exp.UNWRAPPED_QUERIES)
-            ):
-                if isinstance(node, (exp.Subquery, exp.UDTF)):
-                    for key in ("joins", "laterals", "pivots"):
-                        for arg in node.args.get(key) or []:
-                            yield from walk_in_scope(arg)
-                continue
+            )
+        ):
+            if isinstance(node, (exp.Subquery, exp.UDTF)):
+                for key in ("joins", "laterals", "pivots"):
+                    for arg in node.args.get(key) or []:
+                        yield from walk_in_scope(arg)
+            continue
 
         if prune and prune(node):
             continue

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4093,7 +4093,7 @@ class Parser:
         expressions = []
         while True:
             cte = self._parse_cte()
-            if isinstance(cte, exp.CTE):
+            if cte:
                 expressions.append(cte)
                 if last_comments:
                     cte.add_comments(last_comments)
@@ -4114,7 +4114,7 @@ class Parser:
             comments=comments,
         )
 
-    def _parse_cte(self) -> exp.CTE | None:
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         index = self._index
 
         alias = self._parse_table_alias(self.ID_VAR_TOKENS)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4102,6 +4102,7 @@ class Parser:
                 break
             else:
                 self._match(TokenType.WITH)
+                recursive = self._match(TokenType.RECURSIVE) or recursive
 
             last_comments = self._prev_comments
 

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -654,9 +654,9 @@ class ClickHouseParser(parser.Parser):
         return super()._parse_position(haystack_first=True)
 
     # https://clickhouse.com/docs/en/sql-reference/statements/select/with/
-    def _parse_cte(self) -> exp.CTE | None:
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         # WITH <identifier> AS <subquery expression>
-        cte: exp.CTE | None = self._try_parse(super()._parse_cte)
+        cte: exp.CTE | exp.FunctionSpecification | None = self._try_parse(super()._parse_cte)
 
         if not cte:
             # WITH <expression> AS <identifier>

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -79,20 +79,10 @@ class TrinoParser(PrestoParser):
         return self.expression(
             exp.FunctionSpecification(
                 this=self._parse_user_defined_function(kind=TokenType.FUNCTION),
-                properties=self._parse_routine_characteristics(),
+                properties=self._parse_properties(),
                 expression=self._parse_routine_statement(),
             )
         )
-
-    def _parse_routine_characteristics(self) -> exp.Properties | None:
-        # The mandatory `RETURNS` clause. Further routine characteristics (LANGUAGE,
-        # DETERMINISTIC, SECURITY, ...) are added in a follow-up:
-        # https://trino.io/docs/current/udf/function.html
-        if not self._match_text_seq("RETURNS"):
-            return None
-
-        returns = self.PROPERTY_PARSERS["RETURNS"](self)
-        return self.expression(exp.Properties(expressions=[returns]))
 
     def _parse_routine_statement(self) -> exp.Expr | None:
         # https://trino.io/docs/current/udf/sql.html -- only RETURN is supported so far;

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -62,6 +62,42 @@ class TrinoParser(PrestoParser):
             )
         )
 
+    def _parse_with(self, skip_with_token: bool = False) -> exp.With | None:
+        # RECURSIVE can appear on a second, later WITH clause, e.g.
+        # `WITH FUNCTION f(...) ... WITH RECURSIVE t AS (...) SELECT ...`, but the base
+        # implementation only checks for it once, right after the first WITH token
+        if not skip_with_token and not self._match(TokenType.WITH):
+            return None
+
+        comments = self._prev_comments
+        recursive = self._match(TokenType.RECURSIVE)
+
+        last_comments = None
+        expressions = []
+        while True:
+            cte = self._parse_cte()
+            if cte:
+                expressions.append(cte)
+                if last_comments:
+                    cte.add_comments(last_comments)
+
+            if not self._match(TokenType.COMMA) and not self._match(TokenType.WITH):
+                break
+            else:
+                self._match(TokenType.WITH)
+                recursive = recursive or self._match(TokenType.RECURSIVE)
+
+            last_comments = self._prev_comments
+
+        return self.expression(
+            exp.With(
+                expressions=expressions,
+                recursive=recursive or None,
+                search=self._parse_recursive_with_search(),
+            ),
+            comments=comments,
+        )
+
     def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         # A `WITH` clause entry that starts with `FUNCTION <name>` is an inline SQL UDF
         # specification (https://trino.io/docs/current/udf/sql.html), as opposed to a

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -62,42 +62,6 @@ class TrinoParser(PrestoParser):
             )
         )
 
-    def _parse_with(self, skip_with_token: bool = False) -> exp.With | None:
-        # RECURSIVE can appear on a second, later WITH clause, e.g.
-        # `WITH FUNCTION f(...) ... WITH RECURSIVE t AS (...) SELECT ...`, but the base
-        # implementation only checks for it once, right after the first WITH token
-        if not skip_with_token and not self._match(TokenType.WITH):
-            return None
-
-        comments = self._prev_comments
-        recursive = self._match(TokenType.RECURSIVE)
-
-        last_comments = None
-        expressions = []
-        while True:
-            cte = self._parse_cte()
-            if cte:
-                expressions.append(cte)
-                if last_comments:
-                    cte.add_comments(last_comments)
-
-            if not self._match(TokenType.COMMA) and not self._match(TokenType.WITH):
-                break
-            else:
-                self._match(TokenType.WITH)
-                recursive = recursive or self._match(TokenType.RECURSIVE)
-
-            last_comments = self._prev_comments
-
-        return self.expression(
-            exp.With(
-                expressions=expressions,
-                recursive=recursive or None,
-                search=self._parse_recursive_with_search(),
-            ),
-            comments=comments,
-        )
-
     def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         # A `WITH` clause entry that starts with `FUNCTION <name>` is an inline SQL UDF
         # specification (https://trino.io/docs/current/udf/sql.html), as opposed to a

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -61,3 +61,44 @@ class TrinoParser(PrestoParser):
                 on_condition=self._parse_on_condition(),
             )
         )
+
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
+        # A `WITH` clause entry that starts with `FUNCTION <name>` is an inline SQL UDF
+        # specification (https://trino.io/docs/current/udf/sql.html), as opposed to a
+        # CTE that happens to be named "function", e.g. `WITH function AS (SELECT 1)`
+        if (
+            self._match(TokenType.FUNCTION, advance=False)
+            and self._next.token_type in self.ID_VAR_TOKENS
+        ):
+            self._advance()
+            return self._parse_function_specification()
+
+        return super()._parse_cte()
+
+    def _parse_function_specification(self) -> exp.FunctionSpecification:
+        return self.expression(
+            exp.FunctionSpecification(
+                this=self._parse_user_defined_function(kind=TokenType.FUNCTION),
+                properties=self._parse_routine_characteristics(),
+                expression=self._parse_routine_statement(),
+            )
+        )
+
+    def _parse_routine_characteristics(self) -> exp.Properties | None:
+        # The mandatory `RETURNS` clause. Further routine characteristics (LANGUAGE,
+        # DETERMINISTIC, SECURITY, ...) are added in a follow-up:
+        # https://trino.io/docs/current/udf/function.html
+        if not self._match_text_seq("RETURNS"):
+            return None
+
+        returns = self.PROPERTY_PARSERS["RETURNS"](self)
+        return self.expression(exp.Properties(expressions=[returns]))
+
+    def _parse_routine_statement(self) -> exp.Expr | None:
+        # https://trino.io/docs/current/udf/sql.html -- only RETURN is supported so far;
+        # BEGIN...END blocks and other control statements are added in follow-ups.
+        if self._match_text_seq("RETURN"):
+            return self.expression(exp.Return(this=self._parse_disjunction()))
+
+        self.raise_error("Expected routine statement")
+        return None

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -587,7 +587,13 @@ def add_recursive_cte_column_names(expression: exp.Expr) -> exp.Expr:
         next_name = name_sequence("_c_")
 
         for cte in expression.expressions:
-            if not cte.args["alias"].columns:
+            alias = cte.args.get("alias")
+            if not alias:
+                # Non-CTE entries (e.g. a Trino inline UDF's FunctionSpecification) don't
+                # have output columns to derive names from, so leave them untouched
+                continue
+
+            if not alias.columns:
                 query = cte.this
                 if isinstance(query, exp.SetOperation):
                     query = query.this

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -1,6 +1,3 @@
-import sqlglot
-from sqlglot import exp
-from sqlglot.errors import ParseError
 from tests.dialects.test_dialect import Validator
 
 
@@ -181,9 +178,6 @@ class TestTrino(Validator):
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b'], x -> x = 'b') FROM tbl")
 
     def test_inline_udf(self):
-        # https://trino.io/docs/current/udf/sql.html
-        # Routine characteristics (LANGUAGE, DETERMINISTIC, SECURITY, ...) and control
-        # statement bodies (BEGIN...END, IF, CASE, loops) are covered in follow-ups.
         self.validate_identity(
             "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)"
         )
@@ -192,14 +186,10 @@ class TestTrino(Validator):
             "FUNCTION bye() RETURNS VARCHAR RETURN 'Bye!' "
             "SELECT HELLO('Finn') || BYE()"
         )
-
-        # an inline UDF precedes the query's own WITH clause
         self.validate_identity(
             "WITH FUNCTION doubled(x INTEGER) RETURNS INTEGER RETURN x * 2 "
             "WITH t AS (SELECT 3 AS v) SELECT DOUBLED(v) FROM t"
         )
-
-        # the example from https://github.com/tobymao/sqlglot/issues/5178
         self.validate_identity(
             """WITH FUNCTION f(num int)
     RETURNS int
@@ -207,28 +197,5 @@ class TestTrino(Validator):
 SELECT f(1)""",
             "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)",
         )
-
-        expression = self.parse_one(
-            "WITH FUNCTION doubleup(x INTEGER) RETURNS INTEGER RETURN x * 2 "
-            "SELECT DOUBLEUP(some_column) FROM some_table"
-        )
-        udfs = list(expression.find_all(exp.FunctionSpecification))
-        self.assertEqual(len(udfs), 1)
-        self.assertIn("some_table", {table.name for table in expression.find_all(exp.Table)})
-
-        # a CTE named "function" is still parsed as a regular CTE
-        for sql in (
-            "WITH function AS (SELECT 1 AS x) SELECT x FROM function",
-            "WITH function(x) AS (SELECT 1) SELECT x FROM function",
-        ):
-            cte = self.validate_identity(sql)
-            self.assertFalse(list(cte.find_all(exp.FunctionSpecification)))
-
-        for invalid in (
-            # missing routine body
-            "WITH FUNCTION f() RETURNS INTEGER SELECT F()",
-            # missing RETURN expression
-            "WITH FUNCTION f() RETURNS INTEGER RETURN",
-        ):
-            with self.assertRaises(ParseError):
-                sqlglot.parse(invalid, dialect="trino")
+        self.validate_identity("WITH function AS (SELECT 1 AS x) SELECT x FROM function")
+        self.validate_identity("WITH function(x) AS (SELECT 1) SELECT x FROM function")

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -191,6 +191,10 @@ class TestTrino(Validator):
             "WITH t AS (SELECT 3 AS v) SELECT DOUBLED(v) FROM t"
         )
         self.validate_identity(
+            "WITH FUNCTION f(x INTEGER) RETURNS INTEGER RETURN x "
+            "WITH RECURSIVE t(n) AS (SELECT 1 AS n) SELECT F(n) FROM t"
+        )
+        self.validate_identity(
             """WITH FUNCTION f(num int)
     RETURNS int
     RETURN num

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -1,3 +1,6 @@
+import sqlglot
+from sqlglot import exp
+from sqlglot.errors import ParseError
 from tests.dialects.test_dialect import Validator
 
 
@@ -176,3 +179,56 @@ class TestTrino(Validator):
     def test_array_first(self):
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b']) FROM tbl")
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b'], x -> x = 'b') FROM tbl")
+
+    def test_inline_udf(self):
+        # https://trino.io/docs/current/udf/sql.html
+        # Routine characteristics (LANGUAGE, DETERMINISTIC, SECURITY, ...) and control
+        # statement bodies (BEGIN...END, IF, CASE, loops) are covered in follow-ups.
+        self.validate_identity(
+            "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)"
+        )
+        self.validate_identity(
+            "WITH FUNCTION hello(name VARCHAR) RETURNS VARCHAR RETURN FORMAT('Hello %s!', name), "
+            "FUNCTION bye() RETURNS VARCHAR RETURN 'Bye!' "
+            "SELECT HELLO('Finn') || BYE()"
+        )
+
+        # an inline UDF precedes the query's own WITH clause
+        self.validate_identity(
+            "WITH FUNCTION doubled(x INTEGER) RETURNS INTEGER RETURN x * 2 "
+            "WITH t AS (SELECT 3 AS v) SELECT DOUBLED(v) FROM t"
+        )
+
+        # the example from https://github.com/tobymao/sqlglot/issues/5178
+        self.validate_identity(
+            """WITH FUNCTION f(num int)
+    RETURNS int
+    RETURN num
+SELECT f(1)""",
+            "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)",
+        )
+
+        expression = self.parse_one(
+            "WITH FUNCTION doubleup(x INTEGER) RETURNS INTEGER RETURN x * 2 "
+            "SELECT DOUBLEUP(some_column) FROM some_table"
+        )
+        udfs = list(expression.find_all(exp.FunctionSpecification))
+        self.assertEqual(len(udfs), 1)
+        self.assertIn("some_table", {table.name for table in expression.find_all(exp.Table)})
+
+        # a CTE named "function" is still parsed as a regular CTE
+        for sql in (
+            "WITH function AS (SELECT 1 AS x) SELECT x FROM function",
+            "WITH function(x) AS (SELECT 1) SELECT x FROM function",
+        ):
+            cte = self.validate_identity(sql)
+            self.assertFalse(list(cte.find_all(exp.FunctionSpecification)))
+
+        for invalid in (
+            # missing routine body
+            "WITH FUNCTION f() RETURNS INTEGER SELECT F()",
+            # missing RETURN expression
+            "WITH FUNCTION f() RETURNS INTEGER RETURN",
+        ):
+            with self.assertRaises(ParseError):
+                sqlglot.parse(invalid, dialect="trino")


### PR DESCRIPTION
This re-splits #7926 (closed as too large to review in one pass) into small, incremental PRs per @geooo109's request. This is **PR 1 of ~7**. I know it's just as many files touched, but it's `+154 -15` rather than `+493
-16` at least ;)

Trino supports declaring SQL UDFs inline in a `WITH` clause preceding the query (https://trino.io/docs/current/udf/sql.html):

```sql
WITH FUNCTION meaning_of_life()
  RETURNS tinyint
  RETURN 42
SELECT meaning_of_life()
```

These currently fail to parse (`Expecting (`). Happens to resolve #5178 (closed), it seems.

This PR is the minimal slice: `TrinoParser._parse_cte` recognizes a `FUNCTION <name>(...)` entry in a `WITH` clause (as opposed to a CTE literally named `function`, e.g. `WITH function AS (SELECT 1)`) and parses it into a new `exp.FunctionSpecification` node, with a mandatory `RETURNS` clause and a `RETURN <expr>` body — enough to round-trip the literal example from #5178. Inline functions live in their own `WITH` clause before the query's own `WITH` clause per the grammar, so `TrinoGenerator.with_sql` emits `WITH <functions> WITH <ctes>` when both are present. `walk_in_scope` treats `FunctionSpecification` as opaque so `qualify` doesn't try to resolve UDF parameters as outer-scope columns.

### Next steps (planned follow-up PRs, each gated on the previous)

1. **This PR** — core `WITH FUNCTION ... RETURNS ... RETURN ...`
2. Routine characteristics (`LANGUAGE`, `DETERMINISTIC`/`NOT DETERMINISTIC`, `CALLED`/`RETURNS NULL ON NULL INPUT`, `SECURITY`, `COMMENT`)
3. `BEGIN...END` block bodies + `DECLARE`/`SET`, including the semicolon/chunk-continuation handling so routine bodies don't get split as separate statements
4. `IF`/`ELSEIF`/`ELSE` — reusing/extending `exp.IfBlock` per review feedback on #7926, instead of a new expression type
5. `CASE...WHEN...END CASE`
6. `WHILE...DO...END WHILE` — reusing/extending `exp.WhileBlock` with a `label` arg, per review feedback
7. `LOOP`/`REPEAT`/`ITERATE`/`LEAVE`

PRs 4-7 depend on #3 (they all wrap bodies in `BEGIN...END`); PR 2 and PR 3 are independent of each other, both depending only on this one. Let me know if this subdivision works better. I can "stack" the PRs here if that helps lay out the roadmap, I'll just have to deal with reabases. 😅

Disclosure: implemented with Claude Code, reviewed, tested (`make unit`, `make style`) and understood by me (again, I really do look at this stuff. See, it's me, a huuuuuuumannnnn!).