### PR TITLE
feat(starrocks): parse REFRESH EXTERNAL TABLE [CLAUDE]

### DIFF
--- a/sqlglot/dialects/starrocks.py
+++ b/sqlglot/dialects/starrocks.py
@@ -14,6 +14,7 @@ class StarRocks(MySQL):
         KEYWORDS = {
             **MySQL.Tokenizer.KEYWORDS,
             "LARGEINT": TokenType.INT128,
+            "REFRESH": TokenType.REFRESH,
         }
 
     Parser = StarRocksParser

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8815,7 +8815,9 @@ class Parser:
         return self.expression(exp.Commit(chain=chain))
 
     def _parse_refresh(self) -> exp.Refresh | exp.Command:
-        if self._match(TokenType.TABLE):
+        if self._match_text_seq("EXTERNAL", "TABLE"):
+            kind = "EXTERNAL TABLE"
+        elif self._match(TokenType.TABLE):
             kind = "TABLE"
         elif self._match_text_seq("MATERIALIZED", "VIEW"):
             kind = "MATERIALIZED VIEW"

--- a/tests/dialects/test_starrocks.py
+++ b/tests/dialects/test_starrocks.py
@@ -140,6 +140,13 @@ class TestStarrocks(Validator):
         self.validate_identity("INSERT OVERWRITE my_table SELECT * FROM other_table")
         self.validate_identity("CREATE TABLE t (c INT) COMMENT 'c'")
 
+        self.validate_identity("REFRESH EXTERNAL TABLE hive1")
+        self.validate_identity("REFRESH EXTERNAL TABLE hive_catalog.hive_db.hive_table")
+        self.validate_identity(
+            "REFRESH EXTERNAL TABLE hudi1 PARTITION ('date=2022-12-20', 'date=2022-12-21')",
+            "REFRESH EXTERNAL TABLE hudi1 PARTITION('date=2022-12-20', 'date=2022-12-21')",
+        )
+
         ddl_sqls = [
             "PARTITION BY (col1, col2)",
             "PARTITION BY DATE_TRUNC('DAY', col2), col1",


### PR DESCRIPTION
Splits #7998 into smaller, single-purpose PRs per review feedback; this one is just the `REFRESH EXTERNAL TABLE` half.

StarRocks syntax for refreshing metadata on an external-catalog table (https://docs.starrocks.io/docs/sql-reference/sql-statements/table_bucket_part_index/REFRESH_EXTERNAL_TABLE/):

```sql
REFRESH EXTERNAL TABLE [external_catalog.][db_name.]table_name [PARTITION ('partition_name', ...)]
```

Found while triaging [apache/superset#36939](https://github.com/apache/superset/issues/36939), where it raises a hard `ParseError`.

Added as a new `kind` on the existing `exp.Refresh`, reusing the same `_parse_refresh` that already handles `REFRESH TABLE` / `REFRESH MATERIALIZED VIEW`. StarRocks's tokenizer needed its own `"REFRESH": TokenType.REFRESH` keyword entry (mirroring Trino's, which already has one for `REFRESH MATERIALIZED VIEW`), since the base tokenizer doesn't map `REFRESH` by default. The optional trailing `PARTITION (...)` clause is handled for free by the existing generic `exp.Partition`/`_parse_table()` machinery — no new code needed for that part.

### Testing

```bash
make unit
make style
```

Added `validate_identity` coverage to `test_starrocks.py` matching the exact examples from the StarRocks docs.

Disclosure: implemented with Claude Code, reviewed, tested (`make unit`, `make style`) and understood by me.
