### PR TITLE
fix(clickhouse): parse MODIFY COLUMN as AlterColumn

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -250,6 +250,7 @@ class AlterColumn(Expression):
         "allow_null": False,
         "visible": False,
         "rename_to": False,
+        "exists": False,
     }
 
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -487,6 +487,9 @@ class Generator:
     # Whether ALTER COLUMN can set a column's nullability together with its type
     SUPPORTS_ALTER_COLUMN_NULLABILITY = False
 
+    # Whether ALTER COLUMN IF EXISTS is supported
+    SUPPORTS_ALTER_COLUMN_IF_EXISTS = False
+
     # Whether the LikeProperty needs to be specified inside of the schema clause
     LIKE_PROPERTY_INSIDE_SCHEMA = False
 
@@ -4200,6 +4203,11 @@ class Generator:
 
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         this = self.sql(expression, "this")
+        exists = (
+            " IF EXISTS"
+            if expression.args.get("exists") and self.SUPPORTS_ALTER_COLUMN_IF_EXISTS
+            else ""
+        )
 
         dtype = self.sql(expression, "dtype")
         if dtype:
@@ -4210,19 +4218,22 @@ class Generator:
             alter_set_type = self.ALTER_SET_TYPE + " " if self.ALTER_SET_TYPE else ""
             null_constraint = self._alter_column_null_constraint_sql(expression)
 
-            return f"ALTER COLUMN {this} {alter_set_type}{dtype}{collate}{using}{null_constraint}"
+            return (
+                f"ALTER COLUMN{exists} {this} {alter_set_type}{dtype}"
+                f"{collate}{using}{null_constraint}"
+            )
 
         default = self.sql(expression, "default")
         if default:
-            return f"ALTER COLUMN {this} SET DEFAULT {default}"
+            return f"ALTER COLUMN{exists} {this} SET DEFAULT {default}"
 
         comment = self.sql(expression, "comment")
         if comment:
-            return f"ALTER COLUMN {this} COMMENT {comment}"
+            return f"ALTER COLUMN{exists} {this} COMMENT {comment}"
 
         visible = expression.args.get("visible")
         if visible:
-            return f"ALTER COLUMN {this} SET {visible}"
+            return f"ALTER COLUMN{exists} {this} SET {visible}"
 
         allow_null = expression.args.get("allow_null")
         drop = expression.args.get("drop")
@@ -4232,9 +4243,9 @@ class Generator:
 
         if allow_null is not None:
             keyword = "DROP" if drop else "SET"
-            return f"ALTER COLUMN {this} {keyword} NOT NULL"
+            return f"ALTER COLUMN{exists} {this} {keyword} NOT NULL"
 
-        return f"ALTER COLUMN {this} DROP DEFAULT"
+        return f"ALTER COLUMN{exists} {this} DROP DEFAULT"
 
     def _alter_column_null_constraint_sql(self, expression: exp.AlterColumn) -> str:
         allow_null = expression.args.get("allow_null")

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4203,6 +4203,8 @@ class Generator:
 
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         this = self.sql(expression, "this")
+        if expression.args.get("exists") and not self.SUPPORTS_ALTER_COLUMN_IF_EXISTS:
+            self.unsupported("ALTER COLUMN IF EXISTS is not supported by this dialect")
         exists = (
             " IF EXISTS"
             if expression.args.get("exists") and self.SUPPORTS_ALTER_COLUMN_IF_EXISTS

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -175,6 +175,7 @@ class ClickHouseGenerator(generator.Generator):
     STRUCT_DELIMITER = ("(", ")")
     NVL2_SUPPORTED = False
     ALTER_SET_TYPE = "TYPE"
+    SUPPORTS_ALTER_COLUMN_IF_EXISTS = True
     TABLESAMPLE_REQUIRES_PARENS = False
     TABLESAMPLE_SIZE_IS_ROWS = False
     TABLESAMPLE_KEYWORDS = "SAMPLE"

--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -536,6 +536,7 @@ class HiveGenerator(generator.Generator):
             ),
         )
 
+    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         this = self.sql(expression, "this")
         new_name = self.sql(expression, "rename_to") or this

--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -536,8 +536,10 @@ class HiveGenerator(generator.Generator):
             ),
         )
 
-    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
+        if expression.args.get("exists"):
+            self.unsupported("ALTER COLUMN IF EXISTS is not supported by this dialect")
+
         this = self.sql(expression, "this")
         new_name = self.sql(expression, "rename_to") or this
         dtype = self.sql(expression, "dtype")

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -743,6 +743,7 @@ class MySQLGenerator(generator.Generator):
         """
         return super().alterrename_sql(expression, include_to=False)
 
+    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         dtype = self.sql(expression, "dtype")
         if not dtype:

--- a/sqlglot/generators/mysql.py
+++ b/sqlglot/generators/mysql.py
@@ -743,11 +743,13 @@ class MySQLGenerator(generator.Generator):
         """
         return super().alterrename_sql(expression, include_to=False)
 
