### PR TITLE
feat(optimizer)!: annotate localtimestamp for postgres

### DIFF
--- a/sqlglot/typing/postgres.py
+++ b/sqlglot/typing/postgres.py
@@ -44,6 +44,7 @@ EXPRESSION_METADATA = {
         expr_type: {"returns": exp.DType.TIMESTAMP}
         for expr_type in {
             exp.TimestampFromParts,
+            exp.Localtimestamp,
         }
     },
     **{

--- a/tests/fixtures/optimizer/annotate_functions.sql
+++ b/tests/fixtures/optimizer/annotate_functions.sql
@@ -7549,6 +7549,11 @@ SMALLINT;
 BIT_XOR(tbl.bit_col);
 BIT;
 
+# dialect: postgres
+LOCALTIMESTAMP;
+TIMESTAMP;
+
+
 --------------------------------------
 -- Presto / Trino
 --------------------------------------


### PR DESCRIPTION
## This PR annotate the function localtimestamp for postgres

https://www.postgresql.org/docs/17/functions-datetime.html

<img width="976" height="335" alt="Screenshot From 2026-09-01 13-41-42" src="https://github.com/user-attachments/assets/6d16ca87-0b85-402e-8cea-4f1c5bb122fc" />
