### PR TITLE
fix(duckdb): division by zero returns inf, not NULL

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -16,7 +16,6 @@ from sqlglot.typing.duckdb import EXPRESSION_METADATA
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = True
-    SAFE_DIVISION = True
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True
     CONCAT_WS_COALESCE = True

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -2938,6 +2938,19 @@ class TestDuckDB(Validator):
             },
         )
 
+    def test_safe_div(self):
+        # DuckDB follows IEEE 754 for float division, so `a / 0` yields inf
+        # and not NULL, and the divisor must not be wrapped to emulate
+        # NULL-safe division when DuckDB is the source dialect.
+        self.validate_all(
+            "a / b",
+            write={
+                "duckdb": "a / b",
+                "mysql": "a / b",
+                "postgres": "CAST(a AS DOUBLE PRECISION) / b",
+            },
+        )
+
     def test_map_insert(self):
         self.validate_all(
             "SELECT MAP_CONCAT(CAST({'a': 1, 'b': 2} AS MAP(TEXT, DECIMAL(38, 0))), MAP {'c': CAST(3 AS DECIMAL(38, 0))})",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1511,7 +1511,7 @@ COMMENT='客户账户表'"""
                 "bigquery": "a / NULLIF(b, 0)",
                 "clickhouse": "a / b",
                 "databricks": "a / NULLIF(b, 0)",
-                "duckdb": "a / b",
+                "duckdb": "a / NULLIF(b, 0)",
                 "hive": "a / b",
                 "mysql": "a / b",
                 "oracle": "a / NULLIF(b, 0)",


### PR DESCRIPTION
DuckDB is declared `SAFE_DIVISION = True`, which the docstring defines as "whether division by zero throws an error (`False`) or returns `NULL` (`True`)". Since DuckDB 1.1.0 neither is true: float division follows IEEE 754, so `1 / 0` is `inf`, `-1 / 0` is `-inf` and `0 / 0` is `nan`. `NULL` only comes back with `ieee_floating_point_ops = false`, which is not the default. Checked against DuckDB 1.5.5:

```
SELECT 1/0    -> inf
SELECT 0/0    -> nan
SELECT -1/0   -> -inf
SET ieee_floating_point_ops = false;
SELECT 1/0    -> NULL
```

The effect is in `div_sql`, which wraps the divisor in `NULLIF(b, 0)` when the source dialect is NULL-safe and the target is not. DuckDB was declared safe, so the wrap was skipped and `a / b` read as MySQL stayed `a / b` in DuckDB, which evaluates to `inf` where MySQL gives `NULL`. In the other direction sqlglot emulated a `NULL` that DuckDB never produces.

Dropping the flag changes exactly one entry of the existing `test_safe_div` matrix, the DuckDB target. Generating *from* DuckDB no longer wraps the divisor, since there is no NULL to emulate.

I realise that matrix entry was written deliberately, and that neither value of a two-state flag really describes `inf`. If you would rather model the third state explicitly, or keep the current behaviour for compatibility, say so and I will close this.