### PR TITLE
feat(optimizer): Provide support for databricks div(a,b) function

### DIFF
--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -18,12 +18,23 @@ def build_as_cast(to_type: str) -> t.Callable[[list], exp.Expr]:
     return lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.from_str(to_type))
 
 
+def build_int_div(args: list) -> exp.IntDiv:
+    # Wrap the operands if they are binary nodes, e.g. DIV(a + 1, 7) -> (a + 1) DIV 7
+    this = seq_get(args, 0)
+    expression = seq_get(args, 1)
+
+    this = exp.Paren(this=this) if isinstance(this, exp.Binary) else this
+    expression = exp.Paren(this=expression) if isinstance(expression, exp.Binary) else expression
+
+    return exp.IntDiv(this=this, expression=expression)
+
+
 class Spark2Parser(HiveParser):
     TRIM_PATTERN_FIRST = True
     CHANGE_COLUMN_ALTER_SYNTAX = True
     PIVOT_COLUMN_NAMING = "agg_name_if_multiple"
 
-    FUNC_TOKENS = HiveParser.FUNC_TOKENS | {TokenType.AND, TokenType.OR}
+    FUNC_TOKENS = HiveParser.FUNC_TOKENS | {TokenType.AND, TokenType.OR, TokenType.DIV}
 
     FUNCTIONS = {
         **HiveParser.FUNCTIONS,
@@ -36,6 +47,7 @@ class Spark2Parser(HiveParser):
         "DAYOFMONTH": lambda args: exp.DayOfMonth(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
         "DAYOFWEEK": lambda args: exp.DayOfWeek(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
         "DAYOFYEAR": lambda args: exp.DayOfYear(this=exp.TsOrDsToDate(this=seq_get(args, 0))),
+        "DIV": build_int_div,
         "DOUBLE": build_as_cast("double"),
         "ELEMENT_AT": lambda args: exp.Bracket(
             this=seq_get(args, 0),

--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -18,15 +18,17 @@ def build_as_cast(to_type: str) -> t.Callable[[list], exp.Expr]:
     return lambda args: exp.Cast(this=seq_get(args, 0), to=exp.DataType.from_str(to_type))
 
 
-def build_int_div(args: list) -> exp.IntDiv:
-    # Wrap the operands if they are binary nodes, e.g. DIV(a + 1, 7) -> (a + 1) DIV 7
+def build_int_div(args: list) -> exp.IntDiv | exp.Paren:
     this = seq_get(args, 0)
     expression = seq_get(args, 1)
+
+    if this is None or expression is None:
+        return exp.IntDiv(this=this, expression=expression)
 
     this = exp.Paren(this=this) if isinstance(this, exp.Binary) else this
     expression = exp.Paren(this=expression) if isinstance(expression, exp.Binary) else expression
 
-    return exp.IntDiv(this=this, expression=expression)
+    return exp.Paren(this=exp.IntDiv(this=this, expression=expression))
 
 
 class Spark2Parser(HiveParser):


### PR DESCRIPTION
Problem: SQLGlot couldn't parse `DIV(a, b)` as a function call in `Databricks/Spark` — only the infix form `a DIV b `worked, even though the engine supports both.

Fix: Registered `DIV` as a valid function name in the `Spark2` parser (shared by `Spark/Databricks`), with a builder that wraps arithmetic sub-expressions in parens so the infix output` (e.g. (a - 1) DIV b)` round-trips correctly instead of silently changing meaning.


**Tests Executed:**

1. Summary: binary-operator edge cases for DIV(...)

Case | Result
-- | --
DIV(a, b) & c | ✅ (a DIV b) & c
DIV(a, b) \| c | ✅ (a DIV b) \| c
DIV(a, b) ^ c | ✅ (a DIV b) ^ c
c & DIV(a, b) | ✅ c & (a DIV b)
DIV(a, b) << 2 | ✅ SHIFTLEFT((a DIV b), 2)
DIV(a, b) >> 2 | ✅ SHIFTRIGHT((a DIV b), 2)
DIV(a, b) \|\| 'x' | ✅ (a DIV b) \|\| 'x'
DIV(a, b) = DIV(c, d) | ✅ (a DIV b) = (c DIV d)
DIV(a, b) BETWEEN 1 AND 10 | ✅ (a DIV b) BETWEEN 1 AND 10
DIV(a, b) IN (1, 2, 3) | ✅ (a DIV b) IN (1, 2, 3)
DIV(a, b) LIKE '1%' | ✅ (a DIV b) LIKE '1%'
DIV(a, b) * DIV(c, d) | ✅ (a DIV b) * (c DIV d)
DIV(a, b) + DIV(c, d) * 2 | ✅ (a DIV b) + (c DIV d) * 2
a - DIV(b, c) - d | ✅ a - (b DIV c) - d


2. Summary: DDL edge cases tested for DIV(...)

No | Case | Result
-- | -- | --
1 | CREATE TABLE ... c INT GENERATED ALWAYS AS (DIV(a - 1, b)) | ✅ OK — GENERATED ALWAYS AS (((a - 1) DIV b)), idempotent
2 | CREATE TABLE ... a INT DEFAULT DIV(1, 2) | ✅ OK — DEFAULT (1 DIV 2), idempotent
3 | CREATE TABLE ... CHECK (DIV(a - 1, b) > 0) | ✅ OK — CHECK (((a - 1) DIV b) > 0), idempotent
4 | CREATE VIEW v AS SELECT DIV(a - 1, b) FROM t | ✅ OK — idempotent
5 | CREATE TABLE t AS SELECT DIV(a - 1, b) + 1 AS x FROM src (CTAS) | ✅ OK — idempotent
6 | ALTER TABLE t ADD COLUMN c INT DEFAULT DIV(a - 1, b) | ✅ OK — idempotent
7 | INSERT INTO t VALUES (DIV(1 - 1, 2)) | ✅ OK — idempotent
8 | INSERT INTO t SELECT DIV(a - 1, b) FROM src | ✅ OK — idempotent
9 | MERGE ... WHEN MATCHED THEN UPDATE SET t.c = DIV(s.a - 1, s.b) | ✅ OK — idempotent
10 | CREATE FUNCTION f(x, y) RETURNS INT RETURN DIV(x - 1, y) | ✅ OK — idempotent
11 | CREATE TABLE t (...) PARTITIONED BY (DIV(a, b)) | ❌ Round-trip loses content: generates PARTITIONED BY ((a DIV b)), but re-parsing that produces PARTITIONED BY () — silently empty
11b | Isolation check: PARTITIONED BY ((a + b)) (no DIV) | ❌ Same failure on the very first generation, proving this is pre-existing and unrelated to DIV
11c | Isolation check: PARTITIONED BY (a DIV b) (plain infix, no call syntax) | ❌ Fails to parse at all, even on unmodified code — _parse_partitioned_by doesn't accept general expressions





