### PR TITLE
fix(sqlite)!: emit STORED generated columns instead of PERSISTED [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -15,7 +15,7 @@ from sqlglot.dialects.dialect import (
     rename_func,
     strposition_sql,
 )
-from sqlglot.generator import unsupported_args
+from sqlglot.generator import UNSUPPORTED_TEMPLATE, unsupported_args
 from sqlglot.optimizer.scope import find_in_scope
 from sqlglot.tokens import TokenType
 
@@ -246,6 +246,23 @@ class SQLiteGenerator(generator.Generator):
             return self.func("DATE", expression.this)
 
         return super().cast_sql(expression)
+
+    # https://www.sqlite.org/gencol.html
+    # mypyc can't compile a decorated override of an undecorated base method, so the
+    # data_type check is inlined instead of using @unsupported_args
+    def computedcolumnconstraint_sql(self, expression: exp.ComputedColumnConstraint) -> str:
+        if expression.args.get("data_type"):
+            self.unsupported(
+                UNSUPPORTED_TEMPLATE.format(
+                    "data_type", expression.__class__.__name__, self.dialect.__class__.__name__
+                )
+            )
+
+        this = expression.this
+        this_sql = self.sql(this) if isinstance(this, exp.Paren) else f"({self.sql(this)})"
+        storage = " STORED" if expression.args.get("persisted") else ""
+        not_null = " NOT NULL" if expression.args.get("not_null") else ""
+        return f"AS {this_sql}{storage}{not_null}"
 
     # Note: SQLite's TRUNC always returns REAL (e.g., trunc(10.99) -> 10.0), not INTEGER.
     # This creates a transpilation gap affecting division semantics, similar to Presto.

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -298,6 +298,21 @@ class TestSQLite(Validator):
             self.validate_identity("TRUNC(3.14, 2)", "TRUNC(3.14)").assert_is(exp.Trunc)
             self.assertIn("'decimals' is not supported", cm.output[0])
 
+    def test_generated_columns(self):
+        # https://www.sqlite.org/gencol.html
+        self.validate_identity("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)")
+        self.validate_identity("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))")
+        # The unparenthesized postgres expression must be parenthesized for SQLite;
+        # the missing STORED is a pre-existing postgres reader gap
+        self.validate_all(
+            "CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))",
+            read={"postgres": "CREATE TABLE t (a INT, b INT GENERATED ALWAYS AS (a * 2) STORED)"},
+        )
+        self.validate_all(
+            "CREATE TABLE t (a INTEGER, b AS (a * 2) STORED NOT NULL)",
+            read={"tsql": "CREATE TABLE t (a INT, b AS (a * 2) PERSISTED NOT NULL)"},
+        )
+
     def test_ddl(self):
         for conflict_action in ("ABORT", "FAIL", "IGNORE", "REPLACE", "ROLLBACK"):
             with self.subTest(f"ON CONFLICT {conflict_action}"):


### PR DESCRIPTION
Fixes #8081.

```python
import sqlglot
print(sqlglot.parse_one("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)", read="sqlite").sql(dialect="sqlite"))
# before: CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) PERSISTED)   (TSQL keyword; SQLite rejects it)
# after : CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)
```

Valid SQLite DDL became invalid on a same-dialect round-trip. The override (https://www.sqlite.org/gencol.html):

- emits `STORED` instead of the TSQL-only `PERSISTED`;
- parenthesizes expressions that arrive unparenthesized (e.g. from the postgres reader), as SQLite's grammar requires;
- preserves `NOT NULL` (engine-verified: `AS (expr) STORED NOT NULL` is valid);
- warns for the `data_type` argument SQLite cannot express. The check is inlined rather than decorated with `@unsupported_args`: mypyc cannot compile a decorated override of an undecorated base-class method, and the decorated version fails `make install-devc`.

Emitted DDL executed on SQLite 3.53.x, with the generated column verified to compute. Marked `!` because rendered output changes.

Reader-side gaps noted in the issue are deliberately out of scope — including the postgres reader dropping STORED before the generator runs, which the cross-dialect test pins at its current behaviour.

*Developed with LLM assistance; engine results were run against live SQLite.*
