### PR TITLE
Fix: don't crash in exp.cast() when the input is already a cast to INTERVAL (CLAUDE)

### DIFF
--- a/sqlglot/expressions/builders.py
+++ b/sqlglot/expressions/builders.py
@@ -497,9 +497,14 @@ def cast(
 
         existing_cast_type: DType = expr.to.this
         new_cast_type: DType = data_type.this
-        types_are_equivalent = type_mapping.get(
-            existing_cast_type, existing_cast_type.value
-        ) == type_mapping.get(new_cast_type, new_cast_type.value)
+        # `this` is only a plain type enum for simple types; complex ones such as
+        # INTERVAL nest another expression there, so the equivalence check is skipped.
+        types_are_equivalent = (
+            isinstance(existing_cast_type, DType)
+            and isinstance(new_cast_type, DType)
+            and type_mapping.get(existing_cast_type, existing_cast_type.value)
+            == type_mapping.get(new_cast_type, new_cast_type.value)
+        )
 
         if expr.is_type(data_type) or types_are_equivalent:
             return expr

--- a/sqlglot/expressions/builders.py
+++ b/sqlglot/expressions/builders.py
@@ -495,7 +495,7 @@ def cast(
         target_dialect = Dialect.get_or_raise(dialect)
         type_mapping = target_dialect.generator_class.TYPE_MAPPING
 
-        existing_cast_type: DType = expr.to.this
+        existing_cast_type = expr.to.this
         new_cast_type: DType = data_type.this
         # `this` is only a plain type enum for simple types; complex ones such as
         # INTERVAL nest another expression there, so the equivalence check is skipped.

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -536,6 +536,12 @@ class TestExprs(unittest.TestCase):
         self.assertEqual(len(list(recast.find_all(exp.Cast))), 2)
         self.assertEqual(recast.sql(), "CAST(CAST(x AS DATE) AS VARCHAR)")
 
+        # a cast to a complex type (e.g. INTERVAL) nests an expression in `to.this`,
+        # which the equivalence check must not treat as a plain type enum
+        interval_cast = parse_one("CAST(-1 AS INTERVAL HOUR)")
+        recast = exp.cast(interval_cast, to=exp.DataType.Type.BIGINT)
+        self.assertEqual(recast.sql(), "CAST(CAST(-1 AS INTERVAL HOUR) AS BIGINT)")
+
         # check that dialect is used when casting strings
         self.assertEqual(
             exp.cast("x", to="regtype", dialect="postgres").sql(), "CAST(x AS REGTYPE)"


### PR DESCRIPTION
The "don't re-cast if the expression is already the right type" shortcut in `exp.cast()` read `expr.to.this.value`, assuming `this` is a plain type enum. For a complex type such as `INTERVAL`, `to.this` nests another expression (`Interval(unit=HOUR)`), which has no `value`, so the call raised:

```python
import sqlglot.expressions as exp
from sqlglot import parse_one

exp.cast(parse_one("CAST(-1 AS INTERVAL HOUR)"), "BIGINT")
# AttributeError: 'Interval' object has no attribute 'value'
```

It also surfaced during transpilation, e.g. `DATE_ADD(..., CAST(-1 AS INTERVAL HOUR))` to Presto.

This only applies the equivalence check when both types are plain enums, so complex types fall through and get wrapped like any other:

```
CAST(-1 AS INTERVAL HOUR)  ->  CAST(CAST(-1 AS INTERVAL HOUR) AS BIGINT)
```

Closes #8172.

Extended `test_cast` in `tests/test_expressions.py`; `ruff`, `mypy`, and the expression/build/presto suites pass.
