### PR TITLE
fix(executor): only truncate typed division when both operands are integers [CLAUDE]

### DIFF
--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -66,7 +66,9 @@ def _div_sql(self: generator.Generator, e: exp.Div) -> str:
 
     sql = f"DIV({self.sql(e, 'this')}, {denominator})"
 
-    if e.args.get("typed"):
+    if e.args.get("typed") and not (
+        e.this.is_type(*exp.DataType.REAL_TYPES) or e.expression.is_type(*exp.DataType.REAL_TYPES)
+    ):
         sql = f"int({sql})"
 
     return sql

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -701,6 +701,28 @@ class TestExecutor(unittest.TestCase):
                 self.assertEqual(result.columns, tuple(cols))
                 self.assertEqual(result.rows, rows)
 
+    def test_typed_division(self):
+        """Postgres' 10 / 3 is 3, but its 10 / 3.0 and 10 / 3::numeric are not."""
+        schema = {"t": {"n": "INT", "d": "DECIMAL"}}
+        tables = {"t": [{"n": 10, "d": 3}]}
+
+        for sql, expected in (
+            ("SELECT n / 3.0 AS x FROM t", 10 / 3),
+            ("SELECT 3.0 / n AS x FROM t", 3.0 / 10),
+            ("SELECT CAST(n AS DOUBLE) / 3 AS x FROM t", 10 / 3),
+            ("SELECT n / d AS x FROM t", 10 / 3),  # decimal: real, but not a float
+            ("SELECT n / 3 AS x FROM t", 3),
+            ("SELECT -n / 3 AS x FROM t", -3),
+        ):
+            for dialect in ("postgres", "sqlite"):
+                with self.subTest(f"{dialect}: {sql}"):
+                    result = execute(sql, schema=schema, tables=tables, dialect=dialect)
+                    self.assertEqual(result.rows, [(expected,)])
+
+        # unknown operand types are still truncated
+        result = execute("SELECT n / 3 AS x FROM t", tables=tables, dialect="postgres")
+        self.assertEqual(result.rows, [(3,)])
+
     def test_aggregate_without_group_by(self):
         result = execute("SELECT SUM(x) FROM t", tables={"t": [{"x": 1}, {"x": 2}]})
         self.assertEqual(result.columns, ("_col_0",))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -719,7 +719,6 @@ class TestExecutor(unittest.TestCase):
                     result = execute(sql, schema=schema, tables=tables, dialect=dialect)
                     self.assertEqual(result.rows, [(expected,)])
 
-        # unknown operand types are still truncated
         result = execute("SELECT n / 3 AS x FROM t", tables=tables, dialect="postgres")
         self.assertEqual(result.rows, [(3,)])
 


### PR DESCRIPTION
Fixes #8132.

## The bug

The Python executor registers `exp.Div` in `PythonGenerator.TRANSFORMS`, which bypasses `Generator.div_sql` and its operand-type guard. `_div_sql` then applies `int()` to every division carrying `typed=True`, regardless of operand types:

```python
from sqlglot.executor import execute

schema = {"t": {"n": "INT"}}
tables = {"t": [{"n": 10}]}

for dialect in ("postgres", "sqlite", "mysql", "duckdb", None):
    r = execute("SELECT n / 3.0 AS x FROM t", schema=schema, tables=tables, dialect=dialect)
    print(f"{str(dialect):9} -> {[tuple(row) for row in r.rows]}")
```

```
postgres  -> [(3,)]        # expected [(3.3333333333333335,)]
sqlite    -> [(3,)]        # expected [(3.3333333333333335,)]
mysql     -> [(3.3333333333333335,)]
duckdb    -> [(3.3333333333333335,)]
None      -> [(3.3333333333333335,)]
```

It fails silently -- a plausible wrong number, no exception. Casting does not help, because the truncation happens after annotation: `SELECT n::double / 3` returned `3` too.

## The fix

`typed=True` records that the source dialect divides *integers* as integers, not that it truncates everything. Postgres' `10 / 3` is `3`, but `10 / 3.0` is not -- and neither is `10 / 3::numeric`.

So `int()` is applied only when neither operand is a `REAL_TYPES` member, which is the same guard `Generator.div_sql` already applies for this flag. Note `REAL_TYPES` covers `DECIMAL`/`NUMERIC`/`MONEY` as well as the floats, which is what makes it the right predicate here rather than "is it floating point".

Operands whose type is unknown are still truncated, so behaviour with no schema is unchanged -- including the existing `1 / 2 typed=True -> 0` case in `test_execute_callable`.

## Tests

`test_typed_division` covers both `TYPED_DIVISION` dialects across: a float literal on either side, an explicit cast, a decimal column, integer/integer (must stay `3`), negative truncation (must stay `-3`), and the unknown-type fallback.

Full suite passes: `SKIP_INTEGRATION=1 python -m unittest` -> 1314 tests, OK.
