### PR TITLE
fix(optimizer): keep projections referenced by SORT BY / DISTRIBUTE BY / CLUSTER BY

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -28,17 +28,13 @@ SET_RETURNING_FUNCTIONS = (exp.Explode, exp.Inline, exp.Unnest)
 # GROUP BY constructs whose children are grouping items; a one-column set, e.g. ((1)), is a Paren
 GROUPING_CONSTRUCTS = (exp.Cube, exp.GroupingSets, exp.Paren, exp.Rollup, exp.Tuple)
 
-# Query modifiers that can reference output columns; Sort (SORT BY) and Distribute (DISTRIBUTE BY)
-# are Order subclasses, so ORDER BY and its two Spark cousins are all covered by Order
-OUTPUT_REFERENCING_MODIFIERS = (exp.Order, exp.Cluster)
-
 
 def _output_column_refs(expression: exp.Expr, scoped: bool) -> set[str]:
-    # Assume columns without a qualified table are references to output columns
     refs: set[str] = set()
 
-    for node in expression.args.values():
-        if isinstance(node, OUTPUT_REFERENCING_MODIFIERS):
+    for arg in ("order", "sort", "distribute", "cluster"):
+        node = expression.args.get(arg)
+        if node:
             columns = find_all_in_scope(node, exp.Column) if scoped else node.find_all(exp.Column)
             refs.update(c.name for c in columns if not c.table)
 

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -32,10 +32,6 @@ GROUPING_CONSTRUCTS = (exp.Cube, exp.GroupingSets, exp.Paren, exp.Rollup, exp.Tu
 # are Order subclasses, so ORDER BY and its two Spark cousins are all covered by Order
 OUTPUT_REFERENCING_MODIFIERS = (exp.Order, exp.Cluster)
 
-# These trail the last arm of a set operation but apply to its whole result, and the parser
-# attaches them to that arm, so they're hoisted onto the set operation before pruning
-TRAILING_MODIFIERS = (exp.Sort, exp.Distribute, exp.Cluster)
-
 
 def _output_column_refs(expression: exp.Expr, scoped: bool) -> set[str]:
     # Assume columns without a qualified table are references to output columns
@@ -132,11 +128,6 @@ def pushdown_projections(
             if not by_name and len(le.selects) != len(re.selects):
                 scope_sql = scope_expression.sql(dialect=dialect)
                 raise OptimizeError(f"Invalid set operation due to column mismatch: {scope_sql}.")
-
-            for arg, node in list(re.args.items()):
-                if isinstance(node, TRAILING_MODIFIERS):
-                    re.set(arg, None)
-                    scope_expression.set(arg, node)
 
             # Columns referenced by ORDER BY and friends need to be kept too
             if SELECT_ALL not in parent_selections:

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -28,6 +28,26 @@ SET_RETURNING_FUNCTIONS = (exp.Explode, exp.Inline, exp.Unnest)
 # GROUP BY constructs whose children are grouping items; a one-column set, e.g. ((1)), is a Paren
 GROUPING_CONSTRUCTS = (exp.Cube, exp.GroupingSets, exp.Paren, exp.Rollup, exp.Tuple)
 
+# Query modifiers that can reference output columns; Sort (SORT BY) and Distribute (DISTRIBUTE BY)
+# are Order subclasses, so ORDER BY and its two Spark cousins are all covered by Order
+OUTPUT_REFERENCING_MODIFIERS = (exp.Order, exp.Cluster)
+
+# These trail the last arm of a set operation but apply to its whole result, and the parser
+# attaches them to that arm, so they're hoisted onto the set operation before pruning
+TRAILING_MODIFIERS = (exp.Sort, exp.Distribute, exp.Cluster)
+
+
+def _output_column_refs(expression: exp.Expr, scoped: bool) -> set[str]:
+    # Assume columns without a qualified table are references to output columns
+    refs: set[str] = set()
+
+    for node in expression.args.values():
+        if isinstance(node, OUTPUT_REFERENCING_MODIFIERS):
+            columns = find_all_in_scope(node, exp.Column) if scoped else node.find_all(exp.Column)
+            refs.update(c.name for c in columns if not c.table)
+
+    return refs
+
 
 def _is_self_referencing_cte(scope: Scope) -> bool:
     cte = scope.expression.parent
@@ -113,12 +133,16 @@ def pushdown_projections(
                 scope_sql = scope_expression.sql(dialect=dialect)
                 raise OptimizeError(f"Invalid set operation due to column mismatch: {scope_sql}.")
 
-            # Columns in ORDER BY need to be kept too
-            order = scope_expression.args.get("order")
-            if order and SELECT_ALL not in parent_selections:
-                order_refs = {c.name for c in find_all_in_scope(order, exp.Column) if not c.table}
-                if order_refs:
-                    parent_selections = parent_selections | order_refs
+            for arg, node in list(re.args.items()):
+                if isinstance(node, TRAILING_MODIFIERS):
+                    re.set(arg, None)
+                    scope_expression.set(arg, node)
+
+            # Columns referenced by ORDER BY and friends need to be kept too
+            if SELECT_ALL not in parent_selections:
+                output_refs = _output_column_refs(scope_expression, scoped=True)
+                if output_refs:
+                    parent_selections = parent_selections | output_refs
 
             referenced_columns[left] = parent_selections
 
@@ -168,13 +192,7 @@ def pushdown_projections(
 
 def _remove_unused_selections(scope, parent_selections, schema, alias_count, journal=None):
     expression = scope.expression
-    order = expression.args.get("order")
-
-    if order:
-        # Assume columns without a qualified table are references to output columns
-        order_refs = {c.name for c in order.find_all(exp.Column) if not c.table}
-    else:
-        order_refs = set()
+    output_refs = _output_column_refs(expression, scoped=False)
 
     # Resolve GROUP BY ordinals before pruning
     ordinal_refs = _group_by_ordinal_refs(expression)
@@ -200,7 +218,7 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
         if (
             select_all
             or name in parent_selections
-            or name in order_refs
+            or name in output_refs
             or alias_count > 0
             or id(selection) in group_ordinal_selection_ids
             or (implicit_group_by_all and not is_agg_selection)

--- a/sqlglot/optimizer/scope.py
+++ b/sqlglot/optimizer/scope.py
@@ -381,6 +381,7 @@ class Scope:
                     exp.Select,
                     exp.Qualify,
                     exp.Order,
+                    exp.Cluster,
                     exp.Having,
                     exp.Hint,
                     exp.Table,
@@ -393,7 +394,7 @@ class Scope:
                     or isinstance(ancestor, exp.Select)
                     or (isinstance(ancestor, exp.Table) and not isinstance(ancestor.this, exp.Func))
                     or (
-                        isinstance(ancestor, (exp.Order, exp.Distinct))
+                        isinstance(ancestor, (exp.Order, exp.Cluster, exp.Distinct))
                         and (
                             isinstance(ancestor.parent, (exp.Window, exp.WithinGroup))
                             or not isinstance(ancestor.parent, exp.Select)

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -1866,7 +1866,7 @@ class Parser:
 
     # Whether query modifiers such as LIMIT are attached to the UNION node (vs its right operand)
     MODIFIERS_ATTACHED_TO_SET_OP: t.ClassVar = True
-    SET_OP_MODIFIERS: t.ClassVar = {"order", "limit", "offset"}
+    SET_OP_MODIFIERS: t.ClassVar = {"order", "limit", "offset", "sort", "distribute", "cluster"}
 
     # Whether to parse IF statements that aren't followed by a left parenthesis as commands
     NO_PAREN_IF_COMMANDS: t.ClassVar = True

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -284,3 +284,39 @@ SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x 
 
 SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY (1), (2)) t;
 SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY (1), (2)) AS t;
+
+--------------------------------------
+-- Spark's SORT BY / DISTRIBUTE BY / CLUSTER BY reference output columns like ORDER BY does
+--------------------------------------
+
+# dialect: spark
+SELECT t.a FROM (SELECT a, b + 1 AS s FROM x SORT BY s) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x SORT BY s) AS t;
+
+# dialect: spark
+SELECT t.a FROM (SELECT a, b + 1 AS s FROM x DISTRIBUTE BY s) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x DISTRIBUTE BY s) AS t;
+
+# dialect: spark
+SELECT t.a FROM (SELECT a, b + 1 AS s FROM x CLUSTER BY s) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x CLUSTER BY s) AS t;
+
+# dialect: spark
+# title: an output reference nested in a SORT BY expression still keeps its projection
+SELECT t.a FROM (SELECT a, b + 1 AS s FROM x SORT BY s + 1) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x SORT BY s + 1) AS t;
+
+# dialect: spark
+# title: a trailing SORT BY applies to the whole set operation, so both arms keep the projection
+SELECT t.a FROM (SELECT a, b + 1 AS s FROM x UNION ALL SELECT b, b + 2 AS s FROM y SORT BY s) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x UNION ALL SELECT y.b AS b, y.b + 2 AS s FROM y AS y SORT BY s) AS t;
+
+# dialect: spark
+# title: a trailing CLUSTER BY applies to the whole set operation, so both arms keep the projection
+SELECT t.a FROM (SELECT a, b + 1 AS s FROM x UNION ALL SELECT b, b + 2 AS s FROM y CLUSTER BY s) t;
+SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x UNION ALL SELECT y.b AS b, y.b + 2 AS s FROM y AS y CLUSTER BY s) AS t;
+
+# dialect: spark
+# title: a qualified SORT BY reference is not an output reference, even when it matches a projection alias
+SELECT t.a FROM (SELECT a, b + 1 AS b FROM x SORT BY x.b) t;
+SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x SORT BY x.b) AS t;

