### PR TITLE
feat: add SQL anonymizer for logging [DSV4 FLASH]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,9 @@ sqlglot/_version.py
 
 # UV lock file
 uv.lock
+
+# pi (dev. assistant / worktrees)
+.worktrees/
+.pi/
+.pi-subagents/
+.pi-loop.json.lock

--- a/sqlglot/anonymize.py
+++ b/sqlglot/anonymize.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import string
-import typing as t
 
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import TokenError
@@ -23,6 +22,8 @@ ANONYMIZED_TYPES = {
     TokenType.UNICODE_STRING,
     TokenType.VAR,
 }
+QUOTED_TYPES = ANONYMIZED_TYPES - {TokenType.NUMBER, TokenType.VAR}
+REWRITTEN_TYPES = {TokenType.HINT, TokenType.UNKNOWN}
 
 
 def anonymize(
@@ -30,16 +31,17 @@ def anonymize(
     dialect: DialectType = None,
 ) -> list[Token]:
     """Replaces sensitive tokens (identifiers, strings, numbers) with fixed-width,
-    length-preserving, consistent aliases, and blanks out comments. When a SQL string is
-    given, it is tokenized with `dialect` first; any un-tokenized remainder (e.g. an
-    unterminated literal) is appended as a blanked UNKNOWN token. Mutates and returns
-    `sql_or_tokens`.
+    length-preserving, consistent aliases, and blanks out comments and hint bodies. When a
+    SQL string is given, it is tokenized with `dialect` first; any un-tokenized remainder
+    (e.g. an unterminated literal) is appended as a blanked UNKNOWN token. Mutates and
+    returns `sql_or_tokens`.
 
     Args:
         sql_or_tokens: The SQL string to anonymize, or its token list.
         dialect: The dialect used to tokenize a SQL string.
     """
     dialect = Dialect.get_or_raise(dialect)
+    tokenizer_class = dialect.tokenizer_class
     known_functions = dialect.parser_class.FUNCTIONS
 
     errored = False
@@ -55,14 +57,21 @@ def anonymize(
         tokens = sql_or_tokens
         sql = None
 
+    hint_start = tokenizer_class.HINT_START
+    hint_end = tokenizer_class._COMMENTS.get(hint_start)
+    nested = tokenizer_class.NESTED_COMMENTS
+
     seen: dict[tuple[bool, str], str] = {}
     counter = 0
 
     for i, token in enumerate(tokens):
-        token.comments = [
-            "".join(char if char.isspace() else "." for char in comment)
-            for comment in token.comments
-        ]
+        token.comments = [_blank(comment) for comment in token.comments]
+
+        if token.token_type == TokenType.HINT:
+            # A hint's text is the whole /*+ ... */ comment, so its body is blanked as well
+            text, stop = _blank_comment(token.text, 0, hint_start, hint_end, nested)
+            token.text = text + _blank(token.text[stop:])
+            continue
 
         if (
             token.token_type == TokenType.VAR
@@ -86,16 +95,18 @@ def anonymize(
             counter += 1
         token.text = seen[key]
 
-    if sql is not None and errored and tokens:
-        start = tokens[-1].end + 1
+    if sql is not None and errored:
+        start = tokens[-1].end + 1 if tokens else 0
         length = len(sql)
         while start < length and sql[start].isspace():
             start += 1
         if start < length:
+            # The first two characters are kept so that the delimiter the tokenizer choked
+            # on is still visible, e.g. 'u, /*, $$, `u
             tokens.append(
                 Token(
                     TokenType.UNKNOWN,
-                    "." * (length - start),
+                    sql[start : start + 2] + "." * (length - start - 2),
                     start=start,
                     end=length - 1,
                     line=sql.count("\n", 0, start) + 1,
@@ -107,65 +118,85 @@ def anonymize(
 
 
 def render(sql: str, tokens: list[Token], dialect: DialectType = None) -> str:
-    """Recreates the (anonymized) SQL string from the original `sql` and token positions,
-    inserting anonymized comments in the gaps between tokens.
+    """Recreates the (anonymized) SQL string from the original `sql` and token positions.
+
+    Every token is rendered over its own source span, so the result is always as long as
+    `sql`: a token that wasn't anonymized is emitted verbatim, keeping the spelling the
+    tokenizer normalized away, and an anonymized one has its alias fitted between the
+    quotes of its span. The gaps between tokens hold only whitespace and comments, so
+    they're redacted rather than reconstructed: comment markers and whitespace survive,
+    everything else is blanked. That covers anything the tokenizer didn't reach as well,
+    which is a trailing gap whenever `anonymize` wasn't the one to tokenize `sql`.
 
     Args:
         sql: The original SQL string.
         tokens: The anonymized tokens to render.
-        dialect: The dialect used to identify comments in `sql`.
+        dialect: The dialect used to identify comments and quotes in `sql`.
     """
+    tokenizer_class = Dialect.get_or_raise(dialect).tokenizer_class
+    comments = sorted(tokenizer_class._COMMENTS.items(), key=lambda c: len(c[0]), reverse=True)
+    nested = tokenizer_class.NESTED_COMMENTS
+    quotes = sorted(
+        {
+            **tokenizer_class._QUOTES,
+            **{start: end for start, (end, _) in tokenizer_class._FORMAT_STRINGS.items()},
+            **tokenizer_class._IDENTIFIERS,
+        }.items(),
+        key=lambda quote: (len(quote[0]), len(quote[1])),
+        reverse=True,
+    )
+
     result = []
     prev = 0
-    comments = (comment for token in tokens for comment in token.comments)
-    delimiters = [
-        (start, end or "")
-        for start, end in sorted(
-            Dialect.get_or_raise(dialect).tokenizer_class._COMMENTS.items(),
-            key=lambda item: len(item[0]),
-            reverse=True,
-        )
-    ]
+
     for token in tokens:
-        result.append(_replace_comments(sql[prev : token.start], comments, delimiters))
-        result.append(token.text)
+        result.append(_redact(sql[prev : token.start], comments, nested))
         prev = token.end + 1
-    result.append(_replace_comments(sql[prev:], comments, delimiters))
+        span = sql[token.start : prev]
+        if token.token_type in REWRITTEN_TYPES:
+            # Blanked in place by `anonymize`, or synthesized by it, so already span-shaped
+            result.append(token.text)
+        elif token.token_type in ANONYMIZED_TYPES:
+            result.append(_fit(span, token.text, quotes, token.token_type))
+        else:
+            result.append(span)
+
+    result.append(_redact(sql[prev:], comments, nested))
+
     return "".join(result)
 
 
 def _alias(counter: int, text: str) -> str:
-    remaining = counter
-    letters = ""
-    while remaining:
-        remaining, digit = divmod(remaining, ALPHABET_SIZE)
-        letters = ALPHABET[digit] + letters
+    digits = []
+    while counter:
+        counter, digit = divmod(counter, ALPHABET_SIZE)
+        digits.append(ALPHABET[digit])
 
-    letters = letters.rjust(sum(not char.isspace() for char in text), "a")
+    letters = "".join(reversed(digits)).rjust(sum(not char.isspace() for char in text), "a")
 
-    alias = ""
+    alias = []
     i = 0
     for char in text:
         if char.isspace():
-            alias += char
+            alias.append(char)
         else:
-            alias += letters[i]
+            alias.append(letters[i])
             i += 1
 
-    return alias
+    return "".join(alias)
 
 
 def _number_alias(counter: int, text: str) -> str:
     if len(text) > 4000:
         digits_seen = False
-        result = ""
+        blanked = []
         for char in text:
             if char.isdigit():
-                result += "1" if not digits_seen else "0"
+                blanked.append("0" if digits_seen else "1")
                 digits_seen = True
             else:
-                result += char
-        return result
+                blanked.append(char)
+        return "".join(blanked)
 
     sep = "e" if "e" in text else ("E" if "E" in text else "")
     mantissa, _, exponent = text.partition(sep) if sep else (text, "", "")
@@ -182,28 +213,92 @@ def _number_alias(counter: int, text: str) -> str:
     if dot:
         result = result[:integer_length] + "." + result[integer_length:]
     if sep:
+        # The exponent marker is kept even when there are no digits after it, e.g. 1e
+        result += sep + sign
         if exponent_length:
             exponent_value = 10 ** (exponent_length - 1) + (counter // (9 * 10 ** (digits - 1))) % (
                 9 * 10 ** (exponent_length - 1)
             )
-            result += sep + sign + str(exponent_value)
+            result += str(exponent_value)
 
     return result
 
 
-def _replace_comments(
-    sql: str, comments: t.Iterator[str], delimiters: list[tuple[str, str]]
-) -> str:
-    out: list[str] = []
+def _fit(span: str, alias: str, quotes: list[tuple[str, str]], token_type: TokenType) -> str:
+    """Fits `alias` into the quoted region of `span`, so the two are always the same length."""
+    start = end = 0
+
+    if token_type in QUOTED_TYPES:
+        for open_quote, close_quote in quotes:
+            if (
+                len(span) >= len(open_quote) + len(close_quote)
+                and span.startswith(open_quote)
+                and span.endswith(close_quote)
+            ):
+                start, end = len(open_quote), len(close_quote)
+
+                if token_type == TokenType.HEREDOC_STRING:
+                    # A heredoc's tag is part of its delimiter, e.g. $tag$body$tag$
+                    open_end = span.find(close_quote, start)
+                    close_start = span.rfind(open_quote, 0, len(span) - end)
+                    if start <= open_end < close_start:
+                        start, end = open_end + len(close_quote), len(span) - close_start
+
+                break
+
+    width = len(span) - start - end
+    pad = "0" if token_type == TokenType.NUMBER else "a"
+
+    return span[:start] + alias[:width].rjust(width, pad) + span[len(span) - end :]
+
+
+def _blank(sql: str) -> str:
+    return "".join(char if char.isspace() else "." for char in sql)
+
+
+def _blank_comment(sql: str, i: int, start: str, end: str | None, nested: bool) -> tuple[str, int]:
+    """Blanks the body of the comment at `i`, returning its text and the index past it."""
+    body = i + len(start)
+
+    if not end:
+        stop = sql.find("\n", body)
+        stop = len(sql) if stop == -1 else stop
+        return start + _blank(sql[body:stop]), stop
+
+    depth = 1
+    j = body
+    while j < len(sql):
+        if nested and sql.startswith(start, j):
+            depth += 1
+            j += len(start)
+        elif sql.startswith(end, j):
+            j += len(end)
+            depth -= 1
+            if not depth:
+                return start + _blank(sql[body : j - len(end)]) + end, j
+        else:
+            j += 1
+
+    return start + _blank(sql[body:]), len(sql)
+
+
+def _redact(sql: str, comments: list[tuple[str, str | None]], nested: bool) -> str:
+    if not sql or sql.isspace():
+        return sql
+
+    result = []
     i = 0
-    while i < len(sql):
-        for start, end in delimiters:
+    length = len(sql)
+
+    while i < length:
+        for start, end in comments:
             if sql.startswith(start, i):
-                comment = next(comments)
-                out.extend((start, comment, end))
-                i += len(start) + len(comment) + len(end)
+                text, i = _blank_comment(sql, i, start, end, nested)
+                result.append(text)
                 break
         else:
-            out.append(sql[i])
+            char = sql[i]
+            result.append(char if char.isspace() else ".")
             i += 1
-    return "".join(out)
+
+    return "".join(result)

--- a/sqlglot/anonymize.py
+++ b/sqlglot/anonymize.py
@@ -42,7 +42,7 @@ def anonymize(
     """
     dialect = Dialect.get_or_raise(dialect)
     tokenizer_class = dialect.tokenizer_class
-    known_functions = dialect.parser_class.FUNCTIONS
+    parser_class = dialect.parser_class
 
     errored = False
     if isinstance(sql_or_tokens, str):
@@ -77,9 +77,12 @@ def anonymize(
             token.token_type == TokenType.VAR
             and i + 1 < len(tokens)
             and tokens[i + 1].token_type == TokenType.L_PAREN
-            and token.text.upper() in known_functions
         ):
-            continue
+            # A function name can live in either registry, e.g. JSON_OBJECT is only in
+            # FUNCTION_PARSERS. They're consulted separately to avoid building their union
+            name = token.text.upper()
+            if name in parser_class.FUNCTIONS or name in parser_class.FUNCTION_PARSERS:
+                continue
         if token.token_type not in ANONYMIZED_TYPES:
             continue
         if not token.text:

--- a/sqlglot/anonymize.py
+++ b/sqlglot/anonymize.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import string
+import typing as t
+
+from sqlglot.dialects.dialect import Dialect, DialectType
+from sqlglot.errors import TokenError
+from sqlglot.tokens import Token, TokenType
+
+
+ALPHABET = string.ascii_lowercase
+ALPHABET_SIZE = len(ALPHABET)
+ANONYMIZED_TYPES = {
+    TokenType.BIT_STRING,
+    TokenType.BYTE_STRING,
+    TokenType.HEX_STRING,
+    TokenType.HEREDOC_STRING,
+    TokenType.IDENTIFIER,
+    TokenType.NATIONAL_STRING,
+    TokenType.NUMBER,
+    TokenType.RAW_STRING,
+    TokenType.STRING,
+    TokenType.UNICODE_STRING,
+    TokenType.VAR,
+}
+
+
+def anonymize(
+    sql_or_tokens: list[Token] | str,
+    dialect: DialectType = None,
+) -> list[Token]:
+    """Replaces sensitive tokens (identifiers, strings, numbers) with fixed-width,
+    length-preserving, consistent aliases, and blanks out comments. When a SQL string is
+    given, it is tokenized with `dialect` first; any un-tokenized remainder (e.g. an
+    unterminated literal) is appended as a blanked UNKNOWN token. Mutates and returns
+    `sql_or_tokens`.
+
+    Args:
+        sql_or_tokens: The SQL string to anonymize, or its token list.
+        dialect: The dialect used to tokenize a SQL string.
+    """
+    dialect = Dialect.get_or_raise(dialect)
+    known_functions = dialect.parser_class.FUNCTIONS
+
+    errored = False
+    if isinstance(sql_or_tokens, str):
+        sql = sql_or_tokens
+        tokenizer = dialect.tokenizer()
+        try:
+            tokens = tokenizer.tokenize(sql)
+        except TokenError:
+            tokens = tokenizer.tokens
+            errored = True
+    else:
+        tokens = sql_or_tokens
+        sql = None
+
+    seen: dict[tuple[bool, str], str] = {}
+    counter = 0
+
+    for i, token in enumerate(tokens):
+        token.comments = [
+            "".join(char if char.isspace() else "." for char in comment)
+            for comment in token.comments
+        ]
+
+        if (
+            token.token_type == TokenType.VAR
+            and i + 1 < len(tokens)
+            and tokens[i + 1].token_type == TokenType.L_PAREN
+            and token.text.upper() in known_functions
+        ):
+            continue
+        if token.token_type not in ANONYMIZED_TYPES:
+            continue
+        if not token.text:
+            continue
+
+        is_number = token.token_type == TokenType.NUMBER
+        key = (is_number, token.text)
+        alias = seen.get(key)
+        if alias is None:
+            seen[key] = (
+                _number_alias(counter, token.text) if is_number else _alias(counter, token.text)
+            )
+            counter += 1
+        token.text = seen[key]
+
+    if sql is not None and errored and tokens:
+        start = tokens[-1].end + 1
+        length = len(sql)
+        while start < length and sql[start].isspace():
+            start += 1
+        if start < length:
+            tokens.append(
+                Token(
+                    TokenType.UNKNOWN,
+                    "." * (length - start),
+                    start=start,
+                    end=length - 1,
+                    line=sql.count("\n", 0, start) + 1,
+                    col=start - sql.rfind("\n", 0, start),
+                )
+            )
+
+    return tokens
+
+
+def render(sql: str, tokens: list[Token], dialect: DialectType = None) -> str:
+    """Recreates the (anonymized) SQL string from the original `sql` and token positions,
+    inserting anonymized comments in the gaps between tokens.
+
+    Args:
+        sql: The original SQL string.
+        tokens: The anonymized tokens to render.
+        dialect: The dialect used to identify comments in `sql`.
+    """
+    result = []
+    prev = 0
+    comments = (comment for token in tokens for comment in token.comments)
+    delimiters = [
+        (start, end or "")
+        for start, end in sorted(
+            Dialect.get_or_raise(dialect).tokenizer_class._COMMENTS.items(),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        )
+    ]
+    for token in tokens:
+        result.append(_replace_comments(sql[prev : token.start], comments, delimiters))
+        result.append(token.text)
+        prev = token.end + 1
+    result.append(_replace_comments(sql[prev:], comments, delimiters))
+    return "".join(result)
+
+
+def _alias(counter: int, text: str) -> str:
+    remaining = counter
+    letters = ""
+    while remaining:
+        remaining, digit = divmod(remaining, ALPHABET_SIZE)
+        letters = ALPHABET[digit] + letters
+
+    letters = letters.rjust(sum(not char.isspace() for char in text), "a")
+
+    alias = ""
+    i = 0
+    for char in text:
+        if char.isspace():
+            alias += char
+        else:
+            alias += letters[i]
+            i += 1
+
+    return alias
+
+
+def _number_alias(counter: int, text: str) -> str:
+    if len(text) > 4000:
+        digits_seen = False
+        result = ""
+        for char in text:
+            if char.isdigit():
+                result += "1" if not digits_seen else "0"
+                digits_seen = True
+            else:
+                result += char
+        return result
+
+    sep = "e" if "e" in text else ("E" if "E" in text else "")
+    mantissa, _, exponent = text.partition(sep) if sep else (text, "", "")
+    sign = ""
+    if exponent.startswith(("-", "+")):
+        sign, exponent = exponent[0], exponent[1:]
+    exponent_length = len(exponent)
+
+    integer, dot, fraction = mantissa.partition(".")
+    integer_length = len(integer)
+    digits = integer_length + len(fraction)
+    mantissa_value = 10 ** (digits - 1) + counter % (9 * 10 ** (digits - 1))
+    result = str(mantissa_value)
+    if dot:
+        result = result[:integer_length] + "." + result[integer_length:]
+    if sep:
+        if exponent_length:
+            exponent_value = 10 ** (exponent_length - 1) + (counter // (9 * 10 ** (digits - 1))) % (
+                9 * 10 ** (exponent_length - 1)
+            )
+            result += sep + sign + str(exponent_value)
+
+    return result
+
+
+def _replace_comments(
+    sql: str, comments: t.Iterator[str], delimiters: list[tuple[str, str]]
+) -> str:
+    out: list[str] = []
+    i = 0
+    while i < len(sql):
+        for start, end in delimiters:
+            if sql.startswith(start, i):
+                comment = next(comments)
+                out.extend((start, comment, end))
+                i += len(start) + len(comment) + len(end)
+                break
+        else:
+            out.append(sql[i])
+            i += 1
+    return "".join(out)

--- a/sqlglotc/setup.py
+++ b/sqlglotc/setup.py
@@ -43,6 +43,7 @@ def _subpkg_files(src_dir, subpkg, files=None):
 
 def _source_files(src_dir):
     return [
+        "anonymize.py",
         "errors.py",
         "generator.py",
         "helper.py",

--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -1,0 +1,371 @@
+import unittest
+
+from sqlglot.anonymize import anonymize, render
+from sqlglot.tokens import Tokenizer, TokenType
+
+
+class TestAnonymize(unittest.TestCase):
+    def assert_anonymized(self, sql, expected, dialect=None):
+        """expected: list of (TokenType, text[, comments]) for the full anonymized token stream."""
+        tokens = anonymize(sql, dialect)
+        self.assertEqual(
+            [(t.token_type, t.text, t.comments) for t in tokens],
+            [entry + ([],) if len(entry) == 2 else entry for entry in expected],
+        )
+
+    def test_identifiers_rewritten(self):
+        self.assert_anonymized(
+            "SELECT foo FROM bar",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "aaa"),  # foo
+                (TokenType.FROM, "FROM"),
+                (TokenType.VAR, "aab"),  # bar
+            ],
+        )
+
+    def test_consistent_within_call(self):
+        self.assert_anonymized(
+            "SELECT a, a, b FROM t",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "a"),  # a
+                (TokenType.COMMA, ","),
+                (TokenType.VAR, "a"),  # a, same alias as above
+                (TokenType.COMMA, ","),
+                (TokenType.VAR, "b"),  # b
+                (TokenType.FROM, "FROM"),
+                (TokenType.VAR, "c"),  # t
+            ],
+        )
+
+    def test_quoted_identifier_shares_alias(self):
+        self.assert_anonymized(
+            'SELECT foo, "foo"',
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "aaa"),
+                (TokenType.COMMA, ","),
+                (TokenType.IDENTIFIER, "aaa"),
+            ],
+        )
+
+    def test_strings_rewritten(self):
+        self.assert_anonymized(
+            "SELECT 'hello', 'world' FROM t",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.STRING, "aaaaa"),  # hello
+                (TokenType.COMMA, ","),
+                (TokenType.STRING, "aaaab"),  # world
+                (TokenType.FROM, "FROM"),
+                (TokenType.VAR, "c"),  # t
+            ],
+        )
+
+    def test_whitespace(self):
+        self.assert_anonymized(
+            "SELECT 'line1\nline2', 'spam  eggs', 'a\tb', \"my table\" FROM t",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.STRING, "aaaaa\naaaaa"),  # line1 + newline + line2 (line break kept)
+                (TokenType.COMMA, ","),
+                (TokenType.STRING, "aaaa  aaab"),  # spam  eggs (spaces kept)
+                (TokenType.COMMA, ","),
+                (TokenType.STRING, "a\tc"),  # a\tb (tab kept)
+                (TokenType.COMMA, ","),
+                (TokenType.IDENTIFIER, "aa aaaad"),  # "my table" (space kept)
+                (TokenType.FROM, "FROM"),
+                (TokenType.VAR, "e"),  # t
+            ],
+        )
+
+    def test_reserved_keywords_not_rewritten(self):
+        # keyword tokens (e.g. window, out) aren't sensitive; they stay verbatim so
+        # user SQL that trips the parser remains debuggable — while real identifiers get rewritten
+        self.assert_anonymized(
+            "SELECT * FROM window, OUT, apple",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.STAR, "*"),
+                (TokenType.FROM, "FROM"),
+                (TokenType.WINDOW, "window"),
+                (TokenType.COMMA, ","),
+                (TokenType.OUT, "OUT"),
+                (TokenType.COMMA, ","),
+                (TokenType.VAR, "aaaaa"),  # apple
+            ],
+        )
+
+    def test_tokenize_error_tail_blanked(self):
+        tokens = anonymize("SELECT foo, 'secret tail")
+        self.assertEqual(
+            [(t.token_type, t.text) for t in tokens],
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "aaa"),  # foo
+                (TokenType.COMMA, ","),
+                (TokenType.UNKNOWN, "............"),
+            ],
+        )
+
+    def test_comments_redacted(self):
+        self.assert_anonymized(
+            "SELECT a -- secret comment\nFROM t",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "a", [" ...... ......."]),
+                (TokenType.FROM, "FROM"),
+                (TokenType.VAR, "b"),
+            ],
+        )
+
+    def test_tpcds_query_reserialized(self):
+        sql = """WITH inv
+     AS (SELECT w_warehouse_name,
+                w_warehouse_sk,
+                i_item_sk,
+                d_moy,
+                stdev,
+                mean,
+                CASE mean
+                  WHEN 0 THEN NULL
+                  ELSE stdev / mean
+                END cov
+         FROM  (SELECT w_warehouse_name,
+                       w_warehouse_sk,
+                       i_item_sk,
+                       d_moy,
+                       Stddev_samp(inv_quantity_on_hand) stdev,
+                       Avg(inv_quantity_on_hand)         mean
+                FROM   inventory,
+                       item,
+                       warehouse,
+                       date_dim
+                WHERE  inv_item_sk = i_item_sk
+                       AND inv_warehouse_sk = w_warehouse_sk
+                       AND inv_date_sk = d_date_sk
+                       AND d_year = 2002
+                GROUP  BY w_warehouse_name,
+                          w_warehouse_sk,
+                          i_item_sk,
+                          d_moy) foo
+         WHERE  CASE mean
+                  WHEN 0 THEN 0
+                  ELSE stdev / mean
+                END > 1)
+SELECT inv1.w_warehouse_sk,
+       inv1.i_item_sk,
+       inv1.d_moy,
+       inv1.mean,
+       inv1.cov,
+       inv2.w_warehouse_sk,
+       inv2.i_item_sk,
+       inv2.d_moy,
+       inv2.mean,
+       inv2.cov
+FROM   inv inv1,
+       inv inv2
+WHERE  inv1.i_item_sk = inv2.i_item_sk
+       AND inv1.w_warehouse_sk = inv2.w_warehouse_sk
+       AND inv1.d_moy = 1
+       AND inv2.d_moy = 1 + 1
+ORDER  BY inv1.w_warehouse_sk,
+          inv1.i_item_sk,
+          inv1.d_moy,
+          inv1.mean,
+          inv1.cov,
+          inv2.d_moy,
+          inv2.mean,
+          inv2.cov;"""
+        expected = """WITH aaa
+     AS (SELECT aaaaaaaaaaaaaaab,
+                aaaaaaaaaaaaac,
+                aaaaaaaad,
+                aaaae,
+                aaaaf,
+                aaag,
+                CASE aaag
+                  WHEN 8 THEN NULL
+                  ELSE aaaaf / aaag
+                END aai
+         FROM  (SELECT aaaaaaaaaaaaaaab,
+                       aaaaaaaaaaaaac,
+                       aaaaaaaad,
+                       aaaae,
+                       Stddev_samp(aaaaaaaaaaaaaaaaaaaj) aaaaf,
+                       Avg(aaaaaaaaaaaaaaaaaaaj)         aaag
+                FROM   aaaaaaaak,
+                       aaal,
+                       aaaaaaaam,
+                       aaaaaaan
+                WHERE  aaaaaaaaaao = aaaaaaaad
+                       AND aaaaaaaaaaaaaaap = aaaaaaaaaaaaac
+                       AND aaaaaaaaaaq = aaaaaaaar
+                       AND aaaaas = 1019
+                GROUP BY aaaaaaaaaaaaaaab,
+                          aaaaaaaaaaaaac,
+                          aaaaaaaad,
+                          aaaae) aau
+         WHERE  CASE aaag
+                  WHEN 8 THEN 8
+                  ELSE aaaaf / aaag
+                END > 4)
+SELECT aaaw.aaaaaaaaaaaaac,
+       aaaw.aaaaaaaad,
+       aaaw.aaaae,
+       aaaw.aaag,
+       aaaw.aai,
+       aaax.aaaaaaaaaaaaac,
+       aaax.aaaaaaaad,
+       aaax.aaaae,
+       aaax.aaag,
+       aaax.aai
+FROM   aaa aaaw,
+       aaa aaax
+WHERE  aaaw.aaaaaaaad = aaax.aaaaaaaad
+       AND aaaw.aaaaaaaaaaaaac = aaax.aaaaaaaaaaaaac
+       AND aaaw.aaaae = 4
+       AND aaax.aaaae = 4 + 4
+ORDER BY aaaw.aaaaaaaaaaaaac,
+          aaaw.aaaaaaaad,
+          aaaw.aaaae,
+          aaaw.aaag,
+          aaaw.aai,
+          aaax.aaaae,
+          aaax.aaag,
+          aaax.aai;"""
+        self.assertEqual(render(sql, anonymize(sql)), expected)
+
+    def test_functions_anonymized(self):
+        self.assert_anonymized(
+            "SELECT SUM(x), my_udf(...), CURRENT_DATE, CASE WHEN 1 THEN 2 ELSE 3 END",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "SUM"),  # known function — kept
+                (TokenType.L_PAREN, "("),
+                (TokenType.VAR, "a"),  # x
+                (TokenType.R_PAREN, ")"),
+                (TokenType.COMMA, ","),
+                (TokenType.VAR, "aaaaab"),  # my_udf (unknown) — masked
+                (TokenType.L_PAREN, "("),
+                (TokenType.DOT, "."),
+                (TokenType.DOT, "."),
+                (TokenType.DOT, "."),
+                (TokenType.R_PAREN, ")"),
+                (TokenType.COMMA, ","),
+                (TokenType.CURRENT_DATE, "CURRENT_DATE"),  # no-paren function — kept
+                (TokenType.COMMA, ","),
+                (TokenType.CASE, "CASE"),  # keyword — kept
+                (TokenType.WHEN, "WHEN"),
+                (TokenType.NUMBER, "3"),  # 1
+                (TokenType.THEN, "THEN"),
+                (TokenType.NUMBER, "4"),  # 2
+                (TokenType.ELSE, "ELSE"),
+                (TokenType.NUMBER, "5"),  # 3
+                (TokenType.END, "END"),
+            ],
+        )
+
+    def test_string_family_forms_anonymized(self):
+        self.assert_anonymized(
+            "SELECT N'nat', $$her$$, x'4141'",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.NATIONAL_STRING, "aaa"),
+                (TokenType.COMMA, ","),
+                (TokenType.RAW_STRING, "aab"),
+                (TokenType.COMMA, ","),
+                (TokenType.HEX_STRING, "aaac"),
+            ],
+            "snowflake",
+        )
+
+    def test_empty_input(self):
+        self.assertEqual(anonymize(""), [])
+        self.assertEqual(anonymize("   "), [])
+
+    def test_identifiers_with_spaces_stay_distinct(self):
+        self.assert_anonymized(
+            'SELECT "a b", "a c"',
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.IDENTIFIER, "a a"),
+                (TokenType.COMMA, ","),
+                (TokenType.IDENTIFIER, "a b"),
+            ],
+        )
+
+    def test_number_and_string_same_text_stay_distinct(self):
+        self.assert_anonymized(
+            "SELECT 123, '123'",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.NUMBER, "100"),
+                (TokenType.COMMA, ","),
+                (TokenType.STRING, "aab"),
+            ],
+        )
+
+    def test_comments_blanked_in_reserialization(self):
+        sql = "SELECT a -- secret comment\nFROM t"
+        self.assertEqual(render(sql, anonymize(sql)), "SELECT a -- ...... .......\nFROM b")
+
+    def test_huge_numeric_literal_no_crash(self):
+        tokens = anonymize("SELECT " + "1" * 4500)
+        self.assertEqual(tokens[1].token_type, TokenType.NUMBER)
+        self.assertEqual(len(tokens[1].text), 4500)
+
+    def test_known_function_kept_when_passing_tokens(self):
+        tokens = anonymize(
+            Tokenizer(dialect="snowflake").tokenize("SELECT TO_VARIANT(x) FROM t"), "snowflake"
+        )
+        self.assertEqual(
+            [(t.token_type, t.text) for t in tokens],
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "TO_VARIANT"),  # dialect-specific known function — kept
+                (TokenType.L_PAREN, "("),
+                (TokenType.VAR, "a"),  # x
+                (TokenType.R_PAREN, ")"),
+                (TokenType.FROM, "FROM"),
+                (TokenType.VAR, "b"),  # t
+            ],
+        )
+
+    def test_known_function_comment_still_blanked(self):
+        self.assert_anonymized(
+            "SELECT sum/* secretpassword */(x)",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "sum", [" .............. "]),
+                (TokenType.L_PAREN, "("),
+                (TokenType.VAR, "a"),  # x
+                (TokenType.R_PAREN, ")"),
+            ],
+        )
+
+    def test_render(self):
+        cases = [
+            ("", "", None),
+            (" \t\n", " \t\n", None),
+            ("-- leading secret\nSELECT foo", "-- ....... ......\nSELECT aaa", None),
+            (
+                "SELECT /* hidden value */ foo -- trailing secret",
+                "SELECT /* ...... ..... */ aaa -- ........ ......",
+                None,
+            ),
+            (
+                "SELECT foo /* first */ /* second */ FROM bar",
+                "SELECT aaa /* ..... */ /* ...... */ FROM aab",
+                None,
+            ),
+            ("SELECT foo, 'secret tail", "SELECT aaa, ............", None),
+            ("SELECT foo // secret", "SELECT aaa // ......", "snowflake"),
+            ("SELECT foo # secret", "SELECT aaa # ......", "mysql"),
+        ]
+
+        for sql, expected, dialect in cases:
+            rendered = render(sql, anonymize(sql, dialect), dialect)
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))

