### PR TITLE
fix(clickhouse): make VALUES tuple wrapping idempotent [CLAUDE]

### DIFF
--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -977,11 +977,13 @@ class ClickHouseParser(parser.Parser):
         # In INSERT INTO statements the same clause actually references multiple columns (opposite semantics),
         # but the final result is not altered by the extra parentheses.
         # Note: Clickhouse allows VALUES([structure], value, ...) so the branch checks for the last expression
+        # A single-value tuple is generated as "(x)", which is parsed back into a Paren
+        # rather than a Tuple, so it's unwrapped here to keep this rewrite idempotent
         expressions = value.expressions
         if values and not isinstance(expressions[-1], exp.Tuple):
             value.set(
                 "expressions",
-                [self.expression(exp.Tuple(expressions=[expr])) for expr in expressions],
+                [self.expression(exp.Tuple(expressions=[expr.unnest()])) for expr in expressions],
             )
 
         return value

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -815,6 +815,11 @@ class TestClickhouse(Validator):
             "INSERT INTO t (col1, col2) VALUES (('abcd'), (1234))",
         )
 
+        # Wrapping the values in tuples must be idempotent, otherwise re-parsing
+        # generated SQL keeps adding a layer of parentheses on every roundtrip
+        self.validate_identity("INSERT INTO t (col1, col2) VALUES (('abcd'), (1234))")
+        self.validate_identity("SELECT * FROM VALUES ((1), (2), (3))")
+
         self.validate_all(
             "SELECT col FROM (SELECT 1 AS col) AS _t",
             read={


### PR DESCRIPTION
The ClickHouse parser rewrites `VALUES` into a tuple-of-tuples, because in ClickHouse
`SELECT * FROM VALUES (1, 2, 3)` is three single-column rows rather than one three-column row.
The guard skips the rewrite when the last expression is already a `Tuple`, but a single-value
tuple is generated as `(x)`, which parses back into a `Paren`. Re-parsing generated SQL
therefore hits the rewrite again and adds a layer of parentheses every time:

```
INSERT INTO t (a, b) VALUES (1, 2)
-> INSERT INTO t (a, b) VALUES ((1), (2))
-> INSERT INTO t (a, b) VALUES (((1)), ((2)))
-> INSERT INTO t (a, b) VALUES ((((1))), (((2))))
```

The same applies to `SELECT * FROM VALUES (1, 2, 3)`, and to the `ON CONFLICT`,
`ON DUPLICATE KEY` and `FORMAT Values` variants.

Unwrapping the `Paren` before rewrapping makes the rewrite a fixed point. The first pass is
unchanged, so the existing expected outputs in `test_clickhouse_values` still hold; the two
new assertions cover the second pass.

I found this with a harness that checks `f(f(x)) == f(x)` over a corpus of statements across
dialects. Disclosure: I used Claude for that harness and while tracking down the cause. I have
reviewed the change and can explain it.
