### PR TITLE
fix(sqlite): render RegexpLike as the REGEXP operator [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -173,6 +173,7 @@ class SQLiteGenerator(generator.Generator):
         exp.LogicalAnd: rename_func("MIN"),
         exp.Pivot: no_pivot_sql,
         exp.Rand: rename_func("RANDOM"),
+        exp.RegexpLike: lambda self, e: self.binary(e, "REGEXP"),
         exp.Select: transforms.preprocess(
             [
                 _offset_to_limit,

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -23,6 +23,7 @@ class TestSQLite(Validator):
         self.validate_identity("SELECT * FROM t NOT INDEXED")
         self.validate_identity("SELECT match FROM t")
         self.validate_identity("SELECT rowid FROM t1 WHERE t1 MATCH 'lorem'")
+        self.validate_identity("SELECT * FROM t WHERE a REGEXP 'x'")
         self.validate_identity("SELECT RANK() OVER (RANGE CURRENT ROW) FROM tbl")
         self.validate_identity("UNHEX(a, b)")
         self.validate_identity("SELECT DATE()")


### PR DESCRIPTION
Fixes #8080.

SQLite has no `REGEXP_LIKE` function — it exposes `REGEXP` as a binary operator (`X REGEXP Y`, sugar for a user-defined `regexp(Y, X)`). But the SQLite generator falls through to the base `RegexpLike` handler and emits `REGEXP_LIKE(...)`, which is a syntax error in SQLite:

```
$ echo "SELECT 'a' WHERE 'a' REGEXP_LIKE('x');" | sqlite3
Parse error near line 1: near "REGEXP_LIKE": syntax error
```

Before:

```python
>>> sqlglot.transpile("SELECT * FROM t WHERE a REGEXP 'x'", read="sqlite", write="sqlite")
["SELECT * FROM t WHERE REGEXP_LIKE(a, 'x')"]
```

After:

```python
>>> sqlglot.transpile("SELECT * FROM t WHERE a REGEXP 'x'", read="sqlite", write="sqlite")
["SELECT * FROM t WHERE a REGEXP 'x'"]
```

The fix mirrors the existing operator renderings for Postgres (`~`), Hive (`RLIKE`) and Doris/StarRocks (`REGEXP`): a one-line `TRANSFORMS` entry rendering the operator via `self.binary(e, "REGEXP")`. Round-trips identically and matches real sqlite3 syntax. Regression test added to `tests/dialects/test_sqlite.py` (fails before, passes after). `make check` green.

[CLAUDE]
