### PR TITLE
fix!(postgres, duckdb): preserve JSON extraction RHS grouping [CODEX]

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1265,48 +1265,20 @@ def if_sql(
     return _if_sql
 
 
-def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> str:
-    this = expression.this
-    if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
-        this.replace(exp.cast(this, exp.DType.JSON))
-
-    return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
-
-
-_JSON_ARROW_TIGHT_BINARY_RHS = (
-    exp.Add,
-    exp.Collate,
-    exp.Sub,
-    exp.Mul,
-    exp.Div,
-    exp.IntDiv,
-    exp.Mod,
-    exp.Pow,
-    exp.Dot,
-)
-
-
-def _json_arrow_rhs_needs_paren(path: exp.Expression) -> bool:
-    return isinstance(path, (exp.Between, exp.In)) or (
-        isinstance(path, exp.Binary) and not isinstance(path, _JSON_ARROW_TIGHT_BINARY_RHS)
-    )
-
-
-def arrow_operator_json_extract_sql(
-    self: Generator, expression: JSON_EXTRACT_TYPE, op: str | None = None
+def arrow_json_extract_sql(
+    self: Generator,
+    expression: JSON_EXTRACT_TYPE,
+    op: str | None = None,
 ) -> str:
     this = expression.this
     if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
         this.replace(exp.cast(this, exp.DType.JSON))
 
-    path = expression.expression
-    path_sql = self.sql(path)
-
-    if _json_arrow_rhs_needs_paren(path):
-        path_sql = self.wrap(path_sql)
+    if isinstance(expression.expression, (exp.Binary, exp.Predicate, exp.Not)):
+        expression.set("expression", exp.paren(expression.expression, copy=False))
 
     op = op or ("->" if isinstance(expression, exp.JSONExtract) else "->>")
-    return f"{self.sql(expression, 'this')} {self.maybe_comment(op, comments=expression.comments)} {path_sql}"
+    return self.binary(expression, op)
 
 
 def inline_array_sql(self: Generator, expression: exp.Expr) -> str:

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1273,6 +1273,42 @@ def arrow_json_extract_sql(self: Generator, expression: JSON_EXTRACT_TYPE) -> st
     return self.binary(expression, "->" if isinstance(expression, exp.JSONExtract) else "->>")
 
 
+_JSON_ARROW_TIGHT_BINARY_RHS = (
+    exp.Add,
+    exp.Collate,
+    exp.Sub,
+    exp.Mul,
+    exp.Div,
+    exp.IntDiv,
+    exp.Mod,
+    exp.Pow,
+    exp.Dot,
+)
+
+
+def _json_arrow_rhs_needs_paren(path: exp.Expression) -> bool:
+    return isinstance(path, (exp.Between, exp.In)) or (
+        isinstance(path, exp.Binary) and not isinstance(path, _JSON_ARROW_TIGHT_BINARY_RHS)
+    )
+
+
+def arrow_operator_json_extract_sql(
+    self: Generator, expression: JSON_EXTRACT_TYPE, op: str | None = None
+) -> str:
+    this = expression.this
+    if self.JSON_TYPE_REQUIRED_FOR_EXTRACTION and isinstance(this, exp.Literal) and this.is_string:
+        this.replace(exp.cast(this, exp.DType.JSON))
+
+    path = expression.expression
+    path_sql = self.sql(path)
+
+    if _json_arrow_rhs_needs_paren(path):
+        path_sql = self.wrap(path_sql)
+
+    op = op or ("->" if isinstance(expression, exp.JSONExtract) else "->>")
+    return f"{self.sql(expression, 'this')} {self.maybe_comment(op, comments=expression.comments)} {path_sql}"
+
+
 def inline_array_sql(self: Generator, expression: exp.Expr) -> str:
     return f"[{self.expressions(expression, dynamic=True, new_line=True, skip_first=True, skip_last=True)}]"
 

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -10,10 +10,10 @@ from sqlglot.dialects.dialect import (
     DATETIME_DELTA,
     JSON_EXTRACT_TYPE,
     approx_count_distinct_sql,
+    arrow_operator_json_extract_sql,
     array_append_sql,
     array_compact_sql,
     array_concat_sql,
-    arrow_json_extract_sql,
     count_if_to_sum,
     date_delta_to_binary_interval_op,
     datestrtodate_sql,
@@ -879,9 +879,19 @@ WRAPPED_JSON_EXTRACT_EXPRESSIONS = (exp.Binary, exp.Bracket, exp.In, exp.Not)
 
 
 def _arrow_json_extract_sql(self: DuckDBGenerator, expression: JSON_EXTRACT_TYPE) -> str:
-    arrow_sql = arrow_json_extract_sql(self, expression)
-    if not expression.same_parent and isinstance(
-        expression.parent, WRAPPED_JSON_EXTRACT_EXPRESSIONS
+    arrow_sql = arrow_operator_json_extract_sql(
+        self,
+        expression,
+        "->" if isinstance(expression, exp.JSONExtract) else "->>",
+    )
+    parent = expression.parent
+    is_arrow_rhs = isinstance(
+        parent, (exp.JSONExtract, exp.JSONExtractScalar)
+    ) and expression is parent.args.get("expression")
+    if (
+        not is_arrow_rhs
+        and not expression.same_parent
+        and isinstance(parent, WRAPPED_JSON_EXTRACT_EXPRESSIONS)
     ):
         arrow_sql = self.wrap(arrow_sql)
     return arrow_sql

--- a/sqlglot/generators/duckdb.py
+++ b/sqlglot/generators/duckdb.py
@@ -10,7 +10,7 @@ from sqlglot.dialects.dialect import (
     DATETIME_DELTA,
     JSON_EXTRACT_TYPE,
     approx_count_distinct_sql,
-    arrow_operator_json_extract_sql,
+    arrow_json_extract_sql,
     array_append_sql,
     array_compact_sql,
     array_concat_sql,
@@ -879,19 +879,9 @@ WRAPPED_JSON_EXTRACT_EXPRESSIONS = (exp.Binary, exp.Bracket, exp.In, exp.Not)
 
 
 def _arrow_json_extract_sql(self: DuckDBGenerator, expression: JSON_EXTRACT_TYPE) -> str:
-    arrow_sql = arrow_operator_json_extract_sql(
-        self,
-        expression,
-        "->" if isinstance(expression, exp.JSONExtract) else "->>",
-    )
-    parent = expression.parent
-    is_arrow_rhs = isinstance(
-        parent, (exp.JSONExtract, exp.JSONExtractScalar)
-    ) and expression is parent.args.get("expression")
-    if (
-        not is_arrow_rhs
-        and not expression.same_parent
-        and isinstance(parent, WRAPPED_JSON_EXTRACT_EXPRESSIONS)
+    arrow_sql = arrow_json_extract_sql(self, expression)
+    if not expression.same_parent and isinstance(
+        expression.parent, WRAPPED_JSON_EXTRACT_EXPRESSIONS
     ):
         arrow_sql = self.wrap(arrow_sql)
     return arrow_sql

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -7,7 +7,7 @@ from sqlglot.dialects.dialect import (
     DATE_ADD_OR_SUB,
     JSON_EXTRACT_TYPE,
     any_value_to_max_sql,
-    arrow_operator_json_extract_sql,
+    arrow_json_extract_sql,
     array_append_sql,
     array_concat_sql,
     bool_xor_sql,
@@ -190,7 +190,7 @@ def _json_extract_sql(
         if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not ensure_list(
             expression.args.get("expressions")
         ):
-            return arrow_operator_json_extract_sql(self, expression, op)
+            return arrow_json_extract_sql(self, expression, op=op)
 
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)
@@ -348,8 +348,8 @@ class PostgresGenerator(generator.Generator):
         ),
         exp.JSONExtract: _json_extract_sql("JSON_EXTRACT_PATH", "->"),
         exp.JSONExtractScalar: _json_extract_sql("JSON_EXTRACT_PATH_TEXT", "->>"),
-        exp.JSONBExtract: lambda self, e: arrow_operator_json_extract_sql(self, e, "#>"),
-        exp.JSONBExtractScalar: lambda self, e: arrow_operator_json_extract_sql(self, e, "#>>"),
+        exp.JSONBExtract: lambda self, e: arrow_json_extract_sql(self, e, op="#>"),
+        exp.JSONBExtractScalar: lambda self, e: arrow_json_extract_sql(self, e, op="#>>"),
         exp.ParseJSON: lambda self, e: self.sql(exp.cast(e.this, exp.DType.JSON)),
         exp.JSONPathKey: json_path_key_only_name,
         exp.JSONPathRoot: lambda *_: "",

--- a/sqlglot/generators/postgres.py
+++ b/sqlglot/generators/postgres.py
@@ -7,6 +7,7 @@ from sqlglot.dialects.dialect import (
     DATE_ADD_OR_SUB,
     JSON_EXTRACT_TYPE,
     any_value_to_max_sql,
+    arrow_operator_json_extract_sql,
     array_append_sql,
     array_concat_sql,
     bool_xor_sql,
@@ -189,7 +190,7 @@ def _json_extract_sql(
         if not isinstance(path, (exp.JSONPath, exp.Variadic)) and not ensure_list(
             expression.args.get("expressions")
         ):
-            return self.binary(expression, op)
+            return arrow_operator_json_extract_sql(self, expression, op)
 
         if expression.args.get("only_json_types"):
             return json_extract_segments(name, quoted_index=False, op=op)(self, expression)
@@ -347,8 +348,8 @@ class PostgresGenerator(generator.Generator):
         ),
         exp.JSONExtract: _json_extract_sql("JSON_EXTRACT_PATH", "->"),
         exp.JSONExtractScalar: _json_extract_sql("JSON_EXTRACT_PATH_TEXT", "->>"),
-        exp.JSONBExtract: lambda self, e: self.binary(e, "#>"),
-        exp.JSONBExtractScalar: lambda self, e: self.binary(e, "#>>"),
+        exp.JSONBExtract: lambda self, e: arrow_operator_json_extract_sql(self, e, "#>"),
+        exp.JSONBExtractScalar: lambda self, e: arrow_operator_json_extract_sql(self, e, "#>>"),
         exp.ParseJSON: lambda self, e: self.sql(exp.cast(e.this, exp.DType.JSON)),
         exp.JSONPathKey: json_path_key_only_name,
         exp.JSONPathRoot: lambda *_: "",

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -690,6 +690,10 @@ class TestDuckDB(Validator):
             """SELECT '{"foo": [1, 2, 3]}' -> 'foo' -> 0""",
             """SELECT '{"foo": [1, 2, 3]}' -> '$.foo' -> '$[0]'""",
         )
+        self.validate_all(
+            "SELECT a -> ('x' || 'y')",
+            read={"duckdb": "SELECT JSON_EXTRACT(a, 'x' || 'y')"},
+        )
         self.validate_identity(
             "SELECT ($$hello)'world$$)",
             "SELECT ('hello)''world')",

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -1839,6 +1839,23 @@ CROSS JOIN JSON_ARRAY_ELEMENTS(CAST(JSON_EXTRACT_PATH(tbox, 'boxes') AS JSON)) A
         )
 
     def test_json_extract(self):
+        self.validate_all(
+            "SELECT a -> ('x' || 'y')",
+            read={"postgres": "SELECT JSON_EXTRACT(a, 'x' || 'y')"},
+        )
+        self.validate_all(
+            "SELECT a -> (1 + 2)",
+            read={"postgres": "SELECT JSON_EXTRACT(a, 1 + 2)"},
+        )
+        self.validate_all(
+            "SELECT a -> (NOT x)",
+            read={"postgres": "SELECT JSON_EXTRACT(a, NOT x)"},
+        )
+        self.validate_all(
+            "SELECT a #> (n IN (1, 2))",
+            read={"postgres": "SELECT JSONB_EXTRACT(a, n IN (1, 2))"},
+        )
+
         for arrow_op in ("->", "->>"):
             with self.subTest(f"Ensure {arrow_op} operator roundtrips int values as subscripts"):
                 self.validate_all(


### PR DESCRIPTION
Fixes #8211.

PostgreSQL and DuckDB JSON arrow operators can change meaning when a compound right operand is emitted without parentheses. Parenthesize binary expressions, predicates, and `NOT` operands in the AST before using the existing binary generator.

This intentionally allows harmless extra parentheses for tighter binary expressions such as `a -> (1 + 2)`, avoiding a dialect-specific operator precedence list.

Tested with the full PostgreSQL and DuckDB dialect suites and the shared dialect tests.
