### PR TITLE
fix(optimizer)!: T-SQL Sunday week start, connector grouping and DPipe safe flag in simplify

### DIFF
--- a/sqlglot/dialects/tsql.py
+++ b/sqlglot/dialects/tsql.py
@@ -12,6 +12,9 @@ from sqlglot.typing.tsql import EXPRESSION_METADATA
 
 
 class TSQL(Dialect):
+    # Week truncation follows @@DATEFIRST, which defaults to 7 (Sunday)
+    WEEK_OFFSET = -1
+
     LOG_BASE_FIRST = False
     TYPED_DIVISION = True
     CONCAT_COALESCE = True

--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -800,7 +800,9 @@ class Simplifier:
         if isinstance(expression, exp.Not):
             this = expression.this
             if is_null(this):
-                return exp.and_(exp.null(), exp.true(), copy=False)
+                return _parenthesize_nested_connector(
+                    exp.and_(exp.null(), exp.true(), copy=False), expression.parent
+                )
             if this.__class__ in self.COMPLEMENT_COMPARISONS:
                 right = this.expression
                 complement_subquery_predicate = self.COMPLEMENT_SUBQUERY_PREDICATES.get(
@@ -831,7 +833,9 @@ class Simplifier:
                         copy=False,
                     )
                 if is_null(condition):
-                    return exp.and_(exp.null(), exp.true(), copy=False)
+                    return _parenthesize_nested_connector(
+                        exp.and_(exp.null(), exp.true(), copy=False), expression.parent
+                    )
             if always_true(this):
                 return exp.false()
             if is_false(this):
@@ -1384,7 +1388,7 @@ class Simplifier:
         if concat_type is exp.ConcatWs:
             new_args = [sep_expr] + new_args
         elif isinstance(expression, exp.DPipe):
-            return reduce(lambda x, y: exp.DPipe(this=x, expression=y), new_args)
+            return reduce(lambda x, y: exp.DPipe(this=x, expression=y, safe=args["safe"]), new_args)
 
         return concat_type(expressions=new_args, **args)
 

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -82,6 +82,16 @@ TRUE;
 NOT NULL;
 NULL AND TRUE;
 
+-- the NULL-condition rewrite must be parenthesized under NOT or a different connector
+NOT NOT NULL;
+NULL AND TRUE;
+
+x = 1 OR NOT NOT NULL;
+NULL OR x = 1;
+
+x = 1 AND NOT NOT NULL;
+NULL AND x = 1;
+
 NULL = NULL;
 NULL = NULL;
 
@@ -1118,6 +1128,23 @@ x < CAST('2008-11-16' AS DATE) AND x >= CAST('2008-11-09' AS DATE);
 # dialect: bigquery
 DATE_TRUNC(x, WEEK) <> CAST('2008-11-09' AS DATE);
 x < CAST('2008-11-09' AS DATE) OR x >= CAST('2008-11-16' AS DATE);
+
+-- T-SQL week truncation follows @@DATEFIRST, which defaults to 7 (Sunday)
+# dialect: tsql
+DATETRUNC(WEEK, CAST('2021-12-08' AS DATETIME2));
+CAST('2021-12-05 00:00:00' AS DATETIME2);
+
+# dialect: tsql
+DATETRUNC(WEEK, CAST('2023-12-10' AS DATE));
+CAST('2023-12-10' AS DATE);
+
+# dialect: tsql
+DATETRUNC(WEEK, x) = CAST('2023-12-10' AS DATE);
+x < CAST('2023-12-17' AS DATE) AND x >= CAST('2023-12-10' AS DATE);
+
+# dialect: tsql
+DATETRUNC(WEEK, x) > CAST('2023-12-10' AS DATE);
+x >= CAST('2023-12-17' AS DATE);
 
 DATE_TRUNC('year', x) = CAST('2021-01-01' AS DATE);
 x < CAST('2022-01-01' AS DATE) AND x >= CAST('2021-01-01' AS DATE);

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1115,6 +1115,18 @@ class TestOptimizer(unittest.TestCase):
             "CONCAT_WS(' ', a, NULL, 'b c')", simplified_concat_ws.sql(dialect="duckdb")
         )
 
+        # DuckDB's || coerces its args to strings, so the "safe" flag must survive simplification
+        # for the transpiled CONCAT to keep coercing in stricter dialects like Presto
+        dpipe = parse_one("x || 'a' || 'b'", read="duckdb")
+        simplified_dpipe = optimizer.simplify.simplify(dpipe)
+
+        self.assertEqual(simplified_dpipe.args["safe"], True)
+        self.assertEqual("x || 'ab'", simplified_dpipe.sql(dialect="duckdb"))
+        self.assertEqual(
+            "CONCAT(CAST(x AS VARCHAR), CAST('ab' AS VARCHAR))",
+            simplified_dpipe.sql(dialect="presto"),
+        )
+
         anon_unquoted_str = parse_one("anonymous(x, y)")
         self.assertEqual(optimizer.simplify.gen(anon_unquoted_str), "ANONYMOUS(x,y)")
 


### PR DESCRIPTION
- Set `WEEK_OFFSET = -1` for T-SQL: `DATETRUNC(week, ...)` follows `@@DATEFIRST`, which defaults to 7 (Sunday)
- Parenthesize the `NOT NULL` -> `NULL AND TRUE` rewrite when it lands under `NOT` or a different connector, so the generated SQL reparses with the same grouping
- Preserve the `safe` flag when `simplify_concat` rebuilds `||` chains, keeping the coercing `CONCAT(CAST(...))` form on transpilation to strict dialects
