### PR TITLE
feat(postgres): parse BTRIM as TRIM [CLAUDE]

### DIFF
--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -18,6 +18,12 @@ if t.TYPE_CHECKING:
     from sqlglot.dialects.dialect import Dialect
 
 
+def _build_btrim(args: list) -> exp.Trim | exp.Anonymous:
+    if 1 <= len(args) <= 2:
+        return exp.Trim(this=seq_get(args, 0), expression=seq_get(args, 1))
+    return exp.Anonymous(this="BTRIM", expressions=args)
+
+
 def _build_generate_series(args: list) -> exp.ExplodingGenerateSeries:
     # The goal is to convert step values like '1 day' or INTERVAL '1 day' into INTERVAL '1' day
     # Note: postgres allows calls with just two arguments -- the "step" argument defaults to 1
@@ -102,6 +108,7 @@ class PostgresParser(parser.Parser):
         "ARRAY_PREPEND": lambda args: exp.ArrayPrepend(
             this=seq_get(args, 1), expression=seq_get(args, 0)
         ),
+        "BTRIM": _build_btrim,
         "BIT_AND": exp.BitwiseAndAgg.from_arg_list,
         "BIT_OR": exp.BitwiseOrAgg.from_arg_list,
         "BIT_XOR": exp.BitwiseXorAgg.from_arg_list,

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -86,6 +86,14 @@ class TestPostgres(Validator):
         self.validate_identity("SELECT CAST(e'\\176' AS BYTEA)")
         self.validate_identity("SELECT * FROM x WHERE SUBSTRING('Thomas' FROM '...$') IN ('mas')")
         self.validate_identity("SELECT TRIM(' X' FROM ' XXX ')")
+        self.validate_identity("SELECT BTRIM(x, 'ab', 'c')")
+        self.validate_all(
+            "SELECT BTRIM(x, 'ab')",
+            write={
+                "postgres": "SELECT TRIM('ab' FROM x)",
+                "duckdb": "SELECT TRIM(x, 'ab')",
+            },
+        )
         self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ' COLLATE utf8_bin)")
         self.validate_identity("""SELECT * FROM JSON_TO_RECORDSET(z) AS y("rank" INT)""")
         self.validate_identity("SELECT ~x")


### PR DESCRIPTION
`btrim` is not modelled anywhere in sqlglot: it parses to an `Anonymous`, so it survives as the literal text `BTRIM(...)` whatever the target, and raises in the executor. Postgres' `btrim(string, characters)` is exactly `TRIM`, in that argument order.

Every row below reads the same **Postgres** input and only varies the dialect it is generated for:

| input, parsed as postgres | generated for | main | this PR |
| --- | --- | --- | --- |
| `BTRIM(x, 'ab')` | postgres | `BTRIM(x, 'ab')` | `TRIM('ab' FROM x)` |
| `BTRIM(x, 'ab')` | duckdb | `BTRIM(x, 'ab')` — DuckDB has no `btrim`, so this does not run | `TRIM(x, 'ab')` |
| `BTRIM(x, 'ab', 'c')` | postgres | `BTRIM(x, 'ab', 'c')` | `BTRIM(x, 'ab', 'c')` |

Arity falls back to `Anonymous` outside one or two arguments, as `_build_strftime` does; `Trim.from_arg_list` pins none, so a third argument would land in `Trim.position`. A parser mapping rather than an `ENV` entry because Postgres is the only dialect that implements `btrim`.

Disclosure: implemented with Claude.
