### PR TITLE
feat(postgres): transpile T-SQL integer DAY/MONTH/YEAR via 1900 epoch [CLAUDE]

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -81,9 +81,8 @@ def _day_month_year_sql(self: PostgresGenerator, expression: exp.Day | exp.Month
     this = expression.this
     value = this.this if isinstance(this, exp.TsOrDsToDate) else this
     if value.is_int or value.is_type(*exp.DataType.INTEGER_TYPES):
-        self.unsupported(
-            f"Cannot transpile {expression.sql_name()} of an integer value to Postgres"
-        )
+        # T-SQL interprets integers as days since its 1900-01-01 epoch
+        this = exp.cast(exp.Literal.string("1900-01-01"), exp.DType.DATE) + value
 
     return self.sql(exp.Extract(this=exp.var(expression.sql_name()), expression=this))
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1,4 +1,4 @@
-from sqlglot import ErrorLevel, ParseError, UnsupportedError, exp, parse_one, transpile
+from sqlglot import ParseError, UnsupportedError, exp, parse_one, transpile
 from sqlglot.helper import logger as helper_logger
 from sqlglot.optimizer.annotate_types import annotate_types
 from tests.dialects.test_dialect import Validator
@@ -1834,10 +1834,19 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
             "SELECT EXTRACT(DAY FROM CAST(x AS DATE))",
         )
 
-        with self.assertRaises(UnsupportedError):
+        self.validate_all(
+            "SELECT EXTRACT(DAY FROM CAST('1900-01-01' AS DATE) + 0), EXTRACT(MONTH FROM CAST('1900-01-01' AS DATE) + -1), EXTRACT(YEAR FROM CAST('1900-01-01' AS DATE) + 43831)",
+            read={
+                "tsql": "SELECT DAY(0), MONTH(-1), YEAR(43831)",
+            },
+        )
+
+        self.assertEqual(
             annotate_types(
                 parse_one("WITH t AS (SELECT 1 AS col) SELECT YEAR(t.col) FROM t", read="tsql")
-            ).sql("postgres", unsupported_level=ErrorLevel.RAISE)
+            ).sql("postgres"),
+            "WITH t AS (SELECT 1 AS col) SELECT EXTRACT(YEAR FROM CAST('1900-01-01' AS DATE) + t.col) FROM t",
+        )
 
     def test_datatype(self):
         self.assertEqual(exp.DataType.build("XML", dialect="postgres").sql("postgres"), "XML")


### PR DESCRIPTION
## Summary

Follow-up to #7984, as agreed with @geooo109 there: integer arguments to T-SQL `DAY`/`MONTH`/`YEAR` now transpile to Postgres instead of raising an unsupported error.

T-SQL interprets an integer as days since its 1900-01-01 epoch (`DAY(0)` returns 1, `YEAR(0)` returns 1900, negatives count backwards), so the faithful Postgres form is date arithmetic on that epoch:

```python
sqlglot.transpile("SELECT YEAR(0)", read="tsql", write="postgres")[0]
# "SELECT EXTRACT(YEAR FROM CAST('1900-01-01' AS DATE) + 0)"
```

This covers integer literals (including negatives) without type annotation, and integer-typed columns through `annotate_types`, e.g. the CTE example from the previous review now transpiles instead of erroring:

```python
annotate_types(parse_one("WITH t AS (SELECT 1 AS col) SELECT YEAR(t.col) FROM t", read="tsql")).sql("postgres")
# "WITH t AS (SELECT 1 AS col) SELECT EXTRACT(YEAR FROM CAST('1900-01-01' AS DATE) + t.col) FROM t"
```

The T-SQL roundtrip is unaffected (`DAY(0)` stays `DAY(0)`).

Verified against a live Postgres 15: DAY/MONTH/YEAR over twelve day-offsets each (0, +-1, the Feb/Mar 1900 non-leap-year boundary, year boundaries, century dates, and negatives back to 1800) all return the same values T-SQL produces for the equivalent input.

Fixes the remaining scope of #6220.