--- a/tests/fixtures/optimizer/pushdown_projections.sql
+++ b/tests/fixtures/optimizer/pushdown_projections.sql
@@ -284,39 +284,3 @@ SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x 
 
 SELECT t.a, t.s FROM (SELECT a, b, SUM(b) AS s FROM x GROUP BY (1), (2)) t;
 SELECT t.a AS a, t.s AS s FROM (SELECT x.a AS a, x.b AS b, SUM(x.b) AS s FROM x AS x GROUP BY (1), (2)) AS t;
-
---------------------------------------
--- Spark's SORT BY / DISTRIBUTE BY / CLUSTER BY reference output columns like ORDER BY does
---------------------------------------
-
-# dialect: spark
-SELECT t.a FROM (SELECT a, b + 1 AS s FROM x SORT BY s) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x SORT BY s) AS t;
-
-# dialect: spark
-SELECT t.a FROM (SELECT a, b + 1 AS s FROM x DISTRIBUTE BY s) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x DISTRIBUTE BY s) AS t;
-
-# dialect: spark
-SELECT t.a FROM (SELECT a, b + 1 AS s FROM x CLUSTER BY s) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x CLUSTER BY s) AS t;
-
-# dialect: spark
-# title: an output reference nested in a SORT BY expression still keeps its projection
-SELECT t.a FROM (SELECT a, b + 1 AS s FROM x SORT BY s + 1) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x SORT BY s + 1) AS t;
-
-# dialect: spark
-# title: a trailing SORT BY applies to the whole set operation, so both arms keep the projection
-SELECT t.a FROM (SELECT a, b + 1 AS s FROM x UNION ALL SELECT b, b + 2 AS s FROM y SORT BY s) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x UNION ALL SELECT y.b AS b, y.b + 2 AS s FROM y AS y SORT BY s) AS t;
-
-# dialect: spark
-# title: a trailing CLUSTER BY applies to the whole set operation, so both arms keep the projection
-SELECT t.a FROM (SELECT a, b + 1 AS s FROM x UNION ALL SELECT b, b + 2 AS s FROM y CLUSTER BY s) t;
-SELECT t.a AS a FROM (SELECT x.a AS a, x.b + 1 AS s FROM x AS x UNION ALL SELECT y.b AS b, y.b + 2 AS s FROM y AS y CLUSTER BY s) AS t;
-
-# dialect: spark
-# title: a qualified SORT BY reference is not an output reference, even when it matches a projection alias
-SELECT t.a FROM (SELECT a, b + 1 AS b FROM x SORT BY x.b) t;
-SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x SORT BY x.b) AS t;


### PR DESCRIPTION
`pushdown_projections` kept projections referenced by `ORDER BY`, but Spark's `SORT BY`, `DISTRIBUTE BY` and `CLUSTER BY` can reference select aliases too and were not checked, so their projections were pruned.  Treat all three clauses as output references, hoisting them onto the exp.SetOperation when they trail a set operation so both arms keep the projection.

```
-- input (spark)
SELECT t.a FROM (SELECT a, b + c AS s FROM x SORT BY s) t

-- old output: alias `s` no longer exists -> UNRESOLVED_COLUMN
SELECT t.a AS a FROM (SELECT x.a AS a FROM x AS x SORT BY s) AS t

-- fixed output
SELECT t.a AS a FROM (SELECT x.a AS a, x.b + x.c AS s FROM x AS x SORT BY s) AS t
```