### PR TITLE
fix(parser)!: Parse MOD at multiplicative precedence

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -976,7 +976,6 @@ class Parser:
     TERM: t.ClassVar = {
         TokenType.DASH: exp.Sub,
         TokenType.PLUS: exp.Add,
-        TokenType.MOD: exp.Mod,
         TokenType.COLLATE: exp.Collate,
     }
 
@@ -984,6 +983,7 @@ class Parser:
         TokenType.DIV: exp.IntDiv,
         TokenType.LR_ARROW: exp.Distance,
         TokenType.LLRR_ARROW: exp.DistanceNd,
+        TokenType.MOD: exp.Mod,
         TokenType.SLASH: exp.Div,
         TokenType.STAR: exp.Mul,
     }
@@ -5276,7 +5276,7 @@ class Parser:
         else:
             expressions = None
             num = (
-                self._parse_factor()
+                self._parse_factor(parse_mod=False)
                 if self._match(TokenType.NUMBER, advance=False)
                 else self._parse_primary() or self._parse_placeholder()
             )
@@ -5775,16 +5775,7 @@ class Parser:
                 if self.dialect.SUPPORTS_LIMIT_ALL and self._match(TokenType.ALL):
                     return this
 
-                # Parsing LIMIT x% (i.e x PERCENT) as a term leads to an error, since
-                # we try to build an exp.Mod expr. For that matter, we backtrack and instead
-                # consume the factor plus parse the percentage separately
-                index = self._index
-                expression = self._try_parse(self._parse_term)
-                if isinstance(expression, exp.Mod):
-                    self._retreat(index)
-                    expression = self._parse_factor()
-                elif not expression:
-                    expression = self._parse_factor()
+                expression = self._parse_term(parse_mod=False)
             limit_options = self._parse_limit_options()
 
             if self._match(TokenType.COMMA):
@@ -6344,13 +6335,13 @@ class Parser:
 
         return this
 
-    def _parse_term(self) -> exp.Expr | None:
-        this = self._parse_factor()
+    def _parse_term(self, parse_mod: bool = True) -> exp.Expr | None:
+        this = self._parse_factor(parse_mod=parse_mod)
 
         while self._match_set(self.TERM):
             klass = self.TERM[self._prev.token_type]
             comments = self._prev_comments
-            expression = self._parse_factor()
+            expression = self._parse_factor(parse_mod=parse_mod)
 
             this = self.expression(klass(this=this, expression=expression), comments=comments)
 
@@ -6369,11 +6360,15 @@ class Parser:
             if isinstance(ident, exp.Identifier):
                 collate.set("expression", ident if ident.quoted else exp.var(ident.name))
 
-    def _parse_factor(self) -> exp.Expr | None:
+    def _parse_factor(self, parse_mod: bool = True) -> exp.Expr | None:
         parse_method = self._parse_factor_operand
         this = self._parse_at_time_zone(parse_method())
 
-        while self._match_set(self.FACTOR):
+        while self._match_set(self.FACTOR, advance=False):
+            if not parse_mod and self._curr.token_type == TokenType.MOD:
+                break
+
+            self._advance()
             klass = self.FACTOR[self._prev.token_type]
             comments = self._prev_comments
             expression = parse_method()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -272,7 +272,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(expr.sql(dialect="clickhouse"), single_union)
 
     def test_mod_precedence(self):
-        expression = parse_one("SELECT 10 % 3 / 2", read="redshift").expressions[0]
+        expression = parse_one("SELECT 10 % 3 / 2").expressions[0]
 
         self.assertIsInstance(expression, exp.Div)
         self.assertIsInstance(expression.this, exp.Mod)
@@ -281,7 +281,7 @@ class TestParser(unittest.TestCase):
         self.assertEqual(expression.expression.sql(), "2")
 
     def test_limit_percent_parses_without_modulo(self):
-        expression = parse_one("SELECT * FROM range(1000) LIMIT 1 / 10% OFFSET 5", read="duckdb")
+        expression = parse_one("SELECT * FROM range(1000) LIMIT 1 / 10% OFFSET 5")
         limit = expression.args["limit"]
 
         self.assertIsNotNone(limit)
@@ -290,10 +290,7 @@ class TestParser(unittest.TestCase):
         self.assertTrue(limit.args["limit_options"].args["percent"])
 
     def test_tablesample_percent_parses_without_modulo(self):
-        table = parse_one(
-            "SELECT * FROM tbl TABLESAMPLE RESERVOIR (20%)",
-            read="duckdb",
-        ).find(exp.Table)
+        table = parse_one("SELECT * FROM tbl TABLESAMPLE RESERVOIR (20%)").find(exp.Table)
         sample = table.args["sample"]
 
         self.assertIsNotNone(sample)

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -271,6 +271,35 @@ class TestParser(unittest.TestCase):
         self.assertIsNone(expr.args.get("limit"))
         self.assertEqual(expr.sql(dialect="clickhouse"), single_union)
 
