### PR TITLE
fix(optimizer)!: stop pruning implicit GROUP BY ALL keys during projection pushdown

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -187,7 +187,9 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
 
     for selection in scope.expression.selects:
         name = selection.alias_or_name
-        is_agg_selection = find_in_scope(selection, exp.AggFunc) is not None
+        is_agg_selection = (implicit_group_by_all or not is_agg) and find_in_scope(
+            selection, exp.AggFunc
+        ) is not None
 
         if (
             select_all

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -174,6 +174,10 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
     ordinal_refs = _bare_group_by_ordinal_refs(scope.expression)
     group_ordinal_selection_ids = {id(selection) for _, selection in ordinal_refs}
 
+    # GROUP BY ALL with no explicit keys implicitly groups by every non-aggregate
+    # projection, so those projections are grouping keys and can't be pruned
+    implicit_group_by_all = _is_implicit_group_by_all(scope.expression)
+
     new_selections = []
     removed = False
     star = False
@@ -183,6 +187,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
 
     for selection in scope.expression.selects:
         name = selection.alias_or_name
+        is_agg_selection = find_in_scope(selection, exp.AggFunc) is not None
 
         if (
             select_all
@@ -190,6 +195,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
             or name in order_refs
             or alias_count > 0
             or id(selection) in group_ordinal_selection_ids
+            or (implicit_group_by_all and not is_agg_selection)
         ):
             new_selections.append(selection)
             alias_count -= 1
@@ -204,7 +210,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
                 star = True
             removed = True
 
-        if not is_agg and find_in_scope(selection, exp.AggFunc):
+        if not is_agg and is_agg_selection:
             is_agg = True
 
     if star:
@@ -238,6 +244,21 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
 
     if removed:
         scope.clear_cache()
+
+
+def _is_implicit_group_by_all(select: exp.Select) -> bool:
+    """Bare GROUP BY ALL infers its keys from the SELECT list, unlike ALL as a
+    grouping-sets modifier (e.g. GROUP BY ALL CUBE (...) or GROUP BY ALL a, b)."""
+    group = select.args.get("group")
+    if not group or not group.args.get("all"):
+        return False
+
+    return not (
+        group.expressions
+        or group.args.get("cube")
+        or group.args.get("rollup")
+        or group.args.get("grouping_sets")
+    )
 
 
 def _bare_group_by_ordinal_refs(

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -80,13 +80,10 @@ def pushdown_projections(
         alias_count = source_column_alias_count.get(scope, 0)
 
         # We can't remove columns from SELECT DISTINCT nor UNION DISTINCT. INTERSECT and
-        # EXCEPT match on entire rows, so every column is used even in the ALL variants,
-        # and GROUP BY ALL groups by every non-aggregate projection.
-        group = scope.expression.args.get("group")
-        if (
-            scope.expression.args.get("distinct")
-            or (group and group.args.get("all"))
-            or isinstance(scope.expression, (exp.Intersect, exp.Except))
+        # EXCEPT match on entire rows, so every column is used even in the ALL variants.
+        # Bare GROUP BY ALL is handled per-selection in _remove_unused_selections.
+        if scope.expression.args.get("distinct") or isinstance(
+            scope.expression, (exp.Intersect, exp.Except)
         ):
             parent_selections = {SELECT_ALL}
 

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -212,6 +212,11 @@ SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS
 SELECT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
 SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) AS t;
 
+-- Unreferenced aggregate projections stay prunable, including those after the
+-- first aggregate in the SELECT list
+SELECT t.a FROM (SELECT a, SUM(b) AS s1, MAX(b) AS s2 FROM x GROUP BY ALL) t;
+SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x GROUP BY ALL) AS t;
+
 -- An implicit key can be a non-column expression, not just a bare column
 SELECT t.a, t.c FROM (SELECT a, b, b + 1 AS c, SUM(a) AS s FROM x GROUP BY ALL) t;
 SELECT t.a AS a, t.c AS c FROM (SELECT x.a AS a, x.b AS b, x.b + 1 AS c FROM x AS x GROUP BY ALL) AS t;

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -204,3 +204,50 @@ WITH agg AS (SELECT x.a AS a FROM x AS x) SELECT t.n AS n FROM (SELECT COUNT(*) 
 # title: shadowed clause column resolves to the correct side of a join
 SELECT t.n FROM (SELECT ARRAY_AGG(q.b) AS q, COUNT(*) AS n FROM (SELECT a, b FROM x) AS q CROSS JOIN (SELECT c FROM y) AS r GROUP BY a HAVING a > 0) AS t;
 SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS q CROSS JOIN (SELECT 1 AS _ FROM y AS y) AS r GROUP BY a HAVING a > 0) AS t;
+
+--------------------------------------
+-- GROUP BY ALL implicitly groups by every non-aggregate projection, so those
+-- projections must be retained even when unreferenced by the outer scope
+--------------------------------------
+SELECT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) AS t;
+
+-- Selecting only the aggregate must not collapse every implicit key
+SELECT t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
+SELECT t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS t;
+
+-- An implicit key can be a non-column expression, not just a bare column
+SELECT t.a, t.c FROM (SELECT a, b, b + 1 AS c, SUM(a) AS s FROM x GROUP BY ALL) t;
+SELECT t.a AS a, t.c AS c FROM (SELECT x.a AS a, x.b AS b, x.b + 1 AS c FROM x AS x GROUP BY ALL) AS t;
+
+-- Same rule applies when the GROUP BY ALL scope is a named CTE
+WITH t AS (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) SELECT t.a FROM t;
+WITH t AS (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) SELECT t.a AS a FROM t AS t;
+
+-- Same rule applies to every branch of a set operation
+SELECT u.a, u.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL UNION ALL SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) u;
+SELECT u.a AS a, u.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL UNION ALL SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS u;
+
+-- HAVING referencing the aggregate does not make an unrelated implicit key referenced
+SELECT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL HAVING SUM(b) > 1) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL HAVING SUM(x.b) > 1) AS t;
+
+-- An outer SELECT DISTINCT does not protect the inner scope's implicit keys
+SELECT DISTINCT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
+SELECT DISTINCT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) AS t;
+
+-- A join predicate referencing one key must not leave the others unprotected
+SELECT t.s FROM y JOIN (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t ON y.b = t.a;
+SELECT t.s AS s FROM y AS y JOIN (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS t ON y.b = t.a;
+
+-- The rule must hold across nested GROUP BY ALL scopes
+SELECT z.s2 FROM (SELECT y.a AS a, SUM(y.s) AS s2 FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) y GROUP BY ALL) z;
+SELECT z.s2 AS s2 FROM (SELECT y.a AS a, SUM(y.s) AS s2 FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS y GROUP BY ALL) AS z;
+
+-- ALL is a grouping-sets modifier (not implicit-key inference) once CUBE/ROLLUP/an explicit
+-- list is present, so those columns stay prunable like any other explicit GROUP BY column
+SELECT t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL CUBE (a, b)) t;
+SELECT t.s AS s FROM (SELECT SUM(x.b) AS s FROM x AS x GROUP BY ALL CUBE (x.a, x.b)) AS t;
+
+SELECT t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL a, b) t;
+SELECT t.s AS s FROM (SELECT SUM(x.b) AS s FROM x AS x GROUP BY ALL x.a, x.b) AS t;

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -212,37 +212,9 @@ SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS
 SELECT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
 SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) AS t;
 
