### PR TITLE
fix(sqlite): preserve CONCAT NULL semantics

### DIFF
--- a/sqlglot/parsers/sqlite.py
+++ b/sqlglot/parsers/sqlite.py
@@ -23,6 +23,18 @@ def _build_dpipe(
     )
 
 
+def _build_concat(args: list, dialect: t.Any) -> exp.Concat:
+    # SQLite's CONCAT skips NULL args and returns '' only if all of them are NULL, unlike
+    # || which propagates NULL (https://www.sqlite.org/lang_corefunc.html#concat). Mark
+    # the expression as coalescing so the generator's convert_concat_args machinery
+    # preserves this semantics when emitting ||.
+    return exp.Concat(
+        expressions=args,
+        safe=not dialect.STRICT_STRING_CONCAT,
+        coalesce=True,
+    )
+
+
 def _build_json_extract(args: list, dialect: t.Any) -> exp.JSONExtract | exp.JSONExtractScalar:
     # Single-path json_extract() returns an SQL representation like ->>, except
     # that object/array results keep the JSON subtype (json_subtype); the
@@ -68,6 +80,7 @@ class SQLiteParser(parser.Parser):
 
     FUNCTIONS = {
         **parser.Parser.FUNCTIONS,
+        "CONCAT": _build_concat,
         "DATETIME": lambda args: exp.Anonymous(this="DATETIME", expressions=args),
         "EDITDIST3": exp.Levenshtein.from_arg_list,
         "JSON_EXTRACT": _build_json_extract,

--- a/tests/dialects/test_sqlite.py
+++ b/tests/dialects/test_sqlite.py
@@ -1,6 +1,8 @@
+import sqlite3
+
 from tests.dialects.test_dialect import Validator
 
-from sqlglot import exp
+from sqlglot import exp, transpile
 from sqlglot.helper import logger as helper_logger
 
 
@@ -194,6 +196,36 @@ class TestSQLite(Validator):
                 "snowflake": "SELECT CONCAT(a, b) FROM t",
             },
         )
+        # SQLite's CONCAT skips NULL args and returns '' if all of them are NULL,
+        # unlike || which propagates NULL, so the operands keep the COALESCE
+        # wrapping to preserve that semantics on the sqlite -> sqlite round-trip:
+        # https://github.com/tobymao/sqlglot/issues/8343
+        self.validate_all(
+            "SELECT COALESCE(a, '') || COALESCE(b, '') FROM t",
+            read={"sqlite": "SELECT CONCAT(a, b) FROM t"},
+        )
+        self.validate_all(
+            "SELECT COALESCE(NULL, '') || COALESCE(b, '')",
+            read={"sqlite": "SELECT CONCAT(NULL, b)"},
+        )
+        self.validate_all(
+            "SELECT COALESCE(NULL, '') || COALESCE(NULL, '')",
+            read={"sqlite": "SELECT CONCAT(NULL, NULL)"},
+        )
+        self.validate_all(
+            "SELECT '' || COALESCE(b, '')",
+            read={"sqlite": "SELECT CONCAT('', b)"},
+        )
+        # String/literal operands need no COALESCE and || is left as-is.
+        self.validate_all(
+            "SELECT 'a' || 'b'",
+            read={"sqlite": "SELECT CONCAT('a', 'b')"},
+            write={"sqlite": "SELECT 'a' || 'b'"},
+        )
+        self.validate_identity("SELECT a || b FROM t")
+        # CONCAT_WS keeps its own semantics and is untouched.
+        self.validate_identity("SELECT CONCAT_WS('-', a, b)")
+        self.validate_identity("SELECT CONCAT_WS('-', NULL, b)")
         self.validate_all(
             "SELECT JSON_GROUP_ARRAY(name) FROM t",
             read={
@@ -576,6 +608,27 @@ class TestSQLite(Validator):
     def test_analyze(self):
         self.validate_identity("ANALYZE tbl")
         self.validate_identity("ANALYZE schma.tbl")
+
+    def test_concat_null_roundtrip(self):
+        # https://github.com/tobymao/sqlglot/issues/8343
+        # CONCAT() requires SQLite 3.44+, so skip on older bundled sqlite3.
+        if sqlite3.sqlite_version_info < (3, 44):
+            self.skipTest("SQLite CONCAT() requires SQLite 3.44+")
+
+        source = "SELECT CONCAT(NULL, NULL), CONCAT('a', NULL), CONCAT(NULL, 'b'), CONCAT('a', 'b')"
+        generated = transpile(source, read="sqlite", write="sqlite")[0]
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            source_rows = conn.execute(source).fetchall()
+            generated_rows = conn.execute(generated).fetchall()
+        finally:
+            conn.close()
+
+        # SQLite's CONCAT skips NULL args and returns '' if all are NULL; the
+        # transpiled || form must not turn those NULLs into NULL results.
+        self.assertEqual(source_rows, generated_rows)
+        self.assertEqual(source_rows, [("", "a", "b", "ab")])
 
     def test_create_trigger(self):
         """Test that SQLite CREATE TRIGGER statements fall back to Command parsing."""


### PR DESCRIPTION
Fixes #8343.

SQLite's `CONCAT()` skips NULL arguments and returns `''` if all arguments are NULL, but SQLGlot was parsing it with `coalesce=False`, so a SQLite source `CONCAT(a, b)` transpiled back to SQLite as `a || b`, which propagates NULL. On a `sqlite -> sqlite` round-trip:

```sql
-- source: SELECT id, CONCAT(x, y) AS value FROM t
-- generated (before): SELECT id, x || y AS value FROM t
-- generated (after):  SELECT id, COALESCE(x, '') || COALESCE(y, '') AS value FROM t
```

The fix marks SQLite's `CONCAT` as coalescing in the SQLite parser (`exp.Concat(..., coalesce=True)`), so the existing generator machinery emits `COALESCE(arg, '') || COALESCE(arg, '')`. This makes SQLite sources behave like other coalescing CONCAT dialects (e.g. DuckDB/Postgres) and preserves the NULL-skipping semantics on the SQLite round-trip.

Key points:
- Parser-side only; no generic CONCAT machinery or other dialects touched.
- `CONCAT_WS` and the `||` operator are unchanged.
- Version-agnostic by design: the target output is `COALESCE(...) || ...`, so it does not rely on SQLite 3.44+ native `CONCAT()`.
- Regression tests cover nullable columns, single/all-NULL arguments, empty-string arguments, `||` and `CONCAT_WS` stability, plus a real-SQLite execution round-trip verifying `CONCAT(NULL, NULL)` yields `''` (not NULL) after transpilation.