### PR TITLE
fix(optimizer): keep parens around a predicate under bitwise NOT

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -154,7 +154,8 @@ def simplify_parens(expression: exp.Expr, dialect: DialectType) -> exp.Expr:
     if isinstance(this, exp.Predicate) and (
         not (
             parent_is_predicate
-            or isinstance(parent, exp.Neg)
+            # unary operators that bind tighter than the predicate, unlike NOT
+            or isinstance(parent, (exp.Neg, exp.BitwiseNot))
             or (isinstance(parent, exp.Binary) and not isinstance(parent, exp.Connector))
         )
     ):

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -454,6 +454,19 @@ SELECT -(x.a > x.b) FROM x;
 SELECT (-((x.a) IS NULL)) FROM x;
 SELECT -(x.a IS NULL) FROM x;
 
+-- like unary minus, `~` binds tighter than a predicate, so its parens must be kept
+# dialect: postgres
+~(a = b);
+~(a = b);
+
+# dialect: postgres
+~(a LIKE b);
+~(a LIKE b);
+
+# dialect: postgres
+~(a @> b);
+~(a @> b);
+
 SELECT * FROM A WHERE a - (b < c) < 0 AND a + (b > c) >= 0;
 SELECT * FROM A WHERE a + (b > c) >= 0 AND a - (b < c) < 0;
 


### PR DESCRIPTION
`simplify_parens` strips the parens around a `Predicate` unless the parent is itself a predicate, a `Neg`, or a non-connector `Binary`. `BitwiseNot` was missing from that list, so the parens were dropped even though `~` binds *tighter* than the predicate:

```
~(a = b)     ->  ~a = b
~(a LIKE b)  ->  ~a LIKE b
~(a @> b)    ->  ~a @> b
```

This is not just an AST-shape concern. In MySQL booleans are integers, so both forms are valid and disagree at runtime:

```
mysql> SELECT ~(1 = 1), ~1 = 1;
       18446744073709551614,  0
```

`Not` deliberately stays strippable: it binds looser than these operators, so `NOT (a @> b)` -> `NOT a @> b` remains correct. That accounts for every `exp.Unary` subclass — `Neg` and `BitwiseNot` are excluded, `Paren` is handled earlier, and `Not` is the intended case.

Added three fixtures covering `=`, `LIKE` and `@>` under `~`; all three fail without the one-line change.