### PR TITLE
feat(optimizer)!: annotate make_timestamp for postgres

### DIFF
--- a/sqlglot/typing/postgres.py
+++ b/sqlglot/typing/postgres.py
@@ -40,5 +40,11 @@ EXPRESSION_METADATA = {
             exp.TimeFromParts,
         }
     },
+    **{
+        expr_type: {"returns": exp.DType.TIMESTAMP}
+        for expr_type in {
+            exp.TimestampFromParts,
+        }
+    },
     exp.ToNumber: {"returns": exp.DType.DECIMAL},
 }

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -7497,6 +7497,10 @@ TEXT;
 REGEXP_REPLACE(string => tbl.str_col, pattern => 'l', replacement => 'XX', start => 1, "N" => 2, flags => 'i');
 TEXT;
 
+# dialect: postgres
+MAKE_TIMESTAMP(tbl.int_col, tbl.int_col, tbl.int_col, tbl.int_col, tbl.int_col, tbl.double_col);
+TIMESTAMP;
+
 
 --------------------------------------
 -- Presto / Trino


### PR DESCRIPTION
## This PR annotate the function make_timestamp for postgres

https://www.postgresql.org/docs/current/functions-datetime.html

<img width="1052" height="368" alt="Screenshot From 2026-08-25 19-25-16" src="https://github.com/user-attachments/assets/ae6edd45-dc87-4bb5-9242-b45ce379996f" />
