### PR TITLE
fix(sqlite): emit STORED for generated columns instead of PERSISTED

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -15,7 +15,7 @@ from sqlglot.dialects.dialect import (
     rename_func,
     strposition_sql,
 )
-from sqlglot.generator import unsupported_args
+from sqlglot.generator import UNSUPPORTED_TEMPLATE, unsupported_args
 from sqlglot.optimizer.scope import find_in_scope
 from sqlglot.tokens import TokenType
 
@@ -69,7 +69,9 @@ def _generated_to_auto_increment(expression: exp.Expr) -> exp.Expr:
 
     generated = expression.find(exp.GeneratedAsIdentityColumnConstraint)
 
-    if generated:
+    # Only rewrite true identity columns. Expression-bearing forms are computed
+    # columns (GENERATED ALWAYS AS (expr)) and must keep their expression.
+    if generated and generated.expression is None:
         t.cast(exp.ColumnConstraint, generated.parent).pop()
 
         not_null = expression.find(exp.NotNullColumnConstraint)
@@ -252,6 +254,23 @@ class SQLiteGenerator(generator.Generator):
             return self.func("DATE", expression.this)
 
         return super().cast_sql(expression)
+
+    # https://www.sqlite.org/gencol.html
+    # Inline unsupported check: mypyc cannot compile a decorated override of an
+    # undecorated base-class method (same constraint as other SQLite overrides).
+    def computedcolumnconstraint_sql(self, expression: exp.ComputedColumnConstraint) -> str:
+        if expression.args.get("data_type"):
+            self.unsupported(
+                UNSUPPORTED_TEMPLATE.format(
+                    "data_type", expression.__class__.__name__, self.dialect.__class__.__name__
+                )
+            )
+
+        this = expression.this
+        this_sql = self.sql(this) if isinstance(this, exp.Paren) else f"({self.sql(this)})"
+        storage = " STORED" if expression.args.get("persisted") else ""
+        not_null = " NOT NULL" if expression.args.get("not_null") else ""
+        return f"AS {this_sql}{storage}{not_null}"
 
     # Note: SQLite's TRUNC always returns REAL (e.g., trunc(10.99) -> 10.0), not INTEGER.
     # This creates a transpilation gap affecting division semantics, similar to Presto.

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -7499,10 +7499,18 @@ class Parser:
         if (not kind and self._match(TokenType.ALIAS)) or self._match_texts(
             ("ALIAS", "MATERIALIZED")
         ):
+            # Match storage before _parse_types so STORED is not treated as a data type
+            # (needed for typeless columns, e.g. SQLite `b AS (a * 2) STORED`).
             persisted = self._prev.text.upper() == "MATERIALIZED"
+            expression = self._parse_disjunction()
+            if not persisted:
+                if self._match_text_seq("PERSISTED"):
+                    persisted = True
+                elif self._match_texts(("STORED", "VIRTUAL")):
+                    persisted = self._prev.text.upper() == "STORED"
             constraint_kind = exp.ComputedColumnConstraint(
-                this=self._parse_disjunction(),
-                persisted=persisted or self._match_text_seq("PERSISTED"),
+                this=expression,
+                persisted=persisted,
                 data_type=exp.Var(this="AUTO")
                 if self._match_text_seq("AUTO")
                 else self._parse_types(),

--- a/sqlglot/parsers/sqlite.py
+++ b/sqlglot/parsers/sqlite.py
@@ -189,16 +189,16 @@ class SQLiteParser(parser.Parser):
     ):
         this = super()._parse_generated_as_identity()
 
-        matched_storage = self._match_texts(("STORED", "VIRTUAL"))
-        persisted = bool(matched_storage and self._prev.text.upper() == "STORED")
-
+        # Only expression-bearing GENERATED ALWAYS AS (expr) forms are computed
+        # columns. Match STORED/VIRTUAL inside this branch so true identity
+        # (AS IDENTITY) does not silently consume a trailing storage keyword.
         if (
             isinstance(this, exp.GeneratedAsIdentityColumnConstraint)
             and this.expression is not None
         ):
-            # GENERATED ALWAYS AS (expr) [STORED|VIRTUAL] is a computed column.
-            # Without this, the expression-bearing identity form is rewritten to
-            # AUTOINCREMENT by the SQLite generator.
+            persisted = (
+                self._match_texts(("STORED", "VIRTUAL")) and self._prev.text.upper() == "STORED"
+            )
             return self.expression(
                 exp.ComputedColumnConstraint(this=this.expression, persisted=persisted)
             )

--- a/sqlglot/parsers/sqlite.py
+++ b/sqlglot/parsers/sqlite.py
@@ -178,3 +178,29 @@ class SQLiteParser(parser.Parser):
             if is_attach
             else self.expression(exp.Detach(this=this))
         )
