### PR TITLE
fix(optimizer): preserve unreferenced UDTF and anonymous-function projections

### DIFF
--- a/sqlglot/expressions/array.py
+++ b/sqlglot/expressions/array.py
@@ -240,7 +240,7 @@ class Explode(Expression, Func, UDTF):
     is_var_len_args = True
 
 
-class Inline(Expression, Func):
+class Inline(Expression, Func, UDTF):
     pass
 
 

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -19,6 +19,9 @@ if t.TYPE_CHECKING:
 # Sentinel value that means an outer query selecting ALL columns
 SELECT_ALL = object()
 
+# UDTF: functions that multiply rows.  Anonymous: unknown functions may be set-returning.
+SET_RETURNING_FUNCTIONS = (exp.Anonymous, exp.UDTF, exp.ExplodingGenerateSeries)
+
 # GROUP BY constructs whose children are grouping items; a one-column set, e.g. ((1)), is a Paren
 GROUPING_CONSTRUCTS = (exp.Cube, exp.GroupingSets, exp.Paren, exp.Rollup, exp.Tuple)
 
@@ -206,9 +209,8 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
         ):
             new_selections.append(selection)
             alias_count -= 1
-        # UDTFs multiply rows, so unreferenced projections containing them must be kept.
-        # Anonymous functions are conservatively treated as potentially set-returning.
-        elif find_in_scope(selection, (exp.Anonymous, exp.UDTF)):
+        # keep projections containing these functions
+        elif find_in_scope(selection, *SET_RETURNING_FUNCTIONS):
             new_selections.append(selection)
         else:
             if selection.is_star:

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -19,12 +19,6 @@ if t.TYPE_CHECKING:
 # Sentinel value that means an outer query selecting ALL columns
 SELECT_ALL = object()
 
-# Set-returning (table) functions multiply the rows of the entire query, so a projection
-# containing one affects the cardinality of every output column and must never be pruned,
-# even when the projection itself is otherwise unreferenced. Posexplode and the *Outer
-# variants are subclasses of Explode, so matching Explode covers them too.
-SET_RETURNING_FUNCTIONS = (exp.Explode, exp.Inline, exp.Unnest)
-
 # GROUP BY constructs whose children are grouping items; a one-column set, e.g. ((1)), is a Paren
 GROUPING_CONSTRUCTS = (exp.Cube, exp.GroupingSets, exp.Paren, exp.Rollup, exp.Tuple)
 
@@ -212,11 +206,9 @@ def _remove_unused_selections(scope, parent_selections, schema, alias_count, jou
         ):
             new_selections.append(selection)
             alias_count -= 1
-        elif find_in_scope(selection, *SET_RETURNING_FUNCTIONS):
-            # A set-returning function multiplies the rows of the whole query, so this
-            # projection affects the cardinality of every output column and must be kept
-            # even though it is otherwise unreferenced. It is not a positional alias slot,
-            # so alias_count is left untouched.
+        # UDTFs multiply rows, so unreferenced projections containing them must be kept.
+        # Anonymous functions are conservatively treated as potentially set-returning.
+        elif find_in_scope(selection, (exp.Anonymous, exp.UDTF)):
             new_selections.append(selection)
         else:
             if selection.is_star:


### PR DESCRIPTION
`pushdown_projections` was pruning unreferenced select-list projections by checking for a hardcoded tuple of known set-returning expression classes (`exp.Explode, exp.Inline, exp.Unnest`). This silently dropped projections containing unregistered set-returning functions.

Updated `pushdown_projections.py` to remove `SET_RETURNING_FUNCTIONS` and replaced it with `(exp.Anonymous, exp.UDTF)`. `exp.UDTF` catches all registered set-returning functions via the class hierarchy; `exp.Anonymous` is the conservative catch-all for unregistered ones.  Also, added `UDTF` to `Inline`'s base classes since it was always semantically a `UDTF`.

Bug Sample:
```sql
-- Input
SELECT t.a FROM (SELECT a, STACK(2, b, c) AS s FROM x) t

-- Wrong output (STACK pruned — rows halved)
SELECT x.a AS a FROM x AS x

-- Expected output (STACK preserved)
SELECT t.a AS a FROM (SELECT x.a AS a, STACK(2, x.b, x.c) AS s FROM x AS x) AS t
```
`STACK` parses as `exp.Anonymous` and was not in the hardcoded list, so it was pruned. The same latent bug affects any dialect with unregistered set-returning functions.