### PR TITLE
fix(bigquery)!: treat a bare WEEK date part as WEEK(SUNDAY) in truncation functions

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -513,6 +513,17 @@ def datetime_floor(d: date, unit: str, dialect: Dialect) -> date:
     return result
 
 
+def _trunc_unit(unit: exp.Expr, dialect: Dialect) -> str:
+    if isinstance(unit, exp.WeekStart):
+        from sqlglot.dialects.dialect import WEEK_START_DAY_TO_DOW, week_offset_to_dow
+
+        if WEEK_START_DAY_TO_DOW.get(unit.name.upper()) != week_offset_to_dow(dialect.WEEK_OFFSET):
+            raise UnsupportedUnit(f"Unsupported unit: {unit}")
+        return "week"
+
+    return unit.name.lower()
+
+
 def date_ceil(d: date, unit: str, dialect: Dialect) -> date:
     floor = datetime_floor(d, unit, dialect)
 
@@ -1453,7 +1464,7 @@ class Simplifier:
             date = extract_date(this)
             if date and expression.unit:
                 return date_literal(
-                    datetime_floor(date, expression.unit.name.lower(), self.dialect),
+                    datetime_floor(date, _trunc_unit(expression.unit, self.dialect), self.dialect),
                     trunc_type,
                 )
         elif comparison not in self.DATETRUNC_COMPARISONS:
@@ -1468,7 +1479,7 @@ class Simplifier:
                 return expression
 
             trunc_arg = l.this
-            unit = l.args["unit"].name.lower()
+            unit = _trunc_unit(l.args["unit"], self.dialect)
             date = extract_date(r)
 
             if not date:
@@ -1491,7 +1502,7 @@ class Simplifier:
                 and all(self._is_datetrunc_predicate(l, r) for r in rs)
                 and isinstance(l, (exp.DateTrunc, exp.TimestampTrunc))
             ):
-                unit = l.args["unit"].name.lower()
+                unit = _trunc_unit(l.args["unit"], self.dialect)
 
                 ranges = []
                 for r in rs:

--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -31,7 +31,7 @@ def _build_date(args: list) -> exp.Date | exp.DateFromParts:
 def _normalize_bare_week(expr: E) -> E:
     # In BigQuery, a bare WEEK date part is equivalent to WEEK(SUNDAY)
     unit = expr.args.get("unit")
-    if isinstance(unit, exp.Var) and unit.name.upper() == "WEEK":
+    if isinstance(unit, (exp.Literal, exp.Var)) and unit.name.upper() == "WEEK":
         expr.set("unit", exp.WeekStart(this=exp.var("SUNDAY")))
 
     return expr
@@ -234,15 +234,18 @@ class BigQueryParser(parser.Parser):
         "DATE_ADD": build_date_delta_with_interval(exp.DateAdd),
         "DATE_DIFF": build_date_diff(exp.DateDiff),
         "DATE_SUB": build_date_delta_with_interval(exp.DateSub),
-        "DATE_TRUNC": lambda args: exp.DateTrunc(
-            unit=seq_get(args, 1),
-            this=seq_get(args, 0),
-            zone=seq_get(args, 2),
+        "DATE_TRUNC": lambda args: _normalize_bare_week(
+            exp.DateTrunc(
+                unit=seq_get(args, 1),
+                this=seq_get(args, 0),
+                zone=seq_get(args, 2),
+            )
         ),
         "DATETIME": _build_datetime,
         "DATETIME_ADD": build_date_delta_with_interval(exp.DatetimeAdd),
         "DATETIME_DIFF": build_date_diff(exp.DatetimeDiff),
         "DATETIME_SUB": build_date_delta_with_interval(exp.DatetimeSub),
+        "DATETIME_TRUNC": lambda args: _normalize_bare_week(exp.DatetimeTrunc.from_arg_list(args)),
         "DIV": binary_from_function(exp.IntDiv),
         "EDIT_DISTANCE": _build_levenshtein,
         "EMBED": exp.AIEmbed.from_arg_list,
@@ -305,6 +308,9 @@ class BigQueryParser(parser.Parser):
             this=seq_get(args, 0), scale=exp.UnixToTime.MILLIS
         ),
         "TIMESTAMP_SECONDS": lambda args: exp.UnixToTime(this=seq_get(args, 0)),
+        "TIMESTAMP_TRUNC": lambda args: _normalize_bare_week(
+            exp.TimestampTrunc.from_arg_list(args)
+        ),
         "TO_JSON": lambda args: exp.JSONFormat(
             this=seq_get(args, 0), options=seq_get(args, 1), to_json=True
         ),

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3605,26 +3605,28 @@ OPTIONS (
                 "duckdb": "SELECT CAST(CAST('2008-11-10' AS DATE) + INTERVAL ((7 - EXTRACT(DAYOFWEEK FROM CAST('2008-11-10' AS DATE))) % 7) DAY AS DATE)",
             },
         )
