### PR TITLE
fix(optimizer): expand positional GROUP BY in canonicalize_internal_names

### DIFF
--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -3,11 +3,18 @@ from __future__ import annotations
 import typing as t
 
 from sqlglot import exp
-from sqlglot.helper import name_sequence, seq_get
+from sqlglot.dialects.dialect import Dialect
+from sqlglot.helper import name_sequence
+from sqlglot.optimizer.qualify_columns import expand_group_by
 from sqlglot.optimizer.scope import Scope, find_all_in_scope, traverse_scope
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
+
+# canonicalize_internal_names is dialect-agnostic: the source has already been
+# renamed so dialect specific rules (e.g. PROJECTION_ALIASES_SHADOW_SOURCE_NAMES) no
+# longer apply.
+_DEFAULT_DIALECT = Dialect()
 
 
 def canonicalize_internal_names(expression: E) -> E:
@@ -288,7 +295,7 @@ def canonicalize_internal_names(expression: E) -> E:
                 _canon(col.this, output_map[col.name])
 
         # Expand positional GROUP BYs (excluded in qualify) now that the source is renamed
-        _expand_group_by(scope)
+        expand_group_by(scope, _DEFAULT_DIALECT)
 
         # UBN matches branches by original alias. When both branches are internal
         # and aliased to distinct _cN, matching originals land on different slots

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -4,7 +4,7 @@ import typing as t
 
 from sqlglot import exp
 from sqlglot.dialects.dialect import Dialect
-from sqlglot.helper import name_sequence
+from sqlglot.helper import name_sequence, seq_get
 from sqlglot.optimizer.qualify_columns import expand_group_by
 from sqlglot.optimizer.scope import Scope, find_all_in_scope, traverse_scope
 

--- a/sqlglot/optimizer/canonicalize_internal_names.py
+++ b/sqlglot/optimizer/canonicalize_internal_names.py
@@ -287,6 +287,9 @@ def canonicalize_internal_names(expression: E) -> E:
             if not col.table and col.name in output_map:
                 _canon(col.this, output_map[col.name])
 
