### PR TITLE
fix(generator)!: mod generation precedence

### DIFF
--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -72,6 +72,8 @@ AFTER_HAVING_MODIFIER_TRANSFORMS: dict[str, t.Any] = {
     "qualify": lambda self, e: self.sql(e, "qualify"),
 }
 
+MOD_PARENTHESES_PARENT_TYPES = (exp.Mul, exp.Div, exp.IntDiv, exp.Mod, exp.Pow)
+
 
 _DISPATCH_CACHE: dict[type[Generator], dict[type[exp.Expr], t.Callable[..., str]]] = {}
 
@@ -4603,7 +4605,17 @@ class Generator:
         return self.binary(expression, "<=")
 
     def mod_sql(self, expression: exp.Mod) -> str:
-        return self.binary(expression, "%")
+        sql = (
+            f"{self.sql(expression, 'this')}"
+            f" {self.maybe_comment('%', comments=expression.comments)} "
+            f"{self.sql(expression, 'expression')}"
+        )
+        parent = expression.parent
+        return (
+            f"({sql})"
+            if isinstance(parent, MOD_PARENTHESES_PARENT_TYPES) and parent.expression is expression
+            else sql
+        )
 
     def mul_sql(self, expression: exp.Mul) -> str:
         return self.binary(expression, "*")

--- a/sqlglot/generators/teradata.py
+++ b/sqlglot/generators/teradata.py
@@ -128,7 +128,18 @@ class TeradataGenerator(generator.Generator):
         return self.prepend_ctes(expression, sql)
 
     def mod_sql(self, expression: exp.Mod) -> str:
-        return self.binary(expression, "MOD")
+        sql = (
+            f"{self.sql(expression, 'this')}"
+            f" {self.maybe_comment('MOD', comments=expression.comments)} "
+            f"{self.sql(expression, 'expression')}"
+        )
+        parent = expression.parent
+        return (
+            f"({sql})"
+            if isinstance(parent, generator.MOD_PARENTHESES_PARENT_TYPES)
+            and parent.expression is expression
+            else sql
+        )
 
     def rangen_sql(self, expression: exp.RangeN) -> str:
         this = self.sql(expression, "this")


### PR DESCRIPTION
**Problem:** 

`MOD(...)` was being generated as infix `%` without preserving grouping in some parent contexts. That let target-dialect precedence change semantics. The bug was:
`SELECT 2 * MOD(8, 5) -> SELECT 2 * 8 % 5`
which evaluates as `(2 * 8) % 5`, instead of the correct `2 * (8 % 5)`.

**Fix :**

In `generator.py`, `exp.Mod` no longer goes through the generic `binary()` flattener. The fix adds `mod_needs_paren()` and `mod_operator_sql()` so `MOD` is parenthesized only when the current `Mod` node is the right child of `Mul, Div, IntDiv`, or another Mod. That preserves semantics without changing the safe left-associative cases.

In `teradata.py`, Teradata now reuses the same MOD-specific generation path for infix MOD. Shared and dialect-specific regressions were added in `test_dialect.py, test_mysql.py, test_teradata.py, test_databricks.py, test_redshift.py, and test_snowflake.py`. The Snowflake DBT fixture snapshots were updated in the affected shard files to reflect the new safe canonical SQL.


