### PR TITLE
fix(optimizer): preserve negated correlations [CODEX]

### DIFF
--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -5,6 +5,16 @@ from sqlglot.optimizer.scope import ScopeType, find_in_scope, traverse_scope
 from sqlglot._typing import E
 
 
+NEGATED_COMPARISONS = {
+    exp.EQ: exp.NEQ,
+    exp.NEQ: exp.EQ,
+    exp.LT: exp.GTE,
+    exp.LTE: exp.GT,
+    exp.GT: exp.LTE,
+    exp.GTE: exp.LT,
+}
+
+
 def unnest_subqueries(expression: E) -> E:
     """
     Rewrite sqlglot AST to convert some predicates with subqueries into joins.
@@ -153,6 +163,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
     table_alias = next_alias_name()
     keys = []
+    has_negated_correlation = False
 
     # for all external columns in the where statement, find the relevant predicate
     # keys to convert it into a join
@@ -165,6 +176,17 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
         if not predicate or predicate.find_ancestor(exp.Where) is not where:
             return
 
+        negation = predicate.find_ancestor(exp.Not)
+        if negation and negation.find_ancestor(exp.Where) is where:
+            comparison_type = NEGATED_COMPARISONS.get(type(predicate))
+            if not comparison_type or negation.this.unnest() is not predicate:
+                return
+
+            predicate = negation.replace(
+                comparison_type(this=predicate.this, expression=predicate.expression)
+            )
+            has_negated_correlation = True
+
         if isinstance(predicate, exp.Binary):
             key = (
                 predicate.right
@@ -176,7 +198,9 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
         keys.append((key, column, predicate))
 
-    if not any(isinstance(predicate, exp.EQ) for *_, predicate in keys):
+    if not has_negated_correlation and not any(
+        isinstance(predicate, exp.EQ) for *_, predicate in keys
+    ):
         return
 
     is_subquery_projection = any(
@@ -305,9 +329,10 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
                 f"({parent_predicate} AND ARRAY_ANY({nested}, _x -> {predicate}))",
             )
 
+    join_predicates = [predicate for *_, predicate in keys if isinstance(predicate, exp.EQ)]
     parent_select.join(
         select.group_by(*group_by, copy=False),
-        on=[predicate for *_, predicate in keys if isinstance(predicate, exp.EQ)],
+        on=join_predicates or exp.true(),
         join_type="LEFT",
         join_alias=table_alias,
         copy=False,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -403,6 +403,49 @@ class TestExecutor(unittest.TestCase):
                         execute(sql, schema=schema, tables=tables)
                     self.assertIsInstance(ctx.exception.__cause__, rows)
 
+    def test_correlated_exists_with_negated_comparison(self):
+        tables = {
+            "x": [{"id": 1}, {"id": 2}, {"id": 3}],
+            "y": [{"id": 1}, {"id": 2}],
+        }
+
+        for sql, expected in (
+            (
+                "SELECT x.id FROM x AS x "
+                "WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))",
+                [(1,), (2,), (3,)],
+            ),
+            (
+                "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE y.id = x.id)",
+                [(1,), (2,)],
+            ),
+            (
+                "SELECT x.id FROM x AS x "
+                "WHERE NOT EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))",
+                [],
+            ),
+            (
+                "SELECT x.id FROM x AS x WHERE NOT EXISTS (SELECT 1 FROM y AS y WHERE y.id = x.id)",
+                [(3,)],
+            ),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables).rows, expected)
+
+        negated_sql = (
+            "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))"
+        )
+        nullable_tables = {
+            "x": [{"id": 1}, {"id": None}],
+            "y": [{"id": 1}, {"id": None}, {"id": 2}],
+        }
+        self.assertEqual(execute(negated_sql, tables=nullable_tables).rows, [(1,)])
+        self.assertEqual(
+            execute(negated_sql, tables={"x": [{"id": 1}], "y": [{"id": None}]}).rows,
+            [],
+        )
+        self.assertEqual(execute(negated_sql, tables={"x": [{"id": 1}], "y": []}).rows, [])
+
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1187,6 +1187,20 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
     def test_unnest_subqueries(self):
         self.check_file("unnest_subqueries", optimizer.unnest_subqueries.unnest_subqueries)
 
+    def test_unnest_subqueries_preserves_negated_correlations(self):
+        sql = "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))"
+
+        optimized = optimizer.unnest_subqueries.unnest_subqueries(parse_one(sql))
+
+        self.assertEqual(
+            optimized.sql(),
+            "SELECT x.id FROM x AS x "
+            "LEFT JOIN (SELECT ARRAY_AGG(y.id) AS _u_1 FROM y AS y WHERE TRUE) "
+            "AS _u_0 ON TRUE "
+            "WHERE (NOT _u_0._u_1 IS NULL "
+            "AND ARRAY_ANY(_u_0._u_1, _x -> _x <> x.id))",
+        )
+
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)
 


### PR DESCRIPTION
Closes #7958.

A direct `NOT` around a correlated comparison was lost during decorrelation because the inner comparison was replaced with `TRUE`. This change normalizes supported direct negated comparisons to their complementary operator, aggregates the inner key when no positive equality join key exists, and evaluates the preserved predicate with `ARRAY_ANY` after a `LEFT JOIN ... ON TRUE`.

The regression covers `EXISTS`, `NOT EXISTS`, the existing positive-equality path, `NULL`/UNKNOWN values, an all-NULL inner relation, and an empty inner relation.

Validation:
- focused optimizer and executor regressions
- full executor suite: 22 passed
- relevant `unnest_subqueries` optimizer fixture plus regression
- Ruff check and format
- mypy over 180 source files
- `git diff --check`

LLM disclosure: I used OpenAI Codex to assist with analysis, implementation, and test drafting. I reviewed the final diff and validated the behavior and tests.