### PR TITLE
fix(tsql): support nullability in ALTER COLUMN [CLAUDE]

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -484,6 +484,9 @@ class Generator:
     # Whether ALTER TABLE ... CHANGE COLUMN column-rename-and-redefine syntax is supported
     SUPPORTS_CHANGE_COLUMN = False
 
+    # Whether ALTER COLUMN can set a column's nullability together with its type
+    SUPPORTS_ALTER_COLUMN_NULLABILITY = False
+
     # Whether the LikeProperty needs to be specified inside of the schema clause
     LIKE_PROPERTY_INSIDE_SCHEMA = False
 
@@ -4205,7 +4208,16 @@ class Generator:
             using = self.sql(expression, "using")
             using = f" USING {using}" if using else ""
             alter_set_type = self.ALTER_SET_TYPE + " " if self.ALTER_SET_TYPE else ""
-            return f"ALTER COLUMN {this} {alter_set_type}{dtype}{collate}{using}"
+
+            null_constraint = ""
+            allow_null = expression.args.get("allow_null")
+            if allow_null is not None:
+                if self.SUPPORTS_ALTER_COLUMN_NULLABILITY:
+                    null_constraint = " NULL" if allow_null else " NOT NULL"
+                else:
+                    self.unsupported("ALTER COLUMN cannot set nullability along with a type")
+
+            return f"ALTER COLUMN {this} {alter_set_type}{dtype}{collate}{using}{null_constraint}"
 
         default = self.sql(expression, "default")
         if default:

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -147,6 +147,7 @@ class TSQLGenerator(generator.Generator):
     EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
     ALTER_SET_WRAPPED = True
     ALTER_SET_TYPE = ""
+    SUPPORTS_ALTER_COLUMN_NULLABILITY = True
 
     EXPRESSIONS_WITHOUT_NESTED_CTES = {
         exp.Create,

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -807,6 +807,12 @@ class TSQLParser(parser.Parser):
                 identifier = collation.this
                 collation.set("this", exp.Var(this=identifier.name))
 
+            if expression.args.get("dtype"):
+                if self._match_pair(TokenType.NOT, TokenType.NULL):
+                    expression.set("allow_null", False)
+                elif self._match(TokenType.NULL):
+                    expression.set("allow_null", True)
+
         return expression
 
     def _parse_primary_key_part(self) -> exp.Expr | None:

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1338,6 +1338,17 @@ WHERE
                 "tsql": "ALTER TABLE a ALTER COLUMN b INTEGER",
             },
         )
+        self.validate_identity("ALTER TABLE a ALTER COLUMN b INTEGER NOT NULL")
+        self.validate_identity("ALTER TABLE a ALTER COLUMN b INTEGER NULL")
+        self.validate_identity(
+            "ALTER TABLE a ALTER COLUMN b VARCHAR(10) COLLATE Latin1_General_CI_AS NOT NULL"
+        )
+        self.validate_all(
+            "ALTER TABLE a ALTER COLUMN b INTEGER NOT NULL",
+            write={
+                "": UnsupportedError,
+            },
+        )
         self.validate_all(
             "CREATE TABLE #mytemp (a INTEGER, b CHAR(2), c TIME(4), d FLOAT(24))",
             write={


### PR DESCRIPTION
This doesn't parse in tsql:

```
ALTER TABLE t ALTER COLUMN c INT NOT NULL
```

It falls back to a Command because `_parse_alter_table_alter` stops once it has the type. Same with `NULL`, and with `COLLATE abc NOT NULL`. Found it via SQLMesh, where a Command also means macros in the statement don't get resolved.

Generation is behind a flag rather than a tsql-only `altercolumn_sql` so other dialects warn instead of dropping the constraint. Postgres needs a separate `SET NOT NULL` action for it.