-        # Dialects without week-start syntax degrade WEEK(<day>) to their plain week
-        # unit (with an unsupported warning when the week start day differs)
+        # Dialects without week-start syntax degrade WEEK(<day>) to their plain week unit,
+        # warning when that changes the week start day; only outputs that preserve the
+        # source semantics are asserted
         self.validate_all(
             "SELECT DATE_TRUNC(d, WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT DATE_TRUNC(d, WEEK)",
-                "exasol": "SELECT DATE_TRUNC('WEEK', d)",
-                "mysql": "SELECT STR_TO_DATE(CONCAT(YEAR(d), ' ', WEEK(d, 1), ' 1'), '%Y %u %w')",
-                "snowflake": "SELECT DATE_TRUNC('WEEK', d)",
-                "spark": "SELECT TRUNC(d, 'WEEK')",
+                "exasol": UnsupportedError,
+                "mysql": UnsupportedError,
+                "snowflake": UnsupportedError,
+                "spark": UnsupportedError,
             },
         )
         self.validate_all(
             "SELECT TIMESTAMP_TRUNC(ts, WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT TIMESTAMP_TRUNC(ts, WEEK)",
-                "clickhouse": "SELECT dateTrunc('WEEK', ts)",
+                "clickhouse": UnsupportedError,
                 "duckdb": "SELECT DATE_TRUNC('WEEK', ts + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
-                "mysql": "SELECT DATE_ADD('0000-01-01 00:00:00', INTERVAL (TIMESTAMPDIFF(WEEK, '0000-01-01 00:00:00', ts)) WEEK)",
-                "snowflake": "SELECT DATE_TRUNC('WEEK', ts)",
+                "mysql": UnsupportedError,
+                "snowflake": UnsupportedError,
+                "spark": UnsupportedError,
             },
         )
         self.validate_all(
@@ -3634,25 +3636,12 @@ OPTIONS (
                 "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(dt AS TIMESTAMP) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
             },
         )
-        self.validate_all(
-            "SELECT DATE_TRUNC(d, WEEK(SUNDAY))",
-            write={
-                "spark": UnsupportedError,
-            },
-        )
-        self.validate_all(
-            "SELECT TIMESTAMP_TRUNC(ts, WEEK(SUNDAY))",
-            write={
-                "clickhouse": UnsupportedError,
-                "snowflake": UnsupportedError,
-                "spark": UnsupportedError,
-            },
-        )
+        # T-SQL's DATEDIFF counts Sunday-based week boundaries, matching WEEK(SUNDAY) exactly
         self.validate_all(
             "SELECT DATE_DIFF(d1, d2, WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT DATE_DIFF(d1, d2, WEEK)",
-                "snowflake": "SELECT DATEDIFF(WEEK, d2, d1)",
+                "snowflake": UnsupportedError,
                 "tsql": "SELECT DATEDIFF(WEEK, d2, d1)",
             },
         )
@@ -3660,21 +3649,15 @@ OPTIONS (
             "SELECT LAST_DAY(d, WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT LAST_DAY(d, WEEK)",
-                "snowflake": "SELECT LAST_DAY(d, WEEK)",
+                "snowflake": UnsupportedError,
             },
         )
         self.validate_all(
             "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
             write={
                 "bigquery": "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
-                "hive": "SELECT EXTRACT(WEEK FROM d)",
-                "snowflake": "SELECT DATE_PART(WEEK, d)",
-                "spark": "SELECT EXTRACT(WEEK FROM d)",
-            },
-        )
-        self.validate_all(
-            "SELECT EXTRACT(WEEK(THURSDAY) FROM d)",
-            write={
+                "hive": UnsupportedError,
+                "snowflake": UnsupportedError,
                 "spark": UnsupportedError,
             },
         )
@@ -3694,6 +3677,23 @@ OPTIONS (
                 "duckdb": "SELECT DATE_TRUNC('WEEK', CAST('2008-11-10' AS DATE))",
             },
         )
