### PR TITLE
Fix four generator crashes on valid input across dialects (CLAUDE)

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1737,6 +1737,10 @@ def no_datetime_sql(self: Generator, expression: exp.Datetime) -> str:
     this = expression.this
     expr = expression.expression
 
+    if expr is None:
+        # DATETIME(<expr>) with a single argument just builds a timestamp from it
+        return self.sql(exp.cast(this, exp.DType.TIMESTAMP))
+
     if expr.name.lower() in TIMEZONES:
         # Transpile BQ's DATETIME(timestamp, zone) to CAST(TIMESTAMPTZ <timestamp> AT TIME ZONE <zone> AS TIMESTAMP)
         this = exp.cast(this, exp.DType.TIMESTAMPTZ)

--- a/sqlglot/generators/clickhouse.py
+++ b/sqlglot/generators/clickhouse.py
@@ -163,6 +163,18 @@ def _json_cast_sql(self: ClickHouseGenerator, expression: exp.JSONCast) -> str:
     return f"{this}.:{to_sql}"
 
 
+def _codec_sql(self: ClickHouseGenerator, expression: exp.CompressColumnConstraint) -> str:
+    # COMPRESS accepts either a single value or a parenthesized list; only the
+    # list form is stored as a sequence, so render the single value directly.
+    this = expression.args.get("this")
+    codecs = (
+        self.expressions(expression, key="this", flat=True)
+        if isinstance(this, list)
+        else self.sql(expression, "this")
+    )
+    return f"CODEC({codecs})"
+
+
 class ClickHouseGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     TRY_SUPPORTED = False
@@ -299,9 +311,7 @@ class ClickHouseGenerator(generator.Generator):
         exp.CurrentSchemas: rename_func("CURRENT_SCHEMAS"),
         exp.CountIf: rename_func("countIf"),
         exp.CosineDistance: rename_func("cosineDistance"),
-        exp.CompressColumnConstraint: lambda self, e: (
-            f"CODEC({self.expressions(e, key='this', flat=True)})"
-        ),
+        exp.CompressColumnConstraint: _codec_sql,
         exp.ComputedColumnConstraint: lambda self, e: (
             f"{'MATERIALIZED' if e.args.get('persisted') else 'ALIAS'} {self.sql(e, 'this')}"
         ),

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -4313,32 +4313,48 @@ class DuckDBGenerator(generator.Generator):
         parent = expression.parent
 
         # The default Spark aliases are "pos" and "col", unless specified otherwise
-        pos, col = exp.to_identifier("pos"), exp.to_identifier("col")
+        columns: list[exp.Expression] = [exp.to_identifier("pos"), exp.to_identifier("col")]
 
         if isinstance(parent, exp.Aliases):
             # Column case: SELECT POSEXPLODE(col) [AS (a, b)]
-            pos, col = parent.expressions
+            columns = parent.expressions
         elif isinstance(parent, exp.Table):
             # Table case: SELECT * FROM POSEXPLODE(col) [AS (a, b)]
             alias = parent.args.get("alias")
             if alias:
-                pos, col = alias.columns or [pos, col]
+                columns = alias.columns or columns
                 alias.pop()
 
         # Translate POSEXPLODE to UNNEST + GENERATE_SUBSCRIPTS
         # Note: In Spark pos is 0-indexed, but in DuckDB it's 1-indexed, so we subtract 1 from GENERATE_SUBSCRIPTS
