### PR TITLE
fix(parser)!: move JSON extraction operators to Postgres's binary-operator precedence tier

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -39,7 +39,7 @@ from sqlglot.dialects.dialect import (
     ts_or_ds_add_cast,
 )
 from sqlglot.generator import unsupported_args
-from sqlglot.helper import seq_get
+from sqlglot.helper import ensure_list, seq_get
 
 
 DATE_DIFF_FACTOR = {
@@ -185,8 +185,10 @@ def _json_extract_sql(
 ) -> t.Callable[[PostgresGenerator, JSON_EXTRACT_TYPE], str]:
     def _generate(self: PostgresGenerator, expression: JSON_EXTRACT_TYPE) -> str:
         path = expression.expression
-        # A single non-literal path segment (cast, arithmetic, etc.) is already a right-hand operand
-        if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not expression.expressions:
+        # Single non-literal segment: render as infix, not JSON_EXTRACT_PATH[_TEXT] (jsonb-unsafe).
+        if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not ensure_list(
+            expression.args.get("expressions")
+        ):
             return self.binary(expression, op)
 
         if expression.args.get("only_json_types"):

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -184,6 +184,11 @@ def _json_extract_sql(
     name: str, op: str
 ) -> t.Callable[[PostgresGenerator, JSON_EXTRACT_TYPE], str]:
     def _generate(self: PostgresGenerator, expression: JSON_EXTRACT_TYPE) -> str:
+        path = expression.expression
+        # A single non-literal path segment (cast, arithmetic, etc.) is already a right-hand operand
+        if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not expression.expressions:
+            return self.binary(expression, op)
+
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)
         return json_extract_segments(name)(self, expression)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1066,6 +1066,10 @@ class Parser:
         ),
     }
 
+    # Binary-operator-tier JSON extraction ops (Postgres's "any other operator" tier,
+    # below +/-, level with ||). Same value signature as COLUMN_OPERATORS: (self, this, rhs).
+    JSON_EXTRACT_OPERATORS: t.ClassVar[dict[TokenType, t.Callable]] = {}
+
     CAST_COLUMN_OPERATORS: t.ClassVar = {
         TokenType.DOTCOLON,
         TokenType.DCOLON,
@@ -6257,6 +6261,10 @@ class Parser:
             elif self._match_pair(TokenType.GT, TokenType.GT):
                 this = self.expression(
                     exp.BitwiseRightShift(this=this, expression=self._parse_term())
+                )
+            elif self.JSON_EXTRACT_OPERATORS and self._match_set(self.JSON_EXTRACT_OPERATORS):
+                this = self.JSON_EXTRACT_OPERATORS[self._prev.token_type](
+                    self, this, self._parse_term()
                 )
             else:
                 break

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -289,6 +289,46 @@ def _unpivot_target(expr: exp.Expr) -> exp.Expr:
     return expr
 
 
+# Builders for the JSON `->` / `->>` / `#>` / `#>>` / `?` operators, shared between
+# COLUMN_OPERATORS (accessor-tier dialects) and JSON_OPERATORS (Postgres/DuckDB's
+# binary-operator tier).
+def build_json_extract(self: Parser, this: exp.Expr, path: exp.Expr) -> exp.JSONExtract:
+    return self.expression(
+        exp.JSONExtract(
+            this=this,
+            expression=self.dialect.to_json_path(path),
+            only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+        )
+    )
+
+
+def build_json_extract_scalar(
+    self: Parser, this: exp.Expr, path: exp.Expr
+) -> exp.JSONExtractScalar:
+    return self.expression(
+        exp.JSONExtractScalar(
+            this=this,
+            expression=self.dialect.to_json_path(path),
+            only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+            scalar_only=self.dialect.JSON_EXTRACT_SCALAR_SCALAR_ONLY,
+        )
+    )
+
+
+def build_jsonb_extract(self: Parser, this: exp.Expr, path: exp.Expr) -> exp.JSONBExtract:
+    return self.expression(exp.JSONBExtract(this=this, expression=path))
+
+
+def build_jsonb_extract_scalar(
+    self: Parser, this: exp.Expr, path: exp.Expr
+) -> exp.JSONBExtractScalar:
+    return self.expression(exp.JSONBExtractScalar(this=this, expression=path))
+
+
+def build_jsonb_contains(self: Parser, this: exp.Expr, key: exp.Expr) -> exp.JSONBContains:
+    return self.expression(exp.JSONBContains(this=this, expression=key))
+
+
 SENTINEL_NONE: Token = Token(TokenType.SENTINEL, "SENTINEL")
 
 
@@ -1066,9 +1106,9 @@ class Parser:
         ),
     }
 
