### PR TITLE
fix(parser)!: ANALYZE and DROP with multiple tables

### DIFF
--- a/sqlglot/expressions/ddl.py
+++ b/sqlglot/expressions/ddl.py
@@ -345,7 +345,6 @@ class MergeTreeTTL(Expression):
 
 class Drop(Expression):
     arg_types = {
-        "this": False,
         "kind": False,
         "tables": False,
         "expressions": False,

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -1891,7 +1891,7 @@ class Where(Expression):
 class Analyze(Expression):
     arg_types = {
         "kind": False,
-        "this": False,
+        "tables": False,
         "options": False,
         "mode": False,
         "partition": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -1827,9 +1827,7 @@ class Generator:
         return self.prepend_ctes(expression, f"DELETE{hint}{tables}{expression_sql}")
 
     def drop_sql(self, expression: exp.Drop) -> str:
-        this = self.sql(expression, "this")
         tables = self.expressions(expression, key="tables", flat=True)
-        this = f"{this}, {tables}" if tables else this
         expressions = self.expressions(expression, flat=True)
         expressions = f" ({expressions})" if expressions else ""
         kind = expression.args["kind"]
@@ -1851,7 +1849,7 @@ class Generator:
         purge = " PURGE" if expression.args.get("purge") else ""
         sync = " SYNC" if expression.args.get("sync") else ""
         force = " FORCE" if expression.args.get("force") else ""
-        return f"DROP{temporary}{materialized}{iceberg} {kind}{concurrently_sql}{exists_sql}{this}{on_cluster}{expressions}{cascade}{restrict}{constraints}{purge}{sync}{force}"
+        return f"DROP{temporary}{materialized}{iceberg} {kind}{concurrently_sql}{exists_sql}{tables}{on_cluster}{expressions}{cascade}{restrict}{constraints}{purge}{sync}{force}"
 
     def set_operation(self, expression: exp.SetOperation) -> str:
         op_type = type(expression)
@@ -6048,8 +6046,8 @@ class Generator:
         options = f" {options}" if options else ""
         kind = self.sql(expression, "kind")
         kind = f" {kind}" if kind else ""
-        this = self.sql(expression, "this")
-        this = f" {this}" if this else ""
+        tables = self.expressions(expression, key="tables", flat=True)
+        tables = f" {tables}" if tables else ""
         mode = self.sql(expression, "mode")
         mode = f" {mode}" if mode else ""
         properties = self.sql(expression, "properties")
@@ -6058,7 +6056,7 @@ class Generator:
         partition = f" {partition}" if partition else ""
         inner_expression = self.sql(expression, "expression")
         inner_expression = f" {inner_expression}" if inner_expression else ""
-        return f"ANALYZE{options}{kind}{this}{partition}{mode}{inner_expression}{properties}"
+        return f"ANALYZE{options}{kind}{tables}{partition}{mode}{inner_expression}{properties}"
 
     def xmltable_sql(self, expression: exp.XMLTable) -> str:
         this = self.sql(expression, "this")

--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -596,7 +596,8 @@ class TSQLGenerator(generator.Generator):
 
     def drop_sql(self, expression: exp.Drop) -> str:
         if expression.args["kind"] == "VIEW":
-            expression.this.set("catalog", None)
+            for table in expression.args.get("tables") or []:
+                table.set("catalog", None)
         return super().drop_sql(expression)
 
     def options_modifier(self, expression: exp.Expr) -> str:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -2412,16 +2412,13 @@ class Parser:
         concurrently = self._match_text_seq("CONCURRENTLY")
         if_exists = exists or self._parse_exists()
 
+        tables: exp.Expr | list[exp.Expr] | None
         if kind == "COLUMN":
-            this = self._parse_column()
+            tables = self._parse_column()
+        elif kind in ("TABLE", "VIEW"):
+            tables = self._parse_csv(lambda: self._parse_table_parts(schema=True))
         else:
-            this = self._parse_table_parts(schema=True, is_db_reference=kind == "SCHEMA")
-
-        tables = (
-            self._parse_csv(lambda: self._parse_table_parts(schema=True))
-            if kind == "TABLE" and self._match(TokenType.COMMA)
-            else None
-        )
+            tables = self._parse_table_parts(schema=True, is_db_reference=kind == "SCHEMA")
 
         cluster = self._parse_on_property() if self._match(TokenType.ON) else None
 
@@ -2435,8 +2432,7 @@ class Parser:
         return self.expression(
             exp.Drop(
                 exists=if_exists,
-                this=this,
-                tables=tables,
+                tables=ensure_list(tables),
                 expressions=expressions,
                 kind=self.dialect.CREATABLE_KIND_MAPPING.get(kind) or kind,
                 temporary=temporary,
@@ -9318,21 +9314,23 @@ class Parser:
             else:
                 options.append(self._prev.text.upper())
 
-        this: exp.Expr | None = None
+        tables: exp.Expr | list[exp.Expr] | None = None
         inner_expression: exp.Expr | None = None
 
         kind = self._curr.text.upper() if self._curr else None
 
-        if self._match(TokenType.TABLE) or self._match(TokenType.INDEX):
-            this = self._parse_table_parts()
+        if self._match(TokenType.TABLE):
+            tables = self._parse_csv(self._parse_table_parts)
+        elif self._match(TokenType.INDEX):
+            tables = self._parse_table_parts()
         elif self._match_text_seq("TABLES"):
             if self._match_set((TokenType.FROM, TokenType.IN)):
                 kind = f"{kind} {self._prev.text.upper()}"
-                this = self._parse_table(schema=True, is_db_reference=True)
+                tables = self._parse_table(schema=True, is_db_reference=True)
         elif self._match_text_seq("DATABASE"):
-            this = self._parse_table(schema=True, is_db_reference=True)
+            tables = self._parse_table(schema=True, is_db_reference=True)
         elif self._match_text_seq("CLUSTER"):
-            this = self._parse_table()
+            tables = self._parse_table()
         # Try matching inner expr keywords before fallback to parse table.
         elif self._match_texts(self.ANALYZE_EXPRESSION_PARSERS):
             kind = None
@@ -9340,7 +9338,7 @@ class Parser:
         else:
             # Empty kind  https://prestodb.io/docs/current/sql/analyze.html
             kind = None
-            this = self._parse_table_parts()
+            tables = self._parse_csv(self._parse_table_parts)
 
         partition = self._try_parse(self._parse_partition)
         if not partition and self._match_texts(self.PARTITION_KEYWORDS):
@@ -9361,7 +9359,7 @@ class Parser:
         return self.expression(
             exp.Analyze(
                 kind=kind,
-                this=this,
+                tables=ensure_list(tables),
                 mode=mode,
                 partition=partition,
                 properties=properties,

--- a/sqlglot/parsers/spark2.py
+++ b/sqlglot/parsers/spark2.py
@@ -112,7 +112,7 @@ class Spark2Parser(HiveParser):
 
     def _parse_drop_column(self) -> exp.Drop | exp.Command | None:
         return (
-            self.expression(exp.Drop(this=self._parse_schema(), kind="COLUMNS"))
+            self.expression(exp.Drop(tables=[self._parse_schema()], kind="COLUMNS"))
             if self._match_text_seq("DROP", "COLUMNS")
             else None
         )

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -1681,6 +1681,8 @@ COMMENT='客户账户表'"""
     def test_analyze(self):
         self.validate_identity("ANALYZE LOCAL TABLE tbl")
         self.validate_identity("ANALYZE NO_WRITE_TO_BINLOG TABLE tbl")
+        self.validate_identity("ANALYZE TABLE t1, t2")
+        self.validate_identity("ANALYZE LOCAL TABLE db.t1, db.t2, t3")
         self.validate_identity("ANALYZE tbl UPDATE HISTOGRAM ON col1")
         self.validate_identity("ANALYZE tbl UPDATE HISTOGRAM ON col1 USING DATA 'json_data'")
         self.validate_identity("ANALYZE tbl UPDATE HISTOGRAM ON col1 WITH 5 BUCKETS")

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1822,6 +1822,8 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
 
     def test_analyze(self):
         self.validate_identity("ANALYZE TBL")
+        self.validate_identity("ANALYZE t1, t2")
+        self.validate_identity("ANALYZE VERBOSE t1, t2")
         self.validate_identity("ANALYZE TBL(col1, col2)")
         self.validate_identity("ANALYZE VERBOSE SKIP_LOCKED TBL(col1, col2)")
         self.validate_identity("ANALYZE BUFFER_USAGE_LIMIT 1337 TBL")

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -29,6 +29,7 @@ class TestTSQL(Validator):
         self.validate_identity("SELECT go").selects[0].assert_is(exp.Column)
         self.validate_identity("CREATE view a.b.c", "CREATE VIEW b.c")
         self.validate_identity("DROP view a.b.c", "DROP VIEW b.c")
+        self.validate_identity("DROP VIEW a.b.c, a.b.d", "DROP VIEW b.c, b.d")
         self.validate_identity("ROUND(x, 1, 0)")
         self.validate_identity(
             "EXEC MyProc @id = 7, @name = 'Lochristi'",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -963,11 +963,13 @@ class TestParser(unittest.TestCase):
                 self.assertEqual(
                     ast,
                     exp.Drop(
-                        this=exp.Table(
-                            this=None,
-                            db=exp.Identifier(this="schema", quoted=False),
-                            catalog=exp.Identifier(this="catalog", quoted=False),
-                        ),
+                        tables=[
+                            exp.Table(
+                                this=None,
+                                db=exp.Identifier(this="schema", quoted=False),
+                                catalog=exp.Identifier(this="catalog", quoted=False),
+                            )
+                        ],
                         kind="SCHEMA",
                     ),
                 )
@@ -980,11 +982,13 @@ class TestParser(unittest.TestCase):
                 self.assertEqual(
                     ast,
                     exp.Drop(
-                        this=exp.Table(
-                            this=None,
-                            db=exp.Identifier(this="schema", quoted=False),
-                            catalog=exp.Identifier(this="catalog", quoted=False),
-                        ),
+                        tables=[
+                            exp.Table(
+                                this=None,
+                                db=exp.Identifier(this="schema", quoted=False),
+                                catalog=exp.Identifier(this="catalog", quoted=False),
+                            )
+                        ],
                         kind="SCHEMA",
                         exists=True,
                     ),
@@ -998,10 +1002,12 @@ class TestParser(unittest.TestCase):
                 self.assertEqual(
                     ast,
                     exp.Drop(
-                        this=exp.Table(
-                            this=None,
-                            db=exp.Identifier(this="myschema", quoted=False),
-                        ),
+                        tables=[
+                            exp.Table(
+                                this=None,
+                                db=exp.Identifier(this="myschema", quoted=False),
+                            )
+                        ],
                         kind="SCHEMA",
                         exists=True,
                     ),


### PR DESCRIPTION
Fixes #8227

Refactors `DROP` and `ANALYZE` to use `tables` argument, same as the `DELETE`.