### PR TITLE
fix(optimizer): don't merge a derived table with a set-returning projection [CLAUDE]

### DIFF
--- a/sqlglot/optimizer/merge_subqueries.py
+++ b/sqlglot/optimizer/merge_subqueries.py
@@ -75,6 +75,11 @@ SAFE_TO_REPLACE_UNWRAPPED = (
 )
 
 
+# An inner projection of one of these types blocks the merge. A set-returning function
+# multiplies the inner rows, so merging drops a projection the outer row count depends on.
+UNMERGABLE_PROJECTIONS = (exp.AggFunc, exp.Select, exp.UDTF, exp.ExplodingGenerateSeries)
+
+
 def merge_ctes(
     expression: E,
     leave_tables_isolated: bool = False,
@@ -303,7 +308,7 @@ def _mergeable(
         if s.unalias().is_number:
             number_literal_aliases.add(name)
         for node in s.walk():
-            if isinstance(node, (exp.AggFunc, exp.Select, exp.Explode)):
+            if isinstance(node, UNMERGABLE_PROJECTIONS):
                 return False
             if isinstance(node, exp.Window):
                 window_aliases.add(name)

--- a/tests/fixtures/optimizer/optimizer.sql
+++ b/tests/fixtures/optimizer/optimizer.sql
@@ -1223,6 +1223,34 @@ SELECT
   `_0`.`fruitstruct`.`value` AS `value`
 FROM `_0` AS `_0`;
 
+# title: derived table with GENERATE_SERIES cannot be merged
+# dialect: postgres
+# execute: false
+SELECT t.a FROM (SELECT a, GENERATE_SERIES(1, 3) AS s FROM x) AS t;
+WITH "t" AS (
+  SELECT
+    "x"."a" AS "a",
+    GENERATE_SERIES(1, 3) AS "s"
+  FROM "x" AS "x"
+)
+SELECT
+  "t"."a" AS "a"
+FROM "t" AS "t";
+
+# title: derived table with INLINE cannot be merged
+# dialect: spark
+# execute: false
+SELECT t.a FROM (SELECT a, INLINE(b) AS s FROM x) AS t;
+WITH `t` AS (
+  SELECT
+    `x`.`a` AS `a`,
+    INLINE(`x`.`b`) AS `s`
+  FROM `x` AS `x`
+)
+SELECT
+  `t`.`a` AS `a`
+FROM `t` AS `t`;
+
 # title: mysql is case-sensitive by default
 # dialect: mysql
 # execute: false


### PR DESCRIPTION
Follow-on from #8314. merge_subqueries has its own copy of the set-returning check one rule later, and it still only matches `exp.Explode`, so a projection pushdown just kept gets dropped again when the derived table is merged.

```
SELECT t.a FROM (SELECT a, GENERATE_SERIES(1, 3) AS s FROM x) AS t
main:  SELECT "x"."a" AS "a" FROM "x" AS "x"
```

`INLINE` goes the same way now that #8314 made it a UDTF. Widened the guard to `exp.UDTF` and `exp.ExplodingGenerateSeries`; Explode is a UDTF so it stays covered. Both cases are in optimizer.sql and fail on main.

I left `exp.Anonymous` out. Here it would block the merge for every unknown function, which is a lot more expensive than keeping a projection was in pushdown, and it breaks the two `FROM_JSON` fixtures. So the STACK case from the #8314 review is still broken. Can add it if you'd rather be conservative, that one seems like your call.

make unit is green. Pure Python only, I didn't run make testc.
