### PR TITLE
fix(parser)!: preserve the order of CUBE, ROLLUP and GROUPING SETS in GROUP BY

### DIFF
--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -624,7 +624,6 @@ class Group(Expression):
     arg_types = {
         "expressions": False,
         "grouping_sets": False,
-        "grouping_sets_as_group_by_element": False,
         "cube": False,
         "rollup": False,
         "totals": False,

--- a/sqlglot/generator.py
+++ b/sqlglot/generator.py
@@ -2836,7 +2836,7 @@ class Generator:
         ):
             add_separator = True
 
-            if grouping_sets and not expression.args.get("grouping_sets_as_group_by_element"):
+            if grouping_sets:
                 if self.SUPPORTS_GROUPING_SETS_AS_SUFFIX:
                     add_separator = False
                 else:

--- a/sqlglot/parser.py
+++ b/sqlglot/parser.py
@@ -5569,8 +5569,6 @@ class Parser:
             elements["all"] = False
 
         while True:
-            index = self._index
-
             # Stop before consuming modifier tokens like LIMIT, OFFSET and WINDOW,
             # which are also valid identifiers
             if self._match_set(self.QUERY_MODIFIER_TOKENS, advance=False):
@@ -5579,35 +5577,29 @@ class Parser:
             elements["expressions"].extend(
                 self._parse_csv(
                     lambda: (
-                        None
-                        if self._match_set((TokenType.CUBE, TokenType.ROLLUP), advance=False)
-                        else self._parse_disjunction()
+                        self._parse_grouping_sets()
+                        or self._parse_cube_or_rollup()
+                        or self._parse_disjunction()
                     )
                 )
             )
-            grouping_sets_as_group_by_element = (
-                not elements["expressions"] or self._prev.token_type == TokenType.COMMA
-            )
 
             before_with_index = self._index
-            with_prefix = self._match(TokenType.WITH)
 
-            if cube_or_rollup := self._parse_cube_or_rollup(with_prefix=with_prefix):
+            if self._match(TokenType.WITH) and (
+                cube_or_rollup := self._parse_cube_or_rollup(with_prefix=True)
+            ):
                 key = "rollup" if isinstance(cube_or_rollup, exp.Rollup) else "cube"
                 elements[key].append(cube_or_rollup)
             elif grouping_sets := self._parse_grouping_sets():
+                # Hive-style suffix syntax: GROUP BY a, b GROUPING SETS (...)
                 elements["grouping_sets"].append(grouping_sets)
-                elements["grouping_sets_as_group_by_element"] = grouping_sets_as_group_by_element
-                if not grouping_sets_as_group_by_element:
-                    break
+                break
             elif self._match_text_seq("TOTALS"):
                 elements["totals"] = True  # type: ignore
 
             if before_with_index <= self._index <= before_with_index + 1:
                 self._retreat(before_with_index)
-                break
-
-            if index == self._index:
                 break
 
         return self.expression(exp.Group(**elements), comments=comments)  # type: ignore

--- a/tests/dialects/test_presto.py
+++ b/tests/dialects/test_presto.py
@@ -1118,13 +1118,6 @@ class TestPresto(Validator):
         )
 
         self.validate_all(
-            "SELECT a, b, c, d, sum(y) FROM z GROUP BY CUBE(a) ROLLUP(a), GROUPING SETS((b, c)), d",
-            write={
-                "presto": "SELECT a, b, c, d, SUM(y) FROM z GROUP BY d, GROUPING SETS ((b, c)), CUBE (a), ROLLUP (a)",
-                "hive": "SELECT a, b, c, d, SUM(y) FROM z GROUP BY d, GROUPING SETS ((b, c)), CUBE (a), ROLLUP (a)",
-            },
-        )
-        self.validate_all(
             "JSON_FORMAT(CAST(MAP_FROM_ENTRIES(ARRAY[('action_type', 'at')]) AS JSON))",
             write={
                 "presto": "JSON_FORMAT(CAST(MAP_FROM_ENTRIES(ARRAY[('action_type', 'at')]) AS JSON))",

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1212,15 +1212,24 @@ TBLPROPERTIES (
         suffix_sql = "SELECT COUNT(1), d, h FROM t GROUP BY d, h GROUPING SETS ((d, h), (d))"
         element_sql = "SELECT COUNT(1), d, h FROM t GROUP BY d, h, GROUPING SETS ((d, h), (d))"
 
-        for sql, expected_flag in (
-            (suffix_sql, False),
-            (element_sql, True),
-            ("SELECT a FROM t GROUP BY a, GROUPING SETS ((a)), GROUPING SETS ((a))", True),
-            ("SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))", True),
+        for sql, is_suffix in (
+            (suffix_sql, True),
+            (element_sql, False),
+            ("SELECT a FROM t GROUP BY a, GROUPING SETS ((a)), GROUPING SETS ((a))", False),
+            ("SELECT COUNT(1), d, h FROM t GROUP BY GROUPING SETS ((d, h), (d))", False),
         ):
             with self.subTest(sql=sql):
                 group = self.validate_identity(sql).args["group"]
-                self.assertIs(group.args.get("grouping_sets_as_group_by_element"), expected_flag)
+                self.assertIs(bool(group.args.get("grouping_sets")), is_suffix)
+                self.assertIs(
+                    any(isinstance(e, exp.GroupingSets) for e in group.expressions), not is_suffix
+                )
+
+        # The relative order of GROUP BY items must be preserved
+        self.validate_identity("SELECT c1, c2, c3, c4 FROM t GROUP BY CUBE (c1, c2), c3, c4")
+        self.validate_identity("SELECT c1, c2, c3, c4 FROM t GROUP BY c3, CUBE (c1, c2), c4")
+        self.validate_identity("SELECT a, b, c FROM t GROUP BY ROLLUP (a), b, CUBE (c)")
+        self.validate_identity("SELECT a, b, c FROM t GROUP BY a, GROUPING SETS ((a), (b)), c")
 
         with self.assertRaises(ParseError):
             self.parse_one("SELECT a FROM t GROUP BY a GROUPING SETS ((a)), GROUPING SETS ((a))")


### PR DESCRIPTION
Fixes #8311
