### PR TITLE
fix(optimizer)!: resolve pivot chain aliases in star expansion and type annotation

### DIFF
--- a/sqlglot/optimizer/annotate_types.py
+++ b/sqlglot/optimizer/annotate_types.py
@@ -305,56 +305,7 @@ class TypeAnnotator:
             source = scope.sources.get(source_name)
 
             if isinstance(source, Scope):
-                expression = source.expression
-
-                if isinstance(expression, exp.UDTF):
-                    values = []
-
-                    if isinstance(expression, exp.Lateral):
-                        if isinstance(expression.this, exp.Explode):
-                            values = [expression.this.this]
-                    elif isinstance(expression, exp.Unnest):
-                        values = [expression]
-                    elif not isinstance(expression, exp.TableFromRows):
-                        values = expression.expressions[0].expressions
-
-                    if not values:
-                        return {}
-
-                    alias_column_names = expression.alias_column_names
-
-                    if isinstance(expression, exp.Unnest):
-                        exp_type = expression.type
-                    elif isinstance(expression, exp.Lateral) and isinstance(
-                        expression.this, exp.Explode
-                    ):
-                        exp_type = expression.this.type
-                    else:
-                        exp_type = None
-
-                    struct_type = (
-                        exp_type if exp_type and exp_type.is_type(exp.DType.STRUCT) else None
-                    )
-
-                    if struct_type:
-                        selects = {
-                            col_def.name: t.cast(t.Union[exp.DataType, exp.DType], col_def.kind)
-                            for col_def in struct_type.expressions
-                            if isinstance(col_def, exp.ColumnDef) and col_def.kind
-                        }
-                    else:
-                        selects = {
-                            alias: column.type for alias, column in zip(alias_column_names, values)
-                        }
-
-                elif isinstance(expression, exp.SetOperation) and len(
-                    expression.this.selects
-                ) == len(expression.expression.selects):
-                    selects = self._get_setop_column_types(expression)
-
-                elif isinstance(expression, exp.Selectable):
-                    selects = {s.alias_or_name: s.type for s in expression.selects if s.type}
-
+                selects = self._get_source_scope_selects(source)
             else:
                 pivots = (
                     source.args.get("pivots", []) if isinstance(source, exp.Table) else scope.pivots
@@ -365,8 +316,17 @@ class TypeAnnotator:
                     parent = pivots[-1].parent
                     parent_source = scope.sources.get(parent.alias_or_name) if parent else None
 
-                    if parent and isinstance(parent_source, Scope):
-                        src_types = self._get_scope_source_selects(scope, parent.alias_or_name)
+                    if (
+                        not isinstance(parent_source, Scope)
+                        and isinstance(parent, exp.Table)
+                        and not parent.db
+                    ):
+                        # A chain aliased like the CTE it reads from shadows it in
+                        # `scope.sources`, so reach for the CTE's scope directly
+                        parent_source = scope.cte_sources.get(parent.name)
+
+                    if isinstance(parent_source, Scope):
+                        src_types = self._get_source_scope_selects(parent_source)
                     elif isinstance(parent, exp.Table) and isinstance(self.schema, MappingSchema):
                         src_types = (
                             self.schema.find(parent, raise_on_missing=False, ensure_data_types=True)
@@ -387,6 +347,53 @@ class TypeAnnotator:
             self._scope_source_selects[key] = selects
 
         return selects
+
+    def _get_source_scope_selects(self, source: Scope) -> dict[str, exp.DataType | exp.DType]:
+        expression = source.expression
+
+        if isinstance(expression, exp.UDTF):
+            values = []
+
+            if isinstance(expression, exp.Lateral):
+                if isinstance(expression.this, exp.Explode):
+                    values = [expression.this.this]
+            elif isinstance(expression, exp.Unnest):
+                values = [expression]
+            elif not isinstance(expression, exp.TableFromRows):
+                values = expression.expressions[0].expressions
+
+            if not values:
+                return {}
+
+            alias_column_names = expression.alias_column_names
+
+            if isinstance(expression, exp.Unnest):
+                exp_type = expression.type
+            elif isinstance(expression, exp.Lateral) and isinstance(expression.this, exp.Explode):
+                exp_type = expression.this.type
+            else:
+                exp_type = None
+
+            struct_type = exp_type if exp_type and exp_type.is_type(exp.DType.STRUCT) else None
+
+            if struct_type:
+                return {
+                    col_def.name: t.cast(t.Union[exp.DataType, exp.DType], col_def.kind)
+                    for col_def in struct_type.expressions
+                    if isinstance(col_def, exp.ColumnDef) and col_def.kind
+                }
+
+            return {alias: column.type for alias, column in zip(alias_column_names, values)}
+
+        if isinstance(expression, exp.SetOperation) and len(expression.this.selects) == len(
+            expression.expression.selects
+        ):
+            return self._get_setop_column_types(expression)
+
+        if isinstance(expression, exp.Selectable):
+            return {s.alias_or_name: s.type for s in expression.selects if s.type}
+
+        return {}
 
     def annotate_scope(self, scope: Scope) -> None:
         if isinstance(self.schema, MappingSchema):

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -690,11 +690,12 @@ def _qualify_columns(
                 table = resolver.get_table(column.name)
                 if table:
                     column.set("table", table)
-            elif column.name in produced:
+            elif single_chain and column.name in produced:
                 column.set("table", exp.to_identifier(pivoted_source))
 
-        available = pivot.output_columns(available)
-        produced.update(available)
+        if single_chain:
+            available = pivot.output_columns(available)
+            produced.update(available)
 
 
 def _expand_struct_stars_no_parens(
@@ -890,10 +891,23 @@ def _expand_stars(
 
         for table in tables:
             source = scope.sources.get(table)
-            if source is None:
-                raise OptimizeError(f"Unknown table: {table}")
+            pivots: list[exp.Pivot] | None = None
+            source_table = table
 
-            columns = resolver.get_source_columns(table, only_visible=True)
+            if source is None:
+                # The chain's final alias names the resulting source, but only the underlying
+                # source is registered in `scope.sources`, so resolve through the chain's parent
+                chain = scope.pivots
+                parent = chain[-1].parent if chain and chain[-1].alias == table else None
+                if parent:
+                    pivots = chain
+                    source_table = parent.alias_or_name
+                    source = scope.sources.get(source_table)
+
+                if source is None:
+                    raise OptimizeError(f"Unknown table: {table}")
+
+            columns = resolver.get_source_columns(source_table, only_visible=True)
             columns = columns or scope.outer_columns
 
             if pseudocolumns and dialect.EXCLUDES_PSEUDOCOLUMNS_FROM_STAR:
@@ -921,10 +935,18 @@ def _expand_stars(
 
             # The operators belong to a specific source, so a star over a source joined
             # alongside it must expand from that source's own columns
-            selected_node, _ = scope.selected_sources.get(table, (None, None))
-            pivots = (
-                selected_node.args.get("pivots") if isinstance(selected_node, exp.Expr) else None
-            )
+            if pivots is None:
+                selected_node, _ = scope.selected_sources.get(table, (None, None))
+                if selected_node is None and isinstance(source, exp.Table):
+                    # A pivoted CTE reference is registered under the pivot's alias, a name
+                    # `references` doesn't know, so it's absent from `selected_sources`
+                    selected_node = source
+
+                pivots = (
+                    selected_node.args.get("pivots")
+                    if isinstance(selected_node, exp.Expr)
+                    else None
+                )
 
             if pivots:
                 # Each operator consumes the previous one's output, so fold them in order

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -896,9 +896,14 @@ def _expand_stars(
 
             if source is None:
                 # The chain's final alias names the resulting source, but only the underlying
-                # source is registered in `scope.sources`, so resolve through the chain's parent
+                # source is registered in `scope.sources`, so resolve through the chain's parent.
+                # Attribution is only unambiguous for a single chain (all pivots share a parent)
                 chain = scope.pivots
-                parent = chain[-1].parent if chain and chain[-1].alias == table else None
+                parent = (
+                    chain[-1].parent
+                    if chain and chain[0].parent is chain[-1].parent and chain[-1].alias == table
+                    else None
+                )
                 if parent:
                     pivots = chain
                     source_table = parent.alias_or_name

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -1192,3 +1192,28 @@ SELECT x.a AS a, x.b AS b, u.id AS id, u.north AS north, u.south AS south, u.mon
 # dialect: snowflake
 WITH t AS (SELECT 1 AS "Id", 2 AS "Jan", 3 AS "Feb", 4 AS "Nor", 5 AS "Sou") SELECT * FROM t UNPIVOT(v1 FOR n1 IN ("Jan", "Feb")) UNPIVOT(v2 FOR n2 IN ("Nor", "Sou"));
 WITH T AS (SELECT 1 AS "Id", 2 AS "Jan", 3 AS "Feb", 4 AS "Nor", 5 AS "Sou") SELECT T."Id" AS "Id", T.N1 AS N1, T.V1 AS V1, T.N2 AS N2, T.V2 AS V2 FROM T AS T UNPIVOT(V1 FOR N1 IN ("Jan", "Feb")) UNPIVOT(V2 FOR N2 IN ("Nor", "Sou")) AS T;
+
+# title: qualified star over the pivot alias of a pivoted table
+# dialect: duckdb
+SELECT u.* FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u;
+SELECT u.id AS id, u.north AS north, u.south AS south, u.month AS month, u.revenue AS revenue FROM unpivotable AS unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u;
+
+# title: qualified star over the pivot alias, next to a joined plain source
+# dialect: duckdb
+SELECT x.b, u.* FROM x JOIN unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u ON x.a = u.id;
+SELECT x.b AS b, u.id AS id, u.north AS north, u.south AS south, u.month AS month, u.revenue AS revenue FROM x AS x JOIN unpivotable AS unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u ON x.a = u.id;
+
+# title: qualified star over the pivot alias of a pivoted CTE
+# dialect: duckdb
+WITH c AS (SELECT id, jan, feb FROM unpivotable) SELECT piv.* FROM c UNPIVOT(revenue FOR month IN (jan, feb)) AS piv;
+WITH c AS (SELECT unpivotable.id AS id, unpivotable.jan AS jan, unpivotable.feb AS feb FROM unpivotable AS unpivotable) SELECT piv.id AS id, piv.month AS month, piv.revenue AS revenue FROM c AS c UNPIVOT(revenue FOR month IN (jan, feb)) AS piv;
+
+# title: qualified star over the pivot alias of a pivoted subquery
+# dialect: duckdb
+SELECT piv.* FROM (SELECT id, jan, feb FROM unpivotable) UNPIVOT(revenue FOR month IN (jan, feb)) AS piv;
+SELECT piv.id AS id, piv.month AS month, piv.revenue AS revenue FROM (SELECT unpivotable.id AS id, unpivotable.jan AS jan, unpivotable.feb AS feb FROM unpivotable AS unpivotable) AS _0 UNPIVOT(revenue FOR month IN (jan, feb)) AS piv;
+
+# title: qualified star over the alias of a chain of operators
+# dialect: duckdb
+SELECT u.* FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south)) AS u;
+SELECT u.id AS id, u.month AS month, u.revenue AS revenue, u.region AS region, u.headcount AS headcount FROM unpivotable AS unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south)) AS u;

--- a/tests/fixtures/optimizer/qualify_columns__invalid.sql
+++ b/tests/fixtures/optimizer/qualify_columns__invalid.sql
@@ -17,3 +17,4 @@ SELECT x.a FROM x INNER JOIN y ON x.a = c INNER JOIN z ON x.a = c;
 SELECT b FROM x INNER JOIN y ON x.a = y.c INNER JOIN z ON x.a = z.c;
 SELECT unpivotable.north FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south))
 SELECT u1.id FROM unpivotable UNPIVOT(zzz FOR m IN (jan, feb)) AS u1 CROSS JOIN x UNPIVOT(w FOR k IN (zzz)) AS u2
+SELECT u2.* FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) AS u1 CROSS JOIN x UNPIVOT(w FOR k IN (b)) AS u2