--- Selecting only the aggregate must not collapse every implicit key
-SELECT t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
-SELECT t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS t;
-
 -- An implicit key can be a non-column expression, not just a bare column
 SELECT t.a, t.c FROM (SELECT a, b, b + 1 AS c, SUM(a) AS s FROM x GROUP BY ALL) t;
 SELECT t.a AS a, t.c AS c FROM (SELECT x.a AS a, x.b AS b, x.b + 1 AS c FROM x AS x GROUP BY ALL) AS t;
-
--- Same rule applies when the GROUP BY ALL scope is a named CTE
-WITH t AS (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) SELECT t.a FROM t;
-WITH t AS (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) SELECT t.a AS a FROM t AS t;
-
--- Same rule applies to every branch of a set operation
-SELECT u.a, u.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL UNION ALL SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) u;
-SELECT u.a AS a, u.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL UNION ALL SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS u;
-
--- HAVING referencing the aggregate does not make an unrelated implicit key referenced
-SELECT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL HAVING SUM(b) > 1) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL HAVING SUM(x.b) > 1) AS t;
-
--- An outer SELECT DISTINCT does not protect the inner scope's implicit keys
-SELECT DISTINCT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t;
-SELECT DISTINCT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x GROUP BY ALL) AS t;
-
--- A join predicate referencing one key must not leave the others unprotected
-SELECT t.s FROM y JOIN (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t ON y.b = t.a;
-SELECT t.s AS s FROM y AS y JOIN (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS t ON y.b = t.a;
-
--- The rule must hold across nested GROUP BY ALL scopes
-SELECT z.s2 FROM (SELECT y.a AS a, SUM(y.s) AS s2 FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) y GROUP BY ALL) z;
-SELECT z.s2 AS s2 FROM (SELECT y.a AS a, SUM(y.s) AS s2 FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ALL) AS y GROUP BY ALL) AS z;
 
 -- ALL is a grouping-sets modifier (not implicit-key inference) once CUBE/ROLLUP/an explicit
 -- list is present, so those columns stay prunable like any other explicit GROUP BY column


### PR DESCRIPTION
`pushdown_projections` prunes columns that aren't referenced by an outer query. But a bare `GROUP BY ALL` infers its grouping keys from projections in the `SELECT` list, so pruning an "unused" column silently changes which columns are grouped by, corrupting the aggregation.

Input:
```
SELECT t.a FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL) t
```
Wrong output (b and s are dropped):
```
SELECT "t"."a" AS "a" FROM (SELECT "x"."a" AS "a" FROM "x" AS "x" GROUP BY ALL) AS "t"
```
Expected output
```
SELECT "t"."a" AS "a" FROM (SELECT "x"."a" AS "a", "x"."b" AS "b" FROM "x" AS "x" GROUP BY ALL) AS "t"
```

Fix

We now check whether the scope has a `GROUP BY ALL` and keeps projections regardless of outer references.