### PR TITLE
fix(snowflake): rewrite UNNEST projections into lateral FLATTEN [CLAUDE]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -373,6 +373,19 @@ def _eliminate_dot_variant_lookup(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
+def _unnest_projection_to_explode(expression: exp.Expr) -> exp.Expr:
+    # Snowflake has no UNNEST, so one that ends up in a projection has to become a lateral
+    # FLATTEN. Rewriting it as an EXPLODE lets explode_projection_to_unnest do that, instead
+    # of unnest_sql emitting a second FROM clause in the middle of the SELECT list.
+    if isinstance(expression, exp.Select):
+        for projection in expression.expressions:
+            for unnest in list(projection.find_all(exp.Unnest)):
+                if len(unnest.expressions) == 1 and unnest.find_ancestor(exp.Select) is expression:
+                    unnest.replace(exp.Explode(this=unnest.expressions[0].copy()))
+
+    return expression
+
+
 class SnowflakeGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     PARAMETER_TOKEN = "$"
@@ -548,6 +561,7 @@ class SnowflakeGenerator(generator.Generator):
             [
                 transforms.eliminate_window_clause,
                 transforms.eliminate_distinct_on,
+                _unnest_projection_to_explode,
                 transforms.explode_projection_to_unnest(),
                 transforms.eliminate_semi_and_anti_joins,
                 _transform_generate_date_array,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4583,6 +4583,21 @@ WHERE
   )""",
         )
 
+        # An UNNEST that ends up in a projection has to be rewritten into a lateral FLATTEN,
+        # the same way an EXPLODE is, instead of producing a second FROM clause
+        self.validate_all(
+            "SELECT IFF(_u.pos = _u_2.pos_2, _u_2.col, NULL) AS col FROM t"
+            " CROSS JOIN TABLE(FLATTEN(INPUT => ARRAY_GENERATE_RANGE(0, (GREATEST(ARRAY_SIZE(arr)) - 1) + 1)))"
+            " AS _u(seq, key, path, index, pos, this)"
+            " CROSS JOIN TABLE(FLATTEN(INPUT => arr)) AS _u_2(seq, key, path, pos_2, col, this)"
+            " WHERE _u.pos = _u_2.pos_2"
+            " OR (_u.pos > (ARRAY_SIZE(arr) - 1) AND _u_2.pos_2 = (ARRAY_SIZE(arr) - 1))",
+            read={
+                "bigquery": "SELECT UNNEST(arr) FROM t",
+                "snowflake": "SELECT UNNEST(arr) FROM t",
+            },
+        )
+
         self.validate_all(
             """
             select


### PR DESCRIPTION
Snowflake has no `UNNEST`, so `unnest_sql` emits a `FLATTEN` table function. It also emits its own
`FROM` when the `Unnest` is not directly under a `FROM`/`JOIN`/`LATERAL`, so an `UNNEST` that ends up
in a projection produces a query with two `FROM` clauses, which sqlglot then cannot parse back:

```
SELECT UNNEST(arr) FROM t
-> SELECT value FROM TABLE(FLATTEN(INPUT => arr)) AS _u(seq, key, path, index, value, this) FROM t
```

Dialects whose parser produces an `Explode` for that input (duckdb, postgres) were already handled
by `explode_projection_to_unnest`, which moves it into a lateral `FLATTEN`. Only the dialects that
parse it into an `Unnest` (snowflake, bigquery) reached the broken path.

Rewriting a projection `Unnest` into an `Explode` before that transform runs routes it through the
existing machinery, so all four now generate the same lateral `FLATTEN`. `UNNEST` in `FROM` or
`JOIN` position is untouched, and the `{value} FROM ` branch it used to hit is not exercised by any
test in the suite.

Found with a harness that checks `f(f(x)) == f(x)` across dialects; this one surfaced as output that
would not reparse. Disclosure: I used Claude for that harness and while tracing the cause. I have
reviewed the change and can explain it.
