### PR TITLE
fix(executor): execute an IN/ANY subquery that has no FROM [CLAUDE]

### DIFF
--- a/sqlglot/executor/context.py
+++ b/sqlglot/executor/context.py
@@ -67,7 +67,7 @@ class Context:
 
     @property
     def columns(self) -> tuple:
-        return self.table.columns
+        return self.table.columns if self.tables else ()
 
     def __iter__(self):
         self.env["scope"] = self.row_readers

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -265,7 +265,9 @@ class PythonExecutor:
         return sink
 
     def static(self):
-        return self.context({}), [RowReader(())]
+        reader = RowReader(())
+        reader.row = ()
+        return self.context({}), [reader]
 
     def scan_table(self, step):
         table = self.tables.find(step.source)
@@ -483,7 +485,9 @@ class PythonExecutor:
         context = self.context({step.name: table, **{name: table for name in context.tables}})
 
         if step.projections or step.condition:
-            return self.scan(step, context)
+            return self.context(
+                {step.name: self._project_and_filter(context, step, context.table_iter(step.name))}
+            )
         return context
 
     def sort(self, step, context):

--- a/sqlglot/executor/python.py
+++ b/sqlglot/executor/python.py
@@ -265,9 +265,7 @@ class PythonExecutor:
         return sink
 
     def static(self):
-        reader = RowReader(())
-        reader.row = ()
-        return self.context({}), [reader]
+        return self.context({}), [RowReader(())]
 
     def scan_table(self, step):
         table = self.tables.find(step.source)

--- a/sqlglot/executor/table.py
+++ b/sqlglot/executor/table.py
@@ -109,7 +109,7 @@ class RowReader:
             if columns is not None
             else {}
         )
-        self.row = None
+        self.row = ()
 
     def __getitem__(self, column):
         return self.row[self.columns[column]]

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1082,6 +1082,17 @@ class TestExecutor(unittest.TestCase):
         self.assertEqual(result.columns, ("_col_0",))
         self.assertEqual(result.rows, [(3,)])
 
+    def test_in_subquery_without_a_from(self):
+        tables = {"x": [{"a": 1}, {"a": 2}, {"a": None}]}
+
+        for sql, rows in (
+            ("SELECT x.a FROM x WHERE x.a IN (SELECT 1)", [(1,)]),
+            ("SELECT x.a FROM x WHERE x.a IN (SELECT 1 + 1)", [(2,)]),
+            ("SELECT x.a FROM x WHERE x.a IN (SELECT 1 UNION SELECT 2)", [(1,), (2,)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables).rows, rows)
+
     def test_scalar_functions(self):
         now = datetime.datetime.now()
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1082,13 +1082,14 @@ class TestExecutor(unittest.TestCase):
         self.assertEqual(result.columns, ("_col_0",))
         self.assertEqual(result.rows, [(3,)])
 
-    def test_in_subquery_without_a_from(self):
+    def test_in_any_subquery_without_a_from(self):
         tables = {"x": [{"a": 1}, {"a": 2}, {"a": None}]}
 
         for sql, rows in (
             ("SELECT x.a FROM x WHERE x.a IN (SELECT 1)", [(1,)]),
             ("SELECT x.a FROM x WHERE x.a IN (SELECT 1 + 1)", [(2,)]),
             ("SELECT x.a FROM x WHERE x.a IN (SELECT 1 UNION SELECT 2)", [(1,), (2,)]),
+            ("SELECT x.a FROM x WHERE x.a = ANY (SELECT 1)", [(1,)]),
         ):
             with self.subTest(sql):
                 self.assertEqual(execute(sql, tables=tables).rows, rows)


### PR DESCRIPTION
`SELECT x.a FROM x WHERE x.a IN (SELECT 1)` fails on main with `ExecuteError: list index out of range`. The optimizer unnests it into a LEFT JOIN against a table-less `SELECT`, and the executor can't scan a table-less SELECT.

| query | before | after (= duckdb) |
| --- | --- | --- |
| `x.a IN (SELECT 1)` | raises | `[(1,)]` |

Three bugs in sequence, each uncovered by fixing the one before: an empty `Context` had no columns to report, the static `RowReader`'s row was never set, and `aggregate()` re-dispatching through `scan()` threw away a table-less aggregate's own output before projecting over it.

Disclosure: implemented with Claude.
