### PR TITLE
feat(trino): support DENY statements [CLAUDE]

### DIFF
--- a/sqlglot/dialects/trino.py
+++ b/sqlglot/dialects/trino.py
@@ -16,6 +16,7 @@ class Trino(Presto):
             **Presto.Tokenizer.KEYWORDS,
             "REFRESH": TokenType.REFRESH,
             "DECLARE": TokenType.DECLARE,
+            "DENY": TokenType.DENY,
         }
         # Trino has no `SQL SECURITY` clause, only bare `SECURITY DEFINER`/`INVOKER`;
         # the merged base keyword otherwise eats the `SQL` in `LANGUAGE SQL SECURITY DEFINER`.

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -620,6 +620,15 @@ class Revoke(Expression):
     arg_types = {**Grant.arg_types, "cascade": False}
 
 
+class Deny(Expression):
+    arg_types = {
+        "privileges": True,
+        "kind": False,
+        "securable": True,
+        "principals": True,
+    }
+
+
 class Group(Expression):
     arg_types = {
         "expressions": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -5777,7 +5777,7 @@ class Generator:
 
     def _grant_or_revoke_sql(
         self,
-        expression: exp.Grant | exp.Revoke,
+        expression: exp.Grant | exp.Revoke | exp.Deny,
         keyword: str,
         preposition: str,
         grant_option_prefix: str = "",
@@ -5809,6 +5809,9 @@ class Generator:
             preposition="TO",
             grant_option_suffix=" WITH GRANT OPTION",
         )
+
+    def deny_sql(self, expression: exp.Deny) -> str:
+        return self._grant_or_revoke_sql(expression, keyword="DENY", preposition="TO")
 
     def revoke_sql(self, expression: exp.Revoke) -> str:
         return self._grant_or_revoke_sql(

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1168,6 +1168,7 @@ class Parser:
         TokenType.DESCRIBE: lambda self: self._parse_describe(),
         TokenType.DROP: lambda self: self._parse_drop(),
         TokenType.GRANT: lambda self: self._parse_grant(),
+        TokenType.DENY: lambda self: self._parse_deny(),
         TokenType.REVOKE: lambda self: self._parse_revoke(),
         TokenType.INSERT: lambda self: self._parse_insert(),
         TokenType.KILL: lambda self: self._parse_kill(),
@@ -10097,6 +10098,28 @@ class Parser:
                 securable=securable,
                 principals=principals,
                 grant_option=grant_option,
+            )
+        )
+
+    def _parse_deny(self) -> exp.Deny | exp.Command:
+        start = self._prev
+
+        privileges, kind, securable = self._parse_grant_revoke_common()
+
+        if not securable or not self._match_text_seq("TO"):
+            return self._parse_as_command(start)
+
+        principals = self._parse_csv(self._parse_grant_principal)
+
+        if self._curr:
+            return self._parse_as_command(start)
+
+        return self.expression(
+            exp.Deny(
+                privileges=privileges,
+                kind=kind,
+                securable=securable,
+                principals=principals,
             )
         )
 

--- a/sqlglot/tokenizer_core.py
+++ b/sqlglot/tokenizer_core.py
@@ -276,6 +276,7 @@ class TokenType(IntEnum):
     DECLARE = auto()
     DEFAULT = auto()
     DELETE = auto()
+    DENY = auto()
     DESC = auto()
     DESCRIBE = auto()
     DETACH = auto()

--- a/tests/dialects/test_trino.py
+++ b/tests/dialects/test_trino.py
@@ -7,6 +7,12 @@ class TestTrino(Validator):
     dialect = "trino"
 
     def test_trino(self):
+        self.validate_identity("DENY SELECT ON TABLE tbl TO bob")
+        self.validate_identity("DENY SELECT, INSERT ON TABLE tbl TO bob")
+        self.validate_identity("DENY ALL PRIVILEGES ON TABLE tbl TO bob")
+        self.validate_identity("DENY SELECT ON orders TO ROLE PUBLIC")
+        self.validate_identity("DENY DELETE ON SCHEMA finance TO bob")
+        self.validate_identity("DENY SELECT ON TABLE tbl TO bob, ROLE analyst")
         self.validate_identity("REFRESH MATERIALIZED VIEW mynamespace.test_view")
         self.validate_identity("JSON_QUERY(m.properties, 'lax $.area' OMIT QUOTES NULL ON ERROR)")
         self.validate_identity("JSON_EXTRACT(content, json_path)")


### PR DESCRIPTION
Add support for Trino's [DENY](https://trino.io/docs/current/sql/deny.html) statement. The statement syntax mirrors `GRANT` statements, minus the `WITH GRANT OPTION` clause. Currently, parsing a `DENY` statement results in a `ParseError` rather than falling back to parsing as a `Command`.

Only `Trino.Tokenizer` maps the `DENY` keyword; the expression, parser and generator are shared, following the same pattern as `REFRESH`. `deny` still parses as a bare identifier in every other dialect.

`DENY` statements with an `ON BRANCH branch_name IN` clause fall back to parsing as a `Command`, which is consistent with how `GRANT` statements with that clause currently parse.