### PR TITLE
fix(optimizer): remap GROUP BY ordinals nested in grouping constructs

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -25,6 +25,9 @@ SELECT_ALL = object()
 # variants are subclasses of Explode, so matching Explode covers them too.
 SET_RETURNING_FUNCTIONS = (exp.Explode, exp.Inline, exp.Unnest)
 
+# GROUP BY constructs whose children are grouping items; a one-column set, e.g. ((1)), is a Paren
+GROUPING_CONSTRUCTS = (exp.Cube, exp.GroupingSets, exp.Paren, exp.Rollup, exp.Tuple)
+
 
 def _is_self_referencing_cte(scope: Scope) -> bool:
     cte = scope.expression.parent
@@ -173,8 +176,8 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
     else:
         order_refs = set()
 
-    # Resolve bare GROUP BY ordinals before pruning
-    ordinal_refs = _bare_group_by_ordinal_refs(expression)
+    # Resolve GROUP BY ordinals before pruning
+    ordinal_refs = _group_by_ordinal_refs(expression)
     group_ordinal_selection_ids = {id(selection) for _, selection in ordinal_refs}
 
     # GROUP BY ALL with no explicit keys implicitly groups by every non-aggregate
@@ -237,7 +240,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
 
     expression.select(*new_selections, append=False, copy=False)
 
-    # Rewrite bare GROUP BY ordinals to their positions in the pruned SELECT list
+    # Rewrite GROUP BY ordinals to their positions in the pruned SELECT list
     if ordinal_refs:
         new_pos = {id(selection): i + 1 for i, selection in enumerate(new_selections)}
         for node, old_selection in ordinal_refs:
@@ -266,10 +269,11 @@ def _is_implicit_group_by_all(select: exp.Select) -> bool:
     )
 
 
-def _bare_group_by_ordinal_refs(
+def _group_by_ordinal_refs(
     select: exp.Select,
 ) -> list[tuple[exp.Literal, exp.Expr]]:
-    """Map each bare GROUP BY integer ordinal to its pre-prune projection."""
+    """Map each GROUP BY integer ordinal to its pre-prune projection, including the ordinals
+    nested in a grouping construct such as GROUPING SETS / CUBE / ROLLUP."""
     group = select.args.get("group")
     if not group:
         return []
@@ -278,10 +282,15 @@ def _bare_group_by_ordinal_refs(
     n = len(selects)
     refs: list[tuple[exp.Literal, exp.Expr]] = []
 
-    for node in group.expressions:
-        if node.is_int and isinstance(node, exp.Literal):
-            pos = int(node.this)
-            if 1 <= pos <= n:
-                refs.append((node, selects[pos - 1]))
+    def collect(nodes: t.Iterable[exp.Expr]) -> None:
+        for node in nodes:
+            if isinstance(node, GROUPING_CONSTRUCTS):
+                collect(node.iter_expressions())
+            elif node.is_int and isinstance(node, exp.Literal):
+                pos = int(node.this)
+                if 1 <= pos <= n:
+                    refs.append((node, selects[pos - 1]))
+
+    collect(group.iter_expressions())
 
     return refs

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -262,3 +262,25 @@ SELECT t.s AS s FROM (SELECT SUM(x.b) AS s FROM x AS x GROUP BY ALL CUBE (x.a, x
 
 SELECT t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ALL a, b) t;
 SELECT t.s AS s FROM (SELECT SUM(x.b) AS s FROM x AS x GROUP BY ALL x.a, x.b) AS t;
+
+--------------------------------------
+-- GROUP BY ordinals nested in GROUPING SETS / CUBE / ROLLUP reference projections
+-- positionally, so pruning must not shift what they point at
+--------------------------------------
+SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY GROUPING SETS (1, 2)) t;
+SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY GROUPING SETS (1, 2)) AS t;
+
+SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY CUBE (1, 2)) t;
+SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY CUBE (1, 2)) AS t;
+
+SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY ROLLUP (1, 2)) t;
+SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY ROLLUP (1, 2)) AS t;
+
+SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY GROUPING SETS (1, (1, 2))) t;
+SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY GROUPING SETS (1, (1, 2))) AS t;
+
+SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY GROUPING SETS ((1), (2))) t;
+SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY GROUPING SETS ((1), (2))) AS t;
+
+SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY (1), (2)) t;
+SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY (1), (2)) AS t;


### PR DESCRIPTION
`pushdown_projections` resolved GROUP BY ordinals by scanning only `group.expressions`, so ordinals nested in `GROUPING SETS` / `CUBE` / `ROLLUP` were neither pinned nor remapped. Pruning then shifted what they point at.

Input:
```sql
SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY GROUPING SETS (1, 2)) AS t
```

Old output: `b` is pruned, so ordinal `2` now lands on `SUM(x.b)` and the query in duckdb fails with `duckdb: Binder Error: GROUP BY clause cannot contain aggregates!`:
```sql
WITH "t" AS (
  SELECT "x"."a" AS "a", SUM("x"."b") AS "s"
  FROM "x" AS "x"
  GROUP BY GROUPING SETS (1, 2)
)
SELECT "t"."a" AS "a", "t"."s" AS "s" FROM "t" AS "t"
```

Expected:
```sql
WITH "t" AS (
  SELECT "x"."a" AS "a", "x"."b" AS "b", SUM("x"."b") AS "s"
  FROM "x" AS "x"
  GROUP BY GROUPING SETS (1, 2)
)
SELECT "t"."a" AS "a", "t"."s" AS "s" FROM "t" AS "t"
```

The following cases were verified as failing against DuckDB, comparing rows of original vs optimized:

```
| GROUP BY                     | before          | after |
| ---------------------------- | --------------- | ----- |
| GROUPING SETS (1, 2)         | binder error    | equal |
| CUBE (1, 2)                  | binder error    | equal |
| ROLLUP (1, 2)                | binder error    | equal |
| GROUPING SETS (1, (1, 2))    | binder error    | equal |
| GROUPING SETS ((1), (2))     | binder error    | equal |
| (1), (2)                     | binder error    | equal |
```