### PR TITLE
fix(optimizer): prevent pruning columns referenced by GROUP BY / HAVING / QUALIFY

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -135,7 +135,7 @@ def pushdown_projections(
                 col_name = col.name
                 selects[table_name].add(col_name)
 
-            # qualify's alias shadow workaround leaves bare identifier refs that the scan above misses
+            # qualify's alias shadow workaround leaves bare identifier/unqualified column refs that the scan above misses
             resolver = None
             for clause in (
                 scope.expression.args.get("group"),
@@ -144,14 +144,17 @@ def pushdown_projections(
             ):
                 if not clause:
                     continue
-                for ident in find_all_in_scope(clause, exp.Identifier):
-                    if isinstance(ident.parent, (exp.Column, exp.Alias, exp.TableAlias)):
+                for ref in find_all_in_scope(clause, exp.Identifier, exp.Column):
+                    if isinstance(ref, exp.Column):
+                        if ref.table:
+                            continue
+                    elif isinstance(ref.parent, (exp.Column, exp.Alias, exp.TableAlias)):
                         continue
                     if resolver is None:
                         resolver = Resolver(scope, schema)
-                    source_table = resolver.get_table(ident.name)
+                    source_table = resolver.get_table(ref.name)
                     if source_table:
-                        selects[source_table.name].add(ident.name)
+                        selects[source_table.name].add(ref.name)
 
             # Push the selected columns down to the next scope
             for name, (node, source) in scope.selected_sources.items():

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from sqlglot import alias, exp
 from sqlglot.optimizer.journal import Journal, record
 from sqlglot.optimizer.qualify_columns import Resolver
-from sqlglot.optimizer.scope import Scope, find_in_scope, traverse_scope
+from sqlglot.optimizer.scope import Scope, find_all_in_scope, find_in_scope, traverse_scope
 from sqlglot.schema import ensure_schema
 from sqlglot.errors import OptimizeError
 from sqlglot.helper import seq_get
@@ -134,6 +134,24 @@ def pushdown_projections(
                 table_name = col.table
                 col_name = col.name
                 selects[table_name].add(col_name)
+
+            # qualify's alias shadow workaround leaves bare identifier refs that the scan above misses
+            resolver = None
+            for clause in (
+                scope.expression.args.get("group"),
+                scope.expression.args.get("having"),
+                scope.expression.args.get("qualify"),
+            ):
+                if not clause:
+                    continue
+                for ident in find_all_in_scope(clause, exp.Identifier):
+                    if isinstance(ident.parent, (exp.Column, exp.Alias, exp.TableAlias)):
+                        continue
+                    if resolver is None:
+                        resolver = Resolver(scope, schema)
+                    source_table = resolver.get_table(ident.name)
+                    if source_table:
+                        selects[source_table.name].add(ident.name)
 
             # Push the selected columns down to the next scope
             for name, (node, source) in scope.selected_sources.items():

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -175,3 +175,23 @@ SELECT _0.d AS d FROM (SELECT w.d AS d FROM w AS w) AS _0;
 # title: a GROUP BY / HAVING column shadowed by a colliding projection alias is kept by pushdown
 SELECT t.n FROM (SELECT a, ARRAY_AGG(b) AS agg, COUNT(*) AS n FROM (SELECT a, b FROM x) AS agg GROUP BY a HAVING a >= 1) AS t;
 SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS agg GROUP BY a HAVING a >= 1) AS t;
+
+# dialect: bigquery
+# title: shadowed HAVING column left unqualified by qualify's early return is kept by pushdown
+SELECT t.n FROM (SELECT ARRAY_AGG(b) AS agg, COUNT(*) AS n FROM (SELECT a, b FROM x) AS agg GROUP BY a HAVING a >= 1 AND SUM(b) > 0) AS t;
+SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a, x.b AS b FROM x AS x) AS agg GROUP BY a HAVING a >= 1 AND SUM(b) > 0) AS t;
+
+# dialect: bigquery
+# title: shadowed column referenced only in QUALIFY is kept by pushdown
+SELECT t.rn FROM (SELECT ARRAY_AGG(b) OVER (PARTITION BY b) AS agg, ROW_NUMBER() OVER (ORDER BY b) AS rn FROM (SELECT a, b FROM x) AS agg QUALIFY a >= 1) AS t;
+SELECT t.rn AS rn FROM (SELECT ROW_NUMBER() OVER (ORDER BY agg.b) AS rn FROM (SELECT x.a AS a, x.b AS b FROM x AS x) AS agg QUALIFY a >= 1) AS t;
+
+# dialect: bigquery
+# title: shadowed clause column is pushed down into a CTE
+WITH agg AS (SELECT a, b FROM x) SELECT t.n FROM (SELECT ARRAY_AGG(b) AS agg, COUNT(*) AS n FROM agg GROUP BY a HAVING a >= 1) AS t;
+WITH agg AS (SELECT x.a AS a FROM x AS x) SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM agg AS agg GROUP BY a HAVING a >= 1) AS t;
+
+# dialect: bigquery
+# title: shadowed clause column resolves to the correct side of a join
+SELECT t.n FROM (SELECT ARRAY_AGG(q.b) AS q, COUNT(*) AS n FROM (SELECT a, b FROM x) AS q CROSS JOIN (SELECT c FROM y) AS r GROUP BY a HAVING a > 0) AS t;
+SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS q CROSS JOIN (SELECT 1 AS _ FROM y AS y) AS r GROUP BY a HAVING a > 0) AS t;

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -170,3 +170,8 @@ SELECT _0.d AS d FROM (SELECT INLINE(w.e) AS col, w.d AS d FROM w AS w) AS _0;
 -- Window functions do not affect cardinality and stay prunable
 SELECT d FROM (SELECT d, ROW_NUMBER() OVER (PARTITION BY e ORDER BY d) AS rn FROM w);
 SELECT _0.d AS d FROM (SELECT w.d AS d FROM w AS w) AS _0;
