### PR TITLE
fix(optimizer)!: don't fan out EXISTS decorrelation over grouped subqueries

### DIFF
--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -159,12 +159,16 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     if parent_predicate is not None and parent_predicate.parent_select is not parent_select:
         return
 
-    if isinstance(parent_predicate, exp.Exists) and not select.args.get("group"):
+    if isinstance(parent_predicate, exp.Exists):
         if select.args.get("having") or select.args.get("qualify"):
             return
 
-        if _has_aggregate_projection(select):
-            _replace(parent_predicate, exp.true())
+        group = select.args.get("group")
+        if not group:
+            if _has_aggregate_projection(select):
+                _replace(parent_predicate, exp.true())
+                return
+        elif not _is_plain_group(group):
             return
 
     table_alias = next_alias_name()
@@ -265,6 +269,11 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
     # all selects will be added by the optimizer and only used for join keys
     if isinstance(parent_predicate, exp.Exists):
         select.set("expressions", [])
+        # These can't change whether any row is returned, but a GROUP BY would break the
+        # uniqueness of the join keys below, which is what prevents the join from fanning out
+        select.set("group", None)
+        select.set("distinct", None)
+        select.set("order", None)
 
     for key in group_by:
         # add all keys to the projections of the subquery so that we can use it as a join key
@@ -403,6 +412,17 @@ def _is_windowed(agg: exp.Expr) -> bool:
         node, parent = parent, parent.parent
 
     return False
+
+
+def _is_plain_group(group: exp.Group) -> bool:
+    # Grouping sets produce a row for the grand total even when no rows pass the WHERE
+    return not any(
+        group.args.get(arg) for arg in ("grouping_sets", "cube", "rollup", "totals")
+    ) and not any(
+        isinstance(e, (exp.Rollup, exp.Cube, exp.GroupingSets))
+        or (isinstance(e, exp.Tuple) and not e.expressions)
+        for e in group.expressions
+    )
 
 
 def _has_aggregate_projection(select: exp.Select) -> bool:

--- a/sqlglot/optimizer/unnest_subqueries.py
+++ b/sqlglot/optimizer/unnest_subqueries.py
@@ -164,7 +164,12 @@ def decorrelate(select, parent_select, external_columns, next_alias_name):
             return
 
         group = select.args.get("group")
-        if not group:
+
+        # GROUP BY ALL groups by the non-aggregate projections, so without any it's a no-op
+        if not group or (
+            group.args.get("all")
+            and all(find_in_scope(projection, exp.AggFunc) for projection in select.selects)
+        ):
             if _has_aggregate_projection(select):
                 _replace(parent_predicate, exp.true())
                 return

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -283,3 +283,15 @@ SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a GROUP BY ROLLUP (
 # title: exists with an empty grouping set is not unnested
 SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY ());
 SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a GROUP BY ());
+
+# title: exists with group by all and only aggregate projections is always true
+SELECT x.a FROM x WHERE EXISTS (SELECT COUNT(*) FROM y WHERE y.a = x.a GROUP BY ALL);
+SELECT x.a FROM x WHERE TRUE;
+
+# title: exists with group by all and only windowed aggregate projections is a row check
+SELECT x.a FROM x WHERE EXISTS (SELECT COUNT(*) OVER () FROM y WHERE y.a = x.a GROUP BY ALL);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT _u_0._u_1 IS NULL;
+
+# title: exists with group by all and a non-aggregate projection drops it
+SELECT x.a FROM x WHERE EXISTS (SELECT y.c, COUNT(*) FROM y WHERE y.a = x.a GROUP BY ALL);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT _u_0._u_1 IS NULL;

--- a/tests/fixtures/optimizer/unnest_subqueries.sql
+++ b/tests/fixtures/optimizer/unnest_subqueries.sql
@@ -243,3 +243,43 @@ SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a AND y.b > x.b + y
 # title: predicate with an outer column on the key side is not unnested
 SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a + x.b = x.a);
 SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a + x.b = x.a);
+
+# title: exists with a group by drops it so that the join stays unique on its keys
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY y.c);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT _u_0._u_1 IS NULL;
+
+# title: not exists with a group by
+SELECT x.a FROM x WHERE NOT EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY y.c);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT NOT _u_0._u_1 IS NULL;
+
+# title: exists with an aggregate projection and a group by is not always true
+SELECT x.a FROM x WHERE EXISTS (SELECT COUNT(*) FROM y WHERE y.a = x.a GROUP BY y.c);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT _u_0._u_1 IS NULL;
+
+# title: exists with distinct drops it
+SELECT x.a FROM x WHERE EXISTS (SELECT DISTINCT y.c FROM y WHERE y.a = x.a);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT _u_0._u_1 IS NULL;
+
+# title: exists with an order by drops it
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a ORDER BY y.c);
+SELECT x.a FROM x LEFT JOIN (SELECT y.a AS _u_1 FROM y WHERE TRUE GROUP BY y.a) AS _u_0 ON _u_0._u_1 = x.a WHERE NOT _u_0._u_1 IS NULL;
+
+# title: exists with a group by and having is not unnested
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY y.c HAVING COUNT(*) > 1);
+SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a GROUP BY y.c HAVING COUNT(*) > 1);
+
+# title: exists with a group by and qualify is not unnested
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY y.c QUALIFY ROW_NUMBER() OVER (ORDER BY y.c) = 1);
+SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a GROUP BY y.c QUALIFY ROW_NUMBER() OVER (ORDER BY y.c) = 1);
+
+# title: exists with a non-equality key and having is not unnested
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a AND y.b > x.b GROUP BY y.a HAVING COUNT(*) > 1);
+SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a AND y.b > x.b GROUP BY y.a HAVING COUNT(*) > 1);
+
+# title: exists with a rollup is not unnested since it returns a row even for empty input
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY ROLLUP (y.c));
+SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a GROUP BY ROLLUP (y.c));
+
+# title: exists with an empty grouping set is not unnested
+SELECT x.a FROM x WHERE EXISTS (SELECT 1 FROM y WHERE y.a = x.a GROUP BY ());
+SELECT x.a FROM x WHERE EXISTS(SELECT 1 FROM y WHERE y.a = x.a GROUP BY ());


### PR DESCRIPTION
Unnesting an EXISTS subquery with its own GROUP BY appended the join key to the existing grouping, so the derived table was no longer unique on it and the LEFT JOIN emitted one outer row per group. A plain GROUP BY, DISTINCT or ORDER BY can't change whether the subquery returns rows (we already bail earlier for ORDER BY + LIMIT), so they're dropped before decorrelating. Since HAVING and QUALIFY do filter the groups, and grouping sets yield a row even on empty input, those subqueries are no longer unnested.

See also: https://github.com/tobymao/sqlglot/pull/8317#discussion_r3958781681.
