### PR TITLE
perf(optimizer): skip no-op rules via shared structural metadata

### DIFF
--- a/sqlglot/optimizer/eliminate_ctes.py
+++ b/sqlglot/optimizer/eliminate_ctes.py
@@ -10,7 +10,11 @@ if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
 
-def eliminate_ctes(expression: E, journal: Journal | None = None) -> E:
+def eliminate_ctes(
+    expression: E,
+    journal: Journal | None = None,
+    metadata: dict[str, int] | None = None,
+) -> E:
     """
     Remove unused CTEs from an expression.
 
@@ -23,9 +27,13 @@ def eliminate_ctes(expression: E, journal: Journal | None = None) -> E:
 
     Args:
         expression (sqlglot.Expr): expression to optimize
+        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
     Returns:
         sqlglot.Expr: optimized expression
     """
+    if metadata and not metadata["ctes"]:
+        return expression
+
     root = build_scope(expression)
 
     if root:
@@ -43,6 +51,9 @@ def eliminate_ctes(expression: E, journal: Journal | None = None) -> E:
                     if journal is not None and with_node:
                         record(journal, with_node, "expressions")
                     cte_node.pop()
+
+                    if metadata:
+                        metadata["ctes"] -= 1
 
                     # Pop the entire WITH clause if this is the last CTE
                     if with_node and len(with_node.expressions) <= 0:

