### PR TITLE
fix(transforms): keep the table when dropping an unnamed UNIQUE constraint [CLAUDE]

### DIFF
--- a/sqlglot/transforms.py
+++ b/sqlglot/transforms.py
@@ -799,8 +799,8 @@ def unqualify_pivot_fields(expression: exp.Expr) -> exp.Expr:
 def remove_unique_constraints(expression: exp.Expr) -> exp.Expr:
     assert isinstance(expression, exp.Create)
     for constraint in expression.find_all(exp.UniqueColumnConstraint):
-        if constraint.parent:
-            constraint.parent.pop()
+        parent = constraint.parent
+        (parent if isinstance(parent, (exp.ColumnConstraint, exp.Constraint)) else constraint).pop()
 
     return expression
 

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -31,6 +31,17 @@ class TestSpark(Validator):
         self.validate_identity("TRUNCATE TABLE t1 PARTITION(age = 10, name = 'test', address)")
 
         self.validate_all(
+            "CREATE TABLE t (a INT, b STRING, UNIQUE (a))",
+            write={
+                "databricks": "CREATE TABLE t (a INT, b STRING)",
+                "hive": "CREATE TABLE t (a INT, b STRING)",
+                "materialize": "CREATE TABLE t (a INT, b TEXT)",
+                "spark": "CREATE TABLE t (a INT, b STRING)",
+                "spark2": "CREATE TABLE t (a INT, b STRING)",
+                "duckdb": "CREATE TABLE t (a INT, b TEXT, UNIQUE (a))",
+            },
+        )
+        self.validate_all(
             "CREATE TABLE db.example_table (col_a struct<struct_col_a:int, struct_col_b:string>)",
             write={
                 "duckdb": "CREATE TABLE db.example_table (col_a STRUCT(struct_col_a INT, struct_col_b TEXT))",

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -9,6 +9,7 @@ from sqlglot.transforms import (
     eliminate_window_clause,
     inherit_struct_field_names,
     remove_precision_parameterized_types,
+    remove_unique_constraints,
 )
 
 
@@ -146,6 +147,33 @@ class TestTransforms(unittest.TestCase):
             remove_precision_parameterized_types,
             "SELECT CAST(1 AS DECIMAL(10, 2)), CAST('13' AS VARCHAR(10))",
             "SELECT CAST(1 AS DECIMAL), CAST('13' AS VARCHAR)",
+        )
+
+    def test_remove_unique_constraints(self):
+        for sql, target in (
+            ("CREATE TABLE t (a INT UNIQUE)", "CREATE TABLE t (a INT)"),
+            ("CREATE TABLE t (a INT, CONSTRAINT c UNIQUE (a))", "CREATE TABLE t (a INT)"),
+            ("CREATE TABLE t (a INT, b INT, UNIQUE (a))", "CREATE TABLE t (a INT, b INT)"),
+            (
+                "CREATE TABLE t (a INT, b INT, UNIQUE (a), UNIQUE (b))",
+                "CREATE TABLE t (a INT, b INT)",
+            ),
+            (
+                "CREATE TABLE t (a INT, UNIQUE (a), PRIMARY KEY (a), FOREIGN KEY (a) REFERENCES u (b))",
+                "CREATE TABLE t (a INT, PRIMARY KEY (a), FOREIGN KEY (a) REFERENCES u (b))",
+            ),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(remove_unique_constraints(parse_one(sql)).sql(), target)
+
+        self.assertEqual(
+            remove_unique_constraints(
+                parse_one(
+                    "CREATE TABLE t (a INT, b INT, UNIQUE KEY (a), UNIQUE INDEX idx (b))",
+                    read="mysql",
+                )
+            ).sql(dialect="mysql"),
+            "CREATE TABLE t (a INT, b INT)",
         )
 
     def test_eliminate_join_marks(self):


### PR DESCRIPTION
Fixes #8297.

`remove_unique_constraints` pops the parent of every `UniqueColumnConstraint`. That is right for the two wrapped spellings (`a INT UNIQUE` sits in a `ColumnConstraint`, `CONSTRAINT c UNIQUE (a)` in a `Constraint`), but an unnamed table-level `UNIQUE (a)` sits directly in `Schema.expressions`, so its parent is the `Schema` that is `Create.this` and the whole table disappears:

```python
>>> sqlglot.transpile("CREATE TABLE t (a INT, b STRING, UNIQUE (a))", read="duckdb", write="spark")
['CREATE TABLE']
```

After:

```python
>>> sqlglot.transpile("CREATE TABLE t (a INT, b STRING, UNIQUE (a))", read="duckdb", write="spark")
['CREATE TABLE t (a INT, b STRING)']
```

The fix pops the wrapper only when the parent is a `ColumnConstraint` or `Constraint`, and pops the constraint itself otherwise. This affects the four generators that apply the transform (hive, spark, spark2, materialize; databricks inherits from spark). `PRIMARY KEY` and `FOREIGN KEY` in the same position are untouched.

Tests: `test_remove_unique_constraints` in `tests/test_transforms.py` covers the three spellings, multiple constraints, coexistence with PK/FK, and the MySQL `UNIQUE KEY` / `UNIQUE INDEX` parse path; a `validate_all` in `tests/dialects/test_spark.py` pins the output for databricks, hive, materialize, spark and spark2 (duckdb keeps the constraint). The table-level cases fail before the fix and pass after. Full suite: OK.

Disclosure: implemented with Claude. I reviewed each line and reproduced the behavior locally.
