### PR TITLE
fix(sqlite)!: compensate LEAST/GREATEST NULL semantics on SQLite [CLAUDE]

### DIFF
--- a/sqlglot/generators/sqlite.py
+++ b/sqlglot/generators/sqlite.py
@@ -338,17 +338,35 @@ class SQLiteGenerator(generator.Generator):
         separator = expression.args.get("separator")
         return f"GROUP_CONCAT({distinct_sql}{self.format_args(this, separator)})"
 
-    def least_sql(self, expression: exp.Least) -> str:
-        if expression.expressions:
-            return rename_func("MIN")(self, expression)
+    def _min_max_sql(self, expression: exp.Least | exp.Greatest, name: str) -> str:
+        if not expression.expressions:
+            return self.sql(expression, "this")
 
-        return self.sql(expression, "this")
+        if not expression.args.get("ignore_nulls"):
+            # The source dialect and SQLite agree: NULL if any argument is NULL.
+            return rename_func(name)(self, expression)
+
+        # SQLite's multi-argument MIN/MAX return NULL if any argument is NULL,
+        # while the source dialect ignores NULLs. Falling each argument back to
+        # the others keeps every operand non-NULL unless all of them are, which
+        # is exactly the source semantics.
+        args = [expression.this, *expression.expressions]
+        return self.func(
+            name,
+            *(
+                exp.Coalesce(
+                    this=arg.copy(),
+                    expressions=[other.copy() for other in args[index + 1 :] + args[:index]],
+                )
+                for index, arg in enumerate(args)
+            ),
+        )
+
+    def least_sql(self, expression: exp.Least) -> str:
+        return self._min_max_sql(expression, "MIN")
 
     def greatest_sql(self, expression: exp.Greatest) -> str:
-        if expression.expressions:
-            return rename_func("MAX")(self, expression)
-
-        return self.sql(expression, "this")
+        return self._min_max_sql(expression, "MAX")
 
     def transaction_sql(self, expression: exp.Transaction) -> str:
         this = expression.this

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -124,19 +124,16 @@ class TestSQLite(Validator):
         self.validate_all(
             "SELECT LIKE('%y%', 'xyz', '')", write={"sqlite": "SELECT 'xyz' LIKE '%y%' ESCAPE ''"}
         )
+        # LEAST/GREATEST from other dialects is covered by test_least_greatest,
+        # because whether the arguments need NULL compensation depends on the
+        # source dialect's semantics.
         self.validate_all(
             "SELECT MIN(a, b) FROM t",
-            read={
-                "postgres": "SELECT LEAST(a, b) FROM t",
-                "sqlite": "SELECT MIN(a, b) FROM t",
-            },
+            read={"sqlite": "SELECT MIN(a, b) FROM t"},
         )
         self.validate_all(
             "SELECT MAX(a, b) FROM t",
-            read={
-                "postgres": "SELECT GREATEST(a, b) FROM t",
-                "sqlite": "SELECT MAX(a, b) FROM t",
-            },
+            read={"sqlite": "SELECT MAX(a, b) FROM t"},
         )
         # CONCAT skips NULL args in these dialects, but || propagates it, so the
         # operands have to keep the COALESCE wrapping the other targets get.
@@ -345,6 +342,48 @@ class TestSQLite(Validator):
                 "sqlite": "SELECT STRFTIME('%Y-%m-%d', CURRENT_TIMESTAMP)",
             },
         )
