### PR TITLE
fix(trino): TIME literal parsed offset string without timezone

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -6411,12 +6411,11 @@ class Parser:
                 if parser:
                     return parser(self, this, data_type)
 
-                if (
-                    self.ZONE_AWARE_TIMESTAMP_CONSTRUCTOR
-                    and data_type.is_type(exp.DType.TIMESTAMP)
-                    and TIME_ZONE_RE.search(literal)
-                ):
-                    data_type = exp.DType.TIMESTAMPTZ.into_expr()
+                if self.ZONE_AWARE_TIMESTAMP_CONSTRUCTOR and TIME_ZONE_RE.search(literal):
+                    if data_type.is_type(exp.DType.TIMESTAMP):
+                        data_type = exp.DType.TIMESTAMPTZ.into_expr()
+                    elif data_type.is_type(exp.DType.TIME):
+                        data_type = exp.DType.TIMETZ.into_expr()
 
                 return self.expression(exp.Cast(this=this, to=data_type))
 

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -31,6 +31,23 @@ class TestTrino(Validator):
             "SELECT CAST('2012-10-31 01:00 +2' AS TIMESTAMP WITH TIME ZONE)",
         )
 
+        self.validate_identity(
+            "SELECT TIME '01:02:03.456 -08:00'",
+            "SELECT CAST('01:02:03.456 -08:00' AS TIME WITH TIME ZONE)",
+        )
+        self.validate_identity(
+            "SELECT TIME '01:02:03.456'",
+            "SELECT CAST('01:02:03.456' AS TIME)",
+        )
+
+        self.validate_all(
+            "SELECT TIME '01:02:03.456 -08:00'",
+            write={
+                "duckdb": "SELECT CAST('01:02:03.456 -08:00' AS TIMETZ)",
+                "trino": "SELECT CAST('01:02:03.456 -08:00' AS TIME WITH TIME ZONE)",
+            },
+        )
+
         self.validate_all(
             "SELECT FROM_ISO8601_TIMESTAMP_NANOS('2020-05-11T11:15:05.000000000')",
             write={


### PR DESCRIPTION
## Description

In Trino, a `TIME` literal with a timezone offset (e.g. `TIME '01:02:03.456 -08:00'`) is a valid `TIME WITH TIME ZONE` literal and executes correctly on its own. However, sqlglot parses and re-renders it as a cast to plain `TIME`, which is invalid — Trino rejects the resulting statement with `INVALID_CAST_ARGUMENT: Value cannot be cast to time: 01:02:03.456 -08:00`.

## reproduction

```python
import sqlglot

stmt = sqlglot.parse_one("SELECT TIME '01:02:03.456 -08:00'", dialect="trino")
print(stmt.sql(dialect="trino"))
# Actual:   SELECT CAST('01:02:03.456 -08:00' AS TIME)
# Expected: SELECT CAST('01:02:03.456 -08:00' AS TIME WITH TIME ZONE)
```

```shell
trino> SELECT TIME '01:02:03.456 -08:00';
       _col0        
--------------------
 01:02:03.456-08:00 

# error
trino> SELECT CAST('01:02:03.456 -08:00' AS TIME)
    -> ;
Query 20260813_080036_00024_6q8mr failed: Value cannot be cast to time: 01:02:03.456 -08:00

trino> SELECT CAST('01:02:03.456 -08:00' AS TIME WITH TIME ZONE);
       _col0        
--------------------
 01:02:03.456-08:00 
```