### PR TITLE
feat(trino): parse LOOP/REPEAT/ITERATE/LEAVE routine statements [CLAUDE]

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2140,7 +2140,7 @@ class Leave(Expression):
 
 
 class Iterate(Expression):
-    arg_types = {"this": True}
+    pass
 
 
 class EndStatement(Expression):

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2127,6 +2127,22 @@ class WhileBlock(Expression):
     arg_types = {"this": True, "body": True, "label": False}
 
 
+class LoopBlock(Expression):
+    arg_types = {"body": True, "label": False}
+
+
+class RepeatBlock(Expression):
+    arg_types = {"body": True, "until": True, "label": False}
+
+
+class Leave(Expression):
+    arg_types = {"this": True}
+
+
+class Iterate(Expression):
+    arg_types = {"this": True}
+
+
 class EndStatement(Expression):
     arg_types = {}
 

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2136,7 +2136,7 @@ class RepeatBlock(Expression):
 
 
 class Leave(Expression):
-    arg_types = {"this": True}
+    pass
 
 
 class Iterate(Expression):

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -105,6 +105,25 @@ class TrinoGenerator(PrestoGenerator):
         body = self.sql(expression, "body")
         return f"{label_sql}WHILE {condition} DO {body}; END WHILE"
 
+    def loopblock_sql(self, expression: exp.LoopBlock) -> str:
+        label = expression.args.get("label")
+        label_sql = f"{self.sql(label)}: " if label else ""
+        body = self.sql(expression, "body")
+        return f"{label_sql}LOOP {body}; END LOOP"
+
+    def repeatblock_sql(self, expression: exp.RepeatBlock) -> str:
+        label = expression.args.get("label")
+        label_sql = f"{self.sql(label)}: " if label else ""
+        body = self.sql(expression, "body")
+        until = self.sql(expression, "until")
+        return f"{label_sql}REPEAT {body}; UNTIL {until} END REPEAT"
+
+    def leave_sql(self, expression: exp.Leave) -> str:
+        return f"LEAVE {self.sql(expression, 'this')}"
+
+    def iterate_sql(self, expression: exp.Iterate) -> str:
+        return f"ITERATE {self.sql(expression, 'this')}"
+
     def jsonextract_sql(self, expression: exp.JSONExtract) -> str:
         if not expression.args.get("json_query"):
             return super().jsonextract_sql(expression)

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -207,6 +207,21 @@ class TrinoParser(PrestoParser):
         self._match_text_seq("WHILE")
         return self.expression(exp.WhileBlock(this=condition, body=body, label=label))
 
+    def _parse_routine_loop(self, label: exp.Expr | None = None) -> exp.LoopBlock:
+        # https://trino.io/docs/current/udf/sql/loop.html
+        body = self.expression(exp.Block(expressions=self._parse_routine_statements("END")))
+        self._match_text_seq("LOOP")
+        return self.expression(exp.LoopBlock(body=body, label=label))
+
+    def _parse_routine_repeat(self, label: exp.Expr | None = None) -> exp.RepeatBlock:
+        # https://trino.io/docs/current/udf/sql/repeat.html - unlike WHILE/LOOP,
+        # the body is evaluated at least once, with UNTIL <condition> tested after
+        body = self.expression(exp.Block(expressions=self._parse_routine_statements("UNTIL")))
+        until = self._parse_disjunction()
+        self._match_text_seq("END")
+        self._match_text_seq("REPEAT")
+        return self.expression(exp.RepeatBlock(body=body, until=until, label=label))
+
     def _parse_routine_statement(self) -> exp.Expr | None:
         if self._match(TokenType.BEGIN, advance=False):
             return self._parse_routine_block()
@@ -226,8 +241,14 @@ class TrinoParser(PrestoParser):
         if self._match(TokenType.SET):
             return self._parse_set()
 
-        # An optional `label :` can precede WHILE (and, in later phases, LOOP/REPEAT)
-        # to name the block for ITERATE/LEAVE.
+        if self._match_text_seq("ITERATE"):
+            return self.expression(exp.Iterate(this=self._parse_id_var()))
+
+        if self._match_text_seq("LEAVE"):
+            return self.expression(exp.Leave(this=self._parse_id_var()))
+
+        # An optional `label :` can precede WHILE, LOOP, or REPEAT to name the
+        # block for ITERATE/LEAVE.
         label = None
         if self._next and self._next.token_type == TokenType.COLON:
             label = self._parse_id_var()
@@ -235,6 +256,12 @@ class TrinoParser(PrestoParser):
 
         if self._match_text_seq("WHILE"):
             return self._parse_routine_while(label=label)
+
+        if self._match_text_seq("LOOP"):
+            return self._parse_routine_loop(label=label)
+
+        if self._match_text_seq("REPEAT"):
+            return self._parse_routine_repeat(label=label)
 
         self.raise_error("Expected routine statement")
         return None

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -218,8 +218,7 @@ class TrinoParser(PrestoParser):
         # the body is evaluated at least once, with UNTIL <condition> tested after
         body = self.expression(exp.Block(expressions=self._parse_routine_statements("UNTIL")))
         until = self._parse_disjunction()
