### PR TITLE
fix(tsql): stop JSON_QUERY/JSON_VALUE doubling on every round-trip [CLAUDE]

### DIFF
--- a/sqlglot/generators/tsql.py
+++ b/sqlglot/generators/tsql.py
@@ -103,7 +103,15 @@ def qualify_derived_table_outputs(expression: exp.Expr) -> exp.Expr:
 def _json_extract_sql(
     self: TSQLGenerator, expression: exp.JSONExtract | exp.JSONExtractScalar
 ) -> str:
+    # JSON_QUERY returns objects and arrays, JSON_VALUE returns scalars, so only a
+    # generic JSONExtract, whose subtype we don't know, needs to try both
+    if isinstance(expression, exp.JSONExtractScalar):
+        return self.func("JSON_VALUE", expression.this, expression.expression)
+
     json_query = self.func("JSON_QUERY", expression.this, expression.expression)
+    if expression.args.get("json_query"):
+        return json_query
+
     json_value = self.func("JSON_VALUE", expression.this, expression.expression)
     return self.func("ISNULL", json_query, json_value)
 

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -306,10 +306,7 @@ def _build_json_query(args: list, dialect: Dialect) -> exp.JSONExtract:
         args.append(exp.Literal.string("$"))
 
     json_extract = parser.build_extract_json_with_path(exp.JSONExtract)(args, dialect)
-
-    # Record that this came from JSON_QUERY, so it can round-trip as JSON_QUERY
     json_extract.set("json_query", True)
-
     return json_extract
 
 

--- a/sqlglot/parsers/tsql.py
+++ b/sqlglot/parsers/tsql.py
@@ -305,7 +305,12 @@ def _build_json_query(args: list, dialect: Dialect) -> exp.JSONExtract:
         # value for path, JSON_QUERY returns the input expression.
         args.append(exp.Literal.string("$"))
 
-    return parser.build_extract_json_with_path(exp.JSONExtract)(args, dialect)
+    json_extract = parser.build_extract_json_with_path(exp.JSONExtract)(args, dialect)
+
+    # Record that this came from JSON_QUERY, so it can round-trip as JSON_QUERY
+    json_extract.set("json_query", True)
+
+    return json_extract
 
 
 def _build_datetrunc(args: list) -> exp.TimestampTrunc:

--- a/tests/dialects/test_dialect.py
+++ b/tests/dialects/test_dialect.py
@@ -1892,7 +1892,7 @@ class TestDialect(Validator):
                 "snowflake": "JSON_EXTRACT_PATH_TEXT(x, 'y')",
                 "spark": "GET_JSON_OBJECT(x, '$.y')",
                 "sqlite": "x ->> '$.y'",
