### PR TITLE
fix(postgres,duckdb): decode C-style escape sequences in e'...' strings

### DIFF
--- a/sqlglot/dialects/duckdb.py
+++ b/sqlglot/dialects/duckdb.py
@@ -14,6 +14,8 @@ from sqlglot.typing.duckdb import EXPRESSION_METADATA
 
 
 class DuckDB(Dialect):
+    UNESCAPED_SEQUENCES = {"\\a": "a", "\\v": "v"}
+
     NULL_ORDERING = "nulls_are_last"
     SUPPORTS_USER_DEFINED_TYPES = True
     INDEX_OFFSET = 1
@@ -68,6 +70,7 @@ class DuckDB(Dialect):
 
     class Tokenizer(tokens.Tokenizer):
         BYTE_STRINGS = [("e'", "'"), ("E'", "'")]
+        C_STYLE_ESCAPES = True
         BYTE_STRING_ESCAPES = ["'", "\\"]
         HEREDOC_STRINGS = ["$"]
 

--- a/sqlglot/dialects/postgres.py
+++ b/sqlglot/dialects/postgres.py
@@ -9,6 +9,10 @@ from sqlglot.typing.postgres import EXPRESSION_METADATA
 
 
 class Postgres(Dialect):
+    # \a and \v are not in Postgres' escape table, so they fall under the rule that a
+    # backslash before any other character stands for that character
+    UNESCAPED_SEQUENCES = {"\\a": "a", "\\v": "v"}
+
     EXPRESSION_METADATA = EXPRESSION_METADATA.copy()
     INDEX_OFFSET = 1
     ASCII_ONLY_NORMALIZATION = True
@@ -73,6 +77,7 @@ class Postgres(Dialect):
         BIT_STRINGS = [("b'", "'"), ("B'", "'")]
         HEX_STRINGS = [("x'", "'"), ("X'", "'")]
         BYTE_STRINGS = [("e'", "'"), ("E'", "'")]
+        C_STYLE_ESCAPES = True
         UNICODE_STRINGS = [("U&'", "'"), ("u&'", "'")]
         BYTE_STRING_ESCAPES = ["'", "\\"]
         HEREDOC_STRINGS = ["$"]

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1625,7 +1625,12 @@ class Generator:
         if self.dialect.BYTE_START:
             escaped_byte_string = self.escape_str(
                 this,
-                escape_backslash=False,
+                # Only re-escape backslashes for dialects whose escape sequences the tokenizer
+                # fully decodes, so that every remaining backslash is a literal one. Emitted
+                # bare it would pair with the next character, turning e'a\\b' (a, backslash, b)
+                # back into e'a\b', which reads as a followed by a backspace. Where sequences
+                # are left undecoded the backslash still belongs to one of them, so it stays.
+                escape_backslash=self.dialect.tokenizer_class.C_STYLE_ESCAPES,
                 delimiter=self.dialect.BYTE_END,
                 escaped_delimiter=self._escaped_byte_quote_end,
                 is_byte_string=True,
@@ -1646,6 +1651,12 @@ class Generator:
             return delimited_byte_string
 
         if "\\" in self.dialect.tokenizer_class.STRING_ESCAPES:
+            return self.sql(exp.Literal.string(this))
+
+        # An escape string such as Postgres' e'...' is text, not binary, so a dialect without
+        # byte string syntax can still represent it as a plain literal, the same way the
+        # backslash-escaping dialects above do.
+        if not expression.args.get("is_bytes"):
             return self.sql(exp.Literal.string(this))
 
         self.unsupported(f"Byte strings are not supported for {self.dialect.__class__.__name__}")

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -5,6 +5,9 @@ from enum import IntEnum, auto
 
 from sqlglot.errors import TokenError
 
+_HEX_DIGITS = frozenset("0123456789abcdefABCDEF")
+_OCTAL_DIGITS = frozenset("01234567")
+
 # dict lookup is faster than .upper() and .isdigit()
 _CHAR_UPPER: dict[str, str] = {chr(i): chr(i).upper() for i in range(97, 123)}
 _DIGIT_CHARS: frozenset[str] = frozenset("0123456789")
@@ -574,6 +577,7 @@ class TokenizerCore:
         "numbers_can_have_decimals",
         "identifiers_can_start_with_digit",
         "unescaped_sequences",
+        "c_style_escapes",
     )
 
     def __init__(
@@ -605,6 +609,7 @@ class TokenizerCore:
         numbers_can_have_decimals: bool,
         identifiers_can_start_with_digit: bool,
         unescaped_sequences: dict[str, str],
+        c_style_escapes: bool = False,
     ) -> None:
         self.single_tokens = single_tokens
         self.keywords = keywords
