### PR TITLE
feat(executor): implement FIRST [CLAUDE]

### DIFF
--- a/sqlglot/executor/env.py
+++ b/sqlglot/executor/env.py
@@ -241,6 +241,7 @@ ENV = {
     "ARRAYUNIQUEAGG": filter_nulls(lambda acc: list(set(acc))),
     "AVG": filter_nulls(statistics.fmean if PYTHON_VERSION >= (3, 8) else statistics.mean),  # type: ignore
     "COUNT": filter_nulls(lambda acc: sum(1 for _ in acc), False),
+    "FIRST": lambda acc: next(iter(acc), None),
     "MAX": filter_nulls(max),
     "MIN": filter_nulls(min),
     "SUM": filter_nulls(sum),

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1206,6 +1206,16 @@ class TestExecutor(unittest.TestCase):
         self.assertEqual(result.columns, ("_col_0",))
         self.assertEqual(result.rows, [(3,)])
 
+    def test_first(self):
+        tables = {"t": [{"g": 1, "a": 5}, {"g": 1, "a": 1}, {"g": 2, "a": 3}]}
+
+        for sql, rows in (
+            ("SELECT FIRST(a) FROM t", [(5,)]),
+            ("SELECT g, FIRST(a) FROM t GROUP BY g", [(1, 5), (2, 3)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables, dialect="hive").rows, rows)
+
     def test_in_any_subquery_without_a_from(self):
         tables = {"x": [{"a": 1}, {"a": 2}, {"a": None}]}
 


### PR DESCRIPTION
`exp.First` already generates `FIRST(...)` for Hive/Spark and has generator support for Presto/DuckDB, but `ENV` has no such key, so it raises instead of answering:

| query | main | this PR | duckdb 1.5.5 |
| --- | --- | --- | --- |
| `SELECT first(a) FROM t` (5, 1, 3) | `name 'FIRST' is not defined` | `5` | `5` |
| `SELECT first(a) FROM t` (NULL, 5, 3) | `name 'FIRST' is not defined` | `NULL` | `NULL` |

`first()` doesn't skip nulls by default in duckdb — that's `any_value()` — so the executor's `FIRST` doesn't either.

Disclosure: implemented with Claude.
