### PR TITLE
fix(executor): preserve unmatched outer join rows [CODEX]

### DIFF
--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -140,11 +140,29 @@ class PythonExecutor:
             start = max(r.stop for r in column_ranges.values())
             column_ranges[name] = range(start, len(table.columns) + start)
             join_context = self.context({name: table})
+            condition = self.generate(join["condition"])
+            condition_context = (
+                self.context(
+                    {
+                        name: Table(
+                            source_context.columns + join_context.columns,
+                            column_range=column_range,
+                        )
+                        for name, column_range in column_ranges.items()
+                    }
+                )
+                if condition
+                else None
+            )
 
             if join.get("source_key"):
-                table = self.hash_join(join, source_context, join_context)
+                table = self.hash_join(
+                    join, source_context, join_context, condition, condition_context
+                )
             else:
-                table = self.nested_loop_join(join, source_context, join_context)
+                table = self.nested_loop_join(
+                    join, source_context, join_context, condition, condition_context
+                )
 
             source_context = self.context(
                 {
@@ -152,10 +170,6 @@ class PythonExecutor:
                     for name, column_range in column_ranges.items()
                 }
             )
-            condition = self.generate(join["condition"])
-            if condition:
-                source_context.filter(condition)
-
         if not step.condition and not step.projections:
             return source_context
 
@@ -175,41 +189,91 @@ class PythonExecutor:
                 }
             )
 
-    def nested_loop_join(self, _join, source_context, join_context):
-        table = Table(source_context.columns + join_context.columns)
+    @staticmethod
+    def _join_matches(row, condition, condition_context):
+        if not condition:
+            return True
 
-        for reader_a, _ in source_context:
-            for reader_b, _ in join_context:
-                table.append(reader_a.row + reader_b.row)
+        condition_context.set_row(row)
+        return condition_context.eval(condition) is True
+
+    def nested_loop_join(self, join, source_context, join_context, condition, condition_context):
+        table = Table(source_context.columns + join_context.columns)
+        source_rows = source_context.table.rows
+        join_rows = join_context.table.rows
+        matched_source = set()
+        matched_join = set()
+
+        for source_index, source_row in enumerate(source_rows):
+            for join_index, join_row in enumerate(join_rows):
+                row = source_row + join_row
+                if self._join_matches(row, condition, condition_context):
+                    table.append(row)
+                    matched_source.add(source_index)
+                    matched_join.add(join_index)
+
+        self._append_unmatched_join_rows(
+            table, join, source_rows, join_rows, matched_source, matched_join
+        )
 
         return table
 
-    def hash_join(self, join, source_context, join_context):
+    def hash_join(self, join, source_context, join_context, condition, condition_context):
         source_key = self.generate_tuple(join["source_key"])
         join_key = self.generate_tuple(join["join_key"])
-        left = join.get("side") == "LEFT"
-        right = join.get("side") == "RIGHT"
-
         results = collections.defaultdict(lambda: ([], []))
 
-        for reader, ctx in source_context:
-            results[ctx.eval_tuple(source_key)][0].append(reader.row)
-        for reader, ctx in join_context:
-            results[ctx.eval_tuple(join_key)][1].append(reader.row)
+        for index, (reader, ctx) in enumerate(source_context):
+            key = ctx.eval_tuple(source_key)
+            if all(value is not None for value in key):
+                results[key][0].append((index, reader.row))
+        for index, (reader, ctx) in enumerate(join_context):
+            key = ctx.eval_tuple(join_key)
+            if all(value is not None for value in key):
+                results[key][1].append((index, reader.row))
 
         table = Table(source_context.columns + join_context.columns)
-        nulls = [(None,) * len(join_context.columns if left else source_context.columns)]
+        matched_source = set()
+        matched_join = set()
 
-        for a_group, b_group in results.values():
-            if left:
-                b_group = b_group or nulls
-            elif right:
-                a_group = a_group or nulls
+        for source_group, join_group in results.values():
+            for (source_index, source_row), (join_index, join_row) in itertools.product(
+                source_group, join_group
+            ):
+                row = source_row + join_row
+                if self._join_matches(row, condition, condition_context):
+                    table.append(row)
+                    matched_source.add(source_index)
+                    matched_join.add(join_index)
 
-            for a_row, b_row in itertools.product(a_group, b_group):
-                table.append(a_row + b_row)
+        self._append_unmatched_join_rows(
+            table,
+            join,
+            source_context.table.rows,
+            join_context.table.rows,
+            matched_source,
+            matched_join,
+        )
 
         return table
+
+    @staticmethod
+    def _append_unmatched_join_rows(
+        table, join, source_rows, join_rows, matched_source, matched_join
+    ):
+        side = join.get("side")
+        if side in ("LEFT", "FULL"):
+            join_nulls = (None,) * (len(table.columns) - len(source_rows[0]) if source_rows else 0)
+            for index, row in enumerate(source_rows):
+                if index not in matched_source:
+                    table.append(row + join_nulls)
+
+        if side in ("RIGHT", "FULL"):
+            source_width = len(table.columns) - (len(join_rows[0]) if join_rows else 0)
+            source_nulls = (None,) * source_width
+            for index, row in enumerate(join_rows):
+                if index not in matched_join:
+                    table.append(source_nulls + row)
 
     def aggregate(self, step, context):
         group_by = self.generate_tuple(step.group.values())

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -403,6 +403,30 @@ class TestExecutor(unittest.TestCase):
                         execute(sql, schema=schema, tables=tables)
                     self.assertIsInstance(ctx.exception.__cause__, rows)
 
+    def test_outer_joins_preserve_unmatched_rows(self):
+        tables = {
+            "x": [{"id": 1}, {"id": 2}],
+            "y": [{"id": 2}, {"id": 3}],
+        }
+
+        self.assertEqual(
+            set(execute("SELECT x.id, y.id FROM x FULL JOIN y ON x.id = y.id", tables=tables).rows),
+            {(1, None), (2, 2), (None, 3)},
+        )
+        self.assertEqual(
+            set(
+                execute(
+                    "SELECT x.id, y.id FROM x LEFT JOIN y ON x.id = y.id AND y.id > 2",
+                    tables=tables,
+                ).rows
+            ),
+            {(1, None), (2, None)},
+        )
+        self.assertEqual(
+            execute("SELECT x.id, y.id FROM x JOIN y ON x.id < y.id", tables=tables).rows,
+            [(1, 2), (1, 3), (2, 3)],
+        )
+
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {


### PR DESCRIPTION
Fixes #7952.

The Python executor previously filtered join candidates after constructing the join result. That loses preserved-side rows when a complete `ON` condition rejects a candidate, and it cannot synthesize both sides of a FULL JOIN.

This change evaluates the complete `ON` condition while constructing hash and nested-loop joins, tracks matched row indexes, and appends the required null-extended rows for LEFT, RIGHT, and FULL joins. One reusable condition context avoids per-pair setup cost.

Tests cover a disjoint FULL JOIN, a LEFT JOIN with a rejecting residual predicate, and nearby valid non-equi inner-join behavior.

Validation:
- `python -m unittest tests.test_executor.TestExecutor.test_outer_joins_preserve_unmatched_rows`
- `python -m unittest tests.test_executor` (22 passed)
- pure-Python unit suite (1248 passed, 22 skipped)
- Ruff lint and format checks
- mypy (181 source files)

LLM disclosure: Codex assisted with validation, review, and preparation of this contribution. I reviewed the final behavior, tests, and diff and take responsibility for the submission.
