### PR TITLE
feat(databricks): support `and`, `or` function syntax

### DIFF
--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -382,8 +382,8 @@ class ClickHouseParser(parser.Parser):
         "MEDIAN": lambda self: self._parse_quantile(),
         "COLUMNS": lambda self: self._parse_columns(),
         "TUPLE": lambda self: exp.Struct.from_arg_list(self._parse_function_args(alias=True)),
-        "AND": lambda self: exp.and_(*self._parse_function_args(alias=False)),
-        "OR": lambda self: exp.or_(*self._parse_function_args(alias=False)),
+        "AND": lambda self: exp.Paren(this=exp.and_(*self._parse_function_args(alias=False))),
+        "OR": lambda self: exp.Paren(this=exp.or_(*self._parse_function_args(alias=False))),
         "XOR": lambda self: exp.xor(*self._parse_function_args(alias=False)),
     }
 

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -13,12 +13,8 @@ class DatabricksParser(SparkParser):
     COLON_IS_VARIANT_EXTRACT = True
     COLON_CHAIN_IS_SINGLE_EXTRACT = False
 
-    FUNC_TOKENS = parser.Parser.FUNC_TOKENS | {TokenType.AND, TokenType.OR}
-
     FUNCTIONS = {
         **SparkParser.FUNCTIONS,
-        "AND": lambda args: exp.And(this=seq_get(args, 0), expression=seq_get(args, 1)),
-        "OR": lambda args: exp.Or(this=seq_get(args, 0), expression=seq_get(args, 1)),
         "IFF": exp.If.from_arg_list,
         "GETDATE": exp.CurrentTimestamp.from_arg_list,
         "DATEDIFF": build_date_delta(exp.DateDiff),
@@ -61,14 +57,6 @@ class DatabricksParser(SparkParser):
         *SparkParser.CAST_COLUMN_OPERATORS,
         TokenType.QDCOLON,
     }
-
-    def _parse_interval_span(
-        self, this: exp.Expr, parse_function_unit: bool = True
-    ) -> exp.Interval:
-        # AND/OR in FUNC_TOKENS would be consumed as interval units; they never are.
-        if self._curr and self._curr.token_type in (TokenType.AND, TokenType.OR):
-            parse_function_unit = False
-        return super()._parse_interval_span(this, parse_function_unit=parse_function_unit)
 
     def _parse_curdate(self) -> exp.CurrentDate:
         # CURDATE, an alias for CURRENT_DATE, has optional parentheses

--- a/sqlglot/parsers/databricks.py
+++ b/sqlglot/parsers/databricks.py
@@ -13,8 +13,12 @@ class DatabricksParser(SparkParser):
     COLON_IS_VARIANT_EXTRACT = True
     COLON_CHAIN_IS_SINGLE_EXTRACT = False
 
+    FUNC_TOKENS = parser.Parser.FUNC_TOKENS | {TokenType.AND, TokenType.OR}
+
     FUNCTIONS = {
         **SparkParser.FUNCTIONS,
+        "AND": lambda args: exp.And(this=seq_get(args, 0), expression=seq_get(args, 1)),
+        "OR": lambda args: exp.Or(this=seq_get(args, 0), expression=seq_get(args, 1)),
         "IFF": exp.If.from_arg_list,
         "GETDATE": exp.CurrentTimestamp.from_arg_list,
         "DATEDIFF": build_date_delta(exp.DateDiff),
@@ -57,6 +61,14 @@ class DatabricksParser(SparkParser):
         *SparkParser.CAST_COLUMN_OPERATORS,
         TokenType.QDCOLON,
     }
+
+    def _parse_interval_span(
+        self, this: exp.Expr, parse_function_unit: bool = True
+    ) -> exp.Interval:
+        # AND/OR in FUNC_TOKENS would be consumed as interval units; they never are.
+        if self._curr and self._curr.token_type in (TokenType.AND, TokenType.OR):
+            parse_function_unit = False
+        return super()._parse_interval_span(this, parse_function_unit=parse_function_unit)
 
     def _parse_curdate(self) -> exp.CurrentDate:
         # CURDATE, an alias for CURRENT_DATE, has optional parentheses

