### PR TITLE
fix(lineage): narrow struct field lineage through STRUCT and row aggregates

### DIFF
--- a/sqlglot/lineage.py
+++ b/sqlglot/lineage.py
@@ -193,6 +193,45 @@ def lineage(
     return result
 
 
+def _struct_field_source(value: exp.Expression, field: str) -> t.Optional[exp.Expression]:
+    """Resolve one field of a struct-producing expression to the expression it
+    flows from, so `struct_col.field` lineage narrows to that field instead of
+    the whole struct.
+
+    Handles the two shapes that lose field lineage today:
+      * `STRUCT(<expr> AS field, ...)` -> the field's own expression.
+      * a whole-row aggregate/pick such as `ARRAY_AGG(t ORDER BY ... LIMIT 1)[OFFSET(0)]`
+        (BigQuery's "one row per group" idiom) -> `t.field`; the aggregate's
+        ORDER BY/LIMIT are row selectors, not data sources for the field.
+    Returns None when `value` is not a struct this can narrow (callers fall back
+    to whole-expression lineage).
+    """
+    node = value
+    if isinstance(node, exp.Bracket) and len(node.expressions) == 1:
+        node = node.this
+    if isinstance(node, exp.ArrayAgg):
+        node = node.this
+    while isinstance(node, (exp.Order, exp.Limit)):
+        node = node.this
+
+    if isinstance(node, exp.Struct):
+        for member in node.expressions:
+            if isinstance(member, exp.PropertyEQ) and member.name == field:
+                return member.expression
+            if isinstance(member, exp.Alias) and member.alias == field:
+                return member.this
+        return None
+
+    # A whole-row reference (e.g. the table alias `t` aggregated as a row, which
+    # qualify rewrites to a TableColumn): the field is that row's column.
+    if isinstance(node, exp.TableColumn) and node.name:
+        return exp.column(field, table=node.name)
+    if isinstance(node, exp.Column) and not node.args.get("table") and node.name:
+        return exp.column(field, table=node.name)
+
+    return None
+
+
 def to_node(
     column: str | int,
     scope: Scope,
@@ -206,8 +245,9 @@ def to_node(
     _cache: dict[tuple, Node] | None = None,
     _scope_meta: dict[int, tuple[bool, dict[str, exp.Expr]]] | None = None,
     on_node: t.Callable[[Node], None] | None = None,
+    struct_field: str | None = None,
 ) -> Node:
-    cache_key = (column, id(scope), scope_name, source_name, reference_node_name)
+    cache_key = (column, id(scope), scope_name, source_name, reference_node_name, struct_field)
 
     if _cache is not None and cache_key in _cache:
         cached_node = _cache[cache_key]
@@ -361,7 +401,18 @@ def to_node(
                 on_node(star_node)
 
     # Find all columns that went into creating this one to list their lineage nodes.
-    source_columns = set(find_all_in_scope(select, exp.Column))
+    # When this column was reached as a struct field (`struct_col.field`), narrow to
+    # the expression that produced that field so its lineage doesn't collapse into the
+    # whole struct (or into a row aggregate's ORDER BY key).
+    lineage_expr: exp.Expression = select
+    if struct_field:
+        field_source = _struct_field_source(
+            select.unalias() if isinstance(select, exp.Alias) else select, struct_field
+        )
+        if field_source is not None:
+            lineage_expr = field_source
+
+    source_columns = set(find_all_in_scope(lineage_expr, exp.Column))
 
     # If the source is a UDTF find columns used in the UDTF to generate the table
     if isinstance(source, exp.UDTF):
@@ -396,6 +447,13 @@ def to_node(
         table = c.table
         col_source: exp.Table | Scope | None = scope.sources.get(table)
 
+        # If this column is the root of a struct field access (`c.field`), carry the
+        # field into the recursion so the upstream scope narrows to that field.
+        next_struct_field: str | None = None
+        dot_parent = c.parent
+        if isinstance(dot_parent, exp.Dot) and dot_parent.this is c:
+            next_struct_field = dot_parent.expression.name or None
+
         if isinstance(col_source, Scope):
             reference_node_name = None
             if col_source.scope_type == ScopeType.DERIVED_TABLE and table not in source_names:
@@ -418,6 +476,7 @@ def to_node(
                 _cache=_cache,
                 _scope_meta=_scope_meta,
                 on_node=on_node,
+                struct_field=next_struct_field,
             )
         elif pivots and pivots[-1].alias_or_name == c.table:
             # Only the last operator in a chain names the resulting source

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1299,3 +1299,35 @@ class TestLineage(unittest.TestCase):
                 seen.add(id(node))
         for nid in seen:
             self.assertEqual(counts.get(nid, 0), 1)
+
+    def test_struct_field_lineage(self) -> None:
+        schema = {"tbl": {"k": "STRING", "a": "STRING", "b": "STRING", "ts": "TIMESTAMP"}}
+
+        def leaves(column: str, sql: str) -> set[str]:
+            node = lineage(column, sql, schema=schema, dialect="bigquery")
+            found: set[str] = set()
+            stack = [node]
+            while stack:
+                current = stack.pop()
+                if not current.downstream:
+                    found.add(current.name)
+                stack.extend(current.downstream)
+            return found
+
+        # A struct field selected via `struct.*` must narrow to the field's own
+        # source column, not to every column of the struct.
+        struct_sql = "SELECT s.* FROM (SELECT STRUCT(t.a AS a, t.b AS b) AS s FROM tbl AS t)"
+        self.assertEqual(leaves("a", struct_sql), {"t.a"})
+        self.assertEqual(leaves("b", struct_sql), {"t.b"})
+
+        # BigQuery "one row per group" (e.g. dbt_utils.deduplicate): a whole row is
+        # packed with ARRAY_AGG(...)[OFFSET(0)] and selected via `row.*`. Each field
+        # must trace to the row's column -- NOT to the aggregate's ORDER BY key.
+        dedup_sql = (
+            "SELECT unique.* FROM ("
+            "  SELECT ARRAY_AGG(t ORDER BY ts DESC LIMIT 1)[OFFSET(0)] AS unique"
+            "  FROM tbl AS t GROUP BY k"
+            ")"
+        )
+        self.assertEqual(leaves("a", dedup_sql), {"t.a"})
+        self.assertEqual(leaves("ts", dedup_sql), {"t.ts"})


### PR DESCRIPTION
## Problem

`lineage()` doesn't narrow a **struct field access** to the field's own source — it collapses to the whole struct, and for a whole-row aggregate it attributes every field to the aggregate's `ORDER BY` key.

```python
import sqlglot
from sqlglot.lineage import lineage

schema = {"tbl": {"k": "STRING", "a": "STRING", "b": "STRING", "ts": "TIMESTAMP"}}

# 1) STRUCT constructor
sql = "SELECT s.* FROM (SELECT STRUCT(t.a AS a, t.b AS b) AS s FROM tbl AS t)"
lineage("a", sql, schema=schema, dialect="bigquery")   # leaves: {t.a, t.b}   -> want {t.a}

# 2) whole-row "one row per group" pick (e.g. dbt_utils.deduplicate on BigQuery)
sql = ("SELECT u.* FROM (SELECT ARRAY_AGG(t ORDER BY ts DESC LIMIT 1)[OFFSET(0)] AS u "
       "FROM tbl AS t GROUP BY k)")
lineage("a", sql, schema=schema, dialect="bigquery")   # leaves: {t.ts}  (!)  -> want {t.a}
```

`qualify` correctly expands `s.*` / `u.*` into `s.a, s.b, …`, but `to_node` recurses by column name and drops the field, so the field's provenance is lost. In case (2) the only thing traced is the aggregate's `ORDER BY` column, which is a row selector, not a data source for the field.

## Fix

When a column is reached as a struct field (`struct_col.field`), narrow to the expression that produced that field before collecting source columns:

- `STRUCT(<expr> AS field, …)` → the field's expression
- `ARRAY_AGG(<row> …)[OFFSET(n)]` (row picker) → `<row>.field`, ignoring the aggregate's `ORDER BY`/`LIMIT`

A new `struct_field` parameter threads the field into the recursion (and into the cache key); it only activates on struct-field access, so non-struct lineage is unchanged.

### After

```
STRUCT:      a -> {t.a}, b -> {t.b}
ARRAY_AGG:   a -> {t.a}, ts -> {t.ts}   (was: every field -> {t.ts})
```

## Tests

- New `tests/test_lineage.py::test_struct_field_lineage` (fails without the change).
- `tests/test_lineage.py`: 51 passed. `tests/test_optimizer.py`: 95 passed / 4534 subtests. No regressions.

Motivating real-world case: `dbt_utils.deduplicate` views on BigQuery, whose `ARRAY_AGG(row)[OFFSET(0)].*` shape previously lost all column-level lineage.
