### PR TITLE
fix(mysql,starrocks)!: correct DATEDIFF, LIKE, VARIANCE and TO_DAYS semantics [CLAUDE]

### DIFF
--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -226,6 +226,9 @@ class MySQLGenerator(generator.Generator):
         exp.TsOrDsToDate: _ts_or_ds_to_date_sql,
         exp.Unicode: lambda self, e: f"ORD(CONVERT({self.sql(e.this)} USING utf32))",
         exp.UnixToTime: _unix_to_time_sql,
+        # MySQL's VARIANCE is the population variance and it has no VARIANCE_POP
+        exp.Variance: rename_func("VAR_SAMP"),
+        exp.VariancePop: rename_func("VAR_POP"),
         exp.Week: _remove_ts_or_ds_to_date(),
         exp.WeekOfYear: _remove_ts_or_ds_to_date(rename_func("WEEKOFYEAR")),
         exp.Year: _remove_ts_or_ds_to_date(),

--- a/sqlglot/generators/starrocks.py
+++ b/sqlglot/generators/starrocks.py
@@ -10,6 +10,7 @@ from sqlglot.dialects.dialect import (
     inline_array_sql,
     property_sql,
     var_map_sql,
+    week_unit_to_dow,
 )
 from sqlglot.generators.mysql import MySQLGenerator
 
@@ -89,8 +90,11 @@ class StarRocksGenerator(MySQLGenerator):
     TRANSFORMS = {
         # StarRocks uses the native TRIM(str, chars)/LTRIM/RTRIM function form, not
         # MySQL's TRIM(chars FROM str) syntax, so it falls back to the base generator.
+        # DateDiff falls back to datediff_sql, which picks between DATEDIFF and DATE_DIFF.
         **{
-            k: v for k, v in MySQLGenerator.TRANSFORMS.items() if k not in (exp.DateTrunc, exp.Trim)
+            k: v
+            for k, v in MySQLGenerator.TRANSFORMS.items()
+            if k not in (exp.DateDiff, exp.DateTrunc, exp.Trim)
         },
         exp.ArgMax: rename_func("MAX_BY"),
         exp.ArgMin: rename_func("MIN_BY"),
@@ -103,7 +107,6 @@ class StarRocksGenerator(MySQLGenerator):
         exp.ArrayToString: rename_func("ARRAY_JOIN"),
         exp.ApproxDistinct: approx_count_distinct_sql,
         exp.CurrentVersion: lambda *_: "CURRENT_VERSION()",
-        exp.DateDiff: lambda self, e: self.func("DATE_DIFF", unit_to_str(e), e.this, e.expression),
         exp.Delete: transforms.preprocess([_eliminate_between_in_delete]),
         exp.Flatten: rename_func("ARRAY_FLATTEN"),
         exp.JSONExtractScalar: arrow_json_extract_sql,
@@ -286,6 +289,58 @@ class StarRocksGenerator(MySQLGenerator):
         "where",
         "with",
     }
