### PR TITLE
feat(optimizer): allow predicate pushdown through window function partition columns

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -245,22 +245,43 @@ def nodes_for_predicate(
                 nodes[table] = node
 
         if isinstance(node, exp.Select) and len(tables) == 1:
-            # We can't push down window expressions
-            has_window_expression = any(
+            window_expressions = [
                 select for select in node.selects if find_in_scope(select, exp.Window)
-            )
+            ]
+
             # we can't push down predicates to select statements if they are referenced in
             # multiple places.
             if (
                 not node.args.get("group")
                 and scope_ref_count[id(source)] < 2
-                and not has_window_expression
                 # LIMIT/OFFSET and QUALIFY select rows before the outer predicate runs
                 and not node.args.get("limit")
                 and not node.args.get("offset")
                 and not node.args.get("qualify")
             ):
-                nodes[table] = node
+                can_pushdown = True
+                if window_expressions:
+                    inner_predicate = replace_aliases(node, predicate)
+                    predicate_cols = {c.name for c in inner_predicate.find_all(exp.Column)}
+
+                    for select in window_expressions:
+                        for window in select.find_all(exp.Window):
+                            partition_by = window.args.get("partition_by")
+                            if not partition_by:
+                                can_pushdown = False
+                                break
+
+                            partition_cols = {
+                                c.name for part in partition_by for c in part.find_all(exp.Column)
+                            }
+                            if not predicate_cols.issubset(partition_cols):
+                                can_pushdown = False
+                                break
+                        if not can_pushdown:
+                            break
+
+                if can_pushdown:
+                    nodes[table] = node
     return nodes
 
 

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -111,3 +111,23 @@ SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3
 -- A FULL JOIN preserves both sides, so a WHERE predicate on either of them can't be pushed down
 SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
 SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
+
+-- Pushdown predicate through window functions when filtering strictly on partition columns
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.a = 1;
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x WHERE x.a = 1) SELECT t1.a, t1.b FROM t1 WHERE TRUE;
+
+-- Predicate cannot be pushed down because it filters on a non-partition column
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.b = 1;
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.a) AS row_num FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.b = 1;
+
+-- Multiple window functions: predicate must be in ALL partition keys
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS rn1, RANK() OVER (PARTITION BY x.a, x.b) AS rn2 FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.a = 1;
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS rn1, RANK() OVER (PARTITION BY x.a, x.b) AS rn2 FROM x WHERE x.a = 1) SELECT t1.a, t1.b FROM t1 WHERE TRUE;
+
+-- Multiple window functions: predicate not in ALL partition keys (rn1 only partitions by x.a)
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS rn1, RANK() OVER (PARTITION BY x.a, x.b) AS rn2 FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.b = 1;
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (PARTITION BY x.a ORDER BY x.b) AS rn1, RANK() OVER (PARTITION BY x.a, x.b) AS rn2 FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.b = 1;
+
+-- Window function without PARTITION BY (blocks all pushdown)
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (ORDER BY x.a) AS row_num FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.a = 1;
+WITH t1 AS (SELECT x.a, x.b, ROW_NUMBER() OVER (ORDER BY x.a) AS row_num FROM x) SELECT t1.a, t1.b FROM t1 WHERE t1.a = 1;


### PR DESCRIPTION
### Description
Currently, the optimizer's `pushdown_predicates` rule completely blocks pushing down predicates into `Select` nodes if they contain any `Window` expressions. 

This PR enhances the optimizer to safely push down predicates through window functions **if and only if** the predicate strictly filters on columns that are part of the `PARTITION BY` clause of **all** window functions in that scope.

This optimization is mathematically safe (filtering on partition boundaries does not affect window calculations within the partitions) and significantly improves query performance for partitioned window queries.

### Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked that my code passes all tests (`make test` or `python -m unittest tests.test_optimizer`)


Fixes #8071
