### PR TITLE
fix(oracle): support partitioning schemes in CREATE TABLE DDL

### DIFF
--- a/sqlglot/expressions/properties.py
+++ b/sqlglot/expressions/properties.py
@@ -337,6 +337,14 @@ class PartitionByRangeProperty(Property):
     arg_types = {"partition_expressions": True, "create_expressions": True}
 
 
+class PartitionByHashProperty(Property):
+    arg_types = {
+        "partition_expressions": True,
+        "create_expressions": False,
+        "partition_count": False,
+    }
+
+
 class PartitionByRangePropertyDynamic(Expression):
     arg_types = {"this": False, "start": True, "end": True, "every": True}
 
@@ -354,7 +362,11 @@ class RowAccessProperty(Property):
 
 
 class PartitionByListProperty(Property):
-    arg_types = {"partition_expressions": True, "create_expressions": True}
+    arg_types = {
+        "partition_expressions": True,
+        "create_expressions": True,
+        "automatic": False,
+    }
 
 
 class PartitionList(Expression):

--- a/sqlglot/generators/oracle.py
+++ b/sqlglot/generators/oracle.py
@@ -109,8 +109,52 @@ class OracleGenerator(generator.Generator):
 
     PROPERTIES_LOCATION = {
         **generator.Generator.PROPERTIES_LOCATION,
+        exp.PartitionByHashProperty: exp.Properties.Location.POST_SCHEMA,
+        exp.PartitionByListProperty: exp.Properties.Location.POST_SCHEMA,
+        exp.PartitionByRangeProperty: exp.Properties.Location.POST_SCHEMA,
         exp.VolatileProperty: exp.Properties.Location.UNSUPPORTED,
     }
+
+    def partition_sql(self, expression: exp.Partition) -> str:
+        parent = expression.parent
+        if isinstance(parent, (exp.PartitionByRangeProperty, exp.PartitionByListProperty)):
+            return self.expressions(expression, flat=True)
+        if isinstance(parent, exp.PartitionByHashProperty):
+            return f"PARTITION {self.expressions(expression, flat=True)}"
+        return super().partition_sql(expression)
+
+    def _partition_by_sql(
+        self, expression: exp.PartitionByRangeProperty | exp.PartitionByListProperty, kind: str
+    ) -> str:
+        columns = self.expressions(expression, key="partition_expressions", flat=True)
+        definitions = self.expressions(expression, key="create_expressions", flat=True)
+        automatic = " AUTOMATIC" if expression.args.get("automatic") else ""
+        return f"PARTITION BY {kind} ({columns}){automatic} ({definitions})"
+
+    def partitionbyrangeproperty_sql(self, expression: exp.PartitionByRangeProperty) -> str:
+        return self._partition_by_sql(expression, "RANGE")
+
+    def partitionbylistproperty_sql(self, expression: exp.PartitionByListProperty) -> str:
+        return self._partition_by_sql(expression, "LIST")
+
+    def partitionbyhashproperty_sql(self, expression: exp.PartitionByHashProperty) -> str:
+        columns = self.expressions(expression, key="partition_expressions", flat=True)
+        definitions = self.expressions(expression, key="create_expressions", flat=True)
+        count = self.sql(expression, "partition_count")
+
+        if definitions:
+            return f"PARTITION BY HASH ({columns}) ({definitions})"
+        return f"PARTITION BY HASH ({columns}) PARTITIONS {count}"
+
+    def partitionrange_sql(self, expression: exp.PartitionRange) -> str:
+        name = self.sql(expression, "this")
+        values = self.expressions(expression, flat=True)
+        return f"PARTITION {name} VALUES LESS THAN ({values})"
+
+    def partitionlist_sql(self, expression: exp.PartitionList) -> str:
+        name = self.sql(expression, "this")
+        values = self.expressions(expression, flat=True)
+        return f"PARTITION {name} VALUES ({values})"
 
     def currenttimestamp_sql(self, expression: exp.CurrentTimestamp) -> str:
         if expression.args.get("sysdate"):

--- a/sqlglot/parsers/oracle.py
+++ b/sqlglot/parsers/oracle.py
@@ -68,6 +68,7 @@ class OracleParser(parser.Parser):
             self._match_text_seq("TEMPORARY")
             and self.expression(exp.TemporaryProperty(this="GLOBAL"))
         ),
+        "PARTITION BY": lambda self: self._parse_partition_property(),
         "PRIVATE": lambda self: (
             self._match_text_seq("TEMPORARY")
             and self.expression(exp.TemporaryProperty(this="PRIVATE"))
@@ -102,6 +103,75 @@ class OracleParser(parser.Parser):
             ("CHECK", "OPTION"),
         ),
     }
