### PR TITLE
fix(postgres): re-escape apostrophes in Unicode string generation

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1664,6 +1664,8 @@ class Generator:
         if not self.dialect.UNICODE_START or (escape and not self.SUPPORTS_UESCAPE):
             this = escape_pattern.sub(self.UNICODE_SUBSTITUTE or escape_substitute, this)
 
+        this = self.escape_str(this, escape_backslash=False, delimiter=right_quote)
+
         return f"{left_quote}{this}{right_quote}{escape_sql}"
 
     def rawstring_sql(self, expression: exp.RawString) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1646,10 +1646,11 @@ class Generator:
     def unicodestring_sql(self, expression: exp.UnicodeString) -> str:
         this = self.sql(expression, "this")
         escape = expression.args.get("escape")
+        unicode_start = self.dialect.UNICODE_START
 
-        if self.dialect.UNICODE_START:
+        if unicode_start:
             escape_substitute = r"\\\1"
-            left_quote, right_quote = self.dialect.UNICODE_START, self.dialect.UNICODE_END
+            left_quote, right_quote = unicode_start, self.dialect.UNICODE_END or ""
         else:
             escape_substitute = r"\\u\1"
             left_quote, right_quote = self.dialect.QUOTE_START, self.dialect.QUOTE_END
@@ -1661,10 +1662,15 @@ class Generator:
             escape_pattern = ESCAPED_UNICODE_RE
             escape_sql = ""
 
-        if not self.dialect.UNICODE_START or (escape and not self.SUPPORTS_UESCAPE):
+        if not unicode_start or (escape and not self.SUPPORTS_UESCAPE):
             this = escape_pattern.sub(self.UNICODE_SUBSTITUTE or escape_substitute, this)
 
-        this = self.escape_str(this, escape_backslash=False, delimiter=right_quote)
+        if unicode_start:
+            # A Unicode literal only escapes its delimiter by doubling it; the escape character
+            # introduces a code point, so the dialect's ordinary string escapes don't apply here
+            this = self._replace_line_breaks(this).replace(right_quote, right_quote * 2)
+        else:
+            this = self.escape_str(this, escape_backslash=False)
 
         return f"{left_quote}{this}{right_quote}{escape_sql}"
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1607,9 +1607,9 @@ FROM json_data, field_ids""",
         self.validate_identity(
             "SELECT u&'\\0441\\043B\\043E\\043D'", "SELECT U&'\\0441\\043B\\043E\\043D'"
         )
-        # Apostrophes decoded from U&'...' must be re-escaped on generation (#8110)
         self.validate_identity("SELECT U&'can''t'")
         self.validate_identity("SELECT U&'a''b''c'")
+        self.validate_identity("SELECT U&'can''t !0061' UESCAPE '!' AS label")
 
         self.validate_all(
             "SELECT U&'Hello winter \\2603 !'",
@@ -1618,6 +1618,31 @@ FROM json_data, field_ids""",
             },
             write={
                 "presto": "SELECT U&'Hello winter \\2603 !'",
+            },
+        )
+
+        # A Unicode literal doubles its delimiter regardless of the dialect's string escapes,
+        # since a backslash there introduces a code point rather than an escape sequence
+        self.validate_all(
+            "SELECT U&'can''t'",
+            write={
+                "athena": "SELECT U&'can''t'",
+                "bigquery": "SELECT 'can\\'t'",
+                "duckdb": "SELECT 'can''t'",
+                "postgres": "SELECT U&'can''t'",
+                "presto": "SELECT U&'can''t'",
+            },
+        )
+
+        # A control character stays raw inside a Unicode literal, where \n would be read back
+        # as an invalid code point escape; dialects without one fall back to their own escapes
+        self.validate_all(
+            "SELECT U&'a\nb'",
+            write={
+                "athena": "SELECT U&'a\nb'",
+                "bigquery": "SELECT 'a\\nb'",
+                "duckdb": "SELECT 'a\nb'",
+                "postgres": "SELECT U&'a\nb'",
             },
         )
 

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1607,6 +1607,9 @@ FROM json_data, field_ids""",
         self.validate_identity(
             "SELECT u&'\\0441\\043B\\043E\\043D'", "SELECT U&'\\0441\\043B\\043E\\043D'"
         )
+        # Apostrophes decoded from U&'...' must be re-escaped on generation (#8110)
+        self.validate_identity("SELECT U&'can''t'")
+        self.validate_identity("SELECT U&'a''b''c'")
 
         self.validate_all(
             "SELECT U&'Hello winter \\2603 !'",


### PR DESCRIPTION
PostgreSQL U&'...' literals decode doubled apostrophes into the AST, but the generator emitted the decoded form without doubling delimiters again, producing invalid SQL such as U&'can't'. Escape string content with escape_backslash=False so Unicode escapes remain intact.

Fixes #8110