### PR TITLE
feat(optimizer)!: annotate maketime for postgres

### DIFF
--- a/sqlglot/typing/postgres.py
+++ b/sqlglot/typing/postgres.py
@@ -33,5 +33,11 @@ EXPRESSION_METADATA = {
             exp.Decode,
         }
     },
+    **{
+        expr_type: {"returns": exp.DType.TIME}
+        for expr_type in {
+            exp.TimeFromParts,
+        }
+    },
     exp.ToNumber: {"returns": exp.DType.DECIMAL},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -7453,6 +7453,11 @@ TEXT;
 DECODE(tbl.str_col, 'base64');
 VARBINARY;
 
+# dialect: postgres
+MAKE_TIME(tbl.int_col, tbl.int_col, tbl.double_col);
+TIME;
+
+
 --------------------------------------
 -- Presto / Trino
 --------------------------------------


### PR DESCRIPTION
## This PR annotate the function make_time for postgres

https://www.postgresql.org/docs/current/functions-datetime.html

<img width="952" height="375" alt="Screenshot From 2026-08-25 15-41-28" src="https://github.com/user-attachments/assets/fd77ed9c-1838-4e58-8f09-3721fbc52e38" />
