### PR TITLE
fix(sqlite)!: support GROUP_CONCAT with ORDER BY (SQLite 3.44+) [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -308,13 +308,23 @@ class SQLiteGenerator(generator.Generator):
         else:
             distinct_sql = ""
 
+        order_sql = ""
         if isinstance(expression.this, exp.Order):
-            self.unsupported("SQLite GROUP_CONCAT doesn't support ORDER BY.")
             if expression.this.this and not distinct:
                 this = expression.this.this
 
+            # ORDER BY within aggregates requires SQLite 3.44+
+            order = expression.this.copy()
+            order.set("this", None)
+            order_sql = self.sql(order)
+
         separator = expression.args.get("separator")
-        return f"GROUP_CONCAT({distinct_sql}{self.format_args(this, separator)})"
+        if distinct and separator:
+            # SQLite rejects DISTINCT aggregates with more than one argument
+            self.unsupported("SQLite GROUP_CONCAT does not support DISTINCT with a separator")
+            separator = None
+
+        return f"GROUP_CONCAT({distinct_sql}{self.format_args(this, separator)}{order_sql})"
 
     def least_sql(self, expression: exp.Least) -> str:
         if expression.expressions:

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1130,7 +1130,7 @@ class TestMySQL(Validator):
             "GROUP_CONCAT(DISTINCT x ORDER BY y DESC)",
             write={
                 "mysql": "GROUP_CONCAT(DISTINCT x ORDER BY y DESC SEPARATOR ',')",
-                "sqlite": "GROUP_CONCAT(DISTINCT x)",
+                "sqlite": "GROUP_CONCAT(DISTINCT x ORDER BY y DESC)",
                 "tsql": "STRING_AGG(x, ',') WITHIN GROUP (ORDER BY y DESC)",
                 "databricks": "LISTAGG(DISTINCT x, ',') WITHIN GROUP (ORDER BY y DESC)",
                 "postgres": "STRING_AGG(DISTINCT x, ',' ORDER BY y DESC NULLS LAST)",
@@ -1140,7 +1140,7 @@ class TestMySQL(Validator):
             "GROUP_CONCAT(x ORDER BY y SEPARATOR z)",
             write={
                 "mysql": "GROUP_CONCAT(x ORDER BY y SEPARATOR z)",
-                "sqlite": "GROUP_CONCAT(x, z)",
+                "sqlite": "GROUP_CONCAT(x, z ORDER BY y)",
                 "tsql": "STRING_AGG(x, z) WITHIN GROUP (ORDER BY y)",
                 "databricks": "LISTAGG(x, z) WITHIN GROUP (ORDER BY y)",
                 "postgres": "STRING_AGG(x, z ORDER BY y NULLS FIRST)",
@@ -1150,7 +1150,7 @@ class TestMySQL(Validator):
             "GROUP_CONCAT(DISTINCT x ORDER BY y DESC SEPARATOR '')",
             write={
                 "mysql": "GROUP_CONCAT(DISTINCT x ORDER BY y DESC SEPARATOR '')",
-                "sqlite": "GROUP_CONCAT(DISTINCT x, '')",
+                "sqlite": "GROUP_CONCAT(DISTINCT x ORDER BY y DESC)",
                 "tsql": "STRING_AGG(x, '') WITHIN GROUP (ORDER BY y DESC)",
                 "databricks": "LISTAGG(DISTINCT x, '') WITHIN GROUP (ORDER BY y DESC)",
                 "postgres": "STRING_AGG(DISTINCT x, '' ORDER BY y DESC NULLS LAST)",
@@ -1181,7 +1181,7 @@ class TestMySQL(Validator):
             "GROUP_CONCAT(DISTINCT a, b, c SEPARATOR '')",
             write={
                 "mysql": "GROUP_CONCAT(DISTINCT CONCAT(a, b, c) SEPARATOR '')",
-                "sqlite": "GROUP_CONCAT(DISTINCT a || b || c, '')",
+                "sqlite": "GROUP_CONCAT(DISTINCT a || b || c)",
                 "tsql": "STRING_AGG(a + b + c, '')",
                 "databricks": "LISTAGG(DISTINCT CONCAT(a, b, c), '')",
                 "postgres": "STRING_AGG(DISTINCT a || b || c, '')",
@@ -1191,7 +1191,7 @@ class TestMySQL(Validator):
             "GROUP_CONCAT(a, b, c ORDER BY d SEPARATOR '')",
             write={
                 "mysql": "GROUP_CONCAT(CONCAT(a, b, c) ORDER BY d SEPARATOR '')",
-                "sqlite": "GROUP_CONCAT(a || b || c, '')",
+                "sqlite": "GROUP_CONCAT(a || b || c, '' ORDER BY d)",
                 "tsql": "STRING_AGG(a + b + c, '') WITHIN GROUP (ORDER BY d)",
                 "databricks": "LISTAGG(CONCAT(a, b, c), '') WITHIN GROUP (ORDER BY d)",
                 "postgres": "STRING_AGG(a || b || c, '' ORDER BY d NULLS FIRST)",
@@ -1201,7 +1201,7 @@ class TestMySQL(Validator):
             "GROUP_CONCAT(DISTINCT a, b, c ORDER BY d SEPARATOR '')",
             write={
                 "mysql": "GROUP_CONCAT(DISTINCT CONCAT(a, b, c) ORDER BY d SEPARATOR '')",
-                "sqlite": "GROUP_CONCAT(DISTINCT a || b || c, '')",
+                "sqlite": "GROUP_CONCAT(DISTINCT a || b || c ORDER BY d)",
                 "tsql": "STRING_AGG(a + b + c, '') WITHIN GROUP (ORDER BY d)",
                 "databricks": "LISTAGG(DISTINCT CONCAT(a, b, c), '') WITHIN GROUP (ORDER BY d)",
                 "postgres": "STRING_AGG(DISTINCT a || b || c, '' ORDER BY d NULLS FIRST)",

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -1,6 +1,7 @@
 from tests.dialects.test_dialect import Validator
 
-from sqlglot import exp
+from sqlglot import exp, transpile
+from sqlglot.errors import ErrorLevel, UnsupportedError
 from sqlglot.helper import logger as helper_logger
 
 
@@ -288,6 +289,28 @@ class TestSQLite(Validator):
             )
 
             self.assertIn("Named columns are not supported in table alias.", cm.output[0])
+
+    def test_group_concat(self):
+        # ORDER BY within aggregates is supported since SQLite 3.44
+        self.validate_identity("SELECT GROUP_CONCAT(a ORDER BY a) FROM t")
+        self.validate_identity("SELECT GROUP_CONCAT(a, ';' ORDER BY a DESC) FROM t")
+        self.validate_identity("SELECT GROUP_CONCAT(DISTINCT x ORDER BY y) FROM t")
+        self.validate_identity("SELECT GROUP_CONCAT(a) FROM t")
+        self.validate_identity("SELECT GROUP_CONCAT(DISTINCT a) FROM t")
+
+        # SQLite rejects DISTINCT aggregates with more than one argument, so a
+        # custom separator cannot be combined with DISTINCT
+        self.validate_all(
+            "SELECT GROUP_CONCAT(DISTINCT x ORDER BY y DESC) FROM t",
+            read={"mysql": "SELECT GROUP_CONCAT(DISTINCT x ORDER BY y DESC SEPARATOR '') FROM t"},
+        )
+        with self.assertRaises(UnsupportedError):
+            transpile(
+                "SELECT GROUP_CONCAT(DISTINCT x ORDER BY y DESC SEPARATOR '') FROM t",
+                read="mysql",
+                write="sqlite",
+                unsupported_level=ErrorLevel.RAISE,
+            )
 
     def test_trunc(self):
         # SQLite TRUNC only accepts one argument

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -421,7 +421,7 @@ class TestTSQL(Validator):
             write={
                 "tsql": "STRING_AGG(x, y) WITHIN GROUP (ORDER BY z DESC)",
                 "mysql": "GROUP_CONCAT(x ORDER BY z DESC SEPARATOR y)",
-                "sqlite": "GROUP_CONCAT(x, y)",
+                "sqlite": "GROUP_CONCAT(x, y ORDER BY z DESC)",
                 "postgres": "STRING_AGG(x, y ORDER BY z DESC NULLS LAST)",
             },
         )
@@ -430,7 +430,7 @@ class TestTSQL(Validator):
             write={
                 "tsql": "STRING_AGG(x, '|') WITHIN GROUP (ORDER BY z ASC)",
                 "mysql": "GROUP_CONCAT(x ORDER BY z ASC SEPARATOR '|')",
-                "sqlite": "GROUP_CONCAT(x, '|')",
+                "sqlite": "GROUP_CONCAT(x, '|' ORDER BY z ASC)",
                 "postgres": "STRING_AGG(x, '|' ORDER BY z ASC NULLS FIRST)",
             },
         )


### PR DESCRIPTION
Fixes #8078.

```python
import sqlglot
print(sqlglot.parse_one("SELECT GROUP_CONCAT(a ORDER BY a) FROM t", read="sqlite").sql(dialect="sqlite"))
# before: SELECT GROUP_CONCAT(a) FROM t              (clause dropped, warning logged)
# after : SELECT GROUP_CONCAT(a ORDER BY a) FROM t
```

SQLite supports ORDER BY within aggregates since 3.44 (2023-11-01). This intentionally targets 3.44+ — older versions reject the preserved clause, whereas the current behavior silently drops it and changes the result. The two-argument separator shape already passed the clause through, so main was internally inconsistent between the two tree shapes; both are covered now.

While touching the same generator path, the PR also stops emitting SQLite's invalid multi-argument DISTINCT form: DISTINCT with a custom separator reports the unsupported separator and emits the executable one-argument best effort — the previous output for that case (`GROUP_CONCAT(DISTINCT x, '')`) was already invalid SQLite.

mysql/tsql fixtures pinning the lossy outputs are updated. Every new expected statement was executed on SQLite 3.53.x (CPython bundled build and sqlean 3.53.4). Marked `!` because rendered output changes.

*Developed with LLM assistance; engine results were run against live SQLite.*