@@ -633,6 +638,7 @@ class TokenizerCore:
         self.numbers_can_have_decimals = numbers_can_have_decimals
         self.identifiers_can_start_with_digit = identifiers_can_start_with_digit
         self.unescaped_sequences = unescaped_sequences
+        self.c_style_escapes = c_style_escapes
         self.sql = ""
         self.size = 0
         self.tokens: list[Token] = []
@@ -719,6 +725,47 @@ class TokenizerCore:
         end = start + size
 
         return self.sql[start:end] if end <= self.size else ""
+
+    def _decode_c_style_escape(self) -> str:
+        """Consumes the escape sequence starting at the current backslash and returns its value.
+
+        Postgres specifies \\xhh and \\ooo as byte values. Since we work on str rather than
+        bytes they are read as code points, which is exact for ASCII; a sequence above 0x7F
+        denotes a byte that is not a valid UTF-8 character on its own anyway.
+        """
+        sql = self.sql
+        size = self.size
+        start = self._current  # index of self._peek, i.e. the character after the backslash
+        kind = sql[start]
+
+        def digits(offset: int, max_len: int, alphabet: frozenset[str]) -> str:
+            i = pos = start + offset
+            end = min(pos + max_len, size)
+            while i < end and sql[i] in alphabet:
+                i += 1
+            return sql[pos:i]
+
+        if kind == "x":
+            hex_digits = digits(1, 2, _HEX_DIGITS)
+            if hex_digits:
+                self._advance(2 + len(hex_digits))
+                return chr(int(hex_digits, 16))
+        elif kind == "u" or kind == "U":
+            width = 4 if kind == "u" else 8
+            hex_digits = digits(1, width, _HEX_DIGITS)
+            if len(hex_digits) == width:
+                code_point = int(hex_digits, 16)
+                if code_point < 0x110000:
+                    self._advance(2 + width)
+                    return chr(code_point)
+        elif kind in _OCTAL_DIGITS:
+            octal_digits = digits(0, 3, _OCTAL_DIGITS)
+            self._advance(1 + len(octal_digits))
+            return chr(int(octal_digits, 8))
+
+        # A backslash before any other character stands for that character
+        self._advance(2)
+        return kind
 
     def _advance(self, i: int = 1, alnum: bool = False) -> None:
         char = self._char
@@ -1161,6 +1208,8 @@ class TokenizerCore:
                 self._peek = "" if self._end else sql[self._current]
                 return sql[pos:end]
 
+        c_style_escapes = self.c_style_escapes and "\\" in escapes
+
         while True:
             if not raw_string and unescaped_sequences and self._peek and self._char in escapes:
                 unescaped_sequence = unescaped_sequences.get(self._char + self._peek)
@@ -1168,6 +1217,19 @@ class TokenizerCore:
                     self._advance(2)
                     text += unescaped_sequence
                     continue
