### PR TITLE
fix(spark): support VALUES as identifier/alias

### DIFF
--- a/sqlglot/parsers/spark.py
+++ b/sqlglot/parsers/spark.py
@@ -53,6 +53,17 @@ def _build_dateadd(args: list) -> exp.Expr:
 
 
 class SparkParser(Spark2Parser):
+    ID_VAR_TOKENS = Spark2Parser.ID_VAR_TOKENS | {TokenType.VALUES}
+    TABLE_ALIAS_TOKENS = Spark2Parser.TABLE_ALIAS_TOKENS | {TokenType.VALUES}
+    ALIAS_TOKENS = Spark2Parser.ALIAS_TOKENS | {TokenType.VALUES}
+    VALUES_IDENTIFIER_FOLLOW_TOKENS = Spark2Parser.TABLE_TERMINATORS | {
+        TokenType.ALIAS,
+        TokenType.DOT,
+        TokenType.PIVOT,
+        TokenType.TABLE_SAMPLE,
+        TokenType.UNPIVOT,
+    }
+
     NO_PAREN_FUNCTIONS = {
         **Spark2Parser.NO_PAREN_FUNCTIONS,
         TokenType.SESSION_USER: exp.SessionUser,
@@ -110,6 +121,20 @@ class SparkParser(Spark2Parser):
         **Spark2Parser.PLACEHOLDER_PARSERS,
         TokenType.L_BRACE: lambda self: self._parse_query_parameter(),
     }
+
+    def _parse_statement(self) -> exp.Expr | None:
+        if self._match(TokenType.VALUES, advance=False):
+            values = super()._parse_derived_table_values()
+            return self._parse_query_modifiers(self._parse_set_operations(values))
+        return super()._parse_statement()
+
+    def _parse_derived_table_values(self) -> exp.Values | None:
+        if (
+            self._curr.token_type == TokenType.VALUES
+            and self._next.token_type in self.VALUES_IDENTIFIER_FOLLOW_TOKENS
+        ):
+            return None
+        return super()._parse_derived_table_values()
 
     def _parse_query_parameter(self) -> exp.Expr | None:
         this = self._parse_id_var()

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -281,6 +281,52 @@ TBLPROPERTIES (
             },
         )
 
+    def test_values_as_identifier(self):
+        self.validate_all(
+            "SELECT values.transaction_id FROM (SELECT 1 AS transaction_id) AS values",
+            read={
+                "spark": "SELECT values.transaction_id FROM (SELECT 1 AS transaction_id) AS values",
+                "databricks": "SELECT values.transaction_id FROM (SELECT 1 AS transaction_id) AS values",
+            },
+        )
+        self.validate_all(
+            "WITH values AS (SELECT 1) SELECT * FROM values",
+            read={
+                "spark": "WITH values AS (SELECT 1) SELECT * FROM values",
+                "databricks": "WITH values AS (SELECT 1) SELECT * FROM values",
+            },
+        )
+        self.validate_all(
+            "WITH t AS (SELECT 1 AS x) SELECT * FROM t AS values",
+            read={
+                "spark": "WITH t AS (SELECT 1 AS x) SELECT * FROM t values",
+                "databricks": "WITH t AS (SELECT 1 AS x) SELECT * FROM t values",
+            },
+        )
+        self.validate_all(
+            "SELECT 1 AS values",
+            read={
+                "spark": "SELECT 1 values",
+                "databricks": "SELECT 1 values",
+            },
+        )
+        self.validate_all(
+            "WITH values AS (SELECT 1 AS x) SELECT * FROM values TABLESAMPLE (10 PERCENT)",
+            read={
+                "spark": "WITH values AS (SELECT 1 AS x) SELECT * FROM values TABLESAMPLE (10 PERCENT)",
+                "databricks": "WITH values AS (SELECT 1 AS x) SELECT * FROM values TABLESAMPLE (10 PERCENT)",
+            },
+        )
+
+    def test_values_statement_without_parentheses(self):
+        self.validate_all(
+            "VALUES (1)",
+            read={
+                "spark": "VALUES 1",
+                "databricks": "VALUES 1",
+            },
+        )
+
     def test_spark(self):
         # COLLATE on CHAR/VARCHAR should be preserved when the type is rewritten to STRING
         self.validate_identity(


### PR DESCRIPTION
Allows Spark and Databricks to parse `VALUES` as an identifier or alias.

**Implementation note**
In Spark and Databricks, `VALUES` can introduce a row constructor or act as an identifier. 

When `VALUES` appears in table-source position it reaches `_parse_derived_table_values`, where the next token disambiguates it:
- A table terminator, `AS`, or `.` --> identifier
- `PIVOT`, `UNPIVOT`, or `TABLESAMPLE`  --> identifier (table name and postfix)
- Otherwise --> `VALUES` row constructor

When a statement begins with `VALUES`, `_parse_statement` recognizes the constructor before general expression parsing and calls the base `_parse_derived_table_values` implementation directly, bypassing the table-position disambiguation.