### PR TITLE
feat(optimizer)!: type annotation for databricks LEFT

### DIFF
--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -34,6 +34,7 @@ EXPRESSION_METADATA = {
             exp.BitwiseAndAgg,
             exp.BitwiseOrAgg,
             exp.BitwiseXorAgg,
+            exp.Left,
             exp.Overlay,
         }
     },


### PR DESCRIPTION
## Summary
Adds databricks type inference support for LEFT (VARCHAR).

## Tickets
RD-1229702 (LEFT) — annotated, 2 fixtures added

## Test plan
- [ ] make style — PASS
- [ ] make unit — PASS