### PR TITLE
fix(executor): plan DISTINCT before ORDER BY so the sort survives [CLAUDE]

### DIFF
--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -123,32 +123,40 @@ class Step:
             join.source_name = step.name
             join.add_dependency(step)
             step = join
+
+        def make_operand_extractor(prefix: str):
+            # intermediate computations of agg funcs eg x + 1 in SUM(x + 1)
+            operands: dict[exp.Expr, str] = {}
+            aggregations: dict[exp.Expr, None] = {}
+            next_operand_name = name_sequence(prefix)
+
+            def extract_agg_operands(expression: exp.Expr) -> bool:
+                agg_funcs = tuple(find_all_in_scope(expression, exp.AggFunc))
+                if agg_funcs:
+                    aggregations[expression] = None
+
+                for agg in agg_funcs:
+                    for operand in agg.unnest_operands():
+                        if isinstance(operand, exp.Column):
+                            continue
+                        if operand not in operands:
+                            operands[operand] = next_operand_name()
+
+                        operand.replace(exp.column(operands[operand], quoted=True))
+
+                return bool(agg_funcs)
+
+            def set_ops_and_aggs(step) -> None:
+                step.operands = tuple(
+                    alias(operand, alias_) for operand, alias_ in operands.items()
+                )
+                step.aggregations = list(aggregations)
+
+            return extract_agg_operands, set_ops_and_aggs, aggregations
+
         # final selects in this chain of steps representing a select
         projections: list[exp.Expr] = []
-        # intermediate computations of agg funcs eg x + 1 in SUM(x + 1)
-        operands: dict[exp.Expr, str] = {}
-        aggregations: dict[exp.Expr, None] = {}
-        next_operand_name = name_sequence("_a_")
-
-        def extract_agg_operands(expression: exp.Expr) -> bool:
-            agg_funcs = tuple(find_all_in_scope(expression, exp.AggFunc))
-            if agg_funcs:
-                aggregations[expression] = None
-
-            for agg in agg_funcs:
-                for operand in agg.unnest_operands():
-                    if isinstance(operand, exp.Column):
-                        continue
-                    if operand not in operands:
-                        operands[operand] = next_operand_name()
-
-                    operand.replace(exp.column(operands[operand], quoted=True))
-
-            return bool(agg_funcs)
-
-        def set_ops_and_aggs(step) -> None:
-            step.operands = tuple(alias(operand, alias_) for operand, alias_ in operands.items())
-            step.aggregations = list(aggregations)
+        extract_agg_operands, set_ops_and_aggs, aggregations = make_operand_extractor("_a_")
 
         for e in expression.expressions:
             if find_in_scope(e, exp.AggFunc):
@@ -224,23 +232,48 @@ class Step:
         order: exp.Order | None = expression.args.get("order")
 
         if order is not None:
-            if aggregate is not None and step is aggregate:
+            if aggregate is not None:
                 for i, ordered in enumerate(order.expressions):
                     if extract_agg_operands(exp.alias_(ordered.this, f"_o_{i}", quoted=True)):
-                        ordered.this.replace(exp.column(f"_o_{i}", step.name, quoted=True))
+                        ordered.this.replace(exp.column(f"_o_{i}", aggregate.name, quoted=True))
 
                 set_ops_and_aggs(aggregate)
-            elif distinct is not None:
-                # not a DISTINCT output: FIRST() picks a row per group, like duckdb/sqlite
+
+            if distinct is not None:
+                extract_distinct_operands, set_distinct_ops_and_aggs, _ = make_operand_extractor(
+                    "_a_"
+                )
                 next_distinct_order_name = name_sequence("_o_")
 
                 for ordered in order.expressions:
