### PR TITLE
fix(bigquery): parse digit-leading field names after a dot

### DIFF
--- a/sqlglot/parsers/bigquery.py
+++ b/sqlglot/parsers/bigquery.py
@@ -430,6 +430,30 @@ class BigQueryParser(parser.Parser):
 
         return this
 
+    def _parse_field(
+        self,
+        any_token: bool = False,
+        tokens: t.Collection[TokenType] | None = None,
+        anonymous_func: bool = False,
+    ) -> exp.Expr | None:
+        # data.144A_FLAG is tokenized as NUMBER + VAR. After a DOT, glue them
+        # into one identifier, same as _parse_table_part does for foo.bar.25x.
+        # https://github.com/tobymao/sqlglot/issues/8175
+        after_dot = self._prev is not None and self._prev.token_type == TokenType.DOT
+        field = super()._parse_field(
+            any_token=any_token, tokens=tokens, anonymous_func=anonymous_func
+        )
+        if (
+            after_dot
+            and isinstance(field, exp.Literal)
+            and field.is_number
+            and self._is_connected()
+            and self._parse_var(any_token=True)
+        ):
+            name = f"{field.name}{self._prev.text}"
+            field = exp.Identifier(this=name, quoted=True).update_positions(field)
+        return field
+
     def _parse_table_parts(
         self,
         schema: bool = False,

--- a/tests/dialects/test_bigquery.py
+++ b/tests/dialects/test_bigquery.py
@@ -174,6 +174,16 @@ class TestBigQuery(Validator):
         self.validate_identity("CAST(x AS STRUCT<list ARRAY<INT64>>)")
         self.validate_identity("assert.true(1 = 1)")
         self.validate_identity("SELECT jsondoc['some_key']")
+        # Digit-leading JSON/STRUCT fields (https://github.com/tobymao/sqlglot/issues/8175)
+        self.validate_identity("SELECT data.144A_FLAG FROM t", "SELECT data.`144A_FLAG` FROM t")
+        self.validate_identity("SELECT t.1a FROM t", "SELECT t.`1a` FROM t")
+        self.validate_identity(
+            "SELECT STRING(data.144A_FLAG) FROM t", "SELECT STRING(data.`144A_FLAG`) FROM t"
+        )
+        col = self.parse_one("SELECT data.144A_FLAG FROM t").selects[0]
+        self.assertIsInstance(col, exp.Column)
+        self.assertIsInstance(col.this, exp.Identifier)
+        self.assertEqual(col.this.name, "144A_FLAG")
         self.validate_identity("SELECT `p.d.UdF`(data).* FROM `p.d.t`")
         self.validate_identity("SELECT * FROM `my-project.my-dataset.my-table`")
         self.validate_identity("CREATE OR REPLACE TABLE `a.b.c` CLONE `a.b.d`")


### PR DESCRIPTION
`SELECT data.144A_FLAG FROM t` was tokenized as NUMBER `144` + VAR `A_FLAG` and then parsed as `data.144 AS A_FLAG`. BigQuery allows those digit-leading JSON/STRUCT keys (confirmed with a dry run in #8175).

`_parse_table_part` already glues a connected NUMBER+VAR after a dot (`foo.bar.25x`). Do the same in `_parse_field` so column/field access gets a quoted identifier instead of an implicit alias.

Fixes #8175

I used Grok (Cursor) while writing this. I confirmed the mis-parse on main, matched the existing table-part glue, and ran `tests/dialects/test_bigquery.py` (58 tests).