### PR TITLE
fix(trino): prefix JSON_QUERY paths with the lax mode specifier

### DIFF
--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -133,7 +133,7 @@ class TrinoGenerator(PrestoGenerator):
         # Trino's JSON_QUERY requires the path to start with a mode specifier. Paths coming from
         # dialects that don't have one (e.g. T-SQL) are parsed into a JSONPath, so we prefix the
         # standard default mode. Paths that failed to parse stay literals and keep their own mode.
-        if isinstance(expression.args.get("expression"), exp.JSONPath):
+        if isinstance(expression.expression, exp.JSONPath):
             quote = self.dialect.QUOTE_START
             json_path = f"{quote}lax {json_path.removeprefix(quote)}"
 

--- a/sqlglot/generators/trino.py
+++ b/sqlglot/generators/trino.py
@@ -129,6 +129,14 @@ class TrinoGenerator(PrestoGenerator):
             return super().jsonextract_sql(expression)
 
         json_path = self.sql(expression, "expression")
+
+        # Trino's JSON_QUERY requires the path to start with a mode specifier. Paths coming from
+        # dialects that don't have one (e.g. T-SQL) are parsed into a JSONPath, so we prefix the
+        # standard default mode. Paths that failed to parse stay literals and keep their own mode.
+        if isinstance(expression.args.get("expression"), exp.JSONPath):
+            quote = self.dialect.QUOTE_START
+            json_path = f"{quote}lax {json_path.removeprefix(quote)}"
+
         option = self.sql(expression, "option")
         option = f" {option}" if option else ""
 

--- a/tests/dialects/test_tsql.py
+++ b/tests/dialects/test_tsql.py
@@ -1587,7 +1587,7 @@ WHERE
         self.validate_all(
             "JSON_QUERY(x, '$.a')",
             read={"tsql": "JSON_QUERY(x, '$.a')"},
-            write={"trino": "JSON_QUERY(x, '$.a')"},
+            write={"trino": "JSON_QUERY(x, 'lax $.a')"},
         )
 
         self.validate_identity(


### PR DESCRIPTION
Follow-up to your comment on #8287.

Trino wants the JSON path to start with lax or strict. Coming from tsql we
were generating JSON_QUERY(x, '$.a') with no mode, so Trino won't take it.

Paths that come from Trino don't get parsed into a JSONPath at all (the
jsonpath parser can't read the mode prefix), so they stay literals and keep
whatever mode was already there. I only add lax to the structured JSONPath
case, which is what tsql and other dialects without a mode give you.

    tsql in:   JSON_QUERY(x, '$.a')
    trino out: JSON_QUERY(x, 'lax $.a')

Disclaimer: I used an LLM while writing this patch. I have reviewed and
understood every line of it.