-                    if ordered.this.name not in distinct.group:
-                        name = next_distinct_order_name()
-                        distinct.aggregations.append(
-                            exp.alias_(exp.First(this=ordered.this.copy()), name, quoted=True)
-                        )
-                        ordered.this.replace(exp.column(name, step.name, quoted=True))
+                    # already exactly one of DISTINCT's own group expressions
+                    if ordered.this in distinct.group.values():
+                        continue
+
+                    # a bare column is a reference to an output name, never a qualified one
+                    if (
+                        isinstance(ordered.this, exp.Column)
+                        and not ordered.this.table
+                        and ordered.this.name in distinct.group
+                    ):
+                        continue
+
+                    this = ordered.this.copy()
+
+                    # requalify a bare reference to an output name (eg "a" in "a + 1")
+                    for node in this.walk():
+                        if (
+                            isinstance(node, exp.Column)
+                            and not node.table
+                            and node.name in distinct.group
+                        ):
+                            node.replace(distinct.group[node.name].copy())
+
+                    name = next_distinct_order_name()
+                    extract_distinct_operands(exp.alias_(exp.First(this=this), name, quoted=True))
+                    ordered.this.replace(exp.column(name, step.name, quoted=True))
+
+                set_distinct_ops_and_aggs(distinct)
 
             sort = Sort()
             sort.name = step.name

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -246,8 +246,13 @@ class Step:
                 next_distinct_order_name = name_sequence("_o_")
 
                 for ordered in order.expressions:
-                    # already exactly one of DISTINCT's own group expressions
-                    if ordered.this in distinct.group.values():
+                    # already exactly one of DISTINCT's own group expressions -- point at its
+                    # output name instead, since the source it was read from won't survive
+                    group_name = next(
+                        (name for name, e in distinct.group.items() if e == ordered.this), None
+                    )
+                    if group_name:
+                        ordered.this.replace(exp.column(group_name, step.name, quoted=True))
                         continue
 
                     # a bare column is a reference to an output name, never a qualified one
@@ -260,14 +265,17 @@ class Step:
 
                     this = ordered.this.copy()
 
-                    # requalify a bare reference to an output name (eg "a" in "a + 1")
-                    for node in this.walk():
-                        if (
-                            isinstance(node, exp.Column)
-                            and not node.table
-                            and node.name in distinct.group
-                        ):
-                            node.replace(distinct.group[node.name].copy())
+                    # requalify a bare reference to an output name (eg "a" in "a + 1");
+                    # collect matches before replacing so we don't mutate mid-walk
+                    to_requalify = [
+                        node
+                        for node in this.walk()
+                        if isinstance(node, exp.Column)
+                        and not node.table
+                        and node.name in distinct.group
+                    ]
+                    for node in to_requalify:
+                        node.replace(distinct.group[node.name].copy())
 
                     name = next_distinct_order_name()
                     extract_distinct_operands(exp.alias_(exp.First(this=this), name, quoted=True))

--- a/sqlglot/planner.py
+++ b/sqlglot/planner.py
@@ -207,15 +207,40 @@ class Step:
         else:
             aggregate = None
 
+        # Plan DISTINCT before ORDER BY, since Aggregate sorts by its own group key
+        if isinstance(expression, exp.Select) and expression.args.get("distinct"):
+            distinct = Aggregate()
+            distinct.source = step.name
+            distinct.name = step.name
+            distinct.group = {
+                e.alias_or_name: e.unalias() for e in projections or expression.expressions
+            }
+            projections = [exp.column(name, step.name, quoted=True) for name in distinct.group]
+            distinct.add_dependency(step)
+            step = distinct
+        else:
+            distinct = None
+
         order: exp.Order | None = expression.args.get("order")
 
         if order is not None:
-            if aggregate is not None and isinstance(step, Aggregate):
+            if aggregate is not None and step is aggregate:
                 for i, ordered in enumerate(order.expressions):
                     if extract_agg_operands(exp.alias_(ordered.this, f"_o_{i}", quoted=True)):
                         ordered.this.replace(exp.column(f"_o_{i}", step.name, quoted=True))
 
                 set_ops_and_aggs(aggregate)
+            elif distinct is not None:
+                # not a DISTINCT output: FIRST() picks a row per group, like duckdb/sqlite
+                next_distinct_order_name = name_sequence("_o_")
+
+                for ordered in order.expressions:
+                    if ordered.this.name not in distinct.group:
+                        name = next_distinct_order_name()
+                        distinct.aggregations.append(
+                            exp.alias_(exp.First(this=ordered.this.copy()), name, quoted=True)
+                        )
+                        ordered.this.replace(exp.column(name, step.name, quoted=True))
 
             sort = Sort()
             sort.name = step.name
