### PR TITLE
feat(mysql): add `ALTER TABLE ... COMMENT`.

### DIFF
--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -253,6 +253,7 @@ class MySQLParser(parser.Parser):
         "CHANGE": lambda self: self._parse_alter_table_modify(rename=True),
         "MODIFY": lambda self: self._parse_alter_table_modify(),
         "AUTO_INCREMENT": lambda self: self._parse_property_assignment(exp.AutoIncrementProperty),
+        "COMMENT": lambda self: self._parse_property_assignment(exp.SchemaCommentProperty),
     }
 
     ALTER_ALTER_PARSERS = {

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -73,6 +73,8 @@ class TestMySQL(Validator):
             "ALTER TABLE t CHANGE COLUMN a b BIGINT NOT NULL",
         )
         self.validate_identity("ALTER TABLE t AUTO_INCREMENT=3000000000")
+        self.validate_identity("ALTER TABLE t COMMENT='hi'")
+        self.validate_identity("ALTER TABLE t COMMENT 'hi'", "ALTER TABLE t COMMENT='hi'")
         self.validate_identity("ALTER VIEW v AS SELECT a, b, c, d FROM foo")
         self.validate_identity("ALTER VIEW v AS SELECT * FROM foo WHERE c > 100")
         self.validate_identity(


### PR DESCRIPTION
The MySQL `CREATE TABLE` syntax allows a table-level `COMMENT`, but `ALTER TABLE` did not.

```
table_option: {
  ...
  | COMMENT [=] 'string'
  ...
```