### PR TITLE
fix(spark): distinguish GROUPING SETS suffix syntax

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -624,6 +624,7 @@ class Group(Expression):
     arg_types = {
         "expressions": False,
         "grouping_sets": False,
+        "grouping_sets_not_group_by_element": False,
         "cube": False,
         "rollup": False,
         "totals": False,

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -624,7 +624,7 @@ class Group(Expression):
     arg_types = {
         "expressions": False,
         "grouping_sets": False,
-        "grouping_sets_not_group_by_element": False,
+        "grouping_sets_as_group_by_element": False,
         "cube": False,
         "rollup": False,
         "totals": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -353,6 +353,9 @@ class Generator:
     # The separator for grouping sets and rollups
     GROUPINGS_SEP = ","
 
+    # Whether GROUPING SETS can follow GROUP BY expressions without a comma
+    SUPPORTS_GROUPING_SETS_AS_SUFFIX = False
+
     # The string used for creating an index on a table
     INDEX_ON = "ON"
 
@@ -2820,9 +2823,19 @@ class Generator:
             expression.expressions
             and groupings
             and groupings.strip() not in ("WITH CUBE", "WITH ROLLUP")
-            and (not grouping_sets or expression.args.get("grouping_sets_as_group_by_element"))
         ):
-            group_by = f"{group_by}{self.GROUPINGS_SEP}"
+            add_separator = True
+
+            if grouping_sets and not expression.args.get("grouping_sets_as_group_by_element"):
+                if self.SUPPORTS_GROUPING_SETS_AS_SUFFIX:
+                    add_separator = False
+                else:
+                    self.unsupported(
+                        "GROUPING SETS without a comma after GROUP BY expressions is not supported"
+                    )
+
+            if add_separator:
+                group_by += "," if grouping_sets else self.GROUPINGS_SEP
 
         return f"{group_by}{groupings}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2820,6 +2820,7 @@ class Generator:
             expression.expressions
             and groupings
             and groupings.strip() not in ("WITH CUBE", "WITH ROLLUP")
+            and (not grouping_sets or not expression.args.get("grouping_sets_not_group_by_element"))
         ):
             group_by = f"{group_by}{self.GROUPINGS_SEP}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2820,7 +2820,7 @@ class Generator:
             expression.expressions
             and groupings
             and groupings.strip() not in ("WITH CUBE", "WITH ROLLUP")
-            and (not grouping_sets or not expression.args.get("grouping_sets_not_group_by_element"))
+            and (not grouping_sets or expression.args.get("grouping_sets_as_group_by_element"))
         ):
             group_by = f"{group_by}{self.GROUPINGS_SEP}"
 

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2835,7 +2835,7 @@ class Generator:
                     )
 
             if add_separator:
-                group_by += "," if grouping_sets else self.GROUPINGS_SEP
+                group_by = f"{group_by}{self.GROUPINGS_SEP}"
 
         return f"{group_by}{groupings}"
 

--- a/sqlglot/generators/hive.py
+++ b/sqlglot/generators/hive.py
@@ -223,6 +223,7 @@ class HiveGenerator(generator.Generator):
     SELECT_KINDS: tuple[str, ...] = ()
     TRY_SUPPORTED = False
     SUPPORTS_UESCAPE = False
+    SUPPORTS_GROUPING_SETS_AS_SUFFIX = True
     SUPPORTS_DECODE_CASE = False
     LIMIT_FETCH = "LIMIT"
     TABLESAMPLE_WITH_METHOD = False

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5585,6 +5585,9 @@ class Parser:
                     )
                 )
             )
+            grouping_sets_not_group_by_element = (
+                bool(elements["expressions"]) and self._prev.token_type != TokenType.COMMA
+            )
 
             before_with_index = self._index
             with_prefix = self._match(TokenType.WITH)
@@ -5594,6 +5597,9 @@ class Parser:
                 elements[key].append(cube_or_rollup)
             elif grouping_sets := self._parse_grouping_sets():
                 elements["grouping_sets"].append(grouping_sets)
+                elements.setdefault(
+                    "grouping_sets_not_group_by_element", grouping_sets_not_group_by_element
+                )
             elif self._match_text_seq("TOTALS"):
                 elements["totals"] = True  # type: ignore
 

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5585,8 +5585,8 @@ class Parser:
                     )
                 )
             )
