### PR TITLE
fix(postgres)!: normalize DATE_PART unit casing to match EXTRACT [CLAUDE]

### DIFF
--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -326,7 +326,9 @@ class PostgresParser(parser.Parser):
         value = self._parse_bitwise()
 
         if part and isinstance(part, (exp.Column, exp.Literal)):
-            part = exp.var(part.name)
+            # uppercase to match _parse_extract's normalization of the unit,
+            # so DATE_PART and EXTRACT round-trip identically
+            part = exp.var(part.name.upper())
 
         return self.expression(exp.Extract(this=part, expression=value))
 

--- a/sqlglot/parsers/postgres.py
+++ b/sqlglot/parsers/postgres.py
@@ -326,8 +326,6 @@ class PostgresParser(parser.Parser):
         value = self._parse_bitwise()
 
         if part and isinstance(part, (exp.Column, exp.Literal)):
-            # uppercase to match _parse_extract's normalization of the unit,
-            # so DATE_PART and EXTRACT round-trip identically
             part = exp.var(part.name.upper())
 
         return self.expression(exp.Extract(this=part, expression=value))

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -233,6 +233,10 @@ class TestPostgres(Validator):
             "SELECT EXTRACT(CAST('isodow' AS VARCHAR(6)) FROM CURRENT_DATE)",
         )
         self.validate_identity(
+            "SELECT DATE_PART('isoyear', ts)",
+            "SELECT EXTRACT(ISOYEAR FROM ts)",
+        )
+        self.validate_identity(
             "END WORK AND NO CHAIN",
             "COMMIT AND NO CHAIN",
         )
