### PR TITLE
fix(optimizer): decline decorrelation of a negated correlated IN [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -55,7 +55,7 @@ def unnest(select, parent_select, next_alias_name):
         or not parent_select.args.get("from_")
         # NOT IN has three-valued semantics that the LEFT-JOIN-anti rewrite doesn't preserve:
         # a NULL in the subquery makes NOT IN evaluate to NULL for every outer row.
-        or (isinstance(predicate, exp.In) and isinstance(predicate.parent, exp.Not))
+        or (isinstance(predicate, exp.In) and _is_negated(predicate))
     ):
         return
 
@@ -214,8 +214,7 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     if parent_predicate is None and not is_subquery_projection:
         return
 
-    # Same three-valued NOT IN gap as unnest()'s guard above; decorrelate() has no equivalent.
-    if isinstance(parent_predicate, exp.In) and isinstance(parent_predicate.parent, exp.Not):
+    if isinstance(parent_predicate, exp.In) and _is_negated(parent_predicate):
         return
 
     # if the value of the subquery is not an agg or a key, we need to collect it into an array
@@ -326,6 +325,13 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
         join_alias=table_alias,
         copy=False,
     )
+
+
+def _is_negated(expression: exp.Expression) -> bool:
+    parent = expression.parent
+    while isinstance(parent, exp.Paren):
+        parent = parent.parent
+    return isinstance(parent, exp.Not)
 
 
 def _replace(expression: exp.Expr, condition: exp.ExpOrStr) -> exp.Expr:

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -214,6 +214,10 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     if parent_predicate is None and not is_subquery_projection:
         return
 
