### PR TITLE
Fix(postgres): don't emit JSON_EXTRACT_PATH with no keys for a root-only JSON path [CLAUDE]

### DIFF
--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -191,6 +191,15 @@ def _json_extract_sql(
         ):
             return self.binary(expression, op)
 
+        # A root-only path ($) has no key segments, so JSON_EXTRACT_PATH(a) would be
+        # emitted with no path arguments, which PostgreSQL rejects. Emit the path
+        # operator with an empty path array instead: a #> '{}' / a #>> '{}'.
+        if isinstance(path, exp.JSONPath) and path.expressions and all(
+            isinstance(part, exp.JSONPathRoot) for part in path.expressions
+        ):
+            path_op = "#>>" if op == "->>" else "#>"
+            return f"{self.sql(expression, 'this')} {path_op} '{{}}'"
+
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)
         return json_extract_segments(name)(self, expression)

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -191,16 +191,9 @@ def _json_extract_sql(
         ):
             return self.binary(expression, op)
 
-        # A root-only path ($) has no key segments, so JSON_EXTRACT_PATH(a) would be
-        # emitted with no path arguments, which PostgreSQL rejects. Emit the path
-        # operator with an empty path array instead: a #> '{}' / a #>> '{}'.
-        if (
-            isinstance(path, exp.JSONPath)
-            and path.expressions
-            and all(isinstance(part, exp.JSONPathRoot) for part in path.expressions)
-        ):
-            path_op = "#>>" if op == "->>" else "#>"
-            return f"{self.sql(expression, 'this')} {path_op} '{{}}'"
+        # JSON_EXTRACT_PATH requires a key, so use an empty variadic array for the root path
+        if len(path.expressions) == 1 and isinstance(path.expressions[0], exp.JSONPathRoot):
+            expression.set("expression", exp.Variadic(this=exp.Literal.string("{}")))
 
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -194,8 +194,10 @@ def _json_extract_sql(
         # A root-only path ($) has no key segments, so JSON_EXTRACT_PATH(a) would be
         # emitted with no path arguments, which PostgreSQL rejects. Emit the path
         # operator with an empty path array instead: a #> '{}' / a #>> '{}'.
-        if isinstance(path, exp.JSONPath) and path.expressions and all(
-            isinstance(part, exp.JSONPathRoot) for part in path.expressions
+        if (
+            isinstance(path, exp.JSONPath)
+            and path.expressions
+            and all(isinstance(part, exp.JSONPathRoot) for part in path.expressions)
         ):
             path_op = "#>>" if op == "->>" else "#>"
             return f"{self.sql(expression, 'this')} {path_op} '{{}}'"

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -590,6 +590,17 @@ FROM json_data, field_ids""",
         self.validate_identity("SELECT JSON_EXTRACT_PATH(x, 'k1', k2) FROM t")
         self.validate_identity("SELECT JSON_EXTRACT_PATH_TEXT(x, k1, 'k2') FROM t")
 
+        # A root-only JSON path ($) has no keys; JSON_EXTRACT_PATH(a) with no path
+        # arguments is rejected by PostgreSQL, so emit the path operator instead.
+        self.validate_all(
+            "SELECT a #> '{}' FROM t",
+            read={"mysql": "SELECT JSON_EXTRACT(a, '$') FROM t"},
+        )
+        self.validate_all(
+            "SELECT a #>> '{}' FROM t",
+            read={"mysql": "SELECT JSON_EXTRACT_SCALAR(a, '$') FROM t"},
+        )
+
         self.validate_all(
             "x #> 'y'",
             read={

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -590,15 +590,18 @@ FROM json_data, field_ids""",
         self.validate_identity("SELECT JSON_EXTRACT_PATH(x, 'k1', k2) FROM t")
         self.validate_identity("SELECT JSON_EXTRACT_PATH_TEXT(x, k1, 'k2') FROM t")
 
-        # A root-only JSON path ($) has no keys; JSON_EXTRACT_PATH(a) with no path
-        # arguments is rejected by PostgreSQL, so emit the path operator instead.
+        # A root-only JSON path ($) has no keys, so pass an empty variadic array.
         self.validate_all(
-            "SELECT a #> '{}' FROM t",
+            "SELECT JSON_EXTRACT_PATH(a, VARIADIC '{}') FROM t",
             read={"mysql": "SELECT JSON_EXTRACT(a, '$') FROM t"},
         )
         self.validate_all(
-            "SELECT a #>> '{}' FROM t",
+            "SELECT JSON_EXTRACT_PATH_TEXT(a, VARIADIC '{}') FROM t",
             read={"mysql": "SELECT JSON_EXTRACT_SCALAR(a, '$') FROM t"},
+        )
+        self.validate_all(
+            "SELECT 'prefix' || JSON_EXTRACT_PATH_TEXT(a, VARIADIC '{}') FROM t",
+            read={"postgres": "SELECT 'prefix' || JSON_EXTRACT_SCALAR(a, '$') FROM t"},
         )
 
         self.validate_all(


### PR DESCRIPTION
Fixes #8232.

A root-only JSON path (`$`) has no key segments, so the Postgres generator produced `JSON_EXTRACT_PATH` / `JSON_EXTRACT_PATH_TEXT` with **no path arguments**, which PostgreSQL rejects (there is no zero-key overload):

```python
sqlglot.transpile("SELECT json_extract(a, '$') FROM t", read="mysql", write="postgres")
# before: SELECT JSON_EXTRACT_PATH(a) FROM t   -- invalid in Postgres
# after:  SELECT a #> '{}' FROM t
```

In `generators/postgres.py`, `_json_extract_sql` builds the `JSON_EXTRACT_PATH(...)` call from the path's key segments. For a root-only path the segment list is empty, so the call is emitted with just the column and no keys.

The fix detects a root-only `JSONPath` (all parts are `JSONPathRoot`) and emits the path operator with an empty path array instead — `a #> '{}'` for `JSONExtract` (`->`) and `a #>> '{}'` for `JSONExtractScalar` (`->>`), matching what the reporter expected. Keyed paths (`$.k`, `$.k.n`) take the existing code path and are unchanged.

Added two `validate_all` cases in `tests/dialects/test_postgres.py` (root `->` and `->>`); both fail on `main` and pass with this change. Full `test_postgres.py` suite is green.

---

Per CONTRIBUTING, this PR was prepared with AI assistance (hence the `[CLAUDE]` tag); I reviewed and verified every line and the reproduction/tests myself.