### PR TITLE
fix(optimizer): preserve negated correlations [CODEX]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -265,6 +265,8 @@ ENV = {
     "MOD": null_if_any(lambda e, this: e % this),
     "MUL": null_if_any(lambda e, this: e * this),
     "NEQ": null_if_any(lambda this, e: this != e),
+    "NULLSAFEEQ": lambda this, e: this == e,
+    "NULLSAFENEQ": lambda this, e: this != e,
     "ORD": null_if_any(ord),
     "NOT": sql_not,
     "OR": sql_or,

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -12,6 +12,9 @@ NEGATED_COMPARISONS = {
     exp.LTE: exp.GT,
     exp.GT: exp.LTE,
     exp.GTE: exp.LT,
+    exp.Is: exp.NullSafeNEQ,
+    exp.NullSafeEQ: exp.NullSafeNEQ,
+    exp.NullSafeNEQ: exp.NullSafeEQ,
 }
 
 
@@ -176,13 +179,27 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
         if not predicate or predicate.find_ancestor(exp.Where) is not where:
             return
 
+        negations = []
+        negated_expression = predicate
         negation = predicate.find_ancestor(exp.Not)
-        if negation and negation.find_ancestor(exp.Where) is where:
-            comparison_type = NEGATED_COMPARISONS.get(type(predicate))
-            if not comparison_type or negation.this.unnest() is not predicate:
+        while negation and negation.find_ancestor(exp.Where) is where:
+            if negation.this.unnest() is not negated_expression:
                 return
 
-            predicate = negation.replace(
+            negations.append(negation)
+            negated_expression = negation
+            negation = negation.find_ancestor(exp.Not)
+
+        if negations:
+            comparison_type = (
+                type(predicate)
+                if len(negations) % 2 == 0
+                else NEGATED_COMPARISONS.get(type(predicate))
+            )
+            if not comparison_type:
+                return
+
+            predicate = negations[-1].replace(
                 comparison_type(this=predicate.this, expression=predicate.expression)
             )
             has_negated_correlation = True
@@ -198,6 +215,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
         keys.append((key, column, predicate))
 
+    # The no-equality-key path is sound because this branch handles a single correlation.
     if not has_negated_correlation and not any(
         isinstance(predicate, exp.EQ) for *_, predicate in keys
     ):

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -5,6 +5,16 @@ from sqlglot.optimizer.scope import ScopeType, find_in_scope, traverse_scope
 from sqlglot._typing import E
 
 
+NEGATED_COMPARISONS = {
+    exp.EQ: exp.NEQ,
+    exp.NEQ: exp.EQ,
+    exp.LT: exp.GTE,
+    exp.LTE: exp.GT,
+    exp.GT: exp.LTE,
+    exp.GTE: exp.LT,
+}
+
+
 def unnest_subqueries(expression: E) -> E:
     """
     Rewrite sqlglot AST to convert some predicates with subqueries into joins.
@@ -153,6 +163,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
     table_alias = next_alias_name()
     keys = []
+    has_negated_correlation = False
 
     # for all external columns in the where statement, find the relevant predicate
     # keys to convert it into a join
@@ -165,6 +176,17 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
         if not predicate or predicate.find_ancestor(exp.Where) is not where:
             return
 
+        negation = predicate.find_ancestor(exp.Not)
+        if negation and negation.find_ancestor(exp.Where) is where:
+            comparison_type = NEGATED_COMPARISONS.get(type(predicate))
+            if not comparison_type or negation.this.unnest() is not predicate:
+                return
+
+            predicate = negation.replace(
+                comparison_type(this=predicate.this, expression=predicate.expression)
+            )
+            has_negated_correlation = True
+
         if isinstance(predicate, exp.Binary):
             key = (
                 predicate.right
@@ -176,7 +198,9 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
         keys.append((key, column, predicate))
 
-    if not any(isinstance(predicate, exp.EQ) for *_, predicate in keys):
+    if not has_negated_correlation and not any(
+        isinstance(predicate, exp.EQ) for *_, predicate in keys
+    ):
         return
 
     is_subquery_projection = any(
@@ -305,9 +329,10 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
                 f"({parent_predicate} AND ARRAY_ANY({nested}, _x -> {predicate}))",
             )
 
+    join_predicates = [predicate for *_, predicate in keys if isinstance(predicate, exp.EQ)]
     parent_select.join(
         select.group_by(*group_by, copy=False),
-        on=[predicate for *_, predicate in keys if isinstance(predicate, exp.EQ)],
+        on=join_predicates or exp.true(),
         join_type="LEFT",
         join_alias=table_alias,
         copy=False,

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -215,10 +215,9 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
         keys.append((key, column, predicate))
 
-    # The no-equality-key path is sound because this branch handles a single correlation.
-    if not has_negated_correlation and not any(
-        isinstance(predicate, exp.EQ) for *_, predicate in keys
-    ):
+    # The no-equality-key path is only sound for a single correlated predicate.
+    has_equality_key = any(isinstance(predicate, exp.EQ) for *_, predicate in keys)
+    if not has_equality_key and (len(keys) != 1 or not has_negated_correlation):
         return
 
     is_subquery_projection = any(

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -191,17 +191,19 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
             negation = negation.find_ancestor(exp.Not)
 
         if negations:
-            comparison_type = (
-                type(predicate)
-                if len(negations) % 2 == 0
-                else NEGATED_COMPARISONS.get(type(predicate))
-            )
-            if not comparison_type:
-                return
+            if len(negations) % 2 == 0:
+                comparison = type(predicate)(**predicate.args)
+            elif isinstance(predicate, exp.Is) and predicate.args.get("negate"):
+                comparison = exp.Is(**predicate.args)
+                comparison.set("negate", False)
+            else:
+                comparison_type = NEGATED_COMPARISONS.get(type(predicate))
+                if not comparison_type:
+                    return
 
-            predicate = negations[-1].replace(
-                comparison_type(this=predicate.this, expression=predicate.expression)
-            )
+                comparison = comparison_type(this=predicate.this, expression=predicate.expression)
+
+            predicate = negations[-1].replace(comparison)
             has_negated_correlation = True
 
         if isinstance(predicate, exp.Binary):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -491,6 +491,57 @@ class TestExecutor(unittest.TestCase):
         )
         self.assertEqual(execute(negated_sql, tables={"x": [{"id": 1}], "y": []}).rows, [])
 
+        comparison_tables = {
+            "x": [{"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}],
+            "y": [{"id": 1}, {"id": 2}],
+        }
+        for comparison, expected in (
+            ("=", [(0,), (1,), (2,), (3,)]),
+            ("<>", [(1,), (2,)]),
+            ("<", [(0,), (1,), (2,)]),
+            ("<=", [(0,), (1,)]),
+            (">", [(1,), (2,), (3,)]),
+            (">=", [(2,), (3,)]),
+        ):
+            sql = (
+                "SELECT x.id FROM x AS x "
+                f"WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id {comparison} x.id))"
+            )
+            with self.subTest(comparison):
+                self.assertEqual(execute(sql, tables=comparison_tables).rows, expected)
+
+        null_safe_tables = {
+            "x": [{"id": 1}, {"id": 2}, {"id": None}],
+            "y": [{"id": 1}],
+        }
+        for predicate, expected in (
+            ("y.id IS NOT DISTINCT FROM x.id", [(2,), (None,)]),
+            ("y.id IS DISTINCT FROM x.id", [(1,)]),
+            ("x.id IS NULL", [(1,), (2,)]),
+            ("x.id IS NOT NULL", [(None,)]),
+        ):
+            sql = (
+                "SELECT x.id FROM x AS x "
+                f"WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT ({predicate}))"
+            )
+            with self.subTest(predicate):
+                self.assertEqual(execute(sql, tables=null_safe_tables).rows, expected)
+
+        null_only_tables = {
+            "x": [{"id": 1}, {"id": None}],
+            "y": [{"id": None}],
+        }
+        for predicate, expected in (
+            ("y.id IS NOT DISTINCT FROM x.id", [(1,)]),
+            ("y.id IS DISTINCT FROM x.id", [(None,)]),
+        ):
+            sql = (
+                "SELECT x.id FROM x AS x "
+                f"WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT ({predicate}))"
+            )
+            with self.subTest(predicate):
+                self.assertEqual(execute(sql, tables=null_only_tables).rows, expected)
+
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -448,6 +448,49 @@ class TestExecutor(unittest.TestCase):
             [(1, 2), (1, 3), (2, 3)],
         )
 
+    def test_correlated_exists_with_negated_comparison(self):
+        tables = {
+            "x": [{"id": 1}, {"id": 2}, {"id": 3}],
+            "y": [{"id": 1}, {"id": 2}],
+        }
+
+        for sql, expected in (
+            (
+                "SELECT x.id FROM x AS x "
+                "WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))",
+                [(1,), (2,), (3,)],
+            ),
+            (
+                "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE y.id = x.id)",
+                [(1,), (2,)],
+            ),
+            (
+                "SELECT x.id FROM x AS x "
+                "WHERE NOT EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))",
+                [],
+            ),
+            (
+                "SELECT x.id FROM x AS x WHERE NOT EXISTS (SELECT 1 FROM y AS y WHERE y.id = x.id)",
+                [(3,)],
+            ),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables).rows, expected)
+
+        negated_sql = (
+            "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))"
+        )
+        nullable_tables = {
+            "x": [{"id": 1}, {"id": None}],
+            "y": [{"id": 1}, {"id": None}, {"id": 2}],
+        }
+        self.assertEqual(execute(negated_sql, tables=nullable_tables).rows, [(1,)])
+        self.assertEqual(
+            execute(negated_sql, tables={"x": [{"id": 1}], "y": [{"id": None}]}).rows,
+            [],
+        )
+        self.assertEqual(execute(negated_sql, tables={"x": [{"id": 1}], "y": []}).rows, [])
+
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1189,18 +1189,59 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         self.check_file("unnest_subqueries", optimizer.unnest_subqueries.unnest_subqueries)
 
     def test_unnest_subqueries_preserves_negated_correlations(self):
-        sql = "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))"
+        for comparison, complement in (
+            ("=", "<>"),
+            (">", "<="),
+            ("IS NOT DISTINCT FROM", "IS DISTINCT FROM"),
+            ("IS DISTINCT FROM", "IS NOT DISTINCT FROM"),
+        ):
+            sql = (
+                "SELECT x.id FROM x AS x "
+                f"WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id {comparison} x.id))"
+            )
 
+            optimized = optimizer.unnest_subqueries.unnest_subqueries(parse_one(sql))
+
+            with self.subTest(comparison):
+                self.assertEqual(
+                    optimized.sql(),
+                    "SELECT x.id FROM x AS x "
+                    "LEFT JOIN (SELECT ARRAY_AGG(y.id) AS _u_1 FROM y AS y WHERE TRUE) "
+                    "AS _u_0 ON TRUE "
+                    "WHERE (NOT _u_0._u_1 IS NULL "
+                    f"AND ARRAY_ANY(_u_0._u_1, _x -> _x {complement} x.id))",
+                )
+
+        sql = "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id <> x.id))"
         optimized = optimizer.unnest_subqueries.unnest_subqueries(parse_one(sql))
-
         self.assertEqual(
             optimized.sql(),
             "SELECT x.id FROM x AS x "
-            "LEFT JOIN (SELECT ARRAY_AGG(y.id) AS _u_1 FROM y AS y WHERE TRUE) "
-            "AS _u_0 ON TRUE "
-            "WHERE (NOT _u_0._u_1 IS NULL "
-            "AND ARRAY_ANY(_u_0._u_1, _x -> _x <> x.id))",
+            "LEFT JOIN (SELECT y.id AS _u_1 FROM y AS y WHERE TRUE GROUP BY y.id) "
+            "AS _u_0 ON _u_0._u_1 = x.id "
+            "WHERE NOT _u_0._u_1 IS NULL",
         )
+
+        for comparison, complement in (
+            ("IS NULL", "IS DISTINCT FROM"),
+            ("IS NOT NULL", "IS"),
+        ):
+            sql = (
+                "SELECT x.id FROM x AS x "
+                f"WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (x.id {comparison}))"
+            )
+
+            optimized = optimizer.unnest_subqueries.unnest_subqueries(parse_one(sql))
+
+            with self.subTest(comparison):
+                self.assertEqual(
+                    optimized.sql(),
+                    "SELECT x.id FROM x AS x "
+                    "LEFT JOIN (SELECT ARRAY_AGG(NULL) AS _u_1 FROM y AS y WHERE TRUE) "
+                    "AS _u_0 ON TRUE "
+                    "WHERE (NOT _u_0._u_1 IS NULL "
+                    f"AND ARRAY_ANY(_u_0._u_1, _x -> x.id {complement} _x))",
+                )
 
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1243,6 +1243,22 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                     f"AND ARRAY_ANY(_u_0._u_1, _x -> x.id {complement} _x))",
                 )
 
+        sql = (
+            "SELECT x.id FROM x AS x "
+            "WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (x.id IS NOT NULL))"
+        )
+        optimized = optimizer.unnest_subqueries.unnest_subqueries(
+            parse_one(sql, dialect="postgres")
+        )
+        self.assertEqual(
+            optimized.sql(),
+            "SELECT x.id FROM x AS x "
+            "LEFT JOIN (SELECT ARRAY_AGG(NULL) AS _u_1 FROM y AS y WHERE TRUE) "
+            "AS _u_0 ON TRUE "
+            "WHERE (NOT _u_0._u_1 IS NULL "
+            "AND ARRAY_ANY(_u_0._u_1, _x -> x.id IS _x))",
+        )
+
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1188,6 +1188,20 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
     def test_unnest_subqueries(self):
         self.check_file("unnest_subqueries", optimizer.unnest_subqueries.unnest_subqueries)
 
+    def test_unnest_subqueries_preserves_negated_correlations(self):
+        sql = "SELECT x.id FROM x AS x WHERE EXISTS (SELECT 1 FROM y AS y WHERE NOT (y.id = x.id))"
+
+        optimized = optimizer.unnest_subqueries.unnest_subqueries(parse_one(sql))
+
+        self.assertEqual(
+            optimized.sql(),
+            "SELECT x.id FROM x AS x "
+            "LEFT JOIN (SELECT ARRAY_AGG(y.id) AS _u_1 FROM y AS y WHERE TRUE) "
+            "AS _u_0 ON TRUE "
+            "WHERE (NOT _u_0._u_1 IS NULL "
+            "AND ARRAY_ANY(_u_0._u_1, _x -> _x <> x.id))",
+        )
+
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1259,6 +1259,15 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             "AND ARRAY_ANY(_u_0._u_1, _x -> x.id IS _x))",
         )
 
+        sql = (
+            "SELECT x.a, x.b FROM x AS x "
+            "WHERE EXISTS (SELECT 1 FROM y AS y "
+            "WHERE NOT (y.a > x.a) AND NOT (y.b > x.b))"
+        )
+        optimized = optimizer.unnest_subqueries.unnest_subqueries(parse_one(sql))
+        self.assertIsNotNone(optimized.find(exp.Exists))
+        self.assertIsNone(optimized.find(exp.Join))
+
     def test_pushdown_predicates(self):
         self.check_file("pushdown_predicates", optimizer.pushdown_predicates.pushdown_predicates)
 


### PR DESCRIPTION
Closes #7958.

Supersedes #7959 and addresses the owner feedback from that review.

A direct `NOT` around a correlated comparison was lost during decorrelation because the inner comparison was replaced with `TRUE`. This change normalizes direct negated comparisons to their exact complement, aggregates the inner key when no positive equality join key exists, and evaluates the preserved predicate with `ARRAY_ANY` after a `LEFT JOIN ... ON TRUE`.

The resubmission also:
- locks all six equality and ordering complements with executor coverage, including `>` and `<>`;
- supports `IS NULL`, `IS NOT NULL`, `IS [NOT] DISTINCT FROM`, and their three-valued-logic edge cases;
- documents the single-correlation invariant for the no-equality-key path; and
- adds Python executor support for the existing null-safe comparison expressions.

Validation:
- full executor suite plus focused optimizer regressions: 28 passed
- DuckDB differential check: 12 negated-correlation cases passed
- Ruff check and format: passed
- mypy: 181 source files passed
- `git diff --check`: passed

LLM disclosure: I used OpenAI Codex to assist with analysis, implementation, and test drafting. I reviewed the final diff and validated the behavior and tests.