+
+    # Units both DATE_DIFF and DATE_TRUNC support, so a boundary-crossing diff over them
+    # can be lowered by truncating the operands. MILLISECOND is deliberately absent: the
+    # analyzer rejects sub-second DATE_TRUNC over DATETIME-typed arguments (despite the
+    # docs advertising support since 3.1.7), and for second-precision values whole-unit
+    # and boundary counting coincide anyway, so that diff is emitted untruncated.
+    DATE_DIFF_TRUNC_UNITS = {"YEAR", "QUARTER", "MONTH", "HOUR", "MINUTE", "SECOND"}
+
+    def datediff_sql(self, expression: exp.DateDiff) -> str:
+        this = expression.this
+        expr = expression.expression
+        unit = expression.args.get("unit")
+        unit_str = unit_to_str(expression)
+
+        if expression.args.get("date_part_boundary"):
+            # DATEDIFF(a, b) natively counts crossed day boundaries, and a missing unit
+            # is MySQL's DATEDIFF, which also means DAY
+            # https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/datediff/
+            if not unit or (
+                isinstance(unit, (exp.Var, exp.Literal)) and unit.name.upper() == "DAY"
+            ):
+                return self.func("DATEDIFF", this, expr)
+
+            # DATE_DIFF counts whole units, so the operands are truncated down to the
+            # unit to make it count boundary crossings, mirroring the Presto generator
+            dow = week_unit_to_dow(unit)
+            if dow is not None:
+                unit_str = exp.Literal.string("WEEK")
+
+                # DATE_TRUNC('WEEK', ...) is Monday-based; shifting both operands by the
+                # same delta realigns it to the requested week start
+                shift_days = 1 if dow == 7 else 1 - dow
+                if shift_days:
+                    delta = exp.Interval(
+                        this=exp.Literal.string(str(shift_days)), unit=exp.var("DAY")
+                    )
+                    this = exp.Add(this=this, expression=delta)
+                    expr = exp.Add(this=expr, expression=delta.copy())
+
+            if unit_str is not None and (
+                dow is not None
+                or (
+                    isinstance(unit, (exp.Var, exp.Literal))
+                    and unit.name.upper() in self.DATE_DIFF_TRUNC_UNITS
+                )
+            ):
+                this = exp.TimestampTrunc(this=this, unit=unit_str.copy())
+                expr = exp.TimestampTrunc(this=expr, unit=unit_str.copy())
+            # units DATE_TRUNC can't handle, e.g. ISOYEAR, stay untruncated: they fail
+            # loudly on the server rather than silently returning whole-unit counts
+
+        return self.func("DATE_DIFF", unit_str, this, expr)
 
     def create_sql(self, expression: exp.Create) -> str:
         # Starrocks' primary key is defined outside of the schema, so we need to move it there

