### PR TITLE
fix(postgres): transpile DAY/MONTH/YEAR to EXTRACT [CLAUDE]

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1958,6 +1958,23 @@ def ts_or_ds_add_cast(expression: exp.TsOrDsAdd) -> exp.TsOrDsAdd:
     return expression
 
 
+def remove_ts_or_ds_to_date(
+    to_sql: t.Callable[[Generator, exp.Expr], str] | None = None,
+    args: tuple[str, ...] = ("this",),
+) -> t.Callable[[Generator, exp.Func], str]:
+    def func(self: Generator, expression: exp.Func) -> str:
+        for arg_key in args:
+            arg = expression.args.get(arg_key)
+            if isinstance(arg, (exp.TsOrDsToDate, exp.TsOrDsToTimestamp)) and not arg.args.get(
+                "format"
+            ):
+                expression.set(arg_key, arg.this)
+
+        return to_sql(self, expression) if to_sql else self.function_fallback_sql(expression)
+
+    return func
+
+
 def date_delta_sql(name: str, cast: bool = False) -> t.Callable[[Generator, DATE_ADD_OR_DIFF], str]:
     def _delta_sql(self: Generator, expression: DATE_ADD_OR_DIFF) -> str:
         if cast and isinstance(expression, exp.TsOrDsAdd):

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
     no_pivot_sql,
     no_tablesample_sql,
     no_trycast_sql,
+    remove_ts_or_ds_to_date,
     rename_func,
     strposition_sql,
     unit_to_var,
@@ -102,23 +103,6 @@ def _ts_or_ds_to_date_sql(self: MySQLGenerator, expression: exp.TsOrDsToDate) ->
     return _str_to_date_sql(self, expression) if time_format else self.func("DATE", expression.this)
 
 
-def _remove_ts_or_ds_to_date(
-    to_sql: t.Callable[[generator.Generator, exp.Expr], str] | None = None,
-    args: tuple[str, ...] = ("this",),
-) -> t.Callable[[generator.Generator, exp.Func], str]:
-    def func(self: generator.Generator, expression: exp.Func) -> str:
-        for arg_key in args:
-            arg = expression.args.get(arg_key)
-            if isinstance(arg, (exp.TsOrDsToDate, exp.TsOrDsToTimestamp)) and not arg.args.get(
-                "format"
-            ):
-                expression.set(arg_key, arg.this)
-
-        return to_sql(self, expression) if to_sql else self.function_fallback_sql(expression)
-
-    return func
-
-
 class MySQLGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     TRY_SUPPORTED = False
@@ -160,17 +144,17 @@ class MySQLGenerator(generator.Generator):
         exp.Chr: lambda self, e: self.chr_sql(e, "CHAR"),
         exp.CurrentDate: no_paren_current_date_sql,
         exp.CurrentVersion: rename_func("VERSION"),
-        exp.DateDiff: _remove_ts_or_ds_to_date(
+        exp.DateDiff: remove_ts_or_ds_to_date(
             lambda self, e: self.func("DATEDIFF", e.this, e.expression), ("this", "expression")
         ),
-        exp.DateAdd: _remove_ts_or_ds_to_date(date_add_sql("ADD")),
+        exp.DateAdd: remove_ts_or_ds_to_date(date_add_sql("ADD")),
         exp.DateStrToDate: datestrtodate_sql,
-        exp.DateSub: _remove_ts_or_ds_to_date(date_add_sql("SUB")),
+        exp.DateSub: remove_ts_or_ds_to_date(date_add_sql("SUB")),
         exp.DateTrunc: _date_trunc_sql,
-        exp.Day: _remove_ts_or_ds_to_date(),
-        exp.DayOfMonth: _remove_ts_or_ds_to_date(rename_func("DAYOFMONTH")),
-        exp.DayOfWeek: _remove_ts_or_ds_to_date(rename_func("DAYOFWEEK")),
-        exp.DayOfYear: _remove_ts_or_ds_to_date(rename_func("DAYOFYEAR")),
+        exp.Day: remove_ts_or_ds_to_date(),
+        exp.DayOfMonth: remove_ts_or_ds_to_date(rename_func("DAYOFMONTH")),
+        exp.DayOfWeek: remove_ts_or_ds_to_date(rename_func("DAYOFWEEK")),
+        exp.DayOfYear: remove_ts_or_ds_to_date(rename_func("DAYOFYEAR")),
         exp.GroupConcat: lambda self, e: (
             f"""GROUP_CONCAT({self.sql(e, "this")} SEPARATOR {self.sql(e, "separator") or "','"})"""
         ),
@@ -181,7 +165,7 @@ class MySQLGenerator(generator.Generator):
         exp.LogicalAnd: rename_func("MIN"),
         exp.Max: max_or_greatest,
         exp.Min: min_or_least,
-        exp.Month: _remove_ts_or_ds_to_date(),
+        exp.Month: remove_ts_or_ds_to_date(),
         exp.NullSafeEQ: lambda self, e: self.binary(e, "<=>"),
         exp.NullSafeNEQ: lambda self, e: f"NOT {self.binary(e, '<=>')}",
         exp.NumberToStr: rename_func("FORMAT"),
@@ -215,7 +199,7 @@ class MySQLGenerator(generator.Generator):
             e,
             include_precision=not e.args.get("zone"),
         ),
