### PR TITLE
Piya/annotate function regexpreplace v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,113 @@
 Changelog
 =========
 
+## [v30.14.0] - 2026-07-27
+### :boom: BREAKING CHANGES
+- due to [`a715f9f`](https://github.com/tobymao/sqlglot/commit/a715f9f9aa1ba640f558c7602af9a63fc35d8697) - type annotation for databricks NANVL, SIGN, SHIFTLEFT, SIGNUM, SHUFFLE *(PR [#7896](https://github.com/tobymao/sqlglot/pull/7896) by [@fivetran-amrutabhimsenayachit](https://github.com/fivetran-amrutabhimsenayachit))*:
+
+  type annotation for databricks NANVL, SIGN, SHIFTLEFT, SIGNUM, SHUFFLE (#7896)
+
+- due to [`acb635a`](https://github.com/tobymao/sqlglot/commit/acb635a9d5a1e2bdcd4d18e44a63830f10583240) - don't normalize quoted derived output aliases in qualify_outputs *(PR [#7921](https://github.com/tobymao/sqlglot/pull/7921) by [@georgesittas](https://github.com/georgesittas))*:
+
+  don't normalize quoted derived output aliases in qualify_outputs (#7921)
+
+- due to [`c090f35`](https://github.com/tobymao/sqlglot/commit/c090f35c8625d5bb1371a1c0c75ba434f4df6b95) - dedupe colliding star expanded aliases *(PR [#7872](https://github.com/tobymao/sqlglot/pull/7872) by [@fivetran-kwoodbeck](https://github.com/fivetran-kwoodbeck))*:
+
+  dedupe colliding star expanded aliases (#7872)
+
+- due to [`1b442c9`](https://github.com/tobymao/sqlglot/commit/1b442c97deafa067733ff0590f7a612e66ae8aed) - handle non-literal star ILIKE patterns and Snowflake backslash escapes *(PR [#7918](https://github.com/tobymao/sqlglot/pull/7918) by [@georgesittas](https://github.com/georgesittas))*:
+
+  handle non-literal star ILIKE patterns and Snowflake backslash escapes (#7918)
+
+- due to [`66316e3`](https://github.com/tobymao/sqlglot/commit/66316e335fd617d2f3ab8c412ae7a87356431c97) - parse single-digit hour/minute/second without padding CLAUDE *(PR [#7925](https://github.com/tobymao/sqlglot/pull/7925) by [@deepyaman](https://github.com/deepyaman))*:
+
+  parse single-digit hour/minute/second without padding CLAUDE (#7925)
+
+- due to [`c75b7b6`](https://github.com/tobymao/sqlglot/commit/c75b7b610e182fedba20758853d227b81bc1cb34) - annotate unhex for duckdb *(PR [#7930](https://github.com/tobymao/sqlglot/pull/7930) by [@vaishnavi-polekar](https://github.com/vaishnavi-polekar))*:
+
+  annotate unhex for duckdb (#7930)
+
+- due to [`88c4b4a`](https://github.com/tobymao/sqlglot/commit/88c4b4a6f0372978f8ec58c872f0a7f26570bfe3) - parse and annotate duckdb FROM_HEX *(PR [#7931](https://github.com/tobymao/sqlglot/pull/7931) by [@geooo109](https://github.com/geooo109))*:
+
+  parse and annotate duckdb FROM_HEX (#7931)
+
+- due to [`a7725f2`](https://github.com/tobymao/sqlglot/commit/a7725f2a1944bc853deddf8acec29a01946615dd) - annotate convert_tz for mysql *(PR [#7932](https://github.com/tobymao/sqlglot/pull/7932) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate convert_tz for mysql (#7932)
+
+- due to [`85e0b7c`](https://github.com/tobymao/sqlglot/commit/85e0b7c89f3009fe4fbde381df30a1931a975fb4) - annotate UTC_DATE for MySQL *(PR [#7935](https://github.com/tobymao/sqlglot/pull/7935) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate UTC_DATE for MySQL (#7935)
+
+- due to [`7fbb14f`](https://github.com/tobymao/sqlglot/commit/7fbb14f804e601598f3b398276e9d07b9a2d6dbc) - annotate utc_time for mysql *(PR [#7936](https://github.com/tobymao/sqlglot/pull/7936) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate utc_time for mysql (#7936)
+
+- due to [`212fe55`](https://github.com/tobymao/sqlglot/commit/212fe552375e5ef8432a5ed0dd107278075922e8) - annotate utc_timestamp for mysql *(PR [#7937](https://github.com/tobymao/sqlglot/pull/7937) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate utc_timestamp for mysql (#7937)
+
+- due to [`166cd4d`](https://github.com/tobymao/sqlglot/commit/166cd4de90e272c89f14eb7d04d2989d75ef6742) - annotate substringindex for mysql *(PR [#7945](https://github.com/tobymao/sqlglot/pull/7945) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate substringindex for mysql (#7945)
+
+- due to [`26078eb`](https://github.com/tobymao/sqlglot/commit/26078eb7ca56645521fe6f9d60da67d7e9f7e82b) - annotate unhex for mysql *(PR [#7944](https://github.com/tobymao/sqlglot/pull/7944) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate unhex for mysql (#7944)
+
+- due to [`33de21f`](https://github.com/tobymao/sqlglot/commit/33de21fc21cdc05755a2de39318b292c10ccec0f) - annotate regexpsubstr for mysql *(PR [#7946](https://github.com/tobymao/sqlglot/pull/7946) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*:
+
+  annotate regexpsubstr for mysql (#7946)
+
+- due to [`2aae7f7`](https://github.com/tobymao/sqlglot/commit/2aae7f7605ed38fe0950d004cb9defc1dd9621e5) - preserve x IS NOT NULL instead of normalizing to NOT x IS NULL *(PR [#7938](https://github.com/tobymao/sqlglot/pull/7938) by [@geooo109](https://github.com/geooo109))*:
+
+  preserve x IS NOT NULL instead of normalizing to NOT x IS NULL (#7938)
+
+
+### :sparkles: New Features
+- [`c402094`](https://github.com/tobymao/sqlglot/commit/c4020942b711eb0f5c8a182ff580b31541aed07f) - **duckdb**: transpile BigQuery ARRAY_CONCAT_AGG to DuckDB *(PR [#7891](https://github.com/tobymao/sqlglot/pull/7891) by [@sirockin](https://github.com/sirockin))*
+- [`8be76d2`](https://github.com/tobymao/sqlglot/commit/8be76d20a133ee818cffd52e04366fdc74d6a89e) - **duckdb**: convert ARRAY_AGG IGNORE NULLS to FILTER clause *(PR [#7893](https://github.com/tobymao/sqlglot/pull/7893) by [@sirockin](https://github.com/sirockin))*
+- [`a715f9f`](https://github.com/tobymao/sqlglot/commit/a715f9f9aa1ba640f558c7602af9a63fc35d8697) - **optimizer**: type annotation for databricks NANVL, SIGN, SHIFTLEFT, SIGNUM, SHUFFLE *(PR [#7896](https://github.com/tobymao/sqlglot/pull/7896) by [@fivetran-amrutabhimsenayachit](https://github.com/fivetran-amrutabhimsenayachit))*
+- [`ee5a989`](https://github.com/tobymao/sqlglot/commit/ee5a989cd5b756c10068837887f34ffe8606ce7f) - **mysql**: support INSERT ... SET ... syntax closes [#7927](https://github.com/tobymao/sqlglot/pull/7927) *(PR [#7929](https://github.com/tobymao/sqlglot/pull/7929) by [@georgesittas](https://github.com/georgesittas))*
+  - :arrow_lower_right: *addresses issue [#7927](https://github.com/tobymao/sqlglot/issues/7927) opened by [@samerdokas](https://github.com/samerdokas)*
+- [`c75b7b6`](https://github.com/tobymao/sqlglot/commit/c75b7b610e182fedba20758853d227b81bc1cb34) - **optimizer**: annotate unhex for duckdb *(PR [#7930](https://github.com/tobymao/sqlglot/pull/7930) by [@vaishnavi-polekar](https://github.com/vaishnavi-polekar))*
+- [`88c4b4a`](https://github.com/tobymao/sqlglot/commit/88c4b4a6f0372978f8ec58c872f0a7f26570bfe3) - **optimizer**: parse and annotate duckdb FROM_HEX *(PR [#7931](https://github.com/tobymao/sqlglot/pull/7931) by [@geooo109](https://github.com/geooo109))*
+- [`3cd3e58`](https://github.com/tobymao/sqlglot/commit/3cd3e58e10dcdf941f14765889641a5974e550ae) - **duckdb**: transpile BigQuery IN UNNEST(array) to ARRAY_CONTAINS *(PR [#7892](https://github.com/tobymao/sqlglot/pull/7892) by [@sirockin](https://github.com/sirockin))*
+- [`a7725f2`](https://github.com/tobymao/sqlglot/commit/a7725f2a1944bc853deddf8acec29a01946615dd) - **optimizer**: annotate convert_tz for mysql *(PR [#7932](https://github.com/tobymao/sqlglot/pull/7932) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`85e0b7c`](https://github.com/tobymao/sqlglot/commit/85e0b7c89f3009fe4fbde381df30a1931a975fb4) - **optimizer**: annotate UTC_DATE for MySQL *(PR [#7935](https://github.com/tobymao/sqlglot/pull/7935) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`7fbb14f`](https://github.com/tobymao/sqlglot/commit/7fbb14f804e601598f3b398276e9d07b9a2d6dbc) - **optimizer**: annotate utc_time for mysql *(PR [#7936](https://github.com/tobymao/sqlglot/pull/7936) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`212fe55`](https://github.com/tobymao/sqlglot/commit/212fe552375e5ef8432a5ed0dd107278075922e8) - **optimizer**: annotate utc_timestamp for mysql *(PR [#7937](https://github.com/tobymao/sqlglot/pull/7937) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`6bb78c9`](https://github.com/tobymao/sqlglot/commit/6bb78c9aa8982b1c69378f797f02c8f248af97b4) - **snowflake**: add support for input => select ... kwarg syntax *(commit by [@georgesittas](https://github.com/georgesittas))*
+- [`166cd4d`](https://github.com/tobymao/sqlglot/commit/166cd4de90e272c89f14eb7d04d2989d75ef6742) - **optimizer**: annotate substringindex for mysql *(PR [#7945](https://github.com/tobymao/sqlglot/pull/7945) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`26078eb`](https://github.com/tobymao/sqlglot/commit/26078eb7ca56645521fe6f9d60da67d7e9f7e82b) - **optimizer**: annotate unhex for mysql *(PR [#7944](https://github.com/tobymao/sqlglot/pull/7944) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`33de21f`](https://github.com/tobymao/sqlglot/commit/33de21fc21cdc05755a2de39318b292c10ccec0f) - **optimizer**: annotate regexpsubstr for mysql *(PR [#7946](https://github.com/tobymao/sqlglot/pull/7946) by [@PiyaDaswadkar](https://github.com/PiyaDaswadkar))*
+- [`2aae7f7`](https://github.com/tobymao/sqlglot/commit/2aae7f7605ed38fe0950d004cb9defc1dd9621e5) - **postgres**: preserve x IS NOT NULL instead of normalizing to NOT x IS NULL *(PR [#7938](https://github.com/tobymao/sqlglot/pull/7938) by [@geooo109](https://github.com/geooo109))*
+  - :arrow_lower_right: *addresses issue [#7909](https://github.com/tobymao/sqlglot/issues/7909) opened by [@tonywasson](https://github.com/tonywasson)*
+
+### :bug: Bug Fixes
+- [`c368c5e`](https://github.com/tobymao/sqlglot/commit/c368c5eb2d84133a18f38ff98946b112c81f060d) - **duckdb**: handle ORDER BY and LIMIT for bq ARRAY_CONCAT_AGG *(PR [#7920](https://github.com/tobymao/sqlglot/pull/7920) by [@geooo109](https://github.com/geooo109))*
+- [`acb635a`](https://github.com/tobymao/sqlglot/commit/acb635a9d5a1e2bdcd4d18e44a63830f10583240) - **optimizer**: don't normalize quoted derived output aliases in qualify_outputs *(PR [#7921](https://github.com/tobymao/sqlglot/pull/7921) by [@georgesittas](https://github.com/georgesittas))*
+  - :arrow_lower_right: *fixes issue [#7919](https://github.com/tobymao/sqlglot/issues/7919) opened by [@baruchoxman](https://github.com/baruchoxman)*
+- [`c090f35`](https://github.com/tobymao/sqlglot/commit/c090f35c8625d5bb1371a1c0c75ba434f4df6b95) - **optimizer**: dedupe colliding star expanded aliases *(PR [#7872](https://github.com/tobymao/sqlglot/pull/7872) by [@fivetran-kwoodbeck](https://github.com/fivetran-kwoodbeck))*
+- [`1b442c9`](https://github.com/tobymao/sqlglot/commit/1b442c97deafa067733ff0590f7a612e66ae8aed) - handle non-literal star ILIKE patterns and Snowflake backslash escapes *(PR [#7918](https://github.com/tobymao/sqlglot/pull/7918) by [@georgesittas](https://github.com/georgesittas))*
+- [`66316e3`](https://github.com/tobymao/sqlglot/commit/66316e335fd617d2f3ab8c412ae7a87356431c97) - **hive**: parse single-digit hour/minute/second without padding CLAUDE *(PR [#7925](https://github.com/tobymao/sqlglot/pull/7925) by [@deepyaman](https://github.com/deepyaman))*
+- [`e265dca`](https://github.com/tobymao/sqlglot/commit/e265dcafd6a28bdfb43a6491777b433b49a1ebd7) - **optimizer**: canonicalize unaliased scalar subquery projections *(PR [#7928](https://github.com/tobymao/sqlglot/pull/7928) by [@fivetran-kwoodbeck](https://github.com/fivetran-kwoodbeck))*
+- [`b0a8635`](https://github.com/tobymao/sqlglot/commit/b0a8635ff3fcd769743c4848651497cce6acee19) - **parser**: treat `TokenType.OUT` as an identifier token *(PR [#7933](https://github.com/tobymao/sqlglot/pull/7933) by [@georgesittas](https://github.com/georgesittas))*
+- [`ba0bff3`](https://github.com/tobymao/sqlglot/commit/ba0bff3d9164217f06cfcf9fadbdfd35ae84eefe) - **jsonpath**: preserve falsey union members *(PR [#7957](https://github.com/tobymao/sqlglot/pull/7957) by [@dev-willbird1936](https://github.com/dev-willbird1936))*
+  - :arrow_lower_right: *fixes issue [#7956](https://github.com/tobymao/sqlglot/issues/7956) opened by [@dev-willbird1936](https://github.com/dev-willbird1936)*
+- [`b9fd4c9`](https://github.com/tobymao/sqlglot/commit/b9fd4c9a5d3e5aa4ccc5dff395cbde3227f18e5a) - **typing**: on_qualify expects a `Table` argument *(commit by [@georgesittas](https://github.com/georgesittas))*
+
+### :zap: Performance Improvements
+- [`1a38c05`](https://github.com/tobymao/sqlglot/commit/1a38c056a1f47cfc07c9bef4ed11b795a91f947e) - **optimizer**: speed up merge_subqueries *(PR [#7924](https://github.com/tobymao/sqlglot/pull/7924) by [@fivetran-kwoodbeck](https://github.com/fivetran-kwoodbeck))*
+- [`b8180fd`](https://github.com/tobymao/sqlglot/commit/b8180fdb8c2617b7e51e1c9491a76cae852eb87b) - **optimizer**: speed up merge_subqueries *(PR [#7924](https://github.com/tobymao/sqlglot/pull/7924) by [@fivetran-kwoodbeck](https://github.com/fivetran-kwoodbeck))*
+
+### :wrench: Chores
+- [`cda0147`](https://github.com/tobymao/sqlglot/commit/cda0147754257779c4c103d617c04d2deb6979b9) - **generator**: refactor ARRAY_AGG tests and bq -> duckdb transpilation *(PR [#7922](https://github.com/tobymao/sqlglot/pull/7922) by [@geooo109](https://github.com/geooo109))*
+- [`f37d1b5`](https://github.com/tobymao/sqlglot/commit/f37d1b5d6305ff293f7b1757ce1253c3299d8e88) - **duckdb**: refactor transpilation of IN UNNEST *(commit by [@geooo109](https://github.com/geooo109))*
+- [`296d8b0`](https://github.com/tobymao/sqlglot/commit/296d8b02e7f7b4d0634194ed367ac3ce49a03714) - polish README file *(PR [#7947](https://github.com/tobymao/sqlglot/pull/7947) by [@georgesittas](https://github.com/georgesittas))*
+- [`29c651b`](https://github.com/tobymao/sqlglot/commit/29c651b85309693924b8c034501e6a2733d14588) - retrigger v30.14.0 release *(commit by [@georgesittas](https://github.com/georgesittas))*
+
+
 ## [v30.13.0] - 2026-07-20
 ### :boom: BREAKING CHANGES
 - due to [`58f5bf9`](https://github.com/tobymao/sqlglot/commit/58f5bf9b40dda34784bcb2d3bf0a04f02490de12) - databricks type annotation for REGEXP_COUNT, REGEXP_EXTRACT_ALL *(PR [#7797](https://github.com/tobymao/sqlglot/pull/7797) by [@fivetran-amrutabhimsenayachit](https://github.com/fivetran-amrutabhimsenayachit))*:
@@ -15078,3 +15185,4 @@ pip install "sqlglot[c]"   # compiled — faster, but no subclassing
 [v30.11.0]: https://github.com/tobymao/sqlglot/compare/v30.10.0...v30.11.0
 [v30.12.0]: https://github.com/tobymao/sqlglot/compare/v30.11.0...v30.12.0
 [v30.13.0]: https://github.com/tobymao/sqlglot/compare/v30.12.0...v30.13.0
+[v30.14.0]: https://github.com/tobymao/sqlglot/compare/v30.13.0...v30.14.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,14 @@ We use GitHub issues to track public bugs. Report a bug by opening a new issue.
 of the code. If you want to propose a new feature, this is the right place to do it. Just start a discussion, and
 let us know why you think this feature would be a good addition to SQLGlot (by possibly including some usage examples).
 
+## Deployment (maintainers only)
+
+To deploy a new SQLGlot version, follow these steps:
+
+1. Run `git pull` to make sure the local git repo is at the head of the main branch
+2. Do a `git tag` operation to bump the SQLGlot version, e.g. `git tag v28.5.0`
+3. Run `git push && git push --tags` to deploy the new version
+
 ## [License](https://github.com/tobymao/sqlglot/blob/main/LICENSE)
 
 By contributing, you agree that your contributions will be licensed under its MIT License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![SQLGlot logo](sqlglot.png)
 
-SQLGlot is a no-dependency SQL parser, transpiler, optimizer, and engine. It can be used to format SQL or translate between [31 different dialects](https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/__init__.py) like [DuckDB](https://duckdb.org/), [Presto](https://prestodb.io/) / [Trino](https://trino.io/), [Spark](https://spark.apache.org/) / [Databricks](https://www.databricks.com/), [Snowflake](https://www.snowflake.com/en/), and [BigQuery](https://cloud.google.com/bigquery/). It aims to read a wide variety of SQL inputs and output syntactically and semantically correct SQL in the targeted dialects.
+SQLGlot is a no-dependency SQL parser, transpiler, optimizer, and engine. It can be used to format SQL or translate between [over 30 dialects](https://github.com/tobymao/sqlglot/blob/main/sqlglot/dialects/__init__.py) like [DuckDB](https://duckdb.org/), [Presto](https://prestodb.io/) / [Trino](https://trino.io/), [Spark](https://spark.apache.org/) / [Databricks](https://www.databricks.com/), [Snowflake](https://www.snowflake.com/en/), and [BigQuery](https://cloud.google.com/bigquery/). It aims to read a wide variety of SQL inputs and output syntactically and semantically correct SQL in the targeted dialects.
 
 It is a very comprehensive generic SQL parser with a robust [test suite](https://github.com/tobymao/sqlglot/blob/main/tests/). It is also quite [performant](#benchmarks), while being written purely in Python.
 
@@ -32,7 +32,6 @@ Contributions are very welcome in SQLGlot; read the [contribution guide](https:/
 * [Used By](#used-by)
 * [Documentation](#documentation)
 * [Run Tests and Lint](#run-tests-and-lint)
-* [Deployment](#deployment)
 * [Benchmarks](#benchmarks)
 * [Optional Dependencies](#optional-dependencies)
 * [Supported Dialects](#supported-dialects)
@@ -66,11 +65,11 @@ make install-dev
 
 ## Versioning
 
-Given a version number `MAJOR`.`MINOR`.`PATCH`, SQLGlot uses the following versioning strategy:
+Given a version number `MAJOR`.`MINOR`.`PATCH`:
 
-- The `PATCH` version is incremented when there are backwards-compatible fixes or feature additions.
-- The `MINOR` version is incremented when there are backwards-incompatible fixes or feature additions.
-- The `MAJOR` version is incremented when there are significant backwards-incompatible fixes or feature additions.
+- `PATCH` is incremented for backwards-compatible changes.
+- `MINOR` is incremented for backwards-incompatible changes.
+- `MAJOR` is incremented for significant backwards-incompatible changes.
 
 ## Get in Touch
 
@@ -78,17 +77,29 @@ We'd love to hear from you. Join our community [Slack channel](https://tobikodat
 
 ## FAQ
 
-I tried to parse SQL that should be valid but it failed, why did that happen?
+**I tried to parse SQL that should be valid, but it failed. Why?**
 
-* Most of the time, issues like this occur because the "source" dialect is omitted during parsing. For example, this is how to correctly parse a SQL query written in Spark SQL: `parse_one(sql, dialect="spark")` (alternatively: `read="spark"`). If no dialect is specified, `parse_one` will attempt to parse the query according to the "SQLGlot dialect", which is designed to be a superset of all supported dialects. If you tried specifying the dialect and it still doesn't work, please file an issue.
+You probably didn't specify the source dialect. Without it, `parse_one` assumes the "SQLGlot dialect", which is designed to be a superset of all supported dialects. Always pass the dialect when you know it, e.g. `parse_one(sql, dialect="spark")`. If parsing still fails, please file an issue.
 
-I tried to output SQL but it's not in the correct dialect!
+**The generated SQL is not in the correct dialect!**
 
-* Like parsing, generating SQL also requires the target dialect to be specified, otherwise the SQLGlot dialect will be used by default. For example, to transpile a query from Spark SQL to DuckDB, do `parse_one(sql, dialect="spark").sql(dialect="duckdb")` (alternatively: `transpile(sql, read="spark", write="duckdb")`).
+The target dialect must also be specified explicitly. For example, to transpile a query from Spark SQL to DuckDB, do `parse_one(sql, dialect="spark").sql(dialect="duckdb")`, or `transpile(sql, read="spark", write="duckdb")`.
 
-What happened to sqlglot.dataframe?
+**Why does SQLGlot parse my invalid SQL without complaining?**
 
-* The PySpark dataframe api was moved to a standalone library called [SQLFrame](https://github.com/eakmanrq/sqlframe) in v24. It now allows you to run queries as opposed to just generate SQL.
+The parser is intentionally lenient, so it can accept queries that a real engine would reject. SQLGlot is a transpiler, not a validator. A query that parses successfully may still fail at execution time.
+
+**Why doesn't the output preserve my formatting, casing or quoting?**
+
+SQLGlot parses queries into an AST and generates SQL back from it, so it preserves the meaning of a query rather than its exact text. Cosmetic details can change in the process. Use `pretty=True` for formatted output and `identify=True` to quote all identifiers. Comments are preserved on a best-effort basis.
+
+**How can I make parsing faster?**
+
+Install the version compiled with mypyc: `pip3 install "sqlglot[c]"`. It is roughly 3-5x faster than the pure Python version (see [Benchmarks](#benchmarks)).
+
+**My dialect isn't supported. What are my options?**
+
+You can subclass an existing dialect ([Custom Dialects](#custom-dialects)), or ship one as a separate package ([Creating a Dialect Plugin](#creating-a-dialect-plugin)). Keep in mind that subclassing may not work properly with `sqlglot[c]` installed, so custom dialects may require the pure Python version.
 
 ## Examples
 
@@ -177,7 +188,7 @@ print(sqlglot.transpile(sql, read='mysql', pretty=True)[0])
 */
 SELECT
   tbl.cola /* comment 1 */ + tbl.colb /* comment 2 */,
-  CAST(x AS INT), /* comment 3 */
+  CAST(x AS SIGNED), /* comment 3 */
   y /* comment 4 */
 FROM bar /* comment 5 */, tbl /*          comment 6 */
 ```
@@ -253,7 +264,7 @@ sqlglot.transpile("SELECT APPROX_DISTINCT(a, 0.1) FROM foo", read="presto", writ
 ```
 
 ```sql
-APPROX_COUNT_DISTINCT does not support accuracy
+Argument 'accuracy' is not supported for expression 'ApproxDistinct' when targeting Hive.
 'SELECT APPROX_COUNT_DISTINCT(a) FROM foo'
 ```
 
@@ -265,12 +276,12 @@ sqlglot.transpile("SELECT APPROX_DISTINCT(a, 0.1) FROM foo", read="presto", writ
 ```
 
 ```
-sqlglot.errors.UnsupportedError: APPROX_COUNT_DISTINCT does not support accuracy
+sqlglot.errors.UnsupportedError: Argument 'accuracy' is not supported for expression 'ApproxDistinct' when targeting Hive.
 ```
 
-There are queries that require additional information to be accurately transpiled, such as the schemas of the tables referenced in them. This is because certain transformations are type-sensitive, meaning that type inference is needed in order to understand their semantics. Even though the `qualify` and `annotate_types` optimizer [rules](https://github.com/tobymao/sqlglot/tree/main/sqlglot/optimizer) can help with this, they are not used by default because they add significant overhead and complexity.
+Some queries need additional information to be transpiled accurately, such as the schemas of the referenced tables. This is because certain transformations are type-sensitive and depend on type inference. The `qualify` and `annotate_types` optimizer [rules](https://github.com/tobymao/sqlglot/tree/main/sqlglot/optimizer) can provide this information, but they are not used by default because they add overhead and complexity.
 
-Transpilation is generally a hard problem, so SQLGlot employs an "incremental" approach to solving it. This means that there may be dialect pairs that currently lack support for some inputs, but this is expected to improve over time. We highly appreciate well-documented and tested issues or PRs, so feel free to [reach out](#get-in-touch) if you need guidance!
+Transpilation is a hard problem, so SQLGlot solves it incrementally. Some dialect pairs may lack support for certain inputs, but coverage improves over time. We highly appreciate well-documented and tested issues or PRs, so feel free to [reach out](#get-in-touch) if you need guidance!
 
 ### Build and Modify SQL
 
@@ -399,6 +410,8 @@ diff(parse_one("SELECT a + b, c, d"), parse_one("SELECT c, a - b, d"))
 ]
 ```
 
+The sequence consists of `Insert`, `Remove`, `Move`, `Update` and `Keep` actions. The order of the matched (`Keep` / `Move`) actions may vary between runs.
+
 See also: [Semantic Diff for SQL](https://github.com/tobymao/sqlglot/blob/main/posts/sql_diff.md).
 
 ### Custom Dialects
@@ -444,6 +457,8 @@ print(Dialect["custom"])
 ```
 <class '__main__.Custom'>
 ```
+
+Note: when `sqlglot[c]` is installed, subclassing may not work properly, because runtime subclassing of the mypyc-compiled classes has been disabled for performance reasons. Use the pure Python version if you need custom dialects.
 
 ### SQL Execution
 
@@ -532,14 +547,6 @@ make check   # Full test suite & linter checks
 make clean   # Remove compiled C artifacts (.so files, build dirs)
 ```
 
-## Deployment
-
-To deploy a new SQLGlot version, follow these steps:
-
-1. Run `git pull` to make sure the local git repo is at the head of the main branch
-2. Do a `git tag` operation to bump the SQLGlot version, e.g. `git tag v28.5.0`
-3. Run `git push && git push --tags` to deploy the new version
-
 ## Benchmarks
 
 [Benchmarks](https://github.com/tobymao/sqlglot/blob/main/benchmarks/parse.py) run on Python 3.14.3 in seconds.
@@ -592,6 +599,7 @@ x + interval '1' month
 | Drill | Community |
 | Druid | Community |
 | DuckDB | Official |
+| Dune | Community |
 | Exasol | Community |
 | Fabric | Community |
 | Hive | Official |

--- a/sqlglot/dialects/clickhouse.py
+++ b/sqlglot/dialects/clickhouse.py
@@ -17,7 +17,6 @@ class ClickHouse(Dialect):
     NORMALIZE_FUNCTIONS: bool | str = False
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = False
-    SAFE_DIVISION = True
     LOG_BASE_FIRST: bool | None = None
     FORCE_EARLY_ALIAS_REF_EXPANSION = True
     PRESERVE_ORIGINAL_NAMES = True

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -752,6 +752,9 @@ class Dialect(metaclass=_Dialect):
     # Not safe with MySQL and SQLite due to type coercion (may not return boolean)
     SAFE_TO_ELIMINATE_DOUBLE_NEGATION = True
 
+    # Whether `x IS NOT NULL` can be normalized to `NOT x IS NULL`
+    NORMALIZE_NOT_NULL = True
+
     # Whether the INITCAP function supports custom delimiter characters as the second argument
     # Default delimiter characters for INITCAP function: whitespace and non-alphanumeric characters
     INITCAP_SUPPORTS_CUSTOM_DELIMITERS = True

--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -16,7 +16,6 @@ from sqlglot.typing.duckdb import EXPRESSION_METADATA
 class DuckDB(Dialect):
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = True
-    SAFE_DIVISION = True
     INDEX_OFFSET = 1
     CONCAT_COALESCE = True
     CONCAT_WS_COALESCE = True

--- a/sqlglot/dialects/materialize.py
+++ b/sqlglot/dialects/materialize.py
@@ -6,6 +6,8 @@ from sqlglot.parsers.materialize import MaterializeParser
 
 
 class Materialize(Postgres):
+    NORMALIZE_NOT_NULL = True
+
     Parser = MaterializeParser
 
     Generator = MaterializeGenerator

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -11,6 +11,9 @@ from sqlglot.typing.postgres import EXPRESSION_METADATA
 class Postgres(Dialect):
     EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
     INDEX_OFFSET = 1
+    # Normalizing `x IS NOT NULL` to `NOT x IS NULL` is unsafe due to row values,
+    # e.g. `ROW(1, NULL) IS NOT NULL` is false whereas `NOT ROW(1, NULL) IS NULL` is true
+    NORMALIZE_NOT_NULL = False
     TYPED_DIVISION = True
     CONCAT_COALESCE = True
     CONCAT_WS_COALESCE = True

--- a/sqlglot/dialects/redshift.py
+++ b/sqlglot/dialects/redshift.py
@@ -12,6 +12,8 @@ class Redshift(Postgres):
     # https://docs.aws.amazon.com/redshift/latest/dg/r_names.html
     NORMALIZATION_STRATEGY = NormalizationStrategy.CASE_INSENSITIVE
 
+    NORMALIZE_NOT_NULL = True
+
     EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
     SUPPORTS_USER_DEFINED_TYPES = False
     INDEX_OFFSET = 0

--- a/sqlglot/dialects/risingwave.py
+++ b/sqlglot/dialects/risingwave.py
@@ -7,6 +7,8 @@ from sqlglot.tokens import TokenType
 
 
 class RisingWave(Postgres):
+    NORMALIZE_NOT_NULL = True
+
     REQUIRES_PARENTHESIZED_STRUCT_ACCESS = True
     SUPPORTS_STRUCT_STAR_EXPANSION = True
 

--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -9,6 +9,54 @@ from sqlglot.generator import Generator
 from sqlglot.helper import PYTHON_VERSION, is_int, seq_get
 
 
+def sql_not(value):
+    return None if value is None else not bool(value)
+
+
+def sql_and(left, right):
+    left = left()
+    left = None if left is None else bool(left)
+
+    if left is False:
+        return False
+
+    right = right()
+    right = None if right is None else bool(right)
+    if right is False:
+        return False
+
+    return None if left is None or right is None else True
+
+
+def sql_or(left, right):
+    left = left()
+    left = None if left is None else bool(left)
+
+    if left is True:
+        return True
+
+    right = right()
+    right = None if right is None else bool(right)
+    if right is True:
+        return True
+
+    return None if left is None or right is None else False
+
+
+def sql_in(value, *candidates):
+    if value is None:
+        return None
+
+    has_null = False
+    for candidate in candidates:
+        if candidate is None:
+            has_null = True
+        elif value == candidate:
+            return True
+
+    return None if has_null else False
+
+
 class reverse_key:
     def __init__(self, obj):
         self.obj = obj
@@ -168,6 +216,7 @@ def jsonextract(this, expression):
 
 ENV = {
     "exp": exp,
+    "AND": sql_and,
     # aggs
     "ARRAYAGG": list,
     "ARRAYUNIQUEAGG": filter_nulls(lambda acc: list(set(acc))),
@@ -201,6 +250,7 @@ ENV = {
     "GT": null_if_any(lambda this, e: this > e),
     "GTE": null_if_any(lambda this, e: this >= e),
     "IF": lambda predicate, true, false: true if predicate else false,
+    "IN": sql_in,
     "INTDIV": null_if_any(lambda e, this: e // this),
     "INTERVAL": interval,
     "JSONEXTRACT": jsonextract,
@@ -216,6 +266,8 @@ ENV = {
     "MUL": null_if_any(lambda e, this: e * this),
     "NEQ": null_if_any(lambda this, e: this != e),
     "ORD": null_if_any(ord),
+    "NOT": sql_not,
+    "OR": sql_or,
     "ORDERED": ordered,
     "POW": pow,
     "RIGHT": null_if_any(lambda this, e: this[-e:]),

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -374,9 +374,23 @@ class PythonExecutor:
         sink = self.table(left.columns)
 
         if issubclass(step.op, exp.Intersect):
-            sink.rows = list(set(left.rows).intersection(set(right.rows)))
+            right_counts = collections.Counter(right.rows)
+            seen = set()
+            for row in left.rows:
+                if right_counts[row] and (not step.distinct or row not in seen):
+                    sink.append(row)
+                    seen.add(row)
+                    if not step.distinct:
+                        right_counts[row] -= 1
         elif issubclass(step.op, exp.Except):
-            sink.rows = list(set(left.rows).difference(set(right.rows)))
+            right_counts = collections.Counter(right.rows)
+            seen = set()
+            for row in left.rows:
+                if right_counts[row] and not step.distinct:
+                    right_counts[row] -= 1
+                elif not right_counts[row] and (not step.distinct or row not in seen):
+                    sink.append(row)
+                    seen.add(row)
         elif issubclass(step.op, exp.Union) and step.distinct:
             sink.rows = list(set(left.rows).union(set(right.rows)))
         else:

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -140,11 +140,29 @@ class PythonExecutor:
             start = max(r.stop for r in column_ranges.values())
             column_ranges[name] = range(start, len(table.columns) + start)
             join_context = self.context({name: table})
+            condition = self.generate(join["condition"])
+            condition_context = (
+                self.context(
+                    {
+                        name: Table(
+                            source_context.columns + join_context.columns,
+                            column_range=column_range,
+                        )
+                        for name, column_range in column_ranges.items()
+                    }
+                )
+                if condition
+                else None
+            )
 
             if join.get("source_key"):
-                table = self.hash_join(join, source_context, join_context)
+                table = self.hash_join(
+                    join, source_context, join_context, condition, condition_context
+                )
             else:
-                table = self.nested_loop_join(join, source_context, join_context)
+                table = self.nested_loop_join(
+                    join, source_context, join_context, condition, condition_context
+                )
 
             source_context = self.context(
                 {
@@ -152,10 +170,6 @@ class PythonExecutor:
                     for name, column_range in column_ranges.items()
                 }
             )
-            condition = self.generate(join["condition"])
-            if condition:
-                source_context.filter(condition)
-
         if not step.condition and not step.projections:
             return source_context
 
@@ -175,41 +189,91 @@ class PythonExecutor:
                 }
             )
 
-    def nested_loop_join(self, _join, source_context, join_context):
-        table = Table(source_context.columns + join_context.columns)
+    @staticmethod
+    def _join_matches(row, condition, condition_context):
+        if not condition:
+            return True
 
-        for reader_a, _ in source_context:
-            for reader_b, _ in join_context:
-                table.append(reader_a.row + reader_b.row)
+        condition_context.set_row(row)
+        return condition_context.eval(condition) is True
+
+    def nested_loop_join(self, join, source_context, join_context, condition, condition_context):
+        table = Table(source_context.columns + join_context.columns)
+        source_rows = source_context.table.rows
+        join_rows = join_context.table.rows
+        matched_source = set()
+        matched_join = set()
+
+        for source_index, source_row in enumerate(source_rows):
+            for join_index, join_row in enumerate(join_rows):
+                row = source_row + join_row
+                if self._join_matches(row, condition, condition_context):
+                    table.append(row)
+                    matched_source.add(source_index)
+                    matched_join.add(join_index)
+
+        self._append_unmatched_join_rows(
+            table, join, source_rows, join_rows, matched_source, matched_join
+        )
 
         return table
 
-    def hash_join(self, join, source_context, join_context):
+    def hash_join(self, join, source_context, join_context, condition, condition_context):
         source_key = self.generate_tuple(join["source_key"])
         join_key = self.generate_tuple(join["join_key"])
-        left = join.get("side") == "LEFT"
-        right = join.get("side") == "RIGHT"
-
         results = collections.defaultdict(lambda: ([], []))
 
-        for reader, ctx in source_context:
-            results[ctx.eval_tuple(source_key)][0].append(reader.row)
-        for reader, ctx in join_context:
-            results[ctx.eval_tuple(join_key)][1].append(reader.row)
+        for index, (reader, ctx) in enumerate(source_context):
+            key = ctx.eval_tuple(source_key)
+            if all(value is not None for value in key):
+                results[key][0].append((index, reader.row))
+        for index, (reader, ctx) in enumerate(join_context):
+            key = ctx.eval_tuple(join_key)
+            if all(value is not None for value in key):
+                results[key][1].append((index, reader.row))
 
         table = Table(source_context.columns + join_context.columns)
-        nulls = [(None,) * len(join_context.columns if left else source_context.columns)]
+        matched_source = set()
+        matched_join = set()
 
-        for a_group, b_group in results.values():
-            if left:
-                b_group = b_group or nulls
-            elif right:
-                a_group = a_group or nulls
+        for source_group, join_group in results.values():
+            for (source_index, source_row), (join_index, join_row) in itertools.product(
+                source_group, join_group
+            ):
+                row = source_row + join_row
+                if self._join_matches(row, condition, condition_context):
+                    table.append(row)
+                    matched_source.add(source_index)
+                    matched_join.add(join_index)
 
-            for a_row, b_row in itertools.product(a_group, b_group):
-                table.append(a_row + b_row)
+        self._append_unmatched_join_rows(
+            table,
+            join,
+            source_context.table.rows,
+            join_context.table.rows,
+            matched_source,
+            matched_join,
+        )
 
         return table
+
+    @staticmethod
+    def _append_unmatched_join_rows(
+        table, join, source_rows, join_rows, matched_source, matched_join
+    ):
+        side = join.get("side")
+        if side in ("LEFT", "FULL"):
+            join_nulls = (None,) * (len(table.columns) - len(source_rows[0]) if source_rows else 0)
+            for index, row in enumerate(source_rows):
+                if index not in matched_source:
+                    table.append(row + join_nulls)
+
+        if side in ("RIGHT", "FULL"):
+            source_width = len(table.columns) - (len(join_rows[0]) if join_rows else 0)
+            source_nulls = (None,) * source_width
+            for index, row in enumerate(join_rows):
+                if index not in matched_join:
+                    table.append(source_nulls + row)
 
     def aggregate(self, step, context):
         group_by = self.generate_tuple(step.group.values())

--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -2184,7 +2184,7 @@ class IntDiv(Expression, Binary):
 
 
 class Is(Expression, Binary, Predicate):
-    pass
+    arg_types = {"this": True, "expression": True, "negate": False}
 
 
 class Like(Expression, Binary, Predicate):

--- a/sqlglot/expressions/math.py
+++ b/sqlglot/expressions/math.py
@@ -164,6 +164,10 @@ class Log(Expression, Func):
     arg_types = {"this": True, "expression": False}
 
 
+class Negative(Expression, Func):
+    pass
+
+
 class Nanvl(Expression, Func):
     arg_types = {"this": True, "expression": True}
 

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -444,7 +444,7 @@ class RecursiveWithSearch(Expression):
 
 
 class With(Expression):
-    arg_types = {"expressions": True, "recursive": False, "search": False}
+    arg_types = {"expressions": False, "recursive": False, "search": False, "udfs": False}
 
     @property
     def recursive(self) -> bool:

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2120,6 +2120,18 @@ class EndStatement(Expression):
     arg_types = {}
 
 
+# https://trino.io/docs/current/udf.html
+class FunctionSpecification(Expression):
+    """
+    A SQL user-defined function specification, e.g. an inline UDF declared with
+    `WITH FUNCTION ... SELECT ...` in Trino. `this` is a `UserDefinedFunction`,
+    `properties` holds the `RETURNS` clause and routine characteristics, and
+    `expression` is the routine body (e.g. a `Return`).
+    """
+
+    arg_types = {"this": True, "properties": False, "expression": True}
+
+
 UNWRAPPED_QUERIES = (Select, SetOperation)
 
 

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2122,13 +2122,6 @@ class EndStatement(Expression):
 
 # https://trino.io/docs/current/udf.html
 class FunctionSpecification(Expression):
-    """
-    A SQL user-defined function specification, e.g. an inline UDF declared with
-    `WITH FUNCTION ... SELECT ...` in Trino. `this` is a `UserDefinedFunction`,
-    `properties` holds the `RETURNS` clause and routine characteristics, and
-    `expression` is the routine body (e.g. a `Return`).
-    """
-
     arg_types = {"this": True, "properties": False, "expression": True}
 
 

--- a/sqlglot/expressions/string.py
+++ b/sqlglot/expressions/string.py
@@ -141,6 +141,10 @@ class SearchIp(Expression, Func):
     arg_types = {"this": True, "expression": True}
 
 
+class Secret(Expression, Func):
+    arg_types = {"this": True, "expression": True}
+
+
 class Soundex(Expression, Func):
     pass
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1518,7 +1518,11 @@ class Generator:
         return sql
 
     def with_sql(self, expression: exp.With) -> str:
+        udfs = self.expressions(expression, key="udfs", flat=True)
+        udfs = f"WITH {udfs}" if udfs else ""
+
         sql = self.expressions(expression, flat=True)
+
         recursive = (
             "RECURSIVE "
             if self.CTE_RECURSIVE_KEYWORD_REQUIRED and expression.args.get("recursive")
@@ -1527,7 +1531,8 @@ class Generator:
         search = self.sql(expression, "search")
         search = f" {search}" if search else ""
 
-        return f"WITH {recursive}{sql}{search}"
+        sql = f"WITH {recursive}{sql}{search}" if sql else ""
+        return f"{udfs} {sql}" if udfs and sql else f"{udfs}{sql}"
 
     def cte_sql(self, expression: exp.CTE) -> str:
         alias = expression.args.get("alias")
@@ -6214,12 +6219,8 @@ class Generator:
         return f"{expressions}" if expressions else ""
 
     def functionspecification_sql(self, expression: exp.FunctionSpecification) -> str:
-        properties = expression.args.get("properties")
-        properties_sql = (
-            self.properties(properties, prefix=" ", sep=" ", wrapped=False) if properties else ""
-        )
-        body = self.sql(expression, "expression")
-        return f"FUNCTION {self.sql(expression, 'this')}{properties_sql} {body}"
+        self.unsupported("Unsupported Inline UDFs syntax")
+        return ""
 
     def storedprocedure_sql(self, expression: exp.StoredProcedure) -> str:
         self.unsupported("Unsupported Stored Procedure syntax")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -6213,6 +6213,14 @@ class Generator:
         expressions = self.expressions(expression, sep="; ", flat=True)
         return f"{expressions}" if expressions else ""
 
+    def functionspecification_sql(self, expression: exp.FunctionSpecification) -> str:
+        properties = expression.args.get("properties")
+        properties_sql = (
+            self.properties(properties, prefix=" ", sep=" ", wrapped=False) if properties else ""
+        )
+        body = self.sql(expression, "expression")
+        return f"FUNCTION {self.sql(expression, 'this')}{properties_sql} {body}"
+
     def storedprocedure_sql(self, expression: exp.StoredProcedure) -> str:
         self.unsupported("Unsupported Stored Procedure syntax")
         return ""

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4440,11 +4440,11 @@ class Generator:
         return self.binary(expression, ">=")
 
     def is_sql(self, expression: exp.Is) -> str:
+        negate = expression.args.get("negate")
         if not self.IS_BOOL_ALLOWED and isinstance(expression.expression, exp.Boolean):
-            return self.sql(
-                expression.this if expression.expression.this else exp.not_(expression.this)
-            )
-        return self.binary(expression, "IS")
+            positive = bool(expression.expression.this) != bool(negate)
+            return self.sql(expression.this if positive else exp.not_(expression.this))
+        return self.binary(expression, "IS NOT" if negate else "IS")
 
     def _like_sql(
         self,

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -174,6 +174,7 @@ class ClickHouseGenerator(generator.Generator):
     QUERY_HINTS = False
     STRUCT_DELIMITER = ("(", ")")
     NVL2_SUPPORTED = False
+    ALTER_SET_TYPE = "TYPE"
     TABLESAMPLE_REQUIRES_PARENS = False
     TABLESAMPLE_SIZE_IS_ROWS = False
     TABLESAMPLE_KEYWORDS = "SAMPLE"

--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -79,7 +79,7 @@ class PythonGenerator(generator.Generator):
         exp.Case: _case_sql,
         exp.Alias: lambda self, e: self.sql(e.this),
         exp.Array: inline_array_sql,
-        exp.And: lambda self, e: self.binary(e, "and"),
+        exp.And: lambda self, e: f"AND(lambda: {self.sql(e.left)}, lambda: {self.sql(e.right)})",
         exp.Between: _rename,
         exp.Boolean: lambda self, e: "True" if e.this else "False",
         exp.Cast: lambda self, e: f"CAST({self.sql(e.this)}, exp.DType.{e.args['to']})",
@@ -90,7 +90,7 @@ class PythonGenerator(generator.Generator):
         exp.Distinct: lambda self, e: f"set({self.sql(e, 'this')})",
         exp.Div: _div_sql,
         exp.Extract: lambda self, e: f"EXTRACT('{e.name.lower()}', {self.sql(e, 'expression')})",
-        exp.In: lambda self, e: f"{self.sql(e, 'this')} in {{{self.expressions(e, flat=True)}}}",
+        exp.In: lambda self, e: self.func("IN", e.this, *e.expressions),
         exp.Interval: lambda self, e: f"INTERVAL({self.sql(e.this)}, '{self.sql(e.unit)}')",
         exp.Is: lambda self, e: (
             self.binary(e, "!=" if e.args.get("negate") else "==")
@@ -102,9 +102,9 @@ class PythonGenerator(generator.Generator):
         exp.JSONPathKey: lambda self, e: f"'{self.sql(e.this)}'",
         exp.JSONPathSubscript: lambda self, e: f"'{e.this}'",
         exp.Lambda: _lambda_sql,
-        exp.Not: lambda self, e: f"not {self.sql(e.this)}",
+        exp.Not: lambda self, e: self.func("NOT", e.this),
         exp.Null: lambda *_: "None",
-        exp.Or: lambda self, e: self.binary(e, "or"),
+        exp.Or: lambda self, e: f"OR(lambda: {self.sql(e.left)}, lambda: {self.sql(e.right)})",
         exp.Ordered: _ordered_py,
         exp.Star: lambda *_: "1",
     }

--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -93,7 +93,9 @@ class PythonGenerator(generator.Generator):
         exp.In: lambda self, e: f"{self.sql(e, 'this')} in {{{self.expressions(e, flat=True)}}}",
         exp.Interval: lambda self, e: f"INTERVAL({self.sql(e.this)}, '{self.sql(e.unit)}')",
         exp.Is: lambda self, e: (
-            self.binary(e, "==") if isinstance(e.this, exp.Literal) else self.binary(e, "is")
+            self.binary(e, "!=" if e.args.get("negate") else "==")
+            if isinstance(e.this, exp.Literal)
+            else self.binary(e, "is not" if e.args.get("negate") else "is")
         ),
         exp.JSONExtract: lambda self, e: self.func(e.key, e.this, e.expression, *e.expressions),
         exp.JSONPath: lambda self, e: f"[{','.join(self.sql(p) for p in e.expressions[1:])}]",

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -48,6 +48,25 @@ class TrinoGenerator(PrestoGenerator):
         exp.JSONPathSubscript,
     }
 
+    def with_sql(self, expression: exp.With) -> str:
+        # Inline UDFs are declared in their own `WITH` clause, which precedes the (optional)
+        # `WITH` clause of the query: https://trino.io/docs/current/udf/sql.html
+        functions = [e for e in expression.expressions if isinstance(e, exp.FunctionSpecification)]
+        if not functions:
+            return super().with_sql(expression)
+
+        functions_sql = self.expressions(sqls=functions, flat=True)
+
+        if len(functions) == len(expression.expressions):
+            return f"WITH {functions_sql}"
+
+        expression.set(
+            "expressions",
+            [e for e in expression.expressions if not isinstance(e, exp.FunctionSpecification)],
+        )
+
+        return f"WITH {functions_sql} {super().with_sql(expression)}"
+
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):
             return super().jsonextract_sql(expression)

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -48,22 +48,13 @@ class TrinoGenerator(PrestoGenerator):
         exp.JSONPathSubscript,
     }
 
-    def with_sql(self, expression: exp.With) -> str:
-        functions = [e for e in expression.expressions if isinstance(e, exp.FunctionSpecification)]
-        if not functions:
-            return super().with_sql(expression)
-
-        functions_sql = self.expressions(sqls=functions, flat=True)
-
-        if len(functions) == len(expression.expressions):
-            return f"WITH {functions_sql}"
-
-        expression.set(
-            "expressions",
-            [e for e in expression.expressions if not isinstance(e, exp.FunctionSpecification)],
+    def functionspecification_sql(self, expression: exp.FunctionSpecification) -> str:
+        properties = expression.args.get("properties")
+        properties_sql = (
+            self.properties(properties, prefix=" ", sep=" ", wrapped=False) if properties else ""
         )
-
-        return f"WITH {functions_sql} {super().with_sql(expression)}"
+        body = self.sql(expression, "expression")
+        return f"FUNCTION {self.sql(expression, 'this')}{properties_sql} {body}"
 
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -49,8 +49,6 @@ class TrinoGenerator(PrestoGenerator):
     }
 
     def with_sql(self, expression: exp.With) -> str:
-        # Inline UDFs are declared in their own `WITH` clause, which precedes the (optional)
-        # `WITH` clause of the query: https://trino.io/docs/current/udf/sql.html
         functions = [e for e in expression.expressions if isinstance(e, exp.FunctionSpecification)]
         if not functions:
             return super().with_sql(expression)

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -378,9 +378,10 @@ class TSQLGenerator(generator.Generator):
         return "(1 = 1)" if expression.this else "(1 = 0)"
 
     def is_sql(self, expression: exp.Is) -> str:
+        negate = expression.args.get("negate")
         if isinstance(expression.expression, exp.Boolean):
-            return self.binary(expression, "=")
-        return self.binary(expression, "IS")
+            return self.binary(expression, "<>" if negate else "=")
+        return self.binary(expression, "IS NOT" if negate else "IS")
 
     def createable_sql(self, expression: exp.Create, locations: defaultdict) -> str:
         sql = self.sql(expression, "this")

--- a/sqlglot/jsonpath.py
+++ b/sqlglot/jsonpath.py
@@ -135,14 +135,14 @@ def parse(path: str, dialect: DialectType = None) -> exp.JSONPath:
             while _match(TokenType.COMMA):
                 literal = _parse_slice()
 
-                if literal:
+                if isinstance(literal, str) or literal is not False:
                     indexes.append(literal)
 
             if len(indexes) == 1:
-                if isinstance(literal, str):
+                if isinstance(indexes[0], str):
                     node: exp.JSONPathPart = exp.JSONPathKey(this=indexes[0])
-                elif isinstance(literal, exp.JSONPathPart) and isinstance(
-                    literal, (exp.JSONPathScript, exp.JSONPathFilter)
+                elif isinstance(indexes[0], exp.JSONPathPart) and isinstance(
+                    indexes[0], (exp.JSONPathScript, exp.JSONPathFilter)
                 ):
                     node = exp.JSONPathSelector(this=indexes[0])
                 else:

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -582,14 +582,14 @@ class TypeAnnotator:
         we assume type1 does not coerce into type2, so we also return it in this case.
         """
         if isinstance(type1, exp.DataType):
-            if type1.expressions:
+            if type1.expressions or not isinstance(type1.this, exp.DType):
                 return type1
             type1_value = type1.this
         else:
             type1_value = type1
 
         if isinstance(type2, exp.DataType):
-            if type2.expressions:
+            if type2.expressions or not isinstance(type2.this, exp.DType):
                 return type2
             type2_value = type2.this
         else:
@@ -927,7 +927,11 @@ class TypeAnnotator:
         return expression
 
     def _annotate_explode(self, expression: exp.Explode) -> exp.Explode:
-        self._set_type(expression, seq_get(expression.this.type.expressions, 0))
+        input_type = expression.this.type
+        if input_type and input_type.is_type(exp.DType.ARRAY):
+            self._set_type(expression, seq_get(input_type.expressions, 0))
+        else:
+            self._set_type(expression, None)
         return expression
 
     def _annotate_unnest(self, expression: exp.Unnest) -> exp.Unnest:

--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -741,7 +741,8 @@ class TypeAnnotator:
             self._set_type(expression, None)
             return expression
 
-        left_type, right_type = left.type.this, right.type.this  # type: ignore
+        left_type = left.type.this if left.type else exp.DType.UNKNOWN
+        right_type = right.type.this if right.type else exp.DType.UNKNOWN
 
         # TODO (mypyc): should be isinstance(expression, (exp.Connector, exp.Predicate)) but
         # mypyc narrows the variable to the first type in a tuple/or isinstance check when
@@ -803,7 +804,7 @@ class TypeAnnotator:
             for expr in ensure_list(expressions):
                 expr_type = expr.type
 
-                if expr_type.is_type(exp.DType.UNKNOWN):
+                if expr_type is None or expr_type.is_type(exp.DType.UNKNOWN):
                     self._set_type(expression, exp.DType.UNKNOWN)
                     return expression
 
@@ -840,18 +841,19 @@ class TypeAnnotator:
                     and non_literal_this_type in exp.DataType.REAL_TYPES
                 ):
                     result_type = non_literal_type
+
+            if result_type is None:
+                result_type = self._maybe_coerce(non_literal_type, literal_type)
         else:
             result_type = literal_type or non_literal_type or exp.DType.UNKNOWN
 
-        self._set_type(
-            expression,
-            result_type or self._maybe_coerce(non_literal_type, literal_type),  # type: ignore
-        )
+        self._set_type(expression, result_type)
 
         if promote:
-            if expression.type.this in exp.DataType.INTEGER_TYPES:  # type: ignore
+            this_type = result_type.this if isinstance(result_type, exp.DataType) else result_type
+            if this_type in exp.DataType.INTEGER_TYPES:
                 self._set_type(expression, exp.DType.BIGINT)
-            elif expression.type.this in exp.DataType.FLOAT_TYPES:  # type: ignore
+            elif this_type in exp.DataType.FLOAT_TYPES:
                 self._set_type(expression, exp.DType.DOUBLE)
 
         if array:
@@ -893,7 +895,9 @@ class TypeAnnotator:
         return expression
 
     def _annotate_div(self, expression: exp.Div) -> exp.Div:
-        left_type, right_type = expression.left.type.this, expression.right.type.this  # type: ignore
+        left, right = expression.left, expression.right
+        left_type = left.type.this if left.type else exp.DType.UNKNOWN
+        right_type = right.type.this if right.type else exp.DType.UNKNOWN
 
         if (
             expression.args.get("typed")

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -46,7 +46,7 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
         for scope in reversed(list(root.traverse())):
             select = scope.expression
             where: exp.Expr | None = select.args.get("where")
-            joins: list[exp.Expr] = select.args.get("joins") or []
+            joins: list[exp.Join] = select.args.get("joins") or []
             if where:
                 selected_sources: Sources = scope.selected_sources
                 join_index = {join.alias_or_name: i for i, join in enumerate(joins)}
@@ -71,6 +71,10 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
             # so we limit the selected sources to only itself
             for join in joins:
                 name = join.alias_or_name
+
+                if join.side in ("RIGHT", "FULL"):
+                    continue
+
                 if name in scope.selected_sources:
                     pushdown(
                         join.args.get("on"),
@@ -227,10 +231,20 @@ def nodes_for_predicate(
             node = source.expression
 
         if isinstance(node, exp.Join):
-            if node.side and node.side != "RIGHT":
-                return {}
-            nodes[table] = node
-        elif isinstance(node, exp.Select) and len(tables) == 1:
+            if node.side:
+                # A right join preserves its own source, so a WHERE predicate on it can only be
+                # pushed into that source, never into the match-only ON clause.
+                pushable_source = (
+                    source if node.side == "RIGHT" and not isinstance(source, exp.Table) else None
+                )
+                if not pushable_source:
+                    return {}
+
+                node = pushable_source.expression
+            else:
+                nodes[table] = node
+
+        if isinstance(node, exp.Select) and len(tables) == 1:
             # We can't push down window expressions
             has_window_expression = any(
                 select for select in node.selects if select.find(exp.Window)

--- a/sqlglot/optimizer/qualify.py
+++ b/sqlglot/optimizer/qualify.py
@@ -32,7 +32,7 @@ def qualify(
     quote_identifiers: bool = True,
     identify: bool = True,
     canonicalize_table_aliases: bool = False,
-    on_qualify: t.Callable[[exp.Expr], None] | None = None,
+    on_qualify: t.Callable[[exp.Table], None] | None = None,
     sql: str | None = None,
 ) -> E:
     """

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -332,6 +332,8 @@ def eval_boolean(
     expression: object, a: SupportsComparison, b: SupportsComparison
 ) -> exp.Boolean | None:
     if isinstance(expression, (exp.EQ, exp.Is)):
+        if isinstance(expression, exp.Is) and expression.args.get("negate"):
+            return boolean_literal(a != b)
         return boolean_literal(a == b)
     if isinstance(expression, exp.NEQ):
         return boolean_literal(a != b)
@@ -892,8 +894,11 @@ class Simplifier:
         self, expression: exp.Expr, left: exp.Expr, right: exp.Expr, or_: bool = False
     ) -> exp.Expr | None:
         if isinstance(left, self.COMPARISONS) and isinstance(right, self.COMPARISONS):
-            ll, lr = left.args.values()
-            rl, rr = right.args.values()
+            if any(isinstance(e, exp.Is) and e.args.get("negate") for e in (left, right)):
+                return None
+
+            ll, lr = left.this, left.expression
+            rl, rr = right.this, right.expression
 
             largs = {ll, lr}
             rargs = {rl, rr}
@@ -1193,6 +1198,9 @@ class Simplifier:
             else:
                 c = b
                 not_ = False
+
+            if expression.args.get("negate"):
+                not_ = not not_
 
             if is_null(c):
                 if isinstance(a, exp.Literal):
@@ -1699,7 +1707,7 @@ class Gen:
         self._binary(e, " DIV ")
 
     def is_sql(self, e: exp.Is) -> None:
-        self._binary(e, " IS ")
+        self._binary(e, " IS NOT " if e.args.get("negate") else " IS ")
 
     def like_sql(self, e: exp.Like) -> None:
         self._binary(e, " NOT Like " if e.args.get("negate") else " Like ")

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -1018,11 +1018,11 @@ class Simplifier:
         absorption:
             A AND (A OR B) -> A
             A OR (A AND B) -> A
-            A AND (NOT A OR B) -> A AND B
-            A OR (NOT A AND B) -> A OR B
+            A AND (NOT A OR B) -> A AND B (only for non-NULL A)
+            A OR (NOT A AND B) -> A OR B (only for non-NULL A)
         elimination:
-            (A AND B) OR (A AND NOT B) -> A
-            (A OR B) AND (A OR NOT B) -> A
+            (A AND B) OR (A AND NOT B) -> A (only for non-NULL B)
+            (A OR B) AND (A OR NOT B) -> A (only for non-NULL B)
         """
         if isinstance(expression, self.AND_OR) and (root or not expression.same_parent):
             kind = exp.Or if isinstance(expression, exp.And) else exp.And
@@ -1054,9 +1054,10 @@ class Simplifier:
                     subops[i].append(subset)
 
                 a, b = op.unnest_operands()
-                if isinstance(a, exp.Not):
+
+                if isinstance(a, exp.Not) and a.this.meta_get("nonnull") is True:
                     pairs[frozenset((a.this, b))].append((op, b))
-                if isinstance(b, exp.Not):
+                if isinstance(b, exp.Not) and b.this.meta_get("nonnull") is True:
                     pairs[frozenset((a, b.this))].append((op, a))
 
             for op in ops:
@@ -1066,10 +1067,18 @@ class Simplifier:
                 a, b = op.unnest_operands()
 
                 # Absorb
-                if isinstance(a, exp.Not) and a.this in op_set:
+                if (
+                    isinstance(a, exp.Not)
+                    and a.this in op_set
+                    and a.this.meta_get("nonnull") is True
+                ):
                     a.replace(exp.true() if kind == exp.And else exp.false())
                     continue
-                if isinstance(b, exp.Not) and b.this in op_set:
+                if (
+                    isinstance(b, exp.Not)
+                    and b.this in op_set
+                    and b.this.meta_get("nonnull") is True
+                ):
                     b.replace(exp.true() if kind == exp.And else exp.false())
                     continue
                 superset = set(op.flatten())

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4394,10 +4394,14 @@ class Parser:
                 text += " PAST LAST ROW"
             elif self._match_text_seq("TO", "NEXT", "ROW"):
                 text += " TO NEXT ROW"
-            elif self._match_text_seq("TO", "FIRST"):
-                text += f" TO FIRST {self._advance_any().text}"  # type: ignore
-            elif self._match_text_seq("TO", "LAST"):
-                text += f" TO LAST {self._advance_any().text}"  # type: ignore
+            elif self._match_text_seq("TO", "FIRST") or self._match_text_seq("TO", "LAST"):
+                direction = self._prev.text.upper()
+                pattern_var = self._advance_any()
+                if not pattern_var:
+                    self.raise_error(
+                        f"Expecting pattern variable after AFTER MATCH SKIP TO {direction}"
+                    )
+                text += f" TO {direction} {pattern_var.text if pattern_var else ''}"
             after = exp.var(text)
         else:
             after = None

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5950,8 +5950,11 @@ class Parser:
             elif self._match(TokenType.NOTNULL):
                 # Postgres supports ISNULL and NOTNULL for conditions.
                 # https://blog.andreiavram.ro/postgresql-null-composite-type/
-                this = self.expression(exp.Is(this=this, expression=exp.Null()))
-                this = self.expression(exp.Not(this=this))
+                if self.dialect.NORMALIZE_NOT_NULL:
+                    this = self.expression(exp.Is(this=this, expression=exp.Null()))
+                    this = self.expression(exp.Not(this=this))
+                else:
+                    this = self.expression(exp.Is(this=this, expression=exp.Null(), negate=True))
             else:
                 if negate:
                     self._retreat(self._index - 1)
@@ -6007,8 +6010,12 @@ class Parser:
                 self._retreat(index)
                 return None
 
-        this = self.expression(exp.Is(this=this, expression=expression))
-        this = self.expression(exp.Not(this=this)) if negate else this
+        if negate and isinstance(expression, exp.Null) and not self.dialect.NORMALIZE_NOT_NULL:
+            this = self.expression(exp.Is(this=this, expression=expression, negate=True))
+        else:
+            this = self.expression(exp.Is(this=this, expression=expression))
+            this = self.expression(exp.Not(this=this)) if negate else this
+
         return self._parse_column_ops(this)
 
     def _parse_in(self, this: exp.Expr | None, alias: bool = False) -> exp.In:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4097,7 +4097,7 @@ class Parser:
         expressions = []
         while True:
             cte = self._parse_cte()
-            if isinstance(cte, exp.CTE):
+            if cte:
                 expressions.append(cte)
                 if last_comments:
                     cte.add_comments(last_comments)
@@ -4106,6 +4106,7 @@ class Parser:
                 break
             else:
                 self._match(TokenType.WITH)
+                recursive = self._match(TokenType.RECURSIVE) or recursive
 
             last_comments = self._prev_comments
 
@@ -4118,7 +4119,7 @@ class Parser:
             comments=comments,
         )
 
-    def _parse_cte(self) -> exp.CTE | None:
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         index = self._index
 
         alias = self._parse_table_alias(self.ID_VAR_TOKENS)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -4095,10 +4095,15 @@ class Parser:
 
         last_comments = None
         expressions = []
+        udfs = []
         while True:
             cte = self._parse_cte()
             if cte:
-                expressions.append(cte)
+                if isinstance(cte, exp.FunctionSpecification):
+                    udfs.append(cte)
+                else:
+                    expressions.append(cte)
+
                 if last_comments:
                     cte.add_comments(last_comments)
 
@@ -4115,6 +4120,7 @@ class Parser:
                 expressions=expressions,
                 recursive=recursive or None,
                 search=self._parse_recursive_with_search(),
+                udfs=udfs or None,
             ),
             comments=comments,
         )

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -654,9 +654,9 @@ class ClickHouseParser(parser.Parser):
         return super()._parse_position(haystack_first=True)
 
     # https://clickhouse.com/docs/en/sql-reference/statements/select/with/
-    def _parse_cte(self) -> exp.CTE | None:
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
         # WITH <identifier> AS <subquery expression>
-        cte: exp.CTE | None = self._try_parse(super()._parse_cte)
+        cte: exp.CTE | exp.FunctionSpecification | None = self._try_parse(super()._parse_cte)
 
         if not cte:
             # WITH <expression> AS <identifier>

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -156,6 +156,7 @@ AGG_FUNCTIONS = {
     "quantile",
     "quantiles",
     "quantileExact",
+    "quantileExactInclusive",
     "quantilesExact",
     "quantilesExactExclusive",
     "quantileExactLow",

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -61,3 +61,34 @@ class TrinoParser(PrestoParser):
                 on_condition=self._parse_on_condition(),
             )
         )
+
+    def _parse_cte(self) -> exp.CTE | exp.FunctionSpecification | None:
+        # A `WITH` clause entry that starts with `FUNCTION <name>` is an inline SQL UDF
+        # specification (https://trino.io/docs/current/udf/sql.html), as opposed to a
+        # CTE that happens to be named "function", e.g. `WITH function AS (SELECT 1)`
+        if (
+            self._match(TokenType.FUNCTION, advance=False)
+            and self._next.token_type in self.ID_VAR_TOKENS
+        ):
+            self._advance()
+            return self._parse_function_specification()
+
+        return super()._parse_cte()
+
+    def _parse_function_specification(self) -> exp.FunctionSpecification:
+        return self.expression(
+            exp.FunctionSpecification(
+                this=self._parse_user_defined_function(kind=TokenType.FUNCTION),
+                properties=self._parse_properties(),
+                expression=self._parse_routine_statement(),
+            )
+        )
+
+    def _parse_routine_statement(self) -> exp.Expr | None:
+        # https://trino.io/docs/current/udf/sql.html -- only RETURN is supported so far;
+        # BEGIN...END blocks and other control statements are added in follow-ups.
+        if self._match_text_seq("RETURN"):
+            return self.expression(exp.Return(this=self._parse_disjunction()))
+
+        self.raise_error("Expected routine statement")
+        return None

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -68,6 +68,7 @@ class TrinoParser(PrestoParser):
         # CTE that happens to be named "function", e.g. `WITH function AS (SELECT 1)`
         if (
             self._match(TokenType.FUNCTION, advance=False)
+            and self._next
             and self._next.token_type in self.ID_VAR_TOKENS
         ):
             self._advance()

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -85,8 +85,6 @@ class TrinoParser(PrestoParser):
         )
 
     def _parse_routine_statement(self) -> exp.Expr | None:
-        # https://trino.io/docs/current/udf/sql.html -- only RETURN is supported so far;
-        # BEGIN...END blocks and other control statements are added in follow-ups.
         if self._match_text_seq("RETURN"):
             return self.expression(exp.Return(this=self._parse_disjunction()))
 

--- a/sqlglot/schema.py
+++ b/sqlglot/schema.py
@@ -696,6 +696,8 @@ def normalize_name(
 ) -> exp.Identifier:
     if isinstance(identifier, str):
         identifier = exp.parse_identifier(identifier, dialect=dialect)
+    elif normalize:
+        identifier = identifier.copy()
 
     if not normalize:
         return identifier

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -587,7 +587,13 @@ def add_recursive_cte_column_names(expression: exp.Expr) -> exp.Expr:
         next_name = name_sequence("_c_")
 
         for cte in expression.expressions:
-            if not cte.args["alias"].columns:
+            alias = cte.args.get("alias")
+            if not alias:
+                # Non-CTE entries (e.g. a Trino inline UDF's FunctionSpecification) don't
+                # have output columns to derive names from, so leave them untouched
+                continue
+
+            if not alias.columns:
                 query = cte.this
                 if isinstance(query, exp.SetOperation):
                     query = query.this

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -587,13 +587,7 @@ def add_recursive_cte_column_names(expression: exp.Expr) -> exp.Expr:
         next_name = name_sequence("_c_")
 
         for cte in expression.expressions:
-            alias = cte.args.get("alias")
-            if not alias:
-                # Non-CTE entries (e.g. a Trino inline UDF's FunctionSpecification) don't
-                # have output columns to derive names from, so leave them untouched
-                continue
-
-            if not alias.columns:
+            if not cte.args["alias"].columns:
                 query = cte.this
                 if isinstance(query, exp.SetOperation):
                     query = query.this

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -26,6 +26,9 @@ EXPRESSION_METADATA = {
             exp.RegexpInstr,
         }
     },
+    **{
+        exp.BitmapConstructAgg: {"returns": exp.DType.BINARY},
+    },
     exp.RegexpSubstr: {"returns": exp.DType.VARCHAR},
     exp.RegrCount: {"returns": exp.DType.BIGINT},
     exp.Search: {"returns": exp.DType.BOOLEAN},

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -27,13 +27,15 @@ EXPRESSION_METADATA = {
         }
     },
     **{
-        exp.BitmapConstructAgg: {"returns": exp.DType.BINARY},
+        exp_type: {"returns": exp.DType.VARCHAR}
+        for exp_type in {
+            exp.RegexpSubstr,
+            exp.Secret,
+            exp.Trim,
+        }
     },
-    exp.RegexpSubstr: {"returns": exp.DType.VARCHAR},
     exp.RegrCount: {"returns": exp.DType.BIGINT},
     exp.Search: {"returns": exp.DType.BOOLEAN},
-    exp.Secret: {"returns": exp.DType.VARCHAR},
-    exp.Trim: {"returns": exp.DType.VARCHAR},
     exp.RegexpExtractAll: {
         "annotator": lambda self, e: self._set_type(
             e, exp.DataType.from_str("ARRAY<STRING>", dialect="databricks")

--- a/sqlglot/typing/databricks.py
+++ b/sqlglot/typing/databricks.py
@@ -29,6 +29,7 @@ EXPRESSION_METADATA = {
     exp.RegexpSubstr: {"returns": exp.DType.VARCHAR},
     exp.RegrCount: {"returns": exp.DType.BIGINT},
     exp.Search: {"returns": exp.DType.BOOLEAN},
+    exp.Secret: {"returns": exp.DType.VARCHAR},
     exp.Trim: {"returns": exp.DType.VARCHAR},
     exp.RegexpExtractAll: {
         "annotator": lambda self, e: self._set_type(

--- a/sqlglot/typing/hive.py
+++ b/sqlglot/typing/hive.py
@@ -65,6 +65,7 @@ EXPRESSION_METADATA = {
             exp.ArrayExcept,
             exp.First,
             exp.Last,
+            exp.Negative,
             exp.Reverse,
         }
     },

--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -84,6 +84,12 @@ EXPRESSION_METADATA = {
         }
     },
     **{
+        expr_type: {"returns": exp.DType.LONGTEXT}
+        for expr_type in {
+            exp.RegexpReplace,
+        }
+    },
+    **{
         expr_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this")}
         for expr_type in {
             exp.Pad,

--- a/sqlglot/typing/mysql.py
+++ b/sqlglot/typing/mysql.py
@@ -25,6 +25,36 @@ def _annotate_truncate(self: TypeAnnotator, expression: exp.Trunc) -> exp.Expr:
     return self._annotate_by_args(expression, "this")
 
 
+def _annotate_regexp_replace(
+    self: TypeAnnotator,
+    expression: exp.RegexpReplace,
+) -> exp.Expr:
+    args = (
+        expression.this,
+        expression.args.get("expression"),
+        expression.args.get("replacement"),
+    )
+
+    if all(
+        arg.is_type(
+            exp.DType.BINARY,
+            exp.DType.VARBINARY,
+            exp.DType.TINYBLOB,
+            exp.DType.BLOB,
+            exp.DType.MEDIUMBLOB,
+            exp.DType.LONGBLOB,
+        )
+        for arg in args
+        if arg is not None
+    ):
+        return self._set_type(expression, exp.DType.LONGBLOB)
+
+    if all(arg.is_type(*exp.DataType.TEXT_TYPES) for arg in args if arg is not None):
+        return self._set_type(expression, exp.DType.LONGTEXT)
+
+    return self._set_type(expression, exp.DType.UNKNOWN)
+
+
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
@@ -84,12 +114,6 @@ EXPRESSION_METADATA = {
         }
     },
     **{
-        expr_type: {"returns": exp.DType.LONGTEXT}
-        for expr_type in {
-            exp.RegexpReplace,
-        }
-    },
-    **{
         expr_type: {"annotator": lambda self, e: self._annotate_by_args(e, "this")}
         for expr_type in {
             exp.Pad,
@@ -99,4 +123,5 @@ EXPRESSION_METADATA = {
     },
     exp.Reverse: {"annotator": _annotate_reverse},
     exp.Trunc: {"annotator": _annotate_truncate},
+    exp.RegexpReplace: {"annotator": _annotate_regexp_replace},
 }

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -7,6 +7,23 @@ from sqlglot.typing.spark2 import EXPRESSION_METADATA
 EXPRESSION_METADATA = {
     **EXPRESSION_METADATA,
     **{
+        exp_type: {"returns": exp.DType.BINARY}
+        for exp_type in {
+            exp.BitmapConstructAgg,
+            exp.ToBinary,
+        }
+    },
+    **{
+        exp_type: {"returns": exp.DType.DATE}
+        for exp_type in {
+            exp.DateFromUnixDate,
+            # 2-arg `date_add(startDate, numDays)` / `date_sub` are routed to
+            # TsOrDsAdd by Hive/Spark parsers; both return DATE per the Spark
+            # and Databricks contracts.
+            exp.TsOrDsAdd,
+        }
+    },
+    **{
         exp_type: {"returns": exp.DType.DOUBLE}
         for exp_type in {
             exp.Sec,
@@ -40,10 +57,4 @@ EXPRESSION_METADATA = {
     },
     exp.BitmapCount: {"returns": exp.DType.BIGINT},
     exp.Localtimestamp: {"returns": exp.DType.TIMESTAMPNTZ},
-    exp.ToBinary: {"returns": exp.DType.BINARY},
-    exp.DateFromUnixDate: {"returns": exp.DType.DATE},
-    # 2-arg `date_add(startDate, numDays)` / `date_sub` are routed to
-    # TsOrDsAdd by Hive/Spark parsers; both return DATE per the Spark
-    # and Databricks contracts.
-    exp.TsOrDsAdd: {"returns": exp.DType.DATE},
 }

--- a/sqlglot/typing/spark.py
+++ b/sqlglot/typing/spark.py
@@ -34,6 +34,7 @@ EXPRESSION_METADATA = {
             exp.BitwiseAndAgg,
             exp.BitwiseOrAgg,
             exp.BitwiseXorAgg,
+            exp.Left,
             exp.Overlay,
         }
     },

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1465,6 +1465,10 @@ LIFETIME(MIN 0 MAX 0)""",
         def extract_agg_func(query):
             return parse_one(query, read="clickhouse").selects[0].this
 
+        self.validate_identity(
+            "SELECT quantileExactInclusive(0.25)(number) AS x FROM numbers(5)"
+        ).selects[0].this.assert_is(exp.ParameterizedAgg)
+
         self.assertIsInstance(
             extract_agg_func("select quantileGK(100, 0.95) OVER (PARTITION BY id) FROM table"),
             exp.AnonymousAggFunc,

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -752,6 +752,19 @@ class TestClickhouse(Validator):
 
         self.validate_identity("SELECT []")
 
+    def test_safe_div(self):
+        # ClickHouse never returns NULL on division by zero: `/` follows IEEE 754
+        # (`a / 0` yields inf/nan) and DECIMAL division raises, so the divisor must
+        # not be wrapped to emulate NULL-safe division when ClickHouse is the source.
+        self.validate_all(
+            "a / b",
+            write={
+                "clickhouse": "a / b",
+                "mysql": "a / b",
+                "postgres": "CAST(a AS DOUBLE PRECISION) / b",
+            },
+        )
+
     def test_clickhouse_values(self):
         ast = self.parse_one("SELECT * FROM VALUES (1, 2, 3)")
         self.assertEqual(len(list(ast.find_all(exp.Tuple))), 4)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -652,6 +652,16 @@ class TestClickhouse(Validator):
         self.validate_identity("DELETE FROM tbl ON CLUSTER test_cluster WHERE date = '2019-01-01'")
         self.validate_identity("DELETE FROM tbl ON CLUSTER '{cluster}' WHERE date = '2019-01-01'")
 
+        # ClickHouse changes a column's type with ALTER COLUMN ... TYPE, not the
+        # ANSI ALTER COLUMN ... SET DATA TYPE
+        self.validate_all(
+            "ALTER TABLE t ALTER COLUMN c TYPE Nullable(Int64)",
+            read={
+                "clickhouse": "ALTER TABLE t ALTER COLUMN c TYPE Nullable(Int64)",
+                "postgres": "ALTER TABLE t ALTER COLUMN c TYPE BIGINT",
+            },
+        )
+
         self.assertIsInstance(
             parse_one("Tuple(select Int64)", into=exp.DataType, read="clickhouse"), exp.DataType
         )

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -5025,11 +5025,16 @@ FROM subquery2""",
                 "": "x IS NOT UNKNOWN",
                 "bigquery": "x IS NOT UNKNOWN",
                 "mysql": "x IS NOT UNKNOWN",
-                "postgres": "x IS NOT UNKNOWN",
                 "redshift": "x IS NOT UNKNOWN",
                 "duckdb": "x IS NOT UNKNOWN",
                 "spark": "x IS NOT UNKNOWN",
                 "databricks": "x IS NOT UNKNOWN",
+            },
+        )
+        self.validate_all(
+            "x IS NOT NULL",
+            read={
+                "postgres": "x IS NOT UNKNOWN",
             },
         )
 
@@ -5049,6 +5054,11 @@ FROM subquery2""",
                 "": "SELECT col IS NOT NULL::BOOLEAN FROM (SELECT 1 AS col) AS t",
                 "duckdb": "SELECT col IS NOT NULL::BOOLEAN FROM (SELECT 1 AS col) AS t",
                 "redshift": "SELECT col IS NOT NULL::BOOLEAN FROM (SELECT 1 AS col) AS t",
+            },
+        )
+        self.validate_all(
+            "SELECT CAST(col IS NOT NULL AS BOOLEAN) FROM (SELECT 1 AS col) AS t",
+            read={
                 "postgres": "SELECT col IS NOT NULL::BOOLEAN FROM (SELECT 1 AS col) AS t",
             },
         )

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -2938,6 +2938,19 @@ class TestDuckDB(Validator):
             },
         )
 
+    def test_safe_div(self):
+        # DuckDB follows IEEE 754 for float division, so `a / 0` yields inf
+        # and not NULL, and the divisor must not be wrapped to emulate
+        # NULL-safe division when DuckDB is the source dialect.
+        self.validate_all(
+            "a / b",
+            write={
+                "duckdb": "a / b",
+                "mysql": "a / b",
+                "postgres": "CAST(a AS DOUBLE PRECISION) / b",
+            },
+        )
+
     def test_map_insert(self):
         self.validate_all(
             "SELECT MAP_CONCAT(CAST({'a': 1, 'b': 2} AS MAP(TEXT, DECIMAL(38, 0))), MAP {'c': CAST(3 AS DECIMAL(38, 0))})",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1511,7 +1511,7 @@ COMMENT='客户账户表'"""
                 "bigquery": "a / NULLIF(b, 0)",
                 "clickhouse": "a / b",
                 "databricks": "a / NULLIF(b, 0)",
-                "duckdb": "a / b",
+                "duckdb": "a / NULLIF(b, 0)",
                 "hive": "a / b",
                 "mysql": "a / b",
                 "oracle": "a / NULLIF(b, 0)",

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1509,7 +1509,7 @@ COMMENT='客户账户表'"""
             "a / b",
             write={
                 "bigquery": "a / NULLIF(b, 0)",
-                "clickhouse": "a / b",
+                "clickhouse": "a / nullIf(b, 0)",
                 "databricks": "a / NULLIF(b, 0)",
                 "duckdb": "a / NULLIF(b, 0)",
                 "hive": "a / b",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -381,7 +381,7 @@ class TestPostgres(Validator):
         )
         self.validate_identity(
             "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE deleted NOTNULL",
-            "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE NOT deleted IS NULL",
+            "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE deleted IS NOT NULL",
         )
         self.validate_identity(
             "SELECT id, email, CAST(deleted AS TEXT) FROM users WHERE NOT deleted ISNULL",
@@ -2005,3 +2005,14 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
 
     def test_postgis_distance_3d(self):
         self.validate_identity("SELECT a <<->> b")
+
+    def test_preserve_is_not_null(self):
+        self.validate_identity("SELECT r IS NOT NULL FROM t")
+        self.validate_identity("SELECT NOT r IS NULL FROM t")
+        self.validate_identity("SELECT NOT r IS NOT NULL FROM t")
+        self.validate_identity("SELECT r NOTNULL FROM t", "SELECT r IS NOT NULL FROM t")
+        self.validate_identity("SELECT r ISNULL FROM t", "SELECT r IS NULL FROM t")
+
+        is_not_null = self.parse_one("r IS NOT NULL")
+        is_not_null.assert_is(exp.Is)
+        self.assertTrue(is_not_null.args.get("negate"))

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1276,6 +1276,12 @@ class TestPresto(Validator):
         )
 
     def test_json(self):
+        # Presto executes JSONPath bracket unions; falsey members (0, "") must survive round-trips
+        self.validate_identity("SELECT JSON_EXTRACT(x, '$[1,0]')")
+        self.validate_identity("SELECT JSON_EXTRACT_SCALAR(x, '$[1,0]')")
+        self.validate_identity("""SELECT JSON_EXTRACT(x, '$["a",""]')""")
+        self.validate_identity("""SELECT JSON_EXTRACT(x, '$[""]')""")
+
         with self.assertLogs(helper_logger):
             self.validate_all(
                 """SELECT JSON_EXTRACT_SCALAR(TRY(FILTER(CAST(JSON_EXTRACT('{"k1": [{"k2": "{\\"k3\\": 1}", "k4": "v"}]}', '$.k1') AS ARRAY(MAP(VARCHAR, VARCHAR))), x -> x['k4'] = 'v')[1]['k2']), '$.k3')""",

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -176,3 +176,30 @@ class TestTrino(Validator):
     def test_array_first(self):
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b']) FROM tbl")
         self.validate_identity("SELECT ARRAY_FIRST(ARRAY['a', 'b'], x -> x = 'b') FROM tbl")
+
+    def test_inline_udf(self):
+        self.validate_identity(
+            "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)"
+        )
+        self.validate_identity(
+            "WITH FUNCTION hello(name VARCHAR) RETURNS VARCHAR RETURN FORMAT('Hello %s!', name), "
+            "FUNCTION bye() RETURNS VARCHAR RETURN 'Bye!' "
+            "SELECT HELLO('Finn') || BYE()"
+        )
+        self.validate_identity(
+            "WITH FUNCTION doubled(x INTEGER) RETURNS INTEGER RETURN x * 2 "
+            "WITH t AS (SELECT 3 AS v) SELECT DOUBLED(v) FROM t"
+        )
+        self.validate_identity(
+            "WITH FUNCTION f(x INTEGER) RETURNS INTEGER RETURN x "
+            "WITH RECURSIVE t(n) AS (SELECT 1 AS n) SELECT F(n) FROM t"
+        )
+        self.validate_identity(
+            """WITH FUNCTION f(num int)
+    RETURNS int
+    RETURN num
+SELECT f(1)""",
+            "WITH FUNCTION f(num INTEGER) RETURNS INTEGER RETURN num SELECT F(1)",
+        )
+        self.validate_identity("WITH function AS (SELECT 1 AS x) SELECT x FROM function")
+        self.validate_identity("WITH function(x) AS (SELECT 1) SELECT x FROM function")

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6634,6 +6634,24 @@ VARCHAR;
 # dialect: mysql
 REGEXP_SUBSTR(tbl.str_col, tbl.str_col, tbl.int_col, tbl.int_col, tbl.str_col);
 VARCHAR;
+
+# dialect: mysql
+REGEXP_REPLACE(tbl.str_col, tbl.str_col, tbl.str_col);
+LONGTEXT;
+
+# dialect: mysql
+REGEXP_REPLACE(tbl.str_col, tbl.str_col, tbl.str_col, tbl.int_col);
+LONGTEXT;
+
+# dialect: mysql
+REGEXP_REPLACE(tbl.str_col, tbl.str_col, tbl.str_col, tbl.int_col, tbl.int_col);
+LONGTEXT;
+
+# dialect: mysql
+REGEXP_REPLACE(tbl.str_col, tbl.str_col, tbl.str_col, tbl.int_col, tbl.int_col,  tbl.str_col);
+LONGTEXT;
+
+
 --------------------------------------
 -- DuckDB
 --------------------------------------

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4560,6 +4560,10 @@ RPAD(tbl.bin_col, 5);
 BINARY;
 
 # dialect: databricks
+BITMAP_CONSTRUCT_AGG(tbl.int_col);
+BINARY;
+
+# dialect: databricks
 RTRIM(tbl.str_col);
 STRING;
 

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -6655,6 +6655,18 @@ LONGTEXT;
 REGEXP_REPLACE(tbl.str_col, tbl.str_col, tbl.str_col, tbl.int_col, tbl.int_col,  tbl.str_col);
 LONGTEXT;
 
+# dialect: mysql
+REGEXP_REPLACE(tbl.str_col, tbl.bin_col, tbl.str_col);
+UNKNOWN;
+
+# dialect: mysql
+REGEXP_REPLACE(tbl.bin_col, tbl.str_col, tbl.bin_col);
+UNKNOWN;
+
+# dialect: mysql
+REGEXP_REPLACE(tbl.bin_col, tbl.bin_col, tbl.str_col);
+UNKNOWN;
+
 
 --------------------------------------
 -- DuckDB

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -4559,7 +4559,7 @@ STRING;
 RPAD(tbl.bin_col, 5);
 BINARY;
 
-# dialect: databricks
+# dialect: spark, databricks
 BITMAP_CONSTRUCT_AGG(tbl.int_col);
 BINARY;
 

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -91,3 +91,23 @@ SELECT s.a FROM (SELECT a, b FROM x ORDER BY a OFFSET 3) AS s WHERE s.b = 1;
 -- Predicate is not pushed into a subquery with QUALIFY: filtering before the window filter changes its results
 SELECT s.a FROM (SELECT a, b FROM x QUALIFY ROW_NUMBER() OVER (ORDER BY a) <= 10) AS s WHERE s.b = 1;
 SELECT s.a FROM (SELECT a, b FROM x QUALIFY ROW_NUMBER() OVER (ORDER BY a) <= 10) AS s WHERE s.b = 1;
+
+-- The RHS of a RIGHT JOIN is preserved, so a WHERE predicate on it can't become a match-only ON predicate
+SELECT x.a, y.b FROM x RIGHT JOIN y ON x.a = y.b WHERE y.b = 3;
+SELECT x.a, y.b FROM x RIGHT JOIN y ON x.a = y.b WHERE y.b = 3;
+
+-- A WHERE predicate on the preserved RHS of a RIGHT JOIN can still be pushed into an isolated source
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b WHERE y.b = 3;
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y WHERE b = 3) AS y ON x.a = y.b WHERE TRUE;
+
+-- A RIGHT JOIN preserves its own source, so an ON predicate can't be pushed into it as a filter
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+SELECT x.a, y.b FROM x RIGHT JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+
+-- A FULL JOIN preserves its own source, so an ON predicate can't be pushed into it as a filter
+SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3;
+
+-- A FULL JOIN preserves both sides, so a WHERE predicate on either of them can't be pushed down
+SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
+SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -548,6 +548,30 @@ FALSE;
 1 IS NOT NULL;
 TRUE;
 
+# dialect: postgres
+# title: postgres preserves IS NOT NULL, constant folding respects the negation
+NULL IS NOT NULL;
+FALSE;
+
+# dialect: postgres
+'a' IS NOT NULL;
+TRUE;
+
+# dialect: postgres
+# title: IS NULL and IS NOT NULL are distinct predicates, complement law must not fold them
+r IS NULL OR r IS NOT NULL;
+r IS NOT NULL OR r IS NULL;
+
+# dialect: postgres
+# title: IS NULL and IS NOT NULL are not deduplicated
+r IS NULL AND r IS NOT NULL;
+r IS NOT NULL AND r IS NULL;
+
+# dialect: postgres
+# title: IS NOT NULL next to a comparison must not crash the range simplifier
+r IS NOT NULL AND r > 5;
+r > 5 AND r IS NOT NULL;
+
 date '1998-12-01' - interval x day;
 CAST('1998-12-01' AS DATE) - INTERVAL x DAY;
 

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -193,16 +193,22 @@ A AND TRUE;
 A AND TRUE;
 
 A AND (NOT A OR B);
-A AND B;
+A AND (B OR NOT A);
 
 (NOT A OR B) AND A;
-A AND B;
+A AND (B OR NOT A);
 
 A OR (NOT A AND B);
-A OR B;
+A OR (B AND NOT A);
 
 A OR ((((NOT A AND B))));
-A OR B;
+A OR (B AND NOT A);
+
+x IS NULL AND (NOT (x IS NULL) OR B);
+B AND x IS NULL;
+
+x IS NULL OR (NOT (x IS NULL) AND B);
+B OR x IS NULL;
 
 x NOT LIKE 'a%' OR (y IN (1, 2) AND x LIKE 'a%');
 (x LIKE 'a%' AND y IN (1, 2)) OR x NOT LIKE 'a%';
@@ -225,50 +231,60 @@ A AND TRUE;
 (A OR B) AND (A OR C) AND (A OR B OR C);
 (A OR B) AND (A OR C);
 
+# dialect: clickhouse
+SELECT t_bool.a AND (NOT t_bool.a OR t_bool.b) FROM t_bool;
+SELECT t_bool.a AND t_bool.b FROM t_bool;
+
 --------------------------------------
 -- Elimination
 --------------------------------------
 (A AND B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (A AND B) OR (NOT A AND B);
-B AND TRUE;
+(A AND B) OR (B AND NOT A);
 
 (A AND NOT B) OR (A AND B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (NOT A AND B) OR (A AND B);
-B AND TRUE;
+(A AND B) OR (B AND NOT A);
 
 (A OR B) AND (A OR NOT B);
-A AND TRUE;
+(A OR B) AND (A OR NOT B);
 
 (A OR B) AND (NOT A OR B);
-B AND TRUE;
+(A OR B) AND (B OR NOT A);
 
 (A OR NOT B) AND (A OR B);
-A AND TRUE;
+(A OR B) AND (A OR NOT B);
 
 (NOT A OR B) AND (A OR B);
-B AND TRUE;
+(A OR B) AND (B OR NOT A);
 
 (NOT A OR NOT B) AND (NOT A OR B);
-NOT A;
+(B OR NOT A) AND (NOT A OR NOT B);
 
 (NOT A OR NOT B) AND (NOT A OR NOT NOT B);
-NOT A;
+(NOT A OR NOT B) AND (NOT A OR NOT NOT B);
 
 E OR (A AND B) OR C OR D OR (A AND NOT B);
-A OR C OR D OR E;
+(A AND B) OR (A AND NOT B) OR C OR D OR E;
 
 (A AND B) OR (A AND NOT B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (A AND B) OR (A AND B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
 
 (A AND B) OR (A AND NOT B) OR (A AND B) OR (A AND NOT B);
-A AND TRUE;
+(A AND B) OR (A AND NOT B);
+
+(B AND x IS NULL) OR (B AND NOT (x IS NULL));
+B AND TRUE;
+
+(B OR x IS NULL) AND (B OR NOT (x IS NULL));
+B AND TRUE;
 
 SELECT t_bool.a OR t_bool.a FROM t_bool;
 SELECT t_bool.a FROM t_bool;
@@ -281,6 +297,10 @@ SELECT SUM(t.x AND TRUE) FROM t;
 
 SELECT SUM(t.x AND t.x) FROM t;
 SELECT SUM(t.x AND TRUE) FROM t;
+
+# dialect: clickhouse
+SELECT (t_bool.a AND t_bool.b) OR (t_bool.a AND NOT t_bool.b) FROM t_bool;
+SELECT t_bool.a FROM t_bool;
 
 --------------------------------------
 -- Associativity

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -447,6 +447,7 @@ class TestExecutor(unittest.TestCase):
             execute("SELECT x.id, y.id FROM x JOIN y ON x.id < y.id", tables=tables).rows,
             [(1, 2), (1, 3), (2, 3)],
         )
+
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -13,7 +13,7 @@ from pandas.testing import assert_frame_equal
 from sqlglot import exp, find_tables, parse_one, transpile
 from sqlglot.errors import ExecuteError
 from sqlglot.executor import execute
-from sqlglot.executor.python import Python
+from sqlglot.executor.python import Python, PythonExecutor
 from sqlglot.executor.table import Table, ensure_tables
 from sqlglot.optimizer import optimize
 from sqlglot.planner import Plan
@@ -797,6 +797,92 @@ class TestExecutor(unittest.TestCase):
             dialect="oracle",
         )
         self.assertEqual(result.rows, [("a",)])
+
+    def test_sql_three_valued_boolean_logic(self):
+        for sql, expected in [
+            ("NOT TRUE", False),
+            ("NOT FALSE", True),
+            ("NOT NULL", None),
+            ("TRUE AND NULL", None),
+            ("FALSE AND NULL", False),
+            ("TRUE OR NULL", True),
+            ("FALSE OR NULL", None),
+            ("NULL IN (1, 2)", None),
+            ("3 NOT IN (1, 2, NULL)", None),
+            ("3 NOT IN (1, 2)", True),
+        ]:
+            with self.subTest(sql):
+                self.assertEqual(execute(f"SELECT {sql}").rows, [(expected,)])
+
+        tables = {
+            "policy": [
+                {"id": 1, "flag": True},
+                {"id": 2, "flag": False},
+                {"id": 3, "flag": None},
+            ]
+        }
+        schema = {"policy": {"id": "INT", "flag": "BOOLEAN"}}
+        self.assertEqual(
+            execute("SELECT id FROM policy WHERE NOT flag", tables=tables, schema=schema).rows,
+            [(2,)],
+        )
+
+    def test_sql_boolean_logic_with_numpy_scalars(self):
+        tables = {
+            "policy": [
+                {"id": 1, "left_flag": np.bool_(True), "right_flag": np.bool_(True)},
+                {"id": 2, "left_flag": np.bool_(False), "right_flag": np.bool_(True)},
+                {"id": 3, "left_flag": None, "right_flag": np.bool_(True)},
+            ]
+        }
+        schema = {
+            "policy": {
+                "id": "INT",
+                "left_flag": "BOOLEAN",
+                "right_flag": "BOOLEAN",
+            }
+        }
+
+        self.assertEqual(
+            execute("SELECT id FROM policy WHERE left_flag", tables=tables, schema=schema).rows,
+            [(1,)],
+        )
+        self.assertEqual(
+            execute(
+                "SELECT id FROM policy WHERE left_flag AND right_flag",
+                tables=tables,
+                schema=schema,
+            ).rows,
+            [(1,)],
+        )
+        self.assertEqual(
+            execute(
+                "SELECT id FROM policy WHERE left_flag OR right_flag",
+                tables=tables,
+                schema=schema,
+            ).rows,
+            [(1,), (2,), (3,)],
+        )
+
+    def test_sql_boolean_logic_preserves_short_circuiting(self):
+        evaluations = []
+
+        def record_evaluation():
+            evaluations.append(True)
+            return True
+
+        executor = PythonExecutor(env={"RECORD_EVALUATION": record_evaluation})
+        context = executor.context({})
+
+        for sql, expected in [
+            ("FALSE AND RECORD_EVALUATION()", False),
+            ("TRUE OR RECORD_EVALUATION()", True),
+        ]:
+            with self.subTest(sql):
+                expression = parse_one(sql)
+                self.assertEqual(context.eval(executor.generate(expression)), expected)
+
+        self.assertEqual(evaluations, [])
 
     def test_case_sensitivity(self):
         result = execute("SELECT A AS A FROM X", tables={"x": [{"a": 1}]})

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -403,6 +403,30 @@ class TestExecutor(unittest.TestCase):
                         execute(sql, schema=schema, tables=tables)
                     self.assertIsInstance(ctx.exception.__cause__, rows)
 
+    def test_outer_joins_preserve_unmatched_rows(self):
+        tables = {
+            "x": [{"id": 1}, {"id": 2}],
+            "y": [{"id": 2}, {"id": 3}],
+        }
+
+        self.assertEqual(
+            set(execute("SELECT x.id, y.id FROM x FULL JOIN y ON x.id = y.id", tables=tables).rows),
+            {(1, None), (2, 2), (None, 3)},
+        )
+        self.assertEqual(
+            set(
+                execute(
+                    "SELECT x.id, y.id FROM x LEFT JOIN y ON x.id = y.id AND y.id > 2",
+                    tables=tables,
+                ).rows
+            ),
+            {(1, None), (2, None)},
+        )
+        self.assertEqual(
+            execute("SELECT x.id, y.id FROM x JOIN y ON x.id < y.id", tables=tables).rows,
+            [(1, 2), (1, 3), (2, 3)],
+        )
+
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -403,6 +403,27 @@ class TestExecutor(unittest.TestCase):
                         execute(sql, schema=schema, tables=tables)
                     self.assertIsInstance(ctx.exception.__cause__, rows)
 
+        duplicate_tables = {
+            "x": [{"a": 1}, {"a": 1}, {"a": 1}, {"a": 2}],
+            "y": [{"a": 1}, {"a": 1}, {"a": 3}],
+        }
+        self.assertEqual(
+            execute("SELECT a FROM x INTERSECT ALL SELECT a FROM y", tables=duplicate_tables).rows,
+            [(1,), (1,)],
+        )
+        self.assertEqual(
+            execute("SELECT a FROM x EXCEPT ALL SELECT a FROM y", tables=duplicate_tables).rows,
+            [(1,), (2,)],
+        )
+        self.assertEqual(
+            execute("SELECT a FROM x INTERSECT SELECT a FROM y", tables=duplicate_tables).rows,
+            [(1,)],
+        )
+        self.assertEqual(
+            execute("SELECT a FROM x EXCEPT SELECT a FROM y", tables=duplicate_tables).rows,
+            [(2,)],
+        )
+
     def test_outer_joins_preserve_unmatched_rows(self):
         tables = {
             "x": [{"id": 1}, {"id": 2}],
@@ -426,7 +447,6 @@ class TestExecutor(unittest.TestCase):
             execute("SELECT x.id, y.id FROM x JOIN y ON x.id < y.id", tables=tables).rows,
             [(1, 2), (1, 3), (2, 3)],
         )
-
     def test_execute_catalog_db_table(self):
         tables = {
             "catalog": {

--- a/tests/test_jsonpath.py
+++ b/tests/test_jsonpath.py
@@ -47,6 +47,17 @@ class TestJsonpath(unittest.TestCase):
             with self.subTest(f"{selector} -> {expected}"):
                 self.assertEqual(parse(selector).sql(), f"'{expected}'")
 
+    def test_union_preserves_falsey_members(self):
+        for selector, expected in (
+            ("$[1,0]", exp.JSONPathUnion(expressions=[1, 0])),
+            ('$["a",""]', exp.JSONPathUnion(expressions=["a", ""])),
+            ('$["",1]', exp.JSONPathUnion(expressions=["", 1])),
+        ):
+            with self.subTest(selector):
+                self.assertEqual(parse(selector).expressions[-1], expected)
+
+        self.assertEqual(parse("$[0]").expressions[-1], exp.JSONPathSubscript(this=0))
+
     def test_cts_file(self):
         with open(os.path.join(FIXTURES_DIR, "jsonpath", "cts.json"), encoding="utf-8") as file:
             tests = json.load(file)["tests"]

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -63,7 +63,7 @@ def simplify(expression, **kwargs):
     dialect = kwargs.get("dialect")
     schema = kwargs.get("schema")
 
-    expression = annotate_types(expression, schema=schema)
+    expression = annotate_types(expression, schema=schema, dialect=dialect)
     return optimizer.simplify.simplify(
         expression, constant_propagation=True, coalesce_simplification=True, dialect=dialect
     )
@@ -148,6 +148,7 @@ class TestOptimizer(unittest.TestCase):
             },
             "t_bool": {
                 "a": "BOOLEAN",
+                "b": "BOOLEAN",
             },
         }
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -9,7 +9,7 @@ from pandas.testing import assert_frame_equal
 import sqlglot
 from sqlglot import exp, optimizer, parse_one
 from sqlglot.errors import ANSI_RESET, ANSI_UNDERLINE, OptimizeError, SchemaError
-from sqlglot.optimizer.annotate_types import annotate_types
+from sqlglot.optimizer.annotate_types import TypeAnnotator, annotate_types
 from sqlglot.optimizer.canonicalize_internal_names import canonicalize_internal_names
 from sqlglot.optimizer.normalize import normalization_distance
 from sqlglot.optimizer.qualify import qualify
@@ -1774,6 +1774,17 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         # Programmatic set operations with VALUES operands must not crash the Query-typed
         # left/right accessors in compiled builds
         annotate_types(exp.select("*").from_(exp.select("1").union("VALUES (2)").subquery("s")))
+
+    def test_annotate_untyped_binary_operands(self):
+        # Operands that escaped annotation have type None; treat them as UNKNOWN instead
+        # of crashing on `.type.this`
+        annotator = TypeAnnotator(MappingSchema())
+
+        binary = parse_one("a + b")
+        self.assertTrue(annotator._annotate_binary(binary).is_type(exp.DataType.Type.UNKNOWN))
+
+        div = parse_one("a / b")
+        self.assertTrue(annotator._annotate_div(div).is_type(exp.DataType.Type.UNKNOWN))
 
     def test_annotate_types_caches_schema_lookups(self):
         schema = MappingSchema({"t": {"a": "INT"}})

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -412,6 +412,13 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(ParseError):
             parse_one("SELECT A[:")
 
+        # Truncated input must produce a ParseError, not an AttributeError
+        with self.assertRaises(ParseError):
+            parse_one("SELECT * FROM t MATCH_RECOGNIZE(AFTER MATCH SKIP TO FIRST", read="snowflake")
+
+        with self.assertRaises(ParseError):
+            parse_one("SELECT * FROM t MATCH_RECOGNIZE(AFTER MATCH SKIP TO LAST", read="snowflake")
+
         self.assertEqual(parse_one("as as", error_level=ErrorLevel.IGNORE).sql(), "AS as")
 
     def test_space(self):


### PR DESCRIPTION
## Summary

Update MySQL `REGEXP_REPLACE` type annotation to infer the return type based on the types of its first three arguments.

### Changes
- Added a custom annotator for `REGEXP_REPLACE`.
- Return `LONGTEXT` when all of the source, pattern, and replacement arguments are text types.
- Return `UNKNOWN` for mixed or unsupported argument types.
- Replaced the previous fixed `LONGTEXT` metadata annotation with the custom annotator.
- Added optimizer fixture tests covering:
  - Text arguments → `LONGTEXT`
  - Mixed text/binary arguments → `UNKNOWN`

Fixes the review feedback to avoid defaulting to `LONGTEXT` for unsupported argument combinations.