### PR TITLE
Fix: handle single-argument DATETIME when generating DuckDB (CLAUDE)

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1737,6 +1737,10 @@ def no_datetime_sql(self: Generator, expression: exp.Datetime) -> str:
     this = expression.this
     expr = expression.expression
 
+    if expr is None:
+        # DATETIME(<expr>) with a single argument just builds a timestamp from it
+        return self.sql(exp.cast(this, exp.DType.TIMESTAMP))
+
     if expr.name.lower() in TIMEZONES:
         # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIMESTAMP)
         this = exp.cast(this, exp.DType.TIMESTAMPTZ)

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -2036,6 +2036,15 @@ class TestDuckDB(Validator):
             },
         )
 
+        # Single-argument DATETIME(x) has no second argument to inspect
+        self.validate_all(
+            "SELECT CAST('2020-01-01' AS TIMESTAMP)",
+            read={
+                "duckdb": "SELECT DATETIME('2020-01-01')",
+                "spark": "SELECT DATETIME('2020-01-01')",
+            },
+        )
+
         self.validate_all(
             "SELECT TIMESTAMP 'foo'",
             write={


### PR DESCRIPTION
`no_datetime_sql` assumed `DATETIME` always has a second argument and read `expression.expression.name` to check whether it is a timezone. For the single-argument form (e.g. `DATETIME('2020-01-01')`) that argument is `None`, so generating DuckDB raised:

```python
sqlglot.transpile("SELECT DATETIME('2020-01-01')", read="duckdb", write="duckdb")
# AttributeError: 'NoneType' object has no attribute 'name'
```

This treats the single-argument form as a plain cast to `TIMESTAMP` (DuckDB's `DATETIME` is an alias for `TIMESTAMP`), leaving the two-argument date/time and timestamp/zone paths unchanged:

```sql
SELECT DATETIME('2020-01-01')  ->  SELECT CAST('2020-01-01' AS TIMESTAMP)
```

Closes #8168.

Added a case to `test_time` in `tests/dialects/test_duckdb.py`; `ruff`, `mypy`, and the duckdb/bigquery/spark/snowflake suites pass.