+
+            # Numeric escapes (\xhh, \ooo, \uxxxx, \Uxxxxxxxx) and the "any other character
+            # stands for itself" rule. The escape characters themselves (\\, \') are left to
+            # the generic handling below.
+            if (
+                c_style_escapes
+                and not raw_string
+                and self._char == "\\"
+                and self._peek
+                and self._peek not in escapes
+            ):
+                text += self._decode_c_style_escape()
+                continue
 
             is_valid_custom_escape = (
                 escape_follow_chars and self._char == "\\" and self._peek not in escape_follow_chars

--- a/sqlglot/tokens.py
+++ b/sqlglot/tokens.py
@@ -166,6 +166,12 @@ class Tokenizer(_TokenizerBase):
     VAR_SINGLE_TOKENS: t.ClassVar[set[str]] = set()
     ESCAPE_FOLLOW_CHARS: t.ClassVar[list[str]] = []
 
+    # Whether backslash escapes follow the C-style rules Postgres documents for e'...' strings:
+    # numeric escapes (\xhh, \ooo, \uxxxx, \Uxxxxxxxx) are decoded, and a backslash before any
+    # other character yields that character. Only applies where "\\" is an escape character.
+    # https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE
+    C_STYLE_ESCAPES: t.ClassVar[bool] = False
+
     # The strings in this list can always be used as escapes, regardless of the surrounding
     # identifier delimiters. By default, the closing delimiter is assumed to also act as an
     # identifier escape, e.g. if we use double-quotes, then they also act as escapes: "x"""
@@ -570,6 +576,7 @@ class Tokenizer(_TokenizerBase):
             numbers_can_have_decimals=self.NUMBERS_CAN_HAVE_DECIMALS,
             identifiers_can_start_with_digit=self.dialect.IDENTIFIERS_CAN_START_WITH_DIGIT,
             unescaped_sequences=self.dialect.UNESCAPED_SEQUENCES,
+            c_style_escapes=self.C_STYLE_ESCAPES,
         )
 
     def tokenize(self, sql: str) -> list[Token]:

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -82,8 +82,11 @@ class TestPostgres(Validator):
         self.validate_identity("COMMENT ON MATERIALIZED VIEW foo.my_view IS 'x'")
         self.validate_identity("COMMENT ON SEQUENCE public.seq IS 'x'")
         self.validate_identity("COMMENT ON INDEX public.idx IS 'x'")
-        self.validate_identity("SELECT e'\\xDEADBEEF'")
-        self.validate_identity("SELECT CAST(e'\\176' AS BYTEA)")
+        # \xhh and \ooo are decoded, so these no longer round-trip verbatim
+        self.validate_all("SELECT e'\\xDEADBEEF'", write={"postgres": "SELECT e'\xdeADBEEF'"})
+        self.validate_all(
+            "SELECT CAST(e'\\176' AS BYTEA)", write={"postgres": "SELECT CAST(e'~' AS BYTEA)"}
+        )
         self.validate_identity("SELECT * FROM x WHERE SUBSTRING('Thomas' FROM '...$') IN ('mas')")
         self.validate_identity("SELECT TRIM(' X' FROM ' XXX ')")
         self.validate_identity("SELECT TRIM(LEADING 'bla' FROM ' XXX ' COLLATE utf8_bin)")
