### PR TITLE
feat(executor): implement LENGTH [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -261,6 +261,7 @@ ENV = {
     "INTERVAL": interval,
     "JSONEXTRACT": jsonextract,
     "LEFT": null_if_any(lambda this, e: this[:e]),
+    "LENGTH": null_if_any(len),
     "LIKE": null_if_any(lambda this, e: _like(this, e)),
     "ILIKE": null_if_any(lambda this, e: _like(this, e, re.IGNORECASE)),
     "LOWER": null_if_any(lambda arg: arg.lower()),

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -739,6 +739,14 @@ class TestExecutor(unittest.TestCase):
                     negated, [r for r in [("Bump version",), ("Add feature",)] if r not in matches]
                 )
 
+    def test_length(self):
+        tables = {"t": [{"s": "abc"}, {"s": ""}, {"s": None}]}
+
+        for func in ("LENGTH", "CHAR_LENGTH"):
+            with self.subTest(func):
+                rows = execute(f"SELECT {func}(s) FROM t", tables=tables).rows
+                self.assertEqual(rows, [(3,), (0,), (None,)])
+
     def test_ilike_semantics(self):
         tables = {"t": [{"s": "Bump Version"}, {"s": "B.mp Version"}, {"s": "Add feature"}]}
 


### PR DESCRIPTION
`LENGTH` is absent from the executor's `ENV`, so any query calling it raises rather than answering:

```python
>>> execute("SELECT length(s) FROM t", tables=t).rows
ExecuteError: Step 'Join: t (...)' failed: name 'LENGTH' is not defined
```

`char_length()` parses to the same node, so it was unavailable too.

`null_if_any(len)` matches Postgres on all three cases — checked against a real PostgreSQL 18:

```
length('abc') -> 3
length('')    -> 0
length(NULL)  -> NULL
```

One line, plus a test covering both spellings. Full suite: 1318 tests, OK.
