### PR TITLE
fix(postgres): preserve MERGE action predicates [CODEX]

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -38,6 +38,7 @@ from sqlglot.dialects.dialect import (
     trim_sql,
     ts_or_ds_add_cast,
 )
+from sqlglot.errors import UnsupportedError
 from sqlglot.generator import unsupported_args
 from sqlglot.helper import seq_get
 
@@ -220,6 +221,60 @@ def _versioned_anyvalue_sql(self: PostgresGenerator, expression: exp.AnyValue) -
     return rename_func("ANY_VALUE")(self, expression)
 
 
+def _postgres_merge_sql(self: PostgresGenerator, expression: exp.Merge) -> str:
+    """Translate Oracle action predicates to PostgreSQL WHEN conditions."""
+    whens = expression.args["whens"].expressions
+    categories = {
+        category: sum(
+            1
+            for when in whens
+            if (
+                bool(when.args["matched"]),
+                bool(when.args.get("source")),
+            )
+            == category
+        )
+        for category in {
+            (bool(when.args["matched"]), bool(when.args.get("source"))) for when in whens
+        }
+    }
+
+    for when in whens:
+        then = when.args.get("then")
+        where = then.args.get("where") if isinstance(then, (exp.Insert, exp.Update)) else None
+        if not where:
+            continue
+
+        category = (bool(when.args["matched"]), bool(when.args.get("source")))
+        if (
+            category not in {(True, False), (False, False)}
+            or not isinstance(then, (exp.Insert, exp.Update))
+            or categories[category] > 1
+        ):
+            raise UnsupportedError(
+                "PostgreSQL cannot safely translate a MERGE action WHERE clause "
+                "for multiple or unsupported WHEN clauses"
+            )
+
+    for when in whens:
+        then = when.args.get("then")
+        if not isinstance(then, (exp.Insert, exp.Update)):
+            continue
+
+        where = then.args.get("where")
+        if not where:
+            continue
+
+        condition = when.args.get("condition")
+        when.set(
+            "condition",
+            exp.and_(condition, where.this, copy=False) if condition else where.this,
+        )
+        then.set("where", None)
+
+    return merge_without_target_sql(self, expression)
+
+
 def _round_sql(self: PostgresGenerator, expression: exp.Round) -> str:
     this = self.sql(expression, "this")
     decimals = self.sql(expression, "decimals")
@@ -353,7 +408,7 @@ class PostgresGenerator(generator.Generator):
         exp.Max: max_or_greatest,
         exp.MapFromEntries: no_map_from_entries_sql,
         exp.Min: min_or_least,
-        exp.Merge: merge_without_target_sql,
+        exp.Merge: _postgres_merge_sql,
         exp.Month: _day_month_year_sql,
         exp.PartitionedByProperty: lambda self, e: f"PARTITION BY {self.sql(e, 'this')}",
         exp.PercentileCont: transforms.preprocess([transforms.add_within_group_for_percentiles]),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1,4 +1,4 @@
-from sqlglot import ParseError, UnsupportedError, exp, parse_one, transpile
+from sqlglot import ErrorLevel, ParseError, UnsupportedError, exp, parse_one, transpile
 from sqlglot.helper import logger as helper_logger
 from sqlglot.optimizer.annotate_types import annotate_types
 from tests.dialects.test_dialect import Validator
@@ -422,6 +422,57 @@ class TestPostgres(Validator):
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET x.a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
             "MERGE INTO x USING (SELECT id) AS y ON a = b WHEN MATCHED THEN UPDATE SET a = y.b WHEN NOT MATCHED THEN INSERT (a, b) VALUES (y.a, y.b)",
         )