--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -152,6 +152,9 @@ class MySQLParser(parser.Parser):
         ),
         "WEEKOFYEAR": lambda args: exp.WeekOfYear(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
         "YEAR": lambda args: exp.Year(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
+        # VARIANCE is a synonym of VAR_POP, not of VAR_SAMP
+        # https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html
+        "VARIANCE": exp.VariancePop.from_arg_list,
     }
 
     FUNCTION_PARSERS = {

--- a/sqlglot/parsers/starrocks.py
+++ b/sqlglot/parsers/starrocks.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 
 from sqlglot import exp, parser
-from sqlglot.dialects.dialect import build_date_delta_with_interval, build_timestamp_trunc
+from sqlglot.dialects.dialect import (
+    build_date_delta_with_interval,
+    build_like,
+    build_timestamp_trunc,
+)
 from sqlglot.helper import seq_get
 from sqlglot.parsers.mysql import MySQLParser
 from sqlglot.tokens import TokenType
@@ -20,14 +24,26 @@ class StarRocksParser(MySQLParser):
         "DATE_SUB": build_date_delta_with_interval(exp.DateSub, default_unit="DAY"),
         "SUBDATE": build_date_delta_with_interval(exp.DateSub, default_unit="DAY"),
         "DATE_TRUNC": build_timestamp_trunc,
+        # DATEDIFF counts crossed day boundaries, unlike DATE_DIFF which counts whole days
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/datediff/
         "DATEDIFF": lambda args: exp.DateDiff(
-            this=seq_get(args, 0), expression=seq_get(args, 1), unit=exp.Literal.string("DAY")
+            this=seq_get(args, 0),
+            expression=seq_get(args, 1),
+            unit=exp.var("DAY"),
+            date_part_boundary=True,
         ),
         "DATE_DIFF": lambda args: exp.DateDiff(
             this=seq_get(args, 1), expression=seq_get(args, 2), unit=seq_get(args, 0)
         ),
         "ARRAY_FLATTEN": exp.Flatten.from_arg_list,
+        # StarRocks' LIKE(expr, pattern) takes its arguments in the natural order,
+        # unlike the base builder which reverses them
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/like-predicate-functions/like/
+        "LIKE": build_like(exp.Like),
         "REGEXP": exp.RegexpLike.from_arg_list,
+        # StarRocks supports TO_DAYS natively, so it doesn't need MySQL's rewrite
+        # https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/to_days/
+        "TO_DAYS": exp.ToDays.from_arg_list,
         # StarRocks' MAP() is a variadic constructor: MAP(k1, v1, k2, v2, ...)
         # https://docs.starrocks.io/docs/sql-reference/sql-functions/map-functions/map/
         "MAP": parser.build_var_map,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -1660,7 +1660,7 @@ LANGUAGE js AS
             write={
                 "bigquery": "DATE_DIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE), DAY)",
                 "mysql": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
-                "starrocks": "DATE_DIFF('DAY', CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+                "starrocks": "DATEDIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
             },
         )
         self.validate_all(
@@ -1674,7 +1674,7 @@ LANGUAGE js AS
             "DATE_DIFF(DATE '2010-07-07', DATE '2008-12-25', MINUTE)",
             write={
                 "bigquery": "DATE_DIFF(CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE), MINUTE)",
-                "starrocks": "DATE_DIFF('MINUTE', CAST('2010-07-07' AS DATE), CAST('2008-12-25' AS DATE))",
+                "starrocks": "DATE_DIFF('MINUTE', DATE_TRUNC('MINUTE', CAST('2010-07-07' AS DATE)), DATE_TRUNC('MINUTE', CAST('2008-12-25' AS DATE)))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -487,6 +487,23 @@ class TestMySQL(Validator):
         self.validate_identity(
             "SELECT WEEK_OF_YEAR('2023-01-01')", "SELECT WEEKOFYEAR('2023-01-01')"
         )
+        # VARIANCE is a synonym of VAR_POP, and MySQL has no VARIANCE_POP
+        # https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html
+        self.validate_identity("SELECT VARIANCE(a)", "SELECT VAR_POP(a)")
+        self.validate_identity("SELECT VAR_POP(a)")
+        self.validate_identity("SELECT VAR_SAMP(a)")
+        self.validate_all(
+            "SELECT VAR_POP(a), VAR_SAMP(a)",
+            read={
+                "mysql": "SELECT VARIANCE(a), VAR_SAMP(a)",
+            },
+            write={
+                "doris": "SELECT VAR_POP(a), VAR_SAMP(a)",
+                "duckdb": "SELECT VAR_POP(a), VARIANCE(a)",
+                "mysql": "SELECT VAR_POP(a), VAR_SAMP(a)",
+                "postgres": "SELECT VAR_POP(a), VAR_SAMP(a)",
+            },
+        )
         self.validate_all(
             "CHAR(10)",
             write={

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -251,6 +251,116 @@ class TestStarrocks(Validator):
             "SELECT DATE_DIFF('MINUTE', '2010-11-30 23:59:59', '2010-11-30 20:58:59')"
         )
 
+    def test_datediff(self):
+        # DATEDIFF counts crossed day boundaries while DATE_DIFF counts whole days,
+        # so the two must not be rewritten into each other
+        self.validate_identity("SELECT DATEDIFF(a, b)")
+        self.validate_identity("SELECT DATE_DIFF('DAY', a, b)")
+        self.validate_identity("SELECT DATE_DIFF('MINUTE', a, b)")
+
+        # dialects whose day diff counts boundary crossings map onto DATEDIFF
+        self.validate_all(
+            "SELECT DATEDIFF(a, b)",
+            read={
+                "bigquery": "SELECT DATE_DIFF(a, b, DAY)",
+                "mysql": "SELECT DATEDIFF(a, b)",
+            },
+            write={
+                "bigquery": "SELECT DATE_DIFF(a, b, DAY)",
+                "mysql": "SELECT DATEDIFF(a, b)",
+                "postgres": "SELECT (CAST(a AS DATE) - CAST(b AS DATE))",
+                "starrocks": "SELECT DATEDIFF(a, b)",
+            },
+        )
+        # units from dialects sqlglot doesn't flag as boundary-crossing keep DATE_DIFF
+        self.validate_all(
+            "SELECT DATE_DIFF('DAY', b, a)",
+            read={
+                "duckdb": "SELECT DATE_DIFF('day', a, b)",
+            },
+        )
+
+        # a boundary-crossing diff over a non-DAY unit truncates the operands down to
+        # the unit, turning StarRocks' whole-unit counting into boundary counting
+        self.validate_all(
+            "SELECT DATE_DIFF('MONTH', DATE_TRUNC('MONTH', a), DATE_TRUNC('MONTH', b))",
+            read={
+                "bigquery": "SELECT DATE_DIFF(a, b, MONTH)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_DIFF('HOUR', DATE_TRUNC('HOUR', b), DATE_TRUNC('HOUR', a))",
+            read={
+                "snowflake": "SELECT DATEDIFF(hour, a, b)",
+            },
+        )
+        # DATE_TRUNC('WEEK', ...) is Monday-based, so week units shift both operands to
+        # realign the requested week start
+        self.validate_all(
+            "SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', a + INTERVAL '1' DAY), DATE_TRUNC('WEEK', b + INTERVAL '1' DAY))",
+            read={
+                "bigquery": "SELECT DATE_DIFF(a, b, WEEK)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', a), DATE_TRUNC('WEEK', b))",
+            read={
+                "bigquery": "SELECT DATE_DIFF(a, b, ISOWEEK)",
+            },
+        )
+        # units DATE_TRUNC can't handle stay untruncated and fail loudly on the server
+        # rather than silently returning whole-unit counts
+        self.validate_all(
+            "SELECT DATE_DIFF('ISOYEAR', a, b)",
+            read={
+                "bigquery": "SELECT DATE_DIFF(a, b, ISOYEAR)",
+            },
+        )
+
+    def test_to_days(self):
+        # StarRocks has a native TO_DAYS, unlike MySQL it must not be expanded
+        self.validate_identity("SELECT TO_DAYS(a)")
+        self.validate_all(
+            "SELECT TO_DAYS(a)",
+            write={
+                "mysql": "SELECT TO_DAYS(a)",
+                "starrocks": "SELECT TO_DAYS(a)",
+            },
+        )
+
+    def test_like(self):
+        # LIKE(expr, pattern) takes its arguments in the natural order
+        self.validate_identity("SELECT LIKE(a, 'x%')", "SELECT a LIKE 'x%'")
+        self.validate_all(
+            "SELECT a LIKE 'x%'",
+            read={
+                "starrocks": "SELECT LIKE(a, 'x%')",
+            },
+            write={
+                "starrocks": "SELECT a LIKE 'x%'",
+            },
+        )
+
+    def test_variance(self):
+        # VARIANCE / VAR_POP / VARIANCE_POP are the population variance,
+        # VAR_SAMP / VARIANCE_SAMP the sample one
+        self.validate_identity("SELECT VAR_SAMP(a)")
+        self.validate_identity("SELECT VARIANCE_SAMP(a)", "SELECT VAR_SAMP(a)")
+        self.validate_identity("SELECT VAR_POP(a)")
+        self.validate_identity("SELECT VARIANCE(a)", "SELECT VAR_POP(a)")
+        self.validate_identity("SELECT VARIANCE_POP(a)", "SELECT VAR_POP(a)")
+        self.validate_all(
+            "SELECT VAR_SAMP(a), VAR_POP(a)",
+            read={
+                "starrocks": "SELECT VAR_SAMP(a), VARIANCE(a)",
+            },
+            write={
+                "duckdb": "SELECT VARIANCE(a), VAR_POP(a)",
+                "mysql": "SELECT VAR_SAMP(a), VAR_POP(a)",
+                "starrocks": "SELECT VAR_SAMP(a), VAR_POP(a)",
+            },
+        )
+
     def test_date_add_sub(self):
         # Standard INTERVAL form
         self.validate_identity("SELECT DATE_ADD(x, INTERVAL '3' DAY)")


### PR DESCRIPTION
Fixes four rewrites in the StarRocks/MySQL dialects that silently produced **different numbers** rather than an error:

| # | Input | Generated before | Result before → after |
|---|---|---|---|
| 1 | `DATEDIFF(a, b)` (StarRocks) | `DATE_DIFF('DAY', a, b)` | `0` → `1` on DATETIMEs crossing midnight |
| 2 | `like(a, 'x%')` (StarRocks) | `'x%' LIKE a` | predicate flipped: `0` → `1` |
| 3 | `VAR_SAMP(x)` / `VAR_POP(x)` (MySQL family) | `VARIANCE(x)` / `VARIANCE_POP(x)` | sample silently became population; `VARIANCE_POP` isn't valid MySQL |
| 4 | `TO_DAYS(x)` (StarRocks) | `(DATE_DIFF('DAY', DATE(x), DATE('0000-01-01')) + 1)` | off by one: `740051` → `740050` |

### How this was verified

Every claim below was checked by **executing both the original and the generated SQL on a live StarRocks 3.5.18 cluster** and comparing results, not just parse round-trips. The MySQL-layer changes are additionally backed by the MySQL 8.4 Reference Manual, and the two other dialects inheriting the MySQL layer were checked explicitly: Doris (vendor docs confirm the same semantics) and SingleStore (already carried identical overrides, so this is a no-op there).

### 1. DATEDIFF ↔ DATE_DIFF

StarRocks [`DATEDIFF`](https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/datediff/) counts crossed **day boundaries** ("Only the date parts of the values are used"), while [`DATE_DIFF`](https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/date_diff/) counts **whole units**, so rewriting one into the other is lossy on DATETIME inputs:

```sql
SELECT DATEDIFF('2026-03-11 01:00:00', '2026-03-10 23:00:00');         -- 1
SELECT DATE_DIFF('DAY', '2026-03-11 01:00:00', '2026-03-10 23:00:00'); -- 0  (what sqlglot generated)
```

`DATEDIFF` now parses into `exp.DateDiff(..., date_part_boundary=True)` — the flag BigQuery, MySQL and Snowflake parsers already use for boundary-crossing semantics. Generation handles the full unit matrix (each row executed on the cluster):

| Boundary diff arriving at StarRocks | Generated | Notes |
|---|---|---|
| `DAY`, or no unit (MySQL `DATEDIFF`) | `DATEDIFF(a, b)` | native boundary semantics |
| `MONTH`, `QUARTER`, `YEAR`, `HOUR`, `MINUTE`, `SECOND` | `DATE_DIFF('U', DATE_TRUNC('U', a), DATE_TRUNC('U', b))` | truncating the operands turns whole-unit counting into boundary counting, mirroring the Presto generator (#7911) |
| `WEEK` / `WEEK(<DAY>)` / `ISOWEEK` | `DATE_TRUNC('WEEK', x + INTERVAL 'n' DAY)` on both operands | StarRocks' `DATE_TRUNC('WEEK', ...)` is Monday-based; the shared `week_unit_to_dow` helper computes the shift (`+1` for Sunday, `0` for Monday/ISOWEEK, ...) |
| `MILLISECOND` | `DATE_DIFF('MILLISECOND', a, b)` untruncated | the analyzer rejects sub-second `DATE_TRUNC` over DATETIME-typed arguments (verified on 3.5.18 even with `NOW(6)`, despite the [docs](https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/date_trunc/) advertising support since 3.1.7); for second-precision values whole-ms and boundary counting coincide anyway |
| `ISOYEAR` and anything else `DATE_TRUNC` can't handle | `DATE_DIFF('ISOYEAR', a, b)` untruncated | fails loudly on the server instead of silently returning whole-unit counts |
| diffs from whole-unit dialects (StarRocks itself, DuckDB) | plain `DATE_DIFF` | unchanged |

Sample cluster evidence for the truncation rows (raw `DATE_DIFF` returns `0` for all of these):

```sql
SELECT DATE_DIFF('MONTH', DATE_TRUNC('MONTH', CAST('2026-03-01 10:00:00' AS DATETIME)),
                          DATE_TRUNC('MONTH', CAST('2026-02-28 09:00:00' AS DATETIME)));  -- 1 (and -1 reversed)
SELECT DATE_DIFF('WEEK', DATE_TRUNC('WEEK', CAST('2026-03-15' AS DATE) + INTERVAL '1' DAY),
                         DATE_TRUNC('WEEK', CAST('2026-03-14' AS DATE) + INTERVAL '1' DAY)); -- 1 (Sunday-start week)
```

As a side effect, `DATEDIFF` from StarRocks now fans out correctly to other dialects too, e.g. postgres now gets `(CAST(a AS DATE) - CAST(b AS DATE))` instead of an epoch division that counted whole days.

### 2. LIKE()

StarRocks [`like(expr, pattern)`](https://docs.starrocks.io/docs/sql-reference/sql-functions/like-predicate-functions/like/) takes its arguments in the natural order, but the base builder reverses them, which flipped the predicate:

```sql
SELECT like('xyz', 'x%');  -- 1
SELECT 'x%' LIKE 'xyz';    -- 0  (what sqlglot generated)
```

The parser now uses `build_like(exp.Like)`, same as snowflake/spark/clickhouse. The 3-arg ESCAPE form keeps working through the same builder.

### 3. VARIANCE family (MySQL layer)

Per the [MySQL docs](https://dev.mysql.com/doc/refman/8.4/en/aggregate-functions.html), `VARIANCE()` is a synonym for `VAR_POP()` ("Returns the population standard variance ... provided as a MySQL extension"), `VAR_SAMP()` is the sample variance, and `VARIANCE_POP` does not exist. sqlglot treated `VARIANCE` as the sample variance (`exp.Variance._sql_names` includes it) and generated `VARIANCE_POP` for `exp.VariancePop`, so:

- `VAR_SAMP(x)` → `VARIANCE(x)`: a sample variance silently became a population one — `2.3333` vs `1.5556` on `(1, 2, 4)`
- `VAR_POP(x)` → `VARIANCE_POP(x)`: invalid MySQL

The MySQL parser now maps `VARIANCE` to `exp.VariancePop`, and the generator emits `VAR_SAMP`/`VAR_POP`. Inheritance checked: StarRocks documents the same population semantics ([variance,var_pop,variance_pop](https://docs.starrocks.io/docs/sql-reference/sql-functions/aggregate-functions/variance/) with a separate `var_samp` page), and so does [Doris](https://doris.apache.org/docs/dev/sql-manual/sql-functions/aggregate-functions/variance/) ("Unlike VARIANCE (population variance), VAR_SAMP uses n-1"); SingleStore already carried identical parser/generator overrides, which this makes redundant rather than conflicting.

### 4. TO_DAYS

StarRocks supports [`TO_DAYS`](https://docs.starrocks.io/docs/sql-reference/sql-functions/date-time-functions/to_days/) natively, and MySQL's expansion is off by one there:

```sql
SELECT to_days('2026-03-10');                                        -- 740050
SELECT DATE_DIFF('DAY', DATE('2026-03-10'), DATE('0000-01-01')) + 1; -- 740051  (what sqlglot generated)
```

StarRocks now parses `TO_DAYS` into the existing `exp.ToDays`; MySQL keeps its expansion, which is correct for MySQL.

### Breaking changes (hence the `!`)

- MySQL/Doris round trips: `VARIANCE(x)` → `VAR_POP(x)`, `VAR_SAMP(x)` stays `VAR_SAMP(x)` (previously `VARIANCE(x)`)
- StarRocks round trips: `DATEDIFF(a, b)` stays `DATEDIFF(a, b)` (previously `DATE_DIFF('DAY', a, b)`), `TO_DAYS(x)` stays `TO_DAYS(x)`
- StarRocks `TO_DAYS` no longer lowers into day arithmetic for targets without the function — round-trip fidelity on StarRocks is the priority, matching how the base dialect treats `TO_DAYS`

### Deliberately out of scope

- `STDDEV`: MySQL's `STDDEV`/`STD`/`STDDEV_POP` are population functions with the same naming quirk, but their round trip is already stable and changing `exp.Stddev` would affect every dialect
- The reverse direction (whole-unit sources generating into boundary-counting dialects, e.g. StarRocks `DATE_DIFF('MONTH', ...)` → BigQuery) is a target-generator concern shared by all whole-unit dialects
- `TIMESTAMPDIFF` flows through `exp.TimestampDiff` and is untouched

Tests: identity/cross-dialect coverage for every rewrite in `test_starrocks.py`/`test_mysql.py`, including pins for the MONTH/HOUR/WEEK/ISOWEEK/ISOYEAR unit shapes and the Doris/DuckDB/Postgres fan-outs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
