### PR TITLE
fix(optimizer): don't push WHERE predicates into sources a later RIGHT or FULL join null-extends [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -51,18 +51,31 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
                 selected_sources: Sources = scope.selected_sources
                 join_index = {join.alias_or_name: i for i, join in enumerate(joins)}
 
-                # a right join can only push down to itself and not the source FROM table
+                # A RIGHT or FULL join null-extends everything joined before it, and the
+                # outer predicate is what removed those rows, so a source can only be
+                # pushed into if no such join comes after it.
+                last_null_extending = -1
+                for i, join in enumerate(joins):
+                    if join.side in ("RIGHT", "FULL"):
+                        last_null_extending = i
+
                 # presto, trino and athena don't support inner joins where the RHS is an UNNEST expression
                 pushdown_allowed = True
+                reachable: dict[str, tuple[exp.Selectable, t.Union[exp.Table, Scope]]] = {}
                 for k, (node, source) in selected_sources.items():
                     parent = node.find_ancestor(exp.Join, exp.From)
                     if isinstance(parent, exp.Join):
-                        if parent.side == "RIGHT":
-                            selected_sources = {k: (node, source)}
-                            break
                         if isinstance(node, exp.Unnest) and unnest_requires_cross_join:
                             pushdown_allowed = False
                             break
+                        position = join_index.get(parent.alias_or_name, -1)
+                    else:
+                        position = -1
+
+                    if position >= last_null_extending:
+                        reachable[k] = (node, source)
+
+                selected_sources = reachable
 
                 if pushdown_allowed:
                     pushdown(where.this, selected_sources, scope_ref_count, dialect, join_index)

--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -61,7 +61,7 @@ def pushdown_predicates(expression: E, dialect: DialectType = None) -> E:
 
                 # presto, trino and athena don't support inner joins where the RHS is an UNNEST expression
                 pushdown_allowed = True
-                reachable: dict[str, tuple[exp.Selectable, t.Union[exp.Table, Scope]]] = {}
+                reachable: dict[str, tuple[exp.Selectable, exp.Table | Scope]] = {}
                 for k, (node, source) in selected_sources.items():
                     parent = node.find_ancestor(exp.Join, exp.From)
                     if isinstance(parent, exp.Join):

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -111,3 +111,14 @@ SELECT x.a, y.b FROM x FULL JOIN (SELECT b FROM y) AS y ON x.a = y.b AND y.b = 3
 -- A FULL JOIN preserves both sides, so a WHERE predicate on either of them can't be pushed down
 SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
 SELECT x.a, y.b FROM x FULL JOIN y ON x.a = y.b WHERE y.b = 3;
+
+-- That covers anything joined before the FULL JOIN too, not just the FROM source
+SELECT x.a, z.b FROM x JOIN z ON x.b = z.b FULL JOIN y ON x.b = y.b WHERE z.b = 3;
+SELECT x.a, z.b FROM x JOIN z ON x.b = z.b FULL JOIN y ON x.b = y.b WHERE z.b = 3;
+
+SELECT x.a, z.b FROM x JOIN (SELECT b FROM z) AS z ON x.b = z.b FULL JOIN y ON x.b = y.b WHERE z.b = 3;
+SELECT x.a, z.b FROM x JOIN (SELECT b FROM z) AS z ON x.b = z.b FULL JOIN y ON x.b = y.b WHERE z.b = 3;
+
+-- A later RIGHT JOIN null-extends the source of an earlier one
+SELECT x.a, z.b FROM x RIGHT JOIN z ON x.b = z.b RIGHT JOIN y ON x.b = y.b WHERE z.b = 3;
+SELECT x.a, z.b FROM x RIGHT JOIN z ON x.b = z.b RIGHT JOIN y ON x.b = y.b WHERE z.b = 3;


### PR DESCRIPTION
Follow-up to #8278, which you closed because it only handled the direct FROM source. You were right, and it turned out there was a second case in the same area, so this replaces the special case for RIGHT joins with one rule that covers both.

A RIGHT or FULL join null-extends everything joined before it. Pushing a WHERE predicate into one of those sources also removes the outer predicate, and the outer predicate is exactly what discarded the null-extended rows. So a source can only be pushed into if no RIGHT or FULL join comes after it.

That is what the existing RIGHT join special case was doing, but it stopped at the first RIGHT join it found and it did not consider FULL joins at all.

Two shapes are wrong today. A source joined before a FULL JOIN:

```sql
SELECT x.a, z.b FROM x JOIN z ON x.b = z.b FULL JOIN y ON x.b = y.b WHERE z.b = 3
-- becomes ... JOIN z ON x.b = z.b AND z.b = 3 FULL JOIN y ... WHERE TRUE
```

and the source of a RIGHT join that a later RIGHT join null-extends:

```sql
SELECT x.a, z.b FROM x RIGHT JOIN z ON x.b = z.b RIGHT JOIN y ON x.b = y.b WHERE z.b = 3
```

I found these by executing every two-join shape and its optimized form against duckdb and diffing the rows. 48 shapes over the four join types with a predicate on each of the three sources: 7 disagreed before, 0 after. The one from #8278 is in there, and so are the ones it missed.

`tests/test_optimizer.py` passes with 4528 subtests, and the full suite is 1243 passed / 19375 subtests, with one pre-existing failure in `test_lazy_load` that also fails on a clean tree here because it shells out to `python`. Two of the three new fixture cases fail without the change.

I used Claude to build the duckdb differential harness and to write the patch. I ran everything above myself and I am happy to explain any of it.
