### PR TITLE
feat(clickhouse): parse trimLeft/trimRight/trimBoth into Trim

### DIFF
--- a/sqlglot/parsers/clickhouse.py
+++ b/sqlglot/parsers/clickhouse.py
@@ -5,6 +5,7 @@ import typing as t
 from collections import deque
 
 from sqlglot import exp, parser
+from sqlglot.parser import build_trim
 from sqlglot.dialects.dialect import (
     build_date_delta,
     build_formatted_time,
@@ -318,6 +319,11 @@ class ClickHouseParser(parser.Parser):
         "SPLITBYSTRING": _build_split(exp.Split),
         "SUBSTRINGINDEX": exp.SubstringIndex.from_arg_list,
         "TOTYPENAME": exp.Typeof.from_arg_list,
+        "TRIMBOTH": lambda args: exp.Trim(
+            this=seq_get(args, 0), expression=seq_get(args, 1), position="BOTH"
+        ),
+        "TRIMLEFT": lambda args: build_trim(args),
+        "TRIMRIGHT": lambda args: build_trim(args, is_left=False),
         "EDITDISTANCE": exp.Levenshtein.from_arg_list,
         "JAROWINKLERSIMILARITY": exp.JarowinklerSimilarity.from_arg_list,
         "LEVENSHTEINDISTANCE": exp.Levenshtein.from_arg_list,

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -719,6 +719,7 @@ class TestClickhouse(Validator):
             },
             write={
                 "clickhouse": "SELECT TRIM(LEADING 'x' FROM s), TRIM(TRAILING 'x' FROM s), TRIM(BOTH 'x' FROM s)",
+                "doris": "SELECT TRIM(LEADING 'x' FROM s), TRIM(TRAILING 'x' FROM s), TRIM(BOTH 'x' FROM s)",
                 "duckdb": "SELECT LTRIM(s, 'x'), RTRIM(s, 'x'), TRIM(s, 'x')",
                 "postgres": "SELECT TRIM(LEADING 'x' FROM s), TRIM(TRAILING 'x' FROM s), TRIM(BOTH 'x' FROM s)",
             },

--- a/tests/dialects/test_clickhouse.py
+++ b/tests/dialects/test_clickhouse.py
@@ -712,6 +712,23 @@ class TestClickhouse(Validator):
         )
         self.validate_identity("SELECT TRIM(TRAILING ')' FROM '(   Hello, world!   )')")
         self.validate_identity("SELECT TRIM(LEADING '(' FROM '(   Hello, world!   )')")
+        self.validate_all(
+            "SELECT TRIM(LEADING 'x' FROM s), TRIM(TRAILING 'x' FROM s), TRIM(BOTH 'x' FROM s)",
+            read={
+                "clickhouse": "SELECT trimLeft(s, 'x'), trimRight(s, 'x'), trimBoth(s, 'x')",
+            },
+            write={
+                "clickhouse": "SELECT TRIM(LEADING 'x' FROM s), TRIM(TRAILING 'x' FROM s), TRIM(BOTH 'x' FROM s)",
+                "duckdb": "SELECT LTRIM(s, 'x'), RTRIM(s, 'x'), TRIM(s, 'x')",
+                "postgres": "SELECT TRIM(LEADING 'x' FROM s), TRIM(TRAILING 'x' FROM s), TRIM(BOTH 'x' FROM s)",
+            },
+        )
+        self.validate_all(
+            "SELECT LTRIM(s), RTRIM(s), TRIM(s)",
+            read={"clickhouse": "SELECT trimLeft(s), trimRight(s), trimBoth(s)"},
+            write={"duckdb": "SELECT LTRIM(s), RTRIM(s), TRIM(s)"},
+        )
+        self.assertIsInstance(self.parse_one("SELECT trimLeft(s, 'x')").selects[0], exp.Trim)
         self.validate_identity("current_timestamp").assert_is(exp.Column)
 
         self.validate_identity("SELECT * APPLY(sum) FROM columns_transformers")


### PR DESCRIPTION
ClickHouse's `trimLeft`, `trimRight` and `trimBoth` take an optional second argument naming the characters to strip, but the parser left all three as Anonymous, so they reached every target dialect verbatim (`TRIMLEFT(s, 'x')`).

This registers them on `exp.Trim` with the LEADING/TRAILING/BOTH position (reusing `parser.build_trim` for the left/right cases), so they transpile — DuckDB `LTRIM(s, 'x')`, Doris/Postgres `TRIM(LEADING 'x' FROM s)` — and round-trip to the `TRIM(... FROM ...)` form the ClickHouse generator already emits (and which the existing identity tests at the same spot assert as canonical).

Before:
```python
q = "SELECT trimLeft(s, 'x')"
transpile(q, read="clickhouse", write="doris")
# SELECT TRIMLEFT(s, 'x')
transpile(q, read="clickhouse", write="duckdb")
# SELECT TRIMLEFT(s, 'x')
```
After:
```python
# doris:  SELECT TRIM(LEADING 'x' FROM s)
# duckdb: SELECT LTRIM(s, 'x')
```
