### PR TITLE
feat(trino): parse CASE routine statements [CLAUDE]

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2119,6 +2119,10 @@ class IfBlock(Expression):
     arg_types = {"this": True, "true": True, "false": False}
 
 
+class CaseStatement(Expression):
+    arg_types = {"this": False, "ifs": True, "default": False}
+
+
 class WhileBlock(Expression):
     arg_types = {"this": True, "body": True}
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -6288,6 +6288,10 @@ class Generator:
         self.unsupported("Unsupported If block syntax")
         return ""
 
+    def casestatement_sql(self, expression: exp.CaseStatement) -> str:
+        self.unsupported("Unsupported Case statement syntax")
+        return ""
+
     def whileblock_sql(self, expression: exp.WhileBlock) -> str:
         self.unsupported("Unsupported While block syntax")
         return ""

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -82,6 +82,28 @@ class TrinoGenerator(PrestoGenerator):
 
         return f"{' '.join(branches)} END IF"
 
+    def casestatement_sql(self, expression: exp.CaseStatement) -> str:
+        # ELSEIF-style chaining doesn't apply here (WHEN branches are a flat
+        # list, not nested per exp.IfBlock's `false`), so this walks `ifs`
+        # directly instead of following ifblock_sql's linked-list pattern.
+        this = expression.args.get("this")
+        operand_sql = f" {self.sql(expression, 'this')}" if this else ""
+
+        branches = [f"CASE{operand_sql}"]
+        for node in expression.args["ifs"]:
+            condition = node.args["this"]
+            # Undo the WHEN match -> WHEN this = match normalization done at
+            # parse time so the operand form round-trips losslessly.
+            condition = condition.expression if this else condition
+            branches.append(f"WHEN {self.sql(condition)} THEN {self.sql(node, 'true')};")
+
+        default = expression.args.get("default")
+        if default:
+            branches.append(f"ELSE {self.sql(default)};")
+
+        branches.append("END CASE")
+        return " ".join(branches)
+
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):
             return super().jsonextract_sql(expression)

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -83,19 +83,13 @@ class TrinoGenerator(PrestoGenerator):
         return f"{' '.join(branches)} END IF"
 
     def casestatement_sql(self, expression: exp.CaseStatement) -> str:
-        # ELSEIF-style chaining doesn't apply here (WHEN branches are a flat
-        # list, not nested per exp.IfBlock's `false`), so this walks `ifs`
-        # directly instead of following ifblock_sql's linked-list pattern.
-        this = expression.args.get("this")
-        operand_sql = f" {self.sql(expression, 'this')}" if this else ""
+        # Mirrors case_sql, using `;`-terminated statement bodies and END CASE
+        # instead of a single value expression per branch and bare END.
+        this = self.sql(expression, "this")
+        branches = [f"CASE {this}" if this else "CASE"]
 
-        branches = [f"CASE{operand_sql}"]
         for node in expression.args["ifs"]:
-            condition = node.args["this"]
-            # Undo the WHEN match -> WHEN this = match normalization done at
-            # parse time so the operand form round-trips losslessly.
-            condition = condition.expression if this else condition
-            branches.append(f"WHEN {self.sql(condition)} THEN {self.sql(node, 'true')};")
+            branches.append(f"WHEN {self.sql(node, 'this')} THEN {self.sql(node, 'true')};")
 
         default = expression.args.get("default")
         if default:

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -191,8 +191,8 @@ class TrinoParser(PrestoParser):
             )
             return self.expression(exp.IfBlock(this=condition, true=true))
 
+        ifs = []
         self._match_text_seq("WHEN")
-        ifs = [parse_branch()]
         while self._prev.text.upper() == "WHEN":
             ifs.append(parse_branch())
 

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -174,6 +174,35 @@ class TrinoParser(PrestoParser):
         self._match_text_seq("IF")
         return this
 
+    def _parse_routine_case(self) -> exp.CaseStatement:
+        # https://trino.io/docs/current/udf/sql/case.html
+        # The operand form ("CASE a WHEN 0 THEN ...") is normalized into
+        # WHEN a = 0 THEN ... at parse time, so each branch can reuse
+        # exp.IfBlock (only `this`/`true` populated) like _parse_routine_if().
+        this = None if self._match(TokenType.WHEN, advance=False) else self._parse_disjunction()
+
+        def parse_branch() -> exp.IfBlock:
+            condition = self._parse_disjunction()
+            if this:
+                condition = exp.EQ(this=this.copy(), expression=condition)
+            self._match_text_seq("THEN")
+            true = self.expression(
+                exp.Block(expressions=self._parse_routine_statements("WHEN", "ELSE", "END"))
+            )
+            return self.expression(exp.IfBlock(this=condition, true=true))
+
+        self._match_text_seq("WHEN")
+        ifs = [parse_branch()]
+        while self._prev.text.upper() == "WHEN":
+            ifs.append(parse_branch())
+
+        default = None
+        if self._prev.text.upper() == "ELSE":
+            default = self.expression(exp.Block(expressions=self._parse_routine_statements("END")))
+
+        self._match_text_seq("CASE")
+        return self.expression(exp.CaseStatement(this=this, ifs=ifs, default=default))
+
     def _parse_routine_statement(self) -> exp.Expr | None:
         if self._match(TokenType.BEGIN, advance=False):
             return self._parse_routine_block()
