### PR TITLE
feat(dremio): support 4-argument REGEXP_SPLIT

### DIFF
--- a/sqlglot/expressions/string.py
+++ b/sqlglot/expressions/string.py
@@ -478,7 +478,9 @@ class RegexpReplace(Expression, Func):
 
 
 class RegexpSplit(Expression, Func):
-    arg_types = {"this": True, "expression": True, "limit": False}
+    # "mode" is Dremio-specific (e.g. 'ALL'), appended after "limit" so existing
+    # 2/3-arg positional callers (from_arg_list) keep mapping "limit" unchanged
+    arg_types = {"this": True, "expression": True, "limit": False, "mode": False}
 
 
 class RegexpSubstr(Expression, Func):

--- a/sqlglot/expressions/string.py
+++ b/sqlglot/expressions/string.py
@@ -478,8 +478,7 @@ class RegexpReplace(Expression, Func):
 
 
 class RegexpSplit(Expression, Func):
-    # "mode" is Dremio-specific (e.g. 'ALL'), appended after "limit" so existing
-    # 2/3-arg positional callers (from_arg_list) keep mapping "limit" unchanged
+    # "mode" is Dremio-specific, appended after "limit" for from_arg_list compat
     arg_types = {"this": True, "expression": True, "limit": False, "mode": False}
 
 

--- a/sqlglot/generators/dremio.py
+++ b/sqlglot/generators/dremio.py
@@ -70,6 +70,7 @@ class DremioGenerator(generator.Generator):
         exp.DateAdd: _date_delta_sql("DATE_ADD"),
         exp.DateSub: _date_delta_sql("DATE_SUB"),
         exp.GenerateSeries: rename_func("ARRAY_GENERATE_RANGE"),
+        exp.RegexpSplit: rename_func("REGEXP_SPLIT"),
     }
 
     def version_sql(self, expression: exp.Version) -> str:

--- a/sqlglot/generators/dremio.py
+++ b/sqlglot/generators/dremio.py
@@ -70,7 +70,9 @@ class DremioGenerator(generator.Generator):
         exp.DateAdd: _date_delta_sql("DATE_ADD"),
         exp.DateSub: _date_delta_sql("DATE_SUB"),
         exp.GenerateSeries: rename_func("ARRAY_GENERATE_RANGE"),
-        exp.RegexpSplit: rename_func("REGEXP_SPLIT"),
+        exp.RegexpSplit: lambda self, e: self.func(
+            "REGEXP_SPLIT", e.this, e.expression, e.args.get("mode"), e.args.get("limit")
+        ),
     }
 
     def version_sql(self, expression: exp.Version) -> str:

