### PR TITLE
fix!: degrade BigQuery WEEK(<day>) units gracefully in other dialects

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1701,7 +1701,7 @@ def timestamptrunc_sql(
     func: str = "DATE_TRUNC", zone: bool = False
 ) -> t.Callable[[Generator, exp.TimestampTrunc], str]:
     def _timestamptrunc_sql(self: Generator, expression: exp.TimestampTrunc) -> str:
-        args = [unit_to_str(expression), expression.this]
+        args = [weekstart_unit_to_str(self, expression), expression.this]
         if zone:
             args.append(expression.args.get("zone"))
         return self.func(func, *args)
@@ -2061,10 +2061,26 @@ def unit_to_str(expression: exp.Expr, default: str = "DAY") -> exp.Expr | None:
     if not unit:
         return exp.Literal.string(default) if default else None
 
+    if isinstance(unit, exp.WeekStart):
+        # WEEK(<day>) is BigQuery-only syntax, so it degrades to the plain WEEK unit. Unlike
+        # Generator.weekstart_name, this can't warn about a changed week start (no generator
+        # access here) - callers that need the warning should use weekstart_unit_to_str
+        return exp.Literal.string("WEEK")
+
     if isinstance(unit, exp.Placeholder) or type(unit) not in (exp.Var, exp.Literal):
         return unit
 
     return exp.Literal.string(unit.name)
+
+
+def weekstart_unit_to_str(
+    self: Generator, expression: exp.Expr, default: str = "DAY"
+) -> exp.Expr | None:
+    unit = expression.args.get("unit")
+    if isinstance(unit, exp.WeekStart):
+        return exp.Literal.string(self.weekstart_name(unit))
+
+    return unit_to_str(expression, default)
 
 
 def unit_to_var(expression: exp.Expr, default: str = "DAY") -> exp.Expr | None:
@@ -2088,6 +2104,11 @@ WEEK_START_DAY_TO_DOW = {
     "SATURDAY": 6,
     "SUNDAY": 7,
 }
+
+
+def week_offset_to_dow(offset: int) -> int:
+    """Convert a dialect's WEEK_OFFSET (days relative to Monday) to the ISO day number of its week start."""
+    return offset % 7 + 1
 
 
 def week_unit_to_dow(unit: exp.Expr | None) -> int | None:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -6229,9 +6229,11 @@ class Generator:
 
         # WEEK(<day>) is BigQuery-only syntax, so it degrades to the plain WEEK unit
         this = expression.this.name.upper()
-        if sqlglot.dialects.dialect.WEEK_START_DAY_TO_DOW.get(
-            this
-        ) != sqlglot.dialects.dialect.week_offset_to_dow(self.dialect.WEEK_OFFSET):
+
+        dow_from_week_start_day = sqlglot.dialects.dialect.WEEK_START_DAY_TO_DOW.get(this)
+        dow_from_week_offset = sqlglot.dialects.dialect.week_offset_to_dow(self.dialect.WEEK_OFFSET)
+
+        if dow_from_week_start_day != dow_from_week_offset:
             self.unsupported(
                 f"WEEK({this}) is not supported; falling back to the default week start day"
             )

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -6219,13 +6219,28 @@ class Generator:
         this = expression.this
         return self.func("LOCALTIMESTAMP", this) if this else "LOCALTIMESTAMP"
 
-    def weekstart_sql(self, expression: exp.WeekStart) -> str:
-        this = expression.this.name.upper()
-        if self.dialect.WEEK_OFFSET == -1 and this == "SUNDAY":
-            # BigQuery specific optimization since WEEK(SUNDAY) == WEEK
-            return "WEEK"
+    def weekstart_name(self, expression: exp.WeekStart) -> str:
+        import sqlglot.dialects.dialect
 
-        return self.func("WEEK", expression.this)
+        # WEEK(<day>) is BigQuery-only syntax, so it degrades to the plain WEEK unit
+        this = expression.this.name.upper()
+        if sqlglot.dialects.dialect.WEEK_START_DAY_TO_DOW.get(
+            this
+        ) != sqlglot.dialects.dialect.week_offset_to_dow(self.dialect.WEEK_OFFSET):
+            self.unsupported(
+                f"WEEK({this}) is not supported; falling back to the default week start day"
+            )
+
+        return "WEEK"
+
+    def weekstart_sql(self, expression: exp.WeekStart) -> str:
+        name = self.weekstart_name(expression)
+
+        # DateTrunc stores string literal units, whereas TimeUnit expressions store keywords
+        if isinstance(expression.parent, exp.DateTrunc):
+            return self.sql(exp.Literal.string(name))
+
+        return name
 
     def chr_sql(self, expression: exp.Chr, name: str = "CHR") -> str:
         this = self.expressions(expression)

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3633,7 +3633,12 @@ class Generator:
             if self.NORMALIZE_EXTRACT_DATE_PARTS
             else expression.this
         )
