### PR TITLE
fix(sqlite): preserve GREATEST/LEAST NULL semantics

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -342,8 +342,9 @@ class SQLiteGenerator(generator.Generator):
         if not expression.expressions:
             return self.sql(expression, "this")
 
+        name = "MAX" if isinstance(expression, exp.Greatest) else "MIN"
+
         if not expression.args.get("ignore_nulls"):
-            name = "MAX" if isinstance(expression, exp.Greatest) else "MIN"
             return rename_func(name)(self, expression)
 
         # GREATEST/LEAST ignore NULLs, but SQLite's multi-argument MAX/MIN
@@ -354,14 +355,13 @@ class SQLiteGenerator(generator.Generator):
         # yields NULL:
         # GREATEST(a, b, c) -> MAX(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b)).
         args = [expression.this, *expression.expressions]
-        aggregate = exp.Max if isinstance(expression, exp.Greatest) else exp.Min
 
         coalesces = []
         for i in range(len(args)):
             rotated = args[i:] + args[:i]
             coalesces.append(exp.Coalesce(this=rotated[0], expressions=rotated[1:]))
 
-        return self.sql(aggregate(expressions=coalesces))
+        return self.func(name, *coalesces)
 
     def greatest_sql(self, expression: exp.Greatest) -> str:
         return self._greatest_least_sql(expression)

--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -338,17 +338,36 @@ class SQLiteGenerator(generator.Generator):
         separator = expression.args.get("separator")
         return f"GROUP_CONCAT({distinct_sql}{self.format_args(this, separator)})"
 
-    def least_sql(self, expression: exp.Least) -> str:
-        if expression.expressions:
-            return rename_func("MIN")(self, expression)
+    def _greatest_least_sql(self, expression: exp.Greatest | exp.Least) -> str:
+        if not expression.expressions:
+            return self.sql(expression, "this")
 
-        return self.sql(expression, "this")
+        if not expression.args.get("ignore_nulls"):
+            name = "MAX" if isinstance(expression, exp.Greatest) else "MIN"
+            return rename_func(name)(self, expression)
+
+        # GREATEST/LEAST ignore NULLs, but SQLite's multi-argument MAX/MIN
+        # return NULL if any argument is NULL. Emit a rotation of COALESCE
+        # calls so that every argument is the first argument of exactly one
+        # COALESCE, which then returns it if it's non-NULL. Comparing all of
+        # those yields the ignored-NULLs result, and an all-NULL input still
+        # yields NULL:
+        # GREATEST(a, b, c) -> MAX(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b)).
+        args = [expression.this, *expression.expressions]
+        aggregate = exp.Max if isinstance(expression, exp.Greatest) else exp.Min
+
+        coalesces = []
+        for i in range(len(args)):
+            rotated = args[i:] + args[:i]
+            coalesces.append(exp.Coalesce(this=rotated[0], expressions=rotated[1:]))
+
+        return self.sql(aggregate(expressions=coalesces))
 
     def greatest_sql(self, expression: exp.Greatest) -> str:
-        if expression.expressions:
-            return rename_func("MAX")(self, expression)
+        return self._greatest_least_sql(expression)
 
-        return self.sql(expression, "this")
+    def least_sql(self, expression: exp.Least) -> str:
+        return self._greatest_least_sql(expression)
 
     def transaction_sql(self, expression: exp.Transaction) -> str:
         this = expression.this

--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -347,12 +347,7 @@ class SQLiteGenerator(generator.Generator):
         if not expression.args.get("ignore_nulls"):
             return rename_func(name)(self, expression)
 
-        # GREATEST/LEAST ignore NULLs, but SQLite's multi-argument MAX/MIN
-        # return NULL if any argument is NULL. Emit a rotation of COALESCE
-        # calls so that every argument is the first argument of exactly one
-        # COALESCE, which then returns it if it's non-NULL. Comparing all of
-        # those yields the ignored-NULLs result, and an all-NULL input still
-        # yields NULL:
+        # SQLite's multi-argument MAX/MIN return NULL if any argument is NULL.
         # GREATEST(a, b, c) -> MAX(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b)).
         args = [expression.this, *expression.expressions]
 

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -165,6 +165,16 @@ class TestSQLite(Validator):
             "SELECT MIN(COALESCE(3, NULL, 1), COALESCE(NULL, 1, 3), COALESCE(1, 3, NULL))",
             read={"postgres": "SELECT LEAST(3, NULL, 1)"},
         )
