### PR TITLE
fix(generator): escape JSON path bracket keys for the outer string literal [CLAUDE]

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -3814,8 +3814,8 @@ class Generator:
             return str(expression)
 
         if self._quote_json_path_key_using_brackets and self.JSON_PATH_SINGLE_QUOTE_ESCAPE:
-            escaped = expression.replace("'", "\\'")
-            escaped = f"\\'{expression}\\'"
+            escaped = self.escape_str(expression.replace("'", "\\'"))
+            escaped = f"\\'{escaped}\\'"
         else:
             escaped = expression.replace('"', '\\"')
             escaped = f'"{escaped}"'

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -1029,6 +1029,8 @@ class TestHive(Validator):
         self.validate_identity("""SELECT PARSE_JSON('{"key": 123}')""")
         self.validate_identity("""SELECT TO_JSON(PARSE_JSON('{"key": 123}'))""")
 
+        self.validate_identity("""SELECT GET_JSON_OBJECT(x, '$[\\'quo\\\\\\'te\\']')""")
+
     def test_escapes(self) -> None:
         self.validate_identity("'\n'", "'\\n'")
         self.validate_identity("'\\n'")


### PR DESCRIPTION
Fixes #8218

`json_path_part()` computed an escaped version of a bracketed JSON path
key (to handle an embedded single quote) but then discarded it and
interpolated the *unescaped* original into the bracket anyway:

```python
escaped = expression.replace("'", "\\'")
escaped = f"\\'{expression}\\'"   # bug: uses `expression`, not `escaped`
```

This produced output like `'$[\'quo'te\']'`, a string literal with a
stray unescaped quote in the middle — invalid regardless of round-trip
concerns.

Fixing just that line isn't enough for full round-tripping, though: the
whole JSON path is itself rendered as a single quoted SQL string literal
(see `jsonpath_sql`), which uses the same backslash-escaping scheme as
the bracket-notation grammar. So a key's already-escaped quote needs to
be escaped *again* to survive being embedded in that outer literal,
while the bracket's own delimiter quotes still only need a single level
of escaping. This PR uses `self.escape_str()` (already used elsewhere in
this file for exactly this kind of double-escaping) to escape the key
content before wrapping it in the delimiters.

Verified end-to-end:

```python
from sqlglot import exp
path = exp.JSONPath(expressions=[exp.JSONPathRoot(), exp.JSONPathKey(this="quo'te")])
sql = f"SELECT GET_JSON_OBJECT(x, {path.sql(dialect='hive')})"
# SELECT GET_JSON_OBJECT(x, '$[\'quo\\\'te\']')
tree = sqlglot.parse_one(sql, read="hive")
tree.find(exp.JSONPathKey).this == "quo'te"  # True
tree.sql(dialect="hive") == sql  # True (stable round trip)
```

Added a regression test in `test_hive.py` covering this round trip for
`GET_JSON_OBJECT`. Full test suite passes (1094 passed, 2 skipped, only
pre-existing `duckdb`-dependent modules excluded from this local run).

[CLAUDE]-assisted