-        self._match_text_seq("END")
-        self._match_text_seq("REPEAT")
+        self._match_text_seq("END", "REPEAT")
         return self.expression(exp.RepeatBlock(body=body, until=until, label=label))
 
     def _parse_routine_statement(self) -> exp.Expr | None:

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -241,18 +241,19 @@ class TrinoParser(PrestoParser):
         if self._match(TokenType.SET):
             return self._parse_set()
 
-        if self._match_text_seq("ITERATE"):
-            return self.expression(exp.Iterate(this=self._parse_id_var()))
-
-        if self._match_text_seq("LEAVE"):
-            return self.expression(exp.Leave(this=self._parse_id_var()))
-
         # An optional `label :` can precede WHILE, LOOP, or REPEAT to name the
-        # block for ITERATE/LEAVE.
+        # block for ITERATE/LEAVE - and, confirmed against a real Trino
+        # instance, `ITERATE`/`LEAVE` themselves are valid label names (e.g.
+        # `iterate: LOOP ... END LOOP`), so the colon lookahead has to run
+        # first, before either is matched as a keyword.
         label = None
         if self._next and self._next.token_type == TokenType.COLON:
             label = self._parse_id_var()
             self._match(TokenType.COLON)
+        elif self._match_text_seq("ITERATE"):
+            return self.expression(exp.Iterate(this=self._parse_id_var()))
+        elif self._match_text_seq("LEAVE"):
+            return self.expression(exp.Leave(this=self._parse_id_var()))
 
         if self._match_text_seq("WHILE"):
             return self._parse_routine_while(label=label)

--- a/sqlglot/parsers/trino.py
+++ b/sqlglot/parsers/trino.py
@@ -241,10 +241,8 @@ class TrinoParser(PrestoParser):
             return self._parse_set()
 
         # An optional `label :` can precede WHILE, LOOP, or REPEAT to name the
-        # block for ITERATE/LEAVE - and, confirmed against a real Trino
-        # instance, `ITERATE`/`LEAVE` themselves are valid label names (e.g.
-        # `iterate: LOOP ... END LOOP`), so the colon lookahead has to run
-        # first, before either is matched as a keyword.
+        # block for ITERATE/LEAVE; these themselves are valid label names, so
+        # the colon lookahead has to run first, before either is matched as a keyword.
         label = None
         if self._next and self._next.token_type == TokenType.COLON:
             label = self._parse_id_var()

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -540,3 +540,22 @@ SELECT f(1)""",
             "top: LOOP IF i >= n THEN LEAVE top; END IF; SET i = i + 1; END LOOP; END "
             "SELECT LAST_STMT(5)"
         )
+
+        # `ITERATE`/`LEAVE` are themselves valid label names, confirmed against
+        # a real Trino instance to still return 5 for both; the label lookahead
+        # has to be checked before ITERATE/LEAVE are matched as keywords, or
+        # this misparses as a bare (invalid) ITERATE/LEAVE statement
+        self.validate_identity(
+            "WITH FUNCTION label_test(n BIGINT) RETURNS BIGINT "
+            "BEGIN DECLARE i BIGINT DEFAULT 0; "
+            "iterate: LOOP IF i >= n THEN LEAVE iterate; END IF; SET i = i + 1; END LOOP; "
+            "RETURN i; END "
+            "SELECT LABEL_TEST(5)"
+        )
+        self.validate_identity(
+            "WITH FUNCTION label_test2(n BIGINT) RETURNS BIGINT "
+            "BEGIN DECLARE i BIGINT DEFAULT 0; "
+            "leave: LOOP IF i >= n THEN LEAVE leave; END IF; SET i = i + 1; END LOOP; "
+            "RETURN i; END "
+            "SELECT LABEL_TEST2(5)"
+        )

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -477,3 +477,66 @@ SELECT f(1)""",
             "RETURN i; END "
             "SELECT WHILE_CASE(3)"
         )
