### PR TITLE
fix(optimizer): restore FLOOR type annotation lost in ANNOTATORS refactor [CLAUDE]

### DIFF
--- a/sqlglot/typing/__init__.py
+++ b/sqlglot/typing/__init__.py
@@ -148,6 +148,7 @@ EXPRESSION_METADATA: ExprMetadataType = {
             exp.DayOfMonth,
             exp.DayOfWeek,
             exp.DayOfYear,
+            exp.Floor,
             exp.Getbit,
             exp.Hour,
             exp.TimestampDiff,

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -118,6 +118,12 @@ INT;
 UNICODE('bcd');
 INT;
 
+CEIL(tbl.double_col);
+INT;
+
+FLOOR(tbl.double_col);
+INT;
+
 LAST_DAY(tbl.timestamp_col);
 DATE;
 


### PR DESCRIPTION
### Problem

`FLOOR(...)` annotates to `UNKNOWN` in every dialect that doesn't explicitly override it, while its counterpart `CEIL(...)` annotates to `INT`:

```
sqlglot    CEIL -> INT    FLOOR -> UNKNOWN
mysql      CEIL -> INT    FLOOR -> UNKNOWN
duckdb     CEIL -> INT    FLOOR -> UNKNOWN
postgres   CEIL -> INT    FLOOR -> UNKNOWN
hive       CEIL -> INT    FLOOR -> UNKNOWN
spark      CEIL -> INT    FLOOR -> UNKNOWN
tsql       CEIL -> INT    FLOOR -> UNKNOWN
clickhouse CEIL -> INT    FLOOR -> UNKNOWN
```

### Cause

`exp.Floor` was part of the base `INT` annotator set until #3786 (`35ba6a77`, *"Move ANNOTATORS to Dialect for dialect-aware annotation"*). That PR moved the set from `annotate_types.py` into `Dialect.ANNOTATORS`, and `exp.Floor` was dropped on the way while `exp.Ceil` and the other entries survived. It has been missing ever since, through the later move into `sqlglot/typing/__init__.py`.

Presto, Snowflake and BigQuery each override `Ceil` and `Floor` **together** (they preserve the input type), so no dialect deliberately treats the two asymmetrically — which is likely why the omission went unnoticed.

### Fix

Restores `exp.Floor` to the base `INT` set, and adds dialect-agnostic fixture coverage for both `CEIL` and `FLOOR` so the two can't drift apart again.

After:

```
sqlglot/mysql/duckdb/postgres/hive/spark/tsql/clickhouse   CEIL -> INT     FLOOR -> INT
presto/snowflake/bigquery                                  CEIL -> DOUBLE  FLOOR -> DOUBLE
```

Dialects with their own `Floor` annotator are unaffected.

