### PR TITLE
fix(optimizer): don't expand aggregate aliases into GROUP BY

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -356,10 +356,18 @@ def _expand_alias_refs(
             alias_expr, i = alias_to_expression.get(column.name, (None, 1))
 
             if alias_expr:
+                # An aggregate alias must not be expanded into a GROUP BY or another (non-window) aggregate.
                 skip_replace = bool(
                     alias_expr.find(exp.AggFunc)
-                    and column.find_ancestor(exp.AggFunc)
-                    and not isinstance(column.find_ancestor(exp.Window, exp.Select), exp.Window)
+                    and (
+                        is_group_by
+                        or (
+                            column.find_ancestor(exp.AggFunc)
+                            and not isinstance(
+                                column.find_ancestor(exp.Window, exp.Select), exp.Window
+                            )
+                        )
+                    )
                 )
 
                 # BigQuery's having clause gets confused if an alias matches a source.

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -10,7 +10,7 @@ from sqlglot.errors import OptimizeError, highlight_sql
 from sqlglot.helper import seq_get
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
-from sqlglot.optimizer.scope import Scope, build_scope, traverse_scope, walk_in_scope
+from sqlglot.optimizer.scope import Scope, build_scope, find_in_scope, traverse_scope, walk_in_scope
 from sqlglot.optimizer.simplify import simplify_parens
 from sqlglot.schema import Schema, ensure_schema
 
@@ -358,7 +358,7 @@ def _expand_alias_refs(
             if alias_expr:
                 # An aggregate alias must not be expanded into a GROUP BY or another (non-window) aggregate.
                 skip_replace = bool(
-                    alias_expr.find(exp.AggFunc)
+                    find_in_scope(alias_expr, exp.AggFunc)
                     and (
                         is_group_by
                         or (

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -159,9 +159,9 @@ SELECT SUM(x.a) AS c FROM x JOIN y ON x.b = y.b GROUP BY UPPER(c);
 SELECT SUM(x.a) AS c FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY UPPER(y.c);
 
 # title: Aggregate in a subquery scope does not block expanding an alias into GROUP BY
-# execute: false
-SELECT (SELECT MAX(t.a) FROM x AS t) + x.b AS f FROM x GROUP BY f;
-SELECT (SELECT MAX(t.a) AS _col_0 FROM x AS t) + x.b AS f FROM x AS x GROUP BY (SELECT MAX(t.a) AS _col_0 FROM x AS t) + x.b;
+# dialect: duckdb
+WITH x AS (SELECT * FROM (VALUES (1, 10), (2, 10), (3, 20)) AS v(a, b)) SELECT (SELECT MAX(t.a) FROM x AS t) + x.b AS f FROM x GROUP BY f ORDER BY f;
+WITH x AS (SELECT v.a AS a, v.b AS b FROM (VALUES (1, 10), (2, 10), (3, 20)) AS v(a, b)) SELECT (SELECT MAX(t.a) AS _col_0 FROM x AS t) + x.b AS f FROM x AS x GROUP BY (SELECT MAX(t.a) AS _col_0 FROM x AS t) + x.b ORDER BY f;
 
 SELECT a + 1 AS d FROM x WHERE d > 1;
 SELECT x.a + 1 AS d FROM x AS x WHERE (x.a + 1) > 1;

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -141,6 +141,23 @@ SELECT SUM(x.a) AS c FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY y.c;
 SELECT COALESCE(x.a) AS d FROM x JOIN y ON x.b = y.b GROUP BY d;
 SELECT COALESCE(x.a) AS d FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY COALESCE(x.a);
 
+# title: Aggregate alias must not be expanded into a GROUP BY (would nest the aggregate)
+# execute: false
+# validate_qualify_columns: false
+SELECT SUM(x.a) AS d FROM x JOIN y ON x.b = y.b GROUP BY UPPER(d);
+SELECT SUM(x.a) AS d FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY UPPER(d);
+
+# title: Standalone aggregate alias reference in GROUP BY must not be expanded
+# execute: false
+# validate_qualify_columns: false
+SELECT SUM(x.a) AS d FROM x JOIN y ON x.b = y.b GROUP BY d;
+SELECT SUM(x.a) AS d FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY d;
+
+# title: Aggregate alias colliding with a base column resolves the GROUP BY ref to the column
+# execute: false
+SELECT SUM(x.a) AS c FROM x JOIN y ON x.b = y.b GROUP BY UPPER(c);
+SELECT SUM(x.a) AS c FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY UPPER(y.c);
+
 SELECT a + 1 AS d FROM x WHERE d > 1;
 SELECT x.a + 1 AS d FROM x AS x WHERE (x.a + 1) > 1;
 

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -158,6 +158,11 @@ SELECT SUM(x.a) AS d FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY d;
 SELECT SUM(x.a) AS c FROM x JOIN y ON x.b = y.b GROUP BY UPPER(c);
 SELECT SUM(x.a) AS c FROM x AS x JOIN y AS y ON x.b = y.b GROUP BY UPPER(y.c);
 
+# title: Aggregate in a subquery scope does not block expanding an alias into GROUP BY
+# execute: false
+SELECT (SELECT MAX(t.a) FROM x AS t) + x.b AS f FROM x GROUP BY f;
+SELECT (SELECT MAX(t.a) AS _col_0 FROM x AS t) + x.b AS f FROM x AS x GROUP BY (SELECT MAX(t.a) AS _col_0 FROM x AS t) + x.b;
+
 SELECT a + 1 AS d FROM x WHERE d > 1;
 SELECT x.a + 1 AS d FROM x AS x WHERE (x.a + 1) > 1;
 


### PR DESCRIPTION
`qualify_columns` can replace a `GROUP BY` reference with an aggregate alias's definition, nesting an aggregate inside `GROUP BY` which gives invalid SQL and is also non idempotent.  Fixed by ensuring aggregate alias is never expanded when `is_group_by`.

Sample input:
```
SELECT MAX(x) AS x FROM a AS a JOIN b AS b ON a.id = b.id GROUP BY UPPER(x)
```
Previous output:
```
SELECT MAX(x) AS x FROM a AS a JOIN b AS b ON a.id = b.id GROUP BY UPPER(MAX(x))
```
Note: `GROUP BY UPPER(x)` became `GROUP BY UPPER(MAX(x))` which is wrong.

Output after Patch:
```
SELECT MAX(x) AS x FROM a AS a JOIN b AS b ON a.id = b.id GROUP BY UPPER(x)
```