### PR TITLE
fix(snowflake)!: stop dropping structured types on CREATE TABLE [GROK]

### DIFF
--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -97,34 +97,6 @@ def _unqualify_pivot_columns(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-# Structured types are GA on standard + Iceberg tables (Snowflake 9.19).
-# https://docs.snowflake.com/en/release-notes/2025/9_19
-_STRUCTURED_TYPES_UNSUPPORTED = (exp.HybridProperty, exp.ExternalProperty, exp.DynamicProperty)
-
-
-def _flatten_structured_types_when_unsupported(expression: exp.Expr) -> exp.Expr:
-    assert isinstance(expression, exp.Create)
-
-    def _flatten_structured_type(expression: exp.Expr) -> exp.Expr:
-        if isinstance(expression, exp.DataType) and expression.this in exp.DataType.NESTED_TYPES:
-            expression.set("expressions", None)
-        return expression
-
-    props = expression.args.get("properties")
-    if (
-        isinstance(expression.this, exp.Schema)
-        and props
-        and props.find(*_STRUCTURED_TYPES_UNSUPPORTED)
-    ):
-        for schema_expression in expression.this.expressions:
-            if isinstance(schema_expression, exp.ColumnDef):
-                column_type = schema_expression.kind
-                if isinstance(column_type, exp.DataType):
-                    column_type.transform(_flatten_structured_type, copy=False)
-
-    return expression
-
-
 def _unnest_generate_date_array(unnest: exp.Unnest) -> None:
     generate_date_array = unnest.expressions[0]
     start = generate_date_array.args.get("start")
@@ -447,7 +419,6 @@ class SnowflakeGenerator(generator.Generator):
         exp.BitwiseNot: rename_func("BITNOT"),
         exp.BitwiseLeftShift: rename_func("BITSHIFTLEFT"),
         exp.BitwiseRightShift: rename_func("BITSHIFTRIGHT"),
-        exp.Create: transforms.preprocess([_flatten_structured_types_when_unsupported]),
         exp.CurrentTimestamp: lambda self, e: (
             self.func("SYSDATE") if e.args.get("sysdate") else self.function_fallback_sql(e)
         ),

--- a/sqlglot/generators/snowflake.py
+++ b/sqlglot/generators/snowflake.py
@@ -97,7 +97,12 @@ def _unqualify_pivot_columns(expression: exp.Expr) -> exp.Expr:
     return expression
 
 
-def _flatten_structured_types_unless_iceberg(expression: exp.Expr) -> exp.Expr:
+# Structured types are GA on standard + Iceberg tables (Snowflake 9.19).
+# https://docs.snowflake.com/en/release-notes/2025/9_19
+_STRUCTURED_TYPES_UNSUPPORTED = (exp.HybridProperty, exp.ExternalProperty, exp.DynamicProperty)
+
+
+def _flatten_structured_types_when_unsupported(expression: exp.Expr) -> exp.Expr:
     assert isinstance(expression, exp.Create)
 
     def _flatten_structured_type(expression: exp.Expr) -> exp.Expr:
@@ -106,7 +111,11 @@ def _flatten_structured_types_unless_iceberg(expression: exp.Expr) -> exp.Expr:
         return expression
 
     props = expression.args.get("properties")
-    if isinstance(expression.this, exp.Schema) and not (props and props.find(exp.IcebergProperty)):
+    if (
+        isinstance(expression.this, exp.Schema)
+        and props
+        and props.find(*_STRUCTURED_TYPES_UNSUPPORTED)
+    ):
         for schema_expression in expression.this.expressions:
             if isinstance(schema_expression, exp.ColumnDef):
                 column_type = schema_expression.kind
@@ -438,7 +447,7 @@ class SnowflakeGenerator(generator.Generator):
         exp.BitwiseNot: rename_func("BITNOT"),
         exp.BitwiseLeftShift: rename_func("BITSHIFTLEFT"),
         exp.BitwiseRightShift: rename_func("BITSHIFTRIGHT"),
-        exp.Create: transforms.preprocess([_flatten_structured_types_unless_iceberg]),
+        exp.Create: transforms.preprocess([_flatten_structured_types_when_unsupported]),
         exp.CurrentTimestamp: lambda self, e: (
             self.func("SYSDATE") if e.args.get("sysdate") else self.function_fallback_sql(e)
         ),

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4435,14 +4435,6 @@ class TestSnowflake(Validator):
             "CREATE ICEBERG TABLE my_iceberg_table (amount ARRAY(INT)) CATALOG='SNOWFLAKE' EXTERNAL_VOLUME='my_external_volume' BASE_LOCATION='my/relative/path/from/extvol'"
         )
         self.validate_identity(
-            "CREATE DYNAMIC TABLE t (a ARRAY(INT)) TARGET_LAG='1 minute' WAREHOUSE=wh AS SELECT 1",
-            "CREATE DYNAMIC TABLE t (a ARRAY) TARGET_LAG='1 minute' WAREHOUSE=wh AS SELECT 1",
-        )
-        self.validate_identity(
-            "CREATE EXTERNAL TABLE t (a ARRAY(INT) AS (PARSE_JSON(metadata$filename))) LOCATION=@s FILE_FORMAT=(TYPE=JSON)",
-            "CREATE EXTERNAL TABLE t (a ARRAY AS (PARSE_JSON(metadata$filename))) LOCATION=@s FILE_FORMAT=(TYPE=JSON)",
-        )
-        self.validate_identity(
             """CREATE OR REPLACE FUNCTION ibis_udfs.public.object_values("obj" OBJECT) RETURNS ARRAY LANGUAGE JAVASCRIPT RETURNS NULL ON NULL INPUT AS ' return Object.values(obj) '"""
         ).assert_is(exp.Create)
         self.validate_identity(

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4429,7 +4429,18 @@ class TestSnowflake(Validator):
             "CREATE OR REPLACE TABLE EXAMPLE_DB.DEMO.USERS (ID DECIMAL(38, 0) NOT NULL, PRIMARY KEY (ID), FOREIGN KEY (CITY_CODE) REFERENCES EXAMPLE_DB.DEMO.CITIES (CITY_CODE))"
         )
         self.validate_identity(
+            "CREATE TABLE t (a ARRAY(INT), b ARRAY(ARRAY(INT)), c OBJECT(x INT), d MAP(VARCHAR, INT))"
+        )
+        self.validate_identity(
             "CREATE ICEBERG TABLE my_iceberg_table (amount ARRAY(INT)) CATALOG='SNOWFLAKE' EXTERNAL_VOLUME='my_external_volume' BASE_LOCATION='my/relative/path/from/extvol'"
+        )
+        self.validate_identity(
+            "CREATE DYNAMIC TABLE t (a ARRAY(INT)) TARGET_LAG='1 minute' WAREHOUSE=wh AS SELECT 1",
+            "CREATE DYNAMIC TABLE t (a ARRAY) TARGET_LAG='1 minute' WAREHOUSE=wh AS SELECT 1",
+        )
+        self.validate_identity(
+            "CREATE EXTERNAL TABLE t (a ARRAY(INT) AS (PARSE_JSON(metadata$filename))) LOCATION=@s FILE_FORMAT=(TYPE=JSON)",
+            "CREATE EXTERNAL TABLE t (a ARRAY AS (PARSE_JSON(metadata$filename))) LOCATION=@s FILE_FORMAT=(TYPE=JSON)",
         )
         self.validate_identity(
             """CREATE OR REPLACE FUNCTION ibis_udfs.public.object_values("obj" OBJECT) RETURNS ARRAY LANGUAGE JAVASCRIPT RETURNS NULL ON NULL INPUT AS ' return Object.values(obj) '"""

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -57,7 +57,7 @@ class TestSpark(Validator):
                 "presto": "CREATE TABLE db.example_table (col_a ARRAY(INTEGER), col_b ARRAY(ARRAY(INTEGER)))",
                 "hive": "CREATE TABLE db.example_table (col_a ARRAY<INT>, col_b ARRAY<ARRAY<INT>>)",
                 "spark": "CREATE TABLE db.example_table (col_a ARRAY<INT>, col_b ARRAY<ARRAY<INT>>)",
-                "snowflake": "CREATE TABLE db.example_table (col_a ARRAY, col_b ARRAY)",
+                "snowflake": "CREATE TABLE db.example_table (col_a ARRAY(INT), col_b ARRAY(ARRAY(INT)))",
             },
         )
         self.validate_all(


### PR DESCRIPTION
Fixes #8298.

Do not flatten structured types, as they have been GA for standard Snowflake tables since July 2025 ([release notes](https://docs.snowflake.com/en/release-notes/2025/9_19#data-types-structured-types-support-for-standard-snowflake-tables-general-availability)). 

**Breaking due to:**

- `CREATE TABLE` of any form, when using `snowflake` write dialect, will always retain structured type information. Previously, this was done only for Iceberg tables.   

LLM disclaimer: investigated and implemented with LLM assistance.

Made with [Cursor](https://cursor.com)