### PR TITLE
fix(oracle): support NTH_VALUE FROM FIRST and LAST

### DIFF
--- a/sqlglot/generators/oracle.py
+++ b/sqlglot/generators/oracle.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-
 from sqlglot import exp, generator, transforms
 from sqlglot.dialects.dialect import (
     groupconcat_sql,
@@ -110,6 +109,13 @@ class OracleGenerator(generator.Generator):
         **generator.Generator.PROPERTIES_LOCATION,
         exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
     }
+
+    def nthvalue_sql(self, expression: exp.NthValue) -> str:
+        result = self.func("NTH_VALUE", expression.this, expression.args.get("offset"))
+        from_first = expression.args.get("from_first")
+        if from_first is not None:
+            result = result + (" FROM FIRST" if from_first else " FROM LAST")
+        return result
 
     def currenttimestamp_sql(self, expression: exp.CurrentTimestamp) -> str:
         if expression.args.get("sysdate"):

--- a/sqlglot/parsers/oracle.py
+++ b/sqlglot/parsers/oracle.py
@@ -61,6 +61,14 @@ class OracleParser(parser.Parser):
         "TO_NUMBER": lambda self: self._parse_to_number(),
     }
 
+    def _parse_window(self, this: exp.Expr | None, alias: bool = False) -> exp.Expr | None:
+        if isinstance(this, exp.NthValue):
+            if self._match_text_seq("FROM", "FIRST"):
+                this.set("from_first", True)
+            elif self._match_text_seq("FROM", "LAST"):
+                this.set("from_first", False)
+        return super()._parse_window(this, alias)
+
     PROPERTY_PARSERS = {
         **parser.Parser.PROPERTY_PARSERS,
         "GLOBAL": lambda self: (

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -8,6 +8,12 @@ class TestOracle(Validator):
 
     def test_oracle(self):
         self.validate_identity("1 /* /* */", "1 /* / * */")
+        self.validate_identity(
+            "SELECT NTH_VALUE(1, 1) FROM FIRST OVER (ORDER BY 1) AS FIRST_VALUE FROM DUAL"
+        )
+        self.validate_identity(
+            "SELECT NTH_VALUE(1, 1) FROM LAST OVER (ORDER BY 1) AS LAST_VALUE FROM DUAL"
+        )
         self.validate_all(
             "SELECT CONNECT_BY_ROOT x y",
             write={


### PR DESCRIPTION
## Summary

 Fix Oracle parsing and generation of the optional `FROM FIRST` / `FROM LAST` modifier for the `NTH_VALUE` analytic function.

  Oracle supports this syntax:

  ```sql
SELECT NTH_VALUE(1, 1) 
FROM FIRST OVER (ORDER BY 1) AS FIRST_VALUE
 FROM DUAL
```

  ## Before

 SQLGlot failed to parse the statement:

```
File "/project/sqlglot/parser.py", line 2136, in parse
  File "/project/sqlglot/parser.py", line 2256, in _parse
  File "/project/sqlglot/parser.py", line 2223, in _parse_batch_statements
  File "/project/sqlglot/parser.py", line 2386, in _parse_statement
  File "/project/sqlglot/parser.py", line 3991, in _parse_select
  File "/project/sqlglot/parser.py", line 4116, in _parse_select_query
  File "/project/sqlglot/parser.py", line 4452, in _parse_from
  File "/project/sqlglot/parser.py", line 5080, in _parse_table
  File "/project/sqlglot/parser.py", line 4275, in _parse_table_alias
  File "/project/sqlglot/parser.py", line 9707, in _match_r_paren
  File "/project/sqlglot/parser.py", line 2093, in raise_error
sqlglot.errors.ParseError: Expecting ). Line 1, Col: 50.
  SELECT NTH_VALUE(1, 1) FROM FIRST OVER (ORDER BY 1) AS FIRST_VALUE FROM DUAL

```


## After

The Oracle parser recognizes FROM FIRST and FROM LAST immediately after NTH_VALUE(...) and stores the modifier on the existing exp.NthValue.from_first AST argument. The Oracle generator emits the modifier before the OVER clause, preserving the Oracle syntax:

```python
>> sqlglot.parse_one("SELECT NTH_VALUE(1, 1) FROM FIRST OVER (ORDER BY 1) AS FIRST_VALUE FROM DUAL", dialect="oracle")

Select(
  expressions=[
    Alias(
      this=Window(
        this=NthValue(
          this=Literal(this=1, is_string=False),
          offset=Literal(this=1, is_string=False),
          from_first=True),
        order=Order(
          expressions=[
            Ordered(
              this=Literal(this=1, is_string=False),
              nulls_first=False)]),
        over=OVER,
        join_mark=False),
      alias=Identifier(this=FIRST_VALUE, quoted=False))],
  from_=From(
    this=Table(
      this=Identifier(this=DUAL, quoted=False))))

```

## Tests

```bash
  python -m unittest tests.dialects.test_oracle
  make test
  make testc
```
  All passed.
