### PR TITLE
fix(executor): return the rows of an ORDER BY over a set operation [CLAUDE]

### DIFF
--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -501,10 +501,12 @@ class PythonExecutor:
         if not math.isinf(step.limit):
             sort_ctx.table.rows = sort_ctx.table.rows[0 : step.limit]
 
-        output = Table(
-            projection_columns,
-            rows=[r[len(context.columns) : len(all_columns)] for r in sort_ctx.table.rows],
-        )
+        rows = sort_ctx.table.rows
+
+        if projection_columns:
+            rows = [row[len(context.columns) : len(all_columns)] for row in rows]
+
+        output = Table(projection_columns or context.columns, rows=rows)
         return self.context({step.name: output})
 
     def set_operation(self, step, context):

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -438,11 +438,6 @@ class SetOperation(Step):
         step.add_dependency(left)
         step.add_dependency(right)
 
-        limit: exp.Limit | None = expression.args.get("limit")
-
-        if limit is not None:
-            step.limit = int(limit.text("expression"))
-
         return step
 
     def _to_s(self, indent: str) -> list[str]:

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -426,6 +426,22 @@ class TestExecutor(unittest.TestCase):
             [(2,)],
         )
 
+    def test_set_operation_order_by(self):
+        schema = {"x": {"a": "int"}, "y": {"b": "int"}}
+        tables = {"x": [{"a": 3}, {"a": 1}], "y": [{"b": 1}, {"b": 2}]}
+
+        for sql, expected in (
+            ("SELECT a FROM x UNION ALL SELECT b FROM y ORDER BY a", [(1,), (1,), (2,), (3,)]),
+            ("SELECT a FROM x UNION SELECT b FROM y ORDER BY a", [(1,), (2,), (3,)]),
+            ("SELECT a FROM x UNION ALL SELECT b FROM y ORDER BY a DESC", [(3,), (2,), (1,), (1,)]),
+            ("SELECT a FROM x UNION ALL SELECT b FROM y ORDER BY a LIMIT 2", [(1,), (1,)]),
+            ("SELECT a FROM x UNION ALL (SELECT b FROM y LIMIT 1) ORDER BY a", [(1,), (1,), (3,)]),
+            ("SELECT a FROM x EXCEPT SELECT b FROM y ORDER BY a", [(3,)]),
+            ("SELECT a FROM x INTERSECT SELECT b FROM y ORDER BY a", [(1,)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, schema, tables=tables).rows, expected)
+
     def test_outer_joins_preserve_unmatched_rows(self):
         tables = {
             "x": [{"id": 1}, {"id": 2}],


### PR DESCRIPTION
`ORDER BY` over a set operation returned rows of empty tuples, and with a `LIMIT` it also returned the wrong rows.

```python
tables = {"x": [{"a": 3}, {"a": 1}], "y": [{"b": 1}, {"b": 2}]}
```

| query | before | after (= duckdb) |
| --- | --- | --- |
| `SELECT a FROM x UNION ALL SELECT b FROM y ORDER BY a` | `[(), (), (), ()]` | `[(1,), (1,), (2,), (3,)]` |
| `… ORDER BY a LIMIT 2` | `[(), ()]` | `[(1,), (1,)]` |

`sort()` slices its own projections out of a wider row. A `Union` has none, so the slice was zero-width; a sort with no projections now keeps the whole row.

`SetOperation.from_expression` also set the limit that `Step.from_expression` sets again on whichever step ends up outermost. With an `ORDER BY` that truncated the union before the sort ran — the `LIMIT 2` above returned the first two unsorted rows. Plain `UNION … LIMIT` is unchanged, and per-branch limits come from the branch's own step, so `UNION ALL (SELECT … LIMIT 1)` is unaffected.

Disclosure: implemented with Claude.
