### PR TITLE
fix(tsql): UNPIVOT outputs the value column before the name column

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -1761,6 +1761,7 @@ class Pivot(Expression):
         "identify_pivot_strings": False,
         "prefixed_pivot_columns": False,
         "pivot_column_naming": False,
+        "value_columns_first": False,
     }
 
     @property
@@ -1814,7 +1815,13 @@ class Pivot(Expression):
                 for ident in (e.expressions if isinstance(e, Tuple) else [e])
                 if isinstance(ident, Identifier)
             ]
-            outputs = [i.name for i in name_columns + value_columns]
+            # T-SQL emits the value column(s) ahead of the name column, everyone else emits them after it
+            ordered = (
+                value_columns + name_columns
+                if self.args.get("value_columns_first")
+                else name_columns + value_columns
+            )
+            outputs = [i.name for i in ordered]
         else:
             excluded = {c.output_name for c in self.find_all(Column)}
             outputs = [c.output_name for c in self.args.get("columns") or []]

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1790,6 +1790,8 @@ class Parser:
 
     PREFIXED_PIVOT_COLUMNS: t.ClassVar = False
     IDENTIFY_PIVOT_STRINGS: t.ClassVar = False
+    # Whether an UNPIVOT outputs its value column(s) before the name column
+    UNPIVOT_VALUE_COLUMNS_FIRST: t.ClassVar = False
     # Controls when an aggregation's name is included in a pivoted column's name:
     # "agg_name_if_aliased" - only for aggregations that carry an explicit alias
     # "agg_name_if_aliased_or_multiple" - if aliased, or whenever there are multiple aggregations
@@ -5393,6 +5395,8 @@ class Parser:
             for pivot_field in pivot.fields:
                 if isinstance(pivot_field, exp.In):
                     pivot_field.set("this", _unpivot_target(pivot_field.this))
+
+            pivot.set("value_columns_first", self.UNPIVOT_VALUE_COLUMNS_FIRST)
 
         if not self._match_set((TokenType.PIVOT, TokenType.UNPIVOT), advance=False):
             pivot.set("alias", self._parse_table_alias())

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -323,6 +323,7 @@ class TSQLParser(parser.Parser):
     LOG_DEFAULTS_TO_LN = True
     STRING_ALIASES = True
     NO_PAREN_IF_COMMANDS = False
+    UNPIVOT_VALUE_COLUMNS_FIRST = True
 
     NO_PAREN_FUNCTIONS = {
         **parser.Parser.NO_PAREN_FUNCTIONS,

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1,6 +1,7 @@
 from sqlglot import exp, parse_one
 from sqlglot.errors import ParseError, UnsupportedError
 from sqlglot.optimizer.annotate_types import annotate_types
+from sqlglot.optimizer.qualify import qualify
 from tests.dialects.test_dialect import Validator
 
 
@@ -562,6 +563,30 @@ class TestTSQL(Validator):
 
         self.validate_identity("OBJECT_ID('foo')")
         self.validate_identity("OBJECT_ID('foo', 'U')")
+
+    def test_unpivot_value_column_comes_first(self):
+        # T-SQL emits an UNPIVOT's value column ahead of its name column; DuckDB,
+        # Snowflake, Oracle and Spark all emit it after. Verified against SQL Server:
+        # SELECT * over this UNPIVOT returns (id, revenue, month).
+        schema = {"t": {"id": "int", "jan": "int", "feb": "int"}}
+        expression = qualify(
+            parse_one(
+                "SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb)) AS u", dialect="tsql"
+            ),
+            schema=schema,
+            dialect="tsql",
+        )
+        self.assertEqual([s.alias_or_name for s in expression.selects], ["id", "revenue", "month"])
+
+        # ... whereas the same query read as another dialect keeps the name column first
+        expression = qualify(
+            parse_one(
+                "SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb)) AS u", dialect="duckdb"
+            ),
+            schema=schema,
+            dialect="duckdb",
+        )
+        self.assertEqual([s.alias_or_name for s in expression.selects], ["id", "month", "revenue"])
 
     def test_null_ordering_simulation_resolves_ordered_against_projection(self):
         # T-SQL hits the same NULLS FIRST/LAST CASE simulation as MySQL


### PR DESCRIPTION
T-SQL returns an `UNPIVOT`'s value column ahead of its name column; DuckDB, Snowflake, Oracle and Spark all return it after. `SELECT *` therefore expanded in the wrong order for T-SQL:

```
SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb)) AS u

SQL Server:  id, revenue, month
sqlglot was: id, month, revenue
```

Recorded at parse time, so a star expands in the source dialect's order and carries that order explicitly to any target.