### PR TITLE
Fix: don't crash rewriting FILTER over an anonymous aggregate to Snowflake (CLAUDE)

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -1201,7 +1201,11 @@ class SnowflakeGenerator(generator.Generator):
         if isinstance(agg_arg, exp.Order):
             agg_arg = agg_arg.this
 
-        if isinstance(agg_arg, exp.Distinct):
+        if isinstance(agg, exp.Anonymous):
+            # Anonymous aggregates keep the function name in `this`, so the values to
+            # wrap are its `expressions` rather than `this`.
+            targets = agg.expressions
+        elif isinstance(agg_arg, exp.Distinct):
             targets = agg_arg.expressions
         else:
             targets = [agg_arg]

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -368,6 +368,14 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
+            # An anonymous aggregate keeps its name in `this`, with the value in `expressions`
+            "SELECT COLLECT_LIST(x) FILTER (WHERE x > 1) FROM t",
+            write={
+                "duckdb": "SELECT COLLECT_LIST(x) FILTER(WHERE x > 1) FROM t",
+                "snowflake": "SELECT COLLECT_LIST(IFF(x > 1, x, NULL)) FROM t",
+            },
+        )
+        self.validate_all(
             "SELECT COUNT(*) FILTER (WHERE b > 0) FROM t",
             write={
                 "duckdb": "SELECT COUNT(*) FILTER(WHERE b > 0) FROM t",


### PR DESCRIPTION
Snowflake has no `FILTER (WHERE cond)`, so `filter_sql` rewrites the input values into `IFF(cond, value, NULL)`. It read the value from `agg.this`, which for an anonymous aggregate (e.g. `COLLECT_LIST(x)`) is the function-name string rather than the argument, so wrapping it raised:

```python
sqlglot.transpile("SELECT COLLECT_LIST(x) FILTER (WHERE x = 5) FROM t", write="snowflake")
# AttributeError: 'str' object has no attribute 'copy'
```

This takes the values from the aggregate's `expressions` for anonymous functions, the same way `DISTINCT` arguments are already handled, so the rewrite matches the named-aggregate case:

```sql
SELECT COLLECT_LIST(x) FILTER (WHERE x = 5) FROM t
-- snowflake:
SELECT COLLECT_LIST(IFF(x = 5, x, NULL)) FROM t
```

Closes #8170.

Added a case next to the other FILTER rewrites in `tests/dialects/test_duckdb.py`; `ruff`, `mypy`, and the duckdb/snowflake suites pass.
