### PR TITLE
fix(optimizer)!: preserve columns when source is a whole-row reference

### DIFF
--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -163,7 +163,10 @@ def pushdown_projections(
                     if scope.pivots or isinstance(select, exp.QueryTransform):
                         columns: set[object] = {SELECT_ALL}
                     else:
-                        columns = selects.get(name) or set()
+                        unqualified = selects.get("", set())
+                        columns = (
+                            {SELECT_ALL} if name in unqualified else (selects.get(name) or set())
+                        )
 
                     referenced_columns[source].update(columns)
 

--- a/sqlglot/optimizer/pushdown_projections.py
+++ b/sqlglot/optimizer/pushdown_projections.py
@@ -154,6 +154,8 @@ def pushdown_projections(
             selects: dict[str, set[object]] = defaultdict(set)
             for col in scope.columns:
                 selects[col.table].add(col.name)
+            for table_column in scope.table_columns:
+                selects[table_column.name].add(SELECT_ALL)
 
             # Push the selected columns down to the next scope
             for name, (node, source) in scope.selected_sources.items():


### PR DESCRIPTION
`pushdown_projections` was not recognizing when a CTE / subquery was referenced as a whole-row value and treated them as having no named columns in use, which caused column names to be anonymized to `_` and extra columns to be dropped entirely.  Fix by checking whether the source name appears in the unqualified refs and if so, make sure it's consumed as a whole row.

Input:
```sql
WITH t AS (SELECT 1 AS c, 2 AS d) SELECT t FROM t
```
Previous Output (d dropped, c renamed):
```sql
WITH t AS (SELECT 1 AS _) SELECT t AS t FROM t AS t
```
Expected: all columns preserved
```sql
WITH t AS (SELECT 1 AS c, 2 AS d) SELECT t AS t FROM t AS t
```