-    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         dtype = self.sql(expression, "dtype")
         if not dtype:
             return super().altercolumn_sql(expression)
+
+        if expression.args.get("exists"):
+            self.unsupported("ALTER COLUMN IF EXISTS is not supported by this dialect")
 
         this = self.sql(expression, "this")
         null_constraint = self._alter_column_null_constraint_sql(expression)

--- a/sqlglot/generators/singlestore.py
+++ b/sqlglot/generators/singlestore.py
@@ -1585,7 +1585,6 @@ class SingleStoreGenerator(MySQLGenerator):
         new_column = self.sql(expression, "to")
         return f"CHANGE {old_column} {new_column}"
 
-    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         for arg_name in ("drop", "comment", "visible", "using"):
             if expression.args.get(arg_name):

--- a/sqlglot/generators/singlestore.py
+++ b/sqlglot/generators/singlestore.py
@@ -1585,6 +1585,7 @@ class SingleStoreGenerator(MySQLGenerator):
         new_column = self.sql(expression, "to")
         return f"CHANGE {old_column} {new_column}"
 
+    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         for arg_name in ("drop", "comment", "visible", "using"):
             if expression.args.get(arg_name):

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -9,6 +9,7 @@ from sqlglot.dialects.dialect import (
     timestamptrunc_sql,
     weekstart_unit_to_str,
 )
+from sqlglot.generator import unsupported_args
 from sqlglot.generators.hive import HIVE_DATE_FORMAT, HiveGenerator, HIVE_TS_OR_DS_EXPRESSIONS
 from sqlglot.transforms import (
     preprocess,
@@ -239,6 +240,7 @@ class Spark2Generator(HiveGenerator):
 
         return f"USING {expression.name.upper()}"
 
+    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
         this = self.sql(expression, "this")
         new_name = self.sql(expression, "rename_to") or this

--- a/sqlglot/generators/spark2.py
+++ b/sqlglot/generators/spark2.py
@@ -9,7 +9,6 @@ from sqlglot.dialects.dialect import (
     timestamptrunc_sql,
     weekstart_unit_to_str,
 )
-from sqlglot.generator import unsupported_args
 from sqlglot.generators.hive import HIVE_DATE_FORMAT, HiveGenerator, HIVE_TS_OR_DS_EXPRESSIONS
 from sqlglot.transforms import (
     preprocess,
@@ -240,8 +239,10 @@ class Spark2Generator(HiveGenerator):
 
         return f"USING {expression.name.upper()}"
 
-    @unsupported_args("exists")
     def altercolumn_sql(self, expression: exp.AlterColumn) -> str:
+        if expression.args.get("exists"):
+            self.unsupported("ALTER COLUMN IF EXISTS is not supported by this dialect")
+
         this = self.sql(expression, "this")
         new_name = self.sql(expression, "rename_to") or this
         comment = self.sql(expression, "comment")

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8990,23 +8990,38 @@ class Parser:
         # Many dialects support the ALTER [COLUMN] syntax, so if there is no
         # keyword after ALTER we default to parsing this statement
         self._match(TokenType.COLUMN)
+        exists = self._parse_exists()
         column = self._parse_field(any_token=True)
 
         if self._match_pair(TokenType.DROP, TokenType.DEFAULT):
-            return self.expression(exp.AlterColumn(this=column, drop=True))
+            return self.expression(exp.AlterColumn(this=column, drop=True, exists=exists or None))
         if self._match_pair(TokenType.SET, TokenType.DEFAULT):
-            return self.expression(exp.AlterColumn(this=column, default=self._parse_disjunction()))
+            return self.expression(
+                exp.AlterColumn(
+                    this=column, default=self._parse_disjunction(), exists=exists or None
+                )
+            )
         if self._match(TokenType.COMMENT):
-            return self.expression(exp.AlterColumn(this=column, comment=self._parse_string()))
+            return self.expression(
+                exp.AlterColumn(this=column, comment=self._parse_string(), exists=exists or None)
+            )
         if self._match_text_seq("DROP", "NOT", "NULL"):
-            return self.expression(exp.AlterColumn(this=column, drop=True, allow_null=True))
+            return self.expression(
+                exp.AlterColumn(this=column, drop=True, allow_null=True, exists=exists or None)
+            )
         if self._match_text_seq("SET", "NOT", "NULL"):
-            return self.expression(exp.AlterColumn(this=column, allow_null=False))
+            return self.expression(
+                exp.AlterColumn(this=column, allow_null=False, exists=exists or None)
+            )
 
         if self._match_text_seq("SET", "VISIBLE"):
-            return self.expression(exp.AlterColumn(this=column, visible="VISIBLE"))
+            return self.expression(
+                exp.AlterColumn(this=column, visible="VISIBLE", exists=exists or None)
+            )
         if self._match_text_seq("SET", "INVISIBLE"):
-            return self.expression(exp.AlterColumn(this=column, visible="INVISIBLE"))
+            return self.expression(
+                exp.AlterColumn(this=column, visible="INVISIBLE", exists=exists or None)
+            )
 
         self._match_text_seq("SET", "DATA")
         self._match_text_seq("TYPE")
@@ -9016,6 +9031,7 @@ class Parser:
                 dtype=self._parse_types(),
                 collate=self._match(TokenType.COLLATE) and self._parse_term(),
                 using=self._match(TokenType.USING) and self._parse_disjunction(),
+                exists=exists or None,
             )
         )
 

