### PR TITLE
fix(optimizer)!: support multiple (UN)PIVOT operators on a source

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -359,31 +359,30 @@ class TypeAnnotator:
                 pivots = (
                     source.args.get("pivots", []) if isinstance(source, exp.Table) else scope.pivots
                 )
-                for pivot in pivots:
-                    if pivot.alias_or_name == source_name:
-                        parent = pivot.parent
-                        parent_source = scope.sources.get(parent.alias_or_name) if parent else None
+                # Only the last operator in a chain carries the alias that names the
+                # resulting source, so match on it and fold the whole chain in order
+                if pivots and pivots[-1].alias_or_name == source_name:
+                    parent = pivots[-1].parent
+                    parent_source = scope.sources.get(parent.alias_or_name) if parent else None
 
-                        if parent and isinstance(parent_source, Scope):
-                            src_types = self._get_scope_source_selects(scope, parent.alias_or_name)
-                        elif isinstance(parent, exp.Table) and isinstance(
-                            self.schema, MappingSchema
-                        ):
-                            src_types = (
-                                self.schema.find(
-                                    parent, raise_on_missing=False, ensure_data_types=True
-                                )
-                                or {}
-                            )
-                        else:
-                            src_types = {}
+                    if parent and isinstance(parent_source, Scope):
+                        src_types = self._get_scope_source_selects(scope, parent.alias_or_name)
+                    elif isinstance(parent, exp.Table) and isinstance(self.schema, MappingSchema):
+                        src_types = (
+                            self.schema.find(parent, raise_on_missing=False, ensure_data_types=True)
+                            or {}
+                        )
+                    else:
+                        src_types = {}
 