-    # Binary-operator-tier JSON extraction ops (Postgres's "any other operator" tier,
-    # below +/-, level with ||). Same value signature as COLUMN_OPERATORS: (self, this, rhs).
-    JSON_EXTRACT_OPERATORS: t.ClassVar[dict[TokenType, t.Callable]] = {}
+    # JSON/JSONB operators (extraction and containment) at Postgres's "any other operator"
+    # tier, below +/-, level with ||. Same value signature as COLUMN_OPERATORS: (self, this, rhs).
+    JSON_OPERATORS: t.ClassVar[dict[TokenType, t.Callable]] = {}
 
     CAST_COLUMN_OPERATORS: t.ClassVar = {
         TokenType.DOTCOLON,
@@ -6262,10 +6302,8 @@ class Parser:
                 this = self.expression(
                     exp.BitwiseRightShift(this=this, expression=self._parse_term())
                 )
-            elif self.JSON_EXTRACT_OPERATORS and self._match_set(self.JSON_EXTRACT_OPERATORS):
-                this = self.JSON_EXTRACT_OPERATORS[self._prev.token_type](
-                    self, this, self._parse_term()
-                )
+            elif self.JSON_OPERATORS and self._match_set(self.JSON_OPERATORS):
+                this = self.JSON_OPERATORS[self._prev.token_type](self, this, self._parse_term())
             else:
                 break
 

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -85,6 +85,30 @@ class DuckDBParser(parser.Parser):
 
     BITWISE = {k: v for k, v in parser.Parser.BITWISE.items() if k != TokenType.CARET}
 
+    COLUMN_OPERATORS = {
+        k: v
+        for k, v in parser.Parser.COLUMN_OPERATORS.items()
+        if k not in (TokenType.ARROW, TokenType.DARROW)
+    }
+
+    JSON_EXTRACT_OPERATORS = {
+        TokenType.ARROW: lambda self, this, path: self.expression(
+            exp.JSONExtract(
+                this=this,
+                expression=self.dialect.to_json_path(path),
+                only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+            )
+        ),
+        TokenType.DARROW: lambda self, this, path: self.expression(
+            exp.JSONExtractScalar(
+                this=this,
+                expression=self.dialect.to_json_path(path),
+                only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
+                scalar_only=self.dialect.JSON_EXTRACT_SCALAR_SCALAR_ONLY,
+            )
+        ),
+    }
+
     RANGE_PARSERS = {
         **parser.Parser.RANGE_PARSERS,
         TokenType.DAMP: binary_range_parser(exp.ArrayOverlaps),

--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -91,22 +91,9 @@ class DuckDBParser(parser.Parser):
         if k not in (TokenType.ARROW, TokenType.DARROW)
     }
 
-    JSON_EXTRACT_OPERATORS = {
-        TokenType.ARROW: lambda self, this, path: self.expression(
-            exp.JSONExtract(
-                this=this,
-                expression=self.dialect.to_json_path(path),
-                only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
-            )
-        ),
-        TokenType.DARROW: lambda self, this, path: self.expression(
-            exp.JSONExtractScalar(
-                this=this,
-                expression=self.dialect.to_json_path(path),
-                only_json_types=self.JSON_ARROWS_REQUIRE_JSON_TYPE,
-                scalar_only=self.dialect.JSON_EXTRACT_SCALAR_SCALAR_ONLY,
-            )
-        ),
+    JSON_OPERATORS = {
+        TokenType.ARROW: parser.build_json_extract,
+        TokenType.DARROW: parser.build_json_extract_scalar,
     }
 
     RANGE_PARSERS = {

--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -191,7 +191,19 @@ class PostgresParser(parser.Parser):
     JSON_ARROWS_REQUIRE_JSON_TYPE = True
 
     COLUMN_OPERATORS = {
-        **parser.Parser.COLUMN_OPERATORS,
+        k: v
+        for k, v in parser.Parser.COLUMN_OPERATORS.items()
+        if k
+        not in (
+            TokenType.ARROW,
+            TokenType.DARROW,
+            TokenType.HASH_ARROW,
+            TokenType.DHASH_ARROW,
+            TokenType.PLACEHOLDER,
+        )
+    }
+
+    JSON_EXTRACT_OPERATORS = {
         TokenType.ARROW: lambda self, this, path: self.validate_expression(
             build_json_extract_path(
                 exp.JSONExtract, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
@@ -201,6 +213,15 @@ class PostgresParser(parser.Parser):
             build_json_extract_path(
                 exp.JSONExtractScalar, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
             )([this, path])
+        ),
+        TokenType.HASH_ARROW: lambda self, this, path: self.expression(
+            exp.JSONBExtract(this=this, expression=path)
+        ),
+        TokenType.DHASH_ARROW: lambda self, this, path: self.expression(
+            exp.JSONBExtractScalar(this=this, expression=path)
+        ),
+        TokenType.PLACEHOLDER: lambda self, this, key: self.expression(
+            exp.JSONBContains(this=this, expression=key)
         ),
     }
 

--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -203,7 +203,7 @@ class PostgresParser(parser.Parser):
         )
     }
 
-    JSON_EXTRACT_OPERATORS = {
+    JSON_OPERATORS = {
         TokenType.ARROW: lambda self, this, path: self.validate_expression(
             build_json_extract_path(
                 exp.JSONExtract, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
@@ -214,15 +214,9 @@ class PostgresParser(parser.Parser):
                 exp.JSONExtractScalar, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
             )([this, path])
         ),
-        TokenType.HASH_ARROW: lambda self, this, path: self.expression(
-            exp.JSONBExtract(this=this, expression=path)
-        ),
-        TokenType.DHASH_ARROW: lambda self, this, path: self.expression(
-            exp.JSONBExtractScalar(this=this, expression=path)
-        ),
-        TokenType.PLACEHOLDER: lambda self, this, key: self.expression(
-            exp.JSONBContains(this=this, expression=key)
-        ),
+        TokenType.HASH_ARROW: parser.build_jsonb_extract,
+        TokenType.DHASH_ARROW: parser.build_jsonb_extract_scalar,
+        TokenType.PLACEHOLDER: parser.build_jsonb_contains,
     }
 
     ARG_MODE_TOKENS: t.ClassVar = {TokenType.IN, TokenType.OUT, TokenType.INOUT, TokenType.VARIADIC}

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -212,7 +212,7 @@ class TestPostgres(Validator):
         )
         self.validate_identity(
             "x::JSON -> 'duration' ->> -1",
-            "JSON_EXTRACT_PATH_TEXT(CAST(x AS JSON) -> 'duration', -1)",
+            "CAST(x AS JSON) -> 'duration' ->> -1",
         ).assert_is(exp.JSONExtractScalar).this.assert_is(exp.JSONExtract)
         self.validate_identity(
             "SELECT SUBSTRING('Thomas' FOR 3 FROM 2)",
@@ -452,7 +452,7 @@ class TestPostgres(Validator):
     'field_id' AS field_id
 )
 SELECT
-  JSON_ARRAY_ELEMENTS(JSON_EXTRACT_PATH(json_data.data, field_ids.field_id)) AS element
+  JSON_ARRAY_ELEMENTS(json_data.data -> field_ids.field_id) AS element
 FROM json_data, field_ids""",
             pretty=True,
         )


### PR DESCRIPTION
Fixes #8035 where `->`, `->>`, `#>`, `#>>`, and `?` were parsed as tight-binding column accessors (like `.` and `::`) via `COLUMN_OPERATORS`, instead of Postgres's actual "any other operator" precedence tier, below `+`/`-`, level with `||` and the bitwise operators, left-associative.

This caused casts, subscripts, and arithmetic adjacent to these operators to bind to the wrong operand.  To fix it:
- Added `JSON_EXTRACT_OPERATORS`, a new operator tier parsed inside `_parse_bitwise` in `parser.py`, alongside the existing `||` handling.
- Moved the relevant operators out of `COLUMN_OPERATORS` and into `JSON_EXTRACT_OPERATORS` for `PostgresParser` and `DuckDBParser`. Other dialects still treat `->` as lambda syntax.

Sample input:
```
SELECT a #>> b::TEXT[]
```
Previous: cast attaches to the whole extract:
```
SELECT CAST(a #>> b AS TEXT[])
```
Fixed: cast attaches to the path operand, matching Postgres:
```
SELECT a #>> CAST(b AS TEXT[])
```