### PR TITLE
fix(executor): preserve SQL three-valued boolean logic [CODEX]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -9,6 +9,54 @@ from sqlglot.generator import Generator
 from sqlglot.helper import PYTHON_VERSION, is_int, seq_get
 
 
+def sql_not(value):
+    return None if value is None else not bool(value)
+
+
+def sql_and(left, right):
+    left = left()
+    left = None if left is None else bool(left)
+
+    if left is False:
+        return False
+
+    right = right()
+    right = None if right is None else bool(right)
+    if right is False:
+        return False
+
+    return None if left is None or right is None else True
+
+
+def sql_or(left, right):
+    left = left()
+    left = None if left is None else bool(left)
+
+    if left is True:
+        return True
+
+    right = right()
+    right = None if right is None else bool(right)
+    if right is True:
+        return True
+
+    return None if left is None or right is None else False
+
+
+def sql_in(value, *candidates):
+    if value is None:
+        return None
+
+    has_null = False
+    for candidate in candidates:
+        if candidate is None:
+            has_null = True
+        elif value == candidate:
+            return True
+
+    return None if has_null else False
+
+
 class reverse_key:
     def __init__(self, obj):
         self.obj = obj
@@ -168,6 +216,7 @@ def jsonextract(this, expression):
 
 ENV = {
     "exp": exp,
+    "AND": sql_and,
     # aggs
     "ARRAYAGG": list,
     "ARRAYUNIQUEAGG": filter_nulls(lambda acc: list(set(acc))),
@@ -201,6 +250,7 @@ ENV = {
     "GT": null_if_any(lambda this, e: this > e),
     "GTE": null_if_any(lambda this, e: this >= e),
     "IF": lambda predicate, true, false: true if predicate else false,
+    "IN": sql_in,
     "INTDIV": null_if_any(lambda e, this: e // this),
     "INTERVAL": interval,
     "JSONEXTRACT": jsonextract,
@@ -216,6 +266,8 @@ ENV = {
     "MUL": null_if_any(lambda e, this: e * this),
     "NEQ": null_if_any(lambda this, e: this != e),
     "ORD": null_if_any(ord),
+    "NOT": sql_not,
+    "OR": sql_or,
     "ORDERED": ordered,
     "POW": pow,
     "RIGHT": null_if_any(lambda this, e: this[-e:]),

--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -79,7 +79,7 @@ class PythonGenerator(generator.Generator):
         exp.Case: _case_sql,
         exp.Alias: lambda self, e: self.sql(e.this),
         exp.Array: inline_array_sql,
-        exp.And: lambda self, e: self.binary(e, "and"),
+        exp.And: lambda self, e: f"AND(lambda: {self.sql(e.left)}, lambda: {self.sql(e.right)})",
         exp.Between: _rename,
         exp.Boolean: lambda self, e: "True" if e.this else "False",
         exp.Cast: lambda self, e: f"CAST({self.sql(e.this)}, exp.DType.{e.args['to']})",
@@ -90,7 +90,7 @@ class PythonGenerator(generator.Generator):
         exp.Distinct: lambda self, e: f"set({self.sql(e, 'this')})",
         exp.Div: _div_sql,
         exp.Extract: lambda self, e: f"EXTRACT('{e.name.lower()}', {self.sql(e, 'expression')})",
-        exp.In: lambda self, e: f"{self.sql(e, 'this')} in {{{self.expressions(e, flat=True)}}}",
+        exp.In: lambda self, e: self.func("IN", e.this, *e.expressions),
         exp.Interval: lambda self, e: f"INTERVAL({self.sql(e.this)}, '{self.sql(e.unit)}')",
         exp.Is: lambda self, e: (
             self.binary(e, "==") if isinstance(e.this, exp.Literal) else self.binary(e, "is")
@@ -100,9 +100,9 @@ class PythonGenerator(generator.Generator):
         exp.JSONPathKey: lambda self, e: f"'{self.sql(e.this)}'",
         exp.JSONPathSubscript: lambda self, e: f"'{e.this}'",
         exp.Lambda: _lambda_sql,
-        exp.Not: lambda self, e: f"not {self.sql(e.this)}",
+        exp.Not: lambda self, e: self.func("NOT", e.this),
         exp.Null: lambda *_: "None",
-        exp.Or: lambda self, e: self.binary(e, "or"),
+        exp.Or: lambda self, e: f"OR(lambda: {self.sql(e.left)}, lambda: {self.sql(e.right)})",
         exp.Ordered: _ordered_py,
         exp.Star: lambda *_: "1",
     }

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -13,7 +13,7 @@ from pandas.testing import assert_frame_equal
 from sqlglot import exp, find_tables, parse_one, transpile
 from sqlglot.errors import ExecuteError
 from sqlglot.executor import execute
-from sqlglot.executor.python import Python
+from sqlglot.executor.python import Python, PythonExecutor
 from sqlglot.executor.table import Table, ensure_tables
 from sqlglot.optimizer import optimize
 from sqlglot.planner import Plan
@@ -773,6 +773,92 @@ class TestExecutor(unittest.TestCase):
             dialect="oracle",
         )
         self.assertEqual(result.rows, [("a",)])
+
+    def test_sql_three_valued_boolean_logic(self):
+        for sql, expected in [
+            ("NOT TRUE", False),
+            ("NOT FALSE", True),
+            ("NOT NULL", None),
+            ("TRUE AND NULL", None),
+            ("FALSE AND NULL", False),
+            ("TRUE OR NULL", True),
+            ("FALSE OR NULL", None),
+            ("NULL IN (1, 2)", None),
+            ("3 NOT IN (1, 2, NULL)", None),
+            ("3 NOT IN (1, 2)", True),
+        ]:
+            with self.subTest(sql):
+                self.assertEqual(execute(f"SELECT {sql}").rows, [(expected,)])
+
+        tables = {
+            "policy": [
+                {"id": 1, "flag": True},
+                {"id": 2, "flag": False},
+                {"id": 3, "flag": None},
+            ]
+        }
+        schema = {"policy": {"id": "INT", "flag": "BOOLEAN"}}
+        self.assertEqual(
+            execute("SELECT id FROM policy WHERE NOT flag", tables=tables, schema=schema).rows,
+            [(2,)],
+        )
+
+    def test_sql_boolean_logic_with_numpy_scalars(self):
+        tables = {
+            "policy": [
+                {"id": 1, "left_flag": np.bool_(True), "right_flag": np.bool_(True)},
+                {"id": 2, "left_flag": np.bool_(False), "right_flag": np.bool_(True)},
+                {"id": 3, "left_flag": None, "right_flag": np.bool_(True)},
+            ]
+        }
+        schema = {
+            "policy": {
+                "id": "INT",
+                "left_flag": "BOOLEAN",
+                "right_flag": "BOOLEAN",
+            }
+        }
+
+        self.assertEqual(
+            execute("SELECT id FROM policy WHERE left_flag", tables=tables, schema=schema).rows,
+            [(1,)],
+        )
+        self.assertEqual(
+            execute(
+                "SELECT id FROM policy WHERE left_flag AND right_flag",
+                tables=tables,
+                schema=schema,
+            ).rows,
+            [(1,)],
+        )
+        self.assertEqual(
+            execute(
+                "SELECT id FROM policy WHERE left_flag OR right_flag",
+                tables=tables,
+                schema=schema,
+            ).rows,
+            [(1,), (2,), (3,)],
+        )
+
+    def test_sql_boolean_logic_preserves_short_circuiting(self):
+        evaluations = []
+
+        def record_evaluation():
+            evaluations.append(True)
+            return True
+
+        executor = PythonExecutor(env={"RECORD_EVALUATION": record_evaluation})
+        context = executor.context({})
+
+        for sql, expected in [
+            ("FALSE AND RECORD_EVALUATION()", False),
+            ("TRUE OR RECORD_EVALUATION()", True),
+        ]:
+            with self.subTest(sql):
+                expression = parse_one(sql)
+                self.assertEqual(context.eval(executor.generate(expression)), expected)
+
+        self.assertEqual(evaluations, [])
 
     def test_case_sensitivity(self):
         result = execute("SELECT A AS A FROM X", tables={"x": [{"a": 1}]})


### PR DESCRIPTION
Closes #7960.

The Python executor maps SQL boolean operators to Python truthiness, which makes `NOT NULL` evaluate as `True` instead of SQL `UNKNOWN`.

This patch adds SQL-aware `NOT`, `AND`, `OR`, and `IN` helpers. Lazy `AND` and `OR` operands preserve decisive short-circuit behavior, and boolean normalization keeps compatible scalar values working.

Regression tests cover nullable truth tables, nullable `WHERE` filtering, `IN`/`NOT IN`, NumPy boolean scalars, and evaluation count. The focused regressions, all 26 executor tests, Ruff, formatting, mypy, and `git diff --check` pass.

Disclosure: I used OpenAI Codex to assist with analysis and implementation. I reviewed and validated every submitted change.
