### PR TITLE
fix(jsonpath): preserve falsey union members [CODEX]

### DIFF
--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -135,14 +135,14 @@ def parse(path: str, dialect: DialectType = None) -> exp.JSONPath:
             while _match(TokenType.COMMA):
                 literal = _parse_slice()
 
-                if literal:
+                if isinstance(literal, str) or literal is not False:
                     indexes.append(literal)
 
             if len(indexes) == 1:
-                if isinstance(literal, str):
+                if isinstance(indexes[0], str):
                     node: exp.JSONPathPart = exp.JSONPathKey(this=indexes[0])
-                elif isinstance(literal, exp.JSONPathPart) and isinstance(
-                    literal, (exp.JSONPathScript, exp.JSONPathFilter)
+                elif isinstance(indexes[0], exp.JSONPathPart) and isinstance(
+                    indexes[0], (exp.JSONPathScript, exp.JSONPathFilter)
                 ):
                     node = exp.JSONPathSelector(this=indexes[0])
                 else:

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -47,6 +47,17 @@ class TestJsonpath(unittest.TestCase):
             with self.subTest(f"{selector} -> {expected}"):
                 self.assertEqual(parse(selector).sql(), f"'{expected}'")
 
+    def test_union_preserves_falsey_members(self):
+        for selector, expected in (
+            ("$[1,0]", exp.JSONPathUnion(expressions=[1, 0])),
+            ('$["a",""]', exp.JSONPathUnion(expressions=["a", ""])),
+            ('$["",1]', exp.JSONPathUnion(expressions=["", 1])),
+        ):
+            with self.subTest(selector):
+                self.assertEqual(parse(selector).expressions[-1], expected)
+
+        self.assertEqual(parse("$[0]").expressions[-1], exp.JSONPathSubscript(this=0))
+
     def test_cts_file(self):
         with open(os.path.join(FIXTURES_DIR, "jsonpath", "cts.json"), encoding="utf-8") as file:
             tests = json.load(file)["tests"]


### PR DESCRIPTION
## Summary

JSONPath bracket unions currently discard a later `0` or empty-string member
because the parser tests the parsed value's truthiness. This change checks the
parser's `False` sentinel instead and classifies a collapsed singleton from the
retained member.

The regression covers zero, trailing and leading empty strings, and the
existing singleton-subscript behavior.

## Test plan

- `python -m unittest tests.test_jsonpath -v`
- `ruff check sqlglot/jsonpath.py tests/test_jsonpath.py`
- `ruff format --check sqlglot/jsonpath.py tests/test_jsonpath.py`
- `mypy sqlglot`
- `git diff --check origin/main...HEAD`

Closes #7956

LLM disclosure: I used Codex while preparing this change and reviewed the
implementation, tests, and final diff.
