### PR TITLE
fix(optimizer): keep columns referenced by ORDER BY for projection pushdown

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from sqlglot import alias, exp
 from sqlglot.optimizer.journal import Journal, record
 from sqlglot.optimizer.qualify_columns import Resolver
-from sqlglot.optimizer.scope import Scope, find_in_scope, traverse_scope
+from sqlglot.optimizer.scope import Scope, find_all_in_scope, find_in_scope, traverse_scope
 from sqlglot.schema import ensure_schema
 from sqlglot.errors import OptimizeError
 from sqlglot.helper import seq_get
@@ -109,6 +109,13 @@ def pushdown_projections(
             if len(le.selects) != len(re.selects):
                 scope_sql = scope.expression.sql(dialect=dialect)
                 raise OptimizeError(f"Invalid set operation due to column mismatch: {scope_sql}.")
+
+            # columns in ORDER BY need to be kept too
+            order = set_op.args.get("order")
+            if order and SELECT_ALL not in parent_selections:
+                order_refs = {c.name for c in find_all_in_scope(order, exp.Column) if not c.table}
+                if order_refs:
+                    parent_selections = parent_selections | order_refs
 
             referenced_columns[left] = parent_selections
 

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -206,6 +206,34 @@ SELECT t.n FROM (SELECT ARRAY_AGG(q.b) AS q, COUNT(*) AS n FROM (SELECT a, b FRO
 SELECT t.n AS n FROM (SELECT COUNT(*) AS n FROM (SELECT x.a AS a FROM x AS x) AS q CROSS JOIN (SELECT 1 AS _ FROM y AS y) AS r GROUP BY a HAVING a > 0) AS t;
 
 --------------------------------------
+-- Set operation's own ORDER BY keeps referenced columns
+--------------------------------------
+
+SELECT t.a FROM (SELECT a, b FROM x UNION ALL SELECT a, b FROM x ORDER BY b, a LIMIT 3) AS t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x UNION ALL SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY b, a LIMIT 3) AS t;
+
+WITH t AS (SELECT a, b FROM x UNION ALL SELECT a, b FROM x ORDER BY b LIMIT 3) SELECT a FROM t;
+WITH t AS (SELECT x.a AS a, x.b AS b FROM x AS x UNION ALL SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY b LIMIT 3) SELECT t.a AS a FROM t AS t;
+
+SELECT t.a FROM (SELECT a, b FROM x UNION ALL SELECT a, b FROM x UNION ALL SELECT a, b FROM x ORDER BY b) AS t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x UNION ALL SELECT x.a AS a, x.b AS b FROM x AS x UNION ALL SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY b) AS t;
+
+SELECT t.a FROM (SELECT a, b FROM x UNION SELECT a, b FROM x ORDER BY b LIMIT 3) AS t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x UNION SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY b LIMIT 3) AS t;
+
+SELECT t.a FROM (SELECT a, b FROM x UNION ALL SELECT a, b FROM x LIMIT 3) AS t;
+SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x UNION ALL SELECT x.a AS a FROM x AS x LIMIT 3) AS t;
+
+# dialect: bigquery
+# title: set operation's own ORDER BY keeps referenced columns with BY NAME
+SELECT t.a FROM (SELECT 1 AS a, 2 AS c, 3 AS d UNION ALL BY NAME SELECT 6 AS c, 7 AS d, 8 AS a ORDER BY c) AS t;
+SELECT t.a AS a FROM (SELECT 1 AS a, 2 AS c UNION ALL BY NAME SELECT 6 AS c, 8 AS a ORDER BY c) AS t;
+
+# title: a column referenced only inside a correlated subquery in the set operation's ORDER BY is not treated as an output reference
+SELECT t.a FROM (SELECT a, b FROM x UNION ALL SELECT a, b FROM x ORDER BY (SELECT 1 FROM y WHERE b = 5)) AS t;
+SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x UNION ALL SELECT x.a AS a FROM x AS x ORDER BY (SELECT 1 FROM y WHERE b = 5)) AS t;
+
+--------------------------------------
 -- GROUP BY ALL implicitly groups by every non-aggregate projection, so those
 -- projections must be retained even when unreferenced by the outer scope
 --------------------------------------


### PR DESCRIPTION
`pushdown_projections` was pruning columns from a `UNION`/`UNION ALL`/etc. branch's `SELECT` list even when those columns were still referenced by the set operation's own `ORDER BY` clause, producing an invalid query that orders by a column no longer present in the output.

Example Input
```
SELECT t.a FROM (SELECT a, b FROM x UNION ALL SELECT a, b FROM x ORDER BY b, a LIMIT 3) AS t;
```
Previous Output (`b` is pruned even though ORDER BY references it)
```
SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x UNION ALL SELECT x.a AS a FROM x AS x ORDER BY b, a LIMIT 3) AS t;
```
Fixed Output
```
SELECT t.a AS a FROM (SELECT x.a AS a, x.b AS b FROM x AS x UNION ALL SELECT x.a AS a, x.b AS b FROM x AS x ORDER BY b, a LIMIT 3) AS t;
```