### PR TITLE
fix(duckdb): surface LAST_DAY(x, WEEK(<weekday>)) as unsupported instead of silently dropping the unit

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -160,7 +160,19 @@ def _last_day_sql(self: DuckDBGenerator, expression: exp.LastDay) -> str:
     For other date parts (year, quarter, week), we need to implement equivalent logic.
     """
     date_expr = expression.this
+    unit_expr = expression.args.get("unit")
     unit = expression.text("unit")
+
+    # WEEK(<weekday>) parses to a WeekStart node whose ``text`` is empty, so it
+    # must be handled before the ``not unit`` default below. DuckDB has no
+    # weekday-anchored week, and the last day differs by start day
+    # (WEEK(SUNDAY) != WEEK(MONDAY)), so surface it as unsupported instead of
+    # silently returning the last day of the month.
+    if isinstance(unit_expr, exp.WeekStart):
+        self.unsupported(
+            f"Unsupported date part '{unit_expr.sql(dialect='bigquery')}' in LAST_DAY function"
+        )
+        return self.function_fallback_sql(expression)
 
     if not unit or unit.upper() == "MONTH":
         # Default behavior - use DuckDB's native LAST_DAY

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -809,6 +809,19 @@ LANGUAGE js AS
                 "snowflake": "SELECT LAST_DAY(CAST('2008-11-25' AS DATE), QUARTER)",
             },
         )
+        # WEEK(<weekday>) has no DuckDB equivalent and its last day depends on
+        # the week start day, so it must be surfaced (and preserved) as
+        # unsupported rather than silently emitting a plain LAST_DAY. GH #8011.
+        self.validate_all(
+            "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK(MONDAY))",
+            read={
+                "bigquery": "SELECT LAST_DAY(DATE '2008-11-10', WEEK(MONDAY))",
+            },
+            write={
+                "bigquery": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK(MONDAY))",
+                "duckdb": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK(MONDAY))",
+            },
+        )
         self.validate_all(
             "CAST(x AS DATETIME)",
             read={


### PR DESCRIPTION
### What

On the `bigquery` → `duckdb` path, `LAST_DAY(x, WEEK(<weekday>))` silently dropped the week unit and emitted a plain `LAST_DAY(...)` (last day of month), with **no** `unsupported` warning — so the result was wrong and nothing flagged it.

```py
import sqlglot
sqlglot.transpile("SELECT LAST_DAY(DATE '2008-11-10', WEEK(SUNDAY))", read="bigquery", write="duckdb")[0]
# before: SELECT LAST_DAY(CAST('2008-11-10' AS DATE))          # unit dropped, no warning
# after : SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK(SUNDAY))  + "Unsupported date part ..." warning
```

This addresses the first item of #8011.

### Root cause

`_last_day_sql` in `sqlglot/generators/duckdb.py` reads the unit with `expression.text("unit")`. `WEEK(<weekday>)` parses to a `WeekStart` node whose `text` is `""`, so the `if not unit or unit.upper() == "MONTH"` guard wins and the `self.unsupported(...)` branch is unreachable for these units. `ISOWEEK` (a plain `Var`) already routes to `unsupported` correctly; `WEEK(SUNDAY)`/`WEEK(MONDAY)` did not. `_last_day_sql` was added for Snowflake (#6614), which has no `WEEK(<weekday>)` spelling, so the node never came up.

### Fix

Detect the `WeekStart` unit before the `MONTH` default and route it to `self.unsupported(...)`, preserving the unit in the fallback output — matching the existing `ISOWEEK` behaviour. DuckDB has no weekday-anchored week, and the correct last day differs by start day (`WEEK(SUNDAY)` ends Saturday, `WEEK(MONDAY)` ends Sunday), so surfacing it as unsupported is the safe, honest result rather than silently returning the last day of the month.

### Tests

- Added a `bigquery` → `duckdb` regression test in `tests/dialects/test_bigquery.py` next to the existing `LAST_DAY` `MONTH`/`QUARTER` cases (coverage for `LAST_DAY` + any `WEEK` unit to duckdb was previously zero).
- `python -m pytest tests/dialects/` → **757 passed, 11331 subtests passed**, no regressions.

### Scope

Deliberately limited to the `LAST_DAY` guard (item 1 of #8011). The `DATE_TRUNC` bare-`WEEK` vs `WEEK(SUNDAY)` read-side asymmetry (item 2) is intentionally **not** touched here — as the reporter notes, a read-side normalisation ripples through `weekstart_sql` into ~13 write dialects and needs a maintainer decision on the preferred shape. Happy to follow up on that separately.
