### PR TITLE
fix(clickhouse): parse MODIFY COLUMN as Alter / ModifyColumn

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -254,7 +254,7 @@ class AlterColumn(Expression):
 
 
 class ModifyColumn(Expression):
-    arg_types = {"this": True, "rename_from": False}
+    arg_types = {"this": True, "rename_from": False, "exists": False}
 
 
 class AlterIndex(Expression):

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4223,13 +4223,13 @@ class Generator:
     def modifycolumn_sql(self, expression: exp.ModifyColumn) -> str:
         this = self.sql(expression, "this")
         rename_from = self.sql(expression, "rename_from")
-        exists = " IF EXISTS" if expression.args.get("exists") else ""
         if rename_from:
             if not self.SUPPORTS_CHANGE_COLUMN:
                 self.unsupported("CHANGE COLUMN is not supported in this dialect")
-            return f"CHANGE COLUMN{exists} {rename_from} {this}"
+            return f"CHANGE COLUMN {rename_from} {this}"
         if not self.SUPPORTS_MODIFY_COLUMN:
             self.unsupported("MODIFY COLUMN is not supported in this dialect")
+        exists = " IF EXISTS" if expression.args.get("exists") else ""
         return f"MODIFY COLUMN{exists} {this}"
 
     def alterindex_sql(self, expression: exp.AlterIndex) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4223,13 +4223,14 @@ class Generator:
     def modifycolumn_sql(self, expression: exp.ModifyColumn) -> str:
         this = self.sql(expression, "this")
         rename_from = self.sql(expression, "rename_from")
+        exists = " IF EXISTS" if expression.args.get("exists") else ""
         if rename_from:
             if not self.SUPPORTS_CHANGE_COLUMN:
                 self.unsupported("CHANGE COLUMN is not supported in this dialect")
-            return f"CHANGE COLUMN {rename_from} {this}"
+            return f"CHANGE COLUMN{exists} {rename_from} {this}"
         if not self.SUPPORTS_MODIFY_COLUMN:
             self.unsupported("MODIFY COLUMN is not supported in this dialect")
-        return f"MODIFY COLUMN {this}"
+        return f"MODIFY COLUMN{exists} {this}"
 
     def alterindex_sql(self, expression: exp.AlterIndex) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -175,6 +175,7 @@ class ClickHouseGenerator(generator.Generator):
     STRUCT_DELIMITER = ("(", ")")
     NVL2_SUPPORTED = False
     ALTER_SET_TYPE = "TYPE"
+    SUPPORTS_MODIFY_COLUMN = True
     TABLESAMPLE_REQUIRES_PARENS = False
     TABLESAMPLE_SIZE_IS_ROWS = False
     TABLESAMPLE_KEYWORDS = "SAMPLE"

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -911,7 +911,29 @@ class ClickHouseParser(parser.Parser):
     def _parse_alter_table_modify(self) -> exp.Expr | None:
         if properties := self._parse_properties():
             return self.expression(exp.AlterModifySqlSecurity(expressions=properties.expressions))
-        return None
+
+        # https://clickhouse.com/docs/sql-reference/statements/alter/column#modify-column
+        if not self._match(TokenType.COLUMN):
+            return None
+
+        exists = self._parse_exists()
+        column = self._parse_field(any_token=True)
+        if column is None:
+            return None
+
+        # REMOVE / MODIFY SETTING / RESET SETTING / ADD ENUM VALUES stay as Command
+        if (
+            self._match_texts(("REMOVE", "RESET"), advance=False)
+            or self._match_text_seq("MODIFY", "SETTING", advance=False)
+            or self._match_text_seq("ADD", "ENUM", advance=False)
+        ):
+            return None
+
+        column_def = self._parse_column_def(column)
+        if not isinstance(column_def, exp.ColumnDef):
+            return None
+
+        return self.expression(exp.ModifyColumn(this=column_def, exists=exists or None))
 
     def _parse_definer(self) -> exp.DefinerProperty | None:
         self._match(TokenType.EQ)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -662,6 +662,17 @@ class TestClickhouse(Validator):
             },
         )
 
+        # Native ClickHouse MODIFY COLUMN form (type / default / codec / position)
+        modify = self.validate_identity("ALTER TABLE t MODIFY COLUMN c Int64").assert_is(exp.Alter)
+        self.assertIsInstance(modify.args["actions"][0], exp.ModifyColumn)
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN c Int64 DEFAULT 0")
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN IF EXISTS c Int64")
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN c DEFAULT 0")
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN c CODEC(ZSTD)")
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN c Int64 FIRST")
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN c Int64 AFTER b")
+        self.validate_identity("ALTER TABLE t MODIFY COLUMN c String MATERIALIZED toString(x)")
+
         self.assertIsInstance(
             parse_one("Tuple(select Int64)", into=exp.DataType, read="clickhouse"), exp.DataType
         )

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -672,6 +672,14 @@ class TestClickhouse(Validator):
         self.validate_identity("ALTER TABLE t MODIFY COLUMN c Int64 FIRST")
         self.validate_identity("ALTER TABLE t MODIFY COLUMN c Int64 AFTER b")
         self.validate_identity("ALTER TABLE t MODIFY COLUMN c String MATERIALIZED toString(x)")
+        self.assertIsInstance(
+            parse_one(
+                "ALTER TABLE t MODIFY COLUMN c REMOVE DEFAULT",
+                read="clickhouse",
+                error_level=ErrorLevel.IGNORE,
+            ),
+            exp.Command,
+        )
 
         self.assertIsInstance(
             parse_one("Tuple(select Int64)", into=exp.DataType, read="clickhouse"), exp.DataType


### PR DESCRIPTION
ClickHouse `ALTER TABLE ... MODIFY COLUMN` was falling back to `Command` because the ClickHouse `MODIFY` alter parser only handled `MODIFY SQL SECURITY ...`.

This parses the column form into `ModifyColumn` (same AST MySQL already uses), enables ClickHouse generation for it, and leaves `REMOVE` / column settings / `ADD ENUM VALUES` as `Command` for now.

Fixes #8019

Disclosure: used LLM assistance while investigating; I reviewed and tested the change.