-        unnest_sql = self.sql(exp.Unnest(expressions=[this], alias=col))
-        gen_subscripts = self.sql(
-            exp.Alias(
-                this=exp.Anonymous(
-                    this="GENERATE_SUBSCRIPTS", expressions=[this, exp.Literal.number(1)]
+        def _generate_subscripts(array: exp.Expression, alias: exp.Expression) -> str:
+            return self.sql(
+                exp.Alias(
+                    this=exp.Anonymous(
+                        this="GENERATE_SUBSCRIPTS", expressions=[array, exp.Literal.number(1)]
+                    )
+                    - exp.Literal.number(1),
+                    alias=alias,
                 )
-                - exp.Literal.number(1),
-                alias=pos,
             )
-        )
 
-        posexplode_sql = self.format_args(gen_subscripts, unnest_sql)
+        if len(columns) == 3:
+            # POSEXPLODE over a map yields three columns: (pos, key, value)
+            pos, key, value = columns
+            keys = exp.Anonymous(this="MAP_KEYS", expressions=[this.copy()])
+            values = exp.Anonymous(this="MAP_VALUES", expressions=[this.copy()])
+            posexplode_sql = self.format_args(
+                _generate_subscripts(keys.copy(), pos),
+                self.sql(exp.Unnest(expressions=[keys], alias=key)),
+                self.sql(exp.Unnest(expressions=[values], alias=value)),
+            )
+        else:
+            # POSEXPLODE over an array yields two columns: (pos, col)
+            pos, col = columns
+            posexplode_sql = self.format_args(
+                _generate_subscripts(this, pos),
+                self.sql(exp.Unnest(expressions=[this], alias=col)),
+            )
 
         if isinstance(parent, exp.From) or (parent and isinstance(parent.parent, exp.From)):
             # SELECT * FROM POSEXPLODE(col) -> SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(...), UNNEST(...))

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -1201,7 +1201,11 @@ class SnowflakeGenerator(generator.Generator):
         if isinstance(agg_arg, exp.Order):
             agg_arg = agg_arg.this
 
-        if isinstance(agg_arg, exp.Distinct):
+        if isinstance(agg, exp.Anonymous):
+            # Anonymous aggregates keep the function name in `this`, so the values to
+            # wrap are its `expressions` rather than `this`.
+            targets = agg.expressions
+        elif isinstance(agg_arg, exp.Distinct):
             targets = agg_arg.expressions
         else:
             targets = [agg_arg]

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -1011,6 +1011,17 @@ ORDER BY (
             'CREATE TABLE t ("projection" Int8)',
         )
 
+        # A COMPRESS constraint with a single value (stored as a lone expression,
+        # not a list) must still map to CODEC without raising.
+        self.validate_all(
+            "CREATE TABLE t (a Int32 CODEC('x'))",
+            read={"clickhouse": "CREATE TABLE t (a Int32 COMPRESS 'x')"},
+        )
+        self.validate_all(
+            "CREATE TABLE t (a Int32 CODEC('x', 'y'))",
+            read={"clickhouse": "CREATE TABLE t (a Int32 COMPRESS ('x', 'y'))"},
+        )
+
         db_table_expr = exp.Table(this=None, db=exp.to_identifier("foo"), catalog=None)
         create_with_cluster = exp.Create(
             this=db_table_expr,

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -368,6 +368,14 @@ class TestDuckDB(Validator):
             },
         )
         self.validate_all(
+            # An anonymous aggregate keeps its name in `this`, with the value in `expressions`
+            "SELECT COLLECT_LIST(x) FILTER (WHERE x > 1) FROM t",
+            write={
+                "duckdb": "SELECT COLLECT_LIST(x) FILTER(WHERE x > 1) FROM t",
+                "snowflake": "SELECT COLLECT_LIST(IFF(x > 1, x, NULL)) FROM t",
+            },
+        )
+        self.validate_all(
             "SELECT COUNT(*) FILTER (WHERE b > 0) FROM t",
             write={
                 "duckdb": "SELECT COUNT(*) FILTER(WHERE b > 0) FROM t",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -2044,6 +2044,15 @@ class TestDuckDB(Validator):
             },
         )
 
+        # Single-argument DATETIME(x) has no second argument to inspect
+        self.validate_all(
+            "SELECT CAST('2020-01-01' AS TIMESTAMP)",
+            read={
+                "duckdb": "SELECT DATETIME('2020-01-01')",
+                "spark": "SELECT DATETIME('2020-01-01')",
+            },
+        )
+
         self.validate_all(
             "SELECT TIMESTAMP 'foo'",
             write={

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1289,6 +1289,14 @@ TBLPROPERTIES (
             },
         )
         self.validate_all(
+            # POSEXPLODE over a map yields three columns (pos, key, value)
+            "SELECT POSEXPLODE(m) AS (pos, key, value)",
+            write={
+                "duckdb": "SELECT GENERATE_SUBSCRIPTS(MAP_KEYS(m), 1) - 1 AS pos, UNNEST(MAP_KEYS(m)) AS key, UNNEST(MAP_VALUES(m)) AS value",
+                "spark": "SELECT POSEXPLODE(m) AS (pos, key, value)",
+            },
+        )
+        self.validate_all(
             "SELECT * FROM POSEXPLODE(ARRAY('a'))",
             write={
                 "duckdb": "SELECT * FROM (SELECT GENERATE_SUBSCRIPTS(['a'], 1) - 1 AS pos, UNNEST(['a']) AS col)",


### PR DESCRIPTION
Four small, independent generator fixes, each for input that parses fine but crashes on the way back out to SQL. I bundled them into one PR since they're all one-spot generator guards with a regression test each; happy to split if you'd rather take them separately.

`pytest tests/dialects` passes.

### Snowflake: FILTER over an anonymous aggregate (closes #8170)

Snowflake has no `FILTER (WHERE ...)`, so `filter_sql` rewrites the aggregated value into `IFF(cond, value, NULL)`. It read the value from `agg.this`, which for an anonymous aggregate like `COLLECT_LIST(x)` is the function-name string rather than the argument, so wrapping it raised `AttributeError: 'str' object has no attribute 'copy'`. It now takes the values from the aggregate's `expressions` for anonymous functions, the same way DISTINCT arguments already are.

```sql
SELECT COLLECT_LIST(x) FILTER (WHERE x > 1) FROM t   -- write=snowflake
```

### DuckDB: single-argument DATETIME (closes #8168)

`no_datetime_sql` assumed `DATETIME` always has a second argument and read `expression.expression.name` to check for a timezone. For the single-argument form the second argument is `None`, so generating DuckDB raised `AttributeError: 'NoneType' object has no attribute 'name'`. The single-argument form is now treated as a plain cast to `TIMESTAMP`; the two-argument date/time and timestamp/zone paths are unchanged.

```sql
SELECT DATETIME('2020-01-01')   -- write=duckdb
```

### DuckDB: POSEXPLODE over a map (closes #8164)

`POSEXPLODE` of a map yields three columns (pos, key, value), but the DuckDB generator assumed exactly two and unpacked `parent.expressions` into `(pos, col)`, raising `ValueError: too many values to unpack (expected 2, got 3)`. This form is valid Spark/Hive and is present in `identity.sql`. The three-column case now explodes `MAP_KEYS`/`MAP_VALUES` alongside `GENERATE_SUBSCRIPTS`; the two-column array translation is unchanged.

### ClickHouse: single-value COMPRESS constraint (closes #8166)

The `CompressColumnConstraint` -> `CODEC` transform ran `self.expressions()` over the constraint's `this`, which is a list only for the parenthesized multi-value form. A single value like `COMPRESS 'a'` is stored as a lone expression, so iterating it raised `TypeError: 'Literal' object is not iterable`. The single value is now rendered directly, and the list handling is kept for the multi-value form.
