### PR TITLE
fix(optimizer): preserve nullable boolean complements [CODEX]

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -227,6 +227,206 @@ def _is_nonnull_constant(expression: exp.Expr) -> bool:
     return isinstance(expression, exp.NONNULL_CONSTANTS) or _is_date_literal(expression)
 
 
+class _BooleanComplementProver:
+    def __init__(self) -> None:
+        self.clear()
+
+    def clear(self, allow_unresolved_columns: bool = False) -> None:
+        self.allow_unresolved_columns = allow_unresolved_columns
+        self._null_padding: dict[int, tuple[exp.Select, bool]] = {}
+        self._column_sources: dict[int, tuple[exp.Column, tuple[exp.Select, exp.Expr] | None]] = {}
+        self._select_sources: dict[int, tuple[exp.Select, dict[str, exp.Expr]]] = {}
+        self._cte_sources: dict[tuple[int, int], tuple[exp.Table, exp.Select, bool]] = {}
+
+    def _has_null_padding_risk(self, select: exp.Select) -> bool:
+        key = id(select)
+        cached = self._null_padding.get(key)
+        if cached and cached[0] is select:
+            return cached[1]
+
+        risk = (
+            any(column.args.get("join_mark") for column in find_all_in_scope(select, exp.Column))
+            or bool(select.args.get("laterals"))
+            or bool(select.args.get("match"))
+        )
+
+        group = select.args.get("group")
+        risk = risk or bool(
+            group
+            and any(group.args.get(key) for key in ("rollup", "cube", "grouping_sets", "totals"))
+        )
+        risk = risk or bool(
+            not group
+            and any(
+                not isinstance(function, (exp.Connector, exp.Not, exp.Is))
+                for function in find_all_in_scope(select, exp.Func)
+            )
+        )
+
+        if not risk:
+            risk = any(
+                join.side
+                or join.method
+                or join.kind not in ("", "INNER", "CROSS")
+                or isinstance(join.this, exp.Lateral)
+                for join in find_all_in_scope(select, exp.Join)
+            )
+
+        self._null_padding[key] = (select, risk)
+        return risk
+
+    def _get_select_sources(self, select: exp.Select) -> dict[str, exp.Expr]:
+        key = id(select)
+        cached = self._select_sources.get(key)
+        if cached and cached[0] is select:
+            return cached[1]
+
+        from_ = select.args.get("from_")
+        source_expressions = ([from_.this] if from_ else []) + [
+            join.this for join in find_all_in_scope(select, exp.Join)
+        ]
+        sources = {
+            source.alias_or_name: source for source in source_expressions if source.alias_or_name
+        }
+        self._select_sources[key] = (select, sources)
+        return sources
+
+    def _is_cte_source(self, table: exp.Table, select: exp.Select) -> bool:
+        key = (id(table), id(select))
+        cached = self._cte_sources.get(key)
+        if cached and cached[0] is table and cached[1] is select:
+            return cached[2]
+
+        result = False
+        if not table.args.get("catalog") and not table.args.get("db"):
+            table_name = table.name.casefold()
+            ancestor: exp.Expr | None = select
+
+            while ancestor:
+                with_ = ancestor.args.get("with_")
+                if with_ and any(
+                    cte.alias_or_name.casefold() == table_name for cte in with_.expressions
+                ):
+                    result = True
+                    break
+                ancestor = ancestor.parent
+
+        self._cte_sources[key] = (table, select, result)
+        return result
+
+    def _find_column_source(self, column: exp.Column) -> tuple[exp.Select, exp.Expr] | None:
+        key = id(column)
+        cached = self._column_sources.get(key)
+        if cached and cached[0] is column:
+            return cached[1]
+
+        result = None
+        table = column.table
+        select = column.find_ancestor(exp.Select)
+
+        while table and select:
+            source = self._get_select_sources(select).get(table)
+            if source:
+                result = (select, source)
+                break
+            select = select.find_ancestor(exp.Select)
+
+        self._column_sources[key] = (column, result)
+        return result
+
+    def _is_proven_nonnull_column(self, column: exp.Column) -> bool:
+        if column.meta_get("nonnull") is not True:
+            return False
+
+        source = self._find_column_source(column)
+        if not source:
+            return False
+
+        # Schema nullability does not account for joins and grouping operations that pad rows
+        # with NULL. Until that provenance is tracked, only trust direct physical table columns
+        # in scopes that cannot add NULLs.
+        select, source_expression = source
+        return (
+            isinstance(source_expression, exp.Table)
+            and isinstance(source_expression.this, exp.Identifier)
+            and not any(
+                source_expression.args.get(key)
+                for key in (
+                    "pivots",
+                    "system_time",
+                    "version",
+                    "when",
+                    "changes",
+                    "rows_from",
+                    "pattern",
+                )
+            )
+            and not self._is_cte_source(source_expression, select)
+            and not self._has_null_padding_risk(select)
+        )
+
+    def is_proven_nonnull(self, expression: exp.Expr) -> bool:
+        if isinstance(expression, exp.Is):
+            return True
+        if isinstance(expression, exp.Column):
+            return self._is_proven_nonnull_column(expression)
+        if _is_nonnull_constant(expression):
+            return True
+        if expression.meta_get("nonnull") is not True:
+            return False
+        if isinstance(expression, exp.Not):
+            return self.is_proven_nonnull(expression.this)
+        if isinstance(expression, exp.Binary) and issubclass(
+            type(expression), (exp.Connector, exp.Predicate)
+        ):
+            return self.is_proven_nonnull(expression.left) and self.is_proven_nonnull(
+                expression.right
+            )
+        return False
+
+    def is_safe_to_repeat(self, expression: exp.Expr) -> bool:
+        if isinstance(expression, exp.Column):
+            return self._find_column_source(expression) is not None or (
+                self.allow_unresolved_columns and not expression.table
+            )
+        if isinstance(expression, exp.CONSTANTS):
+            return True
+        if isinstance(expression, (exp.Not, exp.Paren)):
+            return self.is_safe_to_repeat(expression.this)
+        if isinstance(expression, exp.Binary) and issubclass(
+            type(expression),
+            (
+                exp.Connector,
+                exp.EQ,
+                exp.GT,
+                exp.GTE,
+                exp.Is,
+                exp.LT,
+                exp.LTE,
+                exp.NEQ,
+                exp.NullSafeEQ,
+                exp.NullSafeNEQ,
+            ),
+        ):
+            return self.is_safe_to_repeat(expression.left) and self.is_safe_to_repeat(
+                expression.right
+            )
+        return False
+
+    def is_safe_to_eliminate(self, expression: exp.Expr) -> bool:
+        if isinstance(expression, (exp.Column, exp.CONSTANTS)):
+            return self.is_safe_to_repeat(expression)
+        if isinstance(expression, (exp.Not, exp.Paren)):
+            return self.is_safe_to_eliminate(expression.this)
+        if isinstance(expression, exp.Binary) and issubclass(
+            type(expression), (exp.Connector, exp.Is)
+        ):
+            return self.is_safe_to_eliminate(expression.left) and self.is_safe_to_eliminate(
+                expression.right
+            )
+        return False
+
+
 def _is_constant(expression: exp.Expr) -> bool:
     expr = expression.this if isinstance(expression, exp.Neg) else expression
     return isinstance(expr, exp.CONSTANTS) or _is_date_literal(expr)