+
+    def test_merge_action_where(self):
+        expression = parse_one(
+            "MERGE INTO target USING source ON target.id = source.id "
+            "WHEN MATCHED THEN UPDATE SET target.value = source.value "
+            "WHERE target.active = 1 "
+            "WHEN NOT MATCHED THEN INSERT (target.id, target.value) "
+            "VALUES (source.id, source.value) WHERE source.enabled = 1",
+            read="oracle",
+        )
+        self.assertEqual(
+            "MERGE INTO target USING source ON target.id = source.id "
+            "WHEN MATCHED AND target.active = 1 THEN UPDATE SET value = source.value "
+            "WHEN NOT MATCHED AND source.enabled = 1 THEN INSERT (id, value) "
+            "VALUES (source.id, source.value)",
+            expression.sql("postgres", unsupported_level=ErrorLevel.RAISE),
+        )
+
+        expression = parse_one(
+            "MERGE INTO target USING source ON target.id = source.id "
+            "WHEN MATCHED AND target.active = 1 OR source.force = 1 "
+            "THEN UPDATE SET target.value = source.value WHERE target.enabled = 1",
+            read="oracle",
+        )
+        self.assertEqual(
+            "MERGE INTO target USING source ON target.id = source.id "
+            "WHEN MATCHED AND (target.active = 1 OR source.force = 1) "
+            "AND target.enabled = 1 THEN UPDATE SET value = source.value",
+            expression.sql("postgres", unsupported_level=ErrorLevel.RAISE),
+        )
+
+    def test_merge_action_where_rejects_unsafe_translation(self):
+        repeated_category = parse_one(
+            "MERGE INTO target USING source ON target.id = source.id "
+            "WHEN MATCHED THEN UPDATE SET value = source.value WHERE target.active = 1 "
+            "WHEN MATCHED THEN DELETE",
+            read="oracle",
+        )
+        for unsupported_level in (None, ErrorLevel.IGNORE):
+            kwargs = {} if unsupported_level is None else {"unsupported_level": unsupported_level}
+            with self.assertRaisesRegex(UnsupportedError, "multiple or unsupported"):
+                repeated_category.sql("postgres", **kwargs)
+
+        unsupported_category = parse_one(
+            "MERGE INTO target USING source ON target.id = source.id "
+            "WHEN MATCHED BY SOURCE THEN UPDATE SET value = source.value "
+            "WHERE source.active = 1",
+            read="oracle",
+        )
+        with self.assertRaisesRegex(UnsupportedError, "multiple or unsupported"):
+            unsupported_category.sql("postgres")
         self.validate_identity(
             "SELECT * FROM t1*",
             "SELECT * FROM t1",


### PR DESCRIPTION
## Summary

- Preserve Oracle `MERGE` action predicates when generating PostgreSQL.
- Reject ambiguous repeated or unsupported `WHEN` shapes instead of emitting broader DML.

Fixes #8093.

## Root cause

The generic `MERGE` generator stored Oracle action `WHERE` predicates in the AST, but PostgreSQL generation removed them after emitting only an unsupported-feature warning. Warning-level transpilation could therefore produce SQL with broader row-selection semantics.

## Fix

The PostgreSQL generator translates the Oracle-compatible `MATCHED UPDATE` and `NOT MATCHED INSERT` action predicates into PostgreSQL `WHEN ... AND` conditions. Existing conditions are combined with explicit precedence, target qualification remains in the moved predicate, and repeated candidate categories or unsupported `WHEN` shapes fail with `UnsupportedError` before the AST is changed.

## Tests

- Positive regression: `python -m unittest tests.dialects.test_postgres.TestPostgres.test_merge_action_where`
- Adversarial regression: `python -m unittest tests.dialects.test_postgres.TestPostgres.test_merge_action_where_rejects_unsafe_translation`
- Targeted suites: `python -m unittest tests.dialects.test_postgres tests.dialects.test_oracle tests.dialects.test_dialect` (158 tests)
- Full suite: `py -m unittest` (1,307 tests)
- Static checks: Ruff format/check and `git diff --check`

## Checklist

- [x] The change is limited to PostgreSQL generation and regression tests.
- [x] Positive and adversarial tests are included.
- [x] Targeted and broader tests pass.
- [x] No documentation or changelog update is required for this internal generator fix.

## Disclosure

I used an LLM to help investigate and draft this change. I reviewed the source, semantics, implementation, tests, and generated SQL myself.
