### PR TITLE
fix(optimizer): preserve precedence when replacing aliases in predicate pushdown [GLM]

### DIFF
--- a/sqlglot/optimizer/pushdown_predicates.py
+++ b/sqlglot/optimizer/pushdown_predicates.py
@@ -276,6 +276,9 @@ def nodes_for_predicate(
     return nodes
 
 
+OPERATOR_EXPRESSIONS = (exp.Binary, exp.Unary, exp.Predicate)
+
+
 def replace_aliases(source: exp.Select, predicate: exp.Expr) -> exp.Expr:
     aliases: dict[str, exp.Expr] = {}
 
@@ -287,7 +290,12 @@ def replace_aliases(source: exp.Select, predicate: exp.Expr) -> exp.Expr:
 
     def _replace_alias(column: exp.Expr) -> exp.Expr:
         if isinstance(column, exp.Column) and column.name in aliases:
-            return aliases[column.name].copy()
+            replaced = aliases[column.name].copy()
+            if isinstance(replaced, OPERATOR_EXPRESSIONS) and isinstance(
+                column.parent, OPERATOR_EXPRESSIONS
+            ):
+                replaced = exp.paren(replaced, copy=False)
+            return replaced
         return column
 
     return predicate.transform(_replace_alias)

--- a/tests/fixtures/optimizer/pushdown_predicates.sql
+++ b/tests/fixtures/optimizer/pushdown_predicates.sql
@@ -14,10 +14,16 @@ SELECT x.a FROM (SELECT * FROM x) AS x JOIN y WHERE (x.a = y.a AND x.a = 1 AND x
 SELECT x.a FROM (SELECT * FROM x) AS x JOIN y ON (x.a = 1 AND x.a = y.a AND x.b = 1) OR x.a = y.b WHERE (x.a = 1 AND x.a = y.a AND x.b = 1) OR x.a = y.b;
 
 SELECT x.a FROM (SELECT x.a AS a, x.b * 1 AS c FROM x) AS x WHERE x.c = 1;
-SELECT x.a FROM (SELECT x.a AS a, x.b * 1 AS c FROM x WHERE x.b * 1 = 1) AS x WHERE TRUE;
+SELECT x.a FROM (SELECT x.a AS a, x.b * 1 AS c FROM x WHERE (x.b * 1) = 1) AS x WHERE TRUE;
 
 SELECT x.a FROM (SELECT x.a AS a, x.b * 1 AS c FROM x) AS x WHERE x.c = 1 or x.c = 2;
-SELECT x.a FROM (SELECT x.a AS a, x.b * 1 AS c FROM x WHERE x.b * 1 = 1 OR x.b * 1 = 2) AS x WHERE TRUE;
+SELECT x.a FROM (SELECT x.a AS a, x.b * 1 AS c FROM x WHERE (x.b * 1) = 1 OR (x.b * 1) = 2) AS x WHERE TRUE;
+
+SELECT x.a FROM (SELECT x.a AS a, x.b OR x.c AS d FROM x) AS x WHERE x.d = FALSE;
+SELECT x.a FROM (SELECT x.a AS a, x.b OR x.c AS d FROM x WHERE (x.b OR x.c) = FALSE) AS x WHERE TRUE;
+
+SELECT x.a FROM (SELECT x.a AS a, x.b AND x.c AS d FROM x) AS x WHERE NOT x.d;
+SELECT x.a FROM (SELECT x.a AS a, x.b AND x.c AS d FROM x WHERE NOT x.b OR NOT x.c) AS x WHERE TRUE;
 
 SELECT x.a AS a FROM (SELECT x.a FROM x AS x) AS x JOIN y WHERE x.a = 1 AND x.b = 1 AND (x.c = 1 OR y.c = 1);
 SELECT x.a AS a FROM (SELECT x.a FROM x AS x WHERE x.a = 1 AND x.b = 1) AS x JOIN y ON x.c = 1 OR y.c = 1 WHERE TRUE AND TRUE AND (TRUE);


### PR DESCRIPTION
Fixes #8341

`replace_aliases` in `pushdown_predicates` inlined projection expressions verbatim, so `WHERE d = FALSE` with `a OR b AS d` became `WHERE a OR b = FALSE`, which re-parses as `a OR (b = FALSE)` and changes results.

The same shape breaks other operator contexts, e.g. `a AND b AS d` filtered with `d = FALSE`, `NOT d`, `d IN (...)`, and `d * 2 = 4` with `d = a + b`.

This wraps the substituted expression in `Paren` when it is an operator expression (`Binary`/`Unary`/`Predicate`) placed inside another operator context. Atomic expressions (columns, literals, function calls, `CASE`, casts) are unaffected, and a column at the predicate root stays unwrapped.

Two existing fixture lines gained the now-required parens (`(x.b * 1) = 1`), and new regression cases are added to `tests/fixtures/optimizer/pushdown_predicates.sql`.

Verified the issue's reproduction against DuckDB: the original and rewritten queries now return the same result.