--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -105,7 +105,7 @@ class TestAnonymize(unittest.TestCase):
                 (TokenType.SELECT, "SELECT"),
                 (TokenType.VAR, "aaa"),  # foo
                 (TokenType.COMMA, ","),
-                (TokenType.UNKNOWN, "............"),
+                (TokenType.UNKNOWN, "'s.........."),  # 'secret tail, delimiter kept
             ],
         )
 
@@ -203,7 +203,7 @@ ORDER  BY inv1.w_warehouse_sk,
                        AND aaaaaaaaaaaaaaap = aaaaaaaaaaaaac
                        AND aaaaaaaaaaq = aaaaaaaar
                        AND aaaaas = 1019
-                GROUP BY aaaaaaaaaaaaaaab,
+                GROUP  BY aaaaaaaaaaaaaaab,
                           aaaaaaaaaaaaac,
                           aaaaaaaad,
                           aaaae) aau
@@ -227,7 +227,7 @@ WHERE  aaaw.aaaaaaaad = aaax.aaaaaaaad
        AND aaaw.aaaaaaaaaaaaac = aaax.aaaaaaaaaaaaac
        AND aaaw.aaaae = 4
        AND aaax.aaaae = 4 + 4
-ORDER BY aaaw.aaaaaaaaaaaaac,
+ORDER  BY aaaw.aaaaaaaaaaaaac,
           aaaw.aaaaaaaad,
           aaaw.aaaae,
           aaaw.aaag,