+
+    # https://www.sqlite.org/gencol.html
+    def _parse_generated_as_identity(
+        self,
+    ) -> (
+        exp.GeneratedAsIdentityColumnConstraint
+        | exp.ComputedColumnConstraint
+        | exp.GeneratedAsRowColumnConstraint
+    ):
+        this = super()._parse_generated_as_identity()
+
+        matched_storage = self._match_texts(("STORED", "VIRTUAL"))
+        persisted = bool(matched_storage and self._prev.text.upper() == "STORED")
+
+        if (
+            isinstance(this, exp.GeneratedAsIdentityColumnConstraint)
+            and this.expression is not None
+        ):
+            # GENERATED ALWAYS AS (expr) [STORED|VIRTUAL] is a computed column.
+            # Without this, the expression-bearing identity form is rewritten to
+            # AUTOINCREMENT by the SQLite generator.
+            return self.expression(
+                exp.ComputedColumnConstraint(this=this.expression, persisted=persisted)
+            )
+
+        return this

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -367,6 +367,33 @@ class TestSQLite(Validator):
             self.validate_identity("TRUNC(3.14, 2)", "TRUNC(3.14)").assert_is(exp.Trunc)
             self.assertIn("'decimals' is not supported", cm.output[0])
 
+    def test_generated_columns(self):
+        # SQLite uses STORED/VIRTUAL; PERSISTED is T-SQL and is rejected by SQLite.
+        # https://www.sqlite.org/gencol.html
+        self.validate_identity("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)")
+        self.validate_identity("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))")
+        self.validate_identity(
+            "CREATE TABLE t (a INTEGER, b INTEGER GENERATED ALWAYS AS (a * 2) STORED)",
+            "CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INTEGER, b INTEGER GENERATED ALWAYS AS (a * 2) VIRTUAL)",
+            "CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INTEGER, b INTEGER GENERATED ALWAYS AS (a * 2))",
+            "CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))",
+        )
+        # True identity still maps to AUTOINCREMENT.
+        self.validate_identity(
+            "CREATE TABLE t (a INTEGER GENERATED ALWAYS AS IDENTITY)",
+            "CREATE TABLE t (a INTEGER AUTOINCREMENT)",
+        )
+        self.validate_all(
+            "CREATE TABLE t (a INTEGER, b AS (a * 2) STORED NOT NULL)",
+            read={"tsql": "CREATE TABLE t (a INT, b AS (a * 2) PERSISTED NOT NULL)"},
+        )
+
     def test_ddl(self):
         for conflict_action in ("ABORT", "FAIL", "IGNORE", "REPLACE", "ROLLBACK"):
             with self.subTest(f"ON CONFLICT {conflict_action}"):

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -372,6 +372,9 @@ class TestSQLite(Validator):
         # https://www.sqlite.org/gencol.html
         self.validate_identity("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)")
         self.validate_identity("CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))")
+        # Typeless computed columns must keep STORED/VIRTUAL (not parse them as types).
+        self.validate_identity("CREATE TABLE t (a INTEGER, b AS (a * 2) STORED)")
+        self.validate_identity("CREATE TABLE t (a INTEGER, b AS (a * 2))")
         self.validate_identity(
             "CREATE TABLE t (a INTEGER, b INTEGER GENERATED ALWAYS AS (a * 2) STORED)",
             "CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2) STORED)",
@@ -384,10 +387,10 @@ class TestSQLite(Validator):
             "CREATE TABLE t (a INTEGER, b INTEGER GENERATED ALWAYS AS (a * 2))",
             "CREATE TABLE t (a INTEGER, b INTEGER AS (a * 2))",
         )
-        # True identity still maps to AUTOINCREMENT.
+        # True identity maps to AUTOINCREMENT; SQLite requires PRIMARY KEY.
         self.validate_identity(
-            "CREATE TABLE t (a INTEGER GENERATED ALWAYS AS IDENTITY)",
-            "CREATE TABLE t (a INTEGER AUTOINCREMENT)",
+            "CREATE TABLE t (a INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY)",
+            "CREATE TABLE t (a INTEGER PRIMARY KEY AUTOINCREMENT)",
         )
         self.validate_all(
             "CREATE TABLE t (a INTEGER, b AS (a * 2) STORED NOT NULL)",


### PR DESCRIPTION
SQLite rejects T-SQL's PERSISTED keyword. Parse GENERATED ALWAYS AS (expr) [STORED|VIRTUAL] as computed columns so they are not rewritten to AUTOINCREMENT, and generate STORED/VIRTUAL correctly.