### PR TITLE
fix(optimizer): preserve UNNEST struct-field columns

### DIFF
--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp
-from sqlglot.helper import name_sequence
+from sqlglot.helper import name_sequence, seq_get
 from sqlglot.optimizer.scope import Scope, find_all_in_scope, traverse_scope
 
 if t.TYPE_CHECKING:
@@ -147,6 +147,15 @@ def canonicalize_internal_names(expression: E) -> E:
 
             table_map[source_name] = (canon_t, ref_alias)
 
+            preserve_names = is_base_source
+
+            # preserve UNNEST struct fields (which canonicalize can't rewrite)
+            src = source.expression
+            if isinstance(src, exp.Unnest) and (
+                element_type := seq_get(src.expressions[0].type.expressions, 0)
+            ):
+                preserve_names = preserve_names or element_type.is_type(exp.DataType.Type.STRUCT)
+
             for src_col in source_cols:
                 # BigQuery whole-row struct ref (`SELECT t FROM t`): the identifier
                 # IS the table alias, so rename it to this reference's alias.
@@ -158,17 +167,17 @@ def canonicalize_internal_names(expression: E) -> E:
                 canon_col = name_map.get(old_name)
 
                 if canon_col is None:
-                    if is_base_source:
+                    if preserve_names:
                         canon_col = old_name
                     else:
                         canon_col = child_output.get(old_name) or next_column()
 
                     name_map[old_name] = canon_col
 
-                # Base-table column refs are part of the data contract => preserve verbatim (including quote state).
-                # Scope-sourced column refs are internal handles pointing at CTE/subquery aliases (injected unquoted
-                # via exp.to_identifier); they must match, so _canon
-                if not is_base_source:
+                # Base-table and UNNEST struct-field column refs name physical columns => preserve
+                # verbatim (including quote state). Scope-sourced refs are internal handles pointing
+                # at CTE/subquery aliases (injected unquoted via exp.to_identifier), so _canon them.
+                if not preserve_names:
                     _canon(src_col.this, canon_col)
 
                 table_id = src_col.args.get("table")

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -151,8 +151,11 @@ def canonicalize_internal_names(expression: E) -> E:
 
             # preserve UNNEST struct fields (which canonicalize can't rewrite)
             src = source.expression
