### PR TITLE
feat(duckdb): map LIST_POSITION and LIST_INDEXOF to exp.ArrayPosition

### DIFF
--- a/sqlglot/parsers/duckdb.py
+++ b/sqlglot/parsers/duckdb.py
@@ -207,6 +207,8 @@ class DuckDBParser(parser.Parser):
             ("GROUP_CONCAT", "LISTAGG", "STRINGAGG"), lambda self: self._parse_string_agg()
         ),
         "APPROX_QUANTILE": lambda self: self._parse_distinct_arg_function(exp.ApproxQuantile),
+        "LIST_INDEXOF": lambda self: exp.ArrayPosition.from_arg_list(self._parse_csv(self._parse_expression)),
+        "LIST_POSITION": lambda self: exp.ArrayPosition.from_arg_list(self._parse_csv(self._parse_expression)),
         "QUANTILE": lambda self: self._parse_distinct_arg_function(exp.Quantile),
         "QUANTILE_CONT": lambda self: self._parse_distinct_arg_function(exp.PercentileCont),
         "QUANTILE_DISC": lambda self: self._parse_distinct_arg_function(exp.PercentileDisc),

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -11,6 +11,21 @@ class TestDuckDB(Validator):
     dialect = "duckdb"
 
     def test_duckdb(self):
+        self.validate_all(
+            "SELECT list_position([10, 20, 30], 20)",
+            write={
+                "duckdb": "SELECT list_position([10, 20, 30], 20)",
+                "postgres": "SELECT ARRAY_POSITION(ARRAY[10, 20, 30], 20)",
+                "snowflake": "SELECT ARRAY_POSITION(20, [10, 20, 30])",
+            },
+        )
+        self.validate_all(
+            "SELECT list_indexof([10, 20, 30], 20)",
+            write={
+                "duckdb": "SELECT list_position([10, 20, 30], 20)",
+                "postgres": "SELECT ARRAY_POSITION(ARRAY[10, 20, 30], 20)",
+            },
+        )
         self.validate_identity("TRUNC(3.14)").assert_is(exp.Trunc)
         self.validate_all(
             "TRUNC(3.14159, 2)",


### PR DESCRIPTION
### Summary
Maps DuckDB's `list_position` and `list_indexof` functions to `exp.ArrayPosition` in `DuckDBParser`.

### Context / Problem
Previously, `list_position` and `list_indexof` fell back to `exp.Anonymous`, causing syntax errors when transpiling across dialects like Snowflake (`ARRAY_POSITION(val, arr)`) and Postgres (`ARRAY_POSITION(arr, val)`).

### Verification
Added test cases in `tests/dialects/test_duckdb.py` validating cross-dialect transpilation.