### PR TITLE
feat(optimizer)!: annotate regexp_extract for duckdb

### DIFF
--- a/sqlglot/typing/duckdb.py
+++ b/sqlglot/typing/duckdb.py
@@ -47,6 +47,7 @@ EXPRESSION_METADATA = {
             exp.Format,
             exp.Reverse,
             exp.Decode,
+            exp.RegexpExtract,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6783,6 +6783,10 @@ REVERSE(tbl.str_col);
 VARCHAR;
 
 # dialect: duckdb
+REGEXP_EXTRACT(tbl.str_col, tbl.str_col);
+VARCHAR;
+
+# dialect: duckdb
 RANDOM();
 DOUBLE;
 


### PR DESCRIPTION
**Annotate regexp_extract for duckdb**

https://duckdb.org/docs/lts/sql/functions/regular_expressions#regexp_extractstring-pattern-group--0-options

<img width="1308" height="621" alt="image" src="https://github.com/user-attachments/assets/df18e078-5cc8-419a-9074-1b3611c44b5d" />