@@ -224,17 +249,6 @@ class Step:
             step = sort
 
         step.projections = projections
-
-        if isinstance(expression, exp.Select) and expression.args.get("distinct"):
-            distinct = Aggregate()
-            distinct.source = step.name
-            distinct.name = step.name
-            distinct.group = {
-                e.alias_or_name: exp.column(col=e.alias_or_name, table=step.name)
-                for e in projections or expression.expressions
-            }
-            distinct.add_dependency(step)
-            step = distinct
 
         limit: exp.Limit | None = expression.args.get("limit")
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -479,6 +479,33 @@ class TestExecutor(unittest.TestCase):
             with self.subTest(sql):
                 self.assertEqual(execute(sql, schema, tables=tables).rows, expected)
 
+    def test_distinct_order_by_computed_expression(self):
+        tables = {"x": [{"a": 1}, {"a": 3}, {"a": 2}, {"a": 3}]}
+        sql = "SELECT DISTINCT a FROM x ORDER BY a + 1 DESC"
+        self.assertEqual(execute(sql, tables=tables).rows, [(3,), (2,), (1,)])
+
+    def test_distinct_group_by_order_by_aggregate(self):
+        tables = {
+            "x": [
+                {"a": 1, "b": 10},
+                {"a": 2, "b": 20},
+                {"a": 3, "b": 28},
+                {"a": 2, "b": 25},
+                {"a": 1, "b": 40},
+            ]
+        }
+        sql = "SELECT DISTINCT a FROM x GROUP BY a ORDER BY AVG(b)"
+        self.assertEqual(execute(sql, tables=tables).rows, [(2,), (1,), (3,)])
+
+    def test_distinct_order_by_column_from_different_table(self):
+        schema = {"x": {"a": "int", "id": "int"}, "y": {"a": "int", "id": "int"}}
+        tables = {
+            "x": [{"a": 1, "id": 1}, {"a": 2, "id": 2}],
+            "y": [{"a": 100, "id": 1}, {"a": 50, "id": 2}],
+        }
+        sql = "SELECT DISTINCT x.a FROM x JOIN y ON x.id = y.id ORDER BY y.a"
+        self.assertEqual(execute(sql, schema, tables=tables).rows, [(2,), (1,)])
+
     def test_offset_order_by(self):
         schema = {"x": {"a": "int"}, "y": {"b": "int"}}
         tables = {"x": [{"a": a} for a in (3, 1, 5, 2, 4)], "y": [{"b": 7}, {"b": 6}]}

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -506,6 +506,22 @@ class TestExecutor(unittest.TestCase):
         sql = "SELECT DISTINCT x.a FROM x JOIN y ON x.id = y.id ORDER BY y.a"
         self.assertEqual(execute(sql, schema, tables=tables).rows, [(2,), (1,)])
 
