### PR TITLE
fix(executor): return NULL from POW instead of raising [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -284,7 +284,7 @@ ENV = {
     "NOT": sql_not,
     "OR": sql_or,
     "ORDERED": ordered,
-    "POW": pow,
+    "POW": null_if_any(pow),
     "RIGHT": null_if_any(lambda this, e: this[-e:]),
     "ROUND": null_if_any(lambda this, decimals=None, truncate=None: round(this, ndigits=decimals)),
     "STRPOSITION": str_position,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -930,6 +930,10 @@ class TestExecutor(unittest.TestCase):
             ("ROUND(1.2)", 1),
             ("ROUND(1.2345, 2)", 1.23),
             ("ROUND(NULL)", None),
+            ("POWER(2, 3)", 8),
+            ("POWER(NULL, 3)", None),
+            ("POWER(2, NULL)", None),
+            ("POWER(NULL, NULL)", None),
             (
                 "UNIXTOTIME(1659981729)",
                 datetime.datetime(2022, 8, 8, 18, 2, 9, tzinfo=datetime.timezone.utc),


### PR DESCRIPTION
`SELECT POWER(NULL, 3)` fails with `ExecuteError: unsupported operand type(s) for ** or pow(): 'NoneType' and 'int'` rather than returning NULL.

`"POW": pow` is the only scalar entry in `ENV` without a `null_if_any` guard, so it is the only one that raises on a NULL operand instead of propagating it. Wrapping it matches every neighbour, and `null_if_any` already handles builtins the same way `LENGTH` and `ORD` wrap `len` and `ord`.

Added `POWER(2, 3)` alongside the NULL cases in `test_scalar_functions` so the non-NULL path stays pinned; the three NULL cases fail on main.

Disclosure: implemented with Claude.
