### PR TITLE
fix(postgres): preserve quoting of the one-byte "char" type [CLAUDE]

### DIFF
--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1943,6 +1943,11 @@ class Parser:
     # e.g. NTH_VALUE(x, 2) FROM LAST IGNORE NULLS OVER (...) (Oracle, Snowflake)
     SUPPORTS_NTH_VALUE_FROM_MODIFIER: t.ClassVar = False
 
+    # Type names that denote a different type when they're quoted, so quoting has to be
+    # preserved instead of resolving them into the built-in type of the same name. These
+    # are matched case sensitively, e.g. PostgreSQL's one-byte "char" is not CHAR
+    QUOTED_TYPES_TO_PRESERVE: t.ClassVar[set[str]] = set()
+
     SHOW_TRIE: t.ClassVar[dict] = new_trie(key.split(" ") for key in SHOW_PARSERS)
     SET_TRIE: t.ClassVar[dict] = new_trie(key.split(" ") for key in SET_PARSERS)
 
@@ -6504,19 +6509,26 @@ class Parser:
                 any_token=False, tokens=(TokenType.VAR,)
             )
             if isinstance(identifier, exp.Identifier):
-                try:
-                    tokens = self.dialect.tokenize(identifier.name)
-                except TokenError:
-                    tokens = None
-
-                if tokens and (type_token := tokens[0].token_type) in self.TYPE_TOKENS:
-                    if len(tokens) > 1:
-                        return exp.DataType.from_str(identifier.name, dialect=self.dialect)
-                elif self.dialect.SUPPORTS_USER_DEFINED_TYPES:
-                    this = self._parse_user_defined_type(identifier)
+                if (
+                    identifier.quoted
+                    and self.dialect.SUPPORTS_USER_DEFINED_TYPES
+                    and identifier.name in self.QUOTED_TYPES_TO_PRESERVE
+                ):
+                    this = exp.DataType.build(identifier, udt=True)
                 else:
-                    self._retreat(self._index - 1)
-                    return None
+                    try:
+                        tokens = self.dialect.tokenize(identifier.name)
+                    except TokenError:
+                        tokens = None
+
+                    if tokens and (type_token := tokens[0].token_type) in self.TYPE_TOKENS:
+                        if len(tokens) > 1:
+                            return exp.DataType.from_str(identifier.name, dialect=self.dialect)
+                    elif self.dialect.SUPPORTS_USER_DEFINED_TYPES:
+                        this = self._parse_user_defined_type(identifier)
+                    else:
+                        self._retreat(self._index - 1)
+                        return None
             else:
                 return None
 

--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -86,6 +86,10 @@ def _build_levenshtein_less_equal(args: list) -> exp.Levenshtein:
 class PostgresParser(parser.Parser):
     SUPPORTS_OMITTED_INTERVAL_SPAN_UNIT = True
 
+    # The one-byte "char" type is distinct from CHAR, and it can only be referenced by
+    # quoting it: https://www.postgresql.org/docs/current/datatype-character.html
+    QUOTED_TYPES_TO_PRESERVE: t.ClassVar = {"char"}
+
     PROPERTY_PARSERS = {
         **{k: v for k, v in parser.Parser.PROPERTY_PARSERS.items() if k != "INPUT"},
         "SET": lambda self: self.expression(exp.SetConfigProperty(this=self._parse_set())),

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -978,6 +978,16 @@ FROM json_data, field_ids""",
         self.validate_identity(
             '1::"udt"', 'CAST(1 AS "udt")'
         ).to.this == exp.DataType.Type.USERDEFINED
+
+        # The one-byte "char" type is not CHAR, so its quotes have to be preserved
+        self.validate_identity('CAST(65 AS "char")')
+        self.validate_identity('65::"char"', 'CAST(65 AS "char")')
+        self.validate_identity('CAST(x AS "char"[])')
+        self.validate_identity('CAST(x AS "CHAR")', "CAST(x AS CHAR)")
+        self.assertEqual(
+            self.parse_one('CAST(65 AS "char")').to.this, exp.DataType.Type.USERDEFINED
+        )
+
         self.validate_identity(
             "COPY tbl (col1, col2) FROM 'file' WITH (FORMAT format, HEADER MATCH, FREEZE TRUE)"
         )


### PR DESCRIPTION
Fixes #8280

PostgreSQL's "char" is a one-byte type that is distinct from CHAR/bpchar, and
quoting is the only way to name it. sqlglot was dropping the quotes and emitting
CAST(x AS CHAR), which answers the same cast with a different value.

Resolving quoted type names is deliberate and tested (1::"int" -> CAST(1 AS INT)),
so I did not change that. Instead I added an opt-in Parser attribute,
QUOTED_TYPES_TO_PRESERVE, that lists type names whose meaning changes when quoted;
Postgres sets it to {"char"}. Matching is case sensitive, since "CHAR" is not the
one-byte type. Such a type is parsed into a USERDEFINED DataType holding the quoted
identifier, which is the same representation already used for 1::"udt".

The check is gated on SUPPORTS_USER_DEFINED_TYPES so Redshift, which inherits the
Postgres parser but has no one-byte "char", keeps its current behaviour.

Tests added in tests/dialects/test_postgres.py cover the cast, the :: form, the
array form, and that "CHAR" still resolves to CHAR.

Disclaimer: I used an LLM while writing this patch. I have reviewed and understand
every line of it and I am happy to answer questions about it.