-        exp.TimeToStr: _remove_ts_or_ds_to_date(
+        exp.TimeToStr: remove_ts_or_ds_to_date(
             lambda self, e: self.func("DATE_FORMAT", e.this, self.format_time(e))
         ),
         exp.Trim: trim_sql,
@@ -226,9 +210,9 @@ class MySQLGenerator(generator.Generator):
         exp.TsOrDsToDate: _ts_or_ds_to_date_sql,
         exp.Unicode: lambda self, e: f"ORD(CONVERT({self.sql(e.this)} USING utf32))",
         exp.UnixToTime: _unix_to_time_sql,
-        exp.Week: _remove_ts_or_ds_to_date(),
-        exp.WeekOfYear: _remove_ts_or_ds_to_date(rename_func("WEEKOFYEAR")),
-        exp.Year: _remove_ts_or_ds_to_date(),
+        exp.Week: remove_ts_or_ds_to_date(),
+        exp.WeekOfYear: remove_ts_or_ds_to_date(rename_func("WEEKOFYEAR")),
+        exp.Year: remove_ts_or_ds_to_date(),
         exp.UtcTimestamp: rename_func("UTC_TIMESTAMP"),
         exp.UtcTime: rename_func("UTC_TIME"),
     }

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -103,10 +103,10 @@ def _ts_or_ds_to_date_sql(self: MySQLGenerator, expression: exp.TsOrDsToDate) ->
 
 
 def _remove_ts_or_ds_to_date(
-    to_sql: t.Callable[[MySQLGenerator, exp.Expr], str] | None = None,
+    to_sql: t.Callable[[generator.Generator, exp.Expr], str] | None = None,
     args: tuple[str, ...] = ("this",),
-) -> t.Callable[[MySQLGenerator, exp.Func], str]:
-    def func(self: MySQLGenerator, expression: exp.Func) -> str:
+) -> t.Callable[[generator.Generator, exp.Func], str]:
+    def func(self: generator.Generator, expression: exp.Func) -> str:
         for arg_key in args:
             arg = expression.args.get(arg_key)
             if isinstance(arg, (exp.TsOrDsToDate, exp.TsOrDsToTimestamp)) and not arg.args.get(

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -77,6 +77,13 @@ def _date_add_sql(kind: str) -> t.Callable[[PostgresGenerator, DATE_ADD_OR_SUB],
     return func
 
 
+def _extract_sql(part: str) -> t.Callable[[PostgresGenerator, exp.Func], str]:
+    def func(self: PostgresGenerator, expression: exp.Func) -> str:
+        return self.sql(exp.Extract(this=exp.var(part), expression=expression.this))
+
+    return func
+
+
 def _date_diff_sql(self: PostgresGenerator, expression: exp.DateDiff | exp.TsOrDsDiff) -> str:
     unit = expression.text("unit").upper()
     factor = DATE_DIFF_FACTOR.get(unit)
@@ -306,6 +313,9 @@ class PostgresGenerator(generator.Generator):
         exp.DateDiff: _date_diff_sql,
         exp.DateStrToDate: datestrtodate_sql,
         exp.DateSub: _date_add_sql("-"),
+        exp.Day: _extract_sql("DAY"),
+        exp.Month: _extract_sql("MONTH"),
+        exp.Year: _extract_sql("YEAR"),
         exp.Explode: rename_func("UNNEST"),
         exp.ExplodingGenerateSeries: rename_func("GENERATE_SERIES"),
         exp.GenerateSeries: generate_series_sql("GENERATE_SERIES"),

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -79,7 +79,13 @@ def _date_add_sql(kind: str) -> t.Callable[[PostgresGenerator, DATE_ADD_OR_SUB],
 
 def _extract_sql(part: str) -> t.Callable[[PostgresGenerator, exp.Func], str]:
     def func(self: PostgresGenerator, expression: exp.Func) -> str:
-        return self.sql(exp.Extract(this=exp.var(part), expression=expression.this))
+        this = expression.this
+        if this.is_type(*exp.DataType.INTEGER_TYPES):
+            self.unsupported(f"Cannot transpile {part} of an integer value to Postgres")
+        if not this.is_type(exp.DType.DATE):
+            this = exp.cast(this, exp.DType.DATE)
+
+        return self.sql(exp.Extract(this=exp.var(part), expression=this))
 
     return func
 

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -77,17 +77,15 @@ def _date_add_sql(kind: str) -> t.Callable[[PostgresGenerator, DATE_ADD_OR_SUB],
     return func
 
 
-def _extract_sql(part: str) -> t.Callable[[PostgresGenerator, exp.Func], str]:
-    def func(self: PostgresGenerator, expression: exp.Func) -> str:
-        this = expression.this
-        if this.is_type(*exp.DataType.INTEGER_TYPES):
-            self.unsupported(f"Cannot transpile {part} of an integer value to Postgres")
-        if not this.is_type(exp.DType.DATE):
-            this = exp.cast(this, exp.DType.DATE)
+def _day_month_year_sql(self: PostgresGenerator, expression: exp.Day | exp.Month | exp.Year) -> str:
+    this = expression.this
+    value = this.this if isinstance(this, exp.TsOrDsToDate) else this
+    if value.is_type(*exp.DataType.INTEGER_TYPES):
+        self.unsupported(
+            f"Cannot transpile {expression.sql_name()} of an integer value to Postgres"
+        )
 
-        return self.sql(exp.Extract(this=exp.var(part), expression=this))
-
-    return func
+    return self.sql(exp.Extract(this=exp.var(expression.sql_name()), expression=this))
 
 
 def _date_diff_sql(self: PostgresGenerator, expression: exp.DateDiff | exp.TsOrDsDiff) -> str:
@@ -319,9 +317,9 @@ class PostgresGenerator(generator.Generator):
         exp.DateDiff: _date_diff_sql,
         exp.DateStrToDate: datestrtodate_sql,
         exp.DateSub: _date_add_sql("-"),
-        exp.Day: _extract_sql("DAY"),
-        exp.Month: _extract_sql("MONTH"),
-        exp.Year: _extract_sql("YEAR"),
+        exp.Day: _day_month_year_sql,
+        exp.Month: _day_month_year_sql,
+        exp.Year: _day_month_year_sql,
         exp.Explode: rename_func("UNNEST"),
         exp.ExplodingGenerateSeries: rename_func("GENERATE_SERIES"),
         exp.GenerateSeries: generate_series_sql("GENERATE_SERIES"),

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -80,7 +80,7 @@ def _date_add_sql(kind: str) -> t.Callable[[PostgresGenerator, DATE_ADD_OR_SUB],
 def _day_month_year_sql(self: PostgresGenerator, expression: exp.Day | exp.Month | exp.Year) -> str:
     this = expression.this
     value = this.this if isinstance(this, exp.TsOrDsToDate) else this
-    if value.is_type(*exp.DataType.INTEGER_TYPES):
+    if value.is_int or value.is_type(*exp.DataType.INTEGER_TYPES):
         self.unsupported(
             f"Cannot transpile {expression.sql_name()} of an integer value to Postgres"
         )
@@ -318,8 +318,6 @@ class PostgresGenerator(generator.Generator):
         exp.DateStrToDate: datestrtodate_sql,
         exp.DateSub: _date_add_sql("-"),
         exp.Day: _day_month_year_sql,
-        exp.Month: _day_month_year_sql,
-        exp.Year: _day_month_year_sql,
         exp.Explode: rename_func("UNNEST"),
         exp.ExplodingGenerateSeries: rename_func("GENERATE_SERIES"),
         exp.GenerateSeries: generate_series_sql("GENERATE_SERIES"),
@@ -349,6 +347,7 @@ class PostgresGenerator(generator.Generator):
         exp.MapFromEntries: no_map_from_entries_sql,
         exp.Min: min_or_least,
         exp.Merge: merge_without_target_sql,
+        exp.Month: _day_month_year_sql,
         exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
         exp.PercentileCont: transforms.preprocess([transforms.add_within_group_for_percentiles]),
         exp.PercentileDisc: transforms.preprocess([transforms.add_within_group_for_percentiles]),
@@ -397,6 +396,7 @@ class PostgresGenerator(generator.Generator):
         exp.VariancePop: rename_func("VAR_POP"),
         exp.Variance: rename_func("VAR_SAMP"),
         exp.Xor: bool_xor_sql,
+        exp.Year: _day_month_year_sql,
         exp.Unicode: rename_func("ASCII"),
         exp.UnixToTime: _unix_to_time_sql,
         exp.Levenshtein: _levenshtein_sql,

--- a/sqlglot/generators/singlestore.py
+++ b/sqlglot/generators/singlestore.py
@@ -13,11 +13,12 @@ from sqlglot.dialects.dialect import (
     timestamptrunc_sql,
     date_add_interval_sql,
     timestampdiff_sql,
+    remove_ts_or_ds_to_date,
 )
 from sqlglot.expressions import DataType
 from sqlglot import generator
 from sqlglot.generator import unsupported_args
-from sqlglot.generators.mysql import MySQLGenerator, _remove_ts_or_ds_to_date, date_add_sql
+from sqlglot.generators.mysql import MySQLGenerator, date_add_sql
 
 
 def _unicode_substitute(m: re.Match[str]) -> str:
@@ -121,7 +122,7 @@ class SingleStoreGenerator(MySQLGenerator):
             f"(DATE_FORMAT({self.sql(e, 'this')}, {self.dialect.DATEINT_FORMAT}) :> INT)"
         ),
         exp.Time: unsupported_args("zone")(lambda self, e: f"{self.sql(e, 'this')} :> TIME"),
-        exp.DatetimeAdd: _remove_ts_or_ds_to_date(date_add_sql("ADD")),
+        exp.DatetimeAdd: remove_ts_or_ds_to_date(date_add_sql("ADD")),
         exp.DatetimeTrunc: unsupported_args("zone")(timestamptrunc_sql()),
         exp.DatetimeSub: date_add_interval_sql("DATE", "SUB"),
         exp.DatetimeDiff: timestampdiff_sql,

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -15,6 +15,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     trim_sql,
 )
+from sqlglot.generators.mysql import _remove_ts_or_ds_to_date
 from sqlglot.helper import seq_get
 from sqlglot.parsers.tsql import OPTIONS_THAT_REQUIRE_EQUAL
 from sqlglot.time import format_time
@@ -200,6 +201,7 @@ class TSQLGenerator(generator.Generator):
         exp.CurrentTimestamp: rename_func("GETDATE"),
         exp.CurrentTimestampLTZ: rename_func("SYSDATETIMEOFFSET"),
         exp.DateStrToDate: datestrtodate_sql,
+        exp.Day: _remove_ts_or_ds_to_date(),
         exp.GeneratedAsIdentityColumnConstraint: generatedasidentitycolumnconstraint_sql,
         exp.GroupConcat: _string_agg_sql,
         exp.If: rename_func("IIF"),
@@ -210,6 +212,7 @@ class TSQLGenerator(generator.Generator):
         exp.Max: max_or_greatest,
         exp.MD5: lambda self, e: self.func("HASHBYTES", exp.Literal.string("MD5"), e.this),
         exp.Min: min_or_least,
+        exp.Month: _remove_ts_or_ds_to_date(),
         exp.NumberToStr: _format_sql,
         exp.Repeat: rename_func("REPLICATE"),
         exp.CurrentSchema: rename_func("SCHEMA_NAME"),
@@ -246,6 +249,7 @@ class TSQLGenerator(generator.Generator):
             exp.Literal.number(1),
         ),
         exp.Uuid: lambda *_: "NEWID()",
+        exp.Year: _remove_ts_or_ds_to_date(),
         exp.DateFromParts: rename_func("DATEFROMPARTS"),
     }
 

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -10,12 +10,12 @@ from sqlglot.dialects.dialect import (
     generatedasidentitycolumnconstraint_sql,
     max_or_greatest,
     min_or_least,
+    remove_ts_or_ds_to_date,
     rename_func,
     strposition_sql,
     timestrtotime_sql,
     trim_sql,
 )
-from sqlglot.generators.mysql import _remove_ts_or_ds_to_date
 from sqlglot.helper import seq_get
 from sqlglot.parsers.tsql import OPTIONS_THAT_REQUIRE_EQUAL
 from sqlglot.time import format_time
@@ -201,7 +201,7 @@ class TSQLGenerator(generator.Generator):
         exp.CurrentTimestamp: rename_func("GETDATE"),
         exp.CurrentTimestampLTZ: rename_func("SYSDATETIMEOFFSET"),
         exp.DateStrToDate: datestrtodate_sql,
-        exp.Day: _remove_ts_or_ds_to_date(),
+        exp.Day: remove_ts_or_ds_to_date(),
         exp.GeneratedAsIdentityColumnConstraint: generatedasidentitycolumnconstraint_sql,
         exp.GroupConcat: _string_agg_sql,
         exp.If: rename_func("IIF"),
@@ -212,7 +212,7 @@ class TSQLGenerator(generator.Generator):
         exp.Max: max_or_greatest,
         exp.MD5: lambda self, e: self.func("HASHBYTES", exp.Literal.string("MD5"), e.this),
         exp.Min: min_or_least,
-        exp.Month: _remove_ts_or_ds_to_date(),
+        exp.Month: remove_ts_or_ds_to_date(),
         exp.NumberToStr: _format_sql,
         exp.Repeat: rename_func("REPLICATE"),
         exp.CurrentSchema: rename_func("SCHEMA_NAME"),
@@ -249,7 +249,7 @@ class TSQLGenerator(generator.Generator):
             exp.Literal.number(1),
         ),
         exp.Uuid: lambda *_: "NEWID()",