--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -459,7 +459,7 @@ class ClickHouseParser(parser.Parser):
 
     ALTER_PARSERS = {
         **parser.Parser.ALTER_PARSERS,
-        "MODIFY": lambda self: self._parse_alter_table_modify(),
+        "MODIFY": lambda self: self._parse_alter_table_alter(),
         "REPLACE": lambda self: self._parse_alter_table_replace(),
     }
 
@@ -908,10 +908,19 @@ class ClickHouseParser(parser.Parser):
             exp.ReplacePartition(expression=partition, source=self._parse_table_parts())
         )
 
-    def _parse_alter_table_modify(self) -> exp.Expr | None:
-        if properties := self._parse_properties():
-            return self.expression(exp.AlterModifySqlSecurity(expressions=properties.expressions))
-        return None
+    def _parse_alter_table_alter(self) -> exp.Expr | None:
+        # Gate SQL SECURITY to MODIFY, since ALTER can now reach this path too
+        if self._prev.text.upper() == "MODIFY" and self._match(
+            TokenType.SQL_SECURITY, advance=False
+        ):
+            if properties := self._parse_properties():
+                return self.expression(
+                    exp.AlterModifySqlSecurity(expressions=properties.expressions)
+                )
+
+        # https://clickhouse.com/docs/sql-reference/statements/alter/column#modify-column
+        alter = super()._parse_alter_table_alter()
+        return None if self._curr else alter
 
     def _parse_definer(self) -> exp.DefinerProperty | None:
         self._match(TokenType.EQ)

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -653,13 +653,32 @@ class TestClickhouse(Validator):
         self.validate_identity("DELETE FROM tbl ON CLUSTER '{cluster}' WHERE date = '2019-01-01'")
 
         # ClickHouse changes a column's type with ALTER COLUMN ... TYPE, not the
-        # ANSI ALTER COLUMN ... SET DATA TYPE
+        # ANSI ALTER COLUMN ... SET DATA TYPE. MODIFY COLUMN is accepted on read and
+        # canonicalized to ALTER COLUMN ... TYPE on write.
         self.validate_all(
             "ALTER TABLE t ALTER COLUMN c TYPE Nullable(Int64)",
             read={
                 "clickhouse": "ALTER TABLE t ALTER COLUMN c TYPE Nullable(Int64)",
                 "postgres": "ALTER TABLE t ALTER COLUMN c TYPE BIGINT",
             },
+        )
+        modify = self.validate_identity(
+            "ALTER TABLE t MODIFY COLUMN c Int64",
+            "ALTER TABLE t ALTER COLUMN c TYPE Int64",
+        ).assert_is(exp.Alter)
+        self.assertIsInstance(modify.args["actions"][0], exp.AlterColumn)
+        self.validate_identity(
+            "ALTER TABLE t MODIFY COLUMN IF EXISTS c Int64",
+            "ALTER TABLE t ALTER COLUMN IF EXISTS c TYPE Int64",
+        )
+        self.validate_identity("ALTER TABLE t ALTER COLUMN IF EXISTS c TYPE Int64")
+        self.assertIsInstance(
+            parse_one(
+                "ALTER TABLE t MODIFY COLUMN c REMOVE DEFAULT",
+                read="clickhouse",
+                error_level=ErrorLevel.IGNORE,
+            ),
+            exp.Command,
         )
 
         self.assertIsInstance(


### PR DESCRIPTION
ClickHouse treats `MODIFY COLUMN` and `ALTER COLUMN` as equivalent. `MODIFY COLUMN` was falling back to `Command` because the ClickHouse `MODIFY` alter parser only handled `MODIFY SQL SECURITY ...`.

This maps `MODIFY` through the alter-column parser (same idea as Snowflake), returns `AlterColumn`, and canonicalizes generation to `ALTER COLUMN ... TYPE`. `IF EXISTS` is parsed on `AlterColumn` and emitted for ClickHouse. Forms the base parser cannot consume (for example `REMOVE`) still fall back to `Command`.

Follow-up to #8020 addressing @treysp's review feedback.

Fixes #8019