### PR TITLE
feat(optimizer)!: Annotate ToNumber function for Postgres

### DIFF
--- a/sqlglot/typing/postgres.py
+++ b/sqlglot/typing/postgres.py
@@ -32,4 +32,5 @@ EXPRESSION_METADATA = {
             exp.Decode,
         }
     },
+    exp.ToNumber: {"returns": exp.DType.DECIMAL},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -7422,6 +7422,10 @@ WIDTH_BUCKET(5, 1, 10, 5);
 INT;
 
 # dialect: postgres
+TO_NUMBER('123.45', '999.99');
+NUMERIC;
+
+# dialect: postgres
 FORMAT('Hello %s, %1$s', 'World');
 TEXT;
 


### PR DESCRIPTION
**This PR annotate TO_NUMBER function for Postgres**

https://www.postgresql.org/docs/current/functions-formatting.html

The PostgreSQL compiler returned Numeric datatype
<img width="1768" height="527" alt="image" src="https://github.com/user-attachments/assets/10387a5d-4d0d-41e9-89f5-4f4bc96775e4" />

SQLGlot internally represents the PostgreSQL NUMERIC type as DECIMAL.
<img width="1077" height="231" alt="image" src="https://github.com/user-attachments/assets/95ebb0ea-ddb6-492b-b325-e7ec6844dea1" />
