### PR TITLE
fix(mysql): `UNIQUE` has options.

### DIFF
--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -397,6 +397,17 @@ class MySQLParser(parser.Parser):
         index_type = self._match(TokenType.USING) and self._advance_any() and self._prev.text
         expressions = self._parse_wrapped_csv(self._parse_ordered)
 
+        return self.expression(
+            exp.IndexColumnConstraint(
+                this=this,
+                expressions=expressions,
+                kind=kind,
+                index_type=index_type,
+                options=self._parse_index_constraint_options(),
+            )
+        )
+
+    def _parse_index_constraint_options(self) -> list[exp.IndexConstraintOption]:
         options = []
         while True:
             if self._match_text_seq("KEY_BLOCK_SIZE"):
@@ -426,15 +437,16 @@ class MySQLParser(parser.Parser):
 
             options.append(opt)
 
-        return self.expression(
-            exp.IndexColumnConstraint(
-                this=this,
-                expressions=expressions,
-                kind=kind,
-                index_type=index_type,
-                options=options,
-            )
-        )
+        return options
+
+    def _parse_unique(self) -> exp.UniqueColumnConstraint:
+        unique = super()._parse_unique()
+
+        # UNIQUE [INDEX | KEY] [index_name] (key_part,...) [index_option] ...
+        if isinstance(unique.this, exp.Schema):
+            unique.set("options", self._parse_index_constraint_options())
+
+        return unique
 
     def _parse_show_mysql(
         self,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -183,6 +183,10 @@ class TestMySQL(Validator):
             "ALTER TABLE t ADD INDEX `i` (`c`)",
         )
         self.validate_identity(
+            "ALTER TABLE t ADD UNIQUE KEY uq (a) USING BTREE COMMENT 'why' INVISIBLE",
+            "ALTER TABLE t ADD UNIQUE uq (a) USING BTREE COMMENT 'why' INVISIBLE",
+        )
+        self.validate_identity(
             "CREATE TABLE `foo` (`id` char(36) NOT NULL DEFAULT (uuid()), PRIMARY KEY (`id`), UNIQUE KEY `id` (`id`))",
             "CREATE TABLE `foo` (`id` CHAR(36) NOT NULL DEFAULT (UUID()), PRIMARY KEY (`id`), UNIQUE `id` (`id`))",
         )
@@ -201,6 +205,10 @@ class TestMySQL(Validator):
         self.validate_identity(
             "CREATE TABLE t (a INT, UNIQUE KEY `Key` (a))",
             "CREATE TABLE t (a INT, UNIQUE `Key` (a))",
+        )
+        self.validate_identity(
+            "CREATE TABLE foo (a BIGINT, UNIQUE KEY b (a) USING BTREE COMMENT 'c' VISIBLE, UNIQUE KEY d (a) KEY_BLOCK_SIZE=8)",
+            "CREATE TABLE foo (a BIGINT, UNIQUE b (a) USING BTREE COMMENT 'c' VISIBLE, UNIQUE d (a) KEY_BLOCK_SIZE = 8)",
         )
         self.validate_identity(
             "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMPTZ, ts_ltz TIMESTAMPLTZ)",
@@ -1885,6 +1893,18 @@ COMMENT='客户账户表'"""
 
         expr = self.parse_one("ALTER TABLE t ADD COLUMN c INT INVISIBLE")
         self.assertIsNotNone(expr.find(exp.InvisibleColumnConstraint))
+
+    def test_unique_key_index_options(self):
+        unique = self.parse_one(
+            "CREATE TABLE t (a INT, UNIQUE KEY u (a) INVISIBLE)"
+        ).this.expressions[1]
+        self.assertIs(unique.args["options"][0].args["visible"], False)
+
+        columns = self.parse_one(
+            "CREATE TABLE t (a INT UNIQUE COMMENT 'c', b INT UNIQUE INVISIBLE)"
+        ).this.expressions
+        self.assertIsInstance(columns[0].constraints[1].kind, exp.CommentColumnConstraint)
+        self.assertIsInstance(columns[1].constraints[1].kind, exp.InvisibleColumnConstraint)
 
     def test_alter_table_auto_increment(self):
         prop = self.parse_one("ALTER TABLE t AUTO_INCREMENT=3000000000").find(


### PR DESCRIPTION
In MySQL, a `CREATE TABLE` or `ALTER TABLE` with a named `UNIQUE` constraint supports most of the same options that a regular secondary index supports. This fixes the `UNIQUE` parsing for MySQL accordingly.