### PR TITLE
fix(expressions): render a DynamicIdentifier in Table.name [CLAUDE]

### DIFF
--- a/sqlglot/expressions/core.py
+++ b/sqlglot/expressions/core.py
@@ -1828,6 +1828,10 @@ class Identifier(Expression):
 class DynamicIdentifier(Expression, Func):
     arg_types = {"this": True, "expressions": False}
 
+    @property
+    def name(self) -> str:
+        return self.this.name if self.this else ""
+
 
 class Opclass(Expression):
     arg_types = {"this": True, "expression": True}

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -12,6 +12,7 @@ from sqlglot.expressions.core import (
     Condition,
     Distinct,
     Dot,
+    DynamicIdentifier,
     Expr,
     Expression,
     Func,
@@ -966,6 +967,8 @@ class Table(Expression, Selectable):
 
     @property
     def name(self) -> str:
+        if isinstance(self.this, DynamicIdentifier):
+            return self.this.name
         if not self.this or isinstance(self.this, Func):
             return ""
         return self.this.name

--- a/sqlglot/expressions/query.py
+++ b/sqlglot/expressions/query.py
@@ -967,11 +967,10 @@ class Table(Expression, Selectable):
 
     @property
     def name(self) -> str:
-        if isinstance(self.this, DynamicIdentifier):
-            return self.this.name
-        if not self.this or isinstance(self.this, Func):
+        this = self.this
+        if not this or (isinstance(this, Func) and not isinstance(this, DynamicIdentifier)):
             return ""
-        return self.this.name
+        return this.name
 
     @property
     def db(self) -> str:

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -782,6 +782,15 @@ class TestSnowflake(Validator):
         self.validate_identity("WITH x AS (SELECT 1 AS foo) SELECT IDENTIFIER('foo') FROM x")
         self.validate_identity("SELECT IDENTIFIER($my_function_name)()")
         self.validate_identity("SELECT IDENTIFIER('speed_of_light')()")
+
+        for sql, name in (
+            ("SELECT * FROM IDENTIFIER(:tbl)", "tbl"),
+            ("SELECT * FROM IDENTIFIER($tbl)", "tbl"),
+            ("SELECT * FROM IDENTIFIER('mytable')", "mytable"),
+        ):
+            table = self.validate_identity(sql).find(exp.Table)
+            self.assertIsInstance(table.this, exp.DynamicIdentifier)
+            self.assertEqual(table.name, name)
         self.validate_all(
             "SELECT IDENTIFIER('my_func')(1, 2)",
             write={


### PR DESCRIPTION
Fixes #8328.

`Table.name` returns `''` for a table named by `IDENTIFIER()`, because it short-circuits on `isinstance(self.this, Func)` and `DynamicIdentifier` is declared `Expression, Func`. That guard is right for table-valued functions like `read_csv()`, but it predates `DynamicIdentifier` by three years and the PRs that added that node only touch generation, so catching it looks accidental rather than intended.

This returns the bare name, matching `Placeholder` and `Parameter` — `'p'` for `:p`, `'v'` for `@v`, with `.sql()` keeping the sigil. It also fixes two knock-on effects described in the issue: `qualify()` no longer gives two unaliased dynamic tables indistinguishable positional aliases, and `exp.table_name()` stops logging an unsupported-argument warning and returning the raw call text.

`read_csv()` and `generate_series()` still return `''`, so the carve-out doesn't reach real table-valued functions. `SKIP_INTEGRATION=1 python -m unittest` is `OK (skipped=48)` at 1354 tests with and without the change; the added assertions fail with `'' != 'tbl'` if the fix is reverted.

I left `Table.db` and `Table.catalog` alone. They are also empty for a dynamic identifier in a qualifier position, but they go through `text()`, which documents itself as handling only strings and leaf expressions, and every `IDENTIFIER()` shape in the test suite puts it in a whole-object position — so I did not want to assume the qualifier form is supported.

*Disclosure: I used Claude to investigate this and draft the patch. I verified the reproduction, root cause and test results myself.*
