### PR TITLE
fix(postgres,duckdb): convert MySQL UPDATE JOIN into UPDATE FROM

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -617,6 +617,14 @@ class Generator:
     # Unsupported (MySQL, SingleStore): UPDATE t1 JOIN t2 ON TRUE SET t1.a = t2.b
     UPDATE_STATEMENT_SUPPORTS_FROM = True
 
+    # Whether an UPDATE statement's target table can carry a JOIN directly on it
+    # (`UPDATE t1 JOIN t2 ON ... SET ...`), as opposed to only ever expecting an
+    # UPDATE ... FROM ... structure. This is used to convert JOINs attached to the
+    # UPDATE target (e.g. parsed from MySQL's native UPDATE JOIN syntax) into a
+    # FROM clause for dialects, like Postgres and DuckDB, whose engines reject
+    # UPDATE ... JOIN ... syntax outright.
+    UPDATE_STATEMENT_SUPPORTS_JOIN = True
+
     # Whether SELECT *, ... EXCLUDE requires wrapping in a subquery for transpilation.
     STAR_EXCLUDE_REQUIRES_DERIVED_TABLE = True
 
@@ -2642,7 +2650,50 @@ class Generator:
         - from_sql: placed after SET clause (standard position)
         Dialects like MySQL need to convert FROM to JOIN syntax.
         """
-        if self.UPDATE_STATEMENT_SUPPORTS_FROM or not (from_expr := expression.args.get("from_")):
+        from_expr = expression.args.get("from_")
+
+        if (
+            self.UPDATE_STATEMENT_SUPPORTS_FROM
+            and not self.UPDATE_STATEMENT_SUPPORTS_JOIN
+            and not from_expr
+        ):
+            # Some dialects (e.g. MySQL) attach JOINs directly onto the target table
+            # instead of using a separate FROM clause, e.g.
+            # `UPDATE t1 JOIN t2 ON t1.id = t2.id SET t1.a = t2.a`. If the target
+            # dialect only supports the `UPDATE ... FROM` form, we must convert
+            # these joins into a FROM clause, otherwise we'd emit an invalid
+            # `UPDATE t1 JOIN t2 ON ... SET ...` statement for that dialect.
+            target_table = expression.this
+            joins = target_table.args.get("joins") if isinstance(target_table, exp.Table) else None
+
+            if joins:
+                first_join, *rest_joins = joins
+                target_table.set("joins", None)
+
+                # The target dialect's SET clause doesn't expect (and may reject) a
+                # table-qualified column when it matches the UPDATE target, e.g.
+                # Postgres errors on `SET foo.a = ...` but accepts `SET a = ...`.
+                target_name = exp.to_identifier(target_table.alias_or_name)
+                for eq in expression.expressions:
+                    col = eq.this
+                    if isinstance(col, exp.Column) and col.table and col.table == target_name.this:
+                        col.set("table", None)
+
+                from_table = first_join.this
+                if rest_joins:
+                    from_table.set("joins", rest_joins)
+
+                on = first_join.args.get("on")
+                if on:
+                    where = expression.args.get("where")
+                    if where:
+                        where.set("this", exp.and_(on, where.this, copy=False))
+                    else:
+                        expression.set("where", exp.Where(this=on))
+
+                return ("", self.sql(exp.From(this=from_table)))
+
+        if self.UPDATE_STATEMENT_SUPPORTS_FROM or not from_expr:
             return ("", self.sql(expression, "from_"))
 
         # Qualify unqualified columns in SET clause with the target table
@@ -2669,8 +2720,11 @@ class Generator:
 
     def update_sql(self, expression: exp.Update) -> str:
         hint = self.sql(expression, "hint")
-        this = self.sql(expression, "this")
+        # NOTE: this must run before rendering `this`, since it may strip JOINs
+        # off the target table (attached there by dialects like MySQL) and move
+        # them into a FROM clause instead.
         join_sql, from_sql = self._update_from_joins_sql(expression)
+        this = self.sql(expression, "this")
         set_sql = self.expressions(expression, flat=True)
         where_sql = self.sql(expression, "where")
         returning = self.sql(expression, "returning")

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -1556,6 +1556,7 @@ class DuckDBGenerator(generator.Generator):
     JOIN_HINTS = False
     TABLE_HINTS = False
     QUERY_HINTS = False
+    UPDATE_STATEMENT_SUPPORTS_JOIN = False
     LIMIT_FETCH = "LIMIT"
     STRUCT_DELIMITER = ("(", ")")
     RENAME_TABLE_WITH_DB = False

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -255,6 +255,7 @@ class PostgresGenerator(generator.Generator):
     TABLE_HINTS = False
     QUERY_HINTS = False
     NVL2_SUPPORTED = False
+    UPDATE_STATEMENT_SUPPORTS_JOIN = False
     PARAMETER_TOKEN = "$"
     NAMED_PLACEHOLDER_TOKEN = "%"
     TABLESAMPLE_SIZE_IS_ROWS = False

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -258,6 +258,19 @@ class TestMySQL(Validator):
         self.validate_identity(
             "UPDATE foo JOIN bar ON TRUE SET foo.a = bar.a WHERE foo.id = bar.id"
         )
+        # MySQL's UPDATE ... JOIN ... syntax must be converted into the
+        # UPDATE ... FROM ... form for target dialects that only support
+        # UPDATE ... FROM (postgres, duckdb, ...), otherwise sqlglot emits
+        # invalid `UPDATE t1 JOIN t2 ON ... SET ...` SQL that fails with a
+        # syntax error against the target engine.
+        self.validate_all(
+            "UPDATE foo JOIN bar ON foo.id = bar.id SET foo.a = bar.a WHERE foo.tenant = 5",
+            write={
+                "mysql": "UPDATE foo JOIN bar ON foo.id = bar.id SET foo.a = bar.a WHERE foo.tenant = 5",
+                "postgres": "UPDATE foo SET a = bar.a FROM bar WHERE foo.id = bar.id AND foo.tenant = 5",
+                "duckdb": "UPDATE foo SET a = bar.a FROM bar WHERE foo.id = bar.id AND foo.tenant = 5",
+            },
+        )
         self.validate_identity(
             "UPDATE items, month SET items.price = month.price WHERE items.id = month.id"
         )


### PR DESCRIPTION
## Summary

Fixes #4469

MySQL supports `UPDATE t1 JOIN t2 ON ... SET ...` syntax, but Postgres and DuckDB reject an UPDATE statement with a JOIN attached directly to the target table; both only support the `UPDATE ... FROM ...` form. Before this change, transpiling the MySQL form to Postgres or DuckDB produced byte identical output, which fails with a syntax error against both engines.

Example:

```sql
UPDATE foo JOIN bar ON foo.id = bar.id SET foo.a = bar.a WHERE foo.tenant = 5
```

transpiled to Postgres as the same invalid string. This PR rewrites it into:

```sql
UPDATE foo SET a = bar.a FROM bar WHERE foo.id = bar.id AND foo.tenant = 5
```

which is valid on both Postgres and DuckDB.

## Approach

- Adds a new generator flag, `UPDATE_STATEMENT_SUPPORTS_JOIN`, defaulting to `True` so existing dialects are unaffected.
- Sets it to `False` for Postgres and DuckDB, the two dialects verified against real engine syntax.
- When a target dialect does not support the join form, the JOIN(s) attached to the UPDATE target are moved into a FROM clause, the join condition is folded into WHERE, and SET columns qualified with the target table name are unqualified to match what these engines require.
- Other dialects that already emit `UPDATE ... JOIN ...` natively (MySQL, SingleStore) are unaffected since the flag defaults to `True`.

## Test plan

- New `validate_all` case in `tests/dialects/test_mysql.py` covering MySQL to Postgres and MySQL to DuckDB transpilation of the JOIN form.
- `tests/dialects/test_mysql.py`: 51 passed, 490 subtests passed
- `tests/dialects/test_postgres.py` + `tests/dialects/test_duckdb.py`: 74 passed, 1030 subtests passed