+
+    def _parse_partition_property(self) -> exp.Expr | None:
+        if self._match_text_seq("RANGE"):
+            partition_expressions = self._parse_wrapped_csv(self._parse_assignment)
+            create_expressions = self._parse_wrapped_csv(self._parse_partition_range_value)
+            return self.expression(
+                exp.PartitionByRangeProperty(
+                    partition_expressions=partition_expressions,
+                    create_expressions=create_expressions,
+                )
+            )
+
+        if self._match_text_seq("LIST"):
+            partition_expressions = self._parse_wrapped_csv(self._parse_assignment)
+            automatic = self._match_text_seq("AUTOMATIC")
+            create_expressions = self._parse_wrapped_csv(self._parse_partition_list_value)
+            return self.expression(
+                exp.PartitionByListProperty(
+                    partition_expressions=partition_expressions,
+                    create_expressions=create_expressions,
+                    automatic=automatic,
+                )
+            )
+
+        if self._match_text_seq("HASH"):
+            partition_expressions = self._parse_wrapped_csv(self._parse_assignment)
+
+            if self._match_text_seq("PARTITIONS"):
+                return self.expression(
+                    exp.PartitionByHashProperty(
+                        partition_expressions=partition_expressions,
+                        partition_count=self._parse_number(),
+                    )
+                )
+
+            return self.expression(
+                exp.PartitionByHashProperty(
+                    partition_expressions=partition_expressions,
+                    create_expressions=self._parse_wrapped_csv(self._parse_hash_partition),
+                )
+            )
+
+        return None
+
+    def _parse_partition_range_value(self) -> exp.Partition:
+        self._match_text_seq("PARTITION")
+        name = self._parse_id_var()
+        self._match_text_seq("VALUES", "LESS", "THAN")
+        values = self._parse_wrapped_csv(self._parse_expression)
+
+        if len(values) == 1 and isinstance(values[0], exp.Column) and values[0].name == "MAXVALUE":
+            values = [exp.var("MAXVALUE")]
+
+        return self.expression(
+            exp.Partition(expressions=[exp.PartitionRange(this=name, expressions=values)])
+        )
+
+    def _parse_partition_list_value(self) -> exp.Partition:
+        self._match_text_seq("PARTITION")
+        name = self._parse_id_var()
+        self._match_text_seq("VALUES")
+        values = self._parse_wrapped_csv(self._parse_expression)
+        return self.expression(
+            exp.Partition(expressions=[exp.PartitionList(this=name, expressions=values)])
+        )
+
+    def _parse_hash_partition(self) -> exp.Partition:
+        self._match_text_seq("PARTITION")
+        return self.expression(exp.Partition(expressions=[self._parse_id_var()]))
 
     def _parse_to_number(self) -> exp.ToNumber:
         # https://docs.oracle.com/en/database/oracle/oracle-database/19/sqlrf/TO_NUMBER.html

--- a/tests/dialects/test_oracle.py
+++ b/tests/dialects/test_oracle.py
@@ -6,6 +6,26 @@ from sqlglot.optimizer.qualify import qualify
 class TestOracle(Validator):
     dialect = "oracle"
 
