### PR TITLE
fix(executor): honor nulls_first when ordering [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -179,10 +179,15 @@ def cast(this, to):
     raise NotImplementedError(f"Casting {this} to '{to}' not implemented.")
 
 
+FIRST = 0
+LAST = 1
+NULL_PLACEHOLDER = 0
+
+
 def ordered(this, desc, nulls_first):
-    if desc:
-        return reverse_key(this)
-    return this
+    if this is None:
+        return (FIRST if nulls_first else LAST, NULL_PLACEHOLDER)
+    return (LAST if nulls_first else FIRST, reverse_key(this) if desc else this)
 
 
 def _like(this, e, flags=0):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -822,6 +822,39 @@ class TestExecutor(unittest.TestCase):
         result = execute("SELECT n / 3 AS x FROM t", tables=tables, dialect="postgres")
         self.assertEqual(result.rows, [(3,)])
 
+    def test_null_ordering(self):
+        """NULLS FIRST/LAST is honored, and each dialect's default is what it says."""
+        schema = {"t": {"a": "INT"}}
+        tables = {"t": [{"a": 1}, {"a": None}, {"a": 3}]}
+
+        for sql, expected in (
+            ("SELECT a FROM t ORDER BY a NULLS FIRST", [None, 1, 3]),
+            ("SELECT a FROM t ORDER BY a NULLS LAST", [1, 3, None]),
+            ("SELECT a FROM t ORDER BY a DESC NULLS FIRST", [None, 3, 1]),
+            ("SELECT a FROM t ORDER BY a DESC NULLS LAST", [3, 1, None]),
+        ):
+            for dialect in ("postgres", "duckdb", "mysql"):
+                with self.subTest(f"{dialect}: {sql}"):
+                    result = execute(sql, schema=schema, tables=tables, dialect=dialect)
+                    self.assertEqual([row[0] for row in result.rows], expected)
+
+        # Without an explicit NULLS clause the parser resolves the dialect's own
+        # default, so DESC must not flip what it decided: Postgres defaults to
+        # NULLS LAST ascending and NULLS FIRST descending, MySQL to the reverse,
+        # and DuckDB to NULLS LAST either way.
+        for dialect, ascending, descending in (
+            ("postgres", [1, 3, None], [None, 3, 1]),
+            ("mysql", [None, 1, 3], [3, 1, None]),
+            ("duckdb", [1, 3, None], [3, 1, None]),
+        ):
+            for sql, expected in (
+                ("SELECT a FROM t ORDER BY a", ascending),
+                ("SELECT a FROM t ORDER BY a DESC", descending),
+            ):
+                with self.subTest(f"{dialect}: {sql}"):
+                    result = execute(sql, schema=schema, tables=tables, dialect=dialect)
+                    self.assertEqual([row[0] for row in result.rows], expected)
+
     def test_aggregate_without_group_by(self):
         result = execute("SELECT SUM(x) FROM t", tables={"t": [{"x": 1}, {"x": 2}]})
         self.assertEqual(result.columns, ("_col_0",))

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -822,30 +822,25 @@ class TestExecutor(unittest.TestCase):
         result = execute("SELECT n / 3 AS x FROM t", tables=tables, dialect="postgres")
         self.assertEqual(result.rows, [(3,)])
 
-    def test_null_ordering(self):
-        """NULLS FIRST/LAST is honored, and each dialect's default is what it says."""
+    def test_null_ordering_honors_nulls_first_and_dialect_defaults(self):
         schema = {"t": {"a": "INT"}}
-        tables = {"t": [{"a": 1}, {"a": None}, {"a": 3}]}
+        tables = {"t": [{"a": 1}, {"a": None}, {"a": 3}, {"a": None}]}
 
         for sql, expected in (
-            ("SELECT a FROM t ORDER BY a NULLS FIRST", [None, 1, 3]),
-            ("SELECT a FROM t ORDER BY a NULLS LAST", [1, 3, None]),
-            ("SELECT a FROM t ORDER BY a DESC NULLS FIRST", [None, 3, 1]),
-            ("SELECT a FROM t ORDER BY a DESC NULLS LAST", [3, 1, None]),
+            ("SELECT a FROM t ORDER BY a NULLS FIRST", [None, None, 1, 3]),
+            ("SELECT a FROM t ORDER BY a NULLS LAST", [1, 3, None, None]),
+            ("SELECT a FROM t ORDER BY a DESC NULLS FIRST", [None, None, 3, 1]),
+            ("SELECT a FROM t ORDER BY a DESC NULLS LAST", [3, 1, None, None]),
         ):
             for dialect in ("postgres", "duckdb", "mysql"):
                 with self.subTest(f"{dialect}: {sql}"):
                     result = execute(sql, schema=schema, tables=tables, dialect=dialect)
                     self.assertEqual([row[0] for row in result.rows], expected)
 
-        # Without an explicit NULLS clause the parser resolves the dialect's own
-        # default, so DESC must not flip what it decided: Postgres defaults to
-        # NULLS LAST ascending and NULLS FIRST descending, MySQL to the reverse,
-        # and DuckDB to NULLS LAST either way.
         for dialect, ascending, descending in (
-            ("postgres", [1, 3, None], [None, 3, 1]),
-            ("mysql", [None, 1, 3], [3, 1, None]),
-            ("duckdb", [1, 3, None], [3, 1, None]),
+            ("postgres", [1, 3, None, None], [None, None, 3, 1]),
+            ("mysql", [None, None, 1, 3], [3, 1, None, None]),
+            ("duckdb", [1, 3, None, None], [3, 1, None, None]),
         ):
             for sql, expected in (
                 ("SELECT a FROM t ORDER BY a", ascending),


### PR DESCRIPTION
`ordered()` takes `nulls_first` and never uses it, so NULL placement follows neither an explicit `NULLS FIRST`/`NULLS LAST` nor the dialect's default. `ORDER BY a DESC` raises `TypeError` on a nullable column, and `ORDER BY a NULLS FIRST` runs but puts NULLs last.

The test covers explicit `NULLS FIRST`/`LAST` in both directions plus the bare defaults, across postgres, mysql and duckdb since the three disagree. 13 of its 18 subtests fail on main.

Another possible phrasing was:

```python
def ordered(this, desc, nulls_first):
    sortkey = reverse_key(this) if desc else this
    is_null = this is None
    is_non_null = not is_null
    if nulls_first:
        return (is_non_null, sortkey)
    return (is_null, sortkey)
```

Which avoid having any module globals, and might be easier to read? your call which you'd prefer.

Disclosure: implemented with Claude.
