### PR TITLE
feat(executor): implement ILIKE [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -185,6 +185,12 @@ def ordered(this, desc, nulls_first):
     return this
 
 
+def _like(this, e, flags=0):
+    return bool(
+        re.fullmatch(re.escape(e).replace("_", ".").replace("%", ".*"), this, re.DOTALL | flags)
+    )
+
+
 @null_if_any
 def interval(this, unit):
     plural = unit + "S"
@@ -255,11 +261,8 @@ ENV = {
     "INTERVAL": interval,
     "JSONEXTRACT": jsonextract,
     "LEFT": null_if_any(lambda this, e: this[:e]),
-    "LIKE": null_if_any(
-        lambda this, e: bool(
-            re.fullmatch(re.escape(e).replace("_", ".").replace("%", ".*"), this, re.DOTALL)
-        )
-    ),
+    "LIKE": null_if_any(lambda this, e: _like(this, e)),
+    "ILIKE": null_if_any(lambda this, e: _like(this, e, re.IGNORECASE)),
     "LOWER": null_if_any(lambda arg: arg.lower()),
     "LT": null_if_any(lambda this, e: this < e),
     "LTE": null_if_any(lambda this, e: this <= e),

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -739,6 +739,30 @@ class TestExecutor(unittest.TestCase):
                     negated, [r for r in [("Bump version",), ("Add feature",)] if r not in matches]
                 )
 
+    def test_ilike_semantics(self):
+        tables = {"t": [{"s": "Bump Version"}, {"s": "B.mp Version"}, {"s": "Add feature"}]}
+
+        for pattern, matches in (
+            ("bump", []),
+            ("bump%", [("Bump Version",)]),
+            ("%version", [("Bump Version",), ("B.mp Version",)]),
+            ("bump_version", [("Bump Version",)]),
+            ("b.mp version", [("B.mp Version",)]),
+            ("b_mp version", [("Bump Version",), ("B.mp Version",)]),
+            ("bump version", [("Bump Version",)]),
+        ):
+            for cased in (pattern.lower(), pattern.upper()):
+                with self.subTest(cased):
+                    rows = execute(f"SELECT s FROM t WHERE s ILIKE '{cased}'", tables=tables).rows
+                    self.assertEqual(rows, matches)
+
+                    negated = execute(
+                        f"SELECT s FROM t WHERE s NOT ILIKE '{cased}'", tables=tables
+                    ).rows
+                    self.assertEqual(
+                        negated, [(r["s"],) for r in tables["t"] if (r["s"],) not in matches]
+                    )
+
     def test_typed_division(self):
         """Postgres' 10 / 3 is 3, but its 10 / 3.0 and 10 / 3::numeric are not."""
         schema = {"t": {"n": "INT", "d": "DECIMAL"}}


### PR DESCRIPTION
## The gap

`ILIKE` is absent from the executor's `ENV` entirely, so both it and `NOT ILIKE` raise rather than answering:

```python
>>> execute("SELECT s FROM t WHERE s ILIKE 'bump%'", tables=t).rows
ExecuteError: Step 'Join: t (...)' failed: name 'ILIKE' is not defined
```

This is the loose end from #8139, which taught the generator to honor `negate` on both `Like` and `ILike` — so the flag now reaches an `ILIKE` the ENV cannot resolve.

## The change

`ILIKE` is `LIKE` with `re.IGNORECASE`, through one shared helper so the two cannot drift. The escaping and anchoring from 44b73a00 is exactly what `ILIKE` needs, and that expression moves into the helper unchanged.

```
ILIKE 'bump%'          -> ['Bump Version']
ILIKE '%version'       -> ['Bump Version', 'B.mp Version']
NOT ILIKE 'bump%'      -> the rest
ILIKE 'b.mp version'   -> ['B.mp Version']                    -- '.' is literal
ILIKE 'b_mp version'   -> ['Bump Version', 'B.mp Version']    -- '_' is the wildcard
```

## Tests

Each pattern is run in **both cases** and expected to give the same rows, which is the property that actually distinguishes `ILIKE` from `LIKE`. Hand-cased patterns assert it only incidentally: they would still pass with `IGNORECASE` dropped, for whichever spelling happened to match. Verified by removing `re.IGNORECASE` — the test fails immediately.

The table carries `"B.mp Version"` alongside `"Bump Version"` so the `.` rows discriminate a literal dot from the `_` wildcard, rather than only asserting a non-match.

Full suite: 1317 tests, OK.
