### PR TITLE
feat(clickhouse): parse lagInFrame/leadInFrame into Lag/Lead

### DIFF
--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -295,6 +295,12 @@ class ClickHouseParser(parser.Parser):
         "JSONEXTRACTSTRING": build_json_extract_path(
             exp.JSONExtractScalar, zero_based_indexing=False
         ),
+        "LAGINFRAME": lambda args: exp.Lag(
+            this=seq_get(args, 0), offset=seq_get(args, 1), default=seq_get(args, 2)
+        ),
+        "LEADINFRAME": lambda args: exp.Lead(
+            this=seq_get(args, 0), offset=seq_get(args, 1), default=seq_get(args, 2)
+        ),
         "LENGTH": lambda args: exp.Length(this=seq_get(args, 0), binary=True),
         "LIKE": build_like(exp.Like),
         "L2Distance": exp.EuclideanDistance.from_arg_list,

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -315,6 +315,7 @@ class TestClickhouse(Validator):
             },
             write={
                 "clickhouse": "SELECT lagInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+                "doris": "SELECT LAG(salary, 1, 0) OVER (ORDER BY CASE WHEN hire_date IS NULL THEN 1 ELSE 0 END, hire_date) AS prev_sal FROM employees",
                 "duckdb": "SELECT LAG(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
                 "oracle": "SELECT LAG(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
             },
@@ -327,6 +328,7 @@ class TestClickhouse(Validator):
             },
             write={
                 "clickhouse": "SELECT leadInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+                "doris": "SELECT LEAD(salary, 1, 0) OVER (ORDER BY CASE WHEN hire_date IS NULL THEN 1 ELSE 0 END, hire_date) AS prev_sal FROM employees",
                 "duckdb": "SELECT LEAD(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
                 "oracle": "SELECT LEAD(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
             },

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -313,6 +313,11 @@ class TestClickhouse(Validator):
                 "clickhouse": "SELECT lagInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
                 "oracle": "SELECT LAG(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
             },
+            write={
+                "clickhouse": "SELECT lagInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+                "duckdb": "SELECT LAG(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+                "oracle": "SELECT LAG(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+            },
         )
         self.validate_all(
             "SELECT leadInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
@@ -320,6 +325,17 @@ class TestClickhouse(Validator):
                 "clickhouse": "SELECT leadInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
                 "oracle": "SELECT LEAD(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
             },
+            write={
+                "clickhouse": "SELECT leadInFrame(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+                "duckdb": "SELECT LEAD(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+                "oracle": "SELECT LEAD(salary, 1, 0) OVER (ORDER BY hire_date) AS prev_sal FROM employees",
+            },
+        )
+        self.validate_identity("SELECT lagInFrame(x) OVER (PARTITION BY g ORDER BY t) FROM t")
+        self.validate_identity("SELECT leadInFrame(x, 2) OVER (ORDER BY t) FROM t")
+        self.assertIsInstance(
+            self.parse_one("SELECT lagInFrame(x) OVER (ORDER BY t) FROM t").selects[0].this,
+            exp.Lag,
         )
         self.validate_all(
             "SELECT CAST(STR_TO_DATE('05 12 2000', '%d %m %Y') AS Nullable(DATE))",


### PR DESCRIPTION
The ClickHouse generator already renders `exp.Lag`/`exp.Lead` as `lagInFrame`/`leadInFrame`, but the parser didn't recognise those names, so the round-trip was one-way: `LAG(x, 1, 0) OVER (...)` coming from any dialect became `lagInFrame(x, 1, 0)` on the way into ClickHouse and came back out as `LAGINFRAME(x, 1, 0)` — an unknown function everywhere else.

This registers both in the ClickHouse parser with the `(this, offset, default)` argument order and extends the existing `lagInFrame`/`leadInFrame` tests with the `write=` direction that actually exercises the parse (the prior tests only covered CH→CH identity, which passes on an Anonymous node).

Before:
```python
q = "SELECT lagInFrame(x, 1, 0) OVER (ORDER BY t)"
transpile(q, read="clickhouse", write="doris")
# SELECT LAGINFRAME(x, 1, 0) OVER (ORDER BY CASE WHEN t IS NULL THEN 1 ELSE 0 END, t)
transpile(q, read="clickhouse", write="duckdb")
# SELECT LAGINFRAME(x, 1, 0) OVER (ORDER BY t)
```
After:
```python
# doris:  SELECT LAG(x, 1, 0) OVER (ORDER BY CASE WHEN t IS NULL THEN 1 ELSE 0 END, t)
# duckdb: SELECT LAG(x, 1, 0) OVER (ORDER BY t)
```