-                "tsql": "ISNULL(JSON_QUERY(x, '$.y'), JSON_VALUE(x, '$.y'))",
+                "tsql": "JSON_VALUE(x, '$.y')",
             },
         )
         self.validate_all(
@@ -1945,7 +1945,7 @@ class TestDialect(Validator):
                 "snowflake": "JSON_EXTRACT_PATH_TEXT(x, 'y[0].z')",
                 "spark": "GET_JSON_OBJECT(x, '$.y[0].z')",
                 "sqlite": "x ->> '$.y[0].z'",
-                "tsql": "ISNULL(JSON_QUERY(x, '$.y[0].z'), JSON_VALUE(x, '$.y[0].z'))",
+                "tsql": "JSON_VALUE(x, '$.y[0].z')",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1559,23 +1559,39 @@ WHERE
         self.validate_all("ISNULL(x, y)", write={"spark": "COALESCE(x, y)"})
 
     def test_json(self):
+        # JSON_QUERY and JSON_VALUE round-trip as themselves. Only an extraction
+        # whose subtype is unknown needs the ISNULL(JSON_QUERY, JSON_VALUE) form,
+        # and that form is itself stable across a round-trip.
+        self.validate_identity("JSON_QUERY(x, '$.a')")
+        self.validate_identity("JSON_VALUE(x, '$.a')")
+        self.validate_identity("ISNULL(JSON_QUERY(x, '$.a'), JSON_VALUE(x, '$.a'))")
+        self.validate_all(
+            "JSON_EXTRACT(x, '$.a')",
+            write={"tsql": "ISNULL(JSON_QUERY(x, '$.a'), JSON_VALUE(x, '$.a'))"},
+        )
+        self.validate_all(
+            "JSON_QUERY(x, '$.a')",
+            read={"tsql": "JSON_QUERY(x, '$.a')"},
+            write={"trino": "JSON_QUERY(x, '$.a')"},
+        )
+
         self.validate_identity(
             """JSON_QUERY(REPLACE(REPLACE(x , '''', '"'), '""', '"'))""",
-            """ISNULL(JSON_QUERY(REPLACE(REPLACE(x, '''', '"'), '""', '"'), '$'), JSON_VALUE(REPLACE(REPLACE(x, '''', '"'), '""', '"'), '$'))""",
+            """JSON_QUERY(REPLACE(REPLACE(x, '''', '"'), '""', '"'), '$')""",
         )
 
         self.validate_all(
             "JSON_QUERY(r.JSON, '$.Attr_INT')",
             write={
                 "spark": "GET_JSON_OBJECT(r.JSON, '$.Attr_INT')",
-                "tsql": "ISNULL(JSON_QUERY(r.JSON, '$.Attr_INT'), JSON_VALUE(r.JSON, '$.Attr_INT'))",
+                "tsql": "JSON_QUERY(r.JSON, '$.Attr_INT')",
             },
         )
         self.validate_all(
             "JSON_VALUE(r.JSON, '$.Attr_INT')",
             write={
                 "spark": "GET_JSON_OBJECT(r.JSON, '$.Attr_INT')",
-                "tsql": "ISNULL(JSON_QUERY(r.JSON, '$.Attr_INT'), JSON_VALUE(r.JSON, '$.Attr_INT'))",
+                "tsql": "JSON_VALUE(r.JSON, '$.Attr_INT')",
             },
         )
 


### PR DESCRIPTION
T-SQL generated both JSONExtract and JSONExtractScalar as
ISNULL(JSON_QUERY(..), JSON_VALUE(..)). Re-reading that output gives two
extractions, each of which expands again, so transpiling valid T-SQL from tsql
to tsql doubles the expression on every pass:

    SELECT JSON_QUERY(x, '$.name')
    pass 1:  63 chars   SELECT ISNULL(JSON_QUERY(x, '$.name'), JSON_VALUE(x, '$.name'))
    pass 2: 129 chars
    pass 3: 261 chars
    pass 4: 525 chars

The ISNULL fallback is only needed when the subtype of the extraction is
unknown. JSON_VALUE returns scalars, so JSONExtractScalar now generates
JSON_VALUE. A JSONExtract parsed from T-SQL's own JSON_QUERY is tagged with the
existing `json_query` arg, the same way Trino tags its JSON_QUERY, and generates
JSON_QUERY. A JSONExtract of unknown subtype keeps the ISNULL form, which is now
itself stable across a round-trip, so all three shapes are fixed points.

I found this with a differential sweep rather than from an issue: parse every
statement in tests/fixtures/identity.sql in 17 dialects, then check that
sql(sql(x)) == sql(x). Rerunning that sweep, tsql goes from 10 non-idempotent
statements to 8 and every other dialect's count is unchanged, so the change is
scoped to these two cases. The remaining 8 have unrelated causes.

Four existing expectations change, all of them the point of the fix:
JSON_QUERY and JSON_VALUE now round-trip as themselves in the tsql tests, and
JSON_EXTRACT_SCALAR -> tsql is now JSON_VALUE rather than the ISNULL pair.

One cross-dialect output changes as a consequence of the `json_query` tag:
tsql JSON_QUERY -> trino is now JSON_QUERY instead of JSON_EXTRACT. That looks
like the more faithful mapping to me, and I have added a test for it, but say
the word if you would rather I kept the tag out of the cross-dialect path and
used a tsql-local marker instead.

Disclaimer: I used an LLM while writing this patch. I have reviewed and
understand every line of it and I am happy to answer questions about it.