### PR TITLE
fix(optimizer)!: only qualify lateral sources in their defining scope

### DIFF
--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -137,6 +137,11 @@ def qualify_tables(
         table_aliases = {}
 
         for name, source in scope.sources.items():
+            # Lateral sources are sources that this scope merely references and they're processed when
+            # their defining (outer) scope is traversed; skip them to avoid double-visiting issues
+            if scope.lateral_sources.get(name) is source:
+                continue
+
             if isinstance(source, exp.Table):
                 # When the name is empty, it means that we have a non-table source, e.g. a pivoted cte
                 is_real_table_source = bool(name)
@@ -215,7 +220,8 @@ def qualify_tables(
             elif (
                 canonical_aliases
                 and column_table
-                and (canonical_table := canonical_aliases.get(column_table, "")) != column_table
+                and (canonical_table := canonical_aliases.get(column_table))
+                and canonical_table != column_table
             ):
                 # Amend existing aliases, e.g. t.c -> _0.c if t is aliased to _0
                 column.set("table", exp.to_identifier(canonical_table))

--- a/sqlglot/optimizer/qualify_tables.py
+++ b/sqlglot/optimizer/qualify_tables.py
@@ -108,6 +108,7 @@ def qualify_tables(
             scope.rename_source(None, new_alias_name)
 
     for scope in traverse_scope(expression):
+        parent = scope.parent
         local_columns = scope.local_columns
         canonical_aliases: dict[str, str] = {}
 
@@ -137,9 +138,10 @@ def qualify_tables(
         table_aliases = {}
 
         for name, source in scope.sources.items():
-            # Lateral sources are sources that this scope merely references and they're processed when
-            # their defining (outer) scope is traversed; skip them to avoid double-visiting issues
-            if scope.lateral_sources.get(name) is source:
+            # A source can appear in many scopes, e.g. as a lateral source of a UDTF scope or as a CTE
+            # propagated to inner scopes. Deferring to the parent scope when it contains the same source
+            # ensures each source is processed once, in the outermost scope that contains it
+            if parent and parent.sources.get(name) is source:
                 continue
 
             if isinstance(source, exp.Table):

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -261,6 +261,16 @@ SELECT * FROM c.db.x AS _1 WHERE _1.a = (SELECT SUM(_0.c) AS c FROM c.db.y AS _0
 SELECT t.foo FROM t AS t, (SELECT t.bar FROM t AS t);
 SELECT _2.foo FROM c.db.t AS _2, (SELECT _0.bar FROM c.db.t AS _0) AS _1;
 
+# title: canonicalize table referenced by lateral unnest
+# canonicalize_table_aliases: true
+SELECT t.a, x FROM t, UNNEST(t.arr) AS x;
+SELECT _0.a, x FROM c.db.t AS _0, UNNEST(_0.arr) AS _1;
+
+# title: canonicalize lateral unnest referencing a previous unnest
+# canonicalize_table_aliases: true
+SELECT t.a, x, z FROM t, UNNEST(t.arr) AS x, UNNEST(x.b) AS z;
+SELECT _0.a, x, z FROM c.db.t AS _0, UNNEST(_0.arr) AS _1, UNNEST(_1.b) AS _2;
+
 # title: Qualify GENERATE_SERIES with its default column generate_series
 # dialect: postgres
 SELECT generate_series FROM GENERATE_SERIES(1,2);

--- a/tests/fixtures/optimizer/qualify_tables.sql
+++ b/tests/fixtures/optimizer/qualify_tables.sql
@@ -166,6 +166,10 @@ SELECT x FROM c.db.t AS t, LATERAL UNNEST(t.xs) AS x;
 SELECT x FROM t, LATERAL UNNEST(t.xs);
 SELECT x FROM c.db.t AS t, LATERAL UNNEST(t.xs) AS _0;
 
+# title: multiple lateral unnests without aliases each get a distinct alias
+SELECT x FROM t, LATERAL UNNEST(t.xs), LATERAL UNNEST(t.ys);
+SELECT x FROM c.db.t AS t, LATERAL UNNEST(t.xs) AS _0, LATERAL UNNEST(t.ys) AS _1;
+
 # title: table with ordinality
 SELECT * FROM t CROSS JOIN JSON_ARRAY_ELEMENTS(t.response) WITH ORDINALITY AS kv_json;
 SELECT * FROM c.db.t AS t CROSS JOIN JSON_ARRAY_ELEMENTS(t.response) WITH ORDINALITY AS kv_json;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -284,6 +284,16 @@ class TestOptimizer(unittest.TestCase):
         )
         self.assertEqual(tables, {"bar", "baz"})
 
+        # Tables referenced by lateral sources (e.g. UNNEST) must only be qualified once
+        qualified = []
+        optimizer.qualify_tables.qualify_tables(
+            parse_one("SELECT a, x FROM t, UNNEST(arr) AS x"),
+            db="db",
+            catalog="c",
+            on_qualify=lambda t: qualified.append(t.sql()),
+        )
+        self.assertEqual(qualified, ["c.db.t AS t"])
+
         self.assertEqual(
             optimizer.qualify.qualify(
                 parse_one("WITH tesT AS (SELECT * FROM t1) SELECT * FROM test", "bigquery"),


### PR DESCRIPTION
`qualify_tables` processed sources shared via `lateral_sources` (e.g., `FROM t, UNNEST(t.arr)`) once per scope, causing:

- `on_qualify` firing twice for the same table
- double alias renames + dangling column refs under `canonicalize_table_aliases`

Also guards the canonical alias remap so a dict miss can't blank a column's table to `""`.
