### PR TITLE
fix(optimizer): prevent fabrication of struct-field refs for schema-less correlated columns

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -89,6 +89,9 @@ def qualify_columns(
             allow_partial_qualification=allow_partial_qualification,
         )
 
+        # Refresh classification caches: a column just qualified in place may have been cached as external
+        scope.clear_column_cache()
+
         if not schema.empty and expand_alias_refs:
             _expand_alias_refs(scope, resolver, dialect)
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -127,6 +127,12 @@ class Scope:
         self.can_be_correlated = can_be_correlated
         self.clear_cache()
 
+    def clear_column_cache(self) -> None:
+        """Invalidate the column-classification caches after columns are qualified in place."""
+        self._columns = None
+        self._external_columns = None
+        self._local_columns = None
+
     def clear_cache(self) -> None:
         self._collected = False
         self._scans_all_subscope_columns = False

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -493,6 +493,21 @@ SELECT i.a AS a FROM x AS i WHERE i.b IN (SELECT j.b AS b FROM y AS j WHERE j.b 
 SELECT (SELECT n.a FROM n WHERE n.id = m.id) FROM m AS m;
 SELECT (SELECT n.a AS a FROM n AS n WHERE n.id = m.id) AS _col_0 FROM m AS m;
 
+# title: correlated aggregate resolves to local source without schema
+# execute: false
+SELECT id FROM t WHERE id > (SELECT AVG(id) FROM u WHERE u.name = t.name);
+SELECT t.id AS id FROM t AS t WHERE t.id > (SELECT AVG(u.id) AS _col_0 FROM u AS u WHERE u.name = t.name);
+
+# title: correlated aggregate with self-correlation via alias
+# execute: false
+SELECT id FROM t WHERE id > (SELECT AVG(id) FROM t AS t2 WHERE t2.k = t.k);
+SELECT t.id AS id FROM t AS t WHERE t.id > (SELECT AVG(t2.id) AS _col_0 FROM t AS t2 WHERE t2.k = t.k);
+
+# title: correlated aggregate where inner column name matches outer table
+# execute: false
+SELECT id FROM t WHERE id > (SELECT AVG(u) FROM u WHERE u.k = t.k);
+SELECT t.id AS id FROM t AS t WHERE t.id > (SELECT AVG(u.u) AS _col_0 FROM u AS u WHERE u.k = t.k);
+
 --------------------------------------
 -- Expand *
 --------------------------------------


### PR DESCRIPTION
When qualifying a correlated subquery without a schema, `qualify` rewrote an unqualified column into a reference to a column that does not exist, producing an invalid query that fails to execute.

The subquery scope resolves correctly. But `external_columns` is computed before `_qualify_columns` runs, so the unqualified id gets cached as an external column.  After it's qualified in place, that stale cache leaks up to the parent scope, whose `_convert_columns_to_dots` then rewrites it (to an invalid identifier)

Input Query:
```
SELECT id FROM t WHERE id > (SELECT AVG(id) FROM u WHERE u.name = t.name)
```
Previous Output: Note, `t.u.id` does not exist.
```
SELECT "t"."id" AS "id" FROM "t" AS "t"
WHERE "t"."id" > (SELECT AVG("t"."u"."id") AS "_col_0" FROM "u" AS "u" WHERE "u"."name" = "t"."name")
```
Correct Output:
```
SELECT "t"."id" AS "id" FROM "t" AS "t"
WHERE "t"."id" > (SELECT AVG("u"."id") AS "_col_0" FROM "u" AS "u" WHERE "u"."name" = "t"."name")
```