--- a/sqlglot/optimizer/eliminate_ctes.py
+++ b/sqlglot/optimizer/eliminate_ctes.py
@@ -27,7 +27,6 @@ def eliminate_ctes(
 
     Args:
         expression (sqlglot.Expr): expression to optimize
-        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
     Returns:
         sqlglot.Expr: optimized expression
     """

--- a/sqlglot/optimizer/eliminate_joins.py
+++ b/sqlglot/optimizer/eliminate_joins.py
@@ -4,13 +4,13 @@ import typing as t
 
 from sqlglot import expressions as exp
 from sqlglot.optimizer.normalize import normalized
-from sqlglot.optimizer.scope import Scope, traverse_scope
+from sqlglot.optimizer.scope import Scope, fill_metadata, traverse_scope
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
 
 
-def eliminate_joins(expression: E) -> E:
+def eliminate_joins(expression: E, metadata: dict[str, int] | None = None) -> E:
     """
     Remove unused joins from an expression.
 
@@ -25,11 +25,20 @@ def eliminate_joins(expression: E) -> E:
 
     Args:
         expression: expression to optimize
+        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
 
     Returns:
         The optimized expression
     """
-    for scope in traverse_scope(expression):
+    if metadata and not metadata["joins"]:
+        return expression
+
+    scopes = traverse_scope(expression)
+
+    if metadata is not None and not metadata:
+        fill_metadata(scopes, metadata)
+
+    for scope in scopes:
         joins: list[exp.Join] = scope.expression.args.get("joins", [])
         if not joins:
             continue
@@ -49,6 +58,9 @@ def eliminate_joins(expression: E) -> E:
             if _should_eliminate_join(scope, join, alias):
                 join.pop()
                 scope.remove_source(alias)
+
+                if metadata:
+                    metadata["joins"] -= 1
 
     return expression
 

--- a/sqlglot/optimizer/eliminate_joins.py
+++ b/sqlglot/optimizer/eliminate_joins.py
@@ -25,7 +25,6 @@ def eliminate_joins(expression: E, metadata: dict[str, int] | None = None) -> E:
 
     Args:
         expression: expression to optimize
-        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
 
     Returns:
         The optimized expression

--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -30,7 +30,6 @@ def eliminate_subqueries(expression: E, metadata: dict[str, int] | None = None) 
 
     Args:
         expression (sqlglot.Expr): expression
-        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
     Returns:
         sqlglot.Expr: expression
     """

--- a/sqlglot/optimizer/eliminate_subqueries.py
+++ b/sqlglot/optimizer/eliminate_subqueries.py
@@ -5,7 +5,7 @@ import typing as t
 
 from sqlglot import expressions as exp
 from sqlglot.helper import find_new_name
-from sqlglot.optimizer.scope import Scope, build_scope
+from sqlglot.optimizer.scope import Scope, build_scope, fill_metadata
 from sqlglot._typing import E
 
 if t.TYPE_CHECKING:
@@ -13,7 +13,7 @@ if t.TYPE_CHECKING:
     TakenNameMapping = dict[str, t.Union[Scope, exp.Expr]]
 
 
-def eliminate_subqueries(expression: E) -> E:
+def eliminate_subqueries(expression: E, metadata: dict[str, int] | None = None) -> E:
     """
     Rewrite derived tables as CTES, deduplicating if possible.
 
@@ -30,6 +30,7 @@ def eliminate_subqueries(expression: E) -> E:
 
     Args:
         expression (sqlglot.Expr): expression
+        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
     Returns:
         sqlglot.Expr: expression
     """
@@ -41,6 +42,13 @@ def eliminate_subqueries(expression: E) -> E:
     root = build_scope(expression)
 
     if not root:
+        return expression
+
+    if metadata is not None and not metadata:
+        fill_metadata(list(root.traverse()), metadata)
+
+    # Only derived tables and existing CTEs can be rewritten as CTEs.
+    if metadata and not metadata["nested_queries"] and not metadata["ctes"]:
         return expression
 
     # Map of alias->Scope|Table
@@ -85,9 +93,12 @@ def eliminate_subqueries(expression: E) -> E:
             if scope is cte_scope:
                 # Don't try to eliminate this CTE itself
                 continue
-            new_cte = _eliminate(scope, existing_ctes, taken)
+            new_cte = _eliminate(scope, existing_ctes, taken, metadata)
             if new_cte:
                 new_ctes.append(new_cte)
+
+                if metadata:
+                    metadata["ctes"] += 1
 
         # Append the existing CTE itself
         cte_parent = cte_scope.expression.parent
@@ -97,9 +108,12 @@ def eliminate_subqueries(expression: E) -> E:
     # Now append the rest
     for scope in itertools.chain(root.union_scopes, root.subquery_scopes, root.table_scopes):
         for child_scope in scope.traverse():
-            new_cte = _eliminate(child_scope, existing_ctes, taken)
+            new_cte = _eliminate(child_scope, existing_ctes, taken, metadata)
             if new_cte:
                 new_ctes.append(new_cte)
+
+                if metadata:
+                    metadata["ctes"] += 1
 
     if new_ctes:
         query = expression.expression if isinstance(expression, exp.DDL) else expression
@@ -114,19 +128,25 @@ def eliminate_subqueries(expression: E) -> E:
 
 
 def _eliminate(
-    scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMapping
+    scope: Scope,
+    existing_ctes: ExistingCTEsMapping,
+    taken: TakenNameMapping,
+    metadata: dict[str, int] | None = None,
 ) -> exp.Expr | None:
     if scope.is_derived_table:
-        return _eliminate_derived_table(scope, existing_ctes, taken)
+        return _eliminate_derived_table(scope, existing_ctes, taken, metadata)
 
     if scope.is_cte:
-        return _eliminate_cte(scope, existing_ctes, taken)
+        return _eliminate_cte(scope, existing_ctes, taken, metadata)
 
     return None
 
 
 def _eliminate_derived_table(
-    scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMapping
+    scope: Scope,
+    existing_ctes: ExistingCTEsMapping,
+    taken: TakenNameMapping,
+    metadata: dict[str, int] | None = None,
 ) -> exp.Expr | None:
     # This makes sure that we don't:
     # - drop the "pivot" arg from a pivoted subquery
@@ -149,11 +169,17 @@ def _eliminate_derived_table(
 
     to_replace.replace(table)
 
+    if metadata:
+        metadata["derived_tables"] -= 1
+
     return cte
 
 
 def _eliminate_cte(
-    scope: Scope, existing_ctes: ExistingCTEsMapping, taken: TakenNameMapping
+    scope: Scope,
+    existing_ctes: ExistingCTEsMapping,
+    taken: TakenNameMapping,
+    metadata: dict[str, int] | None = None,
 ) -> exp.Expr | None:
     parent = scope.expression.parent
     if not parent:
@@ -162,6 +188,9 @@ def _eliminate_cte(
 
     with_ = parent.parent
     parent.pop()
+
+    if metadata:
+        metadata["ctes"] -= 1
     if with_ and not with_.expressions:
         with_.pop()
 

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -41,7 +41,6 @@ def merge_subqueries(
     Args:
         expression (sqlglot.Expr): expression to optimize
         leave_tables_isolated (bool):
-        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
     Returns:
         sqlglot.Expr: optimized expression
     """

--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from sqlglot import expressions as exp
 from sqlglot.helper import find_new_name, seq_get
-from sqlglot.optimizer.scope import Scope, traverse_scope
+from sqlglot.optimizer.scope import Scope, fill_metadata, traverse_scope
 
 if t.TYPE_CHECKING:
     from sqlglot._typing import E
@@ -14,7 +14,11 @@ if t.TYPE_CHECKING:
     FromOrJoin = t.Union[exp.From, exp.Join]
 
 
-def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
+def merge_subqueries(
+    expression: E,
+    leave_tables_isolated: bool = False,
+    metadata: dict[str, int] | None = None,
+) -> E:
     """
     Rewrite sqlglot AST to merge derived tables into the outer query.
 
@@ -37,19 +41,36 @@ def merge_subqueries(expression: E, leave_tables_isolated: bool = False) -> E:
     Args:
         expression (sqlglot.Expr): expression to optimize
         leave_tables_isolated (bool):
+        metadata: optional structural facts, see `sqlglot.optimizer.scope.fill_metadata`
     Returns:
         sqlglot.Expr: optimized expression
     """
+    # Only CTEs and derived tables can be merged.
+    if metadata and not metadata["ctes"] and not metadata["derived_tables"]:
+        return expression
+
     # Shared across both passes so the scope tree is only built once, as long as merge_ctes
     # doesn't mutate the AST; if it does, the scopes it was given are no longer valid, so the
     # scope tree needs to be rebuilt before merge_derived_tables runs.
     scopes = traverse_scope(expression)
-    expression, merged_ctes = merge_ctes(expression, leave_tables_isolated, scopes=scopes)
 
-    if merged_ctes:
-        scopes = traverse_scope(expression)
+    if metadata is not None and not metadata:
+        fill_metadata(scopes, metadata)
 
-    expression = merge_derived_tables(expression, leave_tables_isolated, scopes=scopes)
+    merged_ctes = False
+    if not metadata or metadata["ctes"]:
+        expression, merged_ctes = merge_ctes(
+            expression, leave_tables_isolated, scopes=scopes, metadata=metadata
+        )
+
+    if not metadata or metadata["derived_tables"]:
+        if merged_ctes:
+            scopes = traverse_scope(expression)
+
+        expression = merge_derived_tables(
+            expression, leave_tables_isolated, scopes=scopes, metadata=metadata
+        )
+
     return expression
 
 
@@ -79,6 +100,7 @@ def merge_ctes(
     expression: E,
     leave_tables_isolated: bool = False,
     scopes: list[Scope] | None = None,
+    metadata: dict[str, int] | None = None,
 ) -> tuple[E, bool]:
     # All places where we select from CTEs.
     # We key on the CTE scope so we can detect CTES that are selected from multiple times.
@@ -112,6 +134,9 @@ def merge_ctes(
             _pop_cte(inner_scope)
             outer_scope.clear_cache()
             merged = True
+
+            if metadata:
+                metadata["ctes"] -= 1
     return expression, merged
 
 
@@ -119,6 +144,7 @@ def merge_derived_tables(
     expression: E,
     leave_tables_isolated: bool = False,
     scopes: list[Scope] | None = None,
+    metadata: dict[str, int] | None = None,
 ) -> E:
     for outer_scope in traverse_scope(expression) if scopes is None else scopes:
         for subquery in outer_scope.derived_tables:
@@ -138,6 +164,9 @@ def merge_derived_tables(
                 _merge_where(outer_scope, inner_scope, from_or_join)
                 _merge_hints(outer_scope, inner_scope)
                 outer_scope.clear_cache()
+
+                if metadata:
+                    metadata["derived_tables"] -= 1
 
     return expression
 

--- a/sqlglot/optimizer/optimize_joins.py
+++ b/sqlglot/optimizer/optimize_joins.py
@@ -9,7 +9,7 @@ from sqlglot.helper import tsort
 JOIN_ATTRS = ("on", "side", "kind", "using", "method")
 
 
-def optimize_joins(expression: E) -> E:
+def optimize_joins(expression: E, metadata: dict[str, int] | None = None) -> E:
     """
     Removes cross joins if possible and reorder joins based on predicate dependencies.
 
@@ -18,6 +18,8 @@ def optimize_joins(expression: E) -> E:
         >>> optimize_joins(parse_one("SELECT * FROM x CROSS JOIN y JOIN z ON x.a = z.a AND y.a = z.a")).sql()
         'SELECT * FROM x JOIN z ON x.a = z.a AND TRUE JOIN y ON y.a = z.a'
     """
+    if metadata and not metadata["joins"]:
+        return expression
 
     for select in expression.find_all(exp.Select):
         joins: list[exp.Join] = select.args.get("joins", [])

--- a/sqlglot/optimizer/optimizer.py
+++ b/sqlglot/optimizer/optimizer.py
@@ -86,6 +86,7 @@ def optimize(
         sql: Original SQL string for error highlighting. If not provided, errors will not include
             highlighting. Requires that the expression has position metadata from parsing.
         **kwargs: If a rule has a keyword argument with a same name in **kwargs, it will be passed in.
+            Pass `metadata=None` to disable metadata-based rule skipping.
 
     Returns:
         The optimized expression.
@@ -99,6 +100,7 @@ def optimize(
         "sql": sql,
         "isolate_tables": True,  # needed for other optimizations to perform well
         "quote_identifiers": False,
+        "metadata": {},
         **kwargs,
     }
 

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -79,13 +79,17 @@ def pushdown_projections(
     """
     scopes = traverse_scope(expression)
 
-    # This is the first rule of the default pipeline that builds the scope tree, so it
-    # doubles as the collector of the structural facts shared with the later rules.
     if metadata is not None and not metadata:
         fill_metadata(scopes, metadata)
 
-    # Projections can only be pushed down into nested queries and CTEs.
-    if metadata and not metadata["nested_queries"] and not metadata["ctes"]:
+    # Projections can only be pushed down into nested queries and CTEs. A root-level set
+    # operation must still be visited, since its operands' widths are validated here.
+    if (
+        metadata
+        and not metadata["nested_queries"]
+        and not metadata["ctes"]
+        and not isinstance(expression, exp.SetOperation)
+    ):
         return expression
 
     schema = ensure_schema(schema, dialect=dialect)

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -6,7 +6,13 @@ from collections import defaultdict
 from sqlglot import alias, exp
 from sqlglot.optimizer.journal import Journal, record
 from sqlglot.optimizer.qualify_columns import Resolver
-from sqlglot.optimizer.scope import Scope, find_all_in_scope, find_in_scope, traverse_scope
+from sqlglot.optimizer.scope import (
+    Scope,
+    fill_metadata,
+    find_all_in_scope,
+    find_in_scope,
+    traverse_scope,
+)
 from sqlglot.schema import ensure_schema
 from sqlglot.errors import OptimizeError
 from sqlglot.helper import seq_get
@@ -53,6 +59,7 @@ def pushdown_projections(
     remove_unused_selections: bool = True,
     dialect: DialectType = None,
     journal: Journal | None = None,
+    metadata: dict[str, int] | None = None,
 ) -> E:
     """
     Rewrite sqlglot AST to remove unused columns projections.
@@ -70,6 +77,17 @@ def pushdown_projections(
     Returns:
         sqlglot.Expr: optimized expression
     """
+    scopes = traverse_scope(expression)
+
+    # This is the first rule of the default pipeline that builds the scope tree, so it
+    # doubles as the collector of the structural facts shared with the later rules.
+    if metadata is not None and not metadata:
+        fill_metadata(scopes, metadata)
+
+    # Projections can only be pushed down into nested queries and CTEs.
+    if metadata and not metadata["nested_queries"] and not metadata["ctes"]:
+        return expression
+
     schema = ensure_schema(schema, dialect=dialect)
     source_column_alias_count: dict[exp.Expr | Scope, int] = {}
 
@@ -79,7 +97,7 @@ def pushdown_projections(
     # We build the scope tree (which is traversed in DFS postorder), then iterate
     # over the result in reverse order. This should ensure that the set of selected
     # columns for a particular scope are completely build by the time we get to it.
-    for scope in reversed(traverse_scope(expression)):
+    for scope in reversed(scopes):
         scope_expression = scope.expression
         parent_selections = referenced_columns.get(scope, {SELECT_ALL})
         alias_count = source_column_alias_count.get(scope, 0)

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -704,20 +704,16 @@ def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
 
     ctes = joins = derived_tables = nested_queries = 0
     for scope in scopes:
-        args = scope.expression.args
         ctes += len(scope.ctes)
         derived_tables += len(scope.derived_tables)
 
-        # Joins inside parenthesized FROM sources aren't attached to the select's
-        # "joins" arg, so joins are also detected through their right-hand source
-        # nodes, which the scope buckets always hold.
-        joins += max(
-            len(args.get("joins") or ()),
-            sum(
-                1
-                for node in (*scope.tables, *scope.derived_tables, *scope.udtfs)
-                if isinstance(node.parent, exp.Join)
-            ),
+        # A join's right-hand source is always a table, derived table or UDTF, so
+        # counting bucketed sources that hang under a Join counts every join,
+        # including those inside parenthesized FROM sources.
+        joins += sum(
+            1
+            for node in itertools.chain(scope.tables, scope.derived_tables, scope.udtfs)
+            if isinstance(node.parent, exp.Join)
         )
 
         parent = scope.expression.parent

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -688,6 +688,48 @@ def build_scope(expression: exp.Expr) -> Scope | None:
     return seq_get(traverse_scope(expression), -1)
 
 
+def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
+    """
+    Populate `metadata` with structural facts read off an already-built scope tree, so
+    optimizer rules can share them and skip work that provably does not apply.
+
+    Each counter is an upper bound on the number of corresponding constructs in the
+    tree: 0 means the construct is definitely absent, so a rule may only skip work when
+    a counter is 0. Rules that declare a `metadata` argument uphold this by incrementing
+    counters for any construct they may introduce (decrementing is allowed only for
+    definite removals). An empty dict means the facts are unknown.
+    """
+    if not scopes:
+        return
+
+    ctes = joins = derived_tables = nested_queries = 0
+    for scope in scopes:
+        args = scope.expression.args
+        ctes += len(scope.ctes)
+        derived_tables += len(scope.derived_tables)
+
+        # Joins inside parenthesized FROM sources aren't attached to the select's
+        # "joins" arg, so joins are also detected through their right-hand source
+        # nodes, which the scope buckets always hold.
+        joins += max(
+            len(args.get("joins") or ()),
+            sum(
+                1
+                for node in (*scope.tables, *scope.derived_tables, *scope.udtfs)
+                if isinstance(node.parent, exp.Join)
+            ),
+        )
+
+        parent = scope.expression.parent
+        if parent and not isinstance(parent, exp.SetOperation):
+            nested_queries += 1
+
+    metadata["ctes"] = ctes
+    metadata["joins"] = joins
+    metadata["derived_tables"] = derived_tables
+    metadata["nested_queries"] = nested_queries
+
+
 def _traverse_scope(scope: Scope) -> Iterator[Scope]:
     expression = scope.expression
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -703,10 +703,11 @@ def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
         return
 
     ctes = joins = derived_tables = nested_queries = 0
+    scope_expressions = {id(scope.expression) for scope in scopes}
     for scope in scopes:
         ctes += len(scope.ctes)
         derived_tables += len(scope.derived_tables)
-        joins += _count_joins(scope.expression)
+        joins += _count_joins(scope.expression, scope_expressions)
 
         parent = scope.expression.parent
         if parent and not isinstance(parent, exp.SetOperation):
@@ -718,18 +719,21 @@ def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
     metadata["nested_queries"] = nested_queries
 
 
-def _count_joins(expression: exp.Expr) -> int:
+def _count_joins(expression: exp.Expr, scope_expressions: set[int]) -> int:
     """
-    Counts the joins under `expression` by following only FROM source nodes: `joins`
-    lists, join sources and wrapped (non-query) groups. Bare queries are excluded
-    because they are counted by their own scope, but the joins of an aliased wrapped
-    group can be reachable from two scopes, so the total across scopes is an upper
-    bound rather than an exact count.
+    Counts the joins owned by the scope rooted at `expression` by following only FROM
+    source nodes: `joins` lists, join sources, wrapped groups and set operands. The
+    descent stops at any node that is another scope's expression, since that scope
+    counts its own joins; nodes that no scope owns are counted by whichever scope
+    reaches them.
     """
     count = 0
     stack = [expression]
     while stack:
         node = stack.pop()
+        if node is not expression and id(node) in scope_expressions:
+            continue
+
         joins = node.args.get("joins")
         if joins:
             count += len(joins)
@@ -738,10 +742,10 @@ def _count_joins(expression: exp.Expr) -> int:
             from_ = node.args.get("from_")
             if from_:
                 stack.append(from_.this)
-        elif isinstance(node, (exp.Subquery, exp.Paren)) and not isinstance(
-            node.this, exp.UNWRAPPED_QUERIES
-        ):
+        elif isinstance(node, (exp.Subquery, exp.Paren)):
             stack.append(node.this)
+        elif isinstance(node, exp.SetOperation):
+            stack.extend((node.this, node.expression))
     return count
 
 

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -698,8 +698,12 @@ def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
     a counter is 0. Rules that declare a `metadata` argument uphold this by incrementing
     counters for any construct they may introduce (decrementing is allowed only for
     definite removals). An empty dict means the facts are unknown.
+
+    A scope tree that does not include the root expression (e.g. DML or DDL, where only
+    the inner queries are scoped) can't see constructs attached to the root, so the
+    facts are left unknown.
     """
-    if not scopes:
+    if not any(scope.expression.parent is None for scope in scopes):
         return
 
     ctes = joins = derived_tables = nested_queries = 0

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -706,15 +706,7 @@ def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
     for scope in scopes:
         ctes += len(scope.ctes)
         derived_tables += len(scope.derived_tables)
-
-        # A join's right-hand source is always a table, derived table or UDTF, so
-        # counting bucketed sources that hang under a Join counts every join,
-        # including those inside parenthesized FROM sources.
-        joins += sum(
-            1
-            for node in itertools.chain(scope.tables, scope.derived_tables, scope.udtfs)
-            if isinstance(node.parent, exp.Join)
-        )
+        joins += _count_joins(scope.expression)
 
         parent = scope.expression.parent
         if parent and not isinstance(parent, exp.SetOperation):
@@ -724,6 +716,33 @@ def fill_metadata(scopes: list[Scope], metadata: dict[str, int]) -> None:
     metadata["joins"] = joins
     metadata["derived_tables"] = derived_tables
     metadata["nested_queries"] = nested_queries
+
+
+def _count_joins(expression: exp.Expr) -> int:
+    """
+    Counts the joins under `expression` by following only FROM source nodes: `joins`
+    lists, join sources and wrapped (non-query) groups. Bare queries are excluded
+    because they are counted by their own scope, but the joins of an aliased wrapped
+    group can be reachable from two scopes, so the total across scopes is an upper
+    bound rather than an exact count.
+    """
+    count = 0
+    stack = [expression]
+    while stack:
+        node = stack.pop()
+        joins = node.args.get("joins")
+        if joins:
+            count += len(joins)
+            stack.extend(join.this for join in joins if join.this)
+        if isinstance(node, exp.Select):
+            from_ = node.args.get("from_")
+            if from_:
+                stack.append(from_.this)
+        elif isinstance(node, (exp.Subquery, exp.Paren)) and not isinstance(
+            node.this, exp.UNWRAPPED_QUERIES
+        ):
+            stack.append(node.this)
+    return count
 
 
 def _traverse_scope(scope: Scope) -> Iterator[Scope]:

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -23,6 +23,9 @@ def unnest_subqueries(expression: E, metadata: dict[str, int] | None = None) -> 
     Returns:
         sqlglot.Expr: unnested expression
     """
+    if metadata and not metadata["nested_queries"]:
+        return expression
+
     next_alias_name = name_sequence("_u_")
 
     for scope in traverse_scope(expression):

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -5,7 +5,7 @@ from sqlglot.optimizer.scope import ScopeType, find_in_scope, traverse_scope
 from sqlglot._typing import E
 
 
-def unnest_subqueries(expression: E) -> E:
+def unnest_subqueries(expression: E, metadata: dict[str, int] | None = None) -> E:
     """
     Rewrite sqlglot AST to convert some predicates with subqueries into joins.
 
@@ -31,14 +31,14 @@ def unnest_subqueries(expression: E) -> E:
         if not parent:
             continue
         if scope.external_columns:
-            decorrelate(select, parent, scope.external_columns, next_alias_name)
+            decorrelate(select, parent, scope.external_columns, next_alias_name, metadata)
         elif scope.scope_type == ScopeType.SUBQUERY:
-            unnest(select, parent, next_alias_name)
+            unnest(select, parent, next_alias_name, metadata)
 
     return expression
 
 
-def unnest(select, parent_select, next_alias_name):
+def unnest(select, parent_select, next_alias_name, metadata=None):
     if len(select.selects) > 1:
         return
 
@@ -101,6 +101,11 @@ def unnest(select, parent_select, next_alias_name):
         _replace(select.parent, column)
         parent_select.join(select, on=on_clause, join_type=join_type, join_alias=alias, copy=False)
 
+        if metadata:
+            # The new join wraps the lifted subquery as a derived table.
+            metadata["joins"] += 1
+            metadata["derived_tables"] += 1
+
         return
 
     if find_in_scope(select, exp.Limit, exp.Offset):
@@ -144,8 +149,13 @@ def unnest(select, parent_select, next_alias_name):
         copy=False,
     )
 
+    if metadata:
+        # The new join wraps the lifted subquery as a derived table.
+        metadata["joins"] += 1
+        metadata["derived_tables"] += 1
 
-def decorrelate(select, parent_select, external_columns, next_alias_name):
+
+def decorrelate(select, parent_select, external_columns, next_alias_name, metadata=None):
     where = select.args.get("where")
 
     if not where or where.find(exp.Or) or select.find(exp.Limit, exp.Offset):
@@ -325,6 +335,11 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
         join_alias=table_alias,
         copy=False,
     )
+
+    if metadata:
+        # The new join wraps the lifted subquery as a derived table.
+        metadata["joins"] += 1
+        metadata["derived_tables"] += 1
 
 
 def _is_negated(expression: exp.Expression) -> bool:

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -1590,3 +1590,9 @@ SELECT
   ARRAY_AGG("T"."ID") WITHIN GROUP (ORDER BY
     "T"."ID") OVER (PARTITION BY "T"."GRP") AS "_COL_0"
 FROM "T" AS "T";
+
+# title: eliminated join leaves its subquery-turned-CTE orphaned for eliminate_ctes
+SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b;
+SELECT
+  "x"."a" AS "a"
+FROM "x" AS "x";

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -1592,7 +1592,9 @@ SELECT
 FROM "T" AS "T";
 
 # title: eliminated join leaves its subquery-turned-CTE orphaned for eliminate_ctes
-SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b;
+SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b ORDER BY x.a;
 SELECT
   "x"."a" AS "a"
-FROM "x" AS "x";
+FROM "x" AS "x"
+ORDER BY
+  "x"."a";

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -268,6 +268,12 @@ class TestOptimizer(unittest.TestCase):
             schema=schema,
         )
 
+        sql = "SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b"
+        self.assertEqual(
+            optimizer.optimize(parse_one(sql), schema=schema, metadata=None).sql(),
+            'SELECT "x"."a" AS "a" FROM "x" AS "x"',
+        )
+
     def test_isolate_table_selects(self):
         self.check_file(
             "isolate_table_selects",
@@ -3822,85 +3828,94 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         query = optimizer.qualify.qualify(parse_one(sql), schema=schema_ext)
         optimizer.annotate_types.annotate_types(query, schema=schema_ext)
 
-    def test_metadata_fill(self):
-        def fill(sql):
-            metadata = {}
-            fill_metadata(traverse_scope(parse_one(sql)), metadata)
-            return metadata
+    def test_fill_metadata(self):
+        for sql, expected in (
+            (
+                "SELECT a FROM x",
+                {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 0},
+            ),
+            (
+                "SELECT a FROM x UNION SELECT b FROM y UNION SELECT c FROM z",
+                {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 0},
+            ),
+            (
+                "SELECT * FROM (SELECT a FROM x UNION SELECT b FROM y) AS q",
+                {"ctes": 0, "joins": 0, "derived_tables": 1, "nested_queries": 1},
+            ),
+            (
+                "WITH c AS (SELECT a FROM x) SELECT a FROM c",
+                {"ctes": 1, "joins": 0, "derived_tables": 0, "nested_queries": 1},
+            ),
+            (
+                "SELECT d.a FROM (SELECT a FROM x) AS d JOIN y ON d.a = y.b",
+                {"ctes": 0, "joins": 1, "derived_tables": 1, "nested_queries": 1},
+            ),
+            (
+                "SELECT * FROM ((SELECT * FROM x) INNER JOIN y ON a = c)",
+                {"ctes": 0, "joins": 1, "derived_tables": 1, "nested_queries": 1},
+            ),
+            (
+                "SELECT * FROM a JOIN (b) ON a.x = b.x",
+                {"ctes": 0, "joins": 1, "derived_tables": 0, "nested_queries": 0},
+            ),
+            (
+                "SELECT * FROM a JOIN (b JOIN c ON b.x = c.x) ON a.y = b.y",
+                {"ctes": 0, "joins": 2, "derived_tables": 0, "nested_queries": 0},
+            ),
+            (
+                "SELECT * FROM ((SELECT 1 AS x) CROSS JOIN (SELECT 2 AS y)) AS z",
+                {"ctes": 0, "joins": 1, "derived_tables": 1, "nested_queries": 1},
+            ),
+            ("x = 1", {}),
+        ):
+            with self.subTest(sql):
+                metadata = {}
+                fill_metadata(traverse_scope(parse_one(sql)), metadata)
+                self.assertEqual(metadata, expected)
 
-        self.assertEqual(
-            fill("SELECT a FROM x"),
-            {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 0},
-        )
-
-        # The operands of a root-level set operation chain are not nested
-        self.assertEqual(
-            fill("SELECT a FROM x UNION SELECT b FROM y UNION SELECT c FROM z")["nested_queries"],
-            0,
-        )
-        self.assertEqual(
-            fill("SELECT * FROM (SELECT a FROM x UNION SELECT b FROM y) AS q")["nested_queries"],
-            1,
-        )
-
-        self.assertEqual(fill("WITH c AS (SELECT a FROM x) SELECT a FROM c")["ctes"], 1)
-
-        metadata = fill("SELECT d.a FROM (SELECT a FROM x) AS d JOIN y ON d.a = y.b")
-        self.assertEqual(metadata["derived_tables"], 1)
-        self.assertEqual(metadata["joins"], 1)
-
-        # Joins inside parenthesized FROM sources aren't attached to the select's "joins"
-        # arg and must be detected through their source nodes
-        self.assertEqual(
-            fill("SELECT * FROM ((SELECT * FROM x) INNER JOIN y ON a = c)")["joins"], 1
-        )
-
-        # Not a scopeable expression: the facts must stay unknown so that nothing skips
-        metadata = {}
-        fill_metadata(traverse_scope(parse_one("x = 1")), metadata)
-        self.assertEqual(metadata, {})
-
-    def test_metadata_gates(self):
+    def test_metadata_rule_skipping(self):
         zeros = {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 0}
 
-        for rule, sql in (
+        for rule, sql, expected in (
             (
                 optimizer.pushdown_projections.pushdown_projections,
                 "SELECT _q.a FROM (SELECT x.a AS a, x.b AS b FROM x) AS _q",
+                "SELECT _q.a FROM (SELECT x.a AS a FROM x) AS _q",
             ),
             (
                 optimizer.optimize_joins.optimize_joins,
                 "SELECT * FROM x CROSS JOIN y JOIN z ON x.a = z.a AND y.a = z.a",
+                "SELECT * FROM x JOIN z ON x.a = z.a AND TRUE JOIN y ON y.a = z.a",
             ),
             (
                 optimizer.eliminate_subqueries.eliminate_subqueries,
                 "SELECT a FROM (SELECT * FROM x) AS y",
+                "WITH y AS (SELECT * FROM x) SELECT a FROM y AS y",
             ),
             (
                 optimizer.merge_subqueries.merge_subqueries,
                 "SELECT a FROM (SELECT x.a FROM x) CROSS JOIN y",
+                "SELECT x.a FROM x CROSS JOIN y",
             ),
             (
                 optimizer.eliminate_joins.eliminate_joins,
                 "SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b",
+                "SELECT x.a FROM x",
             ),
             (
                 optimizer.eliminate_ctes.eliminate_ctes,
                 "WITH y AS (SELECT a FROM x) SELECT a FROM z",
+                "SELECT a FROM z",
             ),
         ):
-            # Zeroed facts short-circuit the rule before it does any work
-            self.assertEqual(rule(parse_one(sql), metadata=dict(zeros)).sql(), parse_one(sql).sql())
+            with self.subTest(sql):
+                self.assertEqual(rule(parse_one(sql), metadata=dict(zeros)).sql(), sql)
 
-            # Truthful facts must not change the rule's output
-            metadata = {}
-            fill_metadata(traverse_scope(parse_one(sql)), metadata)
-            self.assertEqual(
-                rule(parse_one(sql), metadata=metadata).sql(), rule(parse_one(sql)).sql()
-            )
+                metadata = {}
+                fill_metadata(traverse_scope(parse_one(sql)), metadata)
+                self.assertEqual(rule(parse_one(sql), metadata=metadata).sql(), expected)
 
-    def test_metadata_captures(self):
-        # Removals decrement: popping both unused CTEs drives the counter to 0
+    def test_metadata_counter_updates(self):
         expression = parse_one("WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS x) SELECT * FROM q")
         metadata = {}
         fill_metadata(traverse_scope(expression), metadata)
@@ -3917,7 +3932,6 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         optimizer.eliminate_joins.eliminate_joins(expression, metadata=metadata)
         self.assertEqual(metadata["joins"], 0)
 
-        # Conversions move counts between counters: derived table -> CTE
         expression = parse_one("SELECT a FROM (SELECT * FROM x) AS y")
         metadata = {}
         fill_metadata(traverse_scope(expression), metadata)
@@ -3925,49 +3939,8 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         optimizer.eliminate_subqueries.eliminate_subqueries(expression, metadata=metadata)
         self.assertEqual((metadata["ctes"], metadata["derived_tables"]), (1, 0))
 
-        # Merges decrement, so later CTE / derived table work can skip
         expression = parse_one("SELECT a FROM (SELECT x.a FROM x) CROSS JOIN y")
         metadata = {}
         fill_metadata(traverse_scope(expression), metadata)
         optimizer.merge_subqueries.merge_subqueries(expression, metadata=metadata)
         self.assertEqual(metadata["derived_tables"], 0)
-
-    def test_metadata_on_off_equivalence(self):
-        # Metadata must never change optimize's output; these shapes exercise every gate,
-        # capture, and the staleness hazards found during development
-        for sql in (
-            # CTE created mid-pipeline, then orphaned by join elimination
-            "SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b",
-            # parenthesized join: not attached to the select's "joins" arg
-            "SELECT * FROM ((SELECT * FROM x) INNER JOIN y ON a = c)",
-            "SELECT a, b FROM x WHERE a = 1",
-            "SELECT a FROM x UNION ALL SELECT b AS a FROM y UNION ALL SELECT c AS a FROM z",
-            "WITH c1 AS (SELECT a, b FROM x), c2 AS (SELECT a, b FROM c1) SELECT a FROM c2 WHERE b > 1",
-            "SELECT * FROM x WHERE a IN (SELECT b FROM y)",
-            "SELECT * FROM x WHERE (SELECT MAX(b) FROM y WHERE y.b = x.b) > 0",
-        ):
-            self.assertEqual(
-                optimizer.optimize(parse_one(sql), schema=self.schema).sql(),
-                optimizer.optimize(parse_one(sql), schema=self.schema, metadata=None).sql(),
-                sql,
-            )
-
-        # The whole optimizer fixture corpus must also match, including error parity
-        schema = {
-            "x": {"a": "INT", "b": "INT"},
-            "y": {"b": "INT", "c": "INT"},
-            "z": {"a": "INT", "c": "INT"},
-            "u": {"f": "INT", "g": "INT", "h": "TEXT"},
-        }
-        for meta, sql, _ in load_sql_fixture_pairs("optimizer/optimizer.sql"):
-            dialect = meta.get("dialect")
-
-            def run(**kwargs):
-                try:
-                    return optimizer.optimize(
-                        parse_one(sql, read=dialect), schema=schema, dialect=dialect, **kwargs
-                    ).sql(dialect=dialect)
-                except Exception as e:
-                    return f"error: {type(e).__name__}"
-
-            self.assertEqual(run(), run(metadata=None), sql)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -3916,6 +3916,11 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                 "WITH y AS (SELECT a FROM x) SELECT a FROM z",
                 "SELECT a FROM z",
             ),
+            (
+                optimizer.unnest_subqueries.unnest_subqueries,
+                "SELECT * FROM x AS x WHERE x.a IN (SELECT y.a AS a FROM y AS y)",
+                "SELECT * FROM x AS x LEFT JOIN (SELECT y.a AS a FROM y AS y GROUP BY y.a) AS _u_0 ON x.a = _u_0.a WHERE NOT _u_0.a IS NULL",
+            ),
         ):
             with self.subTest(sql):
                 self.assertEqual(rule(parse_one(sql), metadata=dict(zeros)).sql(), sql)
@@ -3984,3 +3989,14 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
             self.assertEqual((metadata["joins"], metadata["derived_tables"]), (0, 0))
             optimizer.unnest_subqueries.unnest_subqueries(expression, metadata=metadata)
             self.assertEqual((metadata["joins"], metadata["derived_tables"]), (1, 1), sql)
+
+        metadata = {}
+        expression = optimizer.optimize(
+            parse_one("SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b"),
+            schema=self.schema,
+            metadata=metadata,
+        )
+        self.assertEqual(expression.sql(), 'SELECT "x"."a" AS "a" FROM "x" AS "x"')
+        self.assertEqual(
+            metadata, {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 2}
+        )

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -14,7 +14,7 @@ from sqlglot.optimizer.canonicalize_internal_names import canonicalize_internal_
 from sqlglot.optimizer.journal import record, revert
 from sqlglot.optimizer.normalize import normalization_distance
 from sqlglot.optimizer.qualify import qualify
-from sqlglot.optimizer.scope import build_scope, traverse_scope, walk_in_scope
+from sqlglot.optimizer.scope import build_scope, fill_metadata, traverse_scope, walk_in_scope
 from sqlglot.schema import MappingSchema
 from tests.helpers import (
     TPCDS_SCHEMA,
@@ -3821,3 +3821,153 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         schema_ext = {"t": {"_col": "INT"}}
         query = optimizer.qualify.qualify(parse_one(sql), schema=schema_ext)
         optimizer.annotate_types.annotate_types(query, schema=schema_ext)
+
+    def test_metadata_fill(self):
+        def fill(sql):
+            metadata = {}
+            fill_metadata(traverse_scope(parse_one(sql)), metadata)
+            return metadata
+
+        self.assertEqual(
+            fill("SELECT a FROM x"),
+            {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 0},
+        )
+
+        # The operands of a root-level set operation chain are not nested
+        self.assertEqual(
+            fill("SELECT a FROM x UNION SELECT b FROM y UNION SELECT c FROM z")["nested_queries"],
+            0,
+        )
+        self.assertEqual(
+            fill("SELECT * FROM (SELECT a FROM x UNION SELECT b FROM y) AS q")["nested_queries"],
+            1,
+        )
+
+        self.assertEqual(fill("WITH c AS (SELECT a FROM x) SELECT a FROM c")["ctes"], 1)
+
+        metadata = fill("SELECT d.a FROM (SELECT a FROM x) AS d JOIN y ON d.a = y.b")
+        self.assertEqual(metadata["derived_tables"], 1)
+        self.assertEqual(metadata["joins"], 1)
+
+        # Joins inside parenthesized FROM sources aren't attached to the select's "joins"
+        # arg and must be detected through their source nodes
+        self.assertEqual(
+            fill("SELECT * FROM ((SELECT * FROM x) INNER JOIN y ON a = c)")["joins"], 1
+        )
+
+        # Not a scopeable expression: the facts must stay unknown so that nothing skips
+        metadata = {}
+        fill_metadata(traverse_scope(parse_one("x = 1")), metadata)
+        self.assertEqual(metadata, {})
+
+    def test_metadata_gates(self):
+        zeros = {"ctes": 0, "joins": 0, "derived_tables": 0, "nested_queries": 0}
+
+        for rule, sql in (
+            (
+                optimizer.pushdown_projections.pushdown_projections,
+                "SELECT _q.a FROM (SELECT x.a AS a, x.b AS b FROM x) AS _q",
+            ),
+            (
+                optimizer.optimize_joins.optimize_joins,
+                "SELECT * FROM x CROSS JOIN y JOIN z ON x.a = z.a AND y.a = z.a",
+            ),
+            (
+                optimizer.eliminate_subqueries.eliminate_subqueries,
+                "SELECT a FROM (SELECT * FROM x) AS y",
+            ),
+            (
+                optimizer.merge_subqueries.merge_subqueries,
+                "SELECT a FROM (SELECT x.a FROM x) CROSS JOIN y",
+            ),
+            (
+                optimizer.eliminate_joins.eliminate_joins,
+                "SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b",
+            ),
+            (
+                optimizer.eliminate_ctes.eliminate_ctes,
+                "WITH y AS (SELECT a FROM x) SELECT a FROM z",
+            ),
+        ):
+            # Zeroed facts short-circuit the rule before it does any work
+            self.assertEqual(rule(parse_one(sql), metadata=dict(zeros)).sql(), parse_one(sql).sql())
+
+            # Truthful facts must not change the rule's output
+            metadata = {}
+            fill_metadata(traverse_scope(parse_one(sql)), metadata)
+            self.assertEqual(
+                rule(parse_one(sql), metadata=metadata).sql(), rule(parse_one(sql)).sql()
+            )
+
+    def test_metadata_captures(self):
+        # Removals decrement: popping both unused CTEs drives the counter to 0
+        expression = parse_one("WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS x) SELECT * FROM q")
+        metadata = {}
+        fill_metadata(traverse_scope(expression), metadata)
+        self.assertEqual(metadata["ctes"], 2)
+        optimizer.eliminate_ctes.eliminate_ctes(expression, metadata=metadata)
+        self.assertEqual(metadata["ctes"], 0)
+
+        expression = parse_one(
+            "SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b"
+        )
+        metadata = {}
+        fill_metadata(traverse_scope(expression), metadata)
+        self.assertEqual(metadata["joins"], 1)
+        optimizer.eliminate_joins.eliminate_joins(expression, metadata=metadata)
+        self.assertEqual(metadata["joins"], 0)
+
+        # Conversions move counts between counters: derived table -> CTE
+        expression = parse_one("SELECT a FROM (SELECT * FROM x) AS y")
+        metadata = {}
+        fill_metadata(traverse_scope(expression), metadata)
+        self.assertEqual((metadata["ctes"], metadata["derived_tables"]), (0, 1))
+        optimizer.eliminate_subqueries.eliminate_subqueries(expression, metadata=metadata)
+        self.assertEqual((metadata["ctes"], metadata["derived_tables"]), (1, 0))
+
+        # Merges decrement, so later CTE / derived table work can skip
+        expression = parse_one("SELECT a FROM (SELECT x.a FROM x) CROSS JOIN y")
+        metadata = {}
+        fill_metadata(traverse_scope(expression), metadata)
+        optimizer.merge_subqueries.merge_subqueries(expression, metadata=metadata)
+        self.assertEqual(metadata["derived_tables"], 0)
+
+    def test_metadata_on_off_equivalence(self):
+        # Metadata must never change optimize's output; these shapes exercise every gate,
+        # capture, and the staleness hazards found during development
+        for sql in (
+            # CTE created mid-pipeline, then orphaned by join elimination
+            "SELECT x.a FROM x LEFT JOIN (SELECT DISTINCT y.b FROM y) AS y ON x.b = y.b",
+            # parenthesized join: not attached to the select's "joins" arg
+            "SELECT * FROM ((SELECT * FROM x) INNER JOIN y ON a = c)",
+            "SELECT a, b FROM x WHERE a = 1",
+            "SELECT a FROM x UNION ALL SELECT b AS a FROM y UNION ALL SELECT c AS a FROM z",
+            "WITH c1 AS (SELECT a, b FROM x), c2 AS (SELECT a, b FROM c1) SELECT a FROM c2 WHERE b > 1",
+            "SELECT * FROM x WHERE a IN (SELECT b FROM y)",
+            "SELECT * FROM x WHERE (SELECT MAX(b) FROM y WHERE y.b = x.b) > 0",
+        ):
+            self.assertEqual(
+                optimizer.optimize(parse_one(sql), schema=self.schema).sql(),
+                optimizer.optimize(parse_one(sql), schema=self.schema, metadata=None).sql(),
+                sql,
+            )
+
+        # The whole optimizer fixture corpus must also match, including error parity
+        schema = {
+            "x": {"a": "INT", "b": "INT"},
+            "y": {"b": "INT", "c": "INT"},
+            "z": {"a": "INT", "c": "INT"},
+            "u": {"f": "INT", "g": "INT", "h": "TEXT"},
+        }
+        for meta, sql, _ in load_sql_fixture_pairs("optimizer/optimizer.sql"):
+            dialect = meta.get("dialect")
+
+            def run(**kwargs):
+                try:
+                    return optimizer.optimize(
+                        parse_one(sql, read=dialect), schema=schema, dialect=dialect, **kwargs
+                    ).sql(dialect=dialect)
+                except Exception as e:
+                    return f"error: {type(e).__name__}"
+
+            self.assertEqual(run(), run(metadata=None), sql)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -3874,6 +3874,7 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                 "SELECT * FROM ((SELECT 1 AS x) CROSS JOIN (SELECT p.a AS a FROM p JOIN q ON p.i = q.i)) AS z",
                 {"ctes": 0, "joins": 2, "derived_tables": 1, "nested_queries": 1},
             ),
+            ("WITH a AS (SELECT * FROM b) UPDATE a SET col = 1", {}),
             ("x = 1", {}),
         ):
             with self.subTest(sql):
@@ -3922,6 +3923,19 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                 metadata = {}
                 fill_metadata(traverse_scope(parse_one(sql)), metadata)
                 self.assertEqual(rule(parse_one(sql), metadata=metadata).sql(), expected)
+
+        with self.assertRaises(OptimizeError):
+            optimizer.pushdown_projections.pushdown_projections(
+                parse_one("SELECT x.a AS a FROM x UNION SELECT y.b AS b, y.c AS c FROM y"),
+                schema=self.schema,
+                metadata=dict(zeros),
+            )
+
+        sql = "WITH a AS (SELECT * FROM b) UPDATE a SET col = 1"
+        self.assertEqual(
+            optimizer.optimize(parse_one(sql), schema={"b": {"col": "INT"}}).sql(),
+            'UPDATE "a" SET "col" = 1',
+        )
 
     def test_metadata_counter_updates(self):
         expression = parse_one("WITH a AS (SELECT 1 AS x), b AS (SELECT 2 AS x) SELECT * FROM q")

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -3866,6 +3866,14 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
                 "SELECT * FROM ((SELECT 1 AS x) CROSS JOIN (SELECT 2 AS y)) AS z",
                 {"ctes": 0, "joins": 1, "derived_tables": 1, "nested_queries": 1},
             ),
+            (
+                "SELECT * FROM (tbl1 CROSS JOIN tbl2) AS t",
+                {"ctes": 0, "joins": 1, "derived_tables": 1, "nested_queries": 1},
+            ),
+            (
+                "SELECT * FROM ((SELECT 1 AS x) CROSS JOIN (SELECT p.a AS a FROM p JOIN q ON p.i = q.i)) AS z",
+                {"ctes": 0, "joins": 2, "derived_tables": 1, "nested_queries": 1},
+            ),
             ("x = 1", {}),
         ):
             with self.subTest(sql):
@@ -3944,3 +3952,21 @@ SELECT :with_,WITH :expressions,CTE :this,UNION :this,SELECT :expressions,1,:exp
         fill_metadata(traverse_scope(expression), metadata)
         optimizer.merge_subqueries.merge_subqueries(expression, metadata=metadata)
         self.assertEqual(metadata["derived_tables"], 0)
+
+        expression = parse_one("WITH q AS (SELECT x.a AS a FROM x) SELECT q.a AS a FROM q")
+        metadata = {}
+        fill_metadata(traverse_scope(expression), metadata)
+        self.assertEqual(metadata["ctes"], 1)
+        optimizer.merge_subqueries.merge_subqueries(expression, metadata=metadata)
+        self.assertEqual(metadata["ctes"], 0)
+
+        for sql in (
+            "SELECT * FROM x WHERE x.a IN (SELECT y.a FROM y)",
+            "SELECT * FROM x WHERE (SELECT MAX(y.b) FROM y WHERE y.a = x.a) > 0",
+        ):
+            expression = parse_one(sql)
+            metadata = {}
+            fill_metadata(traverse_scope(expression), metadata)
+            self.assertEqual((metadata["joins"], metadata["derived_tables"]), (0, 0))
+            optimizer.unnest_subqueries.unnest_subqueries(expression, metadata=metadata)
+            self.assertEqual((metadata["joins"], metadata["derived_tables"]), (1, 1), sql)


### PR DESCRIPTION
This PR adds a metadata layer on the optimizer which stores structural information about an AST. Currently, we store the following counters:

1. number of CTEs
2. number of Joins
3. number of Derived Tables
4. number of Nested Queries

By leveraging these counters, we can skip the application of certain optimization rules and avoid heavy traversals.

The counters are upper bounds, not exact counts: 0 means the construct is definitely absent, so a rule may only skip when its counter is 0. Rules increment for constructs they may introduce and decrement only for removals they perform. Metadata never changes a rule's output, only whether it runs: `optimize()` enables it by default, `metadata=None` disables it, and rules called directly are unaffected. For DML/DDL roots (e.g. `WITH ... UPDATE`) the facts are left unknown and every rule runs as before.

| Rule | Skips when | Maintains |
|---|---|---|
| `pushdown_projections` | no `nested_queries`, no `ctes`, and the root isn't a set operation (operand-width validation must still run) | fills the counters |
| `optimize_joins` | no `joins` | — |
| `eliminate_subqueries` | no `nested_queries`, no `ctes` | `derived_tables -1`, `ctes +1` per conversion; `ctes -1` per dedup; self-fills |
| `merge_subqueries` | no `ctes` and no `derived_tables` (plus per-leg skips) | decrements per merge; self-fills |
| `eliminate_joins` | no `joins` | `joins -1` per removal; self-fills |
| `eliminate_ctes` | no `ctes` | `ctes -1` per pop |
| `unnest_subqueries` | no `nested_queries` | `joins +1`, `derived_tables +1` per lifted subquery |

Measured on `optimize()` end to end (metadata on vs off):

| Workload | Speedup |
|---|---|
| simple queries (no joins/CTEs/subqueries) | 1.15x |
| dbt postgres corpus (449 real queries) | 1
| TPC-H / TPC-DS (nothing to skip) | ~1.01x |

We don't apply the metadata logic on the following: `qualify`, `normalize`, `pushdown_predicates`, `quote_identifiers`, `annotate_types`, `canonicalize`, `simplify`.

Follow ups: `pushdown_predicates`