### PR TITLE
fix(optimizer)!: replace find / find_all with scoped lookups

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -24,6 +24,7 @@ from sqlglot.helper import (
     ensure_list,
 )
 from sqlglot.jsonpath import ALL_JSON_PATH_PARTS, JSONPathTokenizer, parse as parse_json_path
+from sqlglot.optimizer.scope import find_all_in_scope
 from sqlglot.parser import Parser
 from sqlglot.parsers.base import BaseParser
 from sqlglot.time import TIMEZONES, format_time, subsecond_precision
@@ -2147,7 +2148,7 @@ def merge_without_target_sql(self: Generator, expression: exp.Merge) -> str:
         then: exp.Insert | exp.Update | None = when.args.get("then")
         if then:
             if isinstance(then, exp.Update):
-                for equals in then.find_all(exp.EQ):
+                for equals in find_all_in_scope(then, exp.EQ):
                     equal_lhs = equals.this
                     if (
                         isinstance(equal_lhs, exp.Column)

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -15,7 +15,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.errors import UnsupportedError
 from sqlglot.generator import unsupported_args
-from sqlglot.optimizer.scope import build_scope
+from sqlglot.optimizer.scope import build_scope, find_in_scope
 from sqlglot.parsers.exasol import DATE_UNITS
 
 
@@ -245,7 +245,7 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
         return expression
 
     if expression.is_star:
-        if any(proj.find(exp.AggFunc) for proj in expression.expressions):
+        if any(find_in_scope(proj, exp.AggFunc) for proj in expression.expressions):
             raise UnsupportedError(
                 "GROUP BY ALL with star projection and aggregates is not supported by Exasol"
             )
@@ -256,7 +256,7 @@ def _group_by_all(expression: exp.Expr) -> exp.Expr:
     group_positions = [
         exp.Literal.number(i)
         for i, proj in enumerate(expression.expressions, start=1)
-        if not proj.find(exp.AggFunc)
+        if not find_in_scope(proj, exp.AggFunc)
     ]
 
     if not group_positions:

--- a/sqlglot/generators/fabric.py
+++ b/sqlglot/generators/fabric.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from sqlglot import exp, transforms
 from sqlglot.generators.tsql import TSQLGenerator
+from sqlglot.optimizer.scope import find_in_scope
 
 
 def _cap_data_type_precision(expression: exp.DataType, max_precision: int = 6) -> exp.DataType:
@@ -109,7 +110,7 @@ class FabricGenerator(TSQLGenerator):
     def attimezone_sql(self, expression: exp.AtTimeZone) -> str:
         # Wrap the AT TIME ZONE expression in a cast to DATETIME2 if it contains a TIMESTAMPTZ
         ## https://learn.microsoft.com/en-us/sql/t-sql/data-types/datetimeoffset-transact-sql#microsoft-fabric-support
-        timestamptz_cast = expression.find(exp.Cast)
+        timestamptz_cast = find_in_scope(expression, exp.Cast)
         if timestamptz_cast and timestamptz_cast.to.is_type(exp.DType.TIMESTAMPTZ):
             # Get the precision from the original TIMESTAMPTZ cast and cap it to 6
             data_type = timestamptz_cast.to

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -27,7 +27,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import find_new_name, flatten, seq_get
-from sqlglot.optimizer.scope import build_scope, find_all_in_scope, find_in_scope
+from sqlglot.optimizer.scope import build_scope, find_all_in_scope
 from sqlglot.parsers.snowflake import (
     RANKING_WINDOW_FUNCTIONS_WITH_FRAME,
     TIMESTAMP_TYPES,
@@ -684,7 +684,7 @@ class SnowflakeGenerator(generator.Generator):
         return self.properties(properties, wrapped=False, prefix=self.sep(""), sep=" ")
 
     def values_sql(self, expression: exp.Values, values_as_table: bool = True) -> str:
-        if find_in_scope(expression, *self.UNSUPPORTED_VALUES_EXPRESSIONS):
+        if expression.find(*self.UNSUPPORTED_VALUES_EXPRESSIONS):
             values_as_table = False
 
         return super().values_sql(expression, values_as_table=values_as_table)

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -27,7 +27,7 @@ from sqlglot.dialects.dialect import (
 )
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import find_new_name, flatten, seq_get
-from sqlglot.optimizer.scope import build_scope, find_all_in_scope
+from sqlglot.optimizer.scope import build_scope, find_all_in_scope, find_in_scope
 from sqlglot.parsers.snowflake import (
     RANKING_WINDOW_FUNCTIONS_WITH_FRAME,
     TIMESTAMP_TYPES,
@@ -684,7 +684,7 @@ class SnowflakeGenerator(generator.Generator):
         return self.properties(properties, wrapped=False, prefix=self.sep(""), sep=" ")
 
     def values_sql(self, expression: exp.Values, values_as_table: bool = True) -> str:
-        if expression.find(*self.UNSUPPORTED_VALUES_EXPRESSIONS):
+        if find_in_scope(expression, *self.UNSUPPORTED_VALUES_EXPRESSIONS):
             values_as_table = False
 
         return super().values_sql(expression, values_as_table=values_as_table)

--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -16,6 +16,7 @@ from sqlglot.dialects.dialect import (
     strposition_sql,
 )
 from sqlglot.generator import unsupported_args
+from sqlglot.optimizer.scope import find_in_scope
 from sqlglot.tokens import TokenType
 
 
@@ -299,7 +300,7 @@ class SQLiteGenerator(generator.Generator):
     # https://www.sqlite.org/lang_aggfunc.html#group_concat
     def groupconcat_sql(self, expression: exp.GroupConcat) -> str:
         this = expression.this
-        distinct = expression.find(exp.Distinct)
+        distinct = find_in_scope(expression, exp.Distinct)
 
         if distinct:
             this = distinct.expressions[0]

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -16,6 +16,7 @@ from sqlglot.dialects.dialect import (
     trim_sql,
 )
 from sqlglot.helper import seq_get
+from sqlglot.optimizer.scope import find_in_scope
 from sqlglot.parsers.tsql import OPTIONS_THAT_REQUIRE_EQUAL
 from sqlglot.time import format_time
 from collections import defaultdict
@@ -48,7 +49,7 @@ def _format_sql(self: TSQLGenerator, expression: exp.NumberToStr | exp.TimeToStr
 
 def _string_agg_sql(self: TSQLGenerator, expression: exp.GroupConcat) -> str:
     this = expression.this
-    distinct = expression.find(exp.Distinct)
+    distinct = find_in_scope(expression, exp.Distinct)
     if distinct:
         # exp.Distinct can appear below an exp.Order or an exp.GroupConcat expression
         self.unsupported("T-SQL STRING_AGG doesn't support DISTINCT.")

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -247,7 +247,7 @@ def nodes_for_predicate(
         if isinstance(node, exp.Select) and len(tables) == 1:
             # We can't push down window expressions
             has_window_expression = any(
-                select for select in node.selects if select.find(exp.Window)
+                select for select in node.selects if find_in_scope(select, exp.Window)
             )
             # we can't push down predicates to select statements if they are referenced in
             # multiple places.

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 from sqlglot import alias, exp
 from sqlglot.optimizer.qualify_columns import Resolver
-from sqlglot.optimizer.scope import Scope, traverse_scope
+from sqlglot.optimizer.scope import Scope, find_in_scope, traverse_scope
 from sqlglot.schema import ensure_schema
 from sqlglot.errors import OptimizeError
 from sqlglot.helper import seq_get
@@ -174,7 +174,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count):
         if select_all or name in parent_selections or name in order_refs or alias_count > 0:
             new_selections.append(selection)
             alias_count -= 1
-        elif selection.find(*SET_RETURNING_FUNCTIONS):
+        elif find_in_scope(selection, *SET_RETURNING_FUNCTIONS):
             # A set-returning function multiplies the rows of the whole query, so this
             # projection affects the cardinality of every output column and must be kept
             # even though it is otherwise unreferenced. It is not a positional alias slot,
@@ -185,7 +185,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count):
                 star = True
             removed = True
 
-        if not is_agg and selection.find(exp.AggFunc):
+        if not is_agg and find_in_scope(selection, exp.AggFunc):
             is_agg = True
 
     if star:

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -217,7 +217,11 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     # if the value of the subquery is not an agg or a key, we need to collect it into an array
     # so that it can be grouped. For subquery projections, we use a MAX aggregation instead.
     agg_func = exp.Max if is_subquery_projection else exp.ArrayAgg
-    if not find_in_scope(value, exp.AggFunc) and value.this not in group_by:
+    if (
+        not isinstance(value, exp.Subquery)
+        and not find_in_scope(value, exp.AggFunc)
+        and value.this not in group_by
+    ):
         select.select(
             exp.alias_(agg_func(this=value.this), value.alias, quoted=False),
             append=False,

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -103,7 +103,7 @@ def unnest(select, parent_select, next_alias_name):
 
         return
 
-    if select.find(exp.Limit, exp.Offset):
+    if find_in_scope(select, exp.Limit, exp.Offset):
         return
 
     if isinstance(predicate, exp.Any):
@@ -217,7 +217,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     # if the value of the subquery is not an agg or a key, we need to collect it into an array
     # so that it can be grouped. For subquery projections, we use a MAX aggregation instead.
     agg_func = exp.Max if is_subquery_projection else exp.ArrayAgg
-    if not value.find(exp.AggFunc) and value.this not in group_by:
+    if not find_in_scope(value, exp.AggFunc) and value.this not in group_by:
         select.select(
             exp.alias_(agg_func(this=value.this), value.alias, quoted=False),
             append=False,
@@ -273,7 +273,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
 
         # COUNT always returns 0 on empty datasets, so we need take that into consideration here
         # by transforming all counts into 0 and using that as the coalesced value
-        if value.find(exp.Count):
+        if find_in_scope(value, exp.Count):
 
             def remove_aggs(node):
                 if isinstance(node, exp.Count):

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -20,6 +20,7 @@ from sqlglot.errors import (
 )
 from sqlglot.expressions import apply_index_offset
 from sqlglot.helper import ensure_list, i64, seq_get
+from sqlglot.optimizer.scope import find_in_scope
 from sqlglot.time import format_time
 from sqlglot.tokens import Token, Tokenizer, TokenType
 from sqlglot.trie import TrieResult, in_trie, new_trie
@@ -8486,7 +8487,7 @@ class Parser:
         #   and Snowflake chose to do the same for familiarity
         #   https://docs.snowflake.com/en/sql-reference/functions/first_value.html#usage-notes
         if isinstance(this, exp.AggFunc):
-            ignore_respect = this.find(exp.IgnoreNulls, exp.RespectNulls)
+            ignore_respect = find_in_scope(this, exp.IgnoreNulls, exp.RespectNulls)
 
             if ignore_respect and ignore_respect is not this:
                 ignore_respect.replace(ignore_respect.this)

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -6,6 +6,7 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.helper import name_sequence
 from sqlglot.optimizer.eliminate_joins import join_condition
+from sqlglot.optimizer.scope import find_all_in_scope, find_in_scope
 from collections.abc import Iterator, Sequence, Iterable
 
 
@@ -128,7 +129,7 @@ class Step:
         next_operand_name = name_sequence("_a_")
 
         def extract_agg_operands(expression: exp.Expr) -> bool:
-            agg_funcs = tuple(expression.find_all(exp.AggFunc))
+            agg_funcs = tuple(find_all_in_scope(expression, exp.AggFunc))
             if agg_funcs:
                 aggregations[expression] = None
 
@@ -148,7 +149,7 @@ class Step:
             step.aggregations = list(aggregations)
 
         for e in expression.expressions:
-            if e.find(exp.AggFunc):
+            if find_in_scope(e, exp.AggFunc):
                 projections.append(exp.column(e.alias_or_name, step.name, quoted=True))
                 extract_agg_operands(e)
             else:


### PR DESCRIPTION
There are various instances where `find` / `find_all` are used (inappropriately) and search the whole subtree and crossing boundaries, which gives matches to nodes inside nested subqueries.  This leads to wrong decisions, invalid SQL, crashes, etc.

This PR swaps a collection of those calls for scope bounded `find_in_scope` / `find_all_in_scope`, which stop at subquery boundaries.  Each of the changes has a confirmed test that fails on main.