+
+# dialect: bigquery
+# title: a GROUP BY / HAVING column shadowed by a colliding projection alias is kept by pushdown
+SELECT t.n FROM (SELECT a, ARRAY_AGG(b) AS agg, COUNT(*) AS n FROM (SELECT a, b FROM x) AS agg GROUP BY a HAVING a >= 1) AS t;
+SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS agg GROUP BY a HAVING a >= 1) AS t;


### PR DESCRIPTION
`pushdown_projections` decides which projections to keep by scanning `Column` nodes and grouping them by source table. For BigQuery (`PROJECTION_ALIASES_SHADOW_SOURCE_NAMES`), the alias-shadow workaround rewrites `GROUP BY` / `HAVING` / `QUALIFY` references into bare `Identifier`s when a projection alias collides with a source name, and its early `return` can also leave later references as unqualified `Column`s. Both forms were invisible to the scan, so the columns they reference were pruned from the inner scope, producing invalid SQL.

Sample Input

```sql
SELECT t.n
FROM (
  SELECT a, ARRAY_AGG(b) AS agg, COUNT(*) AS n
  FROM (SELECT a, b FROM x) AS agg
  GROUP BY a
  HAVING a >= 1
) AS t
```

Previous Output (invalid: `a` is pruned but still referenced by `GROUP BY` / `HAVING`)

```sql
SELECT t.n AS n
FROM (
  SELECT COUNT(*) AS n
  FROM (SELECT 1 AS _ FROM x AS x) AS agg
  GROUP BY a
  HAVING a >= 1
) AS t
```

Expected Output

```sql
SELECT t.n AS n
FROM (
  SELECT COUNT(*) AS n
  FROM (SELECT x.a AS a FROM x AS x) AS agg
  GROUP BY a
  HAVING a >= 1
) AS t
```

The fix scans the `GROUP BY` / `HAVING` / `QUALIFY` clauses for bare `Identifier`s and unqualified `Column`s, resolves them with `Resolver`, and adds them to the kept-column set.