### PR TITLE
feat(executor): add REVERSE to ENV [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -290,6 +290,7 @@ ENV = {
     "OR": sql_or,
     "ORDERED": ordered,
     "POW": null_if_any(pow),
+    "REVERSE": null_if_any(lambda this: this[::-1]),
     "RIGHT": null_if_any(lambda this, e: this[-e:]),
     "ROUND": null_if_any(lambda this, decimals=None, truncate=None: round(this, ndigits=decimals)),
     "STRPOSITION": str_position,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -950,6 +950,8 @@ class TestExecutor(unittest.TestCase):
             ("DATEDIFF('2022-01-03'::date, '2022-01-01'::TIMESTAMP::DATE)", 2),
             ("TRIM(' foo ')", "foo"),
             ("TRIM('afoob', 'ab')", "foo"),
+            ("REVERSE('foo')", "oof"),
+            ("REVERSE(NULL)", None),
             ("ARRAY_JOIN(['foo', 'bar'], ':')", "foo:bar"),
             ("ARRAY_JOIN(['hello', null ,'world'], ' ', ',')", "hello , world"),
             ("ARRAY_JOIN(['', null ,'world'], ' ', ',')", " , world"),


### PR DESCRIPTION
`exp.Reverse` already generates `REVERSE(...)` via `_rename`, but `ENV` has no such key, so it raises instead of answering:

| query | main | this PR | postgres 18.4 |
| --- | --- | --- | --- |
| `SELECT REVERSE('foo')` | `name 'REVERSE' is not defined` | `oof` | `oof` |
| `SELECT REVERSE(NULL)` | `name 'REVERSE' is not defined` | `NULL` | `NULL` |

`null_if_any` gives the entry the NULL propagation every neighbouring one has.

Disclosure: implemented with Claude.