+
+    def test_inline_udf_loop_repeat(self):
+        # https://trino.io/docs/current/udf/sql/loop.html - verbatim from the docs
+        # (wrapped as a function invocation); confirmed against a real Trino
+        # instance to return 10, 20, 30 for step values of 10, 20, 30
+        self.validate_identity(
+            "WITH FUNCTION to_one_hundred(start_value BIGINT, step BIGINT) RETURNS BIGINT "
+            "BEGIN DECLARE count BIGINT DEFAULT 0; DECLARE current BIGINT DEFAULT 0; "
+            "SET current = start_value; "
+            "abc: LOOP IF current >= 100 THEN LEAVE abc; END IF; "
+            "SET count = count + 1; SET current = current + step; END LOOP; "
+            "RETURN count; END "
+            "SELECT TO_ONE_HUNDRED(0, 10)"
+        )
+
+        # https://trino.io/docs/current/udf/sql/repeat.html - verbatim from the
+        # docs; unlike WHILE/LOOP the body always runs at least once, confirmed
+        # against a real Trino instance to return 10, 10, 11, 12, 13 for inputs
+        # 5, 9, 10, 11, 12
+        self.validate_identity(
+            "WITH FUNCTION test_repeat(a BIGINT) RETURNS BIGINT "
+            "BEGIN REPEAT SET a = a + 1; UNTIL a >= 10 END REPEAT; RETURN a; END "
+            "SELECT TEST_REPEAT(5)"
+        )
+
+        # https://trino.io/docs/current/udf/sql/iterate.html - verbatim from the
+        # docs (renamed from the docs' own function name to avoid colliding with
+        # the builtin COUNT aggregate); confirmed against a real Trino instance
+        # to return 7
+        self.validate_identity(
+            "WITH FUNCTION iter_count() RETURNS BIGINT "
+            "BEGIN DECLARE a BIGINT DEFAULT 0; DECLARE b BIGINT DEFAULT 0; "
+            "top: REPEAT SET a = a + 1; IF a <= 3 THEN ITERATE top; END IF; SET b = b + 1; "
+            "UNTIL a >= 10 END REPEAT; "
+            "RETURN b; END "
+            "SELECT ITER_COUNT()"
+        )
+
+        # LOOP can nest inside WHILE, and LEAVE targets the innermost matching
+        # label; confirmed against a real Trino instance to return 6 (2 outer
+        # iterations x 3 inner increments each)
+        self.validate_identity(
+            "WITH FUNCTION nested_test(n BIGINT) RETURNS BIGINT "
+            "BEGIN DECLARE total BIGINT DEFAULT 0; DECLARE i BIGINT DEFAULT 0; DECLARE j BIGINT DEFAULT 0; "
+            "outer_loop: WHILE i < n DO SET j = 0; "
+            "inner_loop: LOOP IF j >= 3 THEN LEAVE inner_loop; END IF; "
+            "SET total = total + 1; SET j = j + 1; END LOOP; "
+            "SET i = i + 1; END WHILE; "
+            "RETURN total; END "
+            "SELECT NESTED_TEST(2)"
+        )
+
+        # LOOP/REPEAT as the literal last statement, with nothing after before
+        # the enclosing END; real Trino rejects this body with "Function must
+        # end in a RETURN statement", the same function-body completeness check
+        # noted on the IF/CASE/WHILE phases. This asserts round-trip grammar
+        # only, confirmed against a real Trino instance.
+        self.validate_identity(
+            "WITH FUNCTION last_stmt(n BIGINT) RETURNS BIGINT "
+            "BEGIN DECLARE i BIGINT DEFAULT 0; "
+            "top: LOOP IF i >= n THEN LEAVE top; END IF; SET i = i + 1; END LOOP; END "
+            "SELECT LAST_STMT(5)"
+        )


### PR DESCRIPTION
Last one! FWIW, I think I found some other issue I can contribute fixes for... but first, let's close this loop. Appreciate your continued patience/help.

This is PR 7 of ~7, continuing #7934/#7981/#8004/#8044/#8068/#8122, building out Trino inline SQL UDF support (original roadmap in #7926, motivated by apache/superset#26162).

This adds parsing/generation for Trino's `[label :] LOOP ... END LOOP` and `[label :] REPEAT ... UNTIL condition END REPEAT` routine statements, plus `ITERATE label` and `LEAVE label` (https://trino.io/docs/current/udf/sql/loop.html, /repeat.html, /iterate.html, /leave.html).

### Design

`LoopBlock`/`RepeatBlock` are new expressions (no existing analog to reuse, unlike WHILE's reuse of T-SQL's `WhileBlock`), but mirror `WhileBlock`'s shape - same optional `label` arg, same `_parse_routine_statements(*terminators)` chunk-continuation helper from #8044 for the body. `REPEAT`'s body parses up to `UNTIL`, then the condition, then `END REPEAT` - the only one of the four loop forms that checks its condition after the body instead of before.

`ITERATE`/`LEAVE` are new single-arg expressions (`Iterate(this=label)`, `Leave(this=label)`) - Trino requires a label on both, no bare/unlabeled form exists, confirmed against a real Trino instance (bare `LEAVE;` is a parse error upstream).

### Verification

Confirmed against a real Trino instance: both docs examples (`to_one_hundred`/`LOOP`+`LEAVE`, `test_repeat`/`REPEAT`+`UNTIL`) return the documented outputs, `ITERATE` skips the expected iterations, LOOP nests correctly inside WHILE with `LEAVE` targeting the innermost label, a trailing label after `END LOOP` is rejected (same as WHILE), and LOOP/REPEAT as the literal last statement hits the same function-body completeness-check limitation noted on the IF/CASE/WHILE phases (round-trip grammar only, real Trino wants a literal trailing `RETURN`).

This closes out the roadmap in #7926 - IF/CASE/WHILE/LOOP/REPEAT/ITERATE/LEAVE are all in.

Related: apache/superset#26162

`make unit` and `make style` pass locally.

Disclosure: Claude Code, with me steering and doing the real-Trino verification myself. In-n-Out is the best burger, and as a human, I'll die on that hill.