### PR TITLE
fix(oracle): generate valid (UN)PIVOT syntax

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -460,6 +460,9 @@ class Generator:
     # Whether UNPIVOT aliases are Identifiers (False means they're Literals)
     UNPIVOT_ALIASES_ARE_IDENTIFIERS = True
 
+    # Whether a (UN)PIVOT's alias is introduced with AS (Oracle rejects it, ORA-03048)
+    PIVOT_ALIAS_WITH_AS = True
+
     # What delimiter to use for separating JSON key/value pairs
     JSON_KEY_VALUE_PAIR_SEP = ":"
 
@@ -2597,7 +2600,8 @@ class Generator:
                 expression.fields[0].set("expressions", new_field_exprs)
 
         alias = self.sql(expression, "alias")
-        alias = f" AS {alias}" if alias else ""
+        if alias:
+            alias = f" AS {alias}" if self.PIVOT_ALIAS_WITH_AS else f" {alias}"
 
         fields = self.expressions(
             expression,

--- a/sqlglot/generators/oracle.py
+++ b/sqlglot/generators/oracle.py
@@ -39,6 +39,7 @@ class OracleGenerator(generator.Generator):
     QUERY_HINT_SEP = " "
     SUPPORTS_DECODE_CASE = True
     UNPIVOT_ALIASES_ARE_IDENTIFIERS = False
+    PIVOT_ALIAS_WITH_AS = False
 
     AFTER_HAVING_MODIFIER_TRANSFORMS = generator.AFTER_HAVING_MODIFIER_TRANSFORMS
 
@@ -65,6 +66,7 @@ class OracleGenerator(generator.Generator):
 
     TRANSFORMS = {
         **generator.Generator.TRANSFORMS,
+        exp.Pivot: transforms.preprocess([transforms.unqualify_pivot_fields]),
         exp.GroupConcat: lambda self, e: groupconcat_sql(self, e, on_overflow=True),
         exp.DateStrToDate: lambda self, e: self.func(
             "TO_DATE", e.this, exp.Literal.string("YYYY-MM-DD")

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -98,25 +98,6 @@ def _unalias_pivot(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-def _unqualify_pivot_columns(expression: exp.Expr) -> exp.Expr:
-    """
-    Spark doesn't allow the column referenced in the PIVOT's field to be qualified,
-    so we need to unqualify it.
-
-    Example:
-        >>> from sqlglot import parse_one
-        >>> expr = parse_one("SELECT * FROM tbl PIVOT (SUM(tbl.sales) FOR tbl.quarter IN ('Q1', 'Q2'))")
-        >>> print(_unqualify_pivot_columns(expr).sql(dialect="spark"))
-        SELECT * FROM tbl PIVOT(SUM(tbl.sales) FOR quarter IN ('Q1', 'Q2'))
-    """
-    if isinstance(expression, exp.Pivot):
-        expression.set(
-            "fields", [transforms.unqualify_columns(field) for field in expression.fields]
-        )
-
-    return expression
-
-
 def temporary_storage_provider(expression: exp.Expr) -> exp.Expr:
     # spark2, spark, Databricks require a storage provider for temporary tables
     provider = exp.FileFormatProperty(this=exp.Literal.string("parquet"))
@@ -187,7 +168,7 @@ class Spark2Generator(HiveGenerator):
             exp.LogicalAnd: rename_func("BOOL_AND"),
             exp.LogicalOr: rename_func("BOOL_OR"),
             exp.Map: _map_sql,
-            exp.Pivot: transforms.preprocess([_unqualify_pivot_columns]),
+            exp.Pivot: transforms.preprocess([transforms.unqualify_pivot_fields]),
             exp.Reduce: rename_func("AGGREGATE"),
             exp.RegexpReplace: lambda self, e: self.func(
                 "REGEXP_REPLACE",

--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -738,6 +738,23 @@ def unqualify_columns(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
+def unqualify_pivot_fields(expression: exp.Expr) -> exp.Expr:
+    """
+    Some dialects only accept simple column names in a (UN)PIVOT's FOR clause and IN-list
+    (Oracle raises ORA-01748), even though the aggregate itself may stay qualified.
+
+    Example:
+        >>> from sqlglot import parse_one
+        >>> expr = parse_one("SELECT * FROM tbl PIVOT (SUM(tbl.sales) FOR tbl.quarter IN ('Q1', 'Q2'))")
+        >>> print(unqualify_pivot_fields(expr).sql(dialect="spark"))
+        SELECT * FROM tbl PIVOT(SUM(tbl.sales) FOR quarter IN ('Q1', 'Q2'))
+    """
+    if isinstance(expression, exp.Pivot):
+        expression.set("fields", [unqualify_columns(field) for field in expression.fields])
+
+    return expression
+
+
 def remove_unique_constraints(expression: exp.Expr) -> exp.Expr:
     assert isinstance(expression, exp.Create)
     for constraint in expression.find_all(exp.UniqueColumnConstraint):

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -396,6 +396,33 @@ class TestOracle(Validator):
         self.validate_identity("L2_DISTANCE(x, y)")
         self.validate_identity("BITMAP_OR_AGG(x)")
 
+    def test_pivot_syntax_restrictions(self):
+        """Oracle only accepts simple column names in a (UN)PIVOT's FOR clause and IN-list
+        (ORA-01748), and rejects AS before the operator's alias (ORA-03048). The aggregate
+        itself may stay qualified. All of these were executed against Oracle Free.
+        """
+        self.validate_all(
+            "SELECT * FROM t UNPIVOT(revenue FOR month IN (t.jan, t.feb)) AS u",
+            write={"oracle": "SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb)) u"},
+        )
+        self.validate_all(
+            "SELECT * FROM t PIVOT(SUM(t.val) FOR t.cat IN ('a' AS a)) AS p",
+            write={"oracle": "SELECT * FROM t PIVOT(SUM(t.val) FOR cat IN ('a' AS a)) p"},
+        )
+
+        # qualify qualifies the IN-list in the AST, which must not reach the generated SQL
+        self.assertEqual(
+            qualify(
+                parse_one(
+                    "SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb))", dialect="oracle"
+                ),
+                schema={"t": {"id": "int", "jan": "int", "feb": "int"}},
+                dialect="oracle",
+            ).sql(dialect="oracle"),
+            'SELECT "T"."ID" AS "ID", "T"."MONTH" AS "MONTH", "T"."REVENUE" AS "REVENUE" '
+            'FROM "T" "T" UNPIVOT("REVENUE" FOR "MONTH" IN ("JAN", "FEB")) "T"',
+        )
+
     def test_join_marker(self):
         self.validate_identity("SELECT e1.x, e2.x FROM e e1, e e2 WHERE e1.y (+) = e2.y")
 


### PR DESCRIPTION
Oracle rejected sqlglot's `(UN)PIVOT` output on two counts, so any pivot transpiled to Oracle failed to run:

```sql
-- ORA-01748: only simple column names allowed here   (qualified FOR/IN)
-- ORA-03048: SQL reserved word 'AS' is not ...       (AS before the alias)
... FROM "T" "T" UNPIVOT("REVENUE" FOR "MONTH" IN ("T"."JAN", "T"."FEB")) AS "T"
... FROM "T" "T" UNPIVOT("REVENUE" FOR "MONTH" IN ("JAN", "FEB")) "T"        -- now
```

The aggregate itself may stay qualified (verified against Oracle Free), so the unqualifying is scoped to the fields — the same thing spark2 was already doing privately, now shared as `transforms.unqualify_pivot_fields`.