### PR TITLE
fix(optimizer): preserve UNPIVOT passthrough columns

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -647,7 +647,7 @@ def _qualify_positional_column(
     column: exp.Column,
     column_table: str,
     column_source: exp.Expr | Scope,
-    source_columns: t.Sequence[str],
+    post_pivot_columns: t.Sequence[str],
     pivots: t.Sequence[exp.Pivot],
     allow_partial_qualification: bool,
 ) -> bool:
@@ -673,7 +673,7 @@ def _qualify_positional_column(
             ),
             None,
         )
-    if pivots or scope_pivot or not source_columns or "*" in source_columns:
+    if pivots or scope_pivot or not post_pivot_columns or "*" in post_pivot_columns:
         if scope_pivot:
             column.set("table", exp.to_identifier(scope_pivot.alias))
         return True
@@ -740,15 +740,31 @@ def _qualify_columns(
 
         if column_table and column_table in scope.sources:
             column_source = scope.sources[column_table]
-            source_columns = resolver.get_source_columns(column_table)
-            # For pivoted sources, source_columns are pre-pivot; validate against the post-pivot set.
+            pre_pivot_columns = resolver.get_source_columns(column_table)
+            post_pivot_columns = pre_pivot_columns
             pivots = (
                 column_source.args.get("pivots", []) if isinstance(column_source, exp.Table) else []
             )
             if pivots:
+                pre_pivot_columns_incomplete = not pre_pivot_columns or "*" in pre_pivot_columns
+                if pre_pivot_columns_incomplete:
+                    post_pivot_columns = [name for name in pre_pivot_columns if name != "*"]
+                    if column_name not in post_pivot_columns:
+                        post_pivot_columns.append(column_name)
+
                 # Each operator's input is the previous one's output
                 for pivot in pivots:
-                    source_columns = pivot.output_columns(source_columns)
+                    # alias column names are, e.g., w and x in `UNPIVOT(v FOR k IN (a, b)) AS i(w, x)`
+                    alias_columns = pivot.alias_column_names
+                    if pre_pivot_columns_incomplete and alias_columns:
+                        # Aliases positionally rename the first len(alias_columns) outputs, but an
+                        # incomplete pre-pivot column list can't determine which columns occupy
+                        # those positions. Placeholders model the scenario where every aliased
+                        # position contains an unknown passthrough column.
+                        placeholder_columns = [f"\0{index}" for index in range(len(alias_columns))]
+                        post_pivot_columns = [*placeholder_columns, *post_pivot_columns]
+
+                    post_pivot_columns = pivot.output_columns(post_pivot_columns)
 
             if _qualify_positional_column(
                 scope,
@@ -756,7 +772,7 @@ def _qualify_columns(
                 column,
                 column_table,
                 column_source,
-                source_columns,
+                post_pivot_columns,
                 pivots,
                 allow_partial_qualification,
             ):
@@ -764,9 +780,9 @@ def _qualify_columns(
             column_name = column.name
             if (
                 not allow_partial_qualification
-                and source_columns
-                and column_name not in source_columns
-                and "*" not in source_columns
+                and post_pivot_columns
+                and column_name not in post_pivot_columns
+                and "*" not in post_pivot_columns
             ):
                 raise OptimizeError(f"Unknown column: {column_name}")
 

--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -647,7 +647,7 @@ def _qualify_positional_column(
     column: exp.Column,
     column_table: str,
     column_source: exp.Expr | Scope,
-    post_pivot_columns: t.Sequence[str],
+    source_columns: t.Sequence[str],
     pivots: t.Sequence[exp.Pivot],
     allow_partial_qualification: bool,
 ) -> bool:
@@ -673,7 +673,7 @@ def _qualify_positional_column(
             ),
             None,
         )
-    if pivots or scope_pivot or not post_pivot_columns or "*" in post_pivot_columns:
+    if pivots or scope_pivot or not source_columns or "*" in source_columns:
         if scope_pivot:
             column.set("table", exp.to_identifier(scope_pivot.alias))
         return True
@@ -740,31 +740,14 @@ def _qualify_columns(
 
         if column_table and column_table in scope.sources:
             column_source = scope.sources[column_table]
-            pre_pivot_columns = resolver.get_source_columns(column_table)
-            post_pivot_columns = pre_pivot_columns
+            source_columns = resolver.get_source_columns(column_table)
             pivots = (
                 column_source.args.get("pivots", []) if isinstance(column_source, exp.Table) else []
             )
-            if pivots:
-                pre_pivot_columns_incomplete = not pre_pivot_columns or "*" in pre_pivot_columns
-                if pre_pivot_columns_incomplete:
-                    post_pivot_columns = [name for name in pre_pivot_columns if name != "*"]
-                    if column_name not in post_pivot_columns:
-                        post_pivot_columns.append(column_name)
-
+            if pivots and source_columns and "*" not in source_columns:
                 # Each operator's input is the previous one's output
                 for pivot in pivots:
-                    # alias column names are, e.g., w and x in `UNPIVOT(v FOR k IN (a, b)) AS i(w, x)`
-                    alias_columns = pivot.alias_column_names
-                    if pre_pivot_columns_incomplete and alias_columns:
-                        # Aliases positionally rename the first len(alias_columns) outputs, but an
-                        # incomplete pre-pivot column list can't determine which columns occupy
-                        # those positions. Placeholders model the scenario where every aliased
-                        # position contains an unknown passthrough column.
-                        placeholder_columns = [f"\0{index}" for index in range(len(alias_columns))]
-                        post_pivot_columns = [*placeholder_columns, *post_pivot_columns]
-
-                    post_pivot_columns = pivot.output_columns(post_pivot_columns)
+                    source_columns = pivot.output_columns(source_columns)
 
             if _qualify_positional_column(
                 scope,
@@ -772,7 +755,7 @@ def _qualify_columns(
                 column,
                 column_table,
                 column_source,
-                post_pivot_columns,
+                source_columns,
                 pivots,
                 allow_partial_qualification,
             ):
@@ -780,9 +763,9 @@ def _qualify_columns(
             column_name = column.name
             if (
                 not allow_partial_qualification
-                and post_pivot_columns
-                and column_name not in post_pivot_columns
-                and "*" not in post_pivot_columns
+                and source_columns
+                and column_name not in source_columns
+                and "*" not in source_columns
             ):
                 raise OptimizeError(f"Unknown column: {column_name}")
 

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -866,30 +866,37 @@ class TestOptimizer(unittest.TestCase):
             "IN ((`produce`.`q1`, `produce`.`q2`) AS 'h1', (`produce`.`q3`, `produce`.`q4`) AS 'h2')) AS `produce`",
         )
 
-    def test_unpivot_unknown_schema_does_not_reject_passthrough(self):
-        sql = "SELECT i.other_col FROM my_table AS i UNPIVOT(v FOR k IN (a, b))"
-
+    def test_unpivot_unknown_schema(self):
         self.assertEqual(
-            qualify(parse_one(sql, dialect="snowflake"), dialect="snowflake").sql(
-                dialect="snowflake"
-            ),
+            qualify(
+                parse_one(
+                    "SELECT i.other_col FROM my_table AS i UNPIVOT(v FOR k IN (a, b))",
+                    dialect="snowflake",
+                ),
+                dialect="snowflake",
+            ).sql(dialect="snowflake"),
             'SELECT "I"."OTHER_COL" AS "OTHER_COL" FROM "MY_TABLE" AS "I" '
             'UNPIVOT("V" FOR "K" IN ("A", "B")) AS "I"',
         )
-
-    def test_unpivot_unknown_schema_rejects_consumed_column(self):
-        sql = "SELECT i.a FROM my_table AS i UNPIVOT(v FOR k IN (a, b))"
-
-        with self.assertRaisesRegex(OptimizeError, "Unknown column: A"):
-            qualify(parse_one(sql, dialect="snowflake"), dialect="snowflake")
-
-    def test_unpivot_unknown_schema_preserves_positional_aliases(self):
-        sql = "SELECT i.z FROM my_table AS i UNPIVOT(v FOR k IN (a, b)) AS i(w, x, y, z)"
-
         self.assertEqual(
-            qualify(parse_one(sql, dialect="snowflake"), dialect="snowflake").sql(
-                dialect="snowflake"
-            ),
+            qualify(
+                parse_one(
+                    "SELECT i.a FROM my_table AS i UNPIVOT(v FOR k IN (a, b))",
+                    dialect="snowflake",
+                ),
+                dialect="snowflake",
+            ).sql(dialect="snowflake"),
+            'SELECT "I"."A" AS "A" FROM "MY_TABLE" AS "I" '
+            'UNPIVOT("V" FOR "K" IN ("A", "B")) AS "I"',
+        )
+        self.assertEqual(
+            qualify(
+                parse_one(
+                    "SELECT i.z FROM my_table AS i UNPIVOT(v FOR k IN (a, b)) AS i(w, x, y, z)",
+                    dialect="snowflake",
+                ),
+                dialect="snowflake",
+            ).sql(dialect="snowflake"),
             'SELECT "I"."Z" AS "Z" FROM "MY_TABLE" AS "I" '
             'UNPIVOT("V" FOR "K" IN ("A", "B")) AS "I"("W", "X", "Y", "Z")',
         )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -866,6 +866,34 @@ class TestOptimizer(unittest.TestCase):
             "IN ((`produce`.`q1`, `produce`.`q2`) AS 'h1', (`produce`.`q3`, `produce`.`q4`) AS 'h2')) AS `produce`",
         )
 
+    def test_unpivot_unknown_schema_does_not_reject_passthrough(self):
+        sql = "SELECT i.other_col FROM my_table AS i UNPIVOT(v FOR k IN (a, b))"
+
+        self.assertEqual(
+            qualify(parse_one(sql, dialect="snowflake"), dialect="snowflake").sql(
+                dialect="snowflake"
+            ),
+            'SELECT "I"."OTHER_COL" AS "OTHER_COL" FROM "MY_TABLE" AS "I" '
+            'UNPIVOT("V" FOR "K" IN ("A", "B")) AS "I"',
+        )
+
+    def test_unpivot_unknown_schema_rejects_consumed_column(self):
+        sql = "SELECT i.a FROM my_table AS i UNPIVOT(v FOR k IN (a, b))"
+
+        with self.assertRaisesRegex(OptimizeError, "Unknown column: A"):
+            qualify(parse_one(sql, dialect="snowflake"), dialect="snowflake")
+
+    def test_unpivot_unknown_schema_preserves_positional_aliases(self):
+        sql = "SELECT i.z FROM my_table AS i UNPIVOT(v FOR k IN (a, b)) AS i(w, x, y, z)"
+
+        self.assertEqual(
+            qualify(parse_one(sql, dialect="snowflake"), dialect="snowflake").sql(
+                dialect="snowflake"
+            ),
+            'SELECT "I"."Z" AS "Z" FROM "MY_TABLE" AS "I" '
+            'UNPIVOT("V" FOR "K" IN ("A", "B")) AS "I"("W", "X", "Y", "Z")',
+        )
+
     def test_multiple_pivots_annotate_types(self):
         # NOTE: the value column takes the type of the first IN-list entry, so the columns
         # folded by a single operator are kept uniformly typed here


### PR DESCRIPTION
Snowflake `UNPIVOT` preserves columns not listed in its `IN` clause. 

With an unknown schema, qualification incorrectly replaced the empty pre-pivot column set with only the generated `UNPIVOT` columns, causing valid passthrough references to raise OptimizeError.

Example: qualification currently rejects `i.other_col` in the query below
- `v` and `k` are generated by the `UNPIVOT`
- `a` and `b` are consumed by the `UNPIVOT`
- `other_col` **may** exist in `i` and pass through the `UNPIVOT`
```
SELECT
  i.v,
  i.k,
  i.other_col
FROM my_table AS i
UNPIVOT(v FOR k IN (a, b))
```

We now treat each referenced column as a possible pre-pivot column through the `(UN)PIVOT` chain. This preserves unknown passthrough columns while still rejecting columns explicitly consumed by `UNPIVOT`.