@@ -513,6 +713,7 @@ class Simplifier:
     def __init__(self, dialect: DialectType = None, annotate_new_expressions: bool = True):
         self.dialect = Dialect.get_or_raise(dialect)
         self.annotate_new_expressions = annotate_new_expressions
+        self._boolean_complement_prover = _BooleanComplementProver()
 
         self._annotator: TypeAnnotator = TypeAnnotator(
             schema=ensure_schema(None, dialect=self.dialect), overwrite_types=False
@@ -616,6 +817,7 @@ class Simplifier:
         constant_propagation: bool = False,
         coalesce_simplification: bool = False,
     ) -> exp.Expr:
+        self._boolean_complement_prover.clear()
         wheres: list[exp.Where] = []
         joins: list[exp.Join] = []
 
@@ -649,9 +851,19 @@ class Simplifier:
                             break
 
             if isinstance(node, exp.Condition):
-                simplified = while_changing(
-                    node, lambda e: self._simplify(e, constant_propagation, coalesce_simplification)
+                allow_unresolved_columns = self._boolean_complement_prover.allow_unresolved_columns
+                self._boolean_complement_prover.allow_unresolved_columns = (
+                    node.find_ancestor(exp.Query) is None
                 )
+                try:
+                    simplified = while_changing(
+                        node,
+                        lambda e: self._simplify(e, constant_propagation, coalesce_simplification),
+                    )
+                finally:
+                    self._boolean_complement_prover.allow_unresolved_columns = (
+                        allow_unresolved_columns
+                    )
 
                 if node is expression:
                     expression = simplified
@@ -692,7 +904,15 @@ class Simplifier:
 
             if not isinstance(node, SIMPLIFIABLE):
                 if isinstance(node, exp.Query):
-                    self.simplify(node, constant_propagation, coalesce_simplification)
+                    allow_unresolved_columns = (
+                        self._boolean_complement_prover.allow_unresolved_columns
+                    )
+                    try:
+                        self.simplify(node, constant_propagation, coalesce_simplification)
+                    finally:
+                        self._boolean_complement_prover.allow_unresolved_columns = (
+                            allow_unresolved_columns
+                        )
                 continue
 
             parent = node.parent
@@ -965,7 +1185,9 @@ class Simplifier:
             ops = set(expression.flatten())
             for op in ops:
                 if isinstance(op, exp.Not) and op.this in ops:
-                    if expression.meta_get("nonnull") is True:
+                    if self._boolean_complement_prover.is_proven_nonnull(
+                        op.this
+                    ) and self._boolean_complement_prover.is_safe_to_eliminate(op.this):
                         return exp.false() if isinstance(expression, exp.And) else exp.true()
 
         return expression
@@ -1013,11 +1235,11 @@ class Simplifier:
         absorption:
             A AND (A OR B) -> A
             A OR (A AND B) -> A
-            A AND (NOT A OR B) -> A AND B
-            A OR (NOT A AND B) -> A OR B
+            A AND (NOT A OR B) -> A AND B (only for non-NULL A)
+            A OR (NOT A AND B) -> A OR B (only for non-NULL A)
         elimination:
-            (A AND B) OR (A AND NOT B) -> A
-            (A OR B) AND (A OR NOT B) -> A
+            (A AND B) OR (A AND NOT B) -> A (only for non-NULL B)
+            (A OR B) AND (A OR NOT B) -> A (only for non-NULL B)
         """
         if isinstance(expression, self.AND_OR) and (root or not expression.same_parent):
             kind = exp.Or if isinstance(expression, exp.And) else exp.And
@@ -1050,9 +1272,9 @@ class Simplifier:
 
                 a, b = op.unnest_operands()
                 if isinstance(a, exp.Not):
-                    pairs[frozenset((a.this, b))].append((op, b))
+                    pairs[frozenset((a.this, b))].append((op, b, a.this))
                 if isinstance(b, exp.Not):
-                    pairs[frozenset((a, b.this))].append((op, a))
+                    pairs[frozenset((a, b.this))].append((op, a, b.this))
 
             for op in ops:
                 if not isinstance(op, kind):
@@ -1061,10 +1283,20 @@ class Simplifier:
                 a, b = op.unnest_operands()
 
                 # Absorb
-                if isinstance(a, exp.Not) and a.this in op_set:
+                if (
+                    isinstance(a, exp.Not)
+                    and a.this in op_set
+                    and self._boolean_complement_prover.is_proven_nonnull(a.this)
+                    and self._boolean_complement_prover.is_safe_to_repeat(a.this)
+                ):
                     a.replace(exp.true() if kind == exp.And else exp.false())
                     continue
-                if isinstance(b, exp.Not) and b.this in op_set:
+                if (
+                    isinstance(b, exp.Not)
+                    and b.this in op_set
+                    and self._boolean_complement_prover.is_proven_nonnull(b.this)
+                    and self._boolean_complement_prover.is_safe_to_repeat(b.this)
+                ):
                     b.replace(exp.true() if kind == exp.And else exp.false())
                     continue
                 superset = set(op.flatten())
@@ -1073,9 +1305,14 @@ class Simplifier:
                     continue
 
                 # Eliminate
-                for other, complement in pairs[frozenset((a, b))]:
-                    op.replace(complement)
-                    other.replace(complement)
+                for other, complement, complemented in pairs[frozenset((a, b))]:
+                    if (
+                        self._boolean_complement_prover.is_proven_nonnull(complemented)
+                        and self._boolean_complement_prover.is_safe_to_eliminate(complemented)
+                        and self._boolean_complement_prover.is_safe_to_repeat(complement)
+                    ):
+                        op.replace(complement)
+                        other.replace(complement)
 
         return expression
 

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -193,16 +193,16 @@ A AND TRUE;
 A AND TRUE;
 
 A AND (NOT A OR B);
-A AND B;
+A AND (B OR NOT A);
 
 (NOT A OR B) AND A;
-A AND B;
+A AND (B OR NOT A);
 
 A OR (NOT A AND B);
-A OR B;
+A OR (B AND NOT A);
 
 A OR ((((NOT A AND B))));
-A OR B;
+A OR (B AND NOT A);
 
 x NOT LIKE 'a%' OR (y IN (1, 2) AND x LIKE 'a%');
 (x LIKE 'a%' AND y IN (1, 2)) OR x NOT LIKE 'a%';
@@ -229,46 +229,46 @@ A AND TRUE;
 -- Elimination
 --------------------------------------
 (A AND B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (A AND B) OR (NOT A AND B);
-B AND TRUE;
+(A AND B) OR (B AND NOT A);
 
 (A AND NOT B) OR (A AND B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (NOT A AND B) OR (A AND B);
-B AND TRUE;
+(A AND B) OR (B AND NOT A);
 
 (A OR B) AND (A OR NOT B);
-A AND TRUE;
+(A OR B) AND (A OR NOT B);
 
 (A OR B) AND (NOT A OR B);
-B AND TRUE;
+(A OR B) AND (B OR NOT A);
 
 (A OR NOT B) AND (A OR B);
-A AND TRUE;
+(A OR B) AND (A OR NOT B);
 
 (NOT A OR B) AND (A OR B);
-B AND TRUE;
+(A OR B) AND (B OR NOT A);
 
 (NOT A OR NOT B) AND (NOT A OR B);
-NOT A;
+(B OR NOT A) AND (NOT A OR NOT B);
 
 (NOT A OR NOT B) AND (NOT A OR NOT NOT B);
-NOT A;
+(NOT A OR NOT B) AND (NOT A OR NOT NOT B);
 
 E OR (A AND B) OR C OR D OR (A AND NOT B);
-A OR C OR D OR E;
+(A AND B) OR (A AND NOT B) OR C OR D OR E;
 
 (A AND B) OR (A AND NOT B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (A AND B) OR (A AND B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (A AND B) OR (A AND NOT B) OR (A AND B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 SELECT t_bool.a OR t_bool.a FROM t_bool;
 SELECT t_bool.a FROM t_bool;
@@ -961,10 +961,10 @@ COALESCE(x, 1) IS NULL;
 FALSE;
 
 COALESCE(ROW() OVER (), 1) = 1;
-ROW() OVER () = 1 OR ROW() OVER () IS NULL;
+(NOT ROW() OVER () IS NULL AND ROW() OVER () = 1) OR ROW() OVER () IS NULL;
 
 a AND b AND COALESCE(ROW() OVER (), 1) = 1;
-(ROW() OVER () = 1 OR ROW() OVER () IS NULL) AND a AND b;
+((NOT ROW() OVER () IS NULL AND ROW() OVER () = 1) OR ROW() OVER () IS NULL) AND a AND b;
 
 COALESCE(1, 2);
 1;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,3 +1,4 @@
+import sqlite3
 import unittest
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from functools import partial
@@ -1186,6 +1187,515 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
 
     def test_unnest_subqueries(self):
         self.check_file("unnest_subqueries", optimizer.unnest_subqueries.unnest_subqueries)
+
+    def test_simplify_preserves_nullable_boolean_complements(self):
+        for sql in (
+            "SELECT a AND (NOT a OR b) AS x FROM (VALUES (NULL, FALSE)) AS policy(a, b)",
+            "SELECT NOT (a AND (NOT a OR b)) AS x FROM (VALUES (NULL, FALSE)) AS policy(a, b)",
+            "SELECT a OR (NOT a AND b) AS x FROM (VALUES (NULL, TRUE)) AS policy(a, b)",
+            "SELECT (a AND b) OR (a AND NOT b) AS x FROM (VALUES (TRUE, NULL)) AS policy(a, b)",
+            "SELECT (a OR b) AND (a OR NOT b) AS x FROM (VALUES (FALSE, NULL)) AS policy(a, b)",
+            "SELECT (SELECT a AND (NOT a OR b) "
+            "FROM (VALUES (NULL, FALSE)) AS policy(a, b)) IS NULL AS x",
+            "SELECT 1 AS x FROM (VALUES (NULL, TRUE)) AS policy(a, b) WHERE a OR (NOT a AND b)",
+            "SELECT 1 AS x FROM (VALUES (TRUE, NULL)) AS policy(a, b) "
+            "WHERE (a AND b) OR (a AND NOT b)",
+        ):
+            with self.subTest(sql):
+                simplified = simplify(parse_one(sql, read="duckdb"), dialect="duckdb")
+                self.assertEqual(
+                    self.conn.sql(sql).fetchall(),
+                    self.conn.sql(simplified.sql(dialect="duckdb")).fetchall(),
+                )
+
+        schema = {"policy": {"id": "INT", "a": "BOOLEAN", "b": "BOOLEAN"}}
+
+        for observer in ("IS FALSE", "IS NULL"):
+            with self.subTest(observer):
+                optimized = optimizer.optimize(
+                    parse_one(f"SELECT id FROM policy WHERE (a AND (NOT a OR b)) {observer}"),
+                    schema=schema,
+                )
+                self.assertIn(
+                    f'("policy"."a" AND ("policy"."b" OR NOT "policy"."a")) {observer}',
+                    optimized.sql(),
+                )
+
+    def test_simplify_boolean_complements_with_nonnull_operands(self):
+        nonnull_boolean = exp.DataType.build("BOOLEAN")
+        nonnull_boolean.set("nullable", False)
+        nonnull_integer = exp.DataType.build("INT")
+        nonnull_integer.set("nullable", False)
+
+        for sql, schema, expected in (
+            (
+                "SELECT a AND (NOT a OR b) AS x FROM policy",
+                {"policy": {"a": nonnull_boolean, "b": "BOOLEAN"}},
+                'SELECT "policy"."a" AND "policy"."b" AS "x" FROM "policy" AS "policy"',
+            ),
+            (
+                "SELECT (a AND b) OR (a AND NOT b) AS x FROM policy",
+                {"policy": {"a": "BOOLEAN", "b": nonnull_boolean}},
+                'SELECT "policy"."a" AS "x" FROM "policy" AS "policy"',
+            ),
+            (
+                "SELECT a OR (NOT a AND b) AS x FROM policy",
+                {"policy": {"a": nonnull_boolean, "b": "BOOLEAN"}},
+                'SELECT "policy"."a" OR "policy"."b" AS "x" FROM "policy" AS "policy"',
+            ),
+            (
+                "SELECT (a OR b) AND (a OR NOT b) AS x FROM policy",
+                {"policy": {"a": "BOOLEAN", "b": nonnull_boolean}},
+                'SELECT "policy"."a" AS "x" FROM "policy" AS "policy"',
+            ),
+            (
+                "SELECT a OR NOT a AS x FROM policy",
+                {"policy": {"a": nonnull_boolean}},
+                'SELECT TRUE AS "x" FROM "policy" AS "policy"',
+            ),
+            (
+                "SELECT (a > 0 AND b) OR (a > 0 AND NOT b) AS x FROM policy",
+                {"policy": {"a": nonnull_integer, "b": nonnull_boolean}},
+                'SELECT "policy"."a" > 0 AS "x" FROM "policy" AS "policy"',
+            ),
+        ):
+            with self.subTest(sql):
+                qualified = optimizer.qualify.qualify(parse_one(sql), schema=schema)
+                self.assertEqual(expected, simplify(qualified, schema=schema).sql())
+
+    def test_simplify_boolean_complements_after_outer_join(self):
+        self.conn.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE optimizer_nonnull_left (a BOOLEAN NOT NULL);
+            CREATE OR REPLACE TEMP TABLE optimizer_nonnull_right (a BOOLEAN NOT NULL);
+            CREATE OR REPLACE TEMP TABLE optimizer_nonnull_empty (a BOOLEAN NOT NULL);
+            CREATE OR REPLACE TEMP TABLE optimizer_nonnull_output (x BOOLEAN NOT NULL);
+            INSERT INTO optimizer_nonnull_left VALUES (TRUE);
+            INSERT INTO optimizer_nonnull_right VALUES (TRUE);
+            """
+        )
+
+        nonnull_boolean = exp.DataType.build("BOOLEAN")
+        nonnull_boolean.set("nullable", False)
+        schema = {
+            "optimizer_nonnull_left": {"a": nonnull_boolean},
+            "optimizer_nonnull_right": {"a": nonnull_boolean},
+            "optimizer_nonnull_empty": {"a": nonnull_boolean},
+            "optimizer_nonnull_output": {"x": nonnull_boolean},
+        }
+
+        def assert_preserved(sql, dialect="duckdb"):
+            qualified = optimizer.qualify.qualify(
+                parse_one(sql, read=dialect), schema=schema, dialect=dialect
+            )
+            simplified = simplify(qualified, schema=schema, dialect=dialect)
+            self.assertEqual(
+                self.conn.sql(sql).fetchall(),
+                self.conn.sql(simplified.sql(dialect="duckdb")).fetchall(),
+            )
+            self.assertIsNotNone(simplified.find(exp.Not))
+
+        for sql in (
+            """
+            SELECT (r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT (r.a OR (NOT r.a AND TRUE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT ((TRUE AND r.a) OR (TRUE AND NOT r.a)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT ((FALSE OR r.a) AND (FALSE OR NOT r.a)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT (l.a AND (NOT l.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            RIGHT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT (r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            FULL JOIN optimizer_nonnull_right AS r ON FALSE
+            ORDER BY x
+            """,
+            """
+            SELECT (SELECT r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT (l.a AND (NOT l.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            JOIN optimizer_nonnull_right AS m ON TRUE
+            RIGHT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+            """
+            SELECT (r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            JOIN optimizer_nonnull_right AS r
+            RIGHT JOIN optimizer_nonnull_left AS e ON FALSE
+            ON TRUE
+            """,
+            """
+            SELECT (r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN (SELECT a FROM optimizer_nonnull_right) AS r ON FALSE
+            """,
+            """
+            SELECT (r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            POSITIONAL JOIN optimizer_nonnull_empty AS r
+            """,
+            """
+            SELECT (r.a OR NOT r.a) IS NULL AS x
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+            """,
+        ):
+            with self.subTest(sql):
+                assert_preserved(sql)
+
+        complement_laws = (
+            "d.a AND (NOT d.a OR FALSE)",
+            "d.a OR (NOT d.a AND TRUE)",
+            "(TRUE AND d.a) OR (TRUE AND NOT d.a)",
+            "(FALSE OR d.a) AND (FALSE OR NOT d.a)",
+        )
+        source = """
+            SELECT r.a
+            FROM optimizer_nonnull_left AS l
+            LEFT JOIN optimizer_nonnull_right AS r ON FALSE
+        """
+
+        for law in complement_laws:
+            for sql in (
+                f"SELECT ({law}) IS NULL AS x FROM ({source}) AS d",
+                f"WITH d AS ({source}) SELECT ({law}) IS NULL AS x FROM d",
+            ):
+                with self.subTest(sql):
+                    assert_preserved(sql)
+
+        insert_sql = f"""
+            WITH d AS ({source})
+            INSERT INTO optimizer_nonnull_output
+            SELECT (d.a OR NOT d.a) IS NULL FROM d
+        """
+        qualified = optimizer.qualify.qualify(
+            parse_one(insert_sql, read="duckdb"), schema=schema, dialect="duckdb"
+        )
+        simplified = simplify(qualified, schema=schema, dialect="duckdb")
+        self.assertIsNotNone(simplified.find(exp.Not))
+
+        self.conn.execute("DELETE FROM optimizer_nonnull_output")
+        self.conn.execute(insert_sql)
+        original = self.conn.sql("SELECT * FROM optimizer_nonnull_output").fetchall()
+        self.conn.execute("DELETE FROM optimizer_nonnull_output")
+        self.conn.execute(simplified.sql(dialect="duckdb"))
+        self.assertEqual(
+            original,
+            self.conn.sql("SELECT * FROM optimizer_nonnull_output").fetchall(),
+        )
+
+        for sql, dialect in (
+            (
+                """
+                SELECT (l.a AND (NOT l.a OR FALSE)) IS NULL AS x
+                FROM optimizer_nonnull_left AS l
+                OUTER APPLY (SELECT 1 AS x) AS r
+                """,
+                "tsql",
+            ),
+            (
+                """
+                SELECT (r.a AND (NOT r.a OR FALSE)) IS NULL AS x
+                FROM optimizer_nonnull_left AS l, optimizer_nonnull_right AS r
+                WHERE l.a = r.a (+)
+                """,
+                "oracle",
+            ),
+        ):
+            with self.subTest(sql):
+                qualified = optimizer.qualify.qualify(
+                    parse_one(sql, read=dialect), schema=schema, dialect=dialect
+                )
+                simplified = simplify(qualified, schema=schema, dialect=dialect)
+                self.assertIsNotNone(simplified.find(exp.Not))
+
+        for law in (
+            "r.a AND (NOT r.a OR FALSE)",
+            "r.a OR (NOT r.a AND TRUE)",
+            "(TRUE AND r.a) OR (TRUE AND NOT r.a)",
+            "(FALSE OR r.a) AND (FALSE OR NOT r.a)",
+            "r.a OR NOT r.a",
+        ):
+            sql = f"""
+                SELECT ({law}) IS NULL AS x
+                FROM optimizer_nonnull_left AS l
+                JOIN optimizer_nonnull_right AS r ON TRUE
+            """
+            with self.subTest(sql):
+                qualified = optimizer.qualify.qualify(parse_one(sql), schema=schema)
+                simplified = simplify(qualified, schema=schema)
+                self.assertEqual(
+                    self.conn.sql(sql).fetchall(),
+                    self.conn.sql(simplified.sql()).fetchall(),
+                )
+                self.assertIsNone(simplified.find(exp.Not))
+
+    def test_simplify_boolean_complements_after_grouping_extension(self):
+        nonnull_boolean = exp.DataType.build("BOOLEAN")
+        nonnull_boolean.set("nullable", False)
+        schema = {"optimizer_grouping": {"a": nonnull_boolean}}
+        self.conn.execute(
+            """
+            CREATE OR REPLACE TEMP TABLE optimizer_grouping (a BOOLEAN NOT NULL);
+            INSERT INTO optimizer_grouping VALUES (TRUE);
+            """
+        )
+
+        for group_by in ("ROLLUP(a)", "CUBE(a)", "GROUPING SETS ((a), ())"):
+            sql = f"""
+                SELECT a, (a AND (NOT a OR FALSE)) IS NULL AS x
+                FROM optimizer_grouping
+                GROUP BY {group_by}
+                ORDER BY a NULLS LAST
+            """
+            with self.subTest(group_by):
+                qualified = optimizer.qualify.qualify(
+                    parse_one(sql, read="duckdb"), schema=schema, dialect="duckdb"
+                )
+                simplified = simplify(qualified, schema=schema, dialect="duckdb")
+                self.assertEqual(
+                    self.conn.sql(sql).fetchall(),
+                    self.conn.sql(simplified.sql(dialect="duckdb")).fetchall(),
+                )
+                self.assertIsNotNone(simplified.find(exp.Not))
+
+        totals_sql = """
+            SELECT a, (a AND (NOT a OR FALSE)) IS NULL AS x
+            FROM optimizer_grouping
+            GROUP BY a WITH TOTALS
+        """
+        qualified = optimizer.qualify.qualify(
+            parse_one(totals_sql, read="clickhouse"), schema=schema, dialect="clickhouse"
+        )
+        simplified = simplify(qualified, schema=schema, dialect="clickhouse")
+        self.assertIsNotNone(simplified.find(exp.Not))
+
+        match_sql = """
+            SELECT (src.a OR NOT src.a) IS NULL AS x
+            FROM src
+            MATCH_RECOGNIZE (
+                MEASURES FIRST(B.a) AS a
+                ONE ROW PER MATCH
+                PATTERN (A B?)
+                DEFINE A AS TRUE, B AS TRUE
+            ) src
+        """
+        qualified = optimizer.qualify.qualify(
+            parse_one(match_sql, read="trino"),
+            schema={"src": {"a": nonnull_boolean}},
+            dialect="trino",
+            validate_qualify_columns=False,
+        )
+        simplified = simplify(qualified, schema={"src": {"a": nonnull_boolean}}, dialect="trino")
+        self.assertIsNotNone(simplified.find(exp.Not))
+
+    def test_simplify_boolean_complements_with_historical_table_sources(self):
+        nonnull_boolean = exp.DataType.build("BOOLEAN")
+        nonnull_boolean.set("nullable", False)
+        schema = {"policy": {"a": nonnull_boolean}}
+
+        for dialect, source in (
+            (
+                "bigquery",
+                "policy AS p FOR SYSTEM_TIME AS OF TIMESTAMP('2020-01-01')",
+            ),
+            ("spark", "policy VERSION AS OF 1 AS p"),
+            ("snowflake", "policy AT (TIMESTAMP => '2020-01-01') AS p"),
+        ):
+            sql = f"SELECT (p.a OR NOT p.a) IS NULL AS x FROM {source}"
+            with self.subTest(dialect):
+                qualified = optimizer.qualify.qualify(
+                    parse_one(sql, read=dialect), schema=schema, dialect=dialect
+                )
+                simplified = simplify(qualified, schema=schema, dialect=dialect)
+                self.assertIsNotNone(simplified.find(exp.Not))
+
+    def test_simplify_boolean_complements_with_volatile_operands(self):
+        nonnull_boolean = exp.DataType.build("BOOLEAN")
+        nonnull_boolean.set("nullable", False)
+        schema = {"policy": {"a": nonnull_boolean, "b": nonnull_boolean}}
+
+        for sql, volatile_type in (
+            (
+                """
+                SELECT (RAND() > 0.5) AND (NOT (RAND() > 0.5) OR a) AS x
+                FROM policy
+                """,
+                exp.Rand,
+            ),
+            (
+                """
+                SELECT ((RAND() > 0.5) AND b) OR ((RAND() > 0.5) AND NOT b) AS x
+                FROM policy
+                """,
+                exp.Rand,
+            ),
+            (
+                """
+                SELECT (RAND() > 0.5) OR NOT (RAND() > 0.5) AS x
+                FROM policy
+                """,
+                exp.Rand,
+            ),
+            (
+                """
+                SELECT (VOLATILE_UDF() AND b) OR (VOLATILE_UDF() AND NOT b) AS x
+                FROM policy
+                """,
+                exp.Anonymous,
+            ),
+            (
+                """
+                SELECT (VOLATILE_WINDOW() OVER () IS NULL)
+                    OR NOT (VOLATILE_WINDOW() OVER () IS NULL) AS x
+                FROM policy
+                """,
+                exp.Anonymous,
+            ),
+            (
+                """
+                SELECT ((SEQ4() % 2 = 0) IS TRUE)
+                    AND (NOT ((SEQ4() % 2 = 0) IS TRUE) OR b) AS x
+                FROM policy
+                """,
+                exp.Seq4,
+            ),
+        ):
+            with self.subTest(sql):
+                qualified = optimizer.qualify.qualify(parse_one(sql), schema=schema)
+                simplified = simplify(qualified, schema=schema)
+                self.assertEqual(2, len(list(simplified.find_all(volatile_type))))
+
+        sequence_sql = """
+            SELECT (seq.NEXTVAL > 0 AND b) OR (seq.NEXTVAL > 0 AND NOT b) AS x
+            FROM policy
+        """
+        qualified = optimizer.qualify.qualify(
+            parse_one(sequence_sql, read="snowflake"),
+            schema=schema,
+            dialect="snowflake",
+            validate_qualify_columns=False,
+        )
+        simplified = simplify(qualified, schema=schema, dialect="snowflake")
+        sequence_columns = [
+            column for column in simplified.find_all(exp.Column) if column.name.upper() == "NEXTVAL"
+        ]
+        self.assertEqual(2, len(sequence_columns))
+
+        alias_projection = """
+            SELECT
+                VOLATILE_BOOL() AS r,
+                VOLATILE_NULLABLE() AS p,
+                (r AND (p IS NULL)) OR (r AND NOT (p IS NULL)) AS x
+        """
+        for alias_sql in (
+            alias_projection,
+            f"INSERT INTO dst {alias_projection}",
+            f"CREATE TABLE dst AS {alias_projection}",
+            f"WITH cte AS (SELECT 1) INSERT INTO dst {alias_projection}",
+        ):
+            with self.subTest(alias_sql):
+                simplified = simplify(parse_one(alias_sql, read="snowflake"), dialect="snowflake")
+                alias_references = [
+                    column
+                    for column in simplified.find_all(exp.Column)
+                    if not column.table and column.name in ("r", "p")
+                ]
+                self.assertEqual(4, len(alias_references))
+
+    def test_simplify_boolean_complements_with_runtime_nulls_and_errors(self):
+        connection = sqlite3.connect(":memory:")
+        self.addCleanup(connection.close)
+
+        for sql in (
+            "SELECT (1 % 0 OR NOT 1 % 0) IS NULL AS x",
+            "SELECT (1 % 0 AND NOT 1 % 0) IS NULL AS x",
+            "SELECT (1 % 0 AND (NOT 1 % 0 OR FALSE)) IS NULL AS x",
+        ):
+            with self.subTest(sql):
+                simplified = simplify(parse_one(sql, read="sqlite"), dialect="sqlite")
+                self.assertEqual(
+                    connection.execute(sql).fetchall(),
+                    connection.execute(simplified.sql(dialect="sqlite")).fetchall(),
+                )
+                self.assertIsNotNone(simplified.find(exp.Not))
+
+        connection.execute("CREATE TABLE optimizer_aggregate (a BOOLEAN NOT NULL)")
+        connection.create_aggregate(
+            "MY_COUNT",
+            1,
+            type("MyCount", (), {"step": lambda *_: None, "finalize": lambda *_: 0}),
+        )
+        connection.create_aggregate(
+            "ABS",
+            1,
+            type("AbsAggregate", (), {"step": lambda *_: None, "finalize": lambda *_: 0}),
+        )
+        connection.create_aggregate(
+            "POWER",
+            2,
+            type("PowerAggregate", (), {"step": lambda *_: None, "finalize": lambda *_: 0}),
+        )
+        nonnull_boolean = exp.DataType.build("BOOLEAN")
+        nonnull_boolean.set("nullable", False)
+        schema = {"optimizer_aggregate": {"a": nonnull_boolean}}
+        for aggregate in ("COUNT(*)", "MY_COUNT(a)", "ABS(a)", "POWER(a, 2)"):
+            aggregate_sql = f"""
+                SELECT (a OR NOT a) IS NULL AS x, {aggregate} AS n
+                FROM optimizer_aggregate
+            """
+            with self.subTest(aggregate):
+                qualified = optimizer.qualify.qualify(
+                    parse_one(aggregate_sql, read="sqlite"), schema=schema, dialect="sqlite"
+                )
+                simplified = simplify(qualified, schema=schema, dialect="sqlite")
+                self.assertEqual(
+                    connection.execute(aggregate_sql).fetchall(),
+                    connection.execute(simplified.sql(dialect="sqlite")).fetchall(),
+                )
+                self.assertIsNotNone(simplified.find(exp.Not))
+
+        division_sql = "SELECT 1 / 0 IS NULL OR NOT 1 / 0 IS NULL AS x"
+        simplified = simplify(parse_one(division_sql, read="postgres"), dialect="postgres")
+        self.assertEqual(2, len(list(simplified.find_all(exp.Div))))
+
+        assignment_sql = """
+            SELECT (@x := @x + 1) IS NULL OR NOT (@x := @x + 1) IS NULL AS x
+        """
+        simplified = simplify(parse_one(assignment_sql, read="mysql"), dialect="mysql")
+        self.assertEqual(2, len(list(simplified.find_all(exp.PropertyEQ))))
+
+        invalid_pattern_sql = "SELECT ('x' SIMILAR TO '[') OR NOT ('x' SIMILAR TO '[') AS x"
+        simplified = simplify(
+            annotate_types(parse_one(invalid_pattern_sql, read="duckdb"), dialect="duckdb"),
+            dialect="duckdb",
+        )
+        self.assertEqual(2, len(list(simplified.find_all(exp.SimilarTo))))
+        for sql in (invalid_pattern_sql, simplified.sql(dialect="duckdb")):
+            with self.subTest(sql):
+                with self.assertRaises(duckdb.InvalidInputException):
+                    self.conn.sql(sql).fetchall()
 
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)


### PR DESCRIPTION
Closes #7962

## Summary

- preserve SQL three-valued semantics for nullable Boolean complement absorption and elimination
- require proven non-null direct physical-table provenance before applying unsafe complement laws, including guards for outer joins, grouping extensions, derived tables, CTEs, and historical sources
- avoid removing or duplicating volatile or error-producing operands while preserving deterministic, proven-safe simplifications

## Validation

- `py -3.12 -m pytest tests/test_optimizer.py -q` — 90 passed, 4,247 subtests passed
- `py -3.12 -m mypy sqlglot` — 180 source files passed
- Ruff format and lint passed
- `git diff --check` passed
- focused semantic regressions cover all four complement laws, nullable observers, joins, grouping, source provenance, volatile aliases, and runtime-error preservation

## LLM disclosure

OpenAI Codex was used to help analyze the bug, implement the fix, and validate the tests. The commit author and commit message contain no AI credit.