+        # A bare WEEK unit means WEEK(SUNDAY), so it must transpile exactly like the explicit
+        # spelling: DuckDB emulates the Sunday start, dialects without week-start syntax warn
+        self.validate_all(
+            "SELECT DATE_TRUNC(DATE '2008-11-10', WEEK)",
+            write={
+                "bigquery": "SELECT DATE_TRUNC(CAST('2008-11-10' AS DATE), WEEK)",
+                "duckdb": "SELECT CAST(DATE_TRUNC('WEEK', CAST('2008-11-10' AS DATE) + INTERVAL '1' DAY) + INTERVAL '-1' DAY AS DATE)",
+                "snowflake": UnsupportedError,
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP_TRUNC(TIMESTAMP '2008-11-10 14:30:00', WEEK)",
+            write={
+                "bigquery": "SELECT TIMESTAMP_TRUNC(CAST('2008-11-10 14:30:00' AS TIMESTAMP), WEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST('2008-11-10 14:30:00' AS TIMESTAMPTZ) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
+            },
+        )
         self.validate_all(
             "SELECT TIMESTAMP_TRUNC(TIMESTAMP '2008-11-10 14:30:00', WEEK(SUNDAY))",
             write={
@@ -3702,10 +3702,24 @@ OPTIONS (
             },
         )
         self.validate_all(
+            "SELECT DATETIME_TRUNC(DATETIME '2008-11-10 14:30:00', WEEK)",
+            write={
+                "bigquery": "SELECT DATETIME_TRUNC(CAST('2008-11-10 14:30:00' AS DATETIME), WEEK)",
+                "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(CAST('2008-11-10 14:30:00' AS TIMESTAMP) AS TIMESTAMP) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
+            },
+        )
+        self.validate_all(
             "SELECT DATETIME_TRUNC(DATETIME '2008-11-10 14:30:00', WEEK(SUNDAY))",
             write={
                 "bigquery": "SELECT DATETIME_TRUNC(CAST('2008-11-10 14:30:00' AS DATETIME), WEEK)",
                 "duckdb": "SELECT DATE_TRUNC('WEEK', CAST(CAST('2008-11-10 14:30:00' AS TIMESTAMP) AS TIMESTAMP) + INTERVAL '1' DAY) + INTERVAL '-1' DAY",
+            },
+        )
+        self.validate_all(
+            "SELECT TIMESTAMP_TRUNC(TIMESTAMP '2008-11-10 14:30:00+00', WEEK, 'America/New_York')",
+            write={
+                "bigquery": "SELECT TIMESTAMP_TRUNC(CAST('2008-11-10 14:30:00+00' AS TIMESTAMP), WEEK, 'America/New_York')",
+                "duckdb": "SELECT (DATE_TRUNC('WEEK', CAST('2008-11-10 14:30:00+00' AS TIMESTAMPTZ) AT TIME ZONE 'America/New_York' + INTERVAL '1' DAY) + INTERVAL '-1' DAY) AT TIME ZONE 'America/New_York'",
             },
         )
         self.validate_all(

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -1129,6 +1129,19 @@ x < CAST('2008-11-16' AS DATE) AND x >= CAST('2008-11-09' AS DATE);
 DATE_TRUNC(x, WEEK) <> CAST('2008-11-09' AS DATE);
 x < CAST('2008-11-09' AS DATE) OR x >= CAST('2008-11-16' AS DATE);
 
+# dialect: bigquery
+DATE_TRUNC(x, WEEK) IN (CAST('2008-11-09' AS DATE), CAST('2008-11-23' AS DATE));
+(x < CAST('2008-11-16' AS DATE) AND x >= CAST('2008-11-09' AS DATE)) OR (x < CAST('2008-11-30' AS DATE) AND x >= CAST('2008-11-23' AS DATE));
+
+-- A week start that doesn't match the dialect's week offset must not be simplified
+# dialect: bigquery
+DATE_TRUNC(CAST('2023-12-15' AS DATE), WEEK(MONDAY));
+DATE_TRUNC(CAST('2023-12-15' AS DATE), WEEK(MONDAY));
+
+# dialect: bigquery
+DATE_TRUNC(x, WEEK(MONDAY)) = CAST('2008-11-10' AS DATE);
+DATE_TRUNC(x, WEEK(MONDAY)) = CAST('2008-11-10' AS DATE);
+
 -- T-SQL week truncation follows @@DATEFIRST, which defaults to 7 (Sunday)
 # dialect: tsql
 DATETRUNC(WEEK, CAST('2021-12-08' AS DATETIME2));


### PR DESCRIPTION
BigQuery [docs](https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/date_functions#date_trunc): "Weeks begin on Sundays. WEEK is equivalent to WEEK(SUNDAY)". The parser already normalized bare WEEK in DATE_DIFF and LAST_DAY, but not in the truncation functions, so the two spellings of the same expression transpiled differently:

```sql
-- 2008-11-10 is a Monday, BigQuery returns 2008-11-09 for both spellings
DATE_TRUNC(DATE '2008-11-10', WEEK(SUNDAY))
-- duckdb before and after: CAST(DATE_TRUNC('WEEK', ... + INTERVAL '1' DAY) + INTERVAL '-1' DAY AS DATE), returns 2008-11-09

DATE_TRUNC(DATE '2008-11-10', WEEK)
-- duckdb before: DATE_TRUNC('WEEK', ...), returns 2008-11-10, silently wrong
-- duckdb after: same output as the WEEK(SUNDAY) spelling
```

The parser now normalizes bare WEEK to WEEK(SUNDAY) in DATE_TRUNC, TIMESTAMP_TRUNC and DATETIME_TRUNC. The simplifier resolves these units through the dialect's week offset, folding when the start day matches and leaving the expression untouched when it doesn't; without this, the existing bare WEEK simplification fixtures regress.

Also reworked the week tests so that degraded outputs assert UnsupportedError instead of pinning SQL whose semantics differ from the source.

Breaking because bare WEEK truncation output changes for every Monday-start target dialect. All new test queries were verified against live BigQuery and DuckDB.

close #8011