### PR TITLE
fix(executor): return NULL from typed division of NULL [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -271,6 +271,7 @@ ENV = {
     "GTE": null_if_any(lambda this, e: this >= e),
     "IF": lambda predicate, true, false: true if predicate else false,
     "IN": sql_in,
+    "INT": null_if_any(int),
     "INTDIV": null_if_any(lambda e, this: e // this),
     "INTERVAL": interval,
     "JSONEXTRACT": jsonextract,

--- a/sqlglot/generators/python.py
+++ b/sqlglot/generators/python.py
@@ -78,7 +78,7 @@ def _div_sql(self: generator.Generator, e: exp.Div) -> str:
     if e.args.get("typed") and not (
         e.this.is_type(*exp.DataType.REAL_TYPES) or e.expression.is_type(*exp.DataType.REAL_TYPES)
     ):
-        sql = f"int({sql})"
+        sql = f"INT({sql})"
 
     return sql
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -822,6 +822,16 @@ class TestExecutor(unittest.TestCase):
         result = execute("SELECT n / 3 AS x FROM t", tables=tables, dialect="postgres")
         self.assertEqual(result.rows, [(3,)])
 
+    def test_typed_division_of_null_is_null(self):
+        schema = {"t": {"n": "INT"}}
+        tables = {"t": [{"n": None}]}
+
+        for sql in ("SELECT n / 3 AS x FROM t", "SELECT 3 / n AS x FROM t"):
+            for dialect in ("postgres", "sqlite"):
+                with self.subTest(f"{dialect}: {sql}"):
+                    result = execute(sql, schema=schema, tables=tables, dialect=dialect)
+                    self.assertEqual(result.rows, [(None,)])
+
     def test_null_ordering_honors_nulls_first_and_dialect_defaults(self):
         schema = {"t": {"a": "INT"}}
         tables = {"t": [{"a": 1}, {"a": None}, {"a": 3}, {"a": None}]}


### PR DESCRIPTION
A typed division of NULL raises instead of returning NULL:

```python
>>> execute("SELECT n / 3 FROM t", tables={"t": [{"n": None}]}, dialect="postgres").rows
ExecuteError: Step 'Join: t (...)' failed: int() argument must be a string, a bytes-like
object or a real number, not 'NoneType'
```

Either operand triggers it, and under a `SAFE_DIVISION` dialect the `DIV(a, b or None)` form hits it for a zero denominator too. Engine column is PostgreSQL 18.4 and SQLite 3.51:

| dialect | `t` | query | main | this PR | engine |
| --- | --- | --- | --- | --- | --- |
| postgres | `[{"n": None}]` | `SELECT n / 3 FROM t` | raises | `NULL` | `NULL` |
| postgres | `[{"n": None}]` | `SELECT 3 / n FROM t` | raises | `NULL` | `NULL` |
| sqlite | `[{"n": None}]` | `SELECT n / 3 FROM t` | raises | `NULL` | `NULL` |
| sqlite | `[{"n": 10}]` | `SELECT n / 0 FROM t` | raises | `NULL` | `NULL` |
| postgres | `[{"n": 10}]` | `SELECT n / 3 FROM t` | `3` | `3` | `3` |
| postgres | `[{"n": -10}]` | `SELECT n / 3 FROM t` | `-3` | `-3` | `-3` |
| postgres | `[{"n": 7}]` | `SELECT n / 2 FROM t` | `3` | `3` | `3` |

`_div_sql` truncates a typed division with Python's bare `int()`. `DIV` is `null_if_any` and returns None, so `int(None)` raises — the guard every neighbouring entry has is missing from just this one step. `"INT": null_if_any(int)` supplies it, the same way `LENGTH` wraps `len`. `INTDIV` was taken, and is floor division rather than truncation.

The last three rows are the regression check: division still truncates toward zero rather than rounding or flooring.

Disclosure: implemented with Claude.