+        # MySQL GREATEST/LEAST propagate NULLs (same as SQLite), so no COALESCE
+        # rotation is needed -- just rename to MAX/MIN.
+        self.validate_all(
+            "SELECT MAX(a, b) FROM t",
+            read={"mysql": "SELECT GREATEST(a, b) FROM t"},
+        )
+        self.validate_all(
+            "SELECT MIN(a, b) FROM t",
+            read={"mysql": "SELECT LEAST(a, b) FROM t"},
+        )
         # CONCAT skips NULL args in these dialects, but || propagates it, so the
         # operands have to keep the COALESCE wrapping the other targets get.
         self.validate_all(

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -127,16 +127,43 @@ class TestSQLite(Validator):
         self.validate_all(
             "SELECT MIN(a, b) FROM t",
             read={
-                "postgres": "SELECT LEAST(a, b) FROM t",
                 "sqlite": "SELECT MIN(a, b) FROM t",
             },
         )
         self.validate_all(
             "SELECT MAX(a, b) FROM t",
             read={
-                "postgres": "SELECT GREATEST(a, b) FROM t",
                 "sqlite": "SELECT MAX(a, b) FROM t",
             },
+        )
+        # GREATEST/LEAST ignore NULL args in Postgres/DuckDB, but SQLite's
+        # multi-arg MAX/MIN return NULL if any argument is NULL, so the args
+        # are rewrapped as a rotation of COALESCEs to keep that behavior.
+        self.validate_all(
+            "SELECT MAX(COALESCE(a, b), COALESCE(b, a)) FROM t",
+            read={"postgres": "SELECT GREATEST(a, b) FROM t"},
+        )
+        self.validate_all(
+            "SELECT MIN(COALESCE(a, b), COALESCE(b, a)) FROM t",
+            read={"postgres": "SELECT LEAST(a, b) FROM t"},
+        )
+        self.validate_all(
+            "SELECT MAX(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b)) FROM t",
+            read={"duckdb": "SELECT GREATEST(a, b, c) FROM t"},
+        )
+        self.validate_all(
+            "SELECT MIN(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b)) FROM t",
+            read={"postgres": "SELECT LEAST(a, b, c) FROM t"},
+        )
+        # Literal NULLs exercise the ignore-NULLs semantics: a NULL anywhere in
+        # the arguments must be skipped and only an all-NULL input returns NULL.
+        self.validate_all(
+            "SELECT MAX(COALESCE(NULL, 1), COALESCE(1, NULL))",
+            read={"postgres": "SELECT GREATEST(NULL, 1)"},
+        )
+        self.validate_all(
+            "SELECT MIN(COALESCE(3, NULL, 1), COALESCE(NULL, 1, 3), COALESCE(1, 3, NULL))",
+            read={"postgres": "SELECT LEAST(3, NULL, 1)"},
         )
         # CONCAT skips NULL args in these dialects, but || propagates it, so the
         # operands have to keep the COALESCE wrapping the other targets get.


### PR DESCRIPTION
Fixes https://github.com/tobymao/sqlglot/issues/8315

## Summary

Fix SQLite transpilation of `GREATEST` and `LEAST` when the source dialect ignores NULL arguments.

SQLite's multi-argument `MAX` and `MIN` return NULL when any argument is NULL, while PostgreSQL and DuckDB `GREATEST`/`LEAST` ignore NULL arguments and return NULL only when all arguments are NULL.

The SQLite generator now honors SQLGlot's existing `ignore_nulls` semantic flag. For dialects where `GREATEST`/`LEAST` ignore NULL values, it generates a COALESCE rotation before applying SQLite `MAX`/`MIN`.

For example:

```sql
-- SQLite does not have GREATEST/LEAST; previously GREatEST was renamed to MAX,
-- silently changing NULL semantics.

-- postgres: SELECT GREATEST(a, b)
SELECT MAX(COALESCE(a, b), COALESCE(b, a))

-- postgres: SELECT LEAST(a, b, c)
SELECT MIN(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b))
```

Each argument is the first argument of exactly one COALESCE in the rotation, so every non-NULL argument is reproduced and compared, while an all-NULL input still yields NULL. This matches PostgreSQL/DuckDB semantics exactly (verified by executing the emitted SQLite SQL).

When the source dialect already returns NULL if any argument is NULL (e.g. MySQL), the previous `MAX`/`MIN` rename is kept unchanged.

## Tests

- Updated the two pre-existing `postgres -> sqlite` assertions in `tests/dialects/test_sqlite.py` that encoded the buggy output.
- Added coverage for Postgres and DuckDB readers, two- and three-argument calls, and literal NULL values.
- All new assertions fail against the previous implementation and pass with this fix.
- Verified at runtime with `sqlite3`: `GREATEST(NULL, 1)` and `LEAST(NULL, 1)` now evaluate to `1` (previously `NULL`).