### PR TITLE
fix(exasol): show full tables case-insensitively mariadb compatibility [CLAUDE]

### DIFF
--- a/sqlglot/generators/exasol.py
+++ b/sqlglot/generators/exasol.py
@@ -906,13 +906,24 @@ class ExasolGenerator(generator.Generator):
     def show_sql(self, expression: exp.Show) -> str:
         if expression.name == "TABLES":
             db_name = expression.text("db")
+            # TABLE_SCHEMA stores identifier text as created, so compare case-insensitively:
+            # Exasol resolves identifiers that way under SQL_IDENTIFIER_COMPARISON =
+            # 'IGNORE CASE', and a schema created lower case never matches otherwise.
             schema_filter: exp.Expression = (
-                exp.Literal.string(db_name.upper()) if db_name else exp.CurrentSchema()
+                exp.Literal.string(db_name.upper())
+                if db_name
+                else exp.func("UPPER", exp.CurrentSchema())
             )
+            projections: t.List[exp.Expression] = [exp.column("TABLE_NAME")]
+            if expression.args.get("full"):
+                # EXA_ALL_TABLES holds only base tables — views live in EXA_ALL_VIEWS.
+                projections.append(
+                    exp.alias_(exp.Literal.string("BASE TABLE"), "Table_type", quoted=True)
+                )
             select = (
-                exp.select(exp.column("TABLE_NAME"))
+                exp.select(*projections)
                 .from_(exp.table_("EXA_ALL_TABLES", db="SYS"))
-                .where(exp.column("TABLE_SCHEMA").eq(schema_filter))
+                .where(exp.func("UPPER", exp.column("TABLE_SCHEMA")).eq(schema_filter))
             )
             return self.sql(select)
 

--- a/tests/dialects/test_exasol.py
+++ b/tests/dialects/test_exasol.py
@@ -986,17 +986,33 @@ class TestExasol(Validator):
 
     def test_show_tables(self):
         self.validate_all(
-            "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = 'TEST'",
+            "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = 'TEST'",
             read={"mysql": "SHOW TABLES FROM test"},
             write={
-                "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = 'TEST'"
+                "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = 'TEST'"
             },
         )
         self.validate_all(
-            "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA",
+            "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = UPPER(CURRENT_SCHEMA)",
             read={"mysql": "SHOW TABLES"},
             write={
-                "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE TABLE_SCHEMA = CURRENT_SCHEMA"
+                "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = UPPER(CURRENT_SCHEMA)"
+            },
+        )
+        # a schema stored lower case still matches, whatever case the query used
+        self.validate_all(
+            "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = 'TEST'",
+            read={"mysql": "SHOW TABLES FROM `test`"},
+            write={
+                "exasol": "SELECT TABLE_NAME FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = 'TEST'"
+            },
+        )
+        # SHOW FULL TABLES also reports a table type
+        self.validate_all(
+            "SELECT TABLE_NAME, 'BASE TABLE' AS \"Table_type\" FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = 'TEST'",
+            read={"mysql": "SHOW FULL TABLES FROM test"},
+            write={
+                "exasol": "SELECT TABLE_NAME, 'BASE TABLE' AS \"Table_type\" FROM SYS.EXA_ALL_TABLES WHERE UPPER(TABLE_SCHEMA) = 'TEST'"
             },
         )
 


### PR DESCRIPTION
SHOW TABLES FROM <db> uppercased the schema name and compared it exactly to EXA_ALL_TABLES.TABLE_SCHEMA, which stores identifier text as created. Exasol resolves identifiers case-insensitively under SQL_IDENTIFIER_ COMPARISON = 'IGNORE CASE', so a schema created lower case matched nothing and the statement silently returned no rows. Compare UPPER() on both sides, including the CURRENT_SCHEMA branch.

Also emit the table-type column for SHOW FULL TABLES, which was parsed and then dropped. EXA_ALL_TABLES holds only base tables, so it's constant.