### PR TITLE
feat(starrocks,doris): support DROP TABLE ... FORCE and REFRESH EXTERNAL TABLE [CLAUDE]

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -14,6 +14,7 @@ class StarRocks(MySQL):
         KEYWORDS = {
             **MySQL.Tokenizer.KEYWORDS,
             "LARGEINT": TokenType.INT128,
+            "REFRESH": TokenType.REFRESH,
         }
 
     Parser = StarRocksParser

--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -358,6 +358,7 @@ class Drop(Expression):
         "concurrently": False,
         "sync": False,
         "iceberg": False,
+        "force": False,
     }
 
     @property

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1820,7 +1820,8 @@ class Generator:
         constraints = " CONSTRAINTS" if expression.args.get("constraints") else ""
         purge = " PURGE" if expression.args.get("purge") else ""
         sync = " SYNC" if expression.args.get("sync") else ""
-        return f"DROP{temporary}{materialized}{iceberg} {kind}{concurrently_sql}{exists_sql}{this}{on_cluster}{expressions}{cascade}{restrict}{constraints}{purge}{sync}"
+        force = " FORCE" if expression.args.get("force") else ""
+        return f"DROP{temporary}{materialized}{iceberg} {kind}{concurrently_sql}{exists_sql}{this}{on_cluster}{expressions}{cascade}{restrict}{constraints}{purge}{sync}{force}"
 
     def set_operation(self, expression: exp.SetOperation) -> str:
         op_type = type(expression)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2378,6 +2378,7 @@ class Parser:
                 concurrently=concurrently,
                 sync=self._match_text_seq("SYNC"),
                 iceberg=iceberg,
+                force=self._match_text_seq("FORCE"),
             )
         )
 
@@ -8815,7 +8816,9 @@ class Parser:
         return self.expression(exp.Commit(chain=chain))
 
     def _parse_refresh(self) -> exp.Refresh | exp.Command:
-        if self._match(TokenType.TABLE):
+        if self._match_text_seq("EXTERNAL", "TABLE"):
+            kind = "EXTERNAL TABLE"
+        elif self._match(TokenType.TABLE):
             kind = "TABLE"
         elif self._match_text_seq("MATERIALIZED", "VIEW"):
             kind = "MATERIALIZED VIEW"

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -92,6 +92,9 @@ class TestDoris(Validator):
         self.validate_identity("CREATE TABLE t (c INT) PROPERTIES ('x'='y')")
         self.validate_identity("CREATE TABLE t (c INT) COMMENT 'c'")
         self.validate_identity("COALECSE(a, b, c, d)")
+        self.validate_identity("DROP TABLE my_table")
+        self.validate_identity("DROP TABLE IF EXISTS example_db.my_table")
+        self.validate_identity("DROP TABLE my_table FORCE")
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")
         self.validate_identity("SELECT APPROX_COUNT_DISTINCT(a) FROM x")
         self.validate_identity(

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -140,6 +140,17 @@ class TestStarrocks(Validator):
         self.validate_identity("INSERT OVERWRITE my_table SELECT * FROM other_table")
         self.validate_identity("CREATE TABLE t (c INT) COMMENT 'c'")
 
+        self.validate_identity("DROP TABLE my_table")
+        self.validate_identity("DROP TABLE IF EXISTS example_db.my_table")
+        self.validate_identity("DROP TABLE my_table FORCE")
+
+        self.validate_identity("REFRESH EXTERNAL TABLE hive1")
+        self.validate_identity("REFRESH EXTERNAL TABLE hive_catalog.hive_db.hive_table")
+        self.validate_identity(
+            "REFRESH EXTERNAL TABLE hudi1 PARTITION ('date=2022-12-20', 'date=2022-12-21')",
+            "REFRESH EXTERNAL TABLE hudi1 PARTITION('date=2022-12-20', 'date=2022-12-21')",
+        )
+
         ddl_sqls = [
             "PARTITION BY (col1, col2)",
             "PARTITION BY DATE_TRUNC('DAY', col2), col1",


### PR DESCRIPTION
Two small, unrelated StarRocks/Doris parser gaps found while triaging [apache/superset#36939](https://github.com/apache/superset/issues/36939): `REFRESH EXTERNAL TABLE ...` and `DROP TABLE ... FORCE` both raise a hard `ParseError`. (The issue's other three statements, `SHOW TABLES`/`SHOW DATABASES`/`SHOW CREATE TABLE`, turned out to be a Superset-side bug unrelated to sqlglot's parser, already fixed in [apache/superset#42588](https://github.com/apache/superset/pull/42588).)

### `DROP TABLE ... FORCE`

Doris/StarRocks-lineage syntax (https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE/, https://doris.apache.org/docs/3.x/sql-manual/sql-statements/table-and-view/table/DROP-TABLE/) that skips the unfinished-transaction check and deletes the table immediately and irrecoverably (no `RECOVER` window). Added as a generic `Drop()` flag in the base parser/generator, the same way ClickHouse's `DROP ... SYNC` was added in #7172 — `FORCE` doesn't exist in base MySQL's own `DROP TABLE` grammar, so it's additive and inert everywhere else.

### `REFRESH EXTERNAL TABLE ...`

StarRocks syntax for refreshing metadata on an external-catalog table (https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/REFRESH_EXTERNAL_TABLE/):

```sql
REFRESH EXTERNAL TABLE [external_catalog.][db_name.]table_name [PARTITION ('partition_name', ...)]
```

Added as a new `kind` on the existing `exp.Refresh`, reusing the same `_parse_refresh` that already handles `REFRESH TABLE` / `REFRESH MATERIALIZED VIEW`. StarRocks's tokenizer needed its own `"REFRESH": TokenType.REFRESH` keyword entry (mirroring Trino's, which already has one for `REFRESH MATERIALIZED VIEW`) since the base tokenizer doesn't map `REFRESH` by default. The optional trailing `PARTITION (...)` clause is handled for free by the existing generic `exp.Partition`/`_parse_table()` machinery — no new code needed for that part.

### Testing

```bash
make unit
make style
```

Added `validate_identity` coverage to `test_starrocks.py` (both statements) and `test_doris.py` (`DROP TABLE ... FORCE`), matching the exact examples from the StarRocks docs.

Disclosure: implemented with Claude Code, reviewed, tested (`make unit`, `make style`) and understood by me.