@@ -236,6 +236,7 @@ ORDER BY aaaw.aaaaaaaaaaaaac,
           aaax.aaag,
           aaax.aai;"""
         self.assertEqual(render(sql, anonymize(sql)), expected)
+        self.assertEqual(len(expected), len(sql))
 
     def test_functions_anonymized(self):
         self.assert_anonymized(
@@ -345,6 +346,134 @@ ORDER BY aaaw.aaaaaaaaaaaaac,
             ],
         )
 
+    def test_quotes_preserved(self):
+        # the alias is fitted between the quotes of the source span, so a literal stays a
+        # literal of the same kind and width instead of collapsing to a bare word
+        cases = [
+            ("SELECT 'hello' AS x", "SELECT 'aaaaa' AS b", None),
+            ("SELECT 'a''b'", "SELECT 'aaaa'", None),  # the escape is content, so it's masked
+            ("SELECT ''", "SELECT ''", None),
+            ("SELECT N'nat', x'4141'", "SELECT N'aaa', x'aaab'", "snowflake"),
+            ('SELECT "my table"', 'SELECT "aa aaaaa"', None),
+            ("SELECT `back tick`", "SELECT `aaaa aaaa`", "mysql"),
+            ("SELECT [brack et]", "SELECT [aaaaa aa]", "tsql"),
+            ("SELECT $$her$$, $tag$body$tag$", "SELECT $$aaa$$, $tag$aaab$tag$", "postgres"),
+        ]
+
+        for sql, expected, dialect in cases:
+            rendered = render(sql, anonymize(sql, dialect), dialect)
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))
+
+    def test_source_spelling_preserved(self):
+        # tokens that aren't anonymized are rendered over their own span, so the spelling
+        # the tokenizer normalized away (GROUP  BY -> GROUP BY) survives
+        cases = [
+            ("SELECT a FROM t GROUP  BY a", "SELECT a FROM b GROUP  BY a"),
+            ("SELECT a ORDER   BY a", "SELECT a ORDER   BY a"),
+            ("select * from window, OUT", "select * from window, OUT"),
+        ]
+
+        for sql, expected in cases:
+            rendered = render(sql, anonymize(sql))
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))
+
+    def test_numbers_keep_their_shape(self):
+        sql = "SELECT 1e, 1.e, 1e10, .5, 2002, 1e-5, 1E+2"
+        rendered = render(sql, anonymize(sql))
+        self.assertEqual(rendered, "SELECT 1e, 2.e, 3e10, .4, 1004, 6e-1, 7E+1")
+        self.assertEqual(len(rendered), len(sql))
+
+    def test_hints_anonymized(self):
+        # a hint's text is the whole /*+ ... */ comment, whether the tokenizer emits it as a
+        # HINT token (only in hint position) or leaves it in the gap as a plain comment
+        cases = [
+            (
+                "SELECT /*+ INDEX(customers ssn_idx) */ a FROM t",
+                "SELECT /*+ ............... ........ */ a FROM b",
+                None,
+            ),
+            (
+                "SELECT /*+ BROADCAST(`y`) */ x FROM y",
+                "SELECT /*+ .............. */ a FROM b",
+                "spark",
+            ),
+            (
+                "INSERT /*+ APPEND */ INTO t VALUES (1)",
+                "INSERT /*+ ...... */ INTO a VALUES (2)",
+                "oracle",
+            ),
+            ("SELECT a /*+ INDEX(secret) */ b", "SELECT a /*+ ............. */ b", None),
+            (
+                "SELECT /*+ INDEX(customers)\n           MORE(ssn) */ a FROM t",
+                "SELECT /*+ ................\n           ......... */ a FROM b",
+                None,
+            ),
+        ]
+
+        for sql, expected, dialect in cases:
+            rendered = render(sql, anonymize(sql, dialect), dialect)
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))
+
+    def test_hint_does_not_desync_following_comments(self):
+        # a hint's body is recorded in Token.comments but its marker isn't left in a gap, so
+        # pairing gap markers with recorded bodies drifts and copies the source through
+        sql = "SELECT /*+ x */ a -- password is hunter2\nFROM t"
+        self.assertEqual(
+            render(sql, anonymize(sql)), "SELECT /*+ . */ a -- ........ .. .......\nFROM b"
+        )
+
+    def test_comments_without_tokens(self):
+        # nothing for the tokenizer to attach the comment to
+        cases = [
+            ("-- top secret", "-- ... ......"),
+            ("/* COMMENT */", "/* ....... */"),
+            ("/*", "/*"),
+        ]
+
+        for sql, expected in cases:
+            rendered = render(sql, anonymize(sql))
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))
+
+    def test_tokenize_error_keeps_delimiter(self):
+        # the two leading characters survive so the delimiter the tokenizer choked on is
+        # still identifiable - an unterminated string reads differently to a comment
+        cases = [
+            ("SELECT a, 'unterminated string", "SELECT a, 'u..................", None),
+            ("SELECT a, /* unterminated comment", "SELECT a, /*.....................", None),
+            ('SELECT a, "unterminated ident', 'SELECT a, "u.................', None),
+            ("SELECT a, $$unterminated heredoc", "SELECT a, $$....................", "postgres"),
+            ("SELECT a, `unterminated backtick", "SELECT a, `u....................", "mysql"),
+            ("'unterminated secret", "'u..................", None),  # nothing tokenized at all
+            ("SELECT a, '", "SELECT a, '", None),  # remainder shorter than the delimiter
+        ]
+
+        for sql, expected, dialect in cases:
+            rendered = render(sql, anonymize(sql, dialect), dialect)
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))
+
+    def test_comment_bodies_fully_blanked(self):
+        # markers inside a comment body are body, not structure, so they're blanked too
+        cases = [
+            ("SELECT a /* x /* nested */ y */ b", "SELECT a /* . .. ...... .. . */ b"),
+            ("SELECT a -- /* not a real block\nFROM t", "SELECT a -- .. ... . .... .....\nFROM b"),
+        ]
+
+        for sql, expected in cases:
+            rendered = render(sql, anonymize(sql))
+            self.assertEqual(rendered, expected)
+            self.assertEqual(len(rendered), len(sql))
+
+    def test_render_without_dialect_still_redacts(self):
+        # an unrecognized marker costs readability, never redaction
+        sql = "SELECT a # secret"
+        self.assertEqual(render(sql, anonymize(sql, "mysql"), "mysql"), "SELECT a # ......")
+        self.assertEqual(render(sql, anonymize(sql, "mysql")), "SELECT a . ......")
+
     def test_render(self):
         cases = [
             ("", "", None),
@@ -360,7 +489,7 @@ ORDER BY aaaw.aaaaaaaaaaaaac,
                 "SELECT aaa /* ..... */ /* ...... */ FROM aab",
                 None,
             ),
-            ("SELECT foo, 'secret tail", "SELECT aaa, ............", None),
+            ("SELECT foo, 'secret tail", "SELECT aaa, 's..........", None),
             ("SELECT foo // secret", "SELECT aaa // ......", "snowflake"),
             ("SELECT foo # secret", "SELECT aaa # ......", "mysql"),
         ]

--- a/tests/test_anonymize.py
+++ b/tests/test_anonymize.py
@@ -268,6 +268,20 @@ ORDER  BY aaaw.aaaaaaaaaaaaac,
             ],
         )
 
+        # JSON_OBJECT is registered in FUNCTION_PARSERS rather than FUNCTIONS
+        self.assert_anonymized(
+            "SELECT JSON_OBJECT('k', v)",
+            [
+                (TokenType.SELECT, "SELECT"),
+                (TokenType.VAR, "JSON_OBJECT"),  # known function — kept
+                (TokenType.L_PAREN, "("),
+                (TokenType.STRING, "a"),  # 'k'
+                (TokenType.COMMA, ","),
+                (TokenType.VAR, "b"),  # v
+                (TokenType.R_PAREN, ")"),
+            ],
+        )
+
     def test_string_family_forms_anonymized(self):
         self.assert_anonymized(
             "SELECT N'nat', $$her$$, x'4141'",


### PR DESCRIPTION
Adds `sqlglot.anonymize` — a token-level SQL anonymizer for safely logging user SQL in web services.

- Replaces identifiers, strings, numbers, and string-family literals with fixed-width, length-preserving, consistent aliases (whitespace/line breaks preserved)
- Blanks comment bodies, and appends a blanked `UNKNOWN` token covering any un-tokenized remainder when tokenization raises (never raises on untrusted input)
- Accepts either a token list or a SQL string (tokenized with the given dialect)
- Handles integer/decimal/scientific/negative/leading-dot numbers; guards against >4300-digit literals
- Reserved keyword tokens (e.g. `window`, `OUT`) are left verbatim so parser-failing SQL stays debuggable

Includes unit tests covering each sensitive bucket, whitespace/line-break preservation, seed-agnostic consistency, the tokenizer-error tail path, and an exact-match reserialization of TPC-DS query 39. `make style` and `make unit` pass (1277 tests).
