### PR TITLE
feat(synapse): add minimal OPENROWSET support

### DIFF
--- a/sqlglot/dialects/__init__.py
+++ b/sqlglot/dialects/__init__.py
@@ -94,6 +94,7 @@ DIALECTS = [
     "Spark2",
     "SQLite",
     "StarRocks",
+    "Synapse",
     "Tableau",
     "Teradata",
     "Trino",

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -110,6 +110,7 @@ class Dialects(str, Enum):
     SPARK2 = "spark2"
     SQLITE = "sqlite"
     STARROCKS = "starrocks"
+    SYNAPSE = "synapse"
     TABLEAU = "tableau"
     TERADATA = "teradata"
     TRINO = "trino"

--- a/sqlglot/dialects/synapse.py
+++ b/sqlglot/dialects/synapse.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from sqlglot.dialects.tsql import TSQL
+from sqlglot.generators.synapse import SynapseGenerator
+from sqlglot.parsers.synapse import SynapseParser
+
+
+class Synapse(TSQL):
+    Parser = SynapseParser
+
+    Generator = SynapseGenerator

--- a/sqlglot/expressions/functions.py
+++ b/sqlglot/expressions/functions.py
@@ -433,6 +433,12 @@ class ReadParquet(Expression, Func):
     arg_types = {"expressions": True}
 
 
+class OpenRowset(Expression, Func):
+    """A Synapse table source that reads a bulk data path in a specified format."""
+
+    arg_types = {"bulk": True, "format": True}
+
+
 # XML
 
 

--- a/sqlglot/generators/synapse.py
+++ b/sqlglot/generators/synapse.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.generators.tsql import TSQLGenerator
+
+
+class SynapseGenerator(TSQLGenerator):
+    def openrowset_sql(self, expression: exp.OpenRowset) -> str:
+        return (
+            f"OPENROWSET(BULK {self.sql(expression, 'bulk')}, "
+            f"FORMAT = {self.sql(expression, 'format')})"
+        )

--- a/sqlglot/parsers/synapse.py
+++ b/sqlglot/parsers/synapse.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from sqlglot import exp
+from sqlglot.parsers.tsql import TSQLParser
+from sqlglot.tokens import TokenType
+
+
+class SynapseParser(TSQLParser):
+    FUNCTION_PARSERS = {
+        **TSQLParser.FUNCTION_PARSERS,
+        "OPENROWSET": lambda self: self._parse_openrowset(),
+    }
+
+    def _parse_openrowset(self) -> exp.OpenRowset:
+        # https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/develop-openrowset
+        if not self._match_text_seq("BULK"):
+            self.raise_error("Expected BULK in OPENROWSET")
+
+        bulk = self._parse_string()
+        if bulk is None:
+            self.raise_error("Expected a BULK path in OPENROWSET")
+
+        if not self._match(TokenType.COMMA) or not self._match_text_seq("FORMAT"):
+            self.raise_error("Expected FORMAT in OPENROWSET")
+
+        if not self._match(TokenType.EQ):
+            self.raise_error("Expected = after FORMAT in OPENROWSET")
+
+        format_ = self._parse_string()
+        if format_ is None:
+            self.raise_error("Expected a FORMAT value in OPENROWSET")
+
+        return self.expression(exp.OpenRowset(bulk=bulk, format=format_))

--- a/tests/dialects/test_synapse.py
+++ b/tests/dialects/test_synapse.py
@@ -1,0 +1,44 @@
+from sqlglot import exp
+from sqlglot.errors import ParseError
+from tests.dialects.test_dialect import Validator
+
+
+class TestSynapse(Validator):
+    dialect = "synapse"
+
+    def test_openrowset(self):
+        expression = self.validate_identity(
+            "SELECT * FROM OPENROWSET(BULK '/lake-raw/file.parquet', FORMAT='PARQUET') AS source",
+            "SELECT * FROM OPENROWSET(BULK '/lake-raw/file.parquet', FORMAT = 'PARQUET') AS source",
+        )
+
+        openrowset = expression.find(exp.OpenRowset)
+        self.assertIsNotNone(openrowset)
+        self.assertEqual("'/lake-raw/file.parquet'", openrowset.args["bulk"].sql())
+        self.assertEqual("'PARQUET'", openrowset.args["format"].sql())
+
+    def test_openrowset_pretty(self):
+        self.validate_identity(
+            "SELECT * FROM OPENROWSET(BULK '/lake-raw/file.parquet', FORMAT='PARQUET') AS source",
+            "SELECT\n"
+            "  *\n"
+            "FROM OPENROWSET(BULK '/lake-raw/file.parquet', FORMAT = 'PARQUET') AS source",
+            pretty=True,
+        )
+
+    def test_openrowset_requires_bulk_and_format(self):
+        with self.assertRaises(ParseError):
+            self.parse_one("SELECT * FROM OPENROWSET(BULK '/lake-raw/file.parquet') AS source")
+
+        with self.assertRaises(ParseError):
+            self.parse_one(
+                "SELECT * FROM OPENROWSET('/lake-raw/file.parquet', FORMAT = 'PARQUET') AS source"
+            )
+
+    def test_openrowset_does_not_parse_unimplemented_options(self):
+        with self.assertRaises(ParseError):
+            self.parse_one(
+                "SELECT * FROM OPENROWSET("
+                "BULK '/lake-raw/file.parquet', FORMAT_OPTIONS = (FIELDQUOTE = '\"')"
+                ") AS source"
+            )


### PR DESCRIPTION
## Summary

- add a `Synapse` dialect derived from T-SQL
- add a semantic `OpenRowset` expression
- parse and generate the minimal serverless Synapse form `OPENROWSET(BULK '<path>', FORMAT = '<format>')`
- add focused identity, AST, pretty-printing, and invalid-syntax tests

This intentionally starts with the smallest documented form so additional Synapse syntax can be reviewed independently.

## Validation

- Ruff lint and format checks
- 161 focused Synapse, T-SQL, and dialect tests, plus 3,548 subtests
- pure-Python focused tests on Python 3.9 through 3.14
- compiled-parser focused tests on Python 3.10, 3.11, 3.13, and 3.14
- `git diff --check`

Repository-wide mypy was also attempted with an available external environment; it reported pre-existing errors outside the changed Synapse files. The project-specific pre-commit executable was not available locally.


Potential follow-up slices, kept out of this PR so each syntax family can be reviewed independently:

1. Parenthesized `BULK` path lists and `DATA_SOURCE`.
2. `OPENROWSET ... WITH (...)` result schemas.
3. CSV options such as `FIRSTROW`, `FIELDQUOTE`, `FIELDTERMINATOR`, and `ROWTERMINATOR`.
4. Synapse file metadata methods such as `filename()` and `filepath()`.
5. External data source, external file format, and external table DDL.
6. `TRY_PARSE(... AS ... USING ...)`.

I will wait for feedback before preparing any follow-up.