### PR TITLE
fix(duckdb)!: LAST_DAY with a WEEK(<day>) part silently returns the last day of the month

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -2092,8 +2092,7 @@ WEEK_START_DAY_TO_DOW = {
 
 def week_unit_to_dow(unit: exp.Expr | None) -> int | None:
     """
-    Compute the week start day for a week-ish diff unit, e.g BigQuery's WEEK(<day>)
-    or ISOWEEK unit parts.
+    Compute the week start day for a week-ish diff unit, e.g BigQuery's WEEK(<day>) or ISOWEEK unit parts.
 
     Args:
         unit: The unit expression (Var for WEEK/ISOWEEK or WeekStart)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -5179,8 +5179,8 @@ class Generator:
         if self.LAST_DAY_SUPPORTS_DATE_PART:
             return self.function_fallback_sql(expression)
 
-        unit = expression.text("unit")
-        if unit and unit != "MONTH":
+        unit = expression.args.get("unit")
+        if unit and unit.name.upper() != "MONTH":
             self.unsupported("Date parts are not supported in LAST_DAY.")
 
         return self.func("LAST_DAY", expression.this)

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -160,6 +160,24 @@ def _last_day_sql(self: DuckDBGenerator, expression: exp.LastDay) -> str:
     For other date parts (year, quarter, week), we need to implement equivalent logic.
     """
     date_expr = expression.this
+    unit_expr = expression.args.get("unit")
+
+    week_start = week_unit_to_dow(unit_expr)
+    if week_start:
+        # The week's last day precedes its start day; DuckDB DAYOFWEEK: Sunday=0, ..., Saturday=6
+        last_dow = week_start - 1
+        dow = exp.func("EXTRACT", "DAYOFWEEK", date_expr)
+
+        # Days to the last day of week: (last_dow + 7 - dayofweek) % 7
+        days_to_last_expr = exp.Mod(
+            this=exp.Paren(this=exp.Sub(this=exp.Literal.number(last_dow + 7), expression=dow)),
+            expression=exp.Literal.number(7),
+        )
+        interval_expr = exp.Interval(this=days_to_last_expr, unit=exp.var("DAY"))
+        add_expr = exp.Add(this=date_expr, expression=interval_expr)
+
+        return self.sql(exp.cast(add_expr, exp.DType.DATE))
+
     unit = expression.text("unit")
 
     if not unit or unit.upper() == "MONTH":
@@ -188,20 +206,6 @@ def _last_day_sql(self: DuckDBGenerator, expression: exp.LastDay) -> str:
         # Last day of the last month of the quarter
         last_day_expr = exp.func("LAST_DAY", first_day_last_month_expr)
         return self.sql(last_day_expr)
-
-    if unit.upper() == "WEEK":
-        # DuckDB DAYOFWEEK: Sunday=0, Monday=1, ..., Saturday=6
-        dow = exp.func("EXTRACT", "DAYOFWEEK", date_expr)
-        # Days to the last day of week: (7 - dayofweek) % 7, assuming the last day of week is Sunday (Snowflake)
-        # Wrap in parentheses to ensure correct precedence
-        days_to_sunday_expr = exp.Mod(
-            this=exp.Paren(this=exp.Sub(this=exp.Literal.number(7), expression=dow)),
-            expression=exp.Literal.number(7),
-        )
-        interval_expr = exp.Interval(this=days_to_sunday_expr, unit=exp.var("DAY"))
-        add_expr = exp.Add(this=date_expr, expression=interval_expr)
-        cast_expr = exp.cast(add_expr, exp.DType.DATE)
-        return self.sql(cast_expr)
 
     self.unsupported(f"Unsupported date part '{unit}' in LAST_DAY function")
     return self.function_fallback_sql(expression)

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -28,22 +28,27 @@ def _build_date(args: list) -> exp.Date | exp.DateFromParts:
     return expr_type.from_arg_list(args)
 
 
+def _normalize_bare_week(expr: E) -> E:
+    # In BigQuery, a bare WEEK date part is equivalent to WEEK(SUNDAY)
+    unit = expr.args.get("unit")
+    if isinstance(unit, exp.Var) and unit.name.upper() == "WEEK":
+        expr.set("unit", exp.WeekStart(this=exp.var("SUNDAY")))
+
+    return expr
+
+
 def build_date_diff(
     expr_type: type[exp.DateDiff | exp.DatetimeDiff],
 ) -> t.Callable[[list], exp.Expr]:
     def _builder(args: list) -> exp.Expr:
-        expr = expr_type(
-            this=seq_get(args, 0),
-            expression=seq_get(args, 1),
-            unit=seq_get(args, 2),
-            date_part_boundary=True,
+        return _normalize_bare_week(
+            expr_type(
+                this=seq_get(args, 0),
+                expression=seq_get(args, 1),
+                unit=seq_get(args, 2),
+                date_part_boundary=True,
+            )
         )
-
-        unit = expr.args.get("unit")
-        if isinstance(unit, exp.Var) and unit.name.upper() == "WEEK":
-            expr.set("unit", exp.WeekStart(this=exp.var("SUNDAY")))
-
-        return expr
 
     return _builder
 
@@ -253,6 +258,7 @@ class BigQueryParser(parser.Parser):
         "JSON_STRIP_NULLS": _build_json_strip_nulls,
         "JSON_VALUE": _build_extract_json_with_default_path(exp.JSONExtractScalar),
         "JSON_VALUE_ARRAY": _build_extract_json_with_default_path(exp.JSONValueArray),
+        "LAST_DAY": lambda args: _normalize_bare_week(exp.LastDay.from_arg_list(args)),
         "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
         "MD5": exp.MD5Digest.from_arg_list,
         "SHA1": exp.SHA1Digest.from_arg_list,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3569,6 +3569,35 @@ OPTIONS (
         )
         self.validate_identity("DATE_DIFF('2017-12-18', '2017-12-17', WEEK(SATURDAY))")
         self.validate_identity("DATETIME_DIFF('2017-12-18', '2017-12-17', WEEK(MONDAY))")
+
+        self.validate_all(
+            "SELECT LAST_DAY(DATE '2008-11-10', WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK)",
+                "duckdb": "SELECT CAST(CAST('2008-11-10' AS DATE) + INTERVAL ((13 - EXTRACT(DAYOFWEEK FROM CAST('2008-11-10' AS DATE))) % 7) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT LAST_DAY(DATE '2008-11-10', WEEK)",
+            write={
+                "bigquery": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK)",
+                "duckdb": "SELECT CAST(CAST('2008-11-10' AS DATE) + INTERVAL ((13 - EXTRACT(DAYOFWEEK FROM CAST('2008-11-10' AS DATE))) % 7) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT LAST_DAY(DATE '2008-11-10', WEEK(MONDAY))",
+            write={
+                "bigquery": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), WEEK(MONDAY))",
+                "duckdb": "SELECT CAST(CAST('2008-11-10' AS DATE) + INTERVAL ((7 - EXTRACT(DAYOFWEEK FROM CAST('2008-11-10' AS DATE))) % 7) DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT LAST_DAY(DATE '2008-11-10', ISOWEEK)",
+            write={
+                "bigquery": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), ISOWEEK)",
+                "duckdb": "SELECT CAST(CAST('2008-11-10' AS DATE) + INTERVAL ((7 - EXTRACT(DAYOFWEEK FROM CAST('2008-11-10' AS DATE))) % 7) DAY AS DATE)",
+            },
+        )
         self.validate_identity(
             "EXTRACT(WEEK(THURSDAY) FROM DATE '2013-12-25')",
             "EXTRACT(WEEK(THURSDAY) FROM CAST('2013-12-25' AS DATE))",


### PR DESCRIPTION
- Transpile `LAST_DAY` week units to DuckDB using the source dialect's week start day,
  instead of always assuming Monday-start weeks (e.g. BigQuery's `WEEK(SUNDAY)`, `ISOWEEK`)
- Normalize BigQuery's bare `WEEK` to `WEEK(SUNDAY)` at parse time (as `DATE_DIFF` already does),
  so `LAST_DAY(d, WEEK)` no longer produces Sunday instead of Saturday
- Warn on unsupported week parts in dialects whose `LAST_DAY` only supports months
- Verified against live BigQuery, Snowflake and DuckDB across a full week of input dates
