### PR TITLE
fix(sqlite): preserve explicit end bound in RANGE CURRENT ROW window frames [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -373,7 +373,7 @@ class SQLiteGenerator(generator.Generator):
         if (
             expression.text("kind").upper() == "RANGE"
             and expression.text("start").upper() == "CURRENT ROW"
-            and not expression.text("end")
+            and expression.args.get("end") is None
         ):
             return "RANGE CURRENT ROW"
 

--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -373,6 +373,7 @@ class SQLiteGenerator(generator.Generator):
         if (
             expression.text("kind").upper() == "RANGE"
             and expression.text("start").upper() == "CURRENT ROW"
+            and not expression.text("end")
         ):
             return "RANGE CURRENT ROW"
 

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -31,6 +31,9 @@ class TestSQLite(Validator):
         self.validate_identity(
             "SELECT RANK() OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM tbl"
         )
+        self.validate_identity(
+            "SELECT RANK() OVER (ORDER BY x RANGE BETWEEN CURRENT ROW AND 1 + 1 FOLLOWING) FROM tbl"
+        )
         self.validate_identity("UNHEX(a, b)")
         self.validate_identity("SELECT DATE()")
         self.validate_identity("SELECT DATE('now', 'start of month', '+1 month', '-1 day')")

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -25,6 +25,12 @@ class TestSQLite(Validator):
         self.validate_identity("SELECT rowid FROM t1 WHERE t1 MATCH 'lorem'")
         self.validate_identity("SELECT * FROM t WHERE a REGEXP 'x'")
         self.validate_identity("SELECT RANK() OVER (RANGE CURRENT ROW) FROM tbl")
+        self.validate_identity(
+            "SELECT RANK() OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM tbl"
+        )
+        self.validate_identity(
+            "SELECT RANK() OVER (RANGE BETWEEN CURRENT ROW AND CURRENT ROW) FROM tbl"
+        )
         self.validate_identity("UNHEX(a, b)")
         self.validate_identity("SELECT DATE()")
         self.validate_identity("SELECT DATE('now', 'start of month', '+1 month', '-1 day')")


### PR DESCRIPTION
## Root cause

`SQLiteGenerator.windowspec_sql` (`sqlglot/generators/sqlite.py`) collapses any `RANGE` frame starting at `CURRENT ROW` down to the short form `RANGE CURRENT ROW`, without checking whether the frame has an explicit end bound. `RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING` therefore transpiles to `RANGE CURRENT ROW`, which is a different frame: it changes an aggregate's result set, not just its formatting.

The original fix (`9b529b744`, "Fix(sqlite): support `RANGE CURRENT ROW` in window spec") only intended to cover the no-end-bound case; its own regression test is `RANGE CURRENT ROW` with nothing else. The guard never checks `expression.text("end")` before returning the short form.

## Fix

Add `and not expression.text("end")` to the guard, so the short form is only emitted when no end bound was specified. When an end bound is present (even an explicit `CURRENT ROW`), the frame now renders through the normal `windowspec_sql` path unchanged.

## Verification

- `sqlglot.transpile("SELECT RANK() OVER (RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) FROM tbl", read="sqlite", write="sqlite")` returns the collapsed, wrong output on `main` (confirmed on HEAD `bac1a897b`) and the unmodified input on this branch, same Docker image both sides.
- Confirmed the semantic difference against real `sqlite3`: `RANGE CURRENT ROW` and `RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING` produce different `SUM(...) OVER (...)` results on the same data.
- Added two `validate_identity` cases to `tests/dialects/test_sqlite.py` (explicit `UNBOUNDED FOLLOWING` end, and explicit `CURRENT ROW` end); both fail on `main` and pass on this branch. Full `tests/dialects` suite (716 tests) passes on Python 3.9 and 3.14, the two ends of the CI matrix.
- `ruff check` / `ruff format --check` on the two changed files: findings are byte-identical between `main` and this branch (all pre-existing), so nothing new. Not verified: the full `mypy sqlglot tests` run and `make testc` (mypyc build); ran `mypy` on the changed file only, which is clean.

Fixes #8209
