### PR TITLE
fix(snowflake): parse qualified wildcard in OBJECT_CONSTRUCT_KEEP_NULL

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -8411,6 +8411,16 @@ class Parser:
 
     def _parse_json_object(self, agg=False):
         star = self._parse_star()
+        if not star:
+            # Snowflake's OBJECT_CONSTRUCT[_KEEP_NULL] allows the wildcard to be qualified,
+            # e.g. OBJECT_CONSTRUCT_KEEP_NULL(t.*)
+            index = self._index
+            this = self._parse_column()
+            if this and this.is_star:
+                star = this
+            else:
+                self._retreat(index)
+
         expressions = (
             [star]
             if star

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -791,6 +791,8 @@ class TestSnowflake(Validator):
         )
         self.validate_identity("INITCAP('iqamqinterestedqinqthisqtopic', 'q')")
         self.validate_identity("OBJECT_CONSTRUCT(*)")
+        self.validate_identity("SELECT OBJECT_CONSTRUCT_KEEP_NULL(t.*) FROM tbl AS t")
+        self.validate_identity("SELECT OBJECT_CONSTRUCT_KEEP_NULL(t.* ILIKE 'col1%') FROM tbl AS t")
         self.validate_identity("SELECT CAST('2021-01-01' AS DATE) + INTERVAL '1 DAY'")
         self.validate_identity("SELECT HLL(*)")
         self.validate_identity("SELECT HLL(a)")


### PR DESCRIPTION
Fixes #8262

`OBJECT_CONSTRUCT_KEEP_NULL(t.*)` raised a `ParseError` while `OBJECT_CONSTRUCT(t.*)` parses fine. `_parse_json_object` only recognized a bare `*`, so a qualified wildcard fell through to key-value parsing. Now it accepts a qualified star (`t.*`, incl. the `ILIKE`/`EXCLUDE` filter forms), matching Snowflake's documented behavior. Round-trips via the existing `JSONObject` generator. Added regression tests.