-        exp.Year: _remove_ts_or_ds_to_date(),
+        exp.Year: remove_ts_or_ds_to_date(),
         exp.DateFromParts: rename_func("DATEFROMPARTS"),
     }
 

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -363,6 +363,7 @@ class TSQLParser(parser.Parser):
         ),
         "DATENAME": _build_formatted_time(exp.TimeToStr, full_format_mapping=True),
         "DATETIMEFROMPARTS": _build_datetimefromparts,
+        "DAY": lambda args: exp.Day(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
         "EOMONTH": _build_eomonth,
         "FORMAT": _build_format,
         "GETDATE": exp.CurrentTimestamp.from_arg_list,
@@ -372,6 +373,7 @@ class TSQLParser(parser.Parser):
         "JSON_VALUE": parser.build_extract_json_with_path(exp.JSONExtractScalar),
         "LEN": _build_with_arg_as_text(exp.Length),
         "LEFT": _build_with_arg_as_text(exp.Left),
+        "MONTH": lambda args: exp.Month(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
         "NEWID": exp.Uuid.from_arg_list,
         "RIGHT": _build_with_arg_as_text(exp.Right),
         "PARSENAME": _build_parsename,
@@ -385,6 +387,7 @@ class TSQLParser(parser.Parser):
         "SYSTEM_USER": exp.CurrentUser.from_arg_list,
         "TIMEFROMPARTS": _build_timefromparts,
         "DATETRUNC": _build_datetrunc,
+        "YEAR": lambda args: exp.Year(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
     }
 
     JOIN_HINTS = {"LOOP", "HASH", "MERGE", "REMOTE"}

--- a/tests/dialects/test_databricks.py
+++ b/tests/dialects/test_databricks.py
@@ -162,7 +162,7 @@ class TestDatabricks(Validator):
             "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",
             write={
                 "databricks": "CREATE TABLE foo (x INT GENERATED ALWAYS AS (YEAR(y)))",
-                "tsql": "CREATE TABLE foo (x AS YEAR(CAST(y AS DATE)))",
+                "tsql": "CREATE TABLE foo (x AS YEAR(y))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1765,6 +1765,14 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
             "ROUND(CAST(x AS DECIMAL(18, 3)), 4)", read={"duckdb": "ROUND(x::DECIMAL, 4)"}
         )
 
+    def test_extract_date_parts(self):
+        self.validate_all(
+            "SELECT EXTRACT(DAY FROM x), EXTRACT(MONTH FROM x), EXTRACT(YEAR FROM x)",
+            read={
+                "tsql": "SELECT DAY(x), MONTH(x), YEAR(x)",
+            },
+        )
+
     def test_datatype(self):
         self.assertEqual(exp.DataType.build("XML", dialect="postgres").sql("postgres"), "XML")
         self.validate_identity("CREATE TABLE foo (data XML)")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1,5 +1,6 @@
-from sqlglot import ParseError, UnsupportedError, exp, transpile
+from sqlglot import ErrorLevel, ParseError, UnsupportedError, exp, parse_one, transpile
 from sqlglot.helper import logger as helper_logger
+from sqlglot.optimizer.annotate_types import annotate_types
 from tests.dialects.test_dialect import Validator
 
 
@@ -1766,12 +1767,25 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
         )
 
     def test_extract_date_parts(self):
+        # T-SQL DAY/MONTH/YEAR accept non-date inputs, so the argument is cast to DATE
         self.validate_all(
-            "SELECT EXTRACT(DAY FROM x), EXTRACT(MONTH FROM x), EXTRACT(YEAR FROM x)",
+            "SELECT EXTRACT(DAY FROM CAST(x AS DATE)), EXTRACT(MONTH FROM CAST(x AS DATE)), EXTRACT(YEAR FROM CAST(x AS DATE))",
             read={
                 "tsql": "SELECT DAY(x), MONTH(x), YEAR(x)",
             },
         )
+
+        # An argument already typed as DATE is not cast again
+        self.assertEqual(
+            annotate_types(parse_one("SELECT DAY(CAST(x AS DATE))", read="tsql")).sql("postgres"),
+            "SELECT EXTRACT(DAY FROM CAST(x AS DATE))",
+        )
+
+        # Integer arguments rely on T-SQL's 1900-01-01 epoch and aren't supported yet
+        with self.assertRaises(UnsupportedError):
+            annotate_types(parse_one("SELECT DAY(0)", read="tsql")).sql(
+                "postgres", unsupported_level=ErrorLevel.RAISE
+            )
 
     def test_datatype(self):
         self.assertEqual(exp.DataType.build("XML", dialect="postgres").sql("postgres"), "XML")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1,6 +1,7 @@
 from sqlglot import ErrorLevel, ParseError, UnsupportedError, exp, parse_one, transpile
 from sqlglot.helper import logger as helper_logger
 from sqlglot.optimizer.annotate_types import annotate_types
+from sqlglot.optimizer.qualify import qualify
 from tests.dialects.test_dialect import Validator
 
 
@@ -1783,9 +1784,15 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
 
         # Integer arguments rely on T-SQL's 1900-01-01 epoch and aren't supported yet
         with self.assertRaises(UnsupportedError):
-            annotate_types(parse_one("SELECT DAY(0)", read="tsql")).sql(
-                "postgres", unsupported_level=ErrorLevel.RAISE
+            transpile(
+                "SELECT DAY(0)", read="tsql", write="postgres", unsupported_level=ErrorLevel.RAISE
             )
+        with self.assertRaises(UnsupportedError):
+            annotate_types(
+                qualify(
+                    parse_one("WITH t AS (SELECT 1 AS col) SELECT YEAR(col) FROM t", read="tsql")
+                )
+            ).sql("postgres", unsupported_level=ErrorLevel.RAISE)
 
     def test_datatype(self):
         self.assertEqual(exp.DataType.build("XML", dialect="postgres").sql("postgres"), "XML")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1,7 +1,6 @@
 from sqlglot import ErrorLevel, ParseError, UnsupportedError, exp, parse_one, transpile
 from sqlglot.helper import logger as helper_logger
 from sqlglot.optimizer.annotate_types import annotate_types
-from sqlglot.optimizer.qualify import qualify
 from tests.dialects.test_dialect import Validator
 
 
@@ -1768,7 +1767,6 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
         )
 
     def test_extract_date_parts(self):
-        # T-SQL DAY/MONTH/YEAR accept non-date inputs, so the argument is cast to DATE
         self.validate_all(
             "SELECT EXTRACT(DAY FROM CAST(x AS DATE)), EXTRACT(MONTH FROM CAST(x AS DATE)), EXTRACT(YEAR FROM CAST(x AS DATE))",
             read={
@@ -1776,22 +1774,14 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
             },
         )
 
-        # An argument already typed as DATE is not cast again
         self.assertEqual(
             annotate_types(parse_one("SELECT DAY(CAST(x AS DATE))", read="tsql")).sql("postgres"),
             "SELECT EXTRACT(DAY FROM CAST(x AS DATE))",
         )
 
-        # Integer arguments rely on T-SQL's 1900-01-01 epoch and aren't supported yet
-        with self.assertRaises(UnsupportedError):
-            transpile(
-                "SELECT DAY(0)", read="tsql", write="postgres", unsupported_level=ErrorLevel.RAISE
-            )
         with self.assertRaises(UnsupportedError):
             annotate_types(
-                qualify(
-                    parse_one("WITH t AS (SELECT 1 AS col) SELECT YEAR(col) FROM t", read="tsql")
-                )
+                parse_one("WITH t AS (SELECT 1 AS col) SELECT YEAR(t.col) FROM t", read="tsql")
             ).sql("postgres", unsupported_level=ErrorLevel.RAISE)
 
     def test_datatype(self):

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -2052,6 +2052,11 @@ WHERE
             write={"spark": r"SELECT '\'test\''"},
         )
 
