### PR TITLE
fix(mysql)!: parse MySQL index prefixes

### DIFF
--- a/sqlglot/parsers/mysql.py
+++ b/sqlglot/parsers/mysql.py
@@ -389,13 +389,26 @@ class MySQLParser(parser.Parser):
         self._match_r_paren()
         return self.expression(exp.ColumnPrefix(this=this, expression=expression))
 
+    def _parse_index_constraint_part(self) -> exp.Expr | None:
+        # key_part: {col_name [(length)] | (expr)}, so only a prefixed column is followed by "("
+        if (
+            not self._match(TokenType.L_PAREN, advance=False)
+            and self._next
+            and self._next.token_type == TokenType.L_PAREN
+        ):
+            return self._parse_primary_key_part()
+
+        return self._parse_disjunction()
+
     def _parse_index_constraint(self, kind: str | None = None) -> exp.IndexColumnConstraint:
         if kind:
             self._match_texts(("INDEX", "KEY"))
 
         this = self._parse_id_var(any_token=False)
         index_type = self._match(TokenType.USING) and self._advance_any() and self._prev.text
-        expressions = self._parse_wrapped_csv(self._parse_ordered)
+        expressions = self._parse_wrapped_csv(
+            lambda: self._parse_ordered(self._parse_index_constraint_part)
+        )
 
         return self.expression(
             exp.IndexColumnConstraint(
@@ -440,13 +453,31 @@ class MySQLParser(parser.Parser):
         return options
 
     def _parse_unique(self) -> exp.UniqueColumnConstraint:
-        unique = super()._parse_unique()
+        self._match_texts(("KEY", "INDEX"))
+        this = self._parse_unique_key()
+        index_type = self._parse_index_type()
 
-        # UNIQUE [INDEX | KEY] [index_name] (key_part,...) [index_option] ...
-        if isinstance(unique.this, exp.Schema):
-            unique.set("options", self._parse_index_constraint_options())
+        # UNIQUE [INDEX | KEY] [index_name] [index_type] (key_part,...) [index_option] ...
+        if not self._match(TokenType.L_PAREN, advance=False):
+            return self.expression(exp.UniqueColumnConstraint(this=this, index_type=index_type))
 
-        return unique
+        expressions = self._parse_wrapped_csv(
+            lambda: self._parse_ordered(self._parse_index_constraint_part)
+        )
+
+        return self.expression(
+            exp.UniqueColumnConstraint(
+                this=self.expression(exp.Schema(this=this, expressions=expressions)),
+                index_type=index_type or self._parse_index_type(),
+                options=self._parse_index_constraint_options(),
+            )
+        )
+
+    def _parse_index_type(self) -> str | None:
+        if self._match(TokenType.USING) and self._advance_any():
+            return self._prev.text
+
+        return None
 
     def _parse_show_mysql(
         self,

--- a/tests/dialects/test_mysql.py
+++ b/tests/dialects/test_mysql.py
@@ -187,6 +187,22 @@ class TestMySQL(Validator):
             "ALTER TABLE t ADD UNIQUE uq (a) USING BTREE COMMENT 'why' INVISIBLE",
         )
         self.validate_identity(
+            "ALTER TABLE t ADD UNIQUE KEY u USING BTREE (c)",
+            "ALTER TABLE t ADD UNIQUE u (c) USING BTREE",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INT, UNIQUE KEY u USING BTREE (a))",
+            "CREATE TABLE t (a INT, UNIQUE u (a) USING BTREE)",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INT, UNIQUE USING BTREE (a))",
+            "CREATE TABLE t (a INT, UNIQUE (a) USING BTREE)",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (a INT, UNIQUE KEY `using` (a) USING BTREE)",
+            "CREATE TABLE t (a INT, UNIQUE `using` (a) USING BTREE)",
+        )
+        self.validate_identity(
             "CREATE TABLE `foo` (`id` char(36) NOT NULL DEFAULT (uuid()), PRIMARY KEY (`id`), UNIQUE KEY `id` (`id`))",
             "CREATE TABLE `foo` (`id` CHAR(36) NOT NULL DEFAULT (UUID()), PRIMARY KEY (`id`), UNIQUE `id` (`id`))",
         )
@@ -209,6 +225,22 @@ class TestMySQL(Validator):
         self.validate_identity(
             "CREATE TABLE foo (a BIGINT, UNIQUE KEY b (a) USING BTREE COMMENT 'c' VISIBLE, UNIQUE KEY d (a) KEY_BLOCK_SIZE=8)",
             "CREATE TABLE foo (a BIGINT, UNIQUE b (a) USING BTREE COMMENT 'c' VISIBLE, UNIQUE d (a) KEY_BLOCK_SIZE = 8)",
+        )
+        self.validate_identity("CREATE TABLE t (c VARCHAR(64), PRIMARY KEY (c(20)))")
+        self.validate_identity("CREATE TABLE t (d INT, INDEX k ((d + 1)))")
+        self.validate_identity(
+            "CREATE TABLE t (c VARCHAR(64), KEY k (c(20)))",
+            "CREATE TABLE t (c VARCHAR(64), INDEX k (c(20)))",
+        )
+        self.validate_identity(
+            "CREATE TABLE t (c VARCHAR(64), UNIQUE KEY u (c(20) DESC))",
+            "CREATE TABLE t (c VARCHAR(64), UNIQUE u (c(20) DESC))",
+        )
+        self.validate_identity("ALTER TABLE t ADD INDEX k (c(20))")
+        self.validate_identity("ALTER TABLE t ADD PRIMARY KEY (c(20))")
+        self.validate_identity(
+            "ALTER TABLE t ADD UNIQUE KEY u (c(20))",
+            "ALTER TABLE t ADD UNIQUE u (c(20))",
         )
         self.validate_identity(
             "CREATE TABLE test (ts TIMESTAMP, ts_tz TIMESTAMPTZ, ts_ltz TIMESTAMPLTZ)",


### PR DESCRIPTION
MySQL index prefixes were only being parsed on the `PRIMARY KEY` constraint path, but not on the `INDEX`/`KEY` or `UNIQUE` paths. This commit makes them run through the same parser, which also fixes other inconsistencies like `USING BTREE`.

This implementation, however, no longer dispatches unique parsing to the base class, which previously allowed invalid, non-MySQL options like `NULLS NOT DISTINCT`. Further, it corrects (albeit changes) the previous parsing of `INDEX k (c(10))` as `INDEX k (C(10))`, though does not affect `INDEX f ((LENGTH(c)))`.