### PR TITLE
ci: compute affected integration test dialects from the import graph

### DIFF
--- a/.github/scripts/get_integration_test_params.py
+++ b/.github/scripts/get_integration_test_params.py
@@ -5,17 +5,11 @@ This script is intended to be used as part of a GitHub Actions workflow in order
 a) be triggered at all
 b) if they should be triggered, should they be triggered for a subset of dialects or all dialects?
 
-The tests can be triggered manually by using the following directive in the PR description:
-
- /integration-tests
-
-To limit them to a certain dialect or dialects, you can specify:
-
- /integration-tests dialects=bigquery,duckdb
-
-If you specify nothing, a `git diff` will be performed between your PR branch and the base branch.
-If any files modified contain one of the SUPPORTED_DIALECTS in the filename, that dialect will be added to the
-list of dialects to test. If no files match, the integration tests will be skipped.
+A `git diff` is performed between your PR branch and the base branch, and each changed file is
+mapped to the set of supported dialects it can affect. This mapping is computed from sqlglot's
+import graph: a changed module affects a dialect iff the dialect's module (or a module the
+integration test harness imports) transitively imports it. Modules outside every closure
+(e.g. the executor, planner, or most optimizer rules) don't trigger any dialect tests.
 
 Note that integration tests in the remote workflow are only implemented for a subset of dialects.
 If new ones are added, update the SUPPORTED_DIALECTS constant below.
@@ -24,6 +18,7 @@ Each dialect is tested against itself (roundtrip) and duckdb (transpilation).
 Supplying a dialect not in this list will cause the tests to get skipped.
 """
 
+import ast
 import typing as t
 import os
 import sys
@@ -31,46 +26,128 @@ import json
 import subprocess
 from pathlib import Path
 
-TRIGGER = "/integration-test"
 SUPPORTED_DIALECTS = ["duckdb", "bigquery", "snowflake"]
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKAGE_ROOT = REPO_ROOT / "sqlglot"
 
-def get_dialects_from_manual_trigger(trigger: str) -> set[str]:
+# Modules imported by the integration test harness itself, on top of each dialect's module
+HARNESS_MODULES = (
+    "sqlglot.optimizer.normalize_identifiers",
+    "sqlglot.optimizer.qualify_columns",
+)
+
+# Changes to the integration test setup itself should re-run everything
+INTEGRATION_TEST_PATHS = (
+    "sqlglot-integration-tests",
+    ".github/workflows/run-integration-tests.yml",
+    ".github/scripts/get_integration_test_params.py",
+)
+
+
+def _module_name(path: str) -> str:
+    """Converts a repo-relative file path to a dotted module name."""
+    return path.removesuffix(".py").removesuffix("/__init__").replace("/", ".")
+
+
+def _walk_runtime_nodes(node: ast.AST) -> t.Iterator[ast.AST]:
+    """Yields all AST nodes reachable at runtime, i.e. skips `if TYPE_CHECKING:` blocks."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, ast.If) and ast.unparse(child.test).endswith("TYPE_CHECKING"):
+            continue
+        yield child
+        yield from _walk_runtime_nodes(child)
+
+
+def _build_import_graph() -> dict[str, set[str]]:
     """
-    Takes a trigger string and parses out the supported dialects
-
-    /integration_test -> []
-    /integration_test dialects=bigquery -> ["bigquery"]
-    /integration_test dialects=bigquery,duckdb -> ["bigquery","duckdb"]
-    /integration_test dialects=exasol,duckdb -> ["duckdb"]
+    Maps each sqlglot module to the set of sqlglot modules it imports. Imports nested inside
+    function bodies count (the generator imports optimizer modules lazily), TYPE_CHECKING-only
+    imports don't. Relative imports aren't supported because the codebase doesn't use them.
     """
+    modules = {
+        _module_name(f.relative_to(REPO_ROOT).as_posix()): f for f in PACKAGE_ROOT.rglob("*.py")
+    }
 
-    if not trigger.startswith(TRIGGER):
-        raise ValueError(f"Invalid trigger: {trigger}")
+    graph: dict[str, set[str]] = {}
 
