### PR TITLE
fix(optimizer): don't push a WHERE predicate into the FROM source of a FULL JOIN [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -51,6 +51,14 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
                 selected_sources: Sources = scope.selected_sources
                 join_index = {join.alias_or_name: i for i, join in enumerate(joins)}
 
+                # a full join preserves the source FROM table, so it can't be filtered before it
+                if any(join.side == "FULL" for join in joins):
+                    selected_sources = {
+                        name: (node, source)
+                        for name, (node, source) in selected_sources.items()
+                        if not isinstance(node.find_ancestor(exp.Join, exp.From), exp.From)
+                    }
+
                 # a right join can only push down to itself and not the source FROM table
                 # presto, trino and athena don't support inner joins where the RHS is an UNNEST expression
                 pushdown_allowed = True

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -111,3 +111,6 @@ SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3
 -- A FULL JOIN preserves both sides, so a WHERE predicate on either of them can't be pushed down
 SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
 SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
+
+SELECT x.a, y.b FROM (SELECT a FROM x) AS x FULL JOIN y ON x.a = y.b WHERE x.a = 3;
+SELECT x.a, y.b FROM (SELECT a FROM x) AS x FULL JOIN y ON x.a = y.b WHERE x.a = 3;


### PR DESCRIPTION
`optimize()` changes the result of a query when the select has a FULL JOIN and a WHERE predicate on the FROM-side table.

```sql
SELECT x.a FROM x FULL JOIN y ON x.b = y.b WHERE x.a = 1
```

optimizes to

```sql
WITH "x_2" AS (
  SELECT "x"."a" AS "a", "x"."b" AS "b" FROM "x" AS "x" WHERE "x"."a" = 1
)
SELECT "x"."a" AS "a" FROM "x_2" AS "x" FULL JOIN "y" AS "y" ON "x"."b" = "y"."b"
```

Filtering `x` before the join leaves more `y` rows unmatched, the full join null-extends them, and there is no longer an outer WHERE to drop them. Running both against duckdb on a 9-row `x` and a 7-row `y`, the original returns 3 rows and the optimized one returns 7, the extra 4 being NULLs.

The ON-clause loop further down already skips `join.side in ("RIGHT", "FULL")`, and `nodes_for_predicate` already refuses to push into a FULL join's own source. The FROM source is the gap: it reaches the pushdown as an `exp.From` and never gets checked against the join side. `pushdown_predicates.sql` line 111 already states the invariant, "a WHERE predicate on either of them can't be pushed down", but only the right half of it is tested.

So I drop the FROM source from `selected_sources` when the select has a FULL join. Predicates can still be pushed into a later inner join's ON clause, which is legal since ON and WHERE are equivalent there. The "complex CTE dependencies" case in `optimizer.sql` covers that and is unchanged. My first attempt blocked all pushdown when a FULL join was present and it broke that fixture, which is what pointed me at the narrower rule.

I found this by generating 855 queries over the `x`/`y`/`z`/`u` schema `test_optimizer` uses, then executing each query and its optimized form against duckdb and diffing the rows. 45 pairs disagreed, 39 of them this bug. The 6 that remain after the fix are 5 queries with LIMIT and no total ORDER BY, so the row choice is arbitrary, plus one unrelated `unnest_subqueries` problem where `COALESCE` gets an aliased argument and duckdb rejects the SQL. I left that one alone.

`SKIP_INTEGRATION=1 python -m unittest` gives the same result on this branch as on main for me (3 errors, all from optional deps missing in my env).

I used an LLM for the fuzzing harness and to draft this description. The change is small enough that I checked it by hand, and I ran the before and after myself.
