### PR TITLE
Feat(tsql): support OPENROWSET with a WITH schema clause

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -2071,6 +2071,11 @@ class OpenJSONColumnDef(Expression):
     arg_types = {"this": True, "kind": True, "path": False, "as_json": False}
 
 
+# https://learn.microsoft.com/en-us/sql/t-sql/functions/openrowset-transact-sql
+class OpenRowset(Expression):
+    arg_types = {"expressions": True, "with": False}
+
+
 class JSONExtractQuote(Expression):
     arg_types = {
         "option": True,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3933,6 +3933,16 @@ class Generator:
         )
         return f"OPENJSON({this}{path}){with_}"
 
+    def openrowset_sql(self, expression: exp.OpenRowset) -> str:
+        expressions = self.expressions(expression, flat=True)
+        columns = self.expressions(expression, key="with")
+        with_ = (
+            f" WITH ({self.seg(self.indent(columns), sep='')}{self.seg(')', sep='')}"
+            if columns
+            else ""
+        )
+        return f"OPENROWSET({expressions}){with_}"
+
     def in_sql(self, expression: exp.In) -> str:
         query = expression.args.get("query")
         unnest = expression.args.get("unnest")

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -445,6 +445,7 @@ class TSQLParser(parser.Parser):
             )
         ),
         "DATEPART": lambda self: self._parse_datepart(),
+        "OPENROWSET": lambda self: self._parse_open_rowset(),
     }
 
     # The DCOLON (::) operator serves as a scope resolution (exp.ScopeResolution) operator in T-SQL
@@ -494,6 +495,17 @@ class TSQLParser(parser.Parser):
         name = map_date_part(this, self.dialect)
 
         return self.expression(exp.Extract(this=name, expression=expression))
+
+    def _parse_open_rowset(self) -> exp.OpenRowset:
+        # OPENROWSET( ... ) [ WITH ( column_name data_type [ COLLATE collation ], ... ) ]
+        expressions = self._parse_function_args()
+
+        columns = None
+        if self._match_pair(TokenType.R_PAREN, TokenType.WITH):
+            self._match_l_paren()
+            columns = self._parse_csv(self._parse_field_def)
+
+        return self.expression(exp.OpenRowset(expressions=expressions, **{"with": columns}))
 
     def _parse_alter_table_set(self) -> exp.AlterSet:
         return self._parse_wrapped(super()._parse_alter_table_set)

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -564,6 +564,23 @@ class TestTSQL(Validator):
         self.validate_identity("OBJECT_ID('foo')")
         self.validate_identity("OBJECT_ID('foo', 'U')")
 
+    def test_openrowset(self):
+        # OPENROWSET without a schema still round-trips
+        self.validate_identity("SELECT * FROM OPENROWSET('MSDASQL', 'DRIVER=x', 'SELECT 1') AS a")
+        self.validate_identity(
+            "SELECT sample_id FROM OPENROWSET(BULK ('/a'), FORMAT = 'csv') AS r",
+            "SELECT sample_id FROM OPENROWSET(BULK('/a'), FORMAT = 'csv') AS r",
+        )
+
+        # Azure Synapse OPENROWSET followed by a WITH (...) schema definition
+        self.validate_identity(
+            "SELECT sample_id FROM OPENROWSET(BULK ('/a/*.parquet'), DATA_SOURCE = 'ds', FORMAT = 'csv', FIRSTROW = 2) WITH (sample_id VARCHAR(50)) AS area_type",
+            "SELECT sample_id FROM OPENROWSET(BULK('/a/*.parquet'), DATA_SOURCE = 'ds', FORMAT = 'csv', FIRSTROW = 2) WITH (sample_id VARCHAR(50)) AS area_type",
+        )
+        self.validate_identity(
+            "SELECT * FROM OPENROWSET(BULK('f.csv'), FORMAT = 'csv') WITH (id INTEGER, name VARCHAR(100) COLLATE Latin1_General_100_CI_AS) AS t"
+        )
+
     def test_unpivot_value_column_comes_first(self):
         # T-SQL emits an UNPIVOT's value column ahead of its name column; DuckDB,
         # Snowflake, Oracle and Spark all emit it after. Verified against SQL Server:


### PR DESCRIPTION
Closes #8151.

The tsql dialect parses an `OPENROWSET(...)` call, but raises on the `WITH (...)` schema definition that Azure Synapse allows after it, so valid Synapse views cannot be parsed (the issue notes this broke a SQLMesh Synapse lineage build).

```python
import sqlglot

sqlglot.parse_one(
    "SELECT sample_id FROM OPENROWSET(BULK ('/a'), FORMAT = 'csv') WITH (sample_id VARCHAR(50)) AS area_type",
    read="tsql",
)
# before: sqlglot.errors.ParseError: Expecting ).
```

I added a dedicated `exp.OpenRowset` node and a tsql function parser that mirrors how `OPENJSON ... WITH (...)` already works: it keeps the `OPENROWSET(...)` call arguments and the optional `WITH` column list, and the generator emits both back. `OPENROWSET` without a `WITH` clause round-trips exactly as before (previously it was a generic `Anonymous`).

The schema columns support `column_name data_type [COLLATE collation]`, which covers the BULK/CSV/parquet case in the issue. I left out the quoted source-path and ordinal column forms for now; glad to add them here if you would like them in this PR.

Existing tsql tests pass and I added round-trip coverage in `test_openrowset` (with and without the schema, plus a COLLATE case).
