### PR TITLE
Fix: don't crash generating ClickHouse CODEC for a single-value COMPRESS (CLAUDE)

### DIFF
--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -163,6 +163,18 @@ def _json_cast_sql(self: ClickHouseGenerator, expression: exp.JSONCast) -> str:
     return f"{this}.:{to_sql}"
 
 
+def _codec_sql(self: ClickHouseGenerator, expression: exp.CompressColumnConstraint) -> str:
+    # COMPRESS accepts either a single value or a parenthesized list; only the
+    # list form is stored as a sequence, so render the single value directly.
+    this = expression.args.get("this")
+    codecs = (
+        self.expressions(expression, key="this", flat=True)
+        if isinstance(this, list)
+        else self.sql(expression, "this")
+    )
+    return f"CODEC({codecs})"
+
+
 class ClickHouseGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     TRY_SUPPORTED = False
@@ -299,9 +311,7 @@ class ClickHouseGenerator(generator.Generator):
         exp.CurrentSchemas: rename_func("CURRENT_SCHEMAS"),
         exp.CountIf: rename_func("countIf"),
         exp.CosineDistance: rename_func("cosineDistance"),
-        exp.CompressColumnConstraint: lambda self, e: (
-            f"CODEC({self.expressions(e, key='this', flat=True)})"
-        ),
+        exp.CompressColumnConstraint: _codec_sql,
         exp.ComputedColumnConstraint: lambda self, e: (
             f"{'MATERIALIZED' if e.args.get('persisted') else 'ALIAS'} {self.sql(e, 'this')}"
         ),

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1011,6 +1011,17 @@ ORDER BY (
             'CREATE TABLE t ("projection" Int8)',
         )
 
+        # A COMPRESS constraint with a single value (stored as a lone expression,
+        # not a list) must still map to CODEC without raising.
+        self.validate_all(
+            "CREATE TABLE t (a Int32 CODEC('x'))",
+            read={"clickhouse": "CREATE TABLE t (a Int32 COMPRESS 'x')"},
+        )
+        self.validate_all(
+            "CREATE TABLE t (a Int32 CODEC('x', 'y'))",
+            read={"clickhouse": "CREATE TABLE t (a Int32 COMPRESS ('x', 'y'))"},
+        )
+
         db_table_expr = exp.Table(this=None, db=exp.to_identifier("foo"), catalog=None)
         create_with_cluster = exp.Create(
             this=db_table_expr,


### PR DESCRIPTION
The ClickHouse `CompressColumnConstraint -> CODEC` transform ran `self.expressions()` over the constraint's `this`, which is a list only for the parenthesized multi-value form. A single value (e.g. `COMPRESS 'a'`) is stored as a lone expression, so iterating it raised `TypeError: 'Literal' object is not iterable`:

```python
sqlglot.transpile("CREATE TABLE t (a Int32 COMPRESS 'x')", read="clickhouse", write="clickhouse")
# TypeError: 'Literal' object is not iterable
```

This renders the single value directly and keeps the list handling for the multi-value form:

```sql
CREATE TABLE t (a Int32 COMPRESS 'x')        -> CREATE TABLE t (a Int32 CODEC('x'))
CREATE TABLE t (a Int32 COMPRESS ('x', 'y')) -> CREATE TABLE t (a Int32 CODEC('x', 'y'))
```

Closes #8166.

Added single/multi cases to `test_ddl` in `tests/dialects/test_clickhouse.py`; `ruff`, `mypy`, and the ClickHouse suite pass.