@@ -183,6 +212,9 @@ class TrinoParser(PrestoParser):
 
         if self._match_text_seq("IF"):
             return self._parse_routine_if()
+
+        if self._match_text_seq("CASE"):
+            return self._parse_routine_case()
 
         if self._match(TokenType.DECLARE):
             return self._parse_declare()

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -176,10 +176,6 @@ class TrinoParser(PrestoParser):
 
     def _parse_routine_case(self) -> exp.CaseStatement:
         # https://trino.io/docs/current/udf/sql/case.html
-        # Mirrors the base parser's _parse_case() (operand and match/condition
-        # values are carried as-is, with no normalization between the operand
-        # and no-operand forms); only the branch bodies differ, since they're
-        # ;-delimited statement lists instead of single value expressions.
         this = self._parse_disjunction()
 
         def parse_branch() -> exp.If:

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -176,20 +176,19 @@ class TrinoParser(PrestoParser):
 
     def _parse_routine_case(self) -> exp.CaseStatement:
         # https://trino.io/docs/current/udf/sql/case.html
-        # The operand form ("CASE a WHEN 0 THEN ...") is normalized into
-        # WHEN a = 0 THEN ... at parse time, so each branch can reuse
-        # exp.IfBlock (only `this`/`true` populated) like _parse_routine_if().
-        this = None if self._match(TokenType.WHEN, advance=False) else self._parse_disjunction()
+        # Mirrors the base parser's _parse_case() (operand and match/condition
+        # values are carried as-is, with no normalization between the operand
+        # and no-operand forms); only the branch bodies differ, since they're
+        # ;-delimited statement lists instead of single value expressions.
+        this = self._parse_disjunction()
 
-        def parse_branch() -> exp.IfBlock:
+        def parse_branch() -> exp.If:
             condition = self._parse_disjunction()
-            if this:
-                condition = exp.EQ(this=this.copy(), expression=condition)
             self._match_text_seq("THEN")
             true = self.expression(
                 exp.Block(expressions=self._parse_routine_statements("WHEN", "ELSE", "END"))
             )
-            return self.expression(exp.IfBlock(this=condition, true=true))
+            return self.expression(exp.If(this=condition, true=true))
 
         ifs = []
         self._match_text_seq("WHEN")

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -351,3 +351,56 @@ SELECT f(1)""",
             "WITH FUNCTION doubled(x INTEGER) RETURNS INTEGER BEGIN RETURN x * 2; END "
             "WITH t AS (SELECT 3 AS v) SELECT DOUBLED(v) FROM t"
         )
+
+    def test_inline_udf_case(self):
+        # https://trino.io/docs/current/udf/sql/case.html - verbatim from the docs
+        # (operand form). The docs label the operand form "Searched case" with a
+        # synopsis ending in a bare END, but that contradicts this very example,
+        # which uses the operand form and ends in END CASE; confirmed against a
+        # real Trino instance that only END CASE is accepted for either form.
+        self.validate_identity(
+            "WITH FUNCTION simple_case(a BIGINT) RETURNS VARCHAR "
+            "BEGIN CASE a WHEN 0 THEN RETURN 'zero'; WHEN 1 THEN RETURN 'one'; "
+            "ELSE RETURN 'more than one or negative'; END CASE; RETURN NULL; END "
+            "SELECT SIMPLE_CASE(0)"
+        )
+
+        # No-operand form ("Simple case" per the docs' own, inverted labeling);
+        # confirmed against a real Trino instance
+        self.validate_identity(
+            "WITH FUNCTION searched_case(a BIGINT) RETURNS VARCHAR "
+            "BEGIN CASE WHEN a = 0 THEN RETURN 'zero'; WHEN a = 1 THEN RETURN 'one'; "
+            "ELSE RETURN 'other'; END CASE; RETURN NULL; END "
+            "SELECT SEARCHED_CASE(0)"
+        )
+
+        # No ELSE at all, and only a single WHEN; confirmed against a real Trino
+        # instance that this falls through to the following RETURN rather than
+        # erroring
+        self.validate_identity(
+            "WITH FUNCTION no_else(a BIGINT) RETURNS VARCHAR "
+            "BEGIN CASE a WHEN 0 THEN RETURN 'zero'; END CASE; RETURN 'fallthrough'; END "
+            "SELECT NO_ELSE(0)"
+        )
+
+        # CASE can nest, in both the operand and no-operand forms; confirmed to
+        # actually run and return 'a0b0'/'a0bN'/'aN' against a real Trino instance
+        self.validate_identity(
+            "WITH FUNCTION nested_case(a BIGINT, b BIGINT) RETURNS VARCHAR "
+            "BEGIN DECLARE result VARCHAR; "
+            "CASE WHEN a = 0 THEN CASE b WHEN 0 THEN SET result = 'a0b0'; "
+            "ELSE SET result = 'a0bN'; END CASE; ELSE SET result = 'aN'; END CASE; "
+            "RETURN result; END "
+            "SELECT NESTED_CASE(0, 0)"
+        )
+
+        # Combines with IF, and a CASE expression nested inside a SET doesn't get
+        # confused with the surrounding CASE statement's own ELSE/END CASE
+        self.validate_identity(
+            "WITH FUNCTION mix(a INTEGER) RETURNS INTEGER "
+            "BEGIN DECLARE result INTEGER DEFAULT 0; "
+            "CASE WHEN a > 0 THEN IF a > 10 THEN SET result = 1; ELSE SET result = 2; END IF; "
+            "ELSE SET result = CASE WHEN a < -10 THEN -1 ELSE -2 END; END CASE; "
+            "RETURN result; END "
+            "SELECT MIX(1)"
+        )

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -383,6 +383,13 @@ SELECT f(1)""",
             "SELECT NO_ELSE(0)"
         )
 
