### PR TITLE
refactor(optimizer)!: represent shadowed clause column refs as qualified Columns

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -1699,7 +1699,16 @@ class AggFunc(Func):
 
 
 class Column(Expression, Condition):
-    arg_types = {"this": True, "table": False, "db": False, "catalog": False, "join_mark": False}
+    # "shadow" marks a column whose qualifier is shadowed by a projection alias, so it must be
+    # rendered unqualified in dialects where PROJECTION_ALIASES_SHADOW_SOURCE_NAMES is set
+    arg_types = {
+        "this": True,
+        "table": False,
+        "db": False,
+        "catalog": False,
+        "join_mark": False,
+        "shadow": False,
+    }
 
     @property
     def table(self) -> str:

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1151,6 +1151,10 @@ class Generator:
         return f"{default}CHARACTER SET={self.sql(expression, 'this')}"
 
     def column_parts(self, expression: exp.Column) -> str:
+        if expression.args.get("shadow") and self.dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES:
+            # The qualifier would be captured by a colliding projection alias (see qualify_columns)
+            return self.sql(expression, "this")
+
         return ".".join(
             self.sql(part)
             for part in (

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from sqlglot import alias, exp
 from sqlglot.optimizer.journal import Journal, record
 from sqlglot.optimizer.qualify_columns import Resolver
-from sqlglot.optimizer.scope import Scope, find_all_in_scope, find_in_scope, traverse_scope
+from sqlglot.optimizer.scope import Scope, find_in_scope, traverse_scope
 from sqlglot.schema import ensure_schema
 from sqlglot.errors import OptimizeError
 from sqlglot.helper import seq_get
@@ -134,27 +134,6 @@ def pushdown_projections(
                 table_name = col.table
                 col_name = col.name
                 selects[table_name].add(col_name)
-
-            # qualify's alias shadow workaround leaves bare identifier/unqualified column refs that the scan above misses
-            resolver = None
-            for clause in (
-                scope.expression.args.get("group"),
-                scope.expression.args.get("having"),
-                scope.expression.args.get("qualify"),
-            ):
-                if not clause:
-                    continue
-                for ref in find_all_in_scope(clause, exp.Identifier, exp.Column):
-                    if isinstance(ref, exp.Column):
-                        if ref.table:
-                            continue
-                    elif isinstance(ref.parent, (exp.Column, exp.Alias, exp.TableAlias)):
-                        continue
-                    if resolver is None:
-                        resolver = Resolver(scope, schema)
-                    source_table = resolver.get_table(ref.name)
-                    if source_table:
-                        selects[source_table.name].add(ref.name)
 
             # Push the selected columns down to the next scope
             for name, (node, source) in scope.selected_sources.items():

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -9,7 +9,14 @@ from sqlglot.dialects.dialect import Dialect, DialectType
 from sqlglot.errors import OptimizeError, highlight_sql
 from sqlglot.optimizer.annotate_types import TypeAnnotator
 from sqlglot.optimizer.resolver import Resolver
-from sqlglot.optimizer.scope import Scope, build_scope, find_in_scope, traverse_scope, walk_in_scope
+from sqlglot.optimizer.scope import (
+    Scope,
+    build_scope,
+    find_all_in_scope,
+    find_in_scope,
+    traverse_scope,
+    walk_in_scope,
+)
 from sqlglot.optimizer.simplify import simplify_parens
 from sqlglot.schema import Schema, ensure_schema
 
@@ -382,24 +389,6 @@ def _expand_alias_refs(
                         node.parts[0].name in projections
                         for node in alias_expr.find_all(exp.Column)
                     )
-            elif dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES and (
-                is_group_by or is_having or is_qualify
-            ):
-                column_table = table.name if table else column.table
-                if column_table in projections:
-                    # In BigQuery's GROUP BY, HAVING and QUALIFY clauses, a qualifier that collides
-                    # with a projection alias resolves to the projection instead of the source. For instance:
-                    # SELECT id, ARRAY_AGG(col) AS custom_fields FROM custom_fields GROUP BY custom_fields.id
-                    # fails with "Column custom_fields contains an aggregation function, which is not
-                    # allowed in GROUP BY", so the reference must be rendered as the bare name "id".
-                    # We keep the column qualified and mark it, deferring to Generator.column_parts
-                    if table:
-                        column.set("table", table)
-
-                    column.set("shadow", True)
-                    replaced = True
-                    continue
-
             if table and (not alias_expr or skip_replace):
                 column.set("table", table)
             elif not column.table and alias_expr and not skip_replace:
@@ -463,6 +452,25 @@ def _expand_alias_refs(
     if dialect.SUPPORTS_ALIAS_REFS_IN_JOIN_CONDITIONS:
         for join in expression.args.get("joins") or []:
             replace_columns(join)
+
+    if dialect.PROJECTION_ALIASES_SHADOW_SOURCE_NAMES:
+        # In BigQuery's GROUP BY, HAVING and QUALIFY clauses, a qualifier that collides with a
+        # projection alias resolves to the projection instead of the source. For instance:
+        # SELECT id, ARRAY_AGG(col) AS custom_fields FROM custom_fields GROUP BY custom_fields.id
+        # fails with "Column custom_fields contains an aggregation function, which is not
+        # allowed in GROUP BY", so such references must be rendered as bare names. We keep the
+        # columns qualified and mark them, deferring to Generator.column_parts
+        for clause in (
+            expression.args.get("group"),
+            expression.args.get("having"),
+            expression.args.get("qualify"),
+        ):
+            if not clause:
+                continue
+
+            for column in find_all_in_scope(clause, exp.Column):
+                if column.table and not column.db:
+                    column.set("shadow", column.table in projections or None)
 
     if replaced:
         scope.clear_cache()

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -387,14 +387,18 @@ def _expand_alias_refs(
             ):
                 column_table = table.name if table else column.table
                 if column_table in projections:
-                    # BigQuery's GROUP BY and HAVING clauses get confused if the column name
-                    # matches a source name and a projection. For instance:
-                    # SELECT id, ARRAY_AGG(col) AS custom_fields FROM custom_fields GROUP BY id HAVING id >= 1
-                    # We should not qualify "id" with "custom_fields" in either clause, since the aggregation shadows the actual table
-                    # and we'd get the error: "Column custom_fields contains an aggregation function, which is not allowed in GROUP BY clause"
-                    column.replace(exp.to_identifier(column.name))
+                    # In BigQuery's GROUP BY, HAVING and QUALIFY clauses, a qualifier that collides
+                    # with a projection alias resolves to the projection instead of the source. For instance:
+                    # SELECT id, ARRAY_AGG(col) AS custom_fields FROM custom_fields GROUP BY custom_fields.id
+                    # fails with "Column custom_fields contains an aggregation function, which is not
+                    # allowed in GROUP BY", so the reference must be rendered as the bare name "id".
+                    # We keep the column qualified and mark it, deferring to Generator.column_parts
+                    if table:
+                        column.set("table", table)
+
+                    column.set("shadow", True)
                     replaced = True
-                    return
+                    continue
 
             if table and (not alias_expr or skip_replace):
                 column.set("table", table)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -3039,6 +3039,19 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             'SELECT "custom_fields"."id" AS "id", ARRAY_AGG("custom_fields"."col") AS "custom_fields" FROM "custom_fields" AS "custom_fields" GROUP BY "custom_fields"."id" HAVING "custom_fields"."id" >= 1',
         )
 
+        # A clause ref whose name matches a projection alias takes the alias-expansion path
+        # instead of the branch above; the final sweep must still mark its colliding qualifier
+        query = "SELECT custom_fields.id AS id, ARRAY_AGG(custom_fields.col) AS custom_fields FROM custom_fields AS custom_fields GROUP BY id HAVING id >= 1"
+        qual = optimizer.qualify.qualify(
+            parse_one(query, dialect=dialect),
+            schema=schema,
+            dialect=dialect,
+        )
+        self.assertEqual(
+            qual.sql(dialect=dialect),
+            "SELECT `custom_fields`.`id` AS `id`, ARRAY_AGG(`custom_fields`.`col`) AS `custom_fields` FROM `custom_fields` AS `custom_fields` GROUP BY `id` HAVING `id` >= 1",
+        )
+
     def test_struct_annotation_bigquery(self):
         sql = """
         WITH t1 AS (SELECT 'foo' AS c),

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -3029,6 +3029,16 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             "SELECT `custom_fields`.`id` AS `id`, ARRAY_AGG(`custom_fields`.`col`) AS `custom_fields` FROM `custom_fields` AS `custom_fields` GROUP BY `id` HAVING `id` >= 1",
         )
 
+        # The shadowed references stay qualified in the AST and only render bare in
+        # dialects where projection aliases shadow source names
+        group_col = qual.args["group"].find(exp.Column)
+        self.assertEqual(group_col.table, "custom_fields")
+        self.assertTrue(group_col.args.get("shadow"))
+        self.assertEqual(
+            qual.sql(dialect="duckdb"),
+            'SELECT "custom_fields"."id" AS "id", ARRAY_AGG("custom_fields"."col") AS "custom_fields" FROM "custom_fields" AS "custom_fields" GROUP BY "custom_fields"."id" HAVING "custom_fields"."id" >= 1',
+        )
+
     def test_struct_annotation_bigquery(self):
         sql = """
         WITH t1 AS (SELECT 'foo' AS c),


### PR DESCRIPTION
BigQuery's group by, having and qualify clauses place projection aliases in the same namespace as source names, and on collision the alias captures the qualifier: with a projection `ARRAY_AGG(b) AS agg` and a source named `agg`, the reference `agg.a` resolves to the projection and then fails with "Column agg contains an aggregation function...", while the bare name a resolves to the source column.

`qualify`'s workaround handled this by replacing the column with its identifier child. That representation caused the pushdown bug fixed in #8121 and is what this PR revisits. This:

- Improves transpilation from bigquery to other dialects, because after we qualify the columns are resolved correctly instead of relying on whatever behavior each engine implements (tested the result and works across most major engines)
- Removes the early return in qualify, which previously aborted the process after the first collision, leaving later refs as unqualified columns, leading to a mixed/inconsistent representation. All refs are now handled uniformly.

There's a known issue prior to this PR which is left as a follow-up: `merge_subqueries` substitutes refs with inner expressions, which can drop the collision state or create a new collision after renaming.