### PR TITLE
fix(mysql): support KEY in CREATE TABLE column definition

### DIFF
--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -300,6 +300,12 @@ class MySQLParser(parser.Parser):
     VALUES_FOLLOWED_BY_PAREN = False
     SUPPORTS_PARTITION_SELECTION = True
 
+    def _parse_column_constraint(self) -> exp.Expr | None:
+        if self._match(TokenType.KEY):
+            return self.expression(exp.ColumnConstraint(kind=self._parse_primary_key()))
+
+        return super()._parse_column_constraint()
+
     def _parse_range(self, this: exp.Expr | None = None) -> exp.Expr | None:
         this = this or self._parse_bitwise()
 

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -297,6 +297,20 @@ class TestMySQL(Validator):
             "CREATE FUNCTION f() RETURNS TEXT LANGUAGE SQL SQL SECURITY INVOKER AS SELECT 'abc'",
         )
 
+    def test_column_key_constraint(self):
+        self.validate_identity(
+            "CREATE TABLE t1 (id INT KEY AUTO_INCREMENT)",
+            "CREATE TABLE t1 (id INT PRIMARY KEY AUTO_INCREMENT)",
+        )
+        self.validate_identity(
+            "CREATE TABLE t1 (id INT AUTO_INCREMENT KEY)",
+            "CREATE TABLE t1 (id INT AUTO_INCREMENT PRIMARY KEY)",
+        )
+        self.validate_identity(
+            "CREATE TABLE t1 (id INT KEY)",
+            "CREATE TABLE t1 (id INT PRIMARY KEY)",
+        )
+
     def test_identity(self):
         self.validate_identity("SELECT HIGH_PRIORITY STRAIGHT_JOIN SQL_CALC_FOUND_ROWS * FROM t")
         self.validate_identity("SELECT CAST(COALESCE(`id`, 'NULL') AS CHAR CHARACTER SET binary)")


### PR DESCRIPTION
In MySQL `CREATE TABLE`, `PRIMARY KEY` can be abbreviated to `KEY`

https://dev.mysql.com/doc/refman/9.7/en/create-table.html
```
column_definition: {
    data_type [NOT NULL | NULL] [DEFAULT {literal | (expr)} ]
      [VISIBLE | INVISIBLE]
      [AUTO_INCREMENT] [UNIQUE [KEY]] [[PRIMARY] KEY]
      [COMMENT 'string']
      [COLLATE collation_name]
      [COLUMN_FORMAT {FIXED | DYNAMIC | DEFAULT}]
      [ENGINE_ATTRIBUTE [=] 'string']
      [SECONDARY_ENGINE_ATTRIBUTE [=] 'string']
      [STORAGE {DISK | MEMORY}]
      [reference_definition]
      [check_constraint_definition]
  | data_type
      [COLLATE collation_name]
      [GENERATED ALWAYS] AS (expr)
      [VIRTUAL | STORED] [NOT NULL | NULL]
      [VISIBLE | INVISIBLE]
      [UNIQUE [KEY]] [[PRIMARY] KEY]    <-------------
      [COMMENT 'string']
      [reference_definition]
      [check_constraint_definition]
}
```

closes #8225 