+
+    def test_least_greatest(self):
+        # SQLite's multi-argument MIN/MAX return NULL if any argument is NULL,
+        # so a dialect that ignores NULLs needs its arguments compensated.
+        self.validate_all(
+            "SELECT MAX(COALESCE(a, b), COALESCE(b, a))",
+            read={
+                "postgres": "SELECT GREATEST(a, b)",
+                "duckdb": "SELECT GREATEST(a, b)",
+                "spark": "SELECT GREATEST(a, b)",
+            },
+        )
+        self.validate_all(
+            "SELECT MIN(COALESCE(a, b), COALESCE(b, a))",
+            read={
+                "postgres": "SELECT LEAST(a, b)",
+                "duckdb": "SELECT LEAST(a, b)",
+            },
+        )
+        self.validate_all(
+            "SELECT MAX(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b))",
+            read={"postgres": "SELECT GREATEST(a, b, c)"},
+        )
+
+        # Dialects whose GREATEST/LEAST are already NULL-if-any agree with
+        # SQLite's MIN/MAX and must not be rewritten.
+        self.validate_all(
+            "SELECT MAX(a, b)",
+            read={
+                "bigquery": "SELECT GREATEST(a, b)",
+                "mysql": "SELECT GREATEST(a, b)",
+                "presto": "SELECT GREATEST(a, b)",
+            },
+        )
+        self.validate_all(
+            "SELECT MIN(a, b)",
+            read={"bigquery": "SELECT LEAST(a, b)", "mysql": "SELECT LEAST(a, b)"},
+        )
+
+        # A single argument is the value itself, in either direction.
+        self.validate_all("SELECT a", read={"postgres": "SELECT GREATEST(a)"})
+        self.validate_all("SELECT a", read={"bigquery": "SELECT LEAST(a)"})
 
     def test_datediff(self):
         self.validate_all(


### PR DESCRIPTION
Fixes #8315.

`GREATEST`/`LEAST` ignore NULL arguments in Postgres, DuckDB and Spark. SQLite's
multi-argument `max()`/`min()` [return NULL if any argument is NULL](https://www.sqlite.org/lang_corefunc.html#max_scalar).
The SQLite generator renamed one to the other unconditionally, so the translated
query ran successfully and returned different values.

```python
import sqlite3, sqlglot

out = sqlglot.transpile("SELECT GREATEST(a, b) AS hi FROM t", read="postgres", write="sqlite")[0]
# before: SELECT MAX(a, b) AS hi FROM t

con = sqlite3.connect(":memory:")
con.execute("CREATE TABLE t (a INTEGER, b INTEGER)")
con.execute("INSERT INTO t VALUES (NULL, 1)")
con.execute(out).fetchall()
# before: [(None,)]   Postgres/DuckDB give [(1,)]
# after:  [(1,)]
```

### Approach

`exp.Greatest`/`exp.Least` already carry `ignore_nulls`, set from the read
dialect's `LEAST_GREATEST_IGNORES_NULLS`, and `generators/duckdb.py` branches on
it in the opposite direction. `generators/sqlite.py` ignored it.

When the source dialect ignores NULLs, each argument falls back to the others, so
every operand is non-NULL unless all of them are:

```
GREATEST(a, b, c)  ->  MAX(COALESCE(a, b, c), COALESCE(b, c, a), COALESCE(c, a, b))
```

When the source dialect is already NULL-if-any — BigQuery, MySQL, Presto,
Snowflake — its semantics match SQLite's and the output is unchanged. A
single-argument call is still unwrapped to the value itself.

I also considered `(SELECT MAX(x) FROM (VALUES (a), (b)))`, since the aggregate
form ignores NULLs natively. It is O(n) rather than O(n²) in output size, but it
introduces a correlated subquery where an expression used to be, so I kept the
rewrite inline. Happy to switch if you would rather bound the expansion.

### Verification

The rewrite was checked against `sqlite3` over every NULL pattern for two, three
and four arguments (672 cases), compared against the max/min of the non-NULL
arguments — no mismatches.

Two existing assertions in `test_sqlite` covered `postgres -> sqlite` and encoded
the old output. They now live in `test_least_greatest`, which pins both the
compensated and the unchanged directions.

`python -m unittest` passes. (`test_lazy_load` fails on my machine both with and
without this change: it shells out to `python`, which this box doesn't have.)