+    def test_distinct_order_by_aliased_projection(self):
+        tables = {"x": [{"a": 1}, {"a": 3}, {"a": 2}, {"a": 3}]}
+
+        for sql, expected in (
+            ("SELECT DISTINCT a AS z FROM x ORDER BY a DESC", [(3,), (2,), (1,)]),
+            ("SELECT DISTINCT a AS z FROM x ORDER BY x.a DESC", [(3,), (2,), (1,)]),
+            ("SELECT DISTINCT a + 1 AS z FROM x ORDER BY a + 1 DESC", [(4,), (3,), (2,)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, tables=tables).rows, expected)
+
+    def test_distinct_order_by_unaliased_projection(self):
+        tables = {"x": [{"c": "a"}, {"c": "c"}, {"c": "b"}, {"c": "c"}]}
+        sql = "SELECT DISTINCT UPPER(c) FROM x ORDER BY UPPER(c) DESC"
+        self.assertEqual(execute(sql, tables=tables).rows, [("C",), ("B",), ("A",)])
+
     def test_offset_order_by(self):
         schema = {"x": {"a": "int"}, "y": {"b": "int"}}
         tables = {"x": [{"a": a} for a in (3, 1, 5, 2, 4)], "y": [{"b": 7}, {"b": 6}]}

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -443,6 +443,42 @@ class TestExecutor(unittest.TestCase):
             with self.subTest(sql):
                 self.assertEqual(execute(sql, schema, tables=tables).rows, expected)
 
+    def test_distinct_order_by(self):
+        schema = {"x": {"a": "int", "b": "int"}, "n": {"a": "int"}}
+        tables = {
+            "x": [{"a": 1, "b": 5}, {"a": 3, "b": 6}, {"a": 2, "b": 7}, {"a": 3, "b": 6}],
+            "n": [{"a": 1}, {"a": None}, {"a": 3}, {"a": None}],
+        }
+
+        for sql, expected in (
+            ("SELECT DISTINCT a FROM x ORDER BY a", [(1,), (2,), (3,)]),
+            ("SELECT DISTINCT a FROM x ORDER BY a DESC", [(3,), (2,), (1,)]),
+            ("SELECT DISTINCT a FROM x ORDER BY a DESC LIMIT 1", [(3,)]),
+            ("SELECT DISTINCT a FROM x ORDER BY a DESC LIMIT 1 OFFSET 1", [(2,)]),
+            ("SELECT DISTINCT a, b FROM x ORDER BY b DESC", [(2, 7), (3, 6), (1, 5)]),
+            ("SELECT DISTINCT a + 1 AS c FROM x ORDER BY c DESC", [(4,), (3,), (2,)]),
+            (
+                "SELECT DISTINCT a, SUM(b) AS s FROM x GROUP BY a ORDER BY a DESC",
+                [(3, 12), (2, 7), (1, 5)],
+            ),
+            ("SELECT DISTINCT a FROM n ORDER BY a NULLS FIRST", [(None,), (1,), (3,)]),
+            ("SELECT DISTINCT a FROM n ORDER BY a DESC NULLS LAST", [(3,), (1,), (None,)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, schema, tables=tables).rows, expected)
+
+    def test_distinct_order_by_column_outside_select_list(self):
+        # duckdb/sqlite pick an arbitrary row's value here instead of rejecting like postgres
+        schema = {"x": {"a": "int", "b": "int"}}
+        tables = {"x": [{"a": 5, "b": 10}, {"a": 1, "b": 10}, {"a": 3, "b": 20}]}
+
+        for sql, expected in (
+            ("SELECT DISTINCT b FROM x ORDER BY a", [(20,), (10,)]),
+            ("SELECT DISTINCT b FROM x ORDER BY a DESC", [(10,), (20,)]),
+        ):
+            with self.subTest(sql):
+                self.assertEqual(execute(sql, schema, tables=tables).rows, expected)
+
     def test_offset_order_by(self):
         schema = {"x": {"a": "int"}, "y": {"b": "int"}}
         tables = {"x": [{"a": a} for a in (3, 1, 5, 2, 4)], "y": [{"b": 7}, {"b": 6}]}


### PR DESCRIPTION
`Step.from_expression` builds the `Sort` step and then stacks the `DISTINCT` `Aggregate` on top of it, so the sort runs first and the aggregate re-sorts ascending by its group key to walk runs of equal keys — discarding `ORDER BY` and putting `LIMIT`/`OFFSET` below the sort, so a top-N query answers with the bottom N.

```python
tables = {"t": [{"a": 1}, {"a": 2}, {"a": 3}]}
```

| query | before | after (= duckdb) |
| --- | --- | --- |
| `SELECT DISTINCT a FROM t ORDER BY a DESC LIMIT 1` | `[(1,)]` | `[(3,)]` |

`GROUP BY` doesn't hit this because its aggregate is built before the `order` block, leaving `Sort` outermost. This moves `DISTINCT` there too, mirroring that shape, so `Sort` carries the projections and `LIMIT`/`OFFSET` apply to it.

An `ORDER BY` key outside the select list has no single value left once `DISTINCT` collapses duplicates. duckdb and sqlite pick an arbitrary matching row's value rather than rejecting the query (postgres does reject it), so the distinct aggregate now carries a `FIRST()` pass-through for such keys, matching duckdb/sqlite instead of raising.

Disclosure: written with Claude.
