### PR TITLE
fix(dialect): fall back on TokenError when an operand isn't a JSON path

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1176,9 +1176,6 @@ class Dialect(metaclass=_Dialect):
             try:
                 return parse_json_path(path_text, self)
             except (ParseError, TokenError) as e:
-                # A JSON path tokenization failure (e.g. an operand that is a plain string
-                # literal rather than a path) raises TokenError, which is a sibling of
-                # ParseError under SqlglotError. Both must fall back to the literal operand.
                 if self.STRICT_JSON_PATH_SYNTAX and not path_text.lstrip().startswith(
                     ("lax", "strict")
                 ):

--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -12,7 +12,7 @@ from builtins import type as Type
 
 from sqlglot import exp
 from sqlglot.dialects import DIALECT_MODULE_NAMES
-from sqlglot.errors import ParseError
+from sqlglot.errors import ParseError, TokenError
 from sqlglot.generator import Generator, unsupported_args
 from sqlglot.expressions import apply_index_offset
 from sqlglot.helper import (
@@ -1175,7 +1175,10 @@ class Dialect(metaclass=_Dialect):
                 path_text = f"[{path_text}]"
             try:
                 return parse_json_path(path_text, self)
-            except ParseError as e:
+            except (ParseError, TokenError) as e:
+                # A JSON path tokenization failure (e.g. an operand that is a plain string
+                # literal rather than a path) raises TokenError, which is a sibling of
+                # ParseError under SqlglotError. Both must fall back to the literal operand.
                 if self.STRICT_JSON_PATH_SYNTAX and not path_text.lstrip().startswith(
                     ("lax", "strict")
                 ):

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -568,6 +568,9 @@ class TestDuckDB(Validator):
             "SELECT * FROM t1 WHERE NOT EXISTS(SELECT * FROM t2 WHERE t2.id = t1.id)",
         )
         self.validate_identity("x -> '$.family'")
+        # A JSON key that isn't a path is a plain literal operand; the apostrophe must not
+        # abort tokenization (STRICT_JSON_PATH_SYNTAX is relaxed for duckdb)
+        self.validate_identity("SELECT a -> 'it''s' FROM t")
         self.validate_identity("CREATE TABLE color (name ENUM('RED', 'GREEN', 'BLUE'))")
         self.validate_identity("SELECT * FROM foo WHERE bar > $baz AND bla = $bob")
         self.validate_identity("SUMMARIZE tbl").assert_is(exp.Summarize)

--- a/tests/dialects/test_duckdb.py
+++ b/tests/dialects/test_duckdb.py
@@ -568,9 +568,8 @@ class TestDuckDB(Validator):
             "SELECT * FROM t1 WHERE NOT EXISTS(SELECT * FROM t2 WHERE t2.id = t1.id)",
         )
         self.validate_identity("x -> '$.family'")
-        # A JSON key that isn't a path is a plain literal operand; the apostrophe must not
-        # abort tokenization (STRICT_JSON_PATH_SYNTAX is relaxed for duckdb)
         self.validate_identity("SELECT a -> 'it''s' FROM t")
+        self.validate_identity("SELECT a ->> 'it''s' FROM t")
         self.validate_identity("CREATE TABLE color (name ENUM('RED', 'GREEN', 'BLUE'))")
         self.validate_identity("SELECT * FROM foo WHERE bar > $baz AND bla = $bob")
         self.validate_identity("SUMMARIZE tbl").assert_is(exp.Summarize)

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -58,9 +58,11 @@ class TestSQLite(Validator):
         self.validate_identity("SELECT JSON_EXTRACT(a, '$.k') FROM t")
         self.validate_identity("SELECT a -> '$.k' FROM t")
         self.validate_identity("SELECT a ->> '$.k' FROM t")
-        # A JSON key that isn't a path is a plain literal operand; the apostrophe must not
-        # abort tokenization of the surrounding statement
-        self.validate_identity("SELECT a -> 'it''s' FROM t")
+        with self.assertLogs(helper_logger, level="WARNING") as logs:
+            self.validate_identity("SELECT a -> 'it''s' FROM t")
+            self.validate_identity("SELECT a ->> 'it''s' FROM t")
+            self.assertEqual(len(logs.output), 2)
+            self.assertTrue(all("Invalid JSON path syntax" in message for message in logs.output))
         self.validate_identity("SELECT JSON_SET('{}', '$.x', JSON_EXTRACT(a, '$.k'))")
         self.validate_identity("SELECT JSON_EXTRACT(a, '$') FROM t")
         self.validate_identity("SELECT JSON_EXTRACT(a, b) FROM t")

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -58,6 +58,9 @@ class TestSQLite(Validator):
         self.validate_identity("SELECT JSON_EXTRACT(a, '$.k') FROM t")
         self.validate_identity("SELECT a -> '$.k' FROM t")
         self.validate_identity("SELECT a ->> '$.k' FROM t")
+        # A JSON key that isn't a path is a plain literal operand; the apostrophe must not
+        # abort tokenization of the surrounding statement
+        self.validate_identity("SELECT a -> 'it''s' FROM t")
         self.validate_identity("SELECT JSON_SET('{}', '$.x', JSON_EXTRACT(a, '$.k'))")
         self.validate_identity("SELECT JSON_EXTRACT(a, '$') FROM t")
         self.validate_identity("SELECT JSON_EXTRACT(a, b) FROM t")


### PR DESCRIPTION
A `->` / `->>` operand that is a plain string literal rather than a JSON path (e.g. a key containing an apostrophe) raises `TokenError` from the JSON path tokenizer. `TokenError` is a sibling of `ParseError` under `SqlglotError`, so it escaped the `to_json_path` fallback and aborted the whole parse instead of leaving the literal operand in place — even for duckdb/sqlite, which relax `STRICT_JSON_PATH_SYNTAX` precisely for this.

```python
sqlglot.parse_one("SELECT a -> 'it''s' FROM t", read="duckdb")  # TokenError on main
```

Widen the except to cover both. Fixes #8249.
