### PR TITLE
fix(sqlite)!: preserve json_extract semantics instead of rewriting to -> [CLAUDE]

### DIFF
--- a/sqlglot/expressions/json.py
+++ b/sqlglot/expressions/json.py
@@ -133,6 +133,7 @@ class JSONExtractScalar(Expression, Binary, Func):
         "expressions": False,
         "json_type": False,
         "scalar_only": False,
+        "json_subtype": False,
     }
     _sql_names = ["JSON_EXTRACT_SCALAR"]
     is_var_len_args = True

--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -163,7 +163,6 @@ class SQLiteGenerator(generator.Generator):
         exp.JSONArrayAgg: unsupported_args("order", "null_handling", "return_type", "strict")(
             rename_func("JSON_GROUP_ARRAY")
         ),
-        exp.JSONExtractScalar: arrow_json_extract_sql,
         exp.JSONObjectAgg: lambda self, e: self._jsonobject_sql(e, name="JSON_GROUP_OBJECT"),
         exp.Levenshtein: unsupported_args("ins_cost", "del_cost", "sub_cost", "max_dist")(
             rename_func("EDITDIST3")
@@ -227,6 +226,13 @@ class SQLiteGenerator(generator.Generator):
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if expression.expressions:
             return self.function_fallback_sql(expression)
+        return arrow_json_extract_sql(self, expression)
+
+    def jsonextractscalar_sql(self, expression: exp.JSONExtractScalar) -> str:
+        if expression.args.get("json_subtype"):
+            # json_extract() keeps the JSON subtype on object/array results;
+            # ->> strips it, observable when the result feeds another JSON function
+            return self.func("JSON_EXTRACT", expression.this, expression.expression)
         return arrow_json_extract_sql(self, expression)
 
     def dateadd_sql(self, expression: exp.DateAdd) -> str:

--- a/sqlglot/parsers/sqlite.py
+++ b/sqlglot/parsers/sqlite.py
@@ -15,6 +15,17 @@ def _build_strftime(args: list) -> exp.Anonymous | exp.TimeToStr:
     return exp.Anonymous(this="STRFTIME", expressions=args)
 
 
+def _build_json_extract(args: list, dialect: t.Any) -> exp.JSONExtract | exp.JSONExtractScalar:
+    # Single-path json_extract() returns an SQL representation like ->>, except
+    # that object/array results keep the JSON subtype (json_subtype); the
+    # multi-path form returns a JSON array. https://www.sqlite.org/json1.html#jex
+    if len(args) == 2:
+        extract = parser.build_extract_json_with_path(exp.JSONExtractScalar)(args, dialect)
+        extract.set("json_subtype", True)
+        return extract
+    return parser.build_extract_json_with_path(exp.JSONExtract)(args, dialect)
+
+
 class SQLiteParser(parser.Parser):
     STRING_ALIASES = True
     ALTER_RENAME_REQUIRES_COLUMN = False
@@ -30,6 +41,7 @@ class SQLiteParser(parser.Parser):
         **parser.Parser.FUNCTIONS,
         "DATETIME": lambda args: exp.Anonymous(this="DATETIME", expressions=args),
         "EDITDIST3": exp.Levenshtein.from_arg_list,
+        "JSON_EXTRACT": _build_json_extract,
         "JSON_GROUP_ARRAY": exp.JSONArrayAgg.from_arg_list,
         "JSON_GROUP_OBJECT": lambda args: exp.JSONObjectAgg(expressions=args),
         "STRFTIME": _build_strftime,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1000,9 +1000,6 @@ class TestMySQL(Validator):
         )
         self.validate_all(
             "SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]')",
-            read={
-                "sqlite": "SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]')",
-            },
             write={
                 "mysql": "SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[1]')",
                 "sqlite": "SELECT '[10, 20, [30, 40]]' -> '$[1]'",

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -51,6 +51,28 @@ class TestSQLite(Validator):
         self.validate_identity(
             "SELECT JSON_EXTRACT('[10, 20, [30, 40]]', '$[2]', '$[0]', '$[1]')",
         )
+        # Single-path json_extract() returns an SQL value like ->>, except that
+        # object/array results keep the JSON subtype (json_subtype variant);
+        # each of the three spellings round-trips to itself
+        self.validate_identity("SELECT JSON_EXTRACT(a, '$.k') FROM t")
+        self.validate_identity("SELECT a -> '$.k' FROM t")
+        self.validate_identity("SELECT a ->> '$.k' FROM t")
+        self.validate_identity("SELECT JSON_SET('{}', '$.x', JSON_EXTRACT(a, '$.k'))")
+        fn = (
+            self.parse_one("SELECT JSON_EXTRACT(a, '$.k') FROM t")
+            .selects[0]
+            .assert_is(exp.JSONExtractScalar)
+        )
+        op = self.parse_one("SELECT a ->> '$.k' FROM t").selects[0].assert_is(exp.JSONExtractScalar)
+        self.assertTrue(fn.args.get("json_subtype"))
+        self.assertNotEqual(fn, op)
+        self.validate_all(
+            "SELECT JSON_EXTRACT(a, '$.k') FROM t",
+            write={
+                "postgres": "SELECT JSON_EXTRACT_PATH_TEXT(a, 'k') FROM t",
+                "mysql": "SELECT a ->> '$.k' FROM t",
+            },
+        )
         self.validate_identity(
             """SELECT item AS "item", some AS "some" FROM data WHERE (item = 'value_1' COLLATE NOCASE) AND (some = 't' COLLATE NOCASE) ORDER BY item ASC LIMIT 1 OFFSET 0"""
         )


### PR DESCRIPTION
Fixes #8076.

## Before / after

```python
import sqlglot
print(sqlglot.parse_one("SELECT json_extract(a, '$.k') FROM t", read="sqlite").sql(dialect="sqlite"))
# before: SELECT a -> '$.k' FROM t              (JSON representation — wrong value AND type on every scalar)
# after : SELECT JSON_EXTRACT(a, '$.k') FROM t  (the caller's spelling and semantics, exactly)
```

Engine ground truth (SQLite 3.53.x):

```
sqlite> SELECT json_extract('{"k":"v"}', '$.k'), '{"k":"v"}' -> '$.k', '{"k":"v"}' ->> '$.k';
v|"v"|v
sqlite> SELECT json_set('{}', '$.x', json_extract('{"a":{"b":1}}', '$.a')), json_set('{}', '$.x', '{"a":{"b":1}}' ->> '$.a');
{"x":{"b":1}}|{"x":"{\"b\":1}"}
```

## What SQLite actually does

Single-path `json_extract` returns an SQL representation like `->>` — same value and SQLite `typeof()` across all nine JSON cases — except that object/array results keep SQLite's JSON subtype (second query above). So neither existing node captures it exactly, and the current `->` rendering is wrong on every scalar.

## The representation

Single-path `json_extract` now parses to `exp.JSONExtractScalar` carrying an optional `json_subtype` arg recording that variant — `scalar_only` and `json_type` already model this family's other per-dialect variants. The sqlite generator maps each spelling back to itself:

- `JSON_EXTRACT(a, path)` ⇄ `JSONExtractScalar` with `json_subtype=True`
- `a ->> path` ⇄ `JSONExtractScalar` (bare)
- `a -> path` ⇄ `JSONExtract` (unchanged)
- multi-path `json_extract` (returns a JSON array) ⇄ `JSONExtract` (unchanged)

All three spellings round-trip to themselves with exact semantics, including through nested JSON functions.

## Cross-dialect effect

Other dialects ignore `json_subtype` and generate the node through their existing `JSONExtractScalar` pathway. Output for sqlite-origin `json_extract` therefore changes from the JSON-representation functions (`JSON_EXTRACT_PATH`, mysql `JSON_EXTRACT`) to the scalar ones (`JSON_EXTRACT_PATH_TEXT`, `->>`), matching the source's scalar semantics for primitives. Those outputs are pinned by test, with no claim of exact cross-dialect type preservation (e.g. `JSON_EXTRACT_PATH_TEXT` returns text where SQLite returns a typed value — a pre-existing property of the scalar pathway).

Marked `!`: read="sqlite" trees change node type for single-path `json_extract`. On main, `json_extract(x, '$.a')` and `x -> '$.a'` parse to equal `JSONExtract` nodes; this PR intentionally separates them, since SQLite gives the two spellings different value, type, and subtype semantics — downstream AST equality checks and class-based dispatch will observe the change.

*Developed with LLM assistance; every engine result was run against live SQLite.*