-    # trim off start at first space (to cover both /integration-test and /integration-tests)
-    trigger_parts = trigger.split(" ")[1:]
+    for module, path in modules.items():
+        imports: set[str] = set()
 
-    print(f"Parsing trigger args: {trigger_parts}")
+        for node in _walk_runtime_nodes(ast.parse(path.read_text())):
+            if isinstance(node, ast.Import):
+                imports.update(a.name for a in node.names if a.name in modules)
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                # `from x import y` can import either the module x.y or an attribute of x
+                imports.update(
+                    m
+                    for m in (node.module, *(f"{node.module}.{a.name}" for a in node.names))
+                    if m in modules
+                )
 
-    dialects: list[str] = []
-    for part in trigger_parts:
-        # try to parse key=value pairs
-        maybe_kv = part.split("=", maxsplit=1)
-        if len(maybe_kv) >= 2:
-            k, v = maybe_kv[0], maybe_kv[1]
-            if k.lower().startswith("dialect"):
-                dialects.extend([d.lower().strip() for d in v.split(",")])
+        graph[module] = imports
 
-    return {d for d in dialects if d in SUPPORTED_DIALECTS}
+    return graph
+
+
+def _closure(roots: t.Iterable[str], graph: dict[str, set[str]]) -> set[str]:
+    seen: set[str] = set()
+    stack = list(roots)
+
+    while stack:
+        module = stack.pop()
+        if module in seen:
+            continue
+
+        seen.add(module)
+        stack.extend(graph.get(module, ()))
+
+        # Importing a module also executes its ancestor packages' __init__.py
+        parts = module.split(".")
+        stack.extend(".".join(parts[:i]) for i in range(1, len(parts)))
+
+    return seen
+
+
+def get_module_dialect_map() -> dict[str, set[str]]:
+    """Maps each sqlglot module to the set of supported dialects whose integration tests it can affect."""
+    graph = _build_import_graph()
+
+    module_dialects: dict[str, set[str]] = {module: set() for module in graph}
+    for dialect in SUPPORTED_DIALECTS:
+        for module in _closure([f"sqlglot.dialects.{dialect}", *HARNESS_MODULES], graph):
+            module_dialects[module].add(dialect)
+
+    return module_dialects
+
+
+def get_affected_dialects(path: str, module_dialects: dict[str, set[str]]) -> set[str]:
+    """Maps a changed file to the set of supported dialects whose integration tests it can affect."""
+    all_dialects = set(SUPPORTED_DIALECTS)
+
+    if path in INTEGRATION_TEST_PATHS:
+        return all_dialects
+
+    # The remote workflow also installs the mypyc-compiled extension
+    if path.startswith("sqlglotc/"):
+        return all_dialects
+
+    if not path.startswith("sqlglot/"):
+        return set()
+
+    if path.endswith(".py"):
+        module = _module_name(path)
+        if module in module_dialects:
+            return module_dialects[module]
+
+    # Fail open for files we can't map (e.g. deleted modules or non-python files)
+    return all_dialects
 
 
 def get_dialects_from_git(base_ref: str, current_ref: str) -> set[str]:
     """
-    Takes two git refs and runs `git diff --name-only <base_ref> <current_ref>`
-
-    If any of the returned file names contain a dialect from SUPPORTED_DIALECTS as
-    a substring, that dialect is included in the returned set
+    Takes two git refs and runs `git diff --name-only <base_ref> <current_ref>`,
+    mapping each changed file to the dialects it affects
     """
     print(f"Checking for files changed between '{base_ref}' and '{current_ref}'")
 
@@ -86,14 +163,13 @@ def get_dialects_from_git(base_ref: str, current_ref: str) -> set[str]:
 
     print(f"Git output:\n{output}")
 
-    matching_dialects = []
+    module_dialects = get_module_dialect_map()
+    matching_dialects: set[str] = set()
 
     for l in output.splitlines():
-        l = l.strip().lower()
+        matching_dialects |= get_affected_dialects(l.strip(), module_dialects)
 
