### PR TITLE
fix(executor): honor the negate flag on LIKE and ILIKE [CLAUDE]

### DIFF
--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -58,6 +58,15 @@ def _lambda_sql(self, e: exp.Lambda) -> str:
     return f"lambda {self.expressions(e, flat=True)}: {self.sql(e, 'this')}"
 
 
+def _like_sql(self: generator.Generator, e: exp.Like | exp.ILike) -> str:
+    sql = self.func(e.key, e.this, e.expression)
+
+    if e.args.get("negate"):
+        sql = f"NOT({sql})"
+
+    return sql
+
+
 def _div_sql(self: generator.Generator, e: exp.Div) -> str:
     denominator = self.sql(e, "expression")
 
@@ -90,6 +99,7 @@ class PythonGenerator(generator.Generator):
         exp.Distinct: lambda self, e: f"set({self.sql(e, 'this')})",
         exp.Div: _div_sql,
         exp.Extract: lambda self, e: f"EXTRACT('{e.name.lower()}', {self.sql(e, 'expression')})",
+        exp.ILike: _like_sql,
         exp.In: lambda self, e: self.func("IN", e.this, *e.expressions),
         exp.Interval: lambda self, e: f"INTERVAL({self.sql(e.this)}, '{self.sql(e.unit)}')",
         exp.Is: lambda self, e: (
@@ -102,6 +112,7 @@ class PythonGenerator(generator.Generator):
         exp.JSONPathKey: lambda self, e: f"'{self.sql(e.this)}'",
         exp.JSONPathSubscript: lambda self, e: f"'{e.this}'",
         exp.Lambda: _lambda_sql,
+        exp.Like: _like_sql,
         exp.Not: lambda self, e: self.func("NOT", e.this),
         exp.Null: lambda *_: "None",
         exp.Or: lambda self, e: f"OR(lambda: {self.sql(e.left)}, lambda: {self.sql(e.right)})",

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -138,6 +138,8 @@ class TestExecutor(unittest.TestCase):
         self.assertEqual(generate(parse_one("MAP([1], [2])")), "MAP([1], [2])")
         self.assertEqual(generate(parse_one("1 is null")), "1 == None")
         self.assertEqual(generate(parse_one("x is null")), "scope[None][x] is None")
+        self.assertEqual(generate(parse_one("x like 'y'")), "LIKE(scope[None][x], 'y')")
+        self.assertEqual(generate(parse_one("x not like 'y'")), "NOT(LIKE(scope[None][x], 'y'))")
 
     def test_optimized_tpch(self):
         for i, (_, sql, optimized) in enumerate(self.tpch_sqls, start=1):
@@ -700,6 +702,20 @@ class TestExecutor(unittest.TestCase):
                 result = execute(sql)
                 self.assertEqual(result.columns, tuple(cols))
                 self.assertEqual(result.rows, rows)
+
+    def test_negated_like(self):
+        """NOT LIKE must exclude what LIKE matches, and match no NULL either."""
+        tables = {"t": [{"s": "Bump version"}, {"s": "Add feature"}, {"s": None}]}
+
+        result = execute("SELECT s FROM t WHERE s LIKE 'Bump%'", tables=tables)
+        self.assertEqual(result.rows, [("Bump version",)])
+
+        for sql in (
+            "SELECT s FROM t WHERE s NOT LIKE 'Bump%'",
+            "SELECT s FROM t WHERE NOT (s LIKE 'Bump%')",
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables).rows, [("Add feature",)])
 
     def test_aggregate_without_group_by(self):
         result = execute("SELECT SUM(x) FROM t", tables={"t": [{"x": 1}, {"x": 2}]})


### PR DESCRIPTION
## The bug

`x NOT LIKE 'p'` parses as a single `exp.Like` carrying `negate=True`, not an `exp.Not` wrapping an `exp.Like`. Neither `Like` nor `ILike` was in `PythonGenerator.TRANSFORMS`, so both fell through to `_rename`, which does not read the flag. `LIKE` and `NOT LIKE` generated byte-identical code:

```
a NOT LIKE 'p'     ->  LIKE(scope[None]["a"], 'p')
a LIKE 'p'         ->  LIKE(scope[None]["a"], 'p')
```

so the predicate returned exactly the rows the query asked to exclude:

```python
>>> from sqlglot.executor import execute
>>> t = {"t": [{"s": "Bump version"}, {"s": "Add feature"}]}
>>> execute("SELECT s FROM t WHERE s NOT LIKE 'Bump%'", tables=t).rows
[('Bump version',)]      # every row it excluded, and none it asked for
```

No exception -- a full result that is quietly the inverse of the query. Spelling it `NOT (x LIKE 'p')` has always worked, which is what makes it easy to miss.

## The fix

`exp.Is` already reads `negate` in `TRANSFORMS`, and `Is`/`Like`/`ILike` are the only three nodes whose `arg_types` carry the flag -- so this completes the set.

The negation is routed through `NOT` rather than inverting in Python, so the generated code is exactly what the `NOT (x LIKE 'p')` spelling already produces and the three-valued logic comes from the same `SQL_NOT`. A NULL operand therefore matches neither form, which the test asserts.

## Note, out of scope

`ILIKE` is separately absent from the executor's `ENV`, so both `ILIKE` and `NOT ILIKE` still raise `name 'ILIKE' is not defined`. That is a different gap -- this change means the flag will be honored once it is filled.

## Tests

`test_negated_like` asserts `NOT LIKE` returns the complement and agrees exactly with `NOT (x LIKE ...)`, NULL row included. `test_py_dialect` gains the two codegen assertions.

Full suite passes: `SKIP_INTEGRATION=1 python -m unittest` -> 1314 tests, OK.

