### PR TITLE
feat(executor): evaluate subqueries the optimizer declines to rewrite [CLAUDE]

### DIFF
--- a/sqlglot/executor/context.py
+++ b/sqlglot/executor/context.py
@@ -19,16 +19,27 @@ class Context:
     evaluation of aggregation functions.
     """
 
-    def __init__(self, tables: dict[str, Table], env: dict | None = None) -> None:
+    def __init__(
+        self, tables: dict[str, Table], env: dict | None = None, outer: dict | None = None
+    ) -> None:
         """
         Args
             tables: representing the scope of the current execution context.
             env: dictionary of functions within the execution context.
+            outer: readers of an enclosing query, for a subquery run once per outer row.
+                Own tables shadow them, as an inner alias shadows an outer one in SQL.
         """
         self.tables = tables
         self._table: Table | None = None
-        self.range_readers = {name: table.range_reader for name, table in self.tables.items()}
-        self.row_readers = {name: table.reader for name, table in tables.items()}
+        range_readers = {name: table.range_reader for name, table in self.tables.items()}
+        row_readers = {name: table.reader for name, table in tables.items()}
+
+        if outer:
+            range_readers = {**outer, **range_readers}
+            row_readers = {**outer, **row_readers}
+
+        self.range_readers = range_readers
+        self.row_readers = row_readers
         self.env = {**ENV, **(env or {}), "scope": self.row_readers}
 
     def eval(self, code):

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -113,14 +113,14 @@ class PythonExecutor:
         query = subquery.this.unnest()
         scope = build_scope(query)
 
-        outer_columns = [column.copy() for column in (scope.external_columns if scope else [])]
+        outer_columns = list(scope.external_columns if scope else [])
 
         plan = self._register_subquery(query)
         parent = subquery.parent
 
         if isinstance(subquery, exp.Exists):
-            return subquery, exp.Anonymous(
-                this="SUBQUERY_EXISTS", expressions=[plan, exp.var("scope"), *outer_columns]
+            return subquery, exp.func(
+                "SUBQUERY_EXISTS", plan, exp.var("scope"), *outer_columns, copy=False
             )
 
         if len(query.selects) != 1:
@@ -134,30 +134,28 @@ class PythonExecutor:
         if isinstance(parent, exp.In) and subquery is parent.args.get("query"):
             return self._compile_quantified(parent, "ANY", plan, outer_columns, op="EQ")
 
-        return subquery, exp.Anonymous(
-            this="SUBQUERY_SCALAR", expressions=[plan, exp.var("scope"), *outer_columns]
+        return subquery, exp.func(
+            "SUBQUERY_SCALAR", plan, exp.var("scope"), *outer_columns, copy=False
         )
 
     def _compile_quantified(self, comparison, quantifier, plan, outer_columns, op=None):
         if not isinstance(comparison, (exp.Binary, exp.In)):
             raise ExecuteError(f"Unsupported {quantifier} subquery: expected a comparison")
 
-        return comparison, exp.Anonymous(
-            this="SUBQUERY_COMPARISON",
-            expressions=[
-                comparison.this.copy(),
-                plan,
-                exp.var("scope"),
-                exp.Literal.string(op or comparison.key.upper()),
-                exp.Literal.string(quantifier),
-                *outer_columns,
-            ],
+        return comparison, exp.func(
+            "SUBQUERY_COMPARISON",
+            comparison.this,
+            plan,
+            exp.var("scope"),
+            exp.Literal.string(op or comparison.key.upper()),
+            exp.Literal.string(quantifier),
+            *outer_columns,
+            copy=False,
         )
 
     def _register_subquery(self, query):
         if self._ctes is not None and not query.args.get("with_"):
-            query = query.copy()
-            query.set("with_", self._ctes.copy())
+            query.set("with_", self._ctes)
 
         sql = query.sql()
         name = self._plan_names_by_sql.get(sql)

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -9,6 +9,9 @@ from sqlglot.executor.context import Context
 from sqlglot.executor.env import ENV
 from sqlglot.executor.table import RowReader, Table
 from sqlglot.generators.python import PythonGenerator
+from sqlglot.optimizer.scope import build_scope
+
+SUBQUERY_NODES = (exp.Subquery, exp.Exists, exp.All, exp.Any)
 
 
 class PythonExecutor:
@@ -16,8 +19,25 @@ class PythonExecutor:
         self.generator = Python().generator(identify=True, comments=False)
         self.env = {**ENV, **(env or {})}
         self.tables = tables or {}
+        self._subquery_plans = {}
+        self._plan_names_by_sql = {}
+        self._ctes = None
+        self._outer_scope = None
+        self.env.update(
+            SUBQUERY_COMPARISON=self._subquery_comparison,
+            SUBQUERY_EXISTS=self._subquery_exists,
+            SUBQUERY_SCALAR=self._subquery_scalar,
+        )
 
-    def execute(self, plan):
+    def execute(self, plan, outer_scope=None):
+        ctes, scope = self._ctes, self._outer_scope
+        self._ctes, self._outer_scope = plan.ctes, outer_scope
+        try:
+            return self._execute(plan)
+        finally:
+            self._ctes, self._outer_scope = ctes, scope
+
+    def _execute(self, plan):
         finished = set()
         queue = set(plan.leaves)
         contexts = {}
@@ -66,8 +86,130 @@ class PythonExecutor:
         if not expression:
             return None
 
+        expression = self._replace_subqueries(expression)
         sql = self.generator.generate(expression)
         return compile(sql, sql, "eval", optimize=2)
+
+    def _replace_subqueries(self, expression):
+        if not expression.find(*SUBQUERY_NODES):
+            return expression
+
+        expression = expression.copy()
+
+        while True:
+            subquery = expression.find(*SUBQUERY_NODES)
+
+            if subquery is None:
+                return expression
+
+            target, replacement = self._compile_subquery(subquery)
+
+            if target is expression:
+                expression = replacement
+            else:
+                target.replace(replacement)
+
+    def _compile_subquery(self, subquery):
+        query = subquery.this.unnest()
+        scope = build_scope(query)
+
+        outer_columns = [column.copy() for column in (scope.external_columns if scope else [])]
+
+        plan = self._register_subquery(query)
+        parent = subquery.parent
+
+        if isinstance(subquery, exp.Exists):
+            return subquery, exp.Anonymous(
+                this="SUBQUERY_EXISTS", expressions=[plan, exp.var("scope"), *outer_columns]
+            )
+
+        if len(query.selects) != 1:
+            raise ExecuteError(
+                f"Subquery used as an expression returned {len(query.selects)} columns"
+            )
+
+        if isinstance(subquery, (exp.All, exp.Any)):
+            return self._compile_quantified(parent, subquery.key.upper(), plan, outer_columns)
+
+        if isinstance(parent, exp.In) and subquery is parent.args.get("query"):
+            return self._compile_quantified(parent, "ANY", plan, outer_columns, op="EQ")
+
+        return subquery, exp.Anonymous(
+            this="SUBQUERY_SCALAR", expressions=[plan, exp.var("scope"), *outer_columns]
+        )
+
+    def _compile_quantified(self, comparison, quantifier, plan, outer_columns, op=None):
+        if not isinstance(comparison, (exp.Binary, exp.In)):
+            raise ExecuteError(f"Unsupported {quantifier} subquery: expected a comparison")
+
+        return comparison, exp.Anonymous(
+            this="SUBQUERY_COMPARISON",
+            expressions=[
+                comparison.this.copy(),
+                plan,
+                exp.var("scope"),
+                exp.Literal.string(op or comparison.key.upper()),
+                exp.Literal.string(quantifier),
+                *outer_columns,
+            ],
+        )
+
+    def _register_subquery(self, query):
+        if self._ctes is not None and not query.args.get("with_"):
+            query = query.copy()
+            query.set("with_", self._ctes.copy())
+
+        sql = query.sql()
+        name = self._plan_names_by_sql.get(sql)
+
+        if name is None:
+            name = self._plan_names_by_sql[sql] = f"_sq_{len(self._subquery_plans)}"
+            self._subquery_plans[name] = (planner.Plan(query), {})
+
+        return exp.Literal.string(name)
+
+    def _subquery_table(self, plan_name, scope, args):
+        plan, cache = self._subquery_plans[plan_name]
+
+        try:
+            return cache[args]
+        except KeyError:
+            pass
+        except TypeError:  # an unhashable correlated value can't be memoized
+            cache = None
+
+        table = self.execute(plan, scope)
+
+        if cache is not None:
+            cache[args] = table
+
+        return table
+
+    def _subquery_exists(self, plan_name, scope, *args):
+        return bool(self._subquery_table(plan_name, scope, args).rows)
+
+    def _subquery_scalar(self, plan_name, scope, *args):
+        rows = self._subquery_table(plan_name, scope, args).rows
+
+        if len(rows) > 1:
+            raise ExecuteError("More than one row returned by a subquery used as an expression")
+
+        return rows[0][0] if rows else None
+
+    def _subquery_comparison(self, value, plan_name, scope, op, quantifier, *args):
+        compare = self.env[op]
+        is_any = quantifier == "ANY"
+        saw_null = False
+
+        for row in self._subquery_table(plan_name, scope, args).rows:
+            result = compare(value, row[0])
+
+            if result is None:
+                saw_null = True
+            elif bool(result) is is_any:
+                return is_any
+
+        return None if saw_null else not is_any
 
     def generate_tuple(self, expressions):
         """Convert an array of SQL expressions into tuple of Python byte code."""
@@ -76,7 +218,7 @@ class PythonExecutor:
         return tuple(self.generate(expression) for expression in expressions)
 
     def context(self, tables):
-        return Context(tables, env=self.env)
+        return Context(tables, env=self.env, outer=self._outer_scope)
 
     def table(self, expressions):
         return Table(

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -13,6 +13,8 @@ from collections.abc import Iterator, Sequence, Iterable
 class Plan:
     def __init__(self, expression: exp.Expr) -> None:
         self.expression: exp.Expr = expression.copy()
+        with_: exp.With | None = self.expression.args.get("with_")
+        self.ctes: exp.With | None = with_.copy() if with_ is not None else None
         self.root: Step = Step.from_expression(self.expression)
         self._dag: dict[Step, set[Step]] = {}
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -28,6 +28,14 @@ from tests.helpers import (
 DIR_TPCH = FIXTURES_DIR + "/optimizer/tpc-h/"
 DIR_TPCDS = FIXTURES_DIR + "/optimizer/tpc-ds/"
 
+SUBQUERY_SCHEMA = {t: {"a" if t == "x" else "b": "int"} for t in ("x", "y", "e", "n")}
+SUBQUERY_TABLES = {
+    "x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}],
+    "y": [{"b": 2}, {"b": 3}],
+    "e": [],
+    "n": [{"b": 2}, {"b": None}],
+}
+
 
 def open_file(file_name):
     """Open a file that may be compressed as gzip and return it in universal newline mode."""
@@ -591,20 +599,126 @@ class TestExecutor(unittest.TestCase):
         self.assertEqual(executed.rows, [])
         self.assertEqual(executed.columns, ("id_alias", "sub_type"))
 
-    def test_unsupported_subqueries(self):
+    def test_subqueries(self):
+        # expected rows are duckdb's, which postgres agrees with on every case here
+        schema = {t: {"a" if t == "x" else "b": "int"} for t in ("x", "y", "e", "n")}
         tables = {
-            "x": [{"id": 1}, {"id": 2}, {"id": 3}],
-            "y": [{"id": 1}, {"id": 2}],
+            "x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}],
+            "y": [{"b": 2}, {"b": 3}],
+            "e": [],
+            "n": [{"b": 2}, {"b": None}],
         }
+        cases = (
+            ("SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = x.a OR b = 3)", []),
+            (
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE NOT b = x.a)",
+                [(1,), (2,), (3,), (5,)],
+            ),
+            ("SELECT a FROM x WHERE EXISTS (SELECT 1 FROM e)", []),
+            (
+                "SELECT a, (SELECT MAX(b) FROM y WHERE b > x.a) AS m FROM x",
+                [(1, 3), (2, 3), (3, None), (5, None)],
+            ),
+            ("SELECT a FROM x WHERE (SELECT COUNT(*) FROM y WHERE b > x.a) > 0", [(1,), (2,)]),
+            ("SELECT a FROM x WHERE a IN (SELECT b FROM y WHERE b = x.a OR b = 3)", [(2,), (3,)]),
+            ("SELECT a FROM x WHERE a NOT IN (SELECT b FROM y)", [(1,), (5,)]),
+            ("SELECT a FROM x WHERE a IN (SELECT b FROM n)", [(2,)]),
+            ("SELECT a FROM x WHERE a NOT IN (SELECT b FROM n)", []),
+            ("SELECT a FROM x WHERE a IN (5, (SELECT MIN(b) FROM y WHERE b > x.a))", [(5,)]),
+            ("SELECT a FROM x WHERE (SELECT MIN(b) FROM y WHERE b > x.a) IN (1, 2)", [(1,)]),
+            ("SELECT a FROM x WHERE a > ANY (SELECT b FROM n)", [(3,), (5,)]),
+            ("SELECT a FROM x WHERE a > ALL (SELECT b FROM n)", []),
+            ("SELECT a FROM x WHERE a > ANY (SELECT b FROM e)", []),
+            ("SELECT a FROM x WHERE a > ALL (SELECT b FROM e)", [(1,), (2,), (3,), (5,)]),
+            ("SELECT a FROM x WHERE a > SOME (SELECT b FROM y)", [(3,), (5,)]),
+            (
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = x.a AND EXISTS (SELECT 1 FROM n WHERE n.b = y.b))",
+                [(2,)],
+            ),
+            (
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = 99 OR EXISTS (SELECT 1 FROM n WHERE n.b = x.a OR n.b = 99))",
+                [(2,)],
+            ),
+            (
+                "SELECT a FROM x WHERE a IN (SELECT b FROM y WHERE b = x.a) OR a IN (SELECT b FROM n WHERE b = x.a)",
+                [(2,), (3,)],
+            ),
+            ("SELECT a FROM x WHERE a IN (SELECT b FROM y UNION SELECT b FROM n)", [(2,), (3,)]),
+            (
+                "SELECT a FROM x WHERE EXISTS ((SELECT 1 FROM y WHERE b = x.a OR b = 99))",
+                [(2,), (3,)],
+            ),
+            ("SELECT a FROM x GROUP BY a HAVING MAX(a) > (SELECT MIN(b) FROM y)", [(3,), (5,)]),
+            (
+                "WITH w AS (SELECT b, COUNT(*) AS k FROM y GROUP BY b) SELECT a FROM x "
+                "WHERE EXISTS (SELECT 1 FROM w WHERE w.b = x.a OR w.k = 2)",
+                [(2,), (3,)],
+            ),
+            (
+                "WITH c AS (SELECT b FROM y) SELECT a FROM x WHERE a IN (SELECT b FROM c) AND NOT EXISTS (SELECT 1 FROM c WHERE b = x.a OR b = 99)",
+                [],
+            ),
+            (
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = x.a OR EXISTS (SELECT 1 FROM n WHERE n.b = x.a))",
+                [(2,), (3,)],
+            ),
+        )
 
-        for sql in (
-            "SELECT x.id FROM x WHERE EXISTS (SELECT 1 FROM y WHERE NOT (y.id = x.id))",
-            "SELECT x.id FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE NOT (y.id = x.id))",
-            "SELECT x.id, (SELECT MAX(y.id) FROM y) AS max_id FROM x",
+        def sort(rows):
+            return sorted(rows, key=lambda row: tuple((v is None, v) for v in row))
+
+        for sql, expected in cases:
+            with self.subTest(sql):
+                self.assertEqual(sort(execute(sql, schema, tables=tables).rows), sort(expected))
+
+    def test_subquery_memoization(self):
+        schema = {"x": {"a": "int"}, "y": {"b": "int"}}
+        tables = {"x": [{"a": i % 3} for i in range(12)], "y": [{"b": 1}, {"b": 2}]}
+
+        for sql, plans in (
+            ("SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = x.a OR b = 9)", 1),
+            (
+                "SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = 9 OR EXISTS "
+                "(SELECT 1 FROM y AS y2 WHERE y2.b = x.a OR y2.b = 9))",
+                2,
+            ),
+        ):
+            with self.subTest(sql):
+                executor = PythonExecutor(tables=ensure_tables(tables))
+                executor.execute(Plan(optimize(sql, schema, leave_tables_isolated=True)))
+
+                # one plan per subquery, and one run per distinct correlated value of the 12 rows
+                self.assertEqual(len(executor._subquery_plans), plans)
+                self.assertEqual(
+                    [len(cache) for _, cache in executor._subquery_plans.values()], [3] * plans
+                )
+
+    def test_subquery_execution_does_not_mutate_the_plan(self):
+        schema = {"x": {"a": "int"}, "y": {"b": "int"}}
+        tables = {"x": [{"a": 1}, {"a": 2}], "y": [{"b": 2}]}
+        sql = "SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = x.a OR b = 9)"
+
+        plan = Plan(optimize(sql, schema, leave_tables_isolated=True))
+        before = plan.expression.sql()
+        PythonExecutor(tables=ensure_tables(tables)).execute(plan)
+
+        self.assertEqual(plan.expression.sql(), before)
+
+    def test_subquery_cardinality(self):
+        # a scalar subquery must yield a single row and column, as in duckdb and postgres
+        for sql, tables in (
+            (
+                "SELECT a, (SELECT b FROM y) AS m FROM x",
+                {"x": [{"a": 1}], "y": [{"b": 2}, {"b": 3}]},
+            ),
+            ("SELECT a, (SELECT b, b FROM y) AS m FROM x", {"x": [{"a": 1}], "y": [{"b": 2}]}),
+            # the column count is a property of the query, so it is rejected even when no
+            # outer row would have evaluated it -- duckdb reports this as a binder error
+            ("SELECT a, (SELECT b, b FROM y) AS m FROM x", {"x": [], "y": [{"b": 2}]}),
         ):
             with self.subTest(sql):
                 with self.assertRaises(ExecuteError):
-                    execute(sql, tables=tables)
+                    execute(sql, schema={"x": {"a": "int"}, "y": {"b": "int"}}, tables=tables)
 
     def test_correlated_count(self):
         tables = {

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -672,18 +672,15 @@ class TestExecutor(unittest.TestCase):
             ),
         )
 
-        def sort(rows):
-            return sorted(rows, key=lambda row: tuple((v is None, v) for v in row))
-
         for sql, expected in cases:
             with self.subTest(sql):
-                self.assertEqual(sort(execute(sql, schema, tables=tables).rows), sort(expected))
+                self.assertCountEqual(execute(sql, schema, tables=tables).rows, expected)
 
     def test_subquery_memoization(self):
         schema = {"x": {"a": "int"}, "y": {"b": "int"}}
         tables = {"x": [{"a": i % 3} for i in range(12)], "y": [{"b": 1}, {"b": 2}]}
 
-        for sql, plans in (
+        for sql, expected_plans in (
             ("SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = x.a OR b = 9)", 1),
             (
                 "SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = 9 OR EXISTS "
@@ -696,9 +693,10 @@ class TestExecutor(unittest.TestCase):
                 executor.execute(Plan(optimize(sql, schema, leave_tables_isolated=True)))
 
                 # one plan per subquery, and one run per distinct correlated value of the 12 rows
-                self.assertEqual(len(executor._subquery_plans), plans)
+                self.assertEqual(len(executor._subquery_plans), expected_plans)
                 self.assertEqual(
-                    [len(cache) for _, cache in executor._subquery_plans.values()], [3] * plans
+                    [len(cache) for _, cache in executor._subquery_plans.values()],
+                    [3] * expected_plans,
                 )
 
     def test_subquery_execution_does_not_mutate_the_plan(self):

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -28,14 +28,6 @@ from tests.helpers import (
 DIR_TPCH = FIXTURES_DIR + "/optimizer/tpc-h/"
 DIR_TPCDS = FIXTURES_DIR + "/optimizer/tpc-ds/"
 
-SUBQUERY_SCHEMA = {t: {"a" if t == "x" else "b": "int"} for t in ("x", "y", "e", "n")}
-SUBQUERY_TABLES = {
-    "x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}],
-    "y": [{"b": 2}, {"b": 3}],
-    "e": [],
-    "n": [{"b": 2}, {"b": None}],
-}
-
 
 def open_file(file_name):
     """Open a file that may be compressed as gzip and return it in universal newline mode."""

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -593,12 +593,17 @@ class TestExecutor(unittest.TestCase):
 
     def test_subqueries(self):
         # expected rows are duckdb's, which postgres agrees with on every case here
-        schema = {t: {"a" if t == "x" else "b": "int"} for t in ("x", "y", "e", "n")}
+        schema = {
+            "x": {"a": "int"},
+            "y": {"b": "int"},
+            "empty_table": {"b": "int"},
+            "tbl_with_null": {"b": "int"},
+        }
         tables = {
             "x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}],
             "y": [{"b": 2}, {"b": 3}],
-            "e": [],
-            "n": [{"b": 2}, {"b": None}],
+            "empty_table": [],
+            "tbl_with_null": [{"b": 2}, {"b": None}],
         }
         cases = (
             ("SELECT a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE b = x.a OR b = 3)", []),
@@ -606,7 +611,7 @@ class TestExecutor(unittest.TestCase):
                 "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE NOT b = x.a)",
                 [(1,), (2,), (3,), (5,)],
             ),
-            ("SELECT a FROM x WHERE EXISTS (SELECT 1 FROM e)", []),
+            ("SELECT a FROM x WHERE EXISTS (SELECT 1 FROM empty_table)", []),
             (
                 "SELECT a, (SELECT MAX(b) FROM y WHERE b > x.a) AS m FROM x",
                 [(1, 3), (2, 3), (3, None), (5, None)],
@@ -614,28 +619,37 @@ class TestExecutor(unittest.TestCase):
             ("SELECT a FROM x WHERE (SELECT COUNT(*) FROM y WHERE b > x.a) > 0", [(1,), (2,)]),
             ("SELECT a FROM x WHERE a IN (SELECT b FROM y WHERE b = x.a OR b = 3)", [(2,), (3,)]),
             ("SELECT a FROM x WHERE a NOT IN (SELECT b FROM y)", [(1,), (5,)]),
-            ("SELECT a FROM x WHERE a IN (SELECT b FROM n)", [(2,)]),
-            ("SELECT a FROM x WHERE a NOT IN (SELECT b FROM n)", []),
+            ("SELECT a FROM x WHERE a IN (SELECT b FROM tbl_with_null)", [(2,)]),
+            ("SELECT a FROM x WHERE a NOT IN (SELECT b FROM tbl_with_null)", []),
             ("SELECT a FROM x WHERE a IN (5, (SELECT MIN(b) FROM y WHERE b > x.a))", [(5,)]),
             ("SELECT a FROM x WHERE (SELECT MIN(b) FROM y WHERE b > x.a) IN (1, 2)", [(1,)]),
-            ("SELECT a FROM x WHERE a > ANY (SELECT b FROM n)", [(3,), (5,)]),
-            ("SELECT a FROM x WHERE a > ALL (SELECT b FROM n)", []),
-            ("SELECT a FROM x WHERE a > ANY (SELECT b FROM e)", []),
-            ("SELECT a FROM x WHERE a > ALL (SELECT b FROM e)", [(1,), (2,), (3,), (5,)]),
+            ("SELECT a FROM x WHERE a > ANY (SELECT b FROM tbl_with_null)", [(3,), (5,)]),
+            ("SELECT a FROM x WHERE a > ALL (SELECT b FROM tbl_with_null)", []),
+            ("SELECT a FROM x WHERE a > ANY (SELECT b FROM empty_table)", []),
+            (
+                "SELECT a FROM x WHERE a > ALL (SELECT b FROM empty_table)",
+                [(1,), (2,), (3,), (5,)],
+            ),
             ("SELECT a FROM x WHERE a > SOME (SELECT b FROM y)", [(3,), (5,)]),
             (
-                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = x.a AND EXISTS (SELECT 1 FROM n WHERE n.b = y.b))",
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = x.a AND EXISTS "
+                "(SELECT 1 FROM tbl_with_null WHERE tbl_with_null.b = y.b))",
                 [(2,)],
             ),
             (
-                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = 99 OR EXISTS (SELECT 1 FROM n WHERE n.b = x.a OR n.b = 99))",
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = 99 OR EXISTS "
+                "(SELECT 1 FROM tbl_with_null WHERE tbl_with_null.b = x.a OR tbl_with_null.b = 99))",
                 [(2,)],
             ),
             (
-                "SELECT a FROM x WHERE a IN (SELECT b FROM y WHERE b = x.a) OR a IN (SELECT b FROM n WHERE b = x.a)",
+                "SELECT a FROM x WHERE a IN (SELECT b FROM y WHERE b = x.a) "
+                "OR a IN (SELECT b FROM tbl_with_null WHERE b = x.a)",
                 [(2,), (3,)],
             ),
-            ("SELECT a FROM x WHERE a IN (SELECT b FROM y UNION SELECT b FROM n)", [(2,), (3,)]),
+            (
+                "SELECT a FROM x WHERE a IN (SELECT b FROM y UNION SELECT b FROM tbl_with_null)",
+                [(2,), (3,)],
+            ),
             (
                 "SELECT a FROM x WHERE EXISTS ((SELECT 1 FROM y WHERE b = x.a OR b = 99))",
                 [(2,), (3,)],
@@ -647,11 +661,13 @@ class TestExecutor(unittest.TestCase):
                 [(2,), (3,)],
             ),
             (
-                "WITH c AS (SELECT b FROM y) SELECT a FROM x WHERE a IN (SELECT b FROM c) AND NOT EXISTS (SELECT 1 FROM c WHERE b = x.a OR b = 99)",
+                "WITH c AS (SELECT b FROM y) SELECT a FROM x WHERE a IN (SELECT b FROM c) "
+                "AND NOT EXISTS (SELECT 1 FROM c WHERE b = x.a OR b = 99)",
                 [],
             ),
             (
-                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = x.a OR EXISTS (SELECT 1 FROM n WHERE n.b = x.a))",
+                "SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE b = x.a OR EXISTS "
+                "(SELECT 1 FROM tbl_with_null WHERE tbl_with_null.b = x.a))",
                 [(2,), (3,)],
             ),
         )


### PR DESCRIPTION
The planner builds no step for a subquery in a predicate or projection, so it reached the scalar expression generator, found no transform for `exp.Select` and inherited the base SQL generator's — putting SQL text into Python source. `exp.In` was worse: it carries its subquery in `args["query"]` while the transform reads `expressions`, so the subquery was dropped rather than compiled.

With three single-column tables:

```python
tables = {
    "x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}],
    "y": [{"b": 2}, {"b": 3}],
    "n": [{"b": 2}, {"b": None}],
}
```

| query | main | this PR | duckdb 1.5.5 |
| --- | --- | --- | --- |
| `SELECT a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE NOT b = x.a)` | `invalid syntax` | `[1, 2, 3, 5]` | `[1, 2, 3, 5]` |
| `SELECT a, (SELECT MAX(b) FROM y WHERE b > x.a) AS m FROM x` | `invalid syntax` | `[(1, 3), (2, 3), (3, NULL), (5, NULL)]` | same |
| `SELECT a FROM x WHERE a > ANY (SELECT b FROM n)` | `invalid syntax` | `[3, 5]` | `[3, 5]` |
| `SELECT a FROM x WHERE a NOT IN (SELECT b FROM y)` | `[1, 2, 3, 5]` | `[1, 5]` | `[1, 5]` |

Such a subquery is now planned once and executed per outer row by re-entering the executor, with its correlated columns resolved through the outer row's readers — `Context` merges them under its own tables, so an inner alias shadows an outer one as in SQL, and nesting composes with no bookkeeping. Results are memoized on the correlated values, so an uncorrelated subquery runs once and a correlated one once per distinct value. `ANY`/`ALL` fold with three-valued logic, which also gives `IN`/`NOT IN` their NULL behaviour and the empty-subquery cases where `> ANY` is false and `> ALL` is true. A scalar subquery yielding more than one row raises, as in duckdb and postgres.

Disclosure: implemented with Claude.