+    def test_mod_precedence(self):
+        expression = parse_one("SELECT 10 % 3 / 2", read="redshift").expressions[0]
+
+        self.assertIsInstance(expression, exp.Div)
+        self.assertIsInstance(expression.this, exp.Mod)
+        self.assertEqual(expression.this.this.sql(), "10")
+        self.assertEqual(expression.this.expression.sql(), "3")
+        self.assertEqual(expression.expression.sql(), "2")
+
+    def test_limit_percent_parses_without_modulo(self):
+        expression = parse_one("SELECT * FROM range(1000) LIMIT 1 / 10% OFFSET 5", read="duckdb")
+        limit = expression.args["limit"]
+
+        self.assertIsNotNone(limit)
+        self.assertEqual(limit.expression.sql(), "1 / 10")
+        self.assertEqual(expression.args["offset"].expression.sql(), "5")
+        self.assertTrue(limit.args["limit_options"].args["percent"])
+
+    def test_tablesample_percent_parses_without_modulo(self):
+        table = parse_one(
+            "SELECT * FROM tbl TABLESAMPLE RESERVOIR (20%)",
+            read="duckdb",
+        ).find(exp.Table)
+        sample = table.args["sample"]
+
+        self.assertIsNotNone(sample)
+        self.assertEqual(sample.args["percent"].sql(), "20")
+        self.assertIsNone(sample.args["size"])
+
     def test_select(self):
         self.assertIsNotNone(parse_one("select 1 natural"))
         self.assertIsNotNone(parse_one("select * from (select 1) x order by x.y").args["order"])


### PR DESCRIPTION
**Problem**
`%` had the wrong precedence — grouped with `+/- `instead of `*//`. `10 % 3 / 2` parsed as `10 % (3/2)` instead of `(10 % 3) / 2`, diverging from every SQL engine.

**Fix**
Moved `MOD` from the `TERM` tier to the `FACTOR` tier in the parser. Added a `parse_mod` flag to preserve `%` as `PERCENT` in `LIMIT x% / TABLESAMPLE (x%)`, and removed the old backtracking hack this replaces.

Verified on 5 engines (DuckDB, Snowflake, Databricks, MySQL, Postgres) + full test suite — no cross-dialect regressions.


Dialect | Command | Result | Matches expected?
-- | -- | -- | --
DuckDB | duckdb -c "SELECT 10 % 3 / 2 AS result, (10 % 3) / 2 AS expected_paren_right, 10 % (3 / 2) AS expected_paren_left;" | result=0.5, expected_paren_right=0.5, expected_paren_left=1.0 | ✅
Snowflake | snow sql -q "SELECT 10 % 3 / 2 AS result, (10 % 3) / 2 AS expected_paren_right, 10 % (3 / 2) AS expected_paren_left;" | result=0.500000, expected_paren_right=0.500000, expected_paren_left=1.000000 | ✅
Databricks | SELECT 10 % 3 / 2 AS mod_then_div, (10 % 3) / 2 AS expected_left_to_right, 10 % (3 / 2) AS wrong_old_behavior, 10 / 2 % 3 AS div_then_mod, 2 * 5 % 3 + 1 AS mul_mod_add, 7200 % 3600 / 60 AS dbt_time_worked_case; (run by user in Databricks SQL) | mod_then_div=0.5, expected_left_to_right=0.5, wrong_old_behavior=1, div_then_mod=2, mul_mod_add=2, dbt_time_worked_case=0 | ✅
MySQL | mysql -e "SELECT 10 % 3 / 2 AS mod_then_div, (10 % 3) / 2 AS expect_left, 10 % (3 / 2) AS wrong_old;" | mod_then_div=0.5000, expect_left=0.5000, wrong_old=1.0000 | ✅
Postgres | psql -c "SELECT 10.0 % 3 / 2 AS mod_then_div, (10.0 % 3) / 2 AS expect_left, 10.0 % (3.0 / 2) AS wrong_old;" (decimal literals used — integer %// truncate to 0 and mask the precedence difference) | mod_then_div=0.50000000000000000000, expect_left=0.50000000000000000000, wrong_old=1.0000000000000000 | ✅

All 5 engines confirm % binds at the same precedence as *// (left-to-right), consistent with the fix. No engine tested reproduces the old (broken) 10 % (3 / 2) grouping.


Suite | Command | Result
-- | -- | --
Parser unit tests | python -m unittest tests.test_parser (incl. new test_mod_precedence, test_limit_percent_parses_without_modulo, test_tablesample_percent_parses_without_modulo) | 70 passed, 99 subtests
Full unit suite | python -m pytest tests/ -q | 1241 passed, 19344 subtests
Integration submodule (all dialects) | pytest tests/sqlglot/ in sqlglot-integration-tests | 137 passed, 619 subtests (incl. new tests in test_redshift.py, test_databricks.py, test_snowflake.py, test_duckdb.py)
Lint / format | ruff check sqlglot/parser.py, ruff format --check sqlglot/parser.py | Clean
Type check | sqlglot-mypy sqlglot/parser.py | No issues

**Cross-dialect impact check**
Verified no dialect subclass overrides the TERM/FACTOR precedence tables (grep -rn "TERM\|FACTOR" sqlglot/dialects/*.py) — confirming the fix applies uniformly across all 34 dialects with no dialect-specific regressions.