### PR TITLE
fix(executor): parenthesize CASE in generated Python [CLAUDE]

### DIFF
--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -43,7 +43,7 @@ def _case_sql(self, expression):
         condition = f"{this} = ({condition})" if this else condition
         chain = f"{true} if {condition} else ({chain})"
 
-    return chain
+    return f"({chain})"
 
 
 def _lambda_sql(self, e: exp.Lambda) -> str:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -703,6 +703,17 @@ class TestExecutor(unittest.TestCase):
                 self.assertEqual(result.columns, tuple(cols))
                 self.assertEqual(result.rows, rows)
 
+    def test_operators_apply_to_a_whole_case_expression(self):
+        tables = {"t": [{"a": 1}, {"a": 2}]}
+
+        for sql, expected in (
+            ("SELECT (CASE WHEN a = 1 THEN 'x' END) IS NOT NULL AS c FROM t", [(True,), (False,)]),
+            ("SELECT (CASE WHEN a = 1 THEN 'x' END) IS NULL AS c FROM t", [(False,), (True,)]),
+            ("SELECT (CASE WHEN a = 1 THEN 1 ELSE 2 END) + 10 AS c FROM t", [(11,), (12,)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables).rows, expected)
+
     def test_negated_like(self):
         """NOT LIKE must exclude what LIKE matches, and match no NULL either."""
         tables = {"t": [{"s": "Bump version"}, {"s": "Add feature"}, {"s": None}]}


### PR DESCRIPTION
An operator applied to a `CASE` binds to the ELSE branch rather than to the whole expression. With `t = {"t": [{"a": 1}, {"a": 2}]}`, so one row per value of `a`:

| query | main | this PR | postgres 18.4 |
| --- | --- | --- | --- |
| `SELECT (CASE WHEN a = 1 THEN 'x' END) IS NOT NULL FROM t` | `False, False` | `True, False` | `True, False` |
| `SELECT (CASE WHEN a = 1 THEN 'x' END) IS NULL FROM t` | `'x', True` | `False, True` | `False, True` |
| `SELECT CASE WHEN a = 1 THEN 'x' ELSE 'y' END FROM t` | `'x', 'y'` | `'x', 'y'` | `'x', 'y'` |
| `SELECT (CASE WHEN a = 1 THEN 1 ELSE 2 END) + 10 FROM t` | `11, 12` | `11, 12` | `11, 12` |

`_case_sql` returns its Python conditional unwrapped, and a conditional binds looser than any operator, so `'x' if EQ(scope[None][a], 1) else (None) is not None` reads as `'x' if ... else ((None) is not None)`. The parens in the SQL do not help — the optimizer removes the `Paren` node before codegen.

The last two rows are why `IS [NOT] NULL` is the only form affected today. `exp.Is` is the only transform that emits a bare Python operator; arithmetic and the bare CASE both go through `ENV` function calls, where the argument list already groups. Wrapping the result fixes `IS [NOT] NULL` and keeps the codegen correct for any operator added later.

Disclosure: implemented with Claude.
