### PR TITLE
duckdb: map ISOWEEK to WEEK for DATE_TRUNC [COPILOT]

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4413,15 +4413,20 @@ class DuckDBGenerator(generator.Generator):
         unit = expression.args.get("unit")
         date = expression.this
 
-        week_start = week_unit_to_dow(unit)
-        unit = unit_to_str(expression)
-
-        if week_start:
-            result = self.sql(
-                _build_week_trunc_expression(date, week_start, preserve_start_day=True)
-            )
+        # BigQuery parses bare ISOWEEK in DATE_TRUNC(date, ISOWEEK) as a string literal,
+        # while DuckDB's DATE_TRUNC already uses ISO/Monday WEEK semantics.
+        if isinstance(unit, exp.Literal) and unit.is_string and unit.name.upper() == "ISOWEEK":
+            result = self.func("DATE_TRUNC", exp.Literal.string("WEEK"), date)
         else:
-            result = self.func("DATE_TRUNC", unit, date)
+            week_start = week_unit_to_dow(unit)
+            unit = unit_to_str(expression)
+
+            if week_start:
+                result = self.sql(
+                    _build_week_trunc_expression(date, week_start, preserve_start_day=True)
+                )
+            else:
+                result = self.func("DATE_TRUNC", unit, date)
 
         if (
             expression.args.get("input_type_preserved")

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3567,6 +3567,15 @@ OPTIONS (
             "LAST_DAY(DATETIME '2008-11-10 15:30:00', WEEK(SUNDAY))",
             "LAST_DAY(CAST('2008-11-10 15:30:00' AS DATETIME), WEEK)",
         )
+
+        # Regression test: ensure ISOWEEK used with DATE_TRUNC in BigQuery maps to WEEK for DuckDB
+        self.validate_all(
+            "SELECT DATE_TRUNC(DATE '2008-11-10', ISOWEEK)",
+            write={
+                "bigquery": "SELECT DATE_TRUNC(CAST('2008-11-10' AS DATE), ISOWEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST('2008-11-10' AS DATE))",
+            },
+        )
         self.validate_identity("DATE_DIFF('2017-12-18', '2017-12-17', WEEK(SATURDAY))")
         self.validate_identity("DATETIME_DIFF('2017-12-18', '2017-12-17', WEEK(MONDAY))")
         self.validate_identity(


### PR DESCRIPTION
Fixes #8011

This change only modifies:
- `sqlglot/generators/duckdb.py`
- `tests/dialects/test_bigquery.py`

What actually happens:
- `parse_one("SELECT DATE_TRUNC(DATE ''2008-11-10'', ISOWEEK)", dialect="bigquery")` produces `exp.DateTrunc` with `unit=Literal(this="ISOWEEK", is_string=True)`.
- The DuckDB generator path for that BigQuery case is `DuckDBGenerator.datetrunc_sql`, not `week_unit_to_dow()`.
- Direct DuckDB `DATE_TRUNC(''ISOWEEK'', x)` parses differently (`exp.TimestampTrunc` with `unit=Var(this=ISOWEEK)`) and still round-trips unchanged.

Fix:
- Keep the DuckDB `DateTrunc` guard on the BigQuery literal shape and emit `DATE_TRUNC(''WEEK'', ...)`, since DuckDB''s `WEEK` already uses ISO/Monday semantics.
- Revert the unrelated comment-only change in `sqlglot/dialects/dialect.py`.

Validation:
- `python -m pytest tests/dialects/test_bigquery.py -k test_week`
- `python -m pytest tests/`