### PR TITLE
fix(postgres,duckdb): parenthesize loose right operand of JSON extraction operators [CLAUDE]

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1265,12 +1265,45 @@ def if_sql(
     return _if_sql
 
 
+# Right operands that bind at Postgres's "any other operator" precedence tier - level with the
+# JSON operators themselves and `||` - or looser (comparisons, IN, BETWEEN, AND, ...). The JSON
+# operators are left-associative and parse their right operand one tier tighter (at `+`/`-`), so
+# such an operand has to be parenthesised or the generated SQL re-parses to a different tree. See
+# https://github.com/tobymao/sqlglot/issues/8211.
+JSON_EXTRACT_LOOSE_RHS = (
+    exp.JSONExtract,
+    exp.JSONExtractScalar,
+    exp.JSONBExtract,
+    exp.JSONBExtractScalar,
+    exp.DPipe,
+    exp.BitwiseAnd,
+    exp.BitwiseOr,
+    exp.BitwiseXor,
+    exp.BitwiseLeftShift,
+    exp.BitwiseRightShift,
+    exp.Connector,
+    exp.Predicate,
+    exp.Not,
+)
+
+
+def json_extract_binary_sql(self: Generator, expression: JSON_EXTRACT_TYPE, op: str) -> str:
+    rhs = expression.expression
+    if isinstance(rhs, JSON_EXTRACT_LOOSE_RHS) and not isinstance(rhs, exp.Paren):
+        expression = expression.copy()
+        expression.set("expression", exp.paren(expression.expression))
+
+    return self.binary(expression, op)
+
+
 def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
     this = expression.this
     if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
         this.replace(exp.cast(this, exp.DType.JSON))
 
-    return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
+    return json_extract_binary_sql(
+        self, expression, "->" if isinstance(expression, exp.JSONExtract) else "->>"
+    )
 
 
 def inline_array_sql(self: Generator, expression: exp.Expr) -> str:

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -17,6 +17,7 @@ from sqlglot.dialects.dialect import (
     getbit_sql,
     groupconcat_sql,
     inline_array_sql,
+    json_extract_binary_sql,
     json_extract_segments,
     json_path_key_only_name,
     max_or_greatest,
@@ -189,7 +190,7 @@ def _json_extract_sql(
         if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not ensure_list(
             expression.args.get("expressions")
         ):
-            return self.binary(expression, op)
+            return json_extract_binary_sql(self, expression, op)
 
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)
@@ -347,8 +348,8 @@ class PostgresGenerator(generator.Generator):
         ),
         exp.JSONExtract: _json_extract_sql("JSON_EXTRACT_PATH", "->"),
         exp.JSONExtractScalar: _json_extract_sql("JSON_EXTRACT_PATH_TEXT", "->>"),
-        exp.JSONBExtract: lambda self, e: self.binary(e, "#>"),
-        exp.JSONBExtractScalar: lambda self, e: self.binary(e, "#>>"),
+        exp.JSONBExtract: lambda self, e: json_extract_binary_sql(self, e, "#>"),
+        exp.JSONBExtractScalar: lambda self, e: json_extract_binary_sql(self, e, "#>>"),
         exp.ParseJSON: lambda self, e: self.sql(exp.cast(e.this, exp.DType.JSON)),
         exp.JSONPathKey: json_path_key_only_name,
         exp.JSONPathRoot: lambda *_: "",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -690,6 +690,13 @@ class TestDuckDB(Validator):
             """SELECT '{"foo": [1, 2, 3]}' -> 'foo' -> 0""",
             """SELECT '{"foo": [1, 2, 3]}' -> '$.foo' -> '$[0]'""",
         )
+        # https://github.com/tobymao/sqlglot/issues/8211: a right operand that binds level with or
+        # looser than the JSON operator has to be parenthesised on output.
+        self.validate_all(
+            "SELECT a -> ('x' || 'y')",
+            read={"duckdb": "SELECT json_extract(a, 'x' || 'y')"},
+        )
+        self.validate_identity("SELECT a -> ('x' || 'y')")
         self.validate_identity(
             "SELECT ($$hello)'world$$)",
             "SELECT ('hello)''world')",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -421,6 +421,31 @@ class TestPostgres(Validator):
             "'[1,2,3]'::json->2",
             "CAST('[1,2,3]' AS JSON) -> 2",
         )
+
+        # https://github.com/tobymao/sqlglot/issues/8211: the JSON operators are left-associative
+        # and parse their right operand one precedence tier tighter (at +/-), so a right operand
+        # that binds at their tier (||, another JSON operator) or looser (comparison, IN, BETWEEN,
+        # AND, ...) must be parenthesised or the output re-parses to a different tree.
+        self.validate_all(
+            "SELECT a -> ('x' || 'y')",
+            read={"postgres": "SELECT json_extract(a, 'x' || 'y')"},
+        )
+        self.validate_all(
+            "SELECT a ->> ('x' || 'y')",
+            read={"postgres": "SELECT json_extract_scalar(a, 'x' || 'y')"},
+        )
+        self.validate_identity("SELECT a -> ('x' || 'y')")
+        self.validate_identity("SELECT a -> (b -> 'k')")
+        self.validate_identity("SELECT a -> (b ->> 'k')")
+        self.validate_identity("SELECT a -> (x = y)")
+        self.validate_identity("SELECT a -> (n IN (1, 2))")
+        self.validate_identity("SELECT a -> (n BETWEEN 1 AND 2)")
+        self.validate_identity("SELECT a -> (x AND y)")
+        self.validate_identity("SELECT a #> ('x' || 'y')")
+        self.validate_identity("SELECT a #>> ('x' || 'y')")
+        # right operands that bind tighter than the JSON operators are left unparenthesised
+        self.validate_identity("SELECT a -> 1 + 2")
+        self.validate_identity("SELECT a -> UPPER('a')")
         self.validate_identity(
             """SELECT JSON_ARRAY_ELEMENTS((foo->'sections')::JSON) AS sections""",
             """SELECT JSON_ARRAY_ELEMENTS(CAST((foo -> 'sections') AS JSON)) AS sections""",


### PR DESCRIPTION
Fixes #8211.

The `->`, `->>`, `#>`, `#>>` operators sit at Postgres's "any other operator" precedence tier — level with `||`, left-associative — and parse their right operand one tier tighter, at `+`/`-`. The generator printed that right operand bare, so a tree whose right operand binds at the same tier or looser was emitted as SQL that re-parses to a different tree:

    json_extract(a, 'x' || 'y')   ->   SELECT a -> 'x' || 'y'

which Postgres reads as `(a -> 'x') || 'y'`. Affected right operands are `||`, another JSON operator, comparisons, `IN`, `BETWEEN`, and `AND`/`OR`.

This is the generator counterpart to #8063, which moved these operators to the correct precedence tier in the parser. The parser now builds the tree Postgres means; this makes the generator print it unambiguously by parenthesizing a right operand that binds at the operators' tier or looser. Operands that bind tighter (arithmetic, function calls, `CAST`, `CASE`, member access) are left as-is.

DuckDB shares the same generator path and is fixed too. Wrapping is done with a `Paren` node, which composes with DuckDB's existing parent-driven wrapping without double-parenthesizing.

Developed with the help of an LLM; I've reviewed the change and the precedence reasoning behind it.