### PR TITLE
fix(snowflake): support ROLLBACK as id var and udf name

### DIFF
--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -361,6 +361,7 @@ class SnowflakeParser(parser.Parser):
         TokenType.POLICY,
         TokenType.POOL,
         TokenType.ROLE,
+        TokenType.ROLLBACK,
         TokenType.RULE,
         TokenType.VOLUME,
     }
@@ -374,6 +375,7 @@ class SnowflakeParser(parser.Parser):
             TokenType.POLICY,
             TokenType.POOL,
             TokenType.ROLE,
+            TokenType.ROLLBACK,
             TokenType.RULE,
             TokenType.SEMI,
             TokenType.VOLUME,

--- a/sqlglot/parsers/snowflake.py
+++ b/sqlglot/parsers/snowflake.py
@@ -348,9 +348,12 @@ class SnowflakeParser(parser.Parser):
         TokenType.POLICY,
         TokenType.POOL,
         TokenType.ROLE,
+        TokenType.ROLLBACK,
         TokenType.RULE,
         TokenType.VOLUME,
     }
+
+    FUNC_TOKENS = parser.Parser.FUNC_TOKENS | {TokenType.ROLLBACK}
 
     ALIAS_TOKENS = parser.Parser.ALIAS_TOKENS | {
         TokenType.INTEGRATION,

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4563,6 +4563,11 @@ class TestSnowflake(Validator):
             "WITH rollback(rollback) AS (SELECT 1) SELECT rollback.rollback FROM rollback"
         )
         self.validate_identity("SELECT ROLLBACK(3)")
+        self.validate_identity("SELECT 1 rollback", "SELECT 1 AS rollback")
+        self.validate_identity(
+            "SELECT rollback.x FROM (SELECT 1 AS x) rollback",
+            "SELECT rollback.x FROM (SELECT 1 AS x) AS rollback",
+        )
         self.assertIsInstance(self.parse_one("ROLLBACK WORK"), exp.Rollback)
 
     def test_stored_procedures(self):

--- a/tests/dialects/test_snowflake.py
+++ b/tests/dialects/test_snowflake.py
@@ -4557,6 +4557,14 @@ class TestSnowflake(Validator):
             "CREATE OR REPLACE FUNCTION repro_fn() RETURNS INT LANGUAGE PYTHON HANDLER = 'fn' RUNTIME_VERSION='3.11' PACKAGES=() AS '\\ndef fn():\\n    return 1\\n'"
         )
 
+    def test_rollback_as_identifier(self):
+        self.validate_identity("SELECT rollback FROM t")
+        self.validate_identity(
+            "WITH rollback(rollback) AS (SELECT 1) SELECT rollback.rollback FROM rollback"
+        )
+        self.validate_identity("SELECT ROLLBACK(3)")
+        self.assertIsInstance(self.parse_one("ROLLBACK WORK"), exp.Rollback)
+
     def test_stored_procedures(self):
         self.validate_identity("CALL a.b.c(x, y)", check_command_warning=True)
         self.validate_identity(


### PR DESCRIPTION
For example:

`SELECT rollback FROM t`

`SELECT 1 rollback`

`WITH rollback(rollback) AS (SELECT 1) SELECT rollback.rollback FROM rollback`

`SELECT ROLLBACK(3)`