-            grouping_sets_not_group_by_element = (
-                bool(elements["expressions"]) and self._prev.token_type != TokenType.COMMA
+            grouping_sets_as_group_by_element = (
+                not elements["expressions"] or self._prev.token_type == TokenType.COMMA
             )
 
             before_with_index = self._index
@@ -5597,8 +5597,9 @@ class Parser:
                 elements[key].append(cube_or_rollup)
             elif grouping_sets := self._parse_grouping_sets():
                 elements["grouping_sets"].append(grouping_sets)
+                # The first GROUPING SETS clause determines the separator from the GROUP BY expressions
                 elements.setdefault(
-                    "grouping_sets_not_group_by_element", grouping_sets_not_group_by_element
+                    "grouping_sets_as_group_by_element", grouping_sets_as_group_by_element
                 )
             elif self._match_text_seq("TOTALS"):
                 elements["totals"] = True  # type: ignore

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5597,10 +5597,9 @@ class Parser:
                 elements[key].append(cube_or_rollup)
             elif grouping_sets := self._parse_grouping_sets():
                 elements["grouping_sets"].append(grouping_sets)
-                # The first GROUPING SETS clause determines the separator from the GROUP BY expressions
-                elements.setdefault(
-                    "grouping_sets_as_group_by_element", grouping_sets_as_group_by_element
-                )
+                elements["grouping_sets_as_group_by_element"] = grouping_sets_as_group_by_element
+                if not grouping_sets_as_group_by_element:
+                    break
             elif self._match_text_seq("TOTALS"):
                 elements["totals"] = True  # type: ignore
 

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -554,10 +554,10 @@ class TestHive(Validator):
             "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, b GROUPING SETS ((a, b), a)"
         )
         self.validate_identity(
-            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, b GROUPING SETS ((t.a, b), a)"
+            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY t.a, b GROUPING SETS ((t.a, b), t.a)"
         )
         self.validate_identity(
-            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, FOO(b) GROUPING SETS ((a, FOO(b)), a)"
+            "SELECT a, ABS(b) AS b, SUM(c) FROM tabl AS t GROUP BY a, ABS(b) GROUPING SETS ((a, ABS(b)), a)"
         )
         self.validate_identity(
             "SELECT key, value, GROUPING__ID, COUNT(*) FROM T1 GROUP BY key, value WITH CUBE"

--- a/tests/dialects/test_hive.py
+++ b/tests/dialects/test_hive.py
@@ -551,13 +551,13 @@ class TestHive(Validator):
             "INSERT OVERWRITE DIRECTORY 'x' ROW FORMAT DELIMITED FIELDS TERMINATED BY '\001' COLLECTION ITEMS TERMINATED BY ',' MAP KEYS TERMINATED BY ':' LINES TERMINATED BY '' STORED AS TEXTFILE SELECT * FROM `a`.`b`"
         )
         self.validate_identity(
-            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, b, GROUPING SETS ((a, b), a)"
+            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, b GROUPING SETS ((a, b), a)"
         )
         self.validate_identity(
-            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, b, GROUPING SETS ((t.a, b), a)"
+            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, b GROUPING SETS ((t.a, b), a)"
         )
         self.validate_identity(
-            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, FOO(b), GROUPING SETS ((a, FOO(b)), a)"
+            "SELECT a, b, SUM(c) FROM tabl AS t GROUP BY a, FOO(b) GROUPING SETS ((a, FOO(b)), a)"
         )
         self.validate_identity(
             "SELECT key, value, GROUPING__ID, COUNT(*) FROM T1 GROUP BY key, value WITH CUBE"
@@ -874,9 +874,9 @@ class TestHive(Validator):
             },
         )
         self.validate_all(
-            "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(b, 'yyyy'), GROUPING SETS ((a, DATE_FORMAT(b, 'yyyy')), a)",
+            "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(b, 'yyyy') GROUPING SETS ((a, DATE_FORMAT(b, 'yyyy')), a)",
             write={
-                "hive": "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(b, 'yyyy'), GROUPING SETS ((a, DATE_FORMAT(b, 'yyyy')), a)",
+                "hive": "SELECT a, SUM(c) FROM t GROUP BY a, DATE_FORMAT(b, 'yyyy') GROUPING SETS ((a, DATE_FORMAT(b, 'yyyy')), a)",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from sqlglot import exp, parse_one
 from sqlglot.dialects.dialect import Dialects
-from sqlglot.errors import ErrorLevel, UnsupportedError
+from sqlglot.errors import ErrorLevel, ParseError, UnsupportedError
 from tests.dialects.test_dialect import Validator
 
 
@@ -1204,44 +1204,32 @@ TBLPROPERTIES (
         for sql, expected_flag in (
             (suffix_sql, False),
             (element_sql, True),
-            ("SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))", False),
+            ("SELECT a FROM t GROUP BY a, GROUPING SETS ((a)), GROUPING SETS ((a))", True),
             ("SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))", True),
         ):
             with self.subTest(sql=sql):
                 group = self.validate_identity(sql).args["group"]
                 self.assertIs(group.args.get("grouping_sets_as_group_by_element"), expected_flag)
 
-        def assert_generation(expression, expected_sql, dialects, unsupported=False):
-            for dialect in dialects:
-                with self.subTest(dialect=dialect):
-                    self.assertEqual(
-                        expression.sql(
-                            dialect,
-                            unsupported_level=(
-                                ErrorLevel.IGNORE if unsupported else ErrorLevel.RAISE
-                            ),
-                        ),
-                        expected_sql,
-                    )
-                    if unsupported:
-                        with self.assertRaises(UnsupportedError):
-                            expression.sql(dialect, unsupported_level=ErrorLevel.RAISE)
+        with self.assertRaises(ParseError):
+            self.parse_one("SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))")
 
         suffix_expression = self.parse_one(suffix_sql)
-        assert_generation(suffix_expression, suffix_sql, ("hive", "spark"))
-        assert_generation(
-            suffix_expression,
-            element_sql,
-            ("trino", "clickhouse"),
-            unsupported=True,
-        )
+        for dialect in ("hive", "spark"):
+            with self.subTest(dialect=dialect):
+                self.assertEqual(
+                    suffix_expression.sql(dialect, unsupported_level=ErrorLevel.RAISE),
+                    suffix_sql,
+                )
 
-        element_expression = self.parse_one(element_sql)
-        assert_generation(
-            element_expression,
-            element_sql,
-            ("hive", "clickhouse"),
-        )
+        for dialect in ("trino", "clickhouse"):
+            with self.subTest(dialect=dialect):
+                self.assertEqual(
+                    suffix_expression.sql(dialect, unsupported_level=ErrorLevel.IGNORE),
+                    element_sql,
+                )
+                with self.assertRaises(UnsupportedError):
+                    suffix_expression.sql(dialect, unsupported_level=ErrorLevel.RAISE)
 
     def test_current_user(self):
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from sqlglot import exp, parse_one
 from sqlglot.dialects.dialect import Dialects
-from sqlglot.errors import UnsupportedError
+from sqlglot.errors import ErrorLevel, UnsupportedError
 from tests.dialects.test_dialect import Validator
 
 
@@ -1198,15 +1198,50 @@ TBLPROPERTIES (
         )
 
     def test_grouping_sets_as_group_by_element(self):
+        suffix_sql = "SELECT COUNT(1), d, h FROM t GROUP BY d, h GROUPING SETS ((d, h), (d))"
+        element_sql = "SELECT COUNT(1), d, h FROM t GROUP BY d, h, GROUPING SETS ((d, h), (d))"
+
         for sql, expected_flag in (
-            ("SELECT COUNT(1), d, h FROM t GROUP BY d, h GROUPING SETS ((d, h), (d))", False),
-            ("SELECT COUNT(1), d, h FROM t GROUP BY d, h, GROUPING SETS ((d, h), (d))", True),
+            (suffix_sql, False),
+            (element_sql, True),
             ("SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))", False),
             ("SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))", True),
         ):
             with self.subTest(sql=sql):
                 group = self.validate_identity(sql).args["group"]
                 self.assertIs(group.args.get("grouping_sets_as_group_by_element"), expected_flag)
+
+        def assert_generation(expression, expected_sql, dialects, unsupported=False):
+            for dialect in dialects:
+                with self.subTest(dialect=dialect):
+                    self.assertEqual(
+                        expression.sql(
+                            dialect,
+                            unsupported_level=(
+                                ErrorLevel.IGNORE if unsupported else ErrorLevel.RAISE
+                            ),
+                        ),
+                        expected_sql,
+                    )
+                    if unsupported:
+                        with self.assertRaises(UnsupportedError):
+                            expression.sql(dialect, unsupported_level=ErrorLevel.RAISE)
+
+        suffix_expression = self.parse_one(suffix_sql)
+        assert_generation(suffix_expression, suffix_sql, ("hive", "spark"))
+        assert_generation(
+            suffix_expression,
+            element_sql,
+            ("trino", "clickhouse"),
+            unsupported=True,
+        )
+
+        element_expression = self.parse_one(element_sql)
+        assert_generation(
+            element_expression,
+            element_sql,
+            ("hive", "clickhouse"),
+        )
 
     def test_current_user(self):
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1197,6 +1197,32 @@ TBLPROPERTIES (
             write={"spark": "SELECT a, BOOL_OR(b) FROM table GROUP BY a"},
         )
 
+    def test_grouping_sets_not_group_by_element(self):
+        element_sql = "SELECT COUNT(1), d, h FROM t GROUP BY d, h, GROUPING SETS ((d, h), (d))"
+
+        for sql, expected_flag in (
+            (
+                "SELECT COUNT(1), d, h FROM t GROUP BY d, h GROUPING SETS ((d, h), (d))",
+                True,
+            ),
+            (element_sql, False),
+            (
+                "SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))",
+                True,
+            ),
+            (
+                "SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))",
+                False,
+            ),
+        ):
+            with self.subTest(sql=sql):
+                group = self.validate_identity(sql).args["group"]
+                self.assertIs(group.args.get("grouping_sets_not_group_by_element"), expected_flag)
+
+        without_flag = self.parse_one(element_sql)
+        without_flag.args["group"].args.pop("grouping_sets_not_group_by_element")
+        self.assertEqual(element_sql, without_flag.sql("spark"))
+
     def test_current_user(self):
         self.validate_all(
             "CURRENT_USER",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1197,31 +1197,16 @@ TBLPROPERTIES (
             write={"spark": "SELECT a, BOOL_OR(b) FROM table GROUP BY a"},
         )
 
-    def test_grouping_sets_not_group_by_element(self):
-        element_sql = "SELECT COUNT(1), d, h FROM t GROUP BY d, h, GROUPING SETS ((d, h), (d))"
-
+    def test_grouping_sets_as_group_by_element(self):
         for sql, expected_flag in (
-            (
-                "SELECT COUNT(1), d, h FROM t GROUP BY d, h GROUPING SETS ((d, h), (d))",
-                True,
-            ),
-            (element_sql, False),
-            (
-                "SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))",
-                True,
-            ),
-            (
-                "SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))",
-                False,
-            ),
+            ("SELECT COUNT(1), d, h FROM t GROUP BY d, h GROUPING SETS ((d, h), (d))", False),
+            ("SELECT COUNT(1), d, h FROM t GROUP BY d, h, GROUPING SETS ((d, h), (d))", True),
+            ("SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))", False),
+            ("SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))", True),
         ):
             with self.subTest(sql=sql):
                 group = self.validate_identity(sql).args["group"]
-                self.assertIs(group.args.get("grouping_sets_not_group_by_element"), expected_flag)
-
-        without_flag = self.parse_one(element_sql)
-        without_flag.args["group"].args.pop("grouping_sets_not_group_by_element")
-        self.assertEqual(element_sql, without_flag.sql("spark"))
+                self.assertIs(group.args.get("grouping_sets_as_group_by_element"), expected_flag)
 
     def test_current_user(self):
         self.validate_all(

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1222,14 +1222,12 @@ TBLPROPERTIES (
                     suffix_sql,
                 )
 
-        for dialect in ("trino", "clickhouse"):
-            with self.subTest(dialect=dialect):
-                self.assertEqual(
-                    suffix_expression.sql(dialect, unsupported_level=ErrorLevel.IGNORE),
-                    element_sql,
-                )
-                with self.assertRaises(UnsupportedError):
-                    suffix_expression.sql(dialect, unsupported_level=ErrorLevel.RAISE)
+        self.assertEqual(
+            suffix_expression.sql("trino", unsupported_level=ErrorLevel.IGNORE),
+            element_sql,
+        )
+        with self.assertRaises(UnsupportedError):
+            suffix_expression.sql("trino", unsupported_level=ErrorLevel.RAISE)
 
     def test_current_user(self):
         self.validate_all(


### PR DESCRIPTION
Hive and Spark support a non-standard form of `GROUP BY` and `GROUPING SETS`, where no comma separates ordinary grouping expressions from `GROUPING SETS` clauses.

Currently, sqlglot incorrectly adds a comma to the no comma form - this PR fixes that.

### Semantics
The semantics differ between the comma and comma-less forms:
 - No comma: `GROUP BY a, b, c GROUPING SETS ((a), (a, b))`
   - GROUPING SETS determines the effective grouping sets: this example produces (a) and (a, b).
   - If selected, `c` is present in the output and NULL in every aggregate row.
 - Comma: `GROUP BY a, b, c, GROUPING SETS ((a), (a, b))`
   - Ordinary grouping expressions are combined with each grouping set using cross-product semantics.
   - In this example, `a`, `b`, and `c` are included in every resulting grouping set. 

### Engine support

- No comma form
  - Hive, Spark, and Databricks support
  - Other engines do not
- Comma form 
  - Hive, Spark 3.1.x, and Clickhouse do NOT support
  - Spark 3.2 and other engines DO support

Closes #8266 