### PR TITLE
fix(optimizer): preserve operand order when simplifying COALESCE comparisons

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -1344,6 +1344,10 @@ class Simplifier:
         # since we already remove COALESCE at the top of this function.
         this: exp.Expr = coalesce if coalesce.expressions else coalesce.this
 
+        # The constant takes the COALESCE's side of the comparison
+        substituted = expression.copy()
+        substituted.set("this" if coalesce is expression.left else "expression", arg.copy())
+
         # This expression is more complex than when we started, but it will get simplified further
         return exp.paren(
             exp.or_(
@@ -1352,11 +1356,7 @@ class Simplifier:
                     expression.copy(),
                     copy=False,
                 ),
-                exp.and_(
-                    this.is_(exp.null()),
-                    type(expression)(this=arg.copy(), expression=other.copy()),
-                    copy=False,
-                ),
+                exp.and_(this.is_(exp.null()), substituted, copy=False),
                 copy=False,
             ),
             copy=False,

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -1072,6 +1072,15 @@ COALESCE(x, 1) = 2;
 2 = COALESCE(x, 1);
 NOT x IS NULL AND x = 2;
 
+1 < COALESCE(x, 0);
+NOT x IS NULL AND x > 1;
+
+0 >= COALESCE(x, 1);
+NOT x IS NULL AND x <= 0;
+
+-1 < COALESCE(x, 0);
+x > -1 OR x IS NULL;
+
 COALESCE(x, 1, 1) = 1 + 1;
 NOT x IS NULL AND x = 2;
 

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -1081,6 +1081,15 @@ NOT x IS NULL AND x <= 0;
 -1 < COALESCE(x, 0);
 x > -1 OR x IS NULL;
 
+1 < COALESCE(x, y, 0);
+COALESCE(x, y) > 1 AND NOT COALESCE(x, y) IS NULL;
+
+0 >= COALESCE(x, y, 1);
+COALESCE(x, y) <= 0 AND NOT COALESCE(x, y) IS NULL;
+
+1 < COALESCE(x, 0, 5);
+NOT x IS NULL AND x > 1;
+
 COALESCE(x, 1, 1) = 1 + 1;
 NOT x IS NULL AND x = 2;
 


### PR DESCRIPTION
In main `simplify_coalesce` rewrites `c op COALESCE(x, d)` into a `NULL` and a `non-NULL` case, but always builts the `NULL` case as `d op c`, regardless of which side the `COALESCE` was on. For asymmetric operators that flips the result:

```sql
-- input
SELECT x FROM t WHERE 1 < COALESCE(x, 0)

-- the rule generates at first  `1 < COALESCE(x, 0) → (NOT x IS NULL AND 1 < COALESCE(x)) OR (x IS NULL AND 0 < 1)`
-- main built the NULL case as 0 < 1, which folds to TRUE, so the branch collapses to x IS NULL
SELECT x FROM t WHERE x > 1 OR x IS NULL

-- this PR
SELECT x FROM t WHERE NOT x IS NULL AND x > 1

Symmetric operators (=, <>) were unaffected, and the existing fixtures only covered those with the COALESCE on the right, so the case went unnoticed.