+    def test_create_partitioned_table(self):
+        self.validate_identity(
+            "CREATE TABLE sales (id NUMBER) "
+            "PARTITION BY RANGE (id) (PARTITION p1 VALUES LESS THAN (100), "
+            "PARTITION p_max VALUES LESS THAN (MAXVALUE))"
+        )
+        self.validate_identity(
+            "CREATE TABLE sales (region VARCHAR2(2)) "
+            "PARTITION BY LIST (region) (PARTITION p_us VALUES ('US'), "
+            "PARTITION p_ca VALUES ('CA'))"
+        )
+        self.validate_identity(
+            "CREATE TABLE sales (region VARCHAR2(2)) "
+            "PARTITION BY LIST (region) AUTOMATIC (PARTITION p_us VALUES ('US'))"
+        )
+        self.validate_identity("CREATE TABLE sales (id NUMBER) PARTITION BY HASH (id) PARTITIONS 4")
+        self.validate_identity(
+            "CREATE TABLE sales (id NUMBER) PARTITION BY HASH (id) (PARTITION p1, PARTITION p2)"
+        )
+
     def test_oracle(self):
         self.validate_identity("1 /* /* */", "1 /* / * */")
         self.validate_all(


### PR DESCRIPTION
## Issue

Oracle `CREATE TABLE` partition clauses are not currently parsed into structured expressions.  They raise `sqlglot.errors.ParseError: Expecting )`:

```sql
  CREATE TABLE sales (
    id NUMBER
  )
  PARTITION BY RANGE (id) (
    PARTITION p1 VALUES LESS THAN (100),
    PARTITION p_max VALUES LESS THAN (MAXVALUE)
  );
```

```sql
CREATE TABLE sales (
    region VARCHAR2(2)
  )
  PARTITION BY LIST (region) AUTOMATIC (
    PARTITION p_us VALUES ('US')
  );
```

Traceback
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    from sqlglot import parse_one; parse_one("CREATE TABLE sales (region VARCHAR2(2)) PARTITION BY LIST (region) (PARTITION p_us VALUES ('US'))", dialect="oracle")
                                   ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abhisoms/sqlglot/sqlglot/__init__.py", line 160, in parse_one
    result = dialect.parse(sql, **opts)
  File "/Users/abhisoms/sqlglot/sqlglot/dialects/dialect.py", line 1169, in parse
    return self.parser(**opts).parse(self.tokenize(sql), sql)
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2136, in parse
    raw_tokens: The list of tokens.
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2256, in _parse
    chunks.append([])
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2223, in _parse_batch_statements
    return expressions
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2375, in _parse_statement
    def _parse_statement(self) -> exp.Expr | None:
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 1162, in <lambda>
    TokenType.COMMIT: lambda self: self._parse_commit_or_rollback(),
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2646, in _parse_create
    self._match(TokenType.COMMA)
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2983, in _parse_properties
    def _parse_properties(self, before: bool | None = None) -> exp.Properties | None:
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2913, in _parse_property
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2919, in _parse_key_value_property
    return self._parse_key_value_property()
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 6816, in _parse_column
    return primary_parser(self, token)
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 6903, in _parse_column_reference
    column.add_comments(all_comments)
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 7142, in _parse_field
    field = (
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 7128, in _parse_primary
    return primary
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 7095, in _parse_paren
    this = self.expression(exp.Paren(this=this))
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 9727, in _match_r_paren
    subparser = parsers[" ".join(this)]
  File "/Users/abhisoms/sqlglot/sqlglot/parser.py", line 2093, in raise_error
    start_context=start_context,
sqlglot.errors.ParseError: Expecting ). Line 1, Col: 89.
  CREATE TABLE sales (region VARCHAR2(2)) PARTITION BY LIST (region) (PARTITION p_us VALUES ('US'))
```


Hash partition counts do not raise, but fall back to an opaque Command expression:

```sql
CREATE TABLE sales (
    id NUMBER
  )
  PARTITION BY HASH (id) PARTITIONS 4;
```
```
CREATE TABLE sales (id NUMBER) PARTITION BY HASH (id) PARTITIONS 4' contains unsupported syntax. Falling back to parsing as a 'Command'.
Command
CREATE TABLE sales (id NUMBER) PARTITION BY HASH (id) PARTITIONS 4
```

## Change

Add Oracle parser and generator support for simple range, list, and hash table partitioning.

- List partitioning property `PartitionByListProperty` is extended to include an automatic=True flag when applicable.
- Hash partitioning is represented with a new `PartitionByHashProperty`

### Examples:

```python
>>> parse_one("CREATE TABLE sales (region VARCHAR2(2)) PARTITION BY LIST (region) (PARTITION p_us VALUES ('US'))", dialect="oracle")

Create(
  this=Schema(
    this=Table(
      this=Identifier(this=sales, quoted=False)),
    expressions=[
      ColumnDef(
        this=Identifier(this=region, quoted=False),
        kind=DataType(
          this=DType.VARCHAR,
          expressions=[
            DataTypeParam(
              this=Literal(this=2, is_string=False))],
          nested=False))]),
  kind=TABLE,
  replace=False,
  refresh=False,
  unique=False,
  exists=False,
  properties=Properties(
    expressions=[
      PartitionByListProperty(
        partition_expressions=[
          Column(
            this=Identifier(this=region, quoted=False),
            join_mark=False)],
        create_expressions=[
          Partition(
            expressions=[
              PartitionList(
                this=Identifier(this=p_us, quoted=False),
                expressions=[
                  Literal(this='US', is_string=True)])])],
        automatic=False)]),
  concurrently=False)

```

```python
>>> parse_one("CREATE TABLE sales (id NUMBER) PARTITION BY RANGE (id) (PARTITION p1 VALUES LESS THAN (100))", dialect="oracle")

Create(
  this=Schema(
    this=Table(
      this=Identifier(this=sales, quoted=False)),
    expressions=[
      ColumnDef(
        this=Identifier(this=id, quoted=False),
        kind=DataType(this=DType.DECIMAL, nested=False))]),
  kind=TABLE,
  replace=False,
  refresh=False,
  unique=False,
  exists=False,
  properties=Properties(
    expressions=[
      PartitionByRangeProperty(
        partition_expressions=[
          Column(
            this=Identifier(this=id, quoted=False),
            join_mark=False)],
        create_expressions=[
          Partition(
            expressions=[
              PartitionRange(
                this=Identifier(this=p1, quoted=False),
                expressions=[
                  Literal(this=100, is_string=False)])])])]),
  concurrently=False)
```