### PR TITLE
fix(sqlite)!: keep MEDIAN instead of rewriting to PERCENTILE_CONT [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -113,7 +113,8 @@ class SQLiteGenerator(generator.Generator):
     SUPPORTS_TO_NUMBER = False
     SUPPORTS_WINDOW_EXCLUDE = True
     EXCEPT_INTERSECT_SUPPORT_ALL_CLAUSE = False
-    SUPPORTS_MEDIAN = False
+    # MEDIAN ships with SQLite's percentile extension, https://www.sqlite.org/percentile.html
+    SUPPORTS_MEDIAN = True
     JSON_KEY_VALUE_PAIR_SEP = ","
     PARSE_JSON_NAME: str | None = None
 

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -220,6 +220,10 @@ class TestSQLite(Validator):
         )
         self.validate_identity("SELECT SQLITE_VERSION()")
 
+    def test_median(self):
+        self.validate_identity("SELECT MEDIAN(x) FROM t")
+        self.validate_identity("SELECT MEDIAN(x) OVER () FROM t")
+
     def test_strftime(self):
         self.validate_identity("SELECT STRFTIME('%Y/%m/%d', 'now')")
         self.validate_identity("SELECT STRFTIME('%Y-%m-%d', '2016-10-16', 'start of month')")


### PR DESCRIPTION
Fixes #8079.

```python
import sqlglot
print(sqlglot.parse_one("SELECT MEDIAN(x) FROM t", read="sqlite").sql(dialect="sqlite"))
# before: SELECT PERCENTILE_CONT(x, 0.5) FROM t
# after : SELECT MEDIAN(x) FROM t
```

MEDIAN ships with SQLite's percentile extension (https://www.sqlite.org/percentile.html) alongside PERCENTILE_CONT, so the documented configuration that runs the current output also has MEDIAN — while builds providing median through other means (verified: sqlean with its stats extension) do not have PERCENTILE_CONT. In every configuration tested the rewrite is at best neutral, and it sometimes turns a working query into an error naming a function the caller never wrote.

`SUPPORTS_MEDIAN = True` controls the generated spelling only; it is not a claim that every SQLite build provides the function — the caller's input already names `MEDIAN`.

Verified on the CPython bundled 3.53.1 build (percentile builtins) and sqlean 3.53.4 with and without stats. Marked `!` because rendered output changes.

*Developed with LLM assistance; engine results were run against live SQLite.*