--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -11,6 +11,7 @@ from sqlglot.dialects.dialect import (
 from sqlglot.helper import ensure_list, seq_get
 from sqlglot.parsers.hive import HiveParser
 from sqlglot.parser import build_trim
+from sqlglot.tokens import TokenType
 
 
 def build_as_cast(to_type: str) -> t.Callable[[list], exp.Expr]:
@@ -21,6 +22,8 @@ class Spark2Parser(HiveParser):
     TRIM_PATTERN_FIRST = True
     CHANGE_COLUMN_ALTER_SYNTAX = True
     PIVOT_COLUMN_NAMING = "agg_name_if_multiple"
+
+    FUNC_TOKENS = HiveParser.FUNC_TOKENS | {TokenType.AND, TokenType.OR}
 
     FUNCTIONS = {
         **HiveParser.FUNCTIONS,
@@ -80,11 +83,13 @@ class Spark2Parser(HiveParser):
 
     FUNCTION_PARSERS = {
         **HiveParser.FUNCTION_PARSERS,
+        "AND": lambda self: exp.and_(*self._parse_function_args(alias=False)),
         "APPROX_PERCENTILE": lambda self: self._parse_distinct_arg_function(exp.ApproxQuantile),
         "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
         "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
         "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),
         "MERGE": lambda self: self._parse_join_hint("MERGE"),
+        "OR": lambda self: exp.or_(*self._parse_function_args(alias=False)),
         "SHUFFLEMERGE": lambda self: self._parse_join_hint("SHUFFLEMERGE"),
         "MERGEJOIN": lambda self: self._parse_join_hint("MERGEJOIN"),
         "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
@@ -97,6 +102,13 @@ class Spark2Parser(HiveParser):
             if self._match_text_seq("DROP", "COLUMNS")
             else None
         )
+
+    def _parse_interval_span(
+        self, this: exp.Expr, parse_function_unit: bool = True
+    ) -> exp.Interval:
+        if self._curr and self._curr.token_type in (TokenType.AND, TokenType.OR):
+            parse_function_unit = False
+        return super()._parse_interval_span(this, parse_function_unit=parse_function_unit)
 
     def _pivot_column_names(self, aggregations: list[exp.Expr]) -> list[str]:
         if len(aggregations) == 1:

--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -83,13 +83,13 @@ class Spark2Parser(HiveParser):
 
     FUNCTION_PARSERS = {
         **HiveParser.FUNCTION_PARSERS,
-        "AND": lambda self: exp.and_(*self._parse_function_args(alias=False)),
+        "AND": lambda self: exp.Paren(this=exp.and_(*self._parse_function_args(alias=False))),
         "APPROX_PERCENTILE": lambda self: self._parse_distinct_arg_function(exp.ApproxQuantile),
         "BROADCAST": lambda self: self._parse_join_hint("BROADCAST"),
         "BROADCASTJOIN": lambda self: self._parse_join_hint("BROADCASTJOIN"),
         "MAPJOIN": lambda self: self._parse_join_hint("MAPJOIN"),
         "MERGE": lambda self: self._parse_join_hint("MERGE"),
-        "OR": lambda self: exp.or_(*self._parse_function_args(alias=False)),
+        "OR": lambda self: exp.Paren(this=exp.or_(*self._parse_function_args(alias=False))),
         "SHUFFLEMERGE": lambda self: self._parse_join_hint("SHUFFLEMERGE"),
         "MERGEJOIN": lambda self: self._parse_join_hint("MERGEJOIN"),
         "SHUFFLE_HASH": lambda self: self._parse_join_hint("SHUFFLE_HASH"),
@@ -102,13 +102,6 @@ class Spark2Parser(HiveParser):
             if self._match_text_seq("DROP", "COLUMNS")
             else None
         )
-
-    def _parse_interval_span(
-        self, this: exp.Expr, parse_function_unit: bool = True
-    ) -> exp.Interval:
-        if self._curr and self._curr.token_type in (TokenType.AND, TokenType.OR):
-            parse_function_unit = False
-        return super()._parse_interval_span(this, parse_function_unit=parse_function_unit)
 
     def _pivot_column_names(self, aggregations: list[exp.Expr]) -> list[str]:
         if len(aggregations) == 1:

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -228,14 +228,6 @@ class TestClickhouse(Validator):
             "SELECT * FROM t1 CROSS JOIN t2",
         )
         self.validate_identity(
-            "SELECT and(1, 2)",
-            "SELECT 1 AND 2",
-        )
-        self.validate_identity(
-            "SELECT or(1, 2)",
-            "SELECT 1 OR 2",
-        )
-        self.validate_identity(
             "SELECT generate_series FROM generate_series(0, 10) AS g",
             "SELECT generate_series FROM generate_series(0, 10) AS g(generate_series)",
         )
@@ -754,10 +746,6 @@ class TestClickhouse(Validator):
         self.validate_identity(
             "SELECT quantilesExactExclusive(0.25, 0.5, 0.75)(x) AS y FROM (SELECT number AS x FROM num)"
         )
-
-        self.validate_identity("SELECT or(0, 1, -2)", "SELECT 0 OR 1 OR -2")
-        self.validate_identity("SELECT and(1, 2, 3)", "SELECT 1 AND 2 AND 3")
-        self.validate_identity("SELECT or(and(3, 0), 5)", "SELECT (3 AND 0) OR 5")
 
         self.validate_identity("arrayCompact([1, 1, nan, nan, 2, 3, 3, 3])").assert_is(
             exp.ArrayCompact


### PR DESCRIPTION
Databricks allows and(a, b) as a function, but SQLGlot's parser only knew AND as a keyword. Adding AND to the function-name whitelist fixed the parsing, and a small override prevented a side-effect where the interval parser mistook AND ( for a function call.

```
 python3 -c "import sqlglot; expr = sqlglot.parse_one('SELECT and(a IS NOT NULL, b IS NOT NULL) FROM t', dialect='databricks'); print(expr.sql('databricks'))"
SELECT NOT a IS NULL AND NOT b IS NULL FROM t
```