### PR TITLE
fix(optimizer): preserve right join semantics in predicates pushdown

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -46,7 +46,7 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
         for scope in reversed(list(root.traverse())):
             select = scope.expression
             where: exp.Expr | None = select.args.get("where")
-            joins: list[exp.Expr] = select.args.get("joins") or []
+            joins: list[exp.Join] = select.args.get("joins") or []
             if where:
                 selected_sources: Sources = scope.selected_sources
                 join_index = {join.alias_or_name: i for i, join in enumerate(joins)}
@@ -71,6 +71,10 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
             # so we limit the selected sources to only itself
             for join in joins:
                 name = join.alias_or_name
+
+                if join.side in ("RIGHT", "FULL"):
+                    continue
+
                 if name in scope.selected_sources:
                     pushdown(
                         join.args.get("on"),
@@ -227,10 +231,20 @@ def nodes_for_predicate(
             node = source.expression
 
         if isinstance(node, exp.Join):
-            if node.side and node.side != "RIGHT":
-                return {}
-            nodes[table] = node
-        elif isinstance(node, exp.Select) and len(tables) == 1:
+            if node.side and (node.side != "RIGHT" or where_condition):
+                # A right join preserves its own source, so a WHERE predicate on it can only be
+                # pushed into that source, never into the match-only ON clause.
+                pushable_source = (
+                    source if node.side == "RIGHT" and not isinstance(source, exp.Table) else None
+                )
+                if not pushable_source:
+                    return {}
+
+                node = pushable_source.expression
+            else:
+                nodes[table] = node
+
+        if isinstance(node, exp.Select) and len(tables) == 1:
             # We can't push down window expressions
             has_window_expression = any(
                 select for select in node.selects if select.find(exp.Window)

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -231,7 +231,7 @@ def nodes_for_predicate(
             node = source.expression
 
         if isinstance(node, exp.Join):
-            if node.side and (node.side != "RIGHT" or where_condition):
+            if node.side:
                 # A right join preserves its own source, so a WHERE predicate on it can only be
                 # pushed into that source, never into the match-only ON clause.
                 pushable_source = (

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -91,3 +91,19 @@ SELECT s.a FROM (SELECT a, b FROM x ORDER BY a OFFSET 3) AS s WHERE s.b = 1;
 -- Predicate is not pushed into a subquery with QUALIFY: filtering before the window filter changes its results
 SELECT s.a FROM (SELECT a, b FROM x QUALIFY ROW_NUMBER() OVER (ORDER BY a) <= 10) AS s WHERE s.b = 1;
 SELECT s.a FROM (SELECT a, b FROM x QUALIFY ROW_NUMBER() OVER (ORDER BY a) <= 10) AS s WHERE s.b = 1;
+
+-- The RHS of a RIGHT JOIN is preserved, so a WHERE predicate on it can't become a match-only ON predicate
+SELECT x.a, y.b FROM x RIGHT JOIN y ON x.a = y.b WHERE y.b = 3;
+SELECT x.a, y.b FROM x RIGHT JOIN y ON x.a = y.b WHERE y.b = 3;
+
+-- A WHERE predicate on the preserved RHS of a RIGHT JOIN can still be pushed into an isolated source
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b WHERE y.b = 3;
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y WHERE b = 3) AS y ON x.a = y.b WHERE TRUE;
+
+-- A RIGHT JOIN preserves its own source, so an ON predicate can't be pushed into it as a filter
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+
+-- A FULL JOIN preserves its own source, so an ON predicate can't be pushed into it as a filter
+SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -107,3 +107,7 @@ SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 
 -- A FULL JOIN preserves its own source, so an ON predicate can't be pushed into it as a filter
 SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
 SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+
+-- A FULL JOIN preserves both sides, so a WHERE predicate on either of them can't be pushed down
+SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
+SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;


### PR DESCRIPTION
Fixes #7964

```
duckdb examples:

CREATE TABLE x(a INT); INSERT INTO x VALUES (1),(2),(3);
CREATE TABLE y(b INT); INSERT INTO y VALUES (1),(2),(99);

input 1:
SELECT x.a, y.b FROM x RIGHT JOIN y ON x.a = y.b WHERE y.b = 1;
>  [(1,1)]

main (output 1):
SELECT x.a, y.b FROM x RIGHT JOIN y ON x.a = y.b AND y.b = 1 WHERE TRUE;
> [(1,1), (NULL,2), (NULL,99)]

==================

input 2:
SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 1;
> [(1,1), (NULL,2), (NULL,99)]

main (output 2):
SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y WHERE b = 1) AS y ON x.a = y.b;
>  [(1,1)]

==================
input 3:
 SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
> [(1,NULL), (2,NULL), (3,NULL), (NULL,1), (NULL,2), (NULL,99)]

main (output 3):
SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y WHERE b = 3) AS y ON x.a = y.b;
>  [(1,NULL), (2,NULL), (3,NULL)]
```