### PR TITLE
feat(executor): implement DPIPE [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -199,6 +199,14 @@ def interval(this, unit):
     return datetime.timedelta(**{unit.lower(): float(this)})
 
 
+@null_if_any
+def arrayconcat(*args):
+    result = []
+    for arg in args:
+        result.extend(arg if isinstance(arg, list) else [arg])
+    return result
+
+
 @null_if_any("this", "expression")
 def arraytostring(this, expression, null=None):
     return expression.join(x for x in (x if x is not None else null for x in this) if x is not None)
@@ -235,6 +243,7 @@ ENV = {
     "ABS": null_if_any(lambda this: abs(this)),
     "ADD": null_if_any(lambda e, this: e + this),
     "ARRAYANY": null_if_any(lambda arr, func: any(func(e) for e in arr)),
+    "ARRAYCONCAT": arrayconcat,
     "ARRAYTOSTRING": arraytostring,
     "BETWEEN": null_if_any(lambda this, low, high: low <= this and this <= high),
     "BITWISEAND": null_if_any(lambda this, e: this & e),

--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -83,6 +83,13 @@ def _div_sql(self: generator.Generator, e: exp.Div) -> str:
     return sql
 
 
+def _dpipe_sql(self: generator.Generator, e: exp.DPipe) -> str:
+    if e.this.is_type(exp.DataType.Type.ARRAY) or e.expression.is_type(exp.DataType.Type.ARRAY):
+        return self.func("ARRAYCONCAT", e.this, e.expression)
+
+    return self.func("SAFECONCAT" if e.args.get("safe") else "CONCAT", e.this, e.expression)
+
+
 class PythonGenerator(generator.Generator):
     TRANSFORMS = {
         **{klass: _rename for klass in subclasses(exp.__name__, exp.Binary)},
@@ -100,6 +107,7 @@ class PythonGenerator(generator.Generator):
         ),
         exp.Distinct: lambda self, e: f"set({self.sql(e, 'this')})",
         exp.Div: _div_sql,
+        exp.DPipe: _dpipe_sql,
         exp.Extract: lambda self, e: f"EXTRACT('{e.name.lower()}', {self.sql(e, 'expression')})",
         exp.ILike: _like_sql,
         exp.In: lambda self, e: self.func("IN", e.this, *e.expressions),

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -747,6 +747,36 @@ class TestExecutor(unittest.TestCase):
                 rows = execute(f"SELECT {func}(s) FROM t", tables=tables).rows
                 self.assertEqual(rows, [(3,), (0,), (None,)])
 
+    def test_dpipe(self):
+        tables = {"t": [{"a": "x", "b": "y", "n": 1, "arr": [1, 2], "nul": None}]}
+
+        for expression, expected in (
+            ("a || b", "xy"),
+            ("a || b || a", "xyx"),
+            ("a || n", "x1"),
+            ("n || a", "1x"),
+            ("a || nul", None),
+            ("nul || a", None),
+            ("arr || arr", [1, 2, 1, 2]),
+            ("arr || n", [1, 2, 1]),
+            ("n || arr", [1, 1, 2]),
+            ("arr || nul", None),
+            ("ARRAY_CONCAT(arr, arr)", [1, 2, 1, 2]),
+            ("ARRAY_CAT(arr, arr, arr)", [1, 2, 1, 2, 1, 2]),
+        ):
+            with self.subTest(expression):
+                rows = execute(f"SELECT {expression} FROM t", tables=tables).rows
+                self.assertEqual(rows, [(expected,)])
+
+    def test_dpipe_source_dialect_coercion(self):
+        tables = {"t": [{"a": "x", "n": 1}]}
+
+        rows = execute("SELECT a || n FROM t", tables=tables, dialect="postgres").rows
+        self.assertEqual(rows, [("x1",)])
+
+        with self.assertRaises(ExecuteError):
+            execute("SELECT a || n FROM t", tables=tables, dialect="trino")
+
     def test_ilike_semantics(self):
         tables = {"t": [{"s": "Bump Version"}, {"s": "B.mp Version"}, {"s": "Add feature"}]}
 


### PR DESCRIPTION
`DPIPE` is absent from the executor's `ENV`, so `||` raises rather than answering:

```python
>>> execute("SELECT a || b FROM t", tables=t).rows
ExecuteError: Step 'Join: t (...)' failed: name 'DPIPE' is not defined
```

## Approach

No `DPIPE` function is added. The generator routes `||` to functions that already exist, choosing by the operand's annotated type:

```python
def _dpipe_sql(self: generator.Generator, e: exp.DPipe) -> str:
    if e.this.is_type(exp.DataType.Type.ARRAY) or e.expression.is_type(exp.DataType.Type.ARRAY):
        return self.func("ARRAYCONCAT", e.this, e.expression)

    return self.func("SAFECONCAT" if e.args.get("safe") else "CONCAT", e.this, e.expression)
```

The source dialect is not available at codegen — the executor generates from the optimized tree — so `safe` (`not STRICT_STRING_CONCAT`) is the only source-dialect signal that survives parsing. It decides whether a non-string operand coerces or raises. Types come from the optimizer, which `execute()` already runs; `execute()` also infers them from `tables=`.

## ARRAYCONCAT

`exp.ArrayConcat` was already generating `ARRAYCONCAT(...)` via `_rename` into an `ENV` with no such key, so `ARRAY_CONCAT` and `ARRAY_CAT` raised `NameError` as well. The one new function fixes those too.

## Behaviour, and one open choice

`arrayconcat` wraps a non-list operand so that an element appends to an array. That single line is the one place this diverges by dialect, so both versions are shown. Checked against PostgreSQL 18.4, SQLite 3.51 and DuckDB 1.5.5:

| | as written | without the wrap | postgres | sqlite | duckdb |
| --- | --- | --- | --- | --- | --- |
| `'a' \|\| 'b'` | `ab` | `ab` | `ab` | `ab` | `ab` |
| `'a' \|\| 1` | `a1` | `a1` | `a1` | `a1` | `a1` |
| `'a' \|\| NULL` | `NULL` | `NULL` | `NULL` | `NULL` | `NULL` |
| `ARRAY[1,2] \|\| ARRAY[3]` | `[1,2,3]` | `[1,2,3]` | `{1,2,3}` | n/a | `[1,2,3]` |
| `ARRAY[1,2] \|\| 3` | `[1,2,3]` | error | `{1,2,3}` | n/a | error |
| `3 \|\| ARRAY[1,2]` | `[3,1,2]` | error | `{3,1,2}` | n/a | error |
| `1 \|\| 2` | `12` | `12` | error | `12` | `12` |

There is no dialect-neutral option: the engines disagree, and the executor has one `ENV` shared by all of them with `safe` as the only dialect knob the parser records. Dropping the wrap does not remove a dialect-specific behaviour, it selects DuckDB's instead of Postgres'. So the question is which divergence to take.

Written as it is, `||` mostly follows Postgres.

The stricter alternative is available rather than impossible: the same type information would support raising wherever any of the three engines would — both operands known-numeric gives Postgres' rejection of `1 || 2`, an array beside a bare element gives DuckDB's. It would be best-effort, since operands are `UNKNOWN` where nothing annotates them, and it has to test for known-numeric rather than for not-text, because a string literal is not always annotated either. I have not taken it because it is more conservative than the surrounding executor, not because it cannot be done: `1 || 2` lands as `'12'` here by routing to the existing `SAFECONCAT`, which is right for the `CONCAT` function — Postgres coerces there too, `concat(1,2)` is `12` — though Postgres' `||` operator does require one operand to already be `text`.

MySQL is unaffected throughout — `||` is logical OR there, so sqlglot parses it to `Or`, not `DPipe`. Under presto/trino — the only dialects setting `STRICT_STRING_CONCAT` — `'a' || 1` raises instead, matching the engine.

Full suite: 1321 tests, OK.