--- a/sqlglot/parsers/dremio.py
+++ b/sqlglot/parsers/dremio.py
@@ -56,6 +56,17 @@ def build_date_delta_with_cast_interval(
     return _builder
 
 
+def _build_regexp_split(args: list[exp.Expr]) -> exp.RegexpSplit:
+    # Dremio's REGEXP_SPLIT(string, pattern, mode, limit) puts "mode" (e.g. 'ALL')
+    # ahead of "limit", unlike the shared exp.RegexpSplit arg order.
+    return exp.RegexpSplit(
+        this=seq_get(args, 0),
+        expression=seq_get(args, 1),
+        mode=seq_get(args, 2),
+        limit=seq_get(args, 3),
+    )
+
+
 def datetype_handler(args: list[exp.Expr], dialect: DialectType) -> exp.Expr:
     from sqlglot.dialects.dialect import Dialect
 
@@ -104,6 +115,7 @@ class DremioParser(parser.Parser):
         "DATE_FORMAT": build_formatted_time(exp.TimeToStr),
         "DATE_SUB": build_date_delta_with_cast_interval(exp.DateSub),
         "REGEXP_MATCHES": exp.RegexpLike.from_arg_list,
+        "REGEXP_SPLIT": _build_regexp_split,
         "REPEATSTR": exp.Repeat.from_arg_list,
         "TO_CHAR": to_char_is_numeric_handler,
         "TO_DATE": build_formatted_time(exp.TsOrDsToDate),

--- a/sqlglot/parsers/dremio.py
+++ b/sqlglot/parsers/dremio.py
@@ -56,17 +56,6 @@ def build_date_delta_with_cast_interval(
     return _builder
 
 
-def _build_regexp_split(args: list[exp.Expr]) -> exp.RegexpSplit:
-    # Dremio's REGEXP_SPLIT(string, pattern, mode, limit) puts "mode" (e.g. 'ALL')
-    # ahead of "limit", unlike the shared exp.RegexpSplit arg order.
-    return exp.RegexpSplit(
-        this=seq_get(args, 0),
-        expression=seq_get(args, 1),
-        mode=seq_get(args, 2),
-        limit=seq_get(args, 3),
-    )
-
-
 def datetype_handler(args: list[exp.Expr], dialect: DialectType) -> exp.Expr:
     from sqlglot.dialects.dialect import Dialect
 
@@ -115,7 +104,12 @@ class DremioParser(parser.Parser):
         "DATE_FORMAT": build_formatted_time(exp.TimeToStr),
         "DATE_SUB": build_date_delta_with_cast_interval(exp.DateSub),
         "REGEXP_MATCHES": exp.RegexpLike.from_arg_list,
-        "REGEXP_SPLIT": _build_regexp_split,
+        "REGEXP_SPLIT": lambda args: exp.RegexpSplit(
+            this=seq_get(args, 0),
+            expression=seq_get(args, 1),
+            mode=seq_get(args, 2),
+            limit=seq_get(args, 3),
+        ),
         "REPEATSTR": exp.Repeat.from_arg_list,
         "TO_CHAR": to_char_is_numeric_handler,
         "TO_DATE": build_formatted_time(exp.TsOrDsToDate),

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -256,6 +256,21 @@ class TestDremio(Validator):
         self.assertEqual(regexp_split.text("mode"), "ALL")
         self.assertEqual(regexp_split.text("limit"), "1000")
 
+        # Construct in exp.RegexpSplit's declared arg_types order (this,
+        # expression, limit, mode), which does NOT match Dremio's real
+        # argument order (this, expression, mode, limit), to prove the
+        # generator renders by key and not by construction/kwarg order.
+        reordered = exp.RegexpSplit(
+            this=exp.column("tags"),
+            expression=exp.Literal.string(","),
+            limit=exp.Literal.number(1000),
+            mode=exp.Literal.string("ALL"),
+        )
+        self.assertEqual(
+            reordered.sql(dialect="dremio"),
+            "REGEXP_SPLIT(tags, ',', 'ALL', 1000)",
+        )
+
     def test_try_cast(self):
         self.validate_all(
             "CAST(a AS FLOAT)",

--- a/tests/dialects/test_dremio.py
+++ b/tests/dialects/test_dremio.py
@@ -250,6 +250,12 @@ class TestDremio(Validator):
         self.validate_identity("DATETYPE(2024,2,2)", "DATE('2024-02-02')")
         self.validate_identity("DATETYPE(x,y,z)", "CAST(CONCAT(x, '-', y, '-', z) AS DATE)")
 
+    def test_regexp_split(self):
+        ast = self.validate_identity("SELECT REGEXP_SPLIT(tags, ',', 'ALL', 1000) AS t")
+        regexp_split = ast.find(exp.RegexpSplit)
+        self.assertEqual(regexp_split.text("mode"), "ALL")
+        self.assertEqual(regexp_split.text("limit"), "1000")
+
     def test_try_cast(self):
         self.validate_all(
             "CAST(a AS FLOAT)",


### PR DESCRIPTION
Found another goofy thing we've been working around in Superset, trying to fix upstream where it belongs.

Dremio's `REGEXP_SPLIT(string, pattern, mode, limit)` takes a required `mode` argument (e.g. `'ALL'`) positioned ahead of `limit`, which is a shape the shared `exp.RegexpSplit` didn't have a slot for.

This adds `mode` to `RegexpSplit.arg_types`, appended *after* `limit` so existing 2/3-arg positional callers via `from_arg_list` (Doris `SPLIT_BY_STRING`, ClickHouse `SPLITBYREGEXP`, DuckDB `STR_SPLIT_REGEX`/`STRING_SPLIT_REGEX`, Hive `SPLIT`) keep mapping their existing args unchanged. 

Dremio's own parser/generator build and render the args in the dialect's real order (`this`, `expression`, `mode`, `limit`) via an explicit builder rather than relying on the shared positional `from_arg_list`.

Found this while rebasing Superset's local Dremio dialect (which previously shadowed sqlglot's native one, see [apache/superset#43099](https://github.com/apache/superset/pull/43099)) onto sqlglot's `DremioParser`/`DremioGenerator`. Superset had a local-only `REGEXP_SPLIT` override to fill this gap.

Tests:
- `tests/dialects/test_dremio.py::test_regexp_split` (new)
- Full `tests/dialects/test_dremio.py` suite: 23 passed
- Cross-checked other `RegexpSplit` consumers for regressions: `test_doris.py`, `test_clickhouse.py`, `test_duckdb.py`, `test_hive.py` — 104 passed
- Full test suite: 1213 passed, 2 skipped