-                        selects = (
+                    for pivot in pivots:
+                        src_types = (
                             self._get_unpivot_column_types(pivot, src_types)
                             if pivot.unpivot
                             else self._get_pivot_column_types(pivot, src_types)
                         )
-                        break
+
+                    selects = src_types
 
             self._scope_source_selects[key] = selects
 
@@ -689,7 +688,12 @@ class TypeAnnotator:
             val_expr = seq_get(pivot.expressions, 0)
             val_cols = val_expr.expressions if isinstance(val_expr, exp.Tuple) else [val_expr]
             for val_col, in_col in zip(val_cols, in_cols):
-                new_types[val_col.output_name] = in_col.type
+                # A chained operator's IN-list may name columns an earlier operator
+                # produced, which carry no annotation of their own
+                in_type = in_col.type
+                if not in_type or in_type.is_type(exp.DType.UNKNOWN):
+                    in_type = src_types.get(in_col.output_name) or in_type
+                new_types[val_col.output_name] = in_type
 
         return {
             name: type_

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -674,8 +674,12 @@ def _qualify_columns(
 
     # In a chain, the Nth operator's IN-list may reference columns produced by operators
     # 1..N-1, which no source exposes. Track that accumulated output so those resolve too.
+    # Only one chain can be tracked at a time -- with several pivoted sources we can't tell
+    # which produced a given column, so leave it unqualified for validation to reject. They
+    # are collected per source, so first and last sharing a parent means there's only one.
+    single_chain = bool(pivots) and pivots[0].parent is pivots[-1].parent
     produced: set[str] = set()
-    pivoted_source = pivots[-1].alias if pivots else ""
+    pivoted_source = pivots[-1].alias if single_chain else ""
     available = (
         list(resolver.get_source_columns(pivoted_source)) if pivoted_source in scope.sources else []
     )

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -672,16 +672,14 @@ def _qualify_columns(
 
     pivots = scope.pivots
 
-    # In a chain, the Nth operator's IN-list may reference columns produced by operators
-    # 1..N-1, which no source exposes. Track that accumulated output so those resolve too.
-    # Only one chain can be tracked at a time -- with several pivoted sources we can't tell
-    # which produced a given column, so leave it unqualified for validation to reject. They
-    # are collected per source, so first and last sharing a parent means there's only one.
+    # A chained operator's IN-list may name columns produced by earlier operators, which no
+    # source exposes; track the chain's accumulated output to resolve them. Attribution is
+    # only unambiguous when all pivots share one parent, i.e. there's a single pivoted source.
     single_chain = bool(pivots) and pivots[0].parent is pivots[-1].parent
     produced: set[str] = set()
     pivoted_source = pivots[-1].alias if single_chain else ""
-    available = (
-        list(resolver.get_source_columns(pivoted_source)) if pivoted_source in scope.sources else []
+    available: t.Collection[str] = (
+        resolver.get_source_columns(pivoted_source) if pivoted_source in scope.sources else []
     )
 
     for pivot in pivots:
@@ -695,7 +693,7 @@ def _qualify_columns(
             elif column.name in produced:
                 column.set("table", exp.to_identifier(pivoted_source))
 
-        available = list(pivot.output_columns(available))
+        available = pivot.output_columns(available)
         produced.update(available)
 
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -7,7 +7,6 @@ import typing as t
 from sqlglot import alias, exp
 from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import OptimizeError, highlight_sql
-from sqlglot.helper import seq_get
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
 from sqlglot.optimizer.scope import Scope, build_scope, find_in_scope, traverse_scope, walk_in_scope
@@ -52,7 +51,8 @@ def qualify_columns(
         The qualified expression.
 
     Notes:
-        - Currently only handles a single PIVOT or UNPIVOT operator
+        - A source may carry a chain of (UN)PIVOT operators; each one is resolved against
+          the output of the one before it, and the last one's alias names the result
     """
     schema = ensure_schema(schema, dialect=dialect)
     annotator = TypeAnnotator(schema)
@@ -632,7 +632,9 @@ def _qualify_columns(
             if isinstance(column_source, exp.Table) and (
                 pivots := column_source.args.get("pivots")
             ):
-                source_columns = pivots[0].output_columns(source_columns)
+                # Each operator's input is the previous one's output
+                for pivot in pivots:
+                    source_columns = pivot.output_columns(source_columns)
             if (
                 not allow_partial_qualification
                 and source_columns
@@ -645,7 +647,7 @@ def _qualify_columns(
             if scope.pivots and not column.find_ancestor(exp.Pivot):
                 # If the column is under the Pivot expression, we need to qualify it
                 # using the name of the pivoted source instead of the pivot's alias
-                column.set("table", exp.to_identifier(scope.pivots[0].alias))
+                column.set("table", exp.to_identifier(scope.pivots[-1].alias))
                 continue
 
             # column_table can be a '' because bigquery unnest has no table alias
@@ -668,12 +670,29 @@ def _qualify_columns(
                 # BigQuery and Postgres allow tables to be referenced as columns, treating them as structs/records
                 scope.replace(column, exp.TableColumn(this=column.this))
 
-    for pivot in scope.pivots:
+    pivots = scope.pivots
+
+    # In a chain, the Nth operator's IN-list may reference columns produced by operators
+    # 1..N-1, which no source exposes. Track that accumulated output so those resolve too.
+    produced: set[str] = set()
+    pivoted_source = pivots[-1].alias if pivots else ""
+    available = (
+        list(resolver.get_source_columns(pivoted_source)) if pivoted_source in scope.sources else []
+    )
+
+    for pivot in pivots:
         for column in pivot.find_all(exp.Column):
-            if not column.table and column.name in resolver.all_columns:
+            if column.table:
+                continue
+            if column.name in resolver.all_columns:
                 table = resolver.get_table(column.name)
                 if table:
                     column.set("table", table)
+            elif column.name in produced:
+                column.set("table", exp.to_identifier(pivoted_source))
+
+        available = list(pivot.output_columns(available))
+        produced.update(available)
 
 
 def _expand_struct_stars_no_parens(
@@ -810,8 +829,6 @@ def _expand_stars(
     coalesced_columns = set()
     dialect = resolver.dialect
 
-    pivot = t.cast(t.Optional[exp.Pivot], seq_get(scope.pivots, 0))
-
     annotated_ahead = dialect.SUPPORTS_STRUCT_STAR_EXPANSION and any(
         isinstance(col, exp.Dot) for col in scope.stars
     )
@@ -900,12 +917,22 @@ def _expand_stars(
                 else set()
             )
 
-            if pivot:
-                pivot_columns = pivot.output_columns(columns) or pivot.alias_column_names
+            # The operators belong to a specific source, so a star over a source joined
+            # alongside it must expand from that source's own columns
+            selected_node, _ = scope.selected_sources.get(table, (None, None))
+            pivots = (
+                selected_node.args.get("pivots") if isinstance(selected_node, exp.Expr) else None
+            )
+
+            if pivots:
+                # Each operator consumes the previous one's output, so fold them in order
+                pivot_columns: t.Collection[str] = columns
+                for pivot in pivots:
+                    pivot_columns = pivot.output_columns(pivot_columns) or pivot.alias_column_names
 
                 if pivot_columns:
                     new_selections.extend(
-                        alias(exp.column(name, table=pivot.alias or None), name, copy=False)
+                        alias(exp.column(name, table=pivots[-1].alias or None), name, copy=False)
                         for name in pivot_columns
                         if name not in columns_to_exclude
                     )

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -131,7 +131,7 @@ def qualify_tables(
                 derived_table.this.set("joins", joins)
 
             _set_alias(derived_table, canonical_aliases, scope=scope)
-            if pivot := seq_get(derived_table.args.get("pivots") or [], 0):
+            if pivot := seq_get(derived_table.args.get("pivots") or [], -1):
                 _set_alias(pivot, canonical_aliases)
 
         table_aliases = {}
@@ -141,7 +141,7 @@ def qualify_tables(
                 # When the name is empty, it means that we have a non-table source, e.g. a pivoted cte
                 is_real_table_source = bool(name)
 
-                if pivot := seq_get(source.args.get("pivots") or [], 0):
+                if pivot := seq_get(source.args.get("pivots") or [], -1):
                     name = source.name
 
                 table_this = source.this

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -846,7 +846,7 @@ def _traverse_tables(scope: Scope) -> Iterator[Scope]:
                 # it is pivoted, because then we get back a new table and hence a new source.
                 pivots = expression.args.get("pivots")
                 if pivots:
-                    sources[pivots[0].alias] = expression
+                    sources[pivots[-1].alias] = expression
                 else:
                     sources[source_name] = scope.sources[table_name]
             elif source_name in sources:

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -3436,6 +3436,14 @@ class TestSnowflake(Validator):
             },
         )
 
+    def test_chained_pivots(self):
+        self.validate_identity(
+            "SELECT * FROM t UNPIVOT(a FOR b IN (c, d)) UNPIVOT(e FOR f IN (g, h))"
+        )
+        self.validate_identity(
+            "SELECT * FROM t PIVOT(SUM(v) FOR c IN ('a' AS a)) UNPIVOT(x FOR y IN (a))"
+        )
+
     def test_pivot_output_column_names(self):
         # Snowflake names a bare IN-list column after the literal, quotes included, but an
         # explicit `<value> AS <alias>` names it after the alias. Both verified in-engine.

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -1156,3 +1156,39 @@ SELECT x.a AS a, COALESCE(x.b, y_2.b) AS b, y_2.c AS c FROM x AS x SEMI JOIN y A
 # title: ANTI + normal joins reinclude the table on scope
 SELECT * FROM x ANTI JOIN y USING (b) JOIN y USING (b);
 SELECT x.a AS a, COALESCE(x.b, y_2.b) AS b, y_2.c AS c FROM x AS x ANTI JOIN y AS y ON x.b = y.b JOIN y AS y_2 ON x.b = y_2.b;
+
+# title: chained UNPIVOT, source is a CTE
+# dialect: duckdb
+WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south));
+WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) SELECT t.id AS id, t.month AS month, t.revenue AS revenue, t.region AS region, t.headcount AS headcount FROM t AS t UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south)) AS t;
+
+# title: chained UNPIVOT, source columns come from the schema
+# dialect: duckdb
+SELECT * FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south));
+SELECT unpivotable.id AS id, unpivotable.month AS month, unpivotable.revenue AS revenue, unpivotable.region AS region, unpivotable.headcount AS headcount FROM unpivotable AS unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south)) AS unpivotable;
+
+# title: chained UNPIVOT, explicit columns under the chain's alias
+# dialect: duckdb
+WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) SELECT u.month, u.headcount FROM t UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south)) AS u;
+WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) SELECT u.month AS month, u.headcount AS headcount FROM t AS t UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south)) AS u;
+
+# title: chained PIVOT, the second groups by what the first produced
+# dialect: duckdb
+SELECT * FROM pivotable PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y));
+SELECT _0.id AS id, _0.a AS a, _0.b AS b, _0.x AS x, _0.y AS y FROM pivotable AS pivotable PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y)) AS _0;
+
+# title: PIVOT then UNPIVOT of the columns it produced
+# dialect: duckdb
+SELECT * FROM pivotable PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) UNPIVOT(v FOR c IN (a, b));
+SELECT pivotable.id AS id, pivotable.kind AS kind, pivotable.amt AS amt, pivotable.c AS c, pivotable.v AS v FROM pivotable AS pivotable PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) UNPIVOT(v FOR c IN (a, b)) AS pivotable;
+
+# title: a source joined next to a pivoted one is not expanded through its operators
+# dialect: duckdb
+SELECT * FROM x JOIN unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u ON x.a = u.id;
+SELECT x.a AS a, x.b AS b, u.id AS id, u.north AS north, u.south AS south, u.month AS month, u.revenue AS revenue FROM x AS x JOIN unpivotable AS unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u ON x.a = u.id;
+
+# title: chained UNPIVOT keeps quoted identifiers case-sensitive, unlike the names it produces
+# execute: false
+# dialect: snowflake
+WITH t AS (SELECT 1 AS "Id", 2 AS "Jan", 3 AS "Feb", 4 AS "Nor", 5 AS "Sou") SELECT * FROM t UNPIVOT(v1 FOR n1 IN ("Jan", "Feb")) UNPIVOT(v2 FOR n2 IN ("Nor", "Sou"));
+WITH T AS (SELECT 1 AS "Id", 2 AS "Jan", 3 AS "Feb", 4 AS "Nor", 5 AS "Sou") SELECT T."Id" AS "Id", T.N1 AS N1, T.V1 AS V1, T.N2 AS N2, T.V2 AS V2 FROM T AS T UNPIVOT(V1 FOR N1 IN ("Jan", "Feb")) UNPIVOT(V2 FOR N2 IN ("Nor", "Sou")) AS T;

--- a/tests/fixtures/optimizer/qualify_columns__invalid.sql
+++ b/tests/fixtures/optimizer/qualify_columns__invalid.sql
@@ -15,3 +15,4 @@ SELECT x FROM tbl AS tbl(a);
 SELECT a JOIN b USING (a);
 SELECT x.a FROM x INNER JOIN y ON x.a = c INNER JOIN z ON x.a = c;
 SELECT b FROM x INNER JOIN y ON x.a = y.c INNER JOIN z ON x.a = z.c;
+SELECT unpivotable.north FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south))

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -117,6 +117,14 @@ class TestOptimizer(unittest.TestCase):
         INSERT INTO y VALUES (null, null);
 
         INSERT INTO w VALUES ('a', 'b');
+
+        CREATE TABLE unpivotable (id INT, jan INT, feb INT, north INT, south INT);
+        INSERT INTO unpivotable VALUES (1, 100, 200, 7, 8);
+        INSERT INTO unpivotable VALUES (2, 300, 400, 9, 10);
+
+        CREATE TABLE pivotable (id INT, cat TEXT, val INT, kind TEXT, amt INT);
+        INSERT INTO pivotable VALUES (1, 'a', 10, 'x', 5);
+        INSERT INTO pivotable VALUES (1, 'b', 20, 'x', 5);
         """
         )
 
@@ -150,6 +158,20 @@ class TestOptimizer(unittest.TestCase):
             "t_bool": {
                 "a": "BOOLEAN",
                 "b": "BOOLEAN",
+            },
+            "unpivotable": {
+                "id": "INT",
+                "jan": "INT",
+                "feb": "INT",
+                "north": "INT",
+                "south": "INT",
+            },
+            "pivotable": {
+                "id": "INT",
+                "cat": "TEXT",
+                "val": "INT",
+                "kind": "TEXT",
+                "amt": "INT",
             },
         }
 
@@ -834,117 +856,6 @@ class TestOptimizer(unittest.TestCase):
             "IN ((`produce`.`q1`, `produce`.`q2`) AS 'h1', (`produce`.`q3`, `produce`.`q4`) AS 'h2')) AS `produce`",
         )
 
-    def test_multiple_pivots(self):
-        """A source can carry a chain of (UN)PIVOT operators, each consuming the previous
-        one's output. Every expectation below was executed in DuckDB, Snowflake and Spark
-        and returns the same rows as the unqualified input.
-        """
-        unpivots = (
-            "WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) "
-            "SELECT * FROM t "
-            "UNPIVOT(revenue FOR month IN (jan, feb)) "
-            "UNPIVOT(headcount FOR region IN (north, south))"
-        )
-
-        # The star expands to the chain's output: jan/feb and north/south are consumed,
-        # month/revenue and region/headcount are produced, id passes through
-        self.assertEqual(
-            optimizer.qualify.qualify(
-                parse_one(unpivots, dialect="snowflake"), dialect="snowflake"
-            ).sql(dialect="snowflake"),
-            'WITH "T" AS (SELECT 1 AS "ID", 100 AS "JAN", 200 AS "FEB", 7 AS "NORTH", 8 AS "SOUTH") '
-            'SELECT "T"."ID" AS "ID", "T"."MONTH" AS "MONTH", "T"."REVENUE" AS "REVENUE", '
-            '"T"."REGION" AS "REGION", "T"."HEADCOUNT" AS "HEADCOUNT" FROM "T" AS "T" '
-            'UNPIVOT("REVENUE" FOR "MONTH" IN ("JAN", "FEB")) '
-            'UNPIVOT("HEADCOUNT" FOR "REGION" IN ("NORTH", "SOUTH")) AS "T"',
-        )
-
-        # Explicit columns, qualified by the chain's alias. Only the last operator's alias
-        # names the resulting source -- referencing an earlier one is an error in-engine.
-        aliased = (
-            "WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) "
-            "SELECT u.month, u.headcount FROM t "
-            "UNPIVOT(revenue FOR month IN (jan, feb)) "
-            "UNPIVOT(headcount FOR region IN (north, south)) AS u"
-        )
-        self.assertEqual(
-            optimizer.qualify.qualify(
-                parse_one(aliased, dialect="snowflake"), dialect="snowflake"
-            ).sql(dialect="snowflake"),
-            'WITH "T" AS (SELECT 1 AS "ID", 100 AS "JAN", 200 AS "FEB", 7 AS "NORTH", 8 AS "SOUTH") '
-            'SELECT "U"."MONTH" AS "MONTH", "U"."HEADCOUNT" AS "HEADCOUNT" FROM "T" AS "T" '
-            'UNPIVOT("REVENUE" FOR "MONTH" IN ("JAN", "FEB")) '
-            'UNPIVOT("HEADCOUNT" FOR "REGION" IN ("NORTH", "SOUTH")) AS "U"',
-        )
-
-        # A chain of PIVOTs: the second groups by the first's output columns
-        pivots = (
-            "WITH t AS (SELECT 1 AS id, 'a' AS cat, 10 AS val, 'x' AS kind, 5 AS amt) "
-            "SELECT * FROM t "
-            "PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) "
-            "PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y))"
-        )
-        self.assertEqual(
-            optimizer.qualify.qualify(
-                parse_one(pivots, dialect="snowflake"), dialect="snowflake"
-            ).sql(dialect="snowflake"),
-            'WITH "T" AS (SELECT 1 AS "ID", \'a\' AS "CAT", 10 AS "VAL", \'x\' AS "KIND", 5 AS "AMT") '
-            'SELECT "_0"."ID" AS "ID", "_0"."A" AS "A", "_0"."B" AS "B", "_0"."X" AS "X", "_0"."Y" AS "Y" '
-            'FROM "T" AS "T" PIVOT(SUM("T"."VAL") FOR "T"."CAT" IN (\'a\' AS "A", \'b\' AS "B")) '
-            'PIVOT(SUM("T"."AMT") FOR "T"."KIND" IN (\'x\' AS "X", \'y\' AS "Y")) AS "_0"',
-        )
-
-        # Mixed chain where the UNPIVOT consumes columns the PIVOT produced -- these
-        # resolve against the accumulated output, not against the base source
-        mixed = (
-            "WITH t AS (SELECT 1 AS id, 'a' AS cat, 10 AS val) SELECT * FROM t "
-            "PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) UNPIVOT(v FOR c IN (a, b))"
-        )
-        self.assertEqual(
-            optimizer.qualify.qualify(
-                parse_one(mixed, dialect="snowflake"), dialect="snowflake"
-            ).sql(dialect="snowflake"),
-            'WITH "T" AS (SELECT 1 AS "ID", \'a\' AS "CAT", 10 AS "VAL") '
-            'SELECT "T"."ID" AS "ID", "T"."C" AS "C", "T"."V" AS "V" FROM "T" AS "T" '
-            'PIVOT(SUM("T"."VAL") FOR "T"."CAT" IN (\'a\' AS "A", \'b\' AS "B")) '
-            'UNPIVOT("V" FOR "C" IN ("A", "B")) AS "T"',
-        )
-
-        # A column consumed by a later operator is no longer part of the chain's output
-        with self.assertRaisesRegex(OptimizeError, "Unknown column: NORTH"):
-            optimizer.qualify.qualify(
-                parse_one(
-                    "SELECT t.north FROM t "
-                    "UNPIVOT(revenue FOR month IN (jan, feb)) "
-                    "UNPIVOT(headcount FOR region IN (north, south))",
-                    dialect="snowflake",
-                ),
-                schema={
-                    "t": {"id": "int", "jan": "int", "feb": "int", "north": "int", "south": "int"}
-                },
-                dialect="snowflake",
-            )
-
-    def test_pivoted_source_joined_alongside_another(self):
-        # The operators belong to one source, so a star over the source joined next to it
-        # must not expand through them. DuckDB returns (id, x, id, month, revenue) here.
-        schema = {"a": {"id": "int", "x": "int"}, "t": {"id": "int", "jan": "int", "feb": "int"}}
-        for join in ("ON a.id = u.id", "USING (id)"):
-            with self.subTest(join):
-                expression = optimizer.qualify.qualify(
-                    parse_one(
-                        "SELECT * FROM a JOIN t UNPIVOT(revenue FOR month IN (jan, feb)) AS u "
-                        f"{join}",
-                        dialect="snowflake",
-                    ),
-                    schema=schema,
-                    dialect="snowflake",
-                )
-                self.assertEqual(
-                    [s.alias_or_name for s in expression.selects],
-                    ["ID", "X", "ID", "MONTH", "REVENUE"],
-                )
-
     def test_multiple_pivots_annotate_types(self):
         # NOTE: the value column takes the type of the first IN-list entry, so the columns
         # folded by a single operator are kept uniformly typed here
@@ -954,9 +865,11 @@ class TestOptimizer(unittest.TestCase):
         expression = annotate_types(
             optimizer.qualify.qualify(
                 parse_one(
-                    "SELECT * FROM t "
-                    "UNPIVOT(revenue FOR month IN (jan, feb)) "
-                    "UNPIVOT(headcount FOR region IN (north, south))",
+                    """
+                    SELECT * FROM t
+                    UNPIVOT(revenue FOR month IN (jan, feb))
+                    UNPIVOT(headcount FOR region IN (north, south))
+                    """,
                     dialect="snowflake",
                 ),
                 schema=schema,
@@ -985,9 +898,11 @@ class TestOptimizer(unittest.TestCase):
         expression = annotate_types(
             optimizer.qualify.qualify(
                 parse_one(
-                    "SELECT * FROM t "
-                    "PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) "
-                    "PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y))",
+                    """
+                    SELECT * FROM t
+                    PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b))
+                    PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y))
+                    """,
                     dialect="snowflake",
                 ),
                 schema=pivot_schema,

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -834,6 +834,175 @@ class TestOptimizer(unittest.TestCase):
             "IN ((`produce`.`q1`, `produce`.`q2`) AS 'h1', (`produce`.`q3`, `produce`.`q4`) AS 'h2')) AS `produce`",
         )
 
+    def test_multiple_pivots(self):
+        """A source can carry a chain of (UN)PIVOT operators, each consuming the previous
+        one's output. Every expectation below was executed in DuckDB, Snowflake and Spark
+        and returns the same rows as the unqualified input.
+        """
+        unpivots = (
+            "WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) "
+            "SELECT * FROM t "
+            "UNPIVOT(revenue FOR month IN (jan, feb)) "
+            "UNPIVOT(headcount FOR region IN (north, south))"
+        )
+
+        # The star expands to the chain's output: jan/feb and north/south are consumed,
+        # month/revenue and region/headcount are produced, id passes through
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(unpivots, dialect="snowflake"), dialect="snowflake"
+            ).sql(dialect="snowflake"),
+            'WITH "T" AS (SELECT 1 AS "ID", 100 AS "JAN", 200 AS "FEB", 7 AS "NORTH", 8 AS "SOUTH") '
+            'SELECT "T"."ID" AS "ID", "T"."MONTH" AS "MONTH", "T"."REVENUE" AS "REVENUE", '
+            '"T"."REGION" AS "REGION", "T"."HEADCOUNT" AS "HEADCOUNT" FROM "T" AS "T" '
+            'UNPIVOT("REVENUE" FOR "MONTH" IN ("JAN", "FEB")) '
+            'UNPIVOT("HEADCOUNT" FOR "REGION" IN ("NORTH", "SOUTH")) AS "T"',
+        )
+
+        # Explicit columns, qualified by the chain's alias. Only the last operator's alias
+        # names the resulting source -- referencing an earlier one is an error in-engine.
+        aliased = (
+            "WITH t AS (SELECT 1 AS id, 100 AS jan, 200 AS feb, 7 AS north, 8 AS south) "
+            "SELECT u.month, u.headcount FROM t "
+            "UNPIVOT(revenue FOR month IN (jan, feb)) "
+            "UNPIVOT(headcount FOR region IN (north, south)) AS u"
+        )
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(aliased, dialect="snowflake"), dialect="snowflake"
+            ).sql(dialect="snowflake"),
+            'WITH "T" AS (SELECT 1 AS "ID", 100 AS "JAN", 200 AS "FEB", 7 AS "NORTH", 8 AS "SOUTH") '
+            'SELECT "U"."MONTH" AS "MONTH", "U"."HEADCOUNT" AS "HEADCOUNT" FROM "T" AS "T" '
+            'UNPIVOT("REVENUE" FOR "MONTH" IN ("JAN", "FEB")) '
+            'UNPIVOT("HEADCOUNT" FOR "REGION" IN ("NORTH", "SOUTH")) AS "U"',
+        )
+
+        # A chain of PIVOTs: the second groups by the first's output columns
+        pivots = (
+            "WITH t AS (SELECT 1 AS id, 'a' AS cat, 10 AS val, 'x' AS kind, 5 AS amt) "
+            "SELECT * FROM t "
+            "PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) "
+            "PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y))"
+        )
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(pivots, dialect="snowflake"), dialect="snowflake"
+            ).sql(dialect="snowflake"),
+            'WITH "T" AS (SELECT 1 AS "ID", \'a\' AS "CAT", 10 AS "VAL", \'x\' AS "KIND", 5 AS "AMT") '
+            'SELECT "_0"."ID" AS "ID", "_0"."A" AS "A", "_0"."B" AS "B", "_0"."X" AS "X", "_0"."Y" AS "Y" '
+            'FROM "T" AS "T" PIVOT(SUM("T"."VAL") FOR "T"."CAT" IN (\'a\' AS "A", \'b\' AS "B")) '
+            'PIVOT(SUM("T"."AMT") FOR "T"."KIND" IN (\'x\' AS "X", \'y\' AS "Y")) AS "_0"',
+        )
+
+        # Mixed chain where the UNPIVOT consumes columns the PIVOT produced -- these
+        # resolve against the accumulated output, not against the base source
+        mixed = (
+            "WITH t AS (SELECT 1 AS id, 'a' AS cat, 10 AS val) SELECT * FROM t "
+            "PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) UNPIVOT(v FOR c IN (a, b))"
+        )
+        self.assertEqual(
+            optimizer.qualify.qualify(
+                parse_one(mixed, dialect="snowflake"), dialect="snowflake"
+            ).sql(dialect="snowflake"),
+            'WITH "T" AS (SELECT 1 AS "ID", \'a\' AS "CAT", 10 AS "VAL") '
+            'SELECT "T"."ID" AS "ID", "T"."C" AS "C", "T"."V" AS "V" FROM "T" AS "T" '
+            'PIVOT(SUM("T"."VAL") FOR "T"."CAT" IN (\'a\' AS "A", \'b\' AS "B")) '
+            'UNPIVOT("V" FOR "C" IN ("A", "B")) AS "T"',
+        )
+
+        # A column consumed by a later operator is no longer part of the chain's output
+        with self.assertRaisesRegex(OptimizeError, "Unknown column: NORTH"):
+            optimizer.qualify.qualify(
+                parse_one(
+                    "SELECT t.north FROM t "
+                    "UNPIVOT(revenue FOR month IN (jan, feb)) "
+                    "UNPIVOT(headcount FOR region IN (north, south))",
+                    dialect="snowflake",
+                ),
+                schema={
+                    "t": {"id": "int", "jan": "int", "feb": "int", "north": "int", "south": "int"}
+                },
+                dialect="snowflake",
+            )
+
+    def test_pivoted_source_joined_alongside_another(self):
+        # The operators belong to one source, so a star over the source joined next to it
+        # must not expand through them. DuckDB returns (id, x, id, month, revenue) here.
+        schema = {"a": {"id": "int", "x": "int"}, "t": {"id": "int", "jan": "int", "feb": "int"}}
+        for join in ("ON a.id = u.id", "USING (id)"):
+            with self.subTest(join):
+                expression = optimizer.qualify.qualify(
+                    parse_one(
+                        "SELECT * FROM a JOIN t UNPIVOT(revenue FOR month IN (jan, feb)) AS u "
+                        f"{join}",
+                        dialect="snowflake",
+                    ),
+                    schema=schema,
+                    dialect="snowflake",
+                )
+                self.assertEqual(
+                    [s.alias_or_name for s in expression.selects],
+                    ["ID", "X", "ID", "MONTH", "REVENUE"],
+                )
+
+    def test_multiple_pivots_annotate_types(self):
+        # NOTE: the value column takes the type of the first IN-list entry, so the columns
+        # folded by a single operator are kept uniformly typed here
+        schema = {
+            "t": {"id": "int", "jan": "int", "feb": "int", "north": "double", "south": "double"}
+        }
+        expression = annotate_types(
+            optimizer.qualify.qualify(
+                parse_one(
+                    "SELECT * FROM t "
+                    "UNPIVOT(revenue FOR month IN (jan, feb)) "
+                    "UNPIVOT(headcount FOR region IN (north, south))",
+                    dialect="snowflake",
+                ),
+                schema=schema,
+                dialect="snowflake",
+            ),
+            schema=schema,
+            dialect="snowflake",
+        )
+
+        # Types flow through every operator, not just the last one: the name columns are
+        # text and each value column takes the type of the columns it was folded from
+        self.assertEqual(
+            [(s.alias_or_name, s.type.sql()) for s in expression.selects],
+            [
+                ("ID", "INT"),
+                ("MONTH", "VARCHAR"),
+                ("REVENUE", "INT"),
+                ("REGION", "VARCHAR"),
+                ("HEADCOUNT", "DOUBLE"),
+            ],
+        )
+
+        pivot_schema = {
+            "t": {"id": "int", "cat": "text", "val": "int", "kind": "text", "amt": "double"}
+        }
+        expression = annotate_types(
+            optimizer.qualify.qualify(
+                parse_one(
+                    "SELECT * FROM t "
+                    "PIVOT(SUM(val) FOR cat IN ('a' AS a, 'b' AS b)) "
+                    "PIVOT(SUM(amt) FOR kind IN ('x' AS x, 'y' AS y))",
+                    dialect="snowflake",
+                ),
+                schema=pivot_schema,
+                dialect="snowflake",
+            ),
+            schema=pivot_schema,
+            dialect="snowflake",
+        )
+
+        # Each PIVOT's outputs take the type of its own aggregate
+        self.assertEqual(
+            [(s.alias_or_name, s.type.sql()) for s in expression.selects],
+            [("ID", "INT"), ("A", "BIGINT"), ("B", "BIGINT"), ("X", "DOUBLE"), ("Y", "DOUBLE")],
+        )
+
     def test_unnest_type_trace_is_memoized(self):
         """Tracing an UNNEST's element type must not re-walk shared parts of the scope graph.
 


### PR DESCRIPTION
A table can have more than one PIVOT/UNPIVOT attached to it, and each one runs on the output of the one before it. We were only ever looking at a single operator, so a chain got resolved against the wrong set of columns; star expansion, column resolution and type inference all had their own copy of the same assumption.

```
SELECT * FROM t UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south))

before: id, north, south, month, revenue
after:  id, month, revenue, region, headcount
```

The "after" is what DuckDB, Snowflake and Spark actually return. It also covers the mixed case, where the second operator's IN-list names columns the first one produced.

While in there: the operators belong to one source, but a star was expanding every source through them, so `a JOIN t UNPIVOT(...)` gave back 7 columns instead of 5 with a's columns attributed to the pivot. That one needs no chain to reproduce.