+    def test_day_month_year(self):
+        self.validate_identity("SELECT DAY(x)", "SELECT DAY(CAST(x AS DATE))")
+        self.validate_identity("SELECT MONTH(x)", "SELECT MONTH(CAST(x AS DATE))")
+        self.validate_identity("SELECT YEAR(x)", "SELECT YEAR(CAST(x AS DATE))")
+
     def test_eomonth(self):
         self.validate_all(
             "EOMONTH(GETDATE())",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -2053,9 +2053,10 @@ WHERE
         )
 
     def test_day_month_year(self):
-        self.validate_identity("SELECT DAY(x)", "SELECT DAY(CAST(x AS DATE))")
-        self.validate_identity("SELECT MONTH(x)", "SELECT MONTH(CAST(x AS DATE))")
-        self.validate_identity("SELECT YEAR(x)", "SELECT YEAR(CAST(x AS DATE))")
+        self.validate_all("DAY(x)", write={"tsql": "DAY(x)", "": "DAY(CAST(x AS DATE))"})
+        self.validate_all("MONTH(x)", write={"tsql": "MONTH(x)", "": "MONTH(CAST(x AS DATE))"})
+        self.validate_all("YEAR(x)", write={"tsql": "YEAR(x)", "": "YEAR(CAST(x AS DATE))"})
+        self.validate_identity("WITH t AS (SELECT 0 AS col) SELECT YEAR(col) FROM t")
 
     def test_eomonth(self):
         self.validate_all(


### PR DESCRIPTION
## Summary

T-SQL scalar date functions `DAY`/`MONTH`/`YEAR` were passed through unchanged when transpiling to Postgres, which has no such functions, so the output was invalid SQL. The T-SQL parser now wraps their argument in `TsOrDsToDate` (the same pattern `EOMONTH` uses), and the Postgres generator renders these nodes as `EXTRACT(part FROM ...)`.

Before:
```python
sqlglot.transpile("SELECT DAY(x)", read="tsql", write="postgres")[0]
# 'SELECT DAY(x)'  (invalid: function day(...) does not exist)
```
After:
```python
# 'SELECT EXTRACT(DAY FROM CAST(x AS DATE))'
```

Postgres exposes date parts only through `EXTRACT`/`date_part`: https://www.postgresql.org/docs/current/functions-datetime.html

This continues #7798 (closed for inactivity, and GitHub does not let me reopen it from my side) with the review suggestions applied:

- The generator factory is inlined into a single `_day_month_year_sql` helper that uses `sql_name()`.
- The cast moved to the T-SQL parse side via `TsOrDsToDate`, so the generator-side cast branch is gone entirely.
- The helper is renamed so it no longer reads like a generic `EXTRACT` generator.
- Integer-typed arguments emit an unsupported message (verified against the `WITH t AS (SELECT 1 AS col) SELECT YEAR(col) FROM t` example from review). The T-SQL days-since-1900 integer semantics stay out of scope for a follow-up PR, as agreed with @geooo109.

Fixes #6220
