### PR TITLE
fix(duckdb)!: respect week start day in TIMESTAMP_TRUNC and DATETIME_TRUNC, support ISOWEEK truncation

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -900,10 +900,18 @@ def _implicit_datetime_cast(
     return arg
 
 
+def _week_trunc_start_dow(unit: exp.Expr | None) -> int | None:
+    # DuckDB's weeks are ISO 8601, so ISOWEEK maps to its plain WEEK unit
+    if isinstance(unit, exp.Literal) and unit.name.upper() == "ISOWEEK":
+        return 1
+    return week_unit_to_dow(unit)
+
+
 def _build_week_trunc_expression(
     date_expr: exp.Expr,
     start_dow: int,
     preserve_start_day: bool = False,
+    cast_to_date: bool = True,
 ) -> exp.Expr:
     """
     Build DATE_TRUNC expression for week boundaries with custom start day.
@@ -917,6 +925,8 @@ def _build_week_trunc_expression(
         preserve_start_day: If True, reverse the shift after truncating so the result lands on the
             correct week start day. Needed for DATE_TRUNC (absolute result matters) but
             not for DATE_DIFF (only relative alignment matters).
+        cast_to_date: If True, cast the shifted result back to DATE; set to False for
+            timestamp-valued inputs, where the result must remain a timestamp.
 
     Shift formula: Sunday (7) gets +1, others get (1 - start_dow).
     """
@@ -932,9 +942,10 @@ def _build_week_trunc_expression(
 
     if preserve_start_day:
         interval = exp.Interval(this=exp.Literal.string(str(-shift_days)), unit=exp.var("DAY"))
-        return exp.cast(
-            exp.DateAdd(this=truncated, expression=interval), to=exp.DType.DATE, copy=False
-        )
+        shifted_back: exp.Expr = exp.DateAdd(this=truncated, expression=interval)
+        if cast_to_date:
+            return exp.cast(shifted_back, to=exp.DType.DATE, copy=False)
+        return shifted_back
 
     return truncated
 
@@ -1778,9 +1789,6 @@ class DuckDBGenerator(generator.Generator):
         ),
         exp.UnixToStr: lambda self, e: self.func(
             "STRFTIME", self.func("TO_TIMESTAMP", e.this), self.format_time(e)
-        ),
-        exp.DatetimeTrunc: lambda self, e: self.func(
-            "DATE_TRUNC", weekstart_unit_to_str(self, e), exp.cast(e.this, exp.DType.DATETIME)
         ),
         exp.UnixToTime: _unix_to_time_sql,
         exp.UnixToTimeStr: lambda self, e: f"CAST(TO_TIMESTAMP({self.sql(e, 'this')}) AS TEXT)",
@@ -4418,7 +4426,7 @@ class DuckDBGenerator(generator.Generator):
         unit = expression.args.get("unit")
         date = expression.this
 
-        week_start = week_unit_to_dow(unit)
+        week_start = _week_trunc_start_dow(unit)
         unit = unit_to_str(expression)
 
         if week_start:
@@ -4437,11 +4445,33 @@ class DuckDBGenerator(generator.Generator):
 
         return result
 
+    def datetimetrunc_sql(self, expression: exp.DatetimeTrunc) -> str:
+        this = exp.cast(expression.this, exp.DType.DATETIME)
+        week_start = _week_trunc_start_dow(expression.args.get("unit"))
+        if week_start:
+            return self.sql(
+                _build_week_trunc_expression(
+                    this, week_start, preserve_start_day=True, cast_to_date=False
+                )
+            )
+
+        return self.func("DATE_TRUNC", unit_to_str(expression), this)
+
     def timestamptrunc_sql(self, expression: exp.TimestampTrunc) -> str:
-        unit = weekstart_unit_to_str(self, expression)
         zone = expression.args.get("zone")
         timestamp = expression.this
-        date_unit = is_date_unit(unit)
+        week_start = _week_trunc_start_dow(expression.args.get("unit"))
+
+        # The week start emulation below is exact, so avoid weekstart_unit_to_str's degrade warning
+        unit = unit_to_str(expression) if week_start else weekstart_unit_to_str(self, expression)
+        date_unit = is_date_unit(unit) or bool(week_start)
+
+        def _trunc_expr(this: exp.Expr) -> exp.Expr:
+            if week_start:
+                return _build_week_trunc_expression(
+                    this, week_start, preserve_start_day=True, cast_to_date=False
+                )
+            return exp.func("DATE_TRUNC", unit, this)
 
         if date_unit and zone:
             # BigQuery's TIMESTAMP_TRUNC with timezone truncates in the target timezone and returns as UTC.
@@ -4449,10 +4479,13 @@ class DuckDBGenerator(generator.Generator):
             # 1. First AT TIME ZONE: ensures truncation happens in the target timezone
             # 2. Second AT TIME ZONE: converts the DATE result back to TIMESTAMPTZ (preserving time component)
             timestamp = exp.AtTimeZone(this=timestamp, zone=zone)
-            result_sql = self.func("DATE_TRUNC", unit, timestamp)
-            return self.sql(exp.AtTimeZone(this=result_sql, zone=zone))
+            trunced = _trunc_expr(timestamp)
+            if isinstance(trunced, exp.DateAdd):
+                # Parenthesize so the trailing AT TIME ZONE binds to the whole shifted expression
+                trunced = exp.Paren(this=trunced)
+            return self.sql(exp.AtTimeZone(this=trunced, zone=zone))
 
-        result = self.func("DATE_TRUNC", unit, timestamp)
+        result = self.sql(_trunc_expr(timestamp))
         if expression.args.get("input_type_preserved"):
             if timestamp.type and timestamp.is_type(exp.DType.TIME, exp.DType.TIMETZ):
                 dummy_date = exp.Cast(

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3622,7 +3622,7 @@ OPTIONS (
             write={
                 "bigquery": "SELECT TIMESTAMP_TRUNC(ts, WEEK)",
                 "clickhouse": "SELECT dateTrunc('WEEK', ts)",
-                "duckdb": "SELECT DATE_TRUNC('WEEK', ts)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', ts + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
                 "mysql": "SELECT DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF(WEEK, '0000-01-01 00:00:00', ts)) WEEK)",
                 "snowflake": "SELECT DATE_TRUNC('WEEK', ts)",
             },
@@ -3631,7 +3631,7 @@ OPTIONS (
             "SELECT DATETIME_TRUNC(dt, WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT DATETIME_TRUNC(dt, WEEK)",
-                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(dt AS TIMESTAMP))",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(dt AS TIMESTAMP) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
             },
         )
         self.validate_all(
@@ -3644,7 +3644,6 @@ OPTIONS (
             "SELECT TIMESTAMP_TRUNC(ts, WEEK(SUNDAY))",
             write={
                 "clickhouse": UnsupportedError,
-                "duckdb": UnsupportedError,
                 "snowflake": UnsupportedError,
                 "spark": UnsupportedError,
             },
@@ -3677,6 +3676,43 @@ OPTIONS (
             "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
             write={
                 "spark": UnsupportedError,
+            },
+        )
+        # DuckDB's weeks are Monday-based, so other week starts need shifting and ISOWEEK
+        # maps to its plain WEEK unit
+        self.validate_all(
+            "SELECT DATE_TRUNC(DATE '2008-11-10', WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT DATE_TRUNC(CAST('2008-11-10' AS DATE), WEEK)",
+                "duckdb": "SELECT CAST(DATE_TRUNC('WEEK', CAST('2008-11-10' AS DATE) + INTERVAL '1' DAY) + INTERVAL '-1' DAY AS DATE)",
+            },
+        )
+        self.validate_all(
+            "SELECT DATE_TRUNC(DATE '2008-11-10', ISOWEEK)",
+            write={
+                "bigquery": "SELECT DATE_TRUNC(CAST('2008-11-10' AS DATE), ISOWEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST('2008-11-10' AS DATE))",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP_TRUNC(TIMESTAMP '2008-11-10 14:30:00', WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT TIMESTAMP_TRUNC(CAST('2008-11-10 14:30:00' AS TIMESTAMP), WEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST('2008-11-10 14:30:00' AS TIMESTAMPTZ) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
+            },
+        )
+        self.validate_all(
+            "SELECT DATETIME_TRUNC(DATETIME '2008-11-10 14:30:00', WEEK(SUNDAY))",
+            write={
+                "bigquery": "SELECT DATETIME_TRUNC(CAST('2008-11-10 14:30:00' AS DATETIME), WEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(CAST('2008-11-10 14:30:00' AS TIMESTAMP) AS TIMESTAMP) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP_TRUNC(TIMESTAMP '2008-11-10 14:30:00+00', WEEK(SUNDAY), 'America/New_York')",
+            write={
+                "bigquery": "SELECT TIMESTAMP_TRUNC(CAST('2008-11-10 14:30:00+00' AS TIMESTAMP), WEEK, 'America/New_York')",
+                "duckdb": "SELECT (DATE_TRUNC('WEEK', CAST('2008-11-10 14:30:00+00' AS TIMESTAMPTZ) AT TIME ZONE 'America/New_York' + INTERVAL '1' DAY) + INTERVAL '-1' DAY) AT TIME ZONE 'America/New_York'",
             },
         )
         self.validate_identity(


### PR DESCRIPTION
DuckDB already emulates BigQuery week start days in `DATE_TRUNC`, but not in `TIMESTAMP_TRUNC` and `DATETIME_TRUNC`; those degraded `WEEK(<day>)` to DuckDB's Monday-based week. `DATE_TRUNC` with `ISOWEEK` also generated SQL DuckDB rejects, since it doesn't recognize that unit.

- `TIMESTAMP_TRUNC` / `DATETIME_TRUNC` now reuse the same day-shift emulation `DATE_TRUNC` uses, keeping timestamp-valued results uncast
- The 3-arg `TIMESTAMP_TRUNC(ts, unit, zone)` form truncates in the target time zone, with the shifted expression parenthesized so the trailing `AT TIME ZONE` binds to all of it
- `ISOWEEK` maps to DuckDB's plain `WEEK` unit, which is already ISO (Monday-based)
- The `WEEK(<day>)` unsupported warning is skipped when emulation makes the translation exact

All new test queries were run against live BigQuery and DuckDB; outputs match, including the time zone case.