-            if isinstance(src, exp.Unnest) and (
-                element_type := seq_get(src.expressions[0].type.expressions, 0)
+            if (
+                isinstance(src, exp.Unnest)
+                and src.expressions
+                and src.expressions[0].type
+                and (element_type := seq_get(src.expressions[0].type.expressions, 0))
             ):
                 preserve_names = preserve_names or element_type.is_type(exp.DataType.Type.STRUCT)
 

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -147,8 +147,6 @@ def canonicalize_internal_names(expression: E) -> E:
 
             table_map[source_name] = (canon_t, ref_alias)
 
-            preserve_names = is_base_source
-
             # UNNEST struct fields are physical columns (preserve); the element alias is not
             struct_field_names: set[str] = set()
             src = source.expression
@@ -169,7 +167,7 @@ def canonicalize_internal_names(expression: E) -> E:
                     continue
 
                 old_name = src_col.name
-                preserve_col = preserve_names or old_name in struct_field_names
+                preserve_col = is_base_source or old_name in struct_field_names
                 canon_col = name_map.get(old_name)
 
                 if canon_col is None:

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -149,15 +149,17 @@ def canonicalize_internal_names(expression: E) -> E:
 
             preserve_names = is_base_source
 
-            # preserve UNNEST struct fields (which canonicalize can't rewrite)
+            # UNNEST struct fields are physical columns (preserve); the element alias is not
+            struct_field_names: set[str] = set()
             src = source.expression
             if (
                 isinstance(src, exp.Unnest)
                 and src.expressions
                 and src.expressions[0].type
                 and (element_type := seq_get(src.expressions[0].type.expressions, 0))
+                and element_type.is_type(exp.DataType.Type.STRUCT)
             ):
-                preserve_names = preserve_names or element_type.is_type(exp.DataType.Type.STRUCT)
+                struct_field_names = {cd.name for cd in element_type.expressions}
 
             for src_col in source_cols:
                 # BigQuery whole-row struct ref (`SELECT t FROM t`): the identifier
@@ -167,10 +169,11 @@ def canonicalize_internal_names(expression: E) -> E:
                     continue
 
                 old_name = src_col.name
+                preserve_col = preserve_names or old_name in struct_field_names
                 canon_col = name_map.get(old_name)
 
                 if canon_col is None:
-                    if preserve_names:
+                    if preserve_col:
                         canon_col = old_name
                     else:
                         canon_col = child_output.get(old_name) or next_column()
@@ -180,7 +183,7 @@ def canonicalize_internal_names(expression: E) -> E:
                 # Base-table and UNNEST struct-field column refs name physical columns => preserve
                 # verbatim (including quote state). Scope-sourced refs are internal handles pointing
                 # at CTE/subquery aliases (injected unquoted via exp.to_identifier), so _canon them.
-                if not preserve_names:
+                if not preserve_col:
                     _canon(src_col.this, canon_col)
 
                 table_id = src_col.args.get("table")

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -229,13 +229,13 @@ SELECT `_t0`.`id` AS `id`, `_c0` AS `u` FROM `c`.`db`.`t` AS `_t0` CROSS JOIN UN
 
 # title: bigquery unnest of a struct array literal preserves field names (physical columns, not internal handles)
 # dialect: bigquery
-SELECT su.k, p.sid FROM su JOIN (SELECT sid FROM UNNEST([STRUCT('a' AS sid), STRUCT('b')])) AS p ON su.k = p.sid;
-SELECT `_t1`.`k` AS `k`, `_t2`.`_c0` AS `sid` FROM `c`.`db`.`su` AS `_t1` JOIN (SELECT `sid` AS `_c0` FROM UNNEST([STRUCT('a' AS `sid`), STRUCT('b')])) AS `_t2` ON `_t1`.`k` = `_t2`.`_c0`;
+SELECT x.a, p.sid FROM x JOIN (SELECT sid FROM UNNEST([STRUCT('a' AS sid), STRUCT('b')])) AS p ON x.a = p.sid;
+SELECT `_t1`.`a` AS `a`, `_t2`.`_c0` AS `sid` FROM `c`.`db`.`x` AS `_t1` JOIN (SELECT `sid` AS `_c0` FROM UNNEST([STRUCT('a' AS `sid`), STRUCT('b')])) AS `_t2` ON `_t1`.`a` = `_t2`.`_c0`;
 
-# title: bigquery unnest of a schema-typed ARRAY<STRUCT> column preserves field names too
+# title: bigquery unnest of an ARRAY<STRUCT> column preserves field names too
 # dialect: bigquery
-SELECT su.k, v.f FROM su CROSS JOIN UNNEST(su.sarr) AS v;
-SELECT `_t0`.`k` AS `k`, `v`.`f` AS `f` FROM `c`.`db`.`su` AS `_t0` CROSS JOIN UNNEST(`_t0`.`sarr`) AS `v`;
+WITH cte AS (SELECT [STRUCT('a' AS sid)] AS arr) SELECT v.sid FROM cte, UNNEST(cte.arr) AS v;
+WITH `_t0` AS (SELECT [STRUCT('a' AS `sid`)] AS `_c0`) SELECT `v`.`sid` AS `sid` FROM `_t0` AS `_t0` CROSS JOIN UNNEST(`_t0`.`_c0`) AS `v`;
 
 # title: bigquery whole-row struct selection — TableColumn follows the table's canonical name, output alias preserves the row-struct's contract name
 # dialect: bigquery

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -227,6 +227,16 @@ SELECT `_c0` AS `n`, `_c1` AS `off` FROM UNNEST([10, 20, 30]) AS `_c0` WITH OFFS
 SELECT t.id, u FROM t CROSS JOIN UNNEST(t.arr) AS u;
 SELECT `_t0`.`id` AS `id`, `_c0` AS `u` FROM `c`.`db`.`t` AS `_t0` CROSS JOIN UNNEST(`_t0`.`arr`) AS `_c0`;
 
+# title: bigquery unnest of a struct array literal preserves field names (physical columns, not internal handles)
+# dialect: bigquery
+SELECT su.k, p.sid FROM su JOIN (SELECT sid FROM UNNEST([STRUCT('a' AS sid), STRUCT('b')])) AS p ON su.k = p.sid;
+SELECT `_t1`.`k` AS `k`, `_t2`.`_c0` AS `sid` FROM `c`.`db`.`su` AS `_t1` JOIN (SELECT `sid` AS `_c0` FROM UNNEST([STRUCT('a' AS `sid`), STRUCT('b')])) AS `_t2` ON `_t1`.`k` = `_t2`.`_c0`;
+
+# title: bigquery unnest of a schema-typed ARRAY<STRUCT> column preserves field names too
+# dialect: bigquery
+SELECT su.k, v.f FROM su CROSS JOIN UNNEST(su.sarr) AS v;
+SELECT `_t0`.`k` AS `k`, `v`.`f` AS `f` FROM `c`.`db`.`su` AS `_t0` CROSS JOIN UNNEST(`_t0`.`sarr`) AS `v`;
+
 # title: bigquery whole-row struct selection — TableColumn follows the table's canonical name, output alias preserves the row-struct's contract name
 # dialect: bigquery
 SELECT t FROM t;

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -232,10 +232,20 @@ SELECT `_t0`.`id` AS `id`, `_c0` AS `u` FROM `c`.`db`.`t` AS `_t0` CROSS JOIN UN
 SELECT x.a, p.sid FROM x JOIN (SELECT sid FROM UNNEST([STRUCT('a' AS sid), STRUCT('b')])) AS p ON x.a = p.sid;
 SELECT `_t1`.`a` AS `a`, `_t2`.`_c0` AS `sid` FROM `c`.`db`.`x` AS `_t1` JOIN (SELECT `sid` AS `_c0` FROM UNNEST([STRUCT('a' AS `sid`), STRUCT('b')])) AS `_t2` ON `_t1`.`a` = `_t2`.`_c0`;
 
-# title: bigquery unnest of an ARRAY<STRUCT> column preserves field names too
+# title: bigquery unnest of an ARRAY<STRUCT> column preserves field names but canonicalizes the element alias
 # dialect: bigquery
 WITH cte AS (SELECT [STRUCT('a' AS sid)] AS arr) SELECT v.sid FROM cte, UNNEST(cte.arr) AS v;
-WITH `_t0` AS (SELECT [STRUCT('a' AS `sid`)] AS `_c0`) SELECT `v`.`sid` AS `sid` FROM `_t0` AS `_t0` CROSS JOIN UNNEST(`_t0`.`_c0`) AS `v`;
+WITH `_t0` AS (SELECT [STRUCT('a' AS `sid`)] AS `_c0`) SELECT `_c1`.`sid` AS `sid` FROM `_t0` AS `_t0` CROSS JOIN UNNEST(`_t0`.`_c0`) AS `_c1`;
+
+# title: bigquery unnest element alias is an internal handle, so equivalent queries share one canonical form
+# dialect: bigquery
+SELECT s.sid FROM UNNEST([STRUCT('a' AS sid)]) AS s;
+SELECT `_c0`.`sid` AS `sid` FROM UNNEST([STRUCT('a' AS `sid`)]) AS `_c0`;
+
+# title: bigquery unnest element alias doubling as a top-level output column
+# dialect: bigquery
+SELECT s FROM UNNEST([STRUCT('a' AS sid)]) AS s;
+SELECT `_c0` AS `s` FROM UNNEST([STRUCT('a' AS `sid`)]) AS `_c0`;
 
 # title: bigquery whole-row struct selection — TableColumn follows the table's canonical name, output alias preserves the row-struct's contract name
 # dialect: bigquery

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1549,9 +1549,8 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         self.assertEqual(len(set(outer_table_aliases)), 3, outer_table_aliases)
         self.assertEqual(len(canon_triple_scope.selected_sources), 3)
 
-        # UNNEST whose element type is unresolved after qualify (DuckDB leaves the arg
-        # untyped) must not crash: the struct-preservation heuristic reads the element
-        # type and has to tolerate a missing one.
+        # test UNNEST whose element type is unresolved after qualify must not crash:
+        # the heuristic reads the element type and has to tolerate a missing one.
         canon_unnest = qualify_then_canonicalize(
             parse_one("SELECT v FROM t, UNNEST(t.arr) AS v(v)", dialect="duckdb"),
             schema={"t": {"arr": "ARRAY<INT>"}},

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1549,6 +1549,19 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         self.assertEqual(len(set(outer_table_aliases)), 3, outer_table_aliases)
         self.assertEqual(len(canon_triple_scope.selected_sources), 3)
 
+        # UNNEST whose element type is unresolved after qualify (DuckDB leaves the arg
+        # untyped) must not crash: the struct-preservation heuristic reads the element
+        # type and has to tolerate a missing one.
+        canon_unnest = qualify_then_canonicalize(
+            parse_one("SELECT v FROM t, UNNEST(t.arr) AS v(v)", dialect="duckdb"),
+            schema={"t": {"arr": "ARRAY<INT>"}},
+            dialect="duckdb",
+        )
+        self.assertEqual(
+            canon_unnest.sql(dialect="duckdb"),
+            'SELECT "_t1"."_c0" AS "v" FROM "_t0" AS "_t0" JOIN UNNEST("_t0"."arr") AS "_t1"("_c0") ON TRUE',
+        )
+
     def test_canonicalize(self):
         optimize = partial(
             optimizer.optimize,


### PR DESCRIPTION
`canonicalize_internal_names` was producing invalid SQL for struct field columns of an `UNNEST`.  An UNNEST of structs exposes struct field names as physical columns, but the rule was treating them as internal handles.

Sample Input
```
SELECT t.id FROM t
JOIN (SELECT sid FROM UNNEST([STRUCT('x' AS sid), STRUCT('y')])) AS q
  ON q.sid = t.id;
```

Previous Output, invalid SQL: references non existent `_c0`
```
SELECT `_t1`.`id` AS `id` FROM `_t1` AS `_t1`
JOIN (SELECT `_c0` AS `_c0` FROM UNNEST([STRUCT('x' AS `sid`), STRUCT('y')])) AS `_t2` ON `_t2`.`_c0` = `_t1`.`id`;
```

Fixed Output: field name `sid` preserved
```
SELECT `_t1`.`id` AS `id` FROM `_t1` AS `_t1` 
JOIN (SELECT `sid` AS `_c0` FROM UNNEST([STRUCT('x' AS `sid`), STRUCT('y')])) AS `_t2` ON `_t2`.`_c0` = `_t1`.`id`;
```
Fix

In canonicalize_internal_names, added a `preserve_names` flag that treats an UNNEST + structs field column as physical.  This is the same way `is_base_source` columns are already preserved.  Scalar UNNEST element aliases are renameable definitions, so they still canonicalize like previously.

Behavior

| source                         | column          | result       |
| ------------------------------ | --------------- | ------------ |
| UNNEST of struct (literal)     | struct field    | preserved    |
| UNNEST of ARRAY<STRUCT> column | struct field    | preserved    |
| scalar UNNEST / WITH OFFSET    | element alias   | `_cN`        |
| correlated scalar UNNEST       | element alias   | `_cN`        |