--- a/tests/fixtures/optimizer/qualify_columns__invalid.sql
+++ b/tests/fixtures/optimizer/qualify_columns__invalid.sql
@@ -16,3 +16,4 @@ SELECT a JOIN b USING (a);
 SELECT x.a FROM x INNER JOIN y ON x.a = c INNER JOIN z ON x.a = c;
 SELECT b FROM x INNER JOIN y ON x.a = y.c INNER JOIN z ON x.a = z.c;
 SELECT unpivotable.north FROM unpivotable UNPIVOT(revenue FOR month IN (jan, feb)) UNPIVOT(headcount FOR region IN (north, south))
+SELECT u1.id FROM unpivotable UNPIVOT(zzz FOR m IN (jan, feb)) AS u1 CROSS JOIN x UNPIVOT(w FOR k IN (zzz)) AS u2

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -918,6 +918,29 @@ class TestOptimizer(unittest.TestCase):
             [("ID", "INT"), ("A", "BIGINT"), ("B", "BIGINT"), ("X", "DOUBLE"), ("Y", "DOUBLE")],
         )
 
+    def test_unpivot_cte_annotate_types(self):
+        # An unaliased operator takes the CTE's name, shadowing it in scope.sources, so
+        # the source types must be resolved through the CTE's scope instead
+        schema = {"t": {"id": "int", "jan": "int", "feb": "int"}}
+        expression = annotate_types(
+            optimizer.qualify.qualify(
+                parse_one(
+                    "WITH c AS (SELECT id, jan, feb FROM t) "
+                    "SELECT * FROM c UNPIVOT(v FOR m IN (jan, feb))",
+                    dialect="duckdb",
+                ),
+                schema=schema,
+                dialect="duckdb",
+            ),
+            schema=schema,
+            dialect="duckdb",
+        )
+
+        self.assertEqual(
+            [(s.alias_or_name, s.type.sql()) for s in expression.selects],
+            [("id", "INT"), ("m", "VARCHAR"), ("v", "INT")],
+        )
+
     def test_unnest_type_trace_is_memoized(self):
         """Tracing an UNNEST's element type must not re-walk shared parts of the scope graph.
 


### PR DESCRIPTION
Follow-up to #8032. A pivot chain's final alias names the resulting source, but two code paths still didn't know that name, breaking valid queries and type inference.

- Qualified star over a pivot alias raised `Unknown table` (table/subquery sources) or silently expanded the pre-pivot columns (CTE sources):

  ```sql
  SELECT u.* FROM t UNPIVOT(v FOR m IN (jan, feb)) AS u
  -- OptimizeError: Unknown table: u
  ```

- Unaliased (UN)PIVOT over a CTE annotated its columns as UNKNOWN, because the chain takes the CTE's name and shadows its scope, so types were resolved against the schema (where the CTE doesn't exist):

  ```sql
  WITH c AS (SELECT id, jan, feb FROM t) SELECT * FROM c UNPIVOT(v FOR m IN (jan, feb))
  -- id/v annotated as UNKNOWN, now INT/INT
  ```

- Also guards the produced-column tracking in `_qualify_columns` behind `single_chain`, so the multi-source case can't emit an empty table qualifier.
