### PR TITLE
fix(duckdb): parenthesize scalar_only JSON extract when parent requires it [CLAUDE]

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4720,9 +4720,15 @@ class DuckDBGenerator(generator.Generator):
 
     def jsonextractscalar_sql(self, expression: exp.JSONExtractScalar) -> str:
         if expression.args.get("scalar_only"):
-            expression = exp.JSONExtractScalar(
+            json_value = exp.JSONExtractScalar(
                 this=rename_func("JSON_VALUE")(self, expression), expression="'$'"
             )
+
+            # Propagate the parent so `_arrow_json_extract_sql` can parenthesize the arrow
+            # expression when needed; `->>` binds looser than most operators in DuckDB
+            json_value.parent = expression.parent
+            expression = json_value
+
         return _arrow_json_extract_sql(self, expression)
 
     def bitwisenot_sql(self, expression: exp.BitwiseNot) -> str:

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -3020,6 +3020,15 @@ OPTIONS (
                     },
                 )
 
+                # `->>` binds looser than most operators in DuckDB, so the arrow expression
+                # must be parenthesized when it's an operand of another operator
+                self.validate_all(
+                    f"SELECT {func}(j, '$.a') IS NOT NULL AND TRUE FROM t",
+                    write={
+                        "duckdb": "SELECT NOT (JSON_VALUE(j, '$.a') ->> '$') IS NULL AND TRUE FROM t",
+                    },
+                )
+
         self.assertEqual(self.parse_one(sql).sql("bigquery", normalize_functions="upper"), sql)
 
         # Test double quote escaping


### PR DESCRIPTION
DISCLAIMER: This is AI generated PR. We should rather take this as an issue and a proposal to fix it. I humanly checked there were tests, the fix seems small. But still might be enough. Let me know! 


### Bug

When transpiling BigQuery `JSON_VALUE(...)` (or `JSON_EXTRACT_SCALAR`) to DuckDB, the generated `JSON_VALUE(x, path) ->> '$'` expression is not parenthesized when it appears as an operand of another operator. Since `->>` binds looser than most operators in DuckDB, the generated SQL parses differently than intended and fails at runtime (or silently changes semantics).

Repro on `main`:

```python
import sqlglot
sqlglot.transpile(
    "SELECT JSON_VALUE(j, '$.a') IS NOT NULL FROM t",
    read="bigquery", write="duckdb",
)[0]
# SELECT NOT JSON_VALUE(j, '$.a') ->> '$' IS NULL FROM t
```

DuckDB rejects this:

```sql
CREATE TABLE t AS SELECT '{"a":"1"}'::JSON j;
SELECT NOT JSON_VALUE(j, '$.a') ->> '$' IS NULL FROM t;
-- Conversion Error: Could not convert string '"1"' to BOOL
```

because it binds as `(NOT JSON_VALUE(j, '$.a')) ->> ('$' IS NULL)`.

### Root cause

`DuckDBGenerator.jsonextractscalar_sql` handles the `scalar_only` case by building a fresh `exp.JSONExtractScalar` node. That node has no parent, so the existing wrap logic in `_arrow_json_extract_sql` (which checks `expression.parent` against `WRAPPED_JSON_EXTRACT_EXPRESSIONS`) never fires. The non-`scalar_only` path wraps correctly, e.g. `duckdb -> duckdb` already produces `NOT (j ->> '$.a') IS NULL`.

### Fix

Propagate the original node's parent to the synthetic node so the existing wrap logic applies:

```python
sqlglot.transpile(
    "SELECT JSON_VALUE(j, '$.a') IS NOT NULL FROM t",
    read="bigquery", write="duckdb",
)[0]
# SELECT NOT (JSON_VALUE(j, '$.a') ->> '$') IS NULL FROM t
```

Contexts that don't need parens are unaffected (bare projection, `CAST(JSON_VALUE(...) AS ...)`, function arguments).

Related: #3782 fixed the same precedence issue for the direct arrow path; this covers the `scalar_only` (BigQuery `JSON_VALUE`/`JSON_EXTRACT_SCALAR`) path.

### Testing

- Added a regression test in `tests/dialects/test_bigquery.py` covering both `JSON_VALUE` and `JSON_EXTRACT_SCALAR`.
- Full test suite passes (`tests/` and `tests/dialects`).
- Verified the generated SQL executes correctly against DuckDB 1.5.5.