+        # Expand positional GROUP BYs (excluded in qualify) now that the source is renamed
+        _expand_group_by(scope)
+
         # UBN matches branches by original alias. When both branches are internal
         # and aliased to distinct _cN, matching originals land on different slots
         # and UBN splits them into disjoint output columns, dropping data. Align

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -450,7 +450,7 @@ def _expand_alias_refs(
         scope.clear_cache()
 
 
-def _expand_group_by(scope: Scope, dialect: Dialect) -> None:
+def _expand_group_by(scope: Scope, dialect: Dialect | None = None) -> None:
     expression = scope.expression
     group = expression.args.get("group")
     if not group:
@@ -506,7 +506,10 @@ def _expand_order_by_and_distinct_on(scope: Scope, resolver: Resolver) -> None:
 
 
 def _expand_positional_references(
-    scope: Scope, expressions: Iterable[exp.Expr], dialect: Dialect, alias: bool = False
+    scope: Scope,
+    expressions: Iterable[exp.Expr],
+    dialect: Dialect | None = None,
+    alias: bool = False,
 ) -> list[exp.Expr]:
     new_nodes: list[exp.Expr] = []
     ambiguous_projections = None
@@ -526,7 +529,7 @@ def _expand_positional_references(
                 # TODO (mypyc): use a separate variable to avoid reusing `select` (Alias) with a different type
                 select_expr: exp.Expr = select.this
 
-                if dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES:
+                if dialect and dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES:
                     if ambiguous_projections is None:
                         # When a projection name is also a source name and it is referenced in the
                         # GROUP BY clause, BQ can't understand what the identifier corresponds to

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -103,7 +103,7 @@ def qualify_columns(
                 )
             qualify_outputs(scope, dialect=dialect)
 
-        _expand_group_by(scope, dialect)
+        expand_group_by(scope, dialect)
 
         # DISTINCT ON and ORDER BY follow the same rules (tested in DuckDB, Postgres, ClickHouse)
         # https://www.postgresql.org/docs/current/sql-select.html#SQL-DISTINCT
@@ -450,7 +450,7 @@ def _expand_alias_refs(
         scope.clear_cache()
 
 
-def _expand_group_by(scope: Scope, dialect: Dialect | None = None) -> None:
+def expand_group_by(scope: Scope, dialect: Dialect) -> None:
     expression = scope.expression
     group = expression.args.get("group")
     if not group:
@@ -508,7 +508,7 @@ def _expand_order_by_and_distinct_on(scope: Scope, resolver: Resolver) -> None:
 def _expand_positional_references(
     scope: Scope,
     expressions: Iterable[exp.Expr],
-    dialect: Dialect | None = None,
+    dialect: Dialect,
     alias: bool = False,
 ) -> list[exp.Expr]:
     new_nodes: list[exp.Expr] = []
@@ -529,7 +529,7 @@ def _expand_positional_references(
                 # TODO (mypyc): use a separate variable to avoid reusing `select` (Alias) with a different type
                 select_expr: exp.Expr = select.this
 
-                if dialect and dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES:
+                if dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES:
                     if ambiguous_projections is None:
                         # When a projection name is also a source name and it is referenced in the
                         # GROUP BY clause, BQ can't understand what the identifier corresponds to

--- a/tests/fixtures/optimizer/canonicalize_internal_names.sql
+++ b/tests/fixtures/optimizer/canonicalize_internal_names.sql
@@ -277,3 +277,23 @@ WITH "_t1" AS (SELECT "_t0"."a" + 1 AS "_c0" FROM "c"."db"."x" AS "_t0") SELECT 
 # title: ORDER BY reference to a CTE-level alias follows the alias's _cN canonicalization
 WITH t AS (SELECT a + 1 AS total FROM x ORDER BY total) SELECT total FROM t;
 WITH "_t1" AS (SELECT "_t0"."a" + 1 AS "_c0" FROM "c"."db"."x" AS "_t0" ORDER BY "_c0") SELECT "_t1"."_c0" AS "total" FROM "_t1" AS "_t1";
+
+# title: GROUP BY ordinal is expanded even when a projection alias shadows the pre-canonicalization source name, so the form is stable once the source is renamed to _t0
+# dialect: bigquery
+SELECT a AS foo, b AS x FROM x GROUP BY 1;
+SELECT `_t0`.`a` AS `foo`, `_t0`.`b` AS `x` FROM `c`.`db`.`x` AS `_t0` GROUP BY `_t0`.`a`;
+
+# title: GROUP BY ordinal is expanded when an aggregate projection alias shadows the source name
+# dialect: bigquery
+SELECT a AS foo, SUM(b) AS x FROM x GROUP BY 1;
+SELECT `_t0`.`a` AS `foo`, SUM(`_t0`.`b`) AS `x` FROM `c`.`db`.`x` AS `_t0` GROUP BY `_t0`.`a`;
+
+# title: GROUP BY ordinal is expanded inside a CTE scope where a projection alias shadows the source name
+# dialect: bigquery
+WITH t AS (SELECT a AS foo, b AS x FROM x GROUP BY 1) SELECT * FROM t;
+WITH `_t1` AS (SELECT `_t0`.`a` AS `_c0`, `_t0`.`b` AS `_c1` FROM `c`.`db`.`x` AS `_t0` GROUP BY `_t0`.`a`) SELECT `_t1`.`_c0` AS `foo`, `_t1`.`_c1` AS `x` FROM `_t1` AS `_t1`;
+
+# title: GROUP BY ordinals both expand once a self-join alias that shadowed a projection alias is renamed
+# dialect: bigquery
+SELECT x.a AS c, y.a AS d, SUM(x.b) AS y FROM x AS x JOIN x AS y ON x.a = y.a GROUP BY 1, 2;
+SELECT `_t0`.`a` AS `c`, `_t1`.`a` AS `d`, SUM(`_t0`.`b`) AS `y` FROM `c`.`db`.`x` AS `_t0` JOIN `c`.`db`.`x` AS `_t1` ON `_t0`.`a` = `_t1`.`a` GROUP BY `_t0`.`a`, `_t1`.`a`;


### PR DESCRIPTION
For BigQuery, `qualify` leaves a positional `GROUP BY` (e.g. `GROUP BY 1`) unexpanded when a projection alias shadows a source name. `canonicalize_internal_names` then renames the source to `_tN`, removing the collision, but never expanded the ordinal, meaning the canonical form keeps a positional reference.

`canonicalize_internal_names` now calls `_expand_group_by` after renaming.  There's no dialect available (and not technically needed), so I made that parameter optional in `qualify_columns`.

Input
```
SELECT a AS foo, b AS x FROM x GROUP BY 1
```
Before
```
SELECT `_t0`.`a` AS `foo`, `_t0`.`b` AS `x` FROM `c`.`db`.`x` AS `_t0` GROUP BY 1
```
After
```
SELECT `_t0`.`a` AS `foo`, `_t0`.`b` AS `x` FROM `c`.`db`.`x` AS `_t0` GROUP BY `_t0`.`a`
```