### PR TITLE
fix(databricks): handle qualified * EXCEPT

### DIFF
--- a/sqlglot/optimizer/qualify_columns.py
+++ b/sqlglot/optimizer/qualify_columns.py
@@ -867,7 +867,7 @@ def _expand_struct_stars_no_parens(
         taken_names.add(name)
 
         this = field.this.copy()
-        root, *parts = [part.copy() for part in itertools.chain(dot_parts, [this])]
+        root, *parts = (part.copy() for part in itertools.chain(dot_parts, [this]))
         new_column = exp.column(
             t.cast(exp.Identifier, root),
             table=dot_column.args.get("table"),
@@ -950,7 +950,6 @@ def _expand_stars(
     """Expand stars to lists of column selections"""
 
     new_selections: list[exp.Expr] = []
-    except_columns: dict[int, set[str]] = {}
     replace_columns: dict[int, dict[str, exp.Alias]] = {}
     rename_columns: dict[int, dict[str, str]] = {}
     ilike_pattern: str | None = None
@@ -971,6 +970,7 @@ def _expand_stars(
         return
 
     for expression in scope_expression.selects:
+        except_columns: dict[int, set[str]] = {}
         tables: list[str] = []
         if isinstance(expression, exp.Star):
             # Only a string literal ILIKE pattern can filter the expansion at optimization time
@@ -1191,10 +1191,16 @@ def _add_except_columns(expression: exp.Expr, tables, except_columns: dict[int, 
     if not except_:
         return
 
-    columns = {e.name for e in except_}
+    for exclusion in except_:
+        if isinstance(exclusion, exp.Column) and exclusion.table:
+            excluded_tables = [table for table in tables if table == exclusion.table]
+            if not excluded_tables:
+                raise OptimizeError(f"Unknown column: {exclusion.sql()}")
+        else:
+            excluded_tables = tables
 
-    for table in tables:
-        except_columns[id(table)] = columns
+        for table in excluded_tables:
+            except_columns.setdefault(id(table), set()).add(exclusion.name)
 
 
 def _add_rename_columns(

--- a/tests/fixtures/optimizer/qualify_columns.sql
+++ b/tests/fixtures/optimizer/qualify_columns.sql
@@ -735,6 +735,18 @@ SELECT x.a AS a, x.b AS b, y.b AS b FROM x AS x LEFT JOIN x AS y ON x.a = y.a;
 SELECT COALESCE(CAST(t1.a AS VARCHAR), '') AS a, t2.* EXCEPT (a) FROM x AS t1, x AS t2;
 SELECT COALESCE(CAST(t1.a AS VARCHAR), '') AS a, t2.b AS b FROM x AS t1, x AS t2;
 
+# title: Databricks qualified star EXCEPT preserves same-named columns from other sources
+# dialect: databricks
+# execute: false
+WITH r AS (SELECT 1 AS pk, 2 AS x), d AS (SELECT 1 AS pk, 3 AS y), j AS (SELECT * EXCEPT (r.pk) FROM r JOIN d ON r.pk = d.pk) SELECT j.pk FROM j;
+WITH r AS (SELECT 1 AS pk, 2 AS x), d AS (SELECT 1 AS pk, 3 AS y), j AS (SELECT r.x AS x, d.pk AS pk, d.y AS y FROM r AS r JOIN d AS d ON r.pk = d.pk) SELECT j.pk AS pk FROM j AS j;
+
+# title: Databricks nested star EXCEPT remains valid after struct qualification
+# dialect: databricks
+# execute: false
+WITH t AS (SELECT named_struct('x', 1, 'y', 2) AS s) SELECT * EXCEPT (s.x) FROM t;
+WITH t AS (SELECT STRUCT(1 AS x, 2 AS y) AS s) SELECT t.s AS s FROM t AS t;
+
 # execute: false
 SELECT * REPLACE(2 AS a) FROM x;
 SELECT 2 AS a, x.b AS b FROM x AS x;

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1141,6 +1141,21 @@ class TestOptimizer(unittest.TestCase):
         )
         self.assertEqual(qualified.selects[0].type.sql("bigquery"), "INT64")
 
+    def test_qualify_star_except_unmatched_qualifier(self):
+        invalid = {
+            "WITH r AS (SELECT 1 AS pk, 2 AS x) SELECT * EXCEPT (z.pk) FROM r": r"z\.pk",
+            (
+                "WITH r AS (SELECT 1 AS pk, 2 AS x), "
+                "d AS (SELECT 1 AS pk, 3 AS y) "
+                "SELECT r.* EXCEPT (d.pk) FROM r JOIN d ON r.pk = d.pk"
+            ): r"d\.pk",
+        }
+
+        for sql, column in invalid.items():
+            with self.subTest(sql):
+                with self.assertRaisesRegex(OptimizeError, rf"Unknown column: {column}$"):
+                    qualify(parse_one(sql, dialect="databricks"), dialect="databricks")
+
     def test_qualify_snowflake_positional_column_with_visible_schema(self):
         visible_schema = MappingSchema(
             {"t": {"hidden": "INT", "HAS SPACE": "INT"}},


### PR DESCRIPTION
Previously, star expansion ignored qualifiers in EXCEPT, so `* EXCEPT (r.pk)` removed every pk from joined sources instead of only r.pk. 