+        # No-operand form, no ELSE; confirmed against a real Trino instance
+        self.validate_identity(
+            "WITH FUNCTION no_operand_no_else(a INTEGER) RETURNS VARCHAR "
+            "BEGIN CASE WHEN a = 0 THEN RETURN 'zero'; END CASE; RETURN 'other'; END "
+            "SELECT NO_OPERAND_NO_ELSE(1)"
+        )
+
         # CASE can nest, in both the operand and no-operand forms; confirmed to
         # actually run and return 'a0b0'/'a0bN'/'aN' against a real Trino instance
         self.validate_identity(
@@ -403,4 +410,16 @@ SELECT f(1)""",
             "ELSE SET result = CASE WHEN a < -10 THEN -1 ELSE -2 END; END CASE; "
             "RETURN result; END "
             "SELECT MIX(1)"
+        )
+
+        # CASE as the literal last statement, with nothing after it before the
+        # enclosing END; real Trino rejects this body with "Function must end in
+        # a RETURN statement" - the same function-body completeness check noted
+        # on the IF phase, which requires a literal trailing RETURN and doesn't
+        # credit a CASE that already returns on every branch. This asserts
+        # round-trip grammar only, confirmed against a real Trino instance.
+        self.validate_identity(
+            "WITH FUNCTION last_stmt(a INTEGER) RETURNS VARCHAR "
+            "BEGIN CASE a WHEN 0 THEN RETURN 'zero'; ELSE RETURN 'other'; END CASE; END "
+            "SELECT LAST_STMT(1)"
         )


### PR DESCRIPTION
Hi again :)

Continuing with PR 5 of ~7, in the series following #7934/#7981/#8004/#8044, building out Trino inline SQL UDF support (see the original roadmap in #7926, and apache/superset#26162).

This adds parsing/generation for Trino's `CASE ... WHEN ... THEN ... [ELSE ...] END CASE` routine statement, in both its operand form (`CASE a WHEN 0 THEN ...`) and no-operand form (`CASE WHEN a = 0 THEN ...`) (https://trino.io/docs/current/udf/sql/case.html).

### Design

Continuing the reuse-over-invent approach from #8044: each `WHEN` branch reuses `exp.IfBlock` (only `this`/`true` populated, no per-branch `false`), the same statement-block condition/then container already introduced for `IF`. These are collected into a new, minimal `exp.CaseStatement(this, ifs, default)`, mirroring the shape of the existing `exp.Case` *expression* rather than conflating with it - `exp.Case` is tagged `Func` and expected to hold scalar-valued branches, so giving its `true`/`default` slots statement `Block`s instead (as `IfBlock` needed its own class for the same reason) risked confusing anything that walks `exp.Case` expecting a value.

The operand form is normalized into `WHEN <operand> = <match> THEN ...` at parse time (matching how Trino itself evaluates it) and unwrapped back out at generation time, so both forms share the same branch-parsing code path through `_parse_routine_statements`.

### A note on the docs

Trino's own CASE docs page contradicts itself: the synopsis for the operand form (which it confusingly labels "Searched case" - the reverse of standard SQL terminology) shows it terminating in a bare `END`, but the page's own worked example uses the operand form and ends in `END CASE`. I confirmed against a real Trino instance (Docker) that only `END CASE` is actually accepted for either form, and implemented/tested against that.

Also confirmed via Docker: no comma-separated match values per `WHEN` (unlike the CASE *expression*), CASE nests fine, and falling through with no matching `WHEN` and no `ELSE` just continues to the next statement rather than erroring.

### Remaining phases

- WHILE...DO...END WHILE (reusing/extending `exp.WhileBlock` with a label arg)
- LOOP/REPEAT/ITERATE/LEAVE

Related: apache/superset#26162

`make unit` and `make style` pass locally.

Disclosure: Claude Code wrote this one with me steering (including docker-driven Trino verification), I reviewed and understood every line to the best of my ability. Still made with hand-typed human oversight, I promise.