@@ -470,7 +473,70 @@ FROM json_data, field_ids""",
             write={
                 "postgres": "SELECT e'a\\tb'",
                 "mysql": "SELECT 'a\\tb'",
-                "sqlite": UnsupportedError,
+                "sqlite": "SELECT 'a\tb'",
+            },
+        )
+        # An escape string is text, not binary, so a dialect without byte string syntax can
+        # still represent it, provided the tokenizer left no backslash behind to interpret.
+        self.validate_all(
+            "SELECT E'hello'",
+            write={
+                "postgres": "SELECT e'hello'",
+                "mysql": "SELECT 'hello'",
+                "sqlite": "SELECT 'hello'",
+                "tsql": "SELECT 'hello'",
+                "oracle": "SELECT 'hello'",
+                "presto": "SELECT 'hello'",
+                "trino": "SELECT 'hello'",
+                "teradata": "SELECT 'hello'",
+            },
+        )
+        self.validate_all(
+            "SELECT E'a\\nb'",
+            write={
+                "postgres": "SELECT e'a\\nb'",
+                "sqlite": "SELECT 'a\nb'",
+            },
+        )
+        self.validate_all(
+            "SELECT LENGTH(E'a\\nb')",
+            write={
+                "postgres": "SELECT LENGTH(e'a\\nb')",
+                "sqlite": "SELECT LENGTH('a\nb')",
+            },
+        )
+        # Hexadecimal, octal and Unicode escapes all denote the character they encode
+        for sql, value in (
+            ("SELECT E'\\x41'", "A"),
+            ("SELECT E'\\x4a'", "J"),
+            ("SELECT E'\\xA'", "\n"),
+            ("SELECT E'\\101'", "A"),
+            ("SELECT E'\\77'", "?"),
+            ("SELECT E'\\u00e9'", "é"),
+            # a backslash before any other character stands for that character
+            ("SELECT E'\\q'", "q"),
+            ("SELECT E'\\a'", "a"),
+            ("SELECT E'\\v'", "v"),
+        ):
+            self.assertEqual(parse_one(sql, read="postgres").selects[0].this, value)
+            self.validate_all(
+                sql, write={"sqlite": f"SELECT '{value}'", "tsql": f"SELECT '{value}'"}
+            )
+
+        # A literal backslash has to survive the round trip rather than pairing up with the
+        # character after it: e'a\\b' must not come back as e'a\b', which reads as a backspace.
+        self.validate_all(
+            "SELECT E'a\\\\b'",
+            write={
+                "postgres": "SELECT e'a\\\\b'",
+                "sqlite": "SELECT 'a\\b'",
+            },
+        )
+        self.validate_all(
+            "SELECT E'C:\\\\tmp\\\\new'",
+            write={
+                "postgres": "SELECT e'C:\\\\tmp\\\\new'",
+                "sqlite": "SELECT 'C:\\tmp\\new'",
             },
         )
         self.validate_all(
@@ -670,7 +736,7 @@ FROM json_data, field_ids""",
             write={
                 "postgres": "e'x'",
                 "mysql": "'x'",
-                "sqlite": UnsupportedError,
+                "sqlite": "'x'",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #8191.

The tokenizer unescapes only the fixed two-character sequences in `UNESCAPED_SEQUENCES`, so the numeric escapes Postgres documents survive into the AST as raw text: `e'\x41'` is carried as the four-character string `\x41` rather than as `A`. Three separate defects follow from that, described with reproductions in the issue — the value is silently changed on the way to eight dialects, the literal is dropped entirely for seventeen others, and a literal backslash is lost on a Postgres-to-Postgres round trip.

### Approach

This is the direction #7678 was closed on, so it is worth saying why it is tractable now. The objection there — that a general fix would mean "pinning down every possible escaped byte sequence and de-escaping it" — was correct about that patch, which converted unconditionally and so would have emitted `e'\x41'` into SQLite as `'\x41'`. But the set is closed and documented in [4.1.2.2](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-ESCAPE): `\b \f \n \r \t`, `\o` `\oo` `\ooo`, `\xh` `\xhh`, `\uxxxx`, `\Uxxxxxxxx`, and a backslash before anything else standing for that character.

Decoding it is what makes the other two fixes safe rather than a trade of one corruption for another:

- **`C_STYLE_ESCAPES`**, a tokenizer flag opted into by Postgres and DuckDB, gated on `"\\"` actually being an escape character so Postgres' plain `'...'` strings are untouched.
- **`\a` and `\v`** are not in Postgres' table, so they now fall under the any-other-character rule, matching the `{"\\a": "a", "\\v": "v"}` override Snowflake already carries.
- **Re-escaping backslashes on output**, keyed on `C_STYLE_ESCAPES` rather than on `BYTE_STRINGS_SUPPORT_ESCAPED_SEQUENCES`. That distinction matters: BigQuery's byte strings support escape sequences but are not decoded, so their backslashes still belong to a sequence and must stay bare. Keying it the other way regresses `b'\x0a$\'x\'00'`.
- **Escape strings are text**, so `bytestring_sql` no longer reports them as unsupported for dialects without byte string syntax. `is_bytes` already distinguishes them and only BigQuery sets it, so real byte strings are unaffected.

### Verification

Values and round trips were checked against DuckDB, whose parser follows Postgres here, over 175 escape sequences — every single-character escape, a hex and octal sweep, and the literal-backslash cases. No mismatches, and the 55 sequences DuckDB itself rejects (high bytes, `\0`) were excluded rather than guessed at.

`SELECT E'hello'`, `SELECT E'\x41'` and `SELECT E'a\\b'` now emit in all 34 dialects; previously the first was dropped in 17.

Suite is green at 1220 passed / 19271 subtests. Four existing expectations changed, all of which encoded the undecoded behaviour: two asserted `UnsupportedError` for SQLite on strings that are plainly representable, and two round-tripped `e'\xDEADBEEF'` and `e'\176'` verbatim. Each of the four parts of the fix was reverted individually to confirm the new tests fail without it.

### Two things to flag

Postgres specifies `\xhh` and `\ooo` as byte values. Since sqlglot works on `str` they are read as code points, which is exact for ASCII and for single-byte encodings; above 0x7F such a sequence does not form a valid UTF-8 character on its own in any case. This is why `e'\xDEADBEEF'` now generates `e'ÞADBEEF'` — that literal is an encoding error in a UTF-8 database either way.

Tokenizing an escape-heavy Postgres corpus costs about 2.8% more (min of 25 runs, 41k characters). Dialects without the flag pay one precomputed boolean outside the loop.