-        matching_dialects.extend([d for d in SUPPORTED_DIALECTS if d in l])
-
-    return set(matching_dialects)
+    return matching_dialects
 
 
 if __name__ == "__main__":
@@ -112,53 +188,31 @@ if __name__ == "__main__":
 
     print("Handling event: \n" + json.dumps(event, indent=2))
 
-    # for pull_request events, the body is located at github.event.pull_request.body
-    pr_description: str = event.get("pull_request", {}).get("body") or ""
+    pull_request_base_ref = event.get("pull_request", {}).get("base", {}).get("sha")
+    if not pull_request_base_ref:
+        raise ValueError("Unable to determine base ref")
 
-    dialects = []
-    should_run = False
+    current_ref = event.get("pull_request", {}).get("head", {}).get("sha")
 
-    pr_description_lines = [l.strip().lower() for l in pr_description.splitlines()]
-    if trigger_line := [l for l in pr_description_lines if l.startswith(TRIGGER)]:
-        # if the user has explicitly requested /integration-tests then use that
-        print(f"Handling trigger line: {trigger_line[0]}")
-        dialects = get_dialects_from_manual_trigger(trigger_line[0])
-        should_run = True
-    else:
-        # otherwise, do a git diff and inspect the changed files
-        print("Explicit trigger line not detected; performing git diff")
-        pull_request_base_ref = event.get("pull_request", {}).get("base", {}).get("sha")
-        if not pull_request_base_ref:
-            raise ValueError("Unable to determine base ref")
+    if not current_ref:
+        raise ValueError("Unable to determine current/head ref")
 
-        current_ref = event.get("pull_request", {}).get("head", {}).get("sha")
+    print(f"Comparing '{current_ref}' against '{pull_request_base_ref}'")
+    # look at git files changed and only trigger if a file relating
+    # to a supported dialect has changed
+    dialects = get_dialects_from_git(base_ref=pull_request_base_ref, current_ref=current_ref)
 
-        if not current_ref:
-            raise ValueError("Unable to determine current/head ref")
-
-        print(f"Comparing '{current_ref}' against '{pull_request_base_ref}'")
-        # otherwise, look at git files changed and only trigger if a file relating
-        # to a supported dialect has changed
-        dialects = get_dialects_from_git(base_ref=pull_request_base_ref, current_ref=current_ref)
-        if dialects:
-            should_run = True
-
-    if should_run:
-        dialects_str = (
-            f"the following dialects: {', '.join(dialects)}"
-            if dialects
-            else "all supported dialects"
-        )
-        print(f"Conclusion: should run tests for {dialects_str}")
+    if dialects:
+        print(f"Conclusion: should run tests for the following dialects: {', '.join(dialects)}")
     else:
         print("Conclusion: No dialect-specific tests to run, but SQLGlot tests will still run")
 
     # Always dispatch so that run-sqlglot-tests (tests/sqlglot/) runs on every PR.
     # When no dialects are detected, pass "none" so the integration test matrix is empty.
     lines = ["skip=false"]
-    if should_run and dialects:
+    if dialects:
         lines.append(f"dialects={','.join(dialects)}")
-    elif not should_run:
+    else:
         lines.append("dialects=none")
 
     with github_output.open("a") as f:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -2,7 +2,6 @@ name: Run Integration Tests
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
 
 jobs:
   should-run:
@@ -20,10 +19,6 @@ jobs:
             Github event name: ${{ github.event_name }}
 
             Github event ${{ toJSON(github.event) }}
-
-            Github event comment body: ${{ github.event.comment.body }}
-
-            Github event pr body: ${{ github.event.pull_request.body }}
 
             Generic Number: ${{ github.event.number }}
 


### PR DESCRIPTION
Replaces the hardcoded path lists in `get_integration_test_params.py` with a static AST scan of
sqlglot's imports: a changed module triggers a dialect iff the dialect's module (or a module the
test harness imports) transitively imports it, including lazy function-level imports and excluding
`TYPE_CHECKING`-only ones. Also points the harness at `qualify_columns` for `quote_identifiers` so
`optimizer.py`'s rule imports don't drag every optimizer rule into the closures.
