### PR TITLE
fix(sqlite)!: render RegexpLike as SQLite's REGEXP operator [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -255,6 +255,10 @@ class SQLiteGenerator(generator.Generator):
     def trunc_sql(self, expression: exp.Trunc) -> str:
         return self.func("TRUNC", expression.this)
 
+    @unsupported_args("flag", "full_match")
+    def regexplike_sql(self, expression: exp.RegexpLike) -> str:
+        return self.binary(expression, "REGEXP")
+
     def generateseries_sql(self, expression: exp.GenerateSeries) -> str:
         parent = expression.parent
         alias = parent and parent.args.get("alias")

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -1,6 +1,7 @@
 from tests.dialects.test_dialect import Validator
 
-from sqlglot import exp
+from sqlglot import exp, transpile
+from sqlglot.errors import ErrorLevel, UnsupportedError
 from sqlglot.helper import logger as helper_logger
 
 
@@ -242,6 +243,20 @@ class TestSQLite(Validator):
                 "sqlite": "SELECT STRFTIME('%Y-%m-%d', CURRENT_TIMESTAMP)",
             },
         )
+
+    def test_regexp(self):
+        self.validate_identity("SELECT a REGEXP 'x' FROM t").assert_is(exp.Select).selects[
+            0
+        ].assert_is(exp.RegexpLike)
+
+        # flag and full_match cannot be expressed with the REGEXP operator
+        with self.assertRaises(UnsupportedError):
+            transpile(
+                "SELECT REGEXP_LIKE(a, 'x', 'i') FROM t",
+                read="snowflake",
+                write="sqlite",
+                unsupported_level=ErrorLevel.RAISE,
+            )
 
     def test_datediff(self):
         self.validate_all(


### PR DESCRIPTION
Fixes #8080.

```python
import sqlglot
print(sqlglot.parse_one("SELECT a REGEXP 'x' FROM t", read="sqlite").sql(dialect="sqlite"))
# before: SELECT REGEXP_LIKE(a, 'x') FROM t   (not defined by SQLite core)
# after : SELECT a REGEXP 'x' FROM t
```

The REGEXP operator is SQLite's documented special syntax for the application-defined `regexp()` function (https://www.sqlite.org/lang_expr.html#regexp) — the input query already depends on that registered function, so the operator spelling preserves rather than introduces the runtime requirement. SQLite core neither defines nor documents `REGEXP_LIKE`, so the rewrite destroyed the caller's working spelling even on a sqlite → sqlite round-trip.

The `flag` and `full_match` arguments (e.g. from Snowflake `REGEXP_LIKE(a, 'x', 'i')`) cannot be expressed with the operator and now warn via `@unsupported_args`.

Emitted SQL executed on SQLite 3.53.x with a registered `regexp()` UDF. Marked `!` because rendered output changes.

*Developed with LLM assistance; engine results were run against live SQLite.*
