### PR TITLE
feat(starrocks,doris): support DROP TABLE ... FORCE [CLAUDE]

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -358,6 +358,7 @@ class Drop(Expression):
         "concurrently": False,
         "sync": False,
         "iceberg": False,
+        "force": False,
     }
 
     @property

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1820,7 +1820,8 @@ class Generator:
         constraints = " CONSTRAINTS" if expression.args.get("constraints") else ""
         purge = " PURGE" if expression.args.get("purge") else ""
         sync = " SYNC" if expression.args.get("sync") else ""
-        return f"DROP{temporary}{materialized}{iceberg} {kind}{concurrently_sql}{exists_sql}{this}{on_cluster}{expressions}{cascade}{restrict}{constraints}{purge}{sync}"
+        force = " FORCE" if expression.args.get("force") else ""
+        return f"DROP{temporary}{materialized}{iceberg} {kind}{concurrently_sql}{exists_sql}{this}{on_cluster}{expressions}{cascade}{restrict}{constraints}{purge}{sync}{force}"
 
     def set_operation(self, expression: exp.SetOperation) -> str:
         op_type = type(expression)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2378,6 +2378,7 @@ class Parser:
                 concurrently=concurrently,
                 sync=self._match_text_seq("SYNC"),
                 iceberg=iceberg,
+                force=self._match_text_seq("FORCE"),
             )
         )
 

--- a/tests/dialects/test_doris.py
+++ b/tests/dialects/test_doris.py
@@ -92,6 +92,9 @@ class TestDoris(Validator):
         self.validate_identity("CREATE TABLE t (c INT) PROPERTIES ('x'='y')")
         self.validate_identity("CREATE TABLE t (c INT) COMMENT 'c'")
         self.validate_identity("COALECSE(a, b, c, d)")
+        self.validate_identity("DROP TABLE my_table")
+        self.validate_identity("DROP TABLE IF EXISTS example_db.my_table")
+        self.validate_identity("DROP TABLE my_table FORCE")
         self.validate_identity("SELECT CAST(`a`.`b` AS INT) FROM foo")
         self.validate_identity("SELECT APPROX_COUNT_DISTINCT(a) FROM x")
         self.validate_identity(

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -140,6 +140,11 @@ class TestStarrocks(Validator):
         self.validate_identity("INSERT OVERWRITE my_table SELECT * FROM other_table")
         self.validate_identity("CREATE TABLE t (c INT) COMMENT 'c'")
 
+        self.validate_identity("DROP TABLE my_table")
+        self.validate_identity("DROP TABLE IF EXISTS example_db.my_table")
+        self.validate_identity("DROP TABLE my_table FORCE")
+        self.validate_identity("DROP TEMPORARY TABLE my_table FORCE")
+
         ddl_sqls = [
             "PARTITION BY (col1, col2)",
             "PARTITION BY DATE_TRUNC('DAY', col2), col1",


### PR DESCRIPTION
Splits #7998 into smaller, single-purpose PRs per review feedback; this one is just the `DROP TABLE ... FORCE` half.

`DROP TABLE ... FORCE` is Doris/StarRocks-lineage syntax (https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/DROP_TABLE/, https://doris.apache.org/docs/3.x/sql-manual/sql-statements/table-and-view/table/DROP-TABLE/) that skips the unfinished-transaction check and deletes the table immediately and irrecoverably (no `RECOVER` window). Found while triaging [apache/superset#36939](https://github.com/apache/superset/issues/36939), where it raises a hard `ParseError`.

Added as a generic `Drop()` flag in the base parser/generator, the same way ClickHouse's `DROP ... SYNC` was added in #7172 — `FORCE` doesn't exist in base MySQL's own `DROP TABLE` grammar, so it's additive and inert everywhere else.

### Testing

```bash
make unit
make style
```

Added `validate_identity` coverage to `test_starrocks.py` (including `DROP TEMPORARY TABLE ... FORCE`, StarRocks's full documented grammar) and `test_doris.py`.

Disclosure: implemented with Claude Code, reviewed, tested (`make unit`, `make style`) and understood by me.
