### PR TITLE
fix: parenthesise JSON operator right operand to prevent regrouping

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1267,7 +1267,21 @@ def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> st
     if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
         this.replace(exp.cast(this, exp.DType.JSON))
 
-    return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
+    expr = expression.expression
+    # Parenthesise the right operand when it is a Binary expression that
+    # is not itself a JSON extract (i.e. not a chained -> chain).  Without
+    # this, operators like || bind differently on output than they did on
+    # input, breaking parse -> generate -> parse stability (#8211).
+    needs_paren = (
+        isinstance(expr, exp.Binary)
+        and not isinstance(expr, (exp.JSONExtract, exp.JSONExtractScalar, exp.JSONBExtract, exp.JSONBExtractScalar))
+    )
+    if needs_paren:
+        expression.set("expression", exp.Paren(this=expr))
+    sql = self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
+    if needs_paren:
+        expression.set("expression", expr)
+    return sql
 
 
 def inline_array_sql(self: Generator, expression: exp.Expr) -> str:

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -189,7 +189,19 @@ def _json_extract_sql(
         if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not ensure_list(
             expression.args.get("expressions")
         ):
-            return self.binary(expression, op)
+            # Parenthesise the right operand when it is a Binary expression
+            # that is not itself a JSON extract, so that operators like ||
+            # do not regroup on output (#8211).
+            needs_paren = (
+                isinstance(path, exp.Binary)
+                and not isinstance(path, (exp.JSONExtract, exp.JSONExtractScalar, exp.JSONBExtract, exp.JSONBExtractScalar))
+            )
+            if needs_paren:
+                expression.set("expression", exp.Paren(this=path))
+            sql = self.binary(expression, op)
+            if needs_paren:
+                expression.set("expression", path)
+            return sql
 
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)


### PR DESCRIPTION
## Summary

Fixes #8211

When the right operand of a JSON operator (`->`, `->>`, `#>`, `#>>`) is a Binary expression that binds at the same or lower precedence level (e.g. `||`, comparisons, `BETWEEN`, `IN`, `AND`), the generator now wraps it in parentheses to prevent incorrect regrouping on output.

## Problem

Without this fix, `a -> 'x' || 'y'` was emitted instead of `a -> ('x' || 'y')`, which changes the meaning because `->` and `||` are left-associative at the same precedence tier in PostgreSQL.

## Fix

- In `postgres.py` `_json_extract_sql`: temporarily wraps the right operand in `Paren` before calling `self.binary()`, then restores the original node
- In `dialect.py` `arrow_json_extract_sql`: same approach for the duckdb/sqlite code path
- Chained JSON extracts (`a -> b -> 'k'`) and simple literals are unaffected

## Testing

All existing postgres (30), duckdb (45), and sqlite (13) tests pass. Verified the reproduction case from the issue:

```python
sql = "SELECT json_extract(a, 'x' || 'y') FROM t"
tree = sqlglot.parse_one(sql, read='postgres')
out = tree.sql(dialect='postgres')
# Before: SELECT a -> 'x' || 'y' FROM t
# After:  SELECT a -> ('x' || 'y') FROM t
```

🤖 Generated with Codebuff
Co-Authored-By: Codebuff <noreply@codebuff.com>