@@ -697,17 +701,17 @@ FROM json_data, field_ids""",
         self.validate_all(
             "SELECT DATE_PART('minute', timestamp '2023-01-04 04:05:06.789')",
             write={
-                "postgres": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
-                "redshift": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
-                "snowflake": "SELECT DATE_PART(minute, CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
+                "postgres": "SELECT EXTRACT(MINUTE FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
+                "redshift": "SELECT EXTRACT(MINUTE FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
+                "snowflake": "SELECT DATE_PART(MINUTE, CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
             },
         )
         self.validate_all(
             "SELECT DATE_PART('month', date '20220502')",
             write={
-                "postgres": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
-                "redshift": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
-                "snowflake": "SELECT DATE_PART(month, CAST('20220502' AS DATE))",
+                "postgres": "SELECT EXTRACT(MONTH FROM CAST('20220502' AS DATE))",
+                "redshift": "SELECT EXTRACT(MONTH FROM CAST('20220502' AS DATE))",
+                "snowflake": "SELECT DATE_PART(MONTH, CAST('20220502' AS DATE))",
             },
         )
         self.validate_all(

--- a/tests/dialects/test_redshift.py
+++ b/tests/dialects/test_redshift.py
@@ -183,17 +183,17 @@ class TestRedshift(Validator):
         self.validate_all(
             "SELECT DATE_PART(minute, timestamp '2023-01-04 04:05:06.789')",
             write={
-                "postgres": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
-                "redshift": "SELECT EXTRACT(minute FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
-                "snowflake": "SELECT DATE_PART(minute, CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
+                "postgres": "SELECT EXTRACT(MINUTE FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
+                "redshift": "SELECT EXTRACT(MINUTE FROM CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
+                "snowflake": "SELECT DATE_PART(MINUTE, CAST('2023-01-04 04:05:06.789' AS TIMESTAMP))",
             },
         )
         self.validate_all(
             "SELECT DATE_PART(month, date '20220502')",
             write={
-                "postgres": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
-                "redshift": "SELECT EXTRACT(month FROM CAST('20220502' AS DATE))",
-                "snowflake": "SELECT DATE_PART(month, CAST('20220502' AS DATE))",
+                "postgres": "SELECT EXTRACT(MONTH FROM CAST('20220502' AS DATE))",
+                "redshift": "SELECT EXTRACT(MONTH FROM CAST('20220502' AS DATE))",
+                "snowflake": "SELECT DATE_PART(MONTH, CAST('20220502' AS DATE))",
             },
         )
         self.validate_all(
@@ -389,7 +389,7 @@ class TestRedshift(Validator):
         )
         self.validate_identity(
             'DATE_PART(year, "somecol")',
-            'EXTRACT(year FROM "somecol")',
+            'EXTRACT(YEAR FROM "somecol")',
         ).this.assert_is(exp.Var)
         self.validate_identity(
             "SELECT CONCAT('abc', 'def')",

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1692,25 +1692,25 @@ WHERE
             },
         )
         self.validate_all(
-            "SELECT DATEPART(month, CAST('2017-03-01' AS DATE))",
+            "SELECT DATEPART(MONTH, CAST('2017-03-01' AS DATE))",
             read={
                 "postgres": "SELECT DATE_PART('month', '2017-03-01'::DATE)",
             },
             write={
-                "postgres": "SELECT EXTRACT(month FROM CAST('2017-03-01' AS DATE))",
-                "spark": "SELECT EXTRACT(month FROM CAST('2017-03-01' AS DATE))",
-                "tsql": "SELECT DATEPART(month, CAST('2017-03-01' AS DATE))",
+                "postgres": "SELECT EXTRACT(MONTH FROM CAST('2017-03-01' AS DATE))",
+                "spark": "SELECT EXTRACT(MONTH FROM CAST('2017-03-01' AS DATE))",
+                "tsql": "SELECT DATEPART(MONTH, CAST('2017-03-01' AS DATE))",
             },
         )
         self.validate_all(
-            "SELECT DATEPART(day, CAST('2017-01-02' AS DATE))",
+            "SELECT DATEPART(DAY, CAST('2017-01-02' AS DATE))",
             read={
                 "postgres": "SELECT DATE_PART('day', '2017-01-02'::DATE)",
             },
             write={
-                "postgres": "SELECT EXTRACT(day FROM CAST('2017-01-02' AS DATE))",
-                "spark": "SELECT EXTRACT(day FROM CAST('2017-01-02' AS DATE))",
-                "tsql": "SELECT DATEPART(day, CAST('2017-01-02' AS DATE))",
+                "postgres": "SELECT EXTRACT(DAY FROM CAST('2017-01-02' AS DATE))",
+                "spark": "SELECT EXTRACT(DAY FROM CAST('2017-01-02' AS DATE))",
+                "tsql": "SELECT DATEPART(DAY, CAST('2017-01-02' AS DATE))",
             },
         )
         self.validate_identity(


### PR DESCRIPTION
Fixes #8292.

`_parse_date_part` keeps the unit's original casing (`exp.var(part.name)`) while `_parse_extract` normalizes it with `_parse_var_or_string(upper=True)`, so SQL entering through `DATE_PART` changes on the second parse -> generate pass:

```python
>>> sqlglot.parse_one("SELECT date_part('isoyear', ts)", read="postgres").sql(dialect="postgres")
'SELECT EXTRACT(isoyear FROM ts)'
>>> sqlglot.parse_one("SELECT EXTRACT(isoyear FROM ts)", read="postgres").sql(dialect="postgres")
'SELECT EXTRACT(ISOYEAR FROM ts)'
```

The fix mirrors `_parse_extract`'s normalization by uppercasing the unit in `_parse_date_part`. The suite already asserts the uppercase form elsewhere (`DATEPART(YEAR, ...)` in `tests/dialects/test_tsql.py`), so the expectations that pinned the old lowercase output in `test_postgres.py`, `test_redshift.py` and `test_tsql.py` are updated to match, and an identity test for the `isoyear` round-trip is added.

The new test fails before the fix and passes after. Full suite: 1349 tests, OK.

Disclosure: implemented with Claude. I reviewed each line and reproduced the behavior locally.