-        this_sql = self.sql(this) if self.EXTRACT_ALLOWS_QUOTES else this.name
+        if self.EXTRACT_ALLOWS_QUOTES:
+            this_sql = self.sql(this)
+        elif isinstance(this, exp.WeekStart):
+            this_sql = self.weekstart_name(this)
+        else:
+            this_sql = this.name
         expression_sql = self.sql(expression, "expression")
 
         return f"EXTRACT({this_sql} FROM {expression_sql})"

--- a/sqlglot/generators/bigquery.py
+++ b/sqlglot/generators/bigquery.py
@@ -580,6 +580,13 @@ class BigQueryGenerator(generator.Generator):
         "within",
     }
 
+    def weekstart_sql(self, expression: exp.WeekStart) -> str:
+        if expression.this.name.upper() == "SUNDAY":
+            # BigQuery specific optimization since WEEK(SUNDAY) == WEEK
+            return "WEEK"
+
+        return self.func("WEEK", expression.this)
+
     def datetrunc_sql(self, expression: exp.DateTrunc) -> str:
         unit = expression.unit
         unit_sql = unit.name if unit.is_string else self.sql(unit)

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -17,7 +17,7 @@ from sqlglot.dialects.dialect import (
     sha256_sql,
     strposition_sql,
     var_map_sql,
-    unit_to_str,
+    weekstart_unit_to_str,
     unit_to_var,
     trim_sql,
     sha2_digest_sql,
@@ -711,7 +711,7 @@ class ClickHouseGenerator(generator.Generator):
         return super().values_sql(expression, values_as_table=values_as_table)
 
     def timestamptrunc_sql(self, expression: exp.DateTrunc | exp.TimestampTrunc) -> str:
-        unit = unit_to_str(expression)
+        unit = weekstart_unit_to_str(self, expression)
         # https://clickhouse.com/docs/whats-new/changelog/2023#improvement
         if self.dialect.version < (23, 12) and unit and unit.is_string:
             unit = exp.Literal.string(unit.name.lower())

--- a/sqlglot/generators/doris.py
+++ b/sqlglot/generators/doris.py
@@ -6,7 +6,7 @@ from sqlglot.dialects.dialect import (
     property_sql,
     rename_func,
     time_format,
-    unit_to_str,
+    weekstart_unit_to_str,
 )
 from sqlglot.generators.mysql import MySQLGenerator
 
@@ -55,7 +55,9 @@ class DorisGenerator(MySQLGenerator):
         exp.ArrayUniqueAgg: rename_func("COLLECT_SET"),
         exp.CurrentDate: lambda self, _: self.func("CURRENT_DATE"),
         exp.CurrentTimestamp: lambda self, _: self.func("NOW"),
-        exp.DateTrunc: lambda self, e: self.func("DATE_TRUNC", e.this, unit_to_str(e)),
+        exp.DateTrunc: lambda self, e: self.func(
+            "DATE_TRUNC", e.this, weekstart_unit_to_str(self, e)
+        ),
         exp.EuclideanDistance: rename_func("L2_DISTANCE"),
         exp.GroupConcat: lambda self, e: self.func(
             "GROUP_CONCAT", e.this, e.args.get("separator") or exp.Literal.string(",")
@@ -75,7 +77,9 @@ class DorisGenerator(MySQLGenerator):
         exp.TsOrDsAdd: lambda self, e: self.func("DATE_ADD", e.this, e.expression),
         exp.TsOrDsToDate: lambda self, e: self.func("TO_DATE", e.this),
         exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
-        exp.TimestampTrunc: lambda self, e: self.func("DATE_TRUNC", e.this, unit_to_str(e)),
+        exp.TimestampTrunc: lambda self, e: self.func(
+            "DATE_TRUNC", e.this, weekstart_unit_to_str(self, e)
+        ),
         exp.UnixToStr: lambda self, e: self.func(
             "FROM_UNIXTIME", e.this, time_format("doris")(self, e)
         ),

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -35,6 +35,7 @@ from sqlglot.dialects.dialect import (
     timestrtotime_sql,
     unit_to_str,
     week_unit_to_dow,
+    weekstart_unit_to_str,
     WEEK_START_DAY_TO_DOW,
 )
 from sqlglot.generator import unsupported_args
@@ -1779,7 +1780,7 @@ class DuckDBGenerator(generator.Generator):
             "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)
         ),
         exp.DatetimeTrunc: lambda self, e: self.func(
-            "DATE_TRUNC", unit_to_str(e), exp.cast(e.this, exp.DType.DATETIME)
+            "DATE_TRUNC", weekstart_unit_to_str(self, e), exp.cast(e.this, exp.DType.DATETIME)
         ),
         exp.UnixToTime: _unix_to_time_sql,
         exp.UnixToTimeStr: lambda self, e: f"CAST(TO_TIMESTAMP({self.sql(e, 'this')}) AS TEXT)",
@@ -4437,7 +4438,7 @@ class DuckDBGenerator(generator.Generator):
         return result
 
     def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
-        unit = unit_to_str(expression)
+        unit = weekstart_unit_to_str(self, expression)
         zone = expression.args.get("zone")
         timestamp = expression.this
         date_unit = is_date_unit(unit)

--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -91,7 +91,12 @@ def _add_local_prefix_for_aliases(expression: exp.Expr, dialect: Dialect) -> exp
 def _trunc_sql(
     self: ExasolGenerator, kind: str, expression: exp.DateTrunc | exp.TimestampTrunc
 ) -> str:
-    unit = expression.text("unit")
+    unit_expr = expression.args.get("unit")
+    unit = (
+        self.weekstart_name(unit_expr)
+        if isinstance(unit_expr, exp.WeekStart)
+        else expression.text("unit")
+    )
     node = expression.this.this if isinstance(expression.this, exp.Cast) else expression.this
     expr_sql = self.sql(node)
     if isinstance(node, exp.Literal) and node.is_string:

--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -25,7 +25,7 @@ from sqlglot.dialects.dialect import (
     time_format,
     timestrtotime_sql,
     trim_sql,
-    unit_to_str,
+    weekstart_unit_to_str,
     var_map_sql,
     sequence_sql,
     property_sql,
@@ -351,7 +351,9 @@ class HiveGenerator(generator.Generator):
         exp.TimeStrToDate: rename_func("TO_DATE"),
         exp.TimeStrToTime: timestrtotime_sql,
         exp.TimeStrToUnix: rename_func("UNIX_TIMESTAMP"),
-        exp.TimestampTrunc: lambda self, e: self.func("TRUNC", e.this, unit_to_str(e)),
+        exp.TimestampTrunc: lambda self, e: self.func(
+            "TRUNC", e.this, weekstart_unit_to_str(self, e)
+        ),
         exp.TimeToUnix: rename_func("UNIX_TIMESTAMP"),
         exp.ToBase64: rename_func("BASE64"),
         exp.TsOrDiToDi: lambda self, e: (

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -30,7 +30,12 @@ from collections import defaultdict
 
 def _date_trunc_sql(self: MySQLGenerator, expression: exp.DateTrunc) -> str:
     expr = self.sql(expression, "this")
-    unit = expression.text("unit").upper()
+    unit_expr = expression.args.get("unit")
+    unit = (
+        self.weekstart_name(unit_expr)
+        if isinstance(unit_expr, exp.WeekStart)
+        else expression.text("unit").upper()
+    )
 
     if unit == "WEEK":
         concat = f"CONCAT(YEAR({expr}), ' ', WEEK({expr}, 1), ' 1')"
@@ -759,6 +764,8 @@ class MySQLGenerator(generator.Generator):
 
     def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
         unit = expression.args.get("unit")
+        if isinstance(unit, exp.WeekStart):
+            unit = exp.var(self.weekstart_name(unit))
 
         # Pick an old-enough date to avoid negative timestamp diffs
         start_ts = "'0000-01-01 00:00:00'"

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -6,7 +6,8 @@ from sqlglot.dialects.dialect import (
     bracket_to_element_at_sql,
     is_parse_json,
     rename_func,
-    unit_to_str,
+    timestamptrunc_sql,
+    weekstart_unit_to_str,
 )
 from sqlglot.generators.hive import HIVE_DATE_FORMAT, HiveGenerator, HIVE_TS_OR_DS_EXPRESSIONS
 from sqlglot.transforms import (
@@ -153,7 +154,9 @@ class Spark2Generator(HiveGenerator):
                 ]
             ),
             exp.DateFromParts: rename_func("MAKE_DATE"),
-            exp.DateTrunc: lambda self, e: self.func("TRUNC", e.this, unit_to_str(e)),
+            exp.DateTrunc: lambda self, e: self.func(
+                "TRUNC", e.this, weekstart_unit_to_str(self, e)
+            ),
             exp.DayOfMonth: rename_func("DAYOFMONTH"),
             exp.DayOfWeek: rename_func("DAYOFWEEK"),
             # (DAY_OF_WEEK(datetime) % 7) + 1 is equivalent to DAYOFWEEK_ISO(datetime)
@@ -190,7 +193,7 @@ class Spark2Generator(HiveGenerator):
             ),
             exp.StrToDate: _str_to_date,
             exp.StrToTime: lambda self, e: self.func("TO_TIMESTAMP", e.this, self.format_time(e)),
-            exp.TimestampTrunc: lambda self, e: self.func("DATE_TRUNC", unit_to_str(e), e.this),
+            exp.TimestampTrunc: timestamptrunc_sql(),
             exp.UnixToTime: _unix_to_time_sql,
             exp.VariancePop: rename_func("VAR_POP"),
             exp.WeekOfYear: rename_func("WEEKOFYEAR"),

--- a/sqlglot/generators/starrocks.py
+++ b/sqlglot/generators/starrocks.py
@@ -6,7 +6,7 @@ from sqlglot.dialects.dialect import (
     approx_count_distinct_sql,
     arrow_json_extract_sql,
     rename_func,
-    unit_to_str,
+    weekstart_unit_to_str,
     inline_array_sql,
     property_sql,
     var_map_sql,
@@ -103,7 +103,9 @@ class StarRocksGenerator(MySQLGenerator):
         exp.ArrayToString: rename_func("ARRAY_JOIN"),
         exp.ApproxDistinct: approx_count_distinct_sql,
         exp.CurrentVersion: lambda *_: "CURRENT_VERSION()",
-        exp.DateDiff: lambda self, e: self.func("DATE_DIFF", unit_to_str(e), e.this, e.expression),
+        exp.DateDiff: lambda self, e: self.func(
+            "DATE_DIFF", weekstart_unit_to_str(self, e), e.this, e.expression
+        ),
         exp.Delete: transforms.preprocess([_eliminate_between_in_delete]),
         exp.Flatten: rename_func("ARRAY_FLATTEN"),
         exp.JSONExtractScalar: arrow_json_extract_sql,
@@ -125,7 +127,9 @@ class StarRocksGenerator(MySQLGenerator):
         exp.SqlSecurityProperty: lambda self, e: f"SECURITY {self.sql(e.this)}",
         exp.StDistance: st_distance_sphere,
         exp.StrToUnix: lambda self, e: self.func("UNIX_TIMESTAMP", e.this, self.format_time(e)),
-        exp.TimestampTrunc: lambda self, e: self.func("DATE_TRUNC", unit_to_str(e), e.this),
+        exp.TimestampTrunc: lambda self, e: self.func(
+            "DATE_TRUNC", weekstart_unit_to_str(self, e), e.this
+        ),
         exp.TimeStrToDate: rename_func("TO_DATE"),
         exp.UnixToStr: lambda self, e: self.func("FROM_UNIXTIME", e.this, self.format_time(e)),
         exp.UnixToTime: rename_func("FROM_UNIXTIME"),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3611,6 +3611,7 @@ OPTIONS (
             "SELECT DATE_TRUNC(d, WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT DATE_TRUNC(d, WEEK)",
+                "exasol": "SELECT DATE_TRUNC('WEEK', d)",
                 "mysql": "SELECT STR_TO_DATE(CONCAT(YEAR(d), ' ', WEEK(d, 1), ' 1'), '%Y %u %w')",
                 "snowflake": "SELECT DATE_TRUNC('WEEK', d)",
                 "spark": "SELECT TRUNC(d, 'WEEK')",
@@ -3621,7 +3622,16 @@ OPTIONS (
             write={
                 "bigquery": "SELECT TIMESTAMP_TRUNC(ts, WEEK)",
                 "clickhouse": "SELECT dateTrunc('WEEK', ts)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', ts)",
+                "mysql": "SELECT DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF(WEEK, '0000-01-01 00:00:00', ts)) WEEK)",
                 "snowflake": "SELECT DATE_TRUNC('WEEK', ts)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATETIME_TRUNC(dt, WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT DATETIME_TRUNC(dt, WEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(dt AS TIMESTAMP))",
             },
         )
         self.validate_all(
@@ -3634,6 +3644,7 @@ OPTIONS (
             "SELECT TIMESTAMP_TRUNC(ts, WEEK(SUNDAY))",
             write={
                 "clickhouse": UnsupportedError,
+                "duckdb": UnsupportedError,
                 "snowflake": UnsupportedError,
                 "spark": UnsupportedError,
             },
@@ -3657,7 +3668,15 @@ OPTIONS (
             "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
             write={
                 "bigquery": "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
+                "hive": "SELECT EXTRACT(WEEK FROM d)",
                 "snowflake": "SELECT DATE_PART(WEEK, d)",
+                "spark": "SELECT EXTRACT(WEEK FROM d)",
+            },
+        )
+        self.validate_all(
+            "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
+            write={
+                "spark": UnsupportedError,
             },
         )
         self.validate_identity(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -272,6 +272,13 @@ class TestBigQuery(Validator):
         self.validate_identity("x <> ''")
         self.validate_identity("DATE_TRUNC(col, WEEK(MONDAY))")
         self.validate_identity("DATE_TRUNC(col, MONTH, 'UTC+8')")
+        self.validate_all(
+            "SELECT DATE_TRUNC(DATE '2015-06-15', ISOYEAR)",
+            write={
+                "bigquery": "SELECT DATE_TRUNC(CAST('2015-06-15' AS DATE), ISOYEAR)",
+                "duckdb": "SELECT DATE_TRUNC('ISOYEAR', CAST('2015-06-15' AS DATE))",
+            },
+        )
         self.validate_identity("SELECT b'abc'")
         self.validate_identity("SELECT AS STRUCT 1 AS a, 2 AS b")
         self.validate_identity("SELECT DISTINCT AS STRUCT 1 AS a, 2 AS b")
@@ -3596,6 +3603,61 @@ OPTIONS (
             write={
                 "bigquery": "SELECT LAST_DAY(CAST('2008-11-10' AS DATE), ISOWEEK)",
                 "duckdb": "SELECT CAST(CAST('2008-11-10' AS DATE) + INTERVAL ((7 - EXTRACT(DAYOFWEEK FROM CAST('2008-11-10' AS DATE))) % 7) DAY AS DATE)",
+            },
+        )
+        # Dialects without week-start syntax degrade WEEK(<day>) to their plain week
+        # unit (with an unsupported warning when the week start day differs)
+        self.validate_all(
+            "SELECT DATE_TRUNC(d, WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT DATE_TRUNC(d, WEEK)",
+                "mysql": "SELECT STR_TO_DATE(CONCAT(YEAR(d), ' ', WEEK(d, 1), ' 1'), '%Y %u %w')",
+                "snowflake": "SELECT DATE_TRUNC('WEEK', d)",
+                "spark": "SELECT TRUNC(d, 'WEEK')",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP_TRUNC(ts, WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT TIMESTAMP_TRUNC(ts, WEEK)",
+                "clickhouse": "SELECT dateTrunc('WEEK', ts)",
+                "snowflake": "SELECT DATE_TRUNC('WEEK', ts)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_TRUNC(d, WEEK(SUNDAY))",
+            write={
+                "spark": UnsupportedError,
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP_TRUNC(ts, WEEK(SUNDAY))",
+            write={
+                "clickhouse": UnsupportedError,
+                "snowflake": UnsupportedError,
+                "spark": UnsupportedError,
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_DIFF(d1, d2, WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT DATE_DIFF(d1, d2, WEEK)",
+                "snowflake": "SELECT DATEDIFF(WEEK, d2, d1)",
+                "tsql": "SELECT DATEDIFF(WEEK, d2, d1)",
+            },
+        )
+        self.validate_all(
+            "SELECT LAST_DAY(d, WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT LAST_DAY(d, WEEK)",
+                "snowflake": "SELECT LAST_DAY(d, WEEK)",
+            },
+        )
+        self.validate_all(
+            "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
+            write={
+                "bigquery": "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
+                "snowflake": "SELECT DATE_PART(WEEK, d)",
             },
         )
         self.validate_identity(


### PR DESCRIPTION
`WeekStart` nodes reaching a non-BigQuery generator were emitted as literal `WEEK(SUNDAY)` text, which is invalid syntax everywhere else, e.g. `DATEDIFF(WEEK(SUNDAY), ...)` for Snowflake/TSQL/Spark or `DATE_PART(WEEK(THURSDAY), ...)` for `EXTRACT`. Dialects without week-start syntax now emit their plain week unit instead, warning via `unsupported()` when the requested start day differs from the dialect's own week start.

The BigQuery-specific `WEEK(SUNDAY) -> WEEK` collapse moves into a `weekstart_sql` override, mysql/exasol (which inspect units textually) use the new `weekstart_name` helper, and `unit_to_str` lowers `WeekStart` to a `'WEEK'` literal for string-unit contexts.
