### PR TITLE
fix(postgres): keep the time zone argument of DATE_TRUNC [CLAUDE]

### DIFF
--- a/sqlglot/dialects/dialect.py
+++ b/sqlglot/dialects/dialect.py
@@ -1929,7 +1929,7 @@ def binary_from_function(expr_type: Type[B]) -> t.Callable[[BuilderArgs], B]:
 
 # Used to represent DATE_TRUNC in Doris, Postgres and Starrocks dialects
 def build_timestamp_trunc(args: BuilderArgs) -> exp.TimestampTrunc:
-    return exp.TimestampTrunc(this=seq_get(args, 1), unit=seq_get(args, 0))
+    return exp.TimestampTrunc(this=seq_get(args, 1), unit=seq_get(args, 0), zone=seq_get(args, 2))
 
 
 def build_trunc(

--- a/tests/dialects/test_postgres.py
+++ b/tests/dialects/test_postgres.py
@@ -43,6 +43,7 @@ class TestPostgres(Validator):
         self.validate_identity("||/ x", "CBRT(x)")
         self.validate_identity("SELECT EXTRACT(QUARTER FROM CAST('2025-04-26' AS DATE))")
         self.validate_identity("SELECT DATE_TRUNC('QUARTER', CAST('2025-04-26' AS DATE))")
+        self.validate_identity("SELECT DATE_TRUNC('DAY', x, 'America/New_York')")
         self.validate_identity("STRING_TO_ARRAY('xx~^~yy~^~zz', '~^~', 'yy')")
         self.validate_identity("SELECT x FROM t WHERE CAST($1 AS TEXT) = 'ok'")
         self.validate_identity("SELECT * FROM t TABLESAMPLE SYSTEM (50) REPEATABLE (55)")


### PR DESCRIPTION
`date_trunc(field, timestamptz, time_zone)` is valid PostgreSQL 12+, and the Postgres generator has emitted that third argument since 5ee0e3d0f ("Fix(postgres): date_trunc supports time zone"). The reader never caught up, so it round-trips as a silent semantic change:

```python
parse_one("SELECT DATE_TRUNC('DAY', x, 'America/New_York')", read="postgres").sql("postgres")
# SELECT DATE_TRUNC('DAY', x)
```

`build_timestamp_trunc` reads only `args[0]` and `args[1]`. `exp.TimestampTrunc` already declares `zone` and `timestamptrunc_sql(zone=True)` already writes it, so filling it in is the whole fix.

Considered and dropped: a Postgres-local builder. StarRocks and Doris share this builder, but neither generator emits a zone, so their output is byte-identical before and after — narrowing buys nothing.

Not fixed here, pre-existing on main: Redshift and StarRocks inherit the Postgres `zone=True` writer, so a zone arriving from another dialect already yields a 3-arg `DATE_TRUNC` those engines reject.

Found with a round-trip differential — re-reading every `validate_all(write=...)` output in its own dialect. It flagged this plus the same shape in Materialize; both clear, and nothing new appears.

`make style` clean (ruff, ruff-format, mypy); full suite 1351 tests green. The added test fails on main.

Disclosure: LLM-assisted (Claude), hence `[CLAUDE]` in the title.
