### PR TITLE
fix(spark): support UNION as identifier

### DIFF
--- a/sqlglot/parsers/spark.py
+++ b/sqlglot/parsers/spark.py
@@ -53,6 +53,11 @@ def _build_dateadd(args: list) -> exp.Expr:
 
 
 class SparkParser(Spark2Parser):
+    ID_VAR_TOKENS = {
+        *Spark2Parser.ID_VAR_TOKENS,
+        TokenType.UNION,
+    }
+
     NO_PAREN_FUNCTIONS = {
         **Spark2Parser.NO_PAREN_FUNCTIONS,
         TokenType.SESSION_USER: exp.SessionUser,

--- a/tests/dialects/test_spark.py
+++ b/tests/dialects/test_spark.py
@@ -1193,6 +1193,9 @@ TBLPROPERTIES (
             },
         )
 
+        self.validate_identity("WITH union AS (SELECT 1 AS x) SELECT * FROM union")
+        self.validate_identity("WITH t AS (SELECT 1 AS union) SELECT union FROM t")
+
     def test_named_struct(self):
         self.validate_all(
             "SELECT named_struct('a', 1, 'b', 'x')",


### PR DESCRIPTION
Change inherited by Databricks 