### PR TITLE
fix(optimizer)!: for simplify fold contradictory comparisons to FALSE only for non-null columns

### DIFF
--- a/sqlglot/optimizer/simplify.py
+++ b/sqlglot/optimizer/simplify.py
@@ -988,31 +988,36 @@ class Simplifier:
                     # python won't compare date and datetime, but many engines will upcast
                     l, r = cast_as_datetime(l), cast_as_datetime(r)
 
+                false = (
+                    exp.false()
+                    if left.meta_get("nonnull") is True and right.meta_get("nonnull") is True
+                    else None
+                )
+
                 for (a, av), (b, bv) in itertools.permutations(((left, l), (right, r))):
                     if isinstance(a, self.LT_LTE) and isinstance(b, self.LT_LTE):
                         return left if (av > bv if or_ else av <= bv) else right
                     if isinstance(a, self.GT_GTE) and isinstance(b, self.GT_GTE):
                         return left if (av < bv if or_ else av >= bv) else right
 
-                    # we can't ever shortcut to true because the column could be null
                     if not or_:
                         if isinstance(a, exp.LT) and isinstance(b, self.GT_GTE):
                             if av <= bv:
-                                return exp.false()
+                                return false
                         elif isinstance(a, exp.GT) and isinstance(b, self.LT_LTE):
                             if av >= bv:
-                                return exp.false()
+                                return false
                         elif isinstance(a, exp.EQ):
                             if isinstance(b, exp.LT):
-                                return exp.false() if av >= bv else a
+                                return false if av >= bv else a
                             if isinstance(b, exp.LTE):
-                                return exp.false() if av > bv else a
+                                return false if av > bv else a
                             if isinstance(b, exp.GT):
-                                return exp.false() if av <= bv else a
+                                return false if av <= bv else a
                             if isinstance(b, exp.GTE):
-                                return exp.false() if av < bv else a
+                                return false if av < bv else a
                             if isinstance(b, exp.NEQ):
-                                return exp.false() if av == bv else a
+                                return false if av == bv else a
         return None
 
     @annotate_types_on_change

--- a/tests/fixtures/optimizer/simplify.sql
+++ b/tests/fixtures/optimizer/simplify.sql
@@ -874,16 +874,16 @@ x > 3;
 x > 0;
 
 x > 1 AND x < 2 AND x > 3;
-FALSE;
+x < 2 AND x > 3;
 
 x > 1 AND x < 1;
-FALSE;
+x < 1 AND x > 1;
 
 x < 2 AND x > 1;
 x < 2 AND x > 1;
 
 x = 1 AND x < 1;
-FALSE;
+x < 1 AND x = 1;
 
 x = 1 AND x < 1.1;
 x = 1;
@@ -892,25 +892,49 @@ x = 1 AND x <= 1;
 x = 1;
 
 x = 1 AND x <= 0.9;
-FALSE;
+x <= 0.9 AND x = 1;
 
 x = 1 AND x > 0.9;
 x = 1;
 
 x = 1 AND x > 1;
-FALSE;
+x = 1 AND x > 1;
 
 x = 1 AND x >= 1;
 x = 1;
 
 x = 1 AND x >= 2;
-FALSE;
+x = 1 AND x >= 2;
 
 x = 1 AND x <> 2;
 x = 1;
 
 x <> 1 AND x = 1;
-FALSE;
+x <> 1 AND x = 1;
+
+SELECT nn.a > 1 AND nn.a < 1 AS r FROM nn;
+SELECT FALSE AS r FROM nn;
+
+SELECT nn.a = 1 AND nn.a <> 1 AS r FROM nn;
+SELECT FALSE AS r FROM nn;
+
+SELECT nn.a > 1 AND nn.a < 2 AND nn.a > 3 AS r FROM nn;
+SELECT FALSE AS r FROM nn;
+
+SELECT nn.a = 1 AND nn.a >= 2 AS r FROM nn;
+SELECT FALSE AS r FROM nn;
+
+SELECT nn.a FROM nn WHERE NOT (nn.a < 1 AND nn.a > 3);
+SELECT nn.a FROM nn;
+
+SELECT x.a FROM x WHERE NOT (x.a < 1 AND x.a > 3);
+SELECT x.a FROM x WHERE x.a <= 3 OR x.a >= 1;
+
+SELECT nn.a, COALESCE(nn.a < 1 AND nn.a > 3, TRUE) AS r FROM nn;
+SELECT nn.a, FALSE AS r FROM nn;
+
+SELECT x.a, COALESCE(x.a < 1 AND x.a > 3, TRUE) AS r FROM x;
+SELECT x.a, COALESCE(x.a < 1 AND x.a > 3, TRUE) AS r FROM x;
 
 x BETWEEN 0 AND 5 AND x > 3;
 x <= 5 AND x > 3;
@@ -1024,7 +1048,7 @@ CAST(CAST(CAST(1 AS INT) AS BOOLEAN) AS INT) = 1;
 CAST(CAST(CAST(1 AS INT) AS BOOLEAN) AS INT) = 1;
 
 x > CAST('2023-01-01' AS DATE) AND x < CAST('2023-01-01' AS DATETIME);
-FALSE;
+x < CAST('2023-01-01' AS DATETIME) AND x > CAST('2023-01-01' AS DATE);
 
 CAST(x AS INT) < 0 AND CAST(x AS INT) >= -500;
 CAST(x AS INT) < 0 AND CAST(x AS INT) >= -500;
@@ -1033,7 +1057,7 @@ CAST(x AS INT) < -1 AND CAST(x AS INT) >= -500;
 CAST(x AS INT) < -1 AND CAST(x AS INT) >= -500;
 
 CAST(x AS INT) < -500 AND CAST(x AS INT) >= -1;
-FALSE;
+CAST(x AS INT) < -500 AND CAST(x AS INT) >= -1;
 
 0 > CAST(x AS INT) AND -500 <= CAST(x AS INT);
 CAST(x AS INT) < 0 AND CAST(x AS INT) >= -500;
@@ -1042,7 +1066,7 @@ CAST(x AS INT) < 0 AND CAST(x AS INT) >= -500;
 CAST(x AS INT) < -1 AND CAST(x AS INT) >= -500;
 
 -500 > CAST(x AS INT) AND -1 <= CAST(x AS INT);
-FALSE;
+CAST(x AS INT) < -500 AND CAST(x AS INT) >= -1;
 
 CAST(x AS INT) < 1000 AND CAST(x AS INT) >= - -500;
 CAST(x AS INT) < 1000 AND CAST(x AS INT) >= 500;


### PR DESCRIPTION
`simplify` folds contradictory comparisons on the same column (`x < 1 AND x > 3`, `x = 1 AND x <> 1`, ...) to `FALSE`. For a NULL `x` the expression is `NULL`, not `FALSE`.

```sql
WITH t(x) AS (VALUES (NULL), (2))
SELECT x FROM t WHERE NOT (x < 1 AND x > 3);
-- 1 row: 2

-- optimizer output before this PR (the WHERE folded to NOT FALSE and was dropped)
WITH t(x) AS (VALUES (NULL), (2))
SELECT x FROM t;
-- 2 rows: NULL, 2

-- optimizer output after this PR
WITH t(x) AS (VALUES (NULL), (2))
SELECT x FROM t WHERE x <= 3 OR x >= 1;
-- 1 row: 2
```
The fold now only happens when both comparisons are on a nonnull column .