### PR TITLE
fix(generator): make base of single-argument LOG explicit for natural-log dialects

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -4622,6 +4622,11 @@ class Generator:
         this = expression.this
         expr = expression.expression
 
+        if expr is None and self.dialect.parser_class.LOG_DEFAULTS_TO_LN:
+            # A single-argument LOG is the base-10 logarithm, but the target dialect reads
+            # LOG(x) as the natural logarithm, so the base must be made explicit.
+            this, expr = exp.Literal.number(10), this
+
         if self.dialect.LOG_BASE_FIRST is False:
             this, expr = expr, this
         elif self.dialect.LOG_BASE_FIRST is None and expr:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -3248,6 +3248,21 @@ SELECT
                 "sqlite": "LOG(x)",
                 "teradata": "LOG(x)",
             },
+            # A single-argument LOG is base 10, so it must not be emitted as a bare LOG(x) for
+            # dialects that read that as the natural logarithm (LOG_DEFAULTS_TO_LN).
+            write={
+                "duckdb": "LOG(x)",
+                "postgres": "LOG(x)",
+                "bigquery": "LOG(x, 10)",
+                "clickhouse": "LOG10(x)",
+                "databricks": "LOG(10, x)",
+                "dremio": "LOG(10, x)",
+                "drill": "LOG(10, x)",
+                "hive": "LOG(10, x)",
+                "mysql": "LOG(10, x)",
+                "spark": "LOG(10, x)",
+                "tsql": "LOG(x, 10)",
+            },
         )
         self.validate_all(
             "LN(x)",


### PR DESCRIPTION
A single-argument `LOG(x)` is the base-10 logarithm (Postgres/DuckDB/Redshift/SQLite/…), and sqlglot parses it to `exp.Log(this=x)` accordingly. When transpiling to a dialect where `LOG_DEFAULTS_TO_LN` is set (mysql, tsql, bigquery, hive, spark, clickhouse, …), the generator emitted a bare `LOG(x)`, which those dialects read as the **natural** log — silently changing the base.

```
transpile("SELECT LOG(x)", read="postgres", write="mysql")
# before: SELECT LOG(x)      -- MySQL reads this as LN(x)
# after:  SELECT LOG(10, x)
```

Fix: when the target dialect reads `LOG(x)` as the natural log, make the base-10 explicit; the existing base-order / `LOG2`/`LOG10` logic then renders the right form per dialect (`LOG(x, 10)` for tsql/bigquery, `LOG10(x)` for clickhouse, etc.). Added coverage to `test_logarithm`.
