### PR TITLE
fix(optimizer): expand qualify inner columns with QUALIFY/HAVING

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -445,6 +445,22 @@ def _expand_alias_refs(
     replace_columns(expression.args.get("having"), resolve_table=True)
     replace_columns(expression.args.get("qualify"), resolve_table=True)
 
+    if resolver.schema.empty:
+        # Resolve window PARTITION BY / argument columns left unqualified by early alias
+        for clause in (expression.args.get("qualify"), expression.args.get("having")):
+            if not clause:
+                continue
+            for column in walk_in_scope(clause):
+                if (
+                    isinstance(column, exp.Column)
+                    and not column.table
+                    and isinstance(column.find_ancestor(exp.Window, exp.Select), exp.Window)
+                ):
+                    table = resolver.get_table(column)
+                    if table:
+                        column.set("table", table)
+                        replaced = True
+
     if dialect.SUPPORTS_ALIAS_REFS_IN_JOIN_CONDITIONS:
         for join in expression.args.get("joins") or []:
             replace_columns(join)

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -411,6 +411,17 @@ def _expand_alias_refs(
                     simplified = simplify_parens(column, dialect)
                     if simplified is not column:
                         column.replace(simplified)
+                        column = simplified
+
+                    if resolve_table and resolver.schema.empty:
+                        # resolve alias spliced into QUALIFY/HAVING with unqualified columns
+                        for inner in walk_in_scope(column):
+                            if (
+                                isinstance(inner, exp.Column)
+                                and not inner.table
+                                and (inner_table := resolver.get_table(inner))
+                            ):
+                                inner.set("table", inner_table)
 
     for i, projection in enumerate(expression.selects):
         replace_columns(projection)
@@ -444,22 +455,6 @@ def _expand_alias_refs(
     replace_columns(expression.args.get("group"), literal_index=True)
     replace_columns(expression.args.get("having"), resolve_table=True)
     replace_columns(expression.args.get("qualify"), resolve_table=True)
-
-    if resolver.schema.empty:
-        # Resolve window PARTITION BY / argument columns left unqualified by early alias
-        for clause in (expression.args.get("qualify"), expression.args.get("having")):
-            if not clause:
-                continue
-            for column in walk_in_scope(clause):
-                if (
-                    isinstance(column, exp.Column)
-                    and not column.table
-                    and isinstance(column.find_ancestor(exp.Window, exp.Select), exp.Window)
-                ):
-                    table = resolver.get_table(column)
-                    if table:
-                        column.set("table", table)
-                        replaced = True
 
     if dialect.SUPPORTS_ALIAS_REFS_IN_JOIN_CONDITIONS:
         for join in expression.args.get("joins") or []:

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -391,6 +391,10 @@ class Scope:
                         )
                     )
                     or (isinstance(ancestor, exp.Star) and not column.arg_key == "except_")
+                    or (
+                        isinstance(ancestor, (exp.Qualify, exp.Having))
+                        and isinstance(column.find_ancestor(exp.Window, exp.Select), exp.Window)
+                    )
                 ):
                     self._columns.append(column)
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -391,10 +391,6 @@ class Scope:
                         )
                     )
                     or (isinstance(ancestor, exp.Star) and not column.arg_key == "except_")
-                    or (
-                        isinstance(ancestor, (exp.Qualify, exp.Having))
-                        and isinstance(column.find_ancestor(exp.Window, exp.Select), exp.Window)
-                    )
                 ):
                     self._columns.append(column)
 


### PR DESCRIPTION
When `qualify_columns` expands a select-alias reference in place inside `QUALIFY` or `HAVING` and no schema is available, the spliced-in columns were left unqualified. After `simplify_parens`, we now walk the expanded expression and qualify any table-less inner columns against the resolver's source.

Example

Input:
```
SELECT a AS a FROM t QUALIFY ROW_NUMBER() OVER (PARTITION BY a ORDER BY b) = 1
```
Before — a in PARTITION BY stays unqualified:
```
SELECT "t"."a" AS "a" FROM "t" AS "t" QUALIFY ROW_NUMBER() OVER (PARTITION BY "a" ORDER BY "t"."b") = 1
```
After:
```
SELECT "t"."a" AS "a" FROM "t" AS "t" QUALIFY ROW_NUMBER() OVER (PARTITION BY "t"."a" ORDER BY "t"."b") = 1
```