+    # Same three-valued NOT IN gap as unnest()'s guard above; decorrelate() has no equivalent.
+    if isinstance(parent_predicate, exp.In) and isinstance(parent_predicate.parent, exp.Not):
+        return
+
     # if the value of the subquery is not an agg or a key, we need to collect it into an array
     # so that it can be grouped. For subquery projections, we use a MAX aggregation instead.
     agg_func = exp.Max if is_subquery_projection else exp.ArrayAgg

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -19,8 +19,9 @@ SELECT * FROM x LEFT JOIN (SELECT SUM(y.b) AS b, y.a AS _u_1 FROM y WHERE TRUE G
 SELECT * FROM x WHERE x.a <> ANY (SELECT y.a AS a FROM y WHERE y.a = x.a);
 SELECT * FROM x LEFT JOIN (SELECT y.a AS a FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0.a = x.a WHERE x.a <> _u_0.a;
 
+# title: correlated NOT IN is not unnested because LEFT-JOIN-anti loses three-valued NULL semantics
 SELECT * FROM x WHERE x.a NOT IN (SELECT y.a AS a FROM y WHERE y.a = x.a);
-SELECT * FROM x LEFT JOIN (SELECT y.a AS a FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0.a = x.a WHERE NOT x.a = _u_0.a;
+SELECT * FROM x WHERE NOT x.a IN (SELECT y.a AS a FROM y WHERE y.a = x.a);
 
 SELECT * FROM x WHERE x.a IN (SELECT y.a AS a FROM y WHERE y.b = x.a);
 SELECT * FROM x LEFT JOIN (SELECT ARRAY_AGG(y.a) AS a, y.b AS _u_1 FROM y WHERE TRUE GROUP BY y.b) AS _u_0 ON _u_0._u_1 = x.a WHERE ARRAY_ANY(_u_0.a, _x -> _x = x.a);

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -23,6 +23,9 @@ SELECT * FROM x LEFT JOIN (SELECT y.a AS a FROM y WHERE TRUE GROUP BY y.a) AS _u
 SELECT * FROM x WHERE x.a NOT IN (SELECT y.a AS a FROM y WHERE y.a = x.a);
 SELECT * FROM x WHERE NOT x.a IN (SELECT y.a AS a FROM y WHERE y.a = x.a);
 
+SELECT * FROM x WHERE NOT (x.a IN (SELECT y.a AS a FROM y WHERE y.a = x.a));
+SELECT * FROM x WHERE NOT (x.a IN (SELECT y.a AS a FROM y WHERE y.a = x.a));
+
 SELECT * FROM x WHERE x.a IN (SELECT y.a AS a FROM y WHERE y.b = x.a);
 SELECT * FROM x LEFT JOIN (SELECT ARRAY_AGG(y.a) AS a, y.b AS _u_1 FROM y WHERE TRUE GROUP BY y.b) AS _u_0 ON _u_0._u_1 = x.a WHERE ARRAY_ANY(_u_0.a, _x -> _x = x.a);
 
@@ -122,6 +125,9 @@ SELECT * FROM x LEFT JOIN (SELECT _u_0.a AS a FROM (SELECT y.a AS a FROM y UNION
 # title: NOT IN is not unnested because LEFT-JOIN-anti loses three-valued NULL semantics
 SELECT * FROM x WHERE x.a NOT IN (SELECT y.a AS a FROM y);
 SELECT * FROM x WHERE NOT x.a IN (SELECT y.a AS a FROM y);
+
+SELECT * FROM x WHERE NOT (x.a IN (SELECT y.a AS a FROM y));
+SELECT * FROM x WHERE NOT (x.a IN (SELECT y.a AS a FROM y));
 
 # title: NOT IN with UNION ALL subquery is not unnested
 SELECT * FROM x WHERE x.a NOT IN (SELECT y.a AS a FROM y UNION ALL SELECT z.a AS a FROM z);

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -796,6 +796,14 @@ class TestExecutor(unittest.TestCase):
 
         self.assertEqual(plan.expression.sql(), before)
 
+    def test_correlated_not_in_is_not_unnested(self):
+        # the LEFT-JOIN-anti rewrite decides NOT IN using `<> `/`IS NULL` logic, which
+        # doesn't reproduce NOT IN's three-valued NULL semantics for a correlated subquery
+        schema = {"x": {"a": "int"}, "y": {"b": "int"}}
+        tables = {"x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}], "y": [{"b": 2}, {"b": 3}]}
+        sql = "SELECT a FROM x WHERE a NOT IN (SELECT b FROM y WHERE b = x.a)"
+        self.assertCountEqual(execute(sql, schema, tables=tables).rows, [(1,), (5,)])
+
     def test_subquery_cardinality(self):
         # a scalar subquery must yield a single row and column, as in duckdb and postgres
         for sql, tables in (

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -802,7 +802,19 @@ class TestExecutor(unittest.TestCase):
         schema = {"x": {"a": "int"}, "y": {"b": "int"}}
         tables = {"x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}], "y": [{"b": 2}, {"b": 3}]}
         sql = "SELECT a FROM x WHERE a NOT IN (SELECT b FROM y WHERE b = x.a)"
-        self.assertCountEqual(execute(sql, schema, tables=tables).rows, [(1,), (5,)])
+        self.assertEqual(execute(sql, schema, tables=tables).rows, [(1,), (5,)])
+
+        sql = "SELECT a FROM x WHERE NOT (a IN (SELECT b FROM y WHERE b = x.a))"
+        self.assertEqual(execute(sql, schema, tables=tables).rows, [(1,), (5,)])
+
+    def test_correlated_not_in_not_join_key_is_not_unnested(self):
+        schema = {"x": {"a": "int", "c": "int"}, "y": {"b": "int", "c": "int"}}
+        tables = {
+            "x": [{"a": 1, "c": 10}, {"a": 2, "c": 20}, {"a": 3, "c": 40}],
+            "y": [{"b": 2, "c": 20}, {"b": 5, "c": 30}],
+        }
+        sql = "SELECT a FROM x WHERE a NOT IN (SELECT b FROM y WHERE y.c = x.c)"
+        self.assertEqual(execute(sql, schema, tables=tables).rows, [(1,), (3,)])
 
     def test_subquery_cardinality(self):
         # a scalar subquery must yield a single row and column, as in duckdb and postgres


### PR DESCRIPTION
`decorrelate()` rewrites a correlated `NOT IN` into a LEFT JOIN plus a `<>` comparison. When the correlated subquery has no matching row for an outer row, the join produces `NULL`, so `<>` against it evaluates to `NULL` and `WHERE` filters that row out — even though `NOT IN` over an empty result should be `TRUE`. No `NULL` in the underlying data is needed to hit this; it comes from the unmatched side of the join itself.

```python
tables = {"x": [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}], "y": [{"b": 2}, {"b": 3}]}
```

| query | before | after (= duckdb) |
| --- | --- | --- |
| correlated `a NOT IN (SELECT b FROM y WHERE b = a)` | `[]` | `[1, 5]` |

Disclosure: implemented with Claude.
