### PR TITLE
fix(postgres)!: parse JSON operators at the || precedence tier [CLAUDE]

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1071,6 +1071,10 @@ class Parser:
         TokenType.DCOLON,
     }
 
+    # Column operators that a dialect instead parses as ordinary binary operators in the
+    # _parse_bitwise tier (with ||), so their operands bind at the engine's precedence
+    BITWISE_COLUMN_OPERATORS: t.ClassVar[dict[TokenType, t.Callable]] = {}
+
     EXPRESSION_PARSERS: t.ClassVar = {
         exp.Cluster: lambda self: self._parse_sort(exp.Cluster, TokenType.CLUSTER_BY),
         exp.Column: lambda self: self._parse_column(),
@@ -6245,6 +6249,10 @@ class Parser:
                         expression=self._parse_term(),
                         safe=not self.dialect.STRICT_STRING_CONCAT,
                     )
+                )
+            elif self.BITWISE_COLUMN_OPERATORS and self._match_set(self.BITWISE_COLUMN_OPERATORS):
+                this = self.BITWISE_COLUMN_OPERATORS[self._prev.token_type](
+                    self, this, self._parse_term()
                 )
             elif self._match(TokenType.DQMARK):
                 this = self.expression(

--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -191,7 +191,22 @@ class PostgresParser(parser.Parser):
     JSON_ARROWS_REQUIRE_JSON_TYPE = True
 
     COLUMN_OPERATORS = {
-        **parser.Parser.COLUMN_OPERATORS,
+        k: v
+        for k, v in parser.Parser.COLUMN_OPERATORS.items()
+        if k
+        not in (
+            TokenType.ARROW,
+            TokenType.DARROW,
+            TokenType.HASH_ARROW,
+            TokenType.DHASH_ARROW,
+            TokenType.PLACEHOLDER,
+        )
+    }
+
+    # Postgres puts the JSON operators in the same tier as ||, below + and -, left
+    # associative — not in the accessor tier with :: and .
+    # https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
+    BITWISE_COLUMN_OPERATORS = {
         TokenType.ARROW: lambda self, this, path: self.validate_expression(
             build_json_extract_path(
                 exp.JSONExtract, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
@@ -201,6 +216,15 @@ class PostgresParser(parser.Parser):
             build_json_extract_path(
                 exp.JSONExtractScalar, arrow_req_json_type=self.JSON_ARROWS_REQUIRE_JSON_TYPE
             )([this, path])
+        ),
+        TokenType.HASH_ARROW: lambda self, this, path: self.expression(
+            exp.JSONBExtract(this=this, expression=path)
+        ),
+        TokenType.DHASH_ARROW: lambda self, this, path: self.expression(
+            exp.JSONBExtractScalar(this=this, expression=path)
+        ),
+        TokenType.PLACEHOLDER: lambda self, this, key: self.expression(
+            exp.JSONBContains(this=this, expression=key)
         ),
     }
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1163,6 +1163,81 @@ FROM json_data, field_ids""",
             "SELECT * FROM schema_name.table_name AS st WHERE JSON_EXTRACT_PATH_TEXT(CAST((st.data) AS JSON), VARIADIC ARRAY[CAST('test' AS TEXT)]) = CAST('test' AS TEXT)",
         )
 
+    def test_json_operator_precedence(self):
+        # Postgres parses ->, ->>, #>, #>> and ? in the same tier as ||, below + and -,
+        # left associative
+        # https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-PRECEDENCE
+
+        # Casts and subscripts bind to the operand
+        self.validate_identity(
+            """SELECT '{"a":4}'::jsonb #>> '{a}'::text[]""",
+            """SELECT CAST('{"a":4}' AS JSONB) #>> CAST('{a}' AS TEXT[])""",
+        ).assert_is(exp.Select).selects[0].assert_is(exp.JSONBExtractScalar).expression.assert_is(
+            exp.Cast
+        )
+        self.validate_identity("SELECT a -> b[1]", "SELECT JSON_EXTRACT_PATH(a, b[1])")
+
+        # Left associativity holds for qualified operands
+        self.validate_identity(
+            "SELECT a -> b.c -> d",
+            "SELECT JSON_EXTRACT_PATH(JSON_EXTRACT_PATH(a, b.c), d)",
+        )
+
+        # + binds tighter, so it belongs to the operand: j -> (1 + 1)
+        self.parse_one("SELECT j -> 1 + 1").selects[0].assert_is(
+            exp.JSONExtract
+        ).expression.assert_is(exp.Add)
+
+        # || is in the same tier: left of the operator it applies first, right of it last
+        self.validate_identity("SELECT 'x' || j ->> 'a'").assert_is(exp.Select).selects[
+            0
+        ].assert_is(exp.JSONExtractScalar).this.assert_is(exp.DPipe)
+        # A non-field right operand (like -1) must not swallow the rest of the tier
+        self.validate_identity(
+            "SELECT j ->> -1 || 'z'", "SELECT JSON_EXTRACT_PATH_TEXT(j, -1) || 'z'"
+        )
+        self.parse_one("SELECT x ->> 'a' || 'z'").selects[0].assert_is(exp.DPipe)
+
+        # - binds tighter than the JSON operators
+        self.validate_identity(
+            """SELECT '{"a":1,"b":2}'::jsonb - 'b' -> 'a'""",
+            """SELECT CAST('{"a":1,"b":2}' AS JSONB) - 'b' -> 'a'""",
+        )
+
+        # ? stops at boolean operators
+        self.parse_one("SELECT a ? 'k' AND b").selects[0].assert_is(exp.And)
+
+        # Casts on the right operand, for every operator
+        self.validate_identity(
+            """SELECT '{"a":{"b":4}}'::jsonb #> '{a}'::text[]""",
+            """SELECT CAST('{"a":{"b":4}}' AS JSONB) #> CAST('{a}' AS TEXT[])""",
+        )
+        self.validate_identity(
+            """SELECT '{"a":4}'::jsonb -> 'a'::text""",
+            """SELECT JSON_EXTRACT_PATH(CAST('{"a":4}' AS JSONB), CAST('a' AS TEXT))""",
+        )
+        self.validate_identity(
+            """SELECT '{"a":4}'::jsonb ->> 'a'::text""",
+            """SELECT JSON_EXTRACT_PATH_TEXT(CAST('{"a":4}' AS JSONB), CAST('a' AS TEXT))""",
+        )
+        self.validate_identity(
+            """SELECT '{"a":4}'::jsonb ? 'a'::text""",
+            """SELECT CAST('{"a":4}' AS JSONB) ? CAST('a' AS TEXT)""",
+        )
+
+        # This is how pg_get_indexdef() renders an expression index over a JSON path
+        self.validate_identity(
+            "CREATE INDEX ix_spans_session_id ON spans (((attributes #>> '{session,id}'::text[])::character varying))",
+            "CREATE INDEX ix_spans_session_id ON spans((CAST((attributes #>> CAST('{session,id}' AS TEXT[])) AS VARCHAR)))",
+        )
+
+        self.validate_identity("x #> y[1]").assert_is(exp.JSONBExtract).expression.assert_is(
+            exp.Bracket
+        )
+        self.validate_identity("x #> y.z #> w").assert_is(exp.JSONBExtract).this.assert_is(
+            exp.JSONBExtract
+        )
+
     def test_ddl(self):
         # Checks that user-defined types are parsed into DataType instead of Identifier
         self.parse_one("CREATE TABLE t (a udt)").this.expressions[0].args["kind"].assert_is(

--- a/tests/dialects/test_singlestore.py
+++ b/tests/dialects/test_singlestore.py
@@ -22,6 +22,11 @@ class TestSingleStore(Validator):
         self.validate_identity("SELECT ELT(2, 'foo', 'bar', 'baz')")
         self.validate_identity("SELECT CHARSET(CHAR(100 USING utf8))")
         self.validate_identity("SELECT TO_JSON(ROW(1, 2) :> RECORD(a INT, b INT))")
+        # `::` takes a field name, not an expression, so a cast that follows it applies
+        # to the extracted value
+        self.validate_identity(
+            "SELECT a::b :> INT FROM t", "SELECT JSON_EXTRACT_JSON(a, 'b') :> INT FROM t"
+        )
 
         self.validate_identity("JSON_KEYS(json_doc, 'a', 'b', 'c', 2)")
         self.validate_identity("SELECT VERSION()")


### PR DESCRIPTION
Fixes #8035 — all four operand-binding cases — by parsing the five JSON operators at the precedence tier Postgres actually gives them. (A narrower `_parse_column_ops` patch covering cases 1–3 was offered in the issue and invited by a collaborator; this PR takes the tier approach instead so that case 4 is fixed as well — happy to narrow to the invited patch if that is preferred.)

## Before / after

```python
import sqlglot  # read="postgres", write="postgres"

"SELECT '{\"a\":4}'::jsonb #>> '{a}'::text[]"     # the pg_get_indexdef() form
# before: SELECT CAST(CAST('{"a":4}' AS JSONB) #>> '{a}' AS TEXT[])   -- malformed array literal
# after : SELECT CAST('{"a":4}' AS JSONB) #>> CAST('{a}' AS TEXT[])   -- returns 4

"SELECT a -> b[1]"
# before: SELECT JSON_EXTRACT_PATH(a, b)[1]
# after : SELECT JSON_EXTRACT_PATH(a, b[1])

"SELECT a -> b.c -> d"
# before: SELECT JSON_EXTRACT_PATH(a, JSON_EXTRACT_PATH(b.c, d))
# after : SELECT JSON_EXTRACT_PATH(JSON_EXTRACT_PATH(a, b.c), d)

"SELECT '[1,2,3]'::json -> 1 + 1"                 # case 4 — out of reach for an operand-level fix
# before: root node Add: (json -> 1) + 1          -- errors: operator does not exist: json + integer
# after : JSON_EXTRACT_PATH(CAST('[1,2,3]' AS JSON), 1 + 1)   -- engine returns 3
```

Also now correct (engine-documented groupings the accessor tier could never produce):

- `'x' || j ->> 'a'` → `('x' || j) ->> 'a'` (PG runs `||` first — its error message proves it)
- `j ->> -1 || 'z'` → `(j ->> -1) || 'z'` (previously the `-1` swallowed the `|| 'z'` via the loose RHS fallback)
- `jsonb - 'b' -> 'a'` → `(jsonb - 'b') -> 'a'` (`-` binds tighter)

## Mechanism

The base parser gains `BITWISE_COLUMN_OPERATORS` — an empty per-dialect hook in the `_parse_bitwise` loop (two lines in the loop, one class var). Postgres moves the five operators there, keeping its existing node builders, and removes them from `COLUMN_OPERATORS`. Operands are parsed with `_parse_term`, so casts/subscripts/qualification/`+`/`-` bind to the operand and the shared loop supplies left associativity with `||`. The hook reuses the existing left-associative loop rather than copying `_parse_bitwise` into the postgres parser; its empty default leaves every other dialect unchanged.

## Scope boundaries (stated, not hidden)

- Postgres and its subclasses (Materialize, RisingWave, Redshift) only; their suites pass, but their engines' precedence was not independently re-verified. Other dialects keep accessor behaviour; DuckDB (`->` as lambda coexists) is a follow-up.
- Same-tier operators parsed via `RANGE_PARSERS` (`@>`, `<@`, `?|`, `?&`, `#-`, `@?`) are not moved: mixed chains like `a @> b -> c` keep their current grouping.
- `MIN(a -> '$.x')` still parses as a lambda (#8074) — `_parse_lambda` claims the arrow before any expression tier runs; independent defect.

Marked `!`: trees change for every previously-misparsed input. Full suite green (pure Python); zero existing fixtures needed updating — which is itself the wrong-tree-right-text blindness these misparses exploit; the new `test_json_operator_precedence` block pins the corrected groupings with node-type assertions.

*Developed with LLM assistance; groupings verified against PostgreSQL 17.10 and DuckDB 1.5.5 engine results documented in tobymao/sqlglot#8035.*