**Test Summary:** 
Category | Query / Command Run | Dialect(s) | Result | Status
-- | -- | -- | -- | --
Bug repro | python3 -c "import sqlglot; print(sqlglot.transpile('SELECT 2 * MOD(8, 5)', read='databricks', write='databricks')[0])" | Databricks generator output | Output was SELECT 2 * 8 % 5 | Expected mismatch, bug confirmed
Focused root regressions | python -m unittest tests.dialects.test_dialect tests.dialects.test_mysql tests.dialects.test_teradata tests.dialects.test_snowflake tests.dialects.test_redshift tests.dialects.test_databricks | Shared, MySQL, Teradata, Snowflake, Redshift, Databricks | Ran 303 tests ... OK | Pass
Focused integration regressions | PYTHONPATH=".:/Users/amruta.ayachit/Tobiko/sqlglot" python -m unittest tests.sqlglot.test_databricks tests.sqlglot.test_redshift tests.sqlglot.test_snowflake | Databricks, Redshift, Snowflake | Ran 67 tests ... OK | Pass
Style validation | make style | Root repo + integration checks | ruff, ruff-format, mypy, pre-commit all passed | Pass
Full unit suite | make unit | Root repo | Ran 1488 tests ... OK (skipped=46) | Pass
Targeted fixture recheck | Custom Python re-run of Snowflake failing fixture indices 23948, 25144, 31901, 39639, 43056, 43650, 43691, 43774 | Snowflake DBT fixtures | ALL_MATCH True | Matches expectation
Engine validation | SELECT 2 * MOD(8,5), 2 * (8 % 5), 2 / MOD(8,5), 2 / (8 % 5), 20 % MOD(8,5), 20 % (8 % 5), MOD(8,5) * 2, (8 % 5) * 2, 10 DIV MOD(8,5), 10 DIV (8 % 5) via mysql -Nse | MySQL | 6=6, 0.6667=0.6667, 2=2, 6=6, 3=3 | Matches expectation
Engine validation | SELECT 2 * MOD(8,5), 2 * (8 % 5), 2 / MOD(8,5), 2 / (8 % 5), 20 % MOD(8,5), 20 % (8 % 5), MOD(8,5) * 2, (8 % 5) * 2 via snow sql -q | Snowflake | 6=6, 0.666667=0.666667, 2=2, 6=6 | Matches expectation
Engine validation | SELECT 2 * MOD(8,5), 2 * (8 % 5), 20 % MOD(8,5), 20 % (8 % 5), MOD(8,5) * 2, (8 % 5) * 2 via psql -tAqc | PostgreSQL proxy for Redshift | 6=6, 2=2, 6=6 | Matches expectation
Engine sanity | SELECT -(8 % 5), (-8) % 5, 2 * (8 % 5), 20 % (8 % 5) via duckdb -c | DuckDB | -3=-3, 6, 2 | Matches expectation
Engine validation | SELECT 20 % MOD(8,5) AS nested_func, 20 % (8 % 5) AS nested_fixed, MOD(8,5) * 2 AS left_func, (8 % 5) * 2 AS left_fixed on real cluster | Databricks | 2, 2, 6, 6 | Matches expectation
Fusion validation | python scripts/run_fusion_tests.py --output test_results/fusion-check-snowflake.py --shard snowflake --max-failures 1 | Snowflake | Roundtrip 24244/24245 passed, 1 unrelated roundtrip failure; schema baseline failures remain | Matches expectation, non-blocking baseline noise
Fusion validation | python scripts/run_fusion_tests.py --output test_results/fusion-check-databricks.py --shard databricks --max-failures 1 | Databricks | Roundtrip 5210/5225 passed, 15 unrelated roundtrip failures; schema baseline failures remain | Matches expectation, non-blocking baseline noise
Fusion validation | python scripts/run_fusion_tests.py --output test_results/fusion-check-redshift.py --shard redshift --max-failures 1 | Redshift | Roundtrip 5097/5112 passed, 15 unrelated roundtrip failures; schema baseline failures remain | Matches expectation, non-blocking baseline noise


Added test scenario | Where covered | Engine tested | Outcome
-- | -- | -- | --
SELECT 2 * MOD(8, 5) | Shared root tests and Databricks/Redshift integration tests | Yes | Matches expectation
SELECT 2 / MOD(8, 5) | Shared root tests and Databricks/Snowflake integration tests | Yes | Matches expectation
SELECT 20 % MOD(8, 5) | Shared root tests and Databricks/Redshift/Snowflake integration tests | Yes | Matches expectation
SELECT MOD(8, 5) * 2 | Shared root tests and Databricks/Redshift/Snowflake integration tests | Yes | Matches expectation
SELECT 10 DIV MOD(8, 5) | MySQL-specific root test | Yes | Matches expectation
Teradata target generation SELECT 2 * (8 MOD 5) and SELECT 20 MOD (8 MOD 5) | Teradata root test | Yes, as target-generation checks from reachable source SQL | Matches expectation



