### PR TITLE
Fix: transpile POSEXPLODE over a map to DuckDB (CLAUDE)

### DIFF
--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4313,32 +4313,48 @@ class DuckDBGenerator(generator.Generator):
         parent = expression.parent
 
         # The default Spark aliases are "pos" and "col", unless specified otherwise
-        pos, col = exp.to_identifier("pos"), exp.to_identifier("col")
+        columns: list[exp.Expression] = [exp.to_identifier("pos"), exp.to_identifier("col")]
 
         if isinstance(parent, exp.Aliases):
             # Column case: SELECT POSEXPLODE(col) [AS (a, b)]
-            pos, col = parent.expressions
+            columns = parent.expressions
         elif isinstance(parent, exp.Table):
             # Table case: SELECT * FROM POSEXPLODE(col) [AS (a, b)]
             alias = parent.args.get("alias")
             if alias:
-                pos, col = alias.columns or [pos, col]
+                columns = alias.columns or columns
                 alias.pop()
 
         # Translate POSEXPLODE to UNNEST + GENERATE_SUBSCRIPTS
         # Note: In Spark pos is 0-indexed, but in DuckDB it's 1-indexed, so we subtract 1 from GENERATE_SUBSCRIPTS
-        unnest_sql = self.sql(exp.Unnest(expressions=[this], alias=col))
-        gen_subscripts = self.sql(
-            exp.Alias(
-                this=exp.Anonymous(
-                    this="GENERATE_SUBSCRIPTS", expressions=[this, exp.Literal.number(1)]
+        def _generate_subscripts(array: exp.Expression, alias: exp.Expression) -> str:
+            return self.sql(
+                exp.Alias(
+                    this=exp.Anonymous(
+                        this="GENERATE_SUBSCRIPTS", expressions=[array, exp.Literal.number(1)]
+                    )
+                    - exp.Literal.number(1),
+                    alias=alias,
                 )
-                - exp.Literal.number(1),
-                alias=pos,
             )
-        )
 
-        posexplode_sql = self.format_args(gen_subscripts, unnest_sql)
+        if len(columns) == 3:
+            # POSEXPLODE over a map yields three columns: (pos, key, value)
+            pos, key, value = columns
+            keys = exp.Anonymous(this="MAP_KEYS", expressions=[this.copy()])
+            values = exp.Anonymous(this="MAP_VALUES", expressions=[this.copy()])
+            posexplode_sql = self.format_args(
+                _generate_subscripts(keys.copy(), pos),
+                self.sql(exp.Unnest(expressions=[keys], alias=key)),
+                self.sql(exp.Unnest(expressions=[values], alias=value)),
+            )
+        else:
+            # POSEXPLODE over an array yields two columns: (pos, col)
+            pos, col = columns
+            posexplode_sql = self.format_args(
+                _generate_subscripts(this, pos),
+                self.sql(exp.Unnest(expressions=[this], alias=col)),
+            )
 
         if isinstance(parent, exp.From) or (parent and isinstance(parent.parent, exp.From)):
             # SELECT * FROM POSEXPLODE(col) -> SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(...), UNNEST(...))

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1289,6 +1289,14 @@ TBLPROPERTIES (
             },
         )
         self.validate_all(
+            # POSEXPLODE over a map yields three columns (pos, key, value)
+            "SELECT POSEXPLODE(m) AS (pos, key, value)",
+            write={
+                "duckdb": "SELECT GENERATE_SUBSCRIPTS(MAP_KEYS(m), 1) - 1 AS pos, UNNEST(MAP_KEYS(m)) AS key, UNNEST(MAP_VALUES(m)) AS value",
+                "spark": "SELECT POSEXPLODE(m) AS (pos, key, value)",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM POSEXPLODE(ARRAY('a'))",
             write={
                 "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(['a'], 1) - 1 AS pos, UNNEST(['a']) AS col)",


### PR DESCRIPTION
`POSEXPLODE` over a map produces three columns (pos, key, value), but the DuckDB generator only handled the two-column array form: `posexplode_sql` unpacked `parent.expressions` into `(pos, col)` and raised `ValueError: too many values to unpack (expected 2, got 3)` on the map form. That shape is valid Spark/Hive and even lives in `identity.sql`, so it round-trips in the base dialect but blew up when targeting DuckDB.

This adds the three-column path, exploding `MAP_KEYS`/`MAP_VALUES` next to the position from `GENERATE_SUBSCRIPTS`; the array translation is unchanged. Output verified against DuckDB (0-indexed position, key, value):

```sql
SELECT POSEXPLODE(m) AS (pos, key, value)
-- duckdb:
SELECT GENERATE_SUBSCRIPTS(MAP_KEYS(m), 1) - 1 AS pos, UNNEST(MAP_KEYS(m)) AS key, UNNEST(MAP_VALUES(m)) AS value
```

Closes #8164.

Added a map case to the POSEXPLODE -> DuckDB assertions in `tests/dialects/test_spark.py`; `ruff`, `mypy